### PR TITLE
chore: address Copilot rename follow-ups from #17

### DIFF
--- a/ai/skills/tauri/SKILL.md
+++ b/ai/skills/tauri/SKILL.md
@@ -151,7 +151,7 @@ Adding a Tauri command:
 # Rust type check (fast, no binary output)
 cd tauri/src-tauri && cargo check
 
-# Full debug build + launch (builds hecate first)
+# Full debug build + launch (builds gateway first)
 make tauri-dev
 
 # Release bundle for current platform
@@ -181,7 +181,7 @@ Three workflow files split responsibilities:
 | `ubuntu-22.04` | `x86_64-unknown-linux-gnu` | `.deb`, `.AppImage` |
 | `windows-latest` | `x86_64-pc-windows-msvc` | `.msi` |
 
-**Steps per matrix leg** (in `_tauri-shared.yml`): Rust + Go + Bun setup → Linux Tauri 2 prereqs (webkit2gtk-4.1, libxdo, patchelf, …) → `make ui-install` → `make build` → stage sidecar as `binaries/hecate-{triple}[.exe]` → `cd tauri && bun install --frozen-lockfile` → `bun scripts/stamp-version.ts` → `tauri-apps/tauri-action@v0` (build, conditionally upload).
+**Steps per matrix leg** (in `_tauri-shared.yml`): Rust + Go + Bun setup → Linux Tauri 2 prereqs (webkit2gtk-4.1, libxdo, patchelf, …) → `make ui-install` → `make build` → stage sidecar as `binaries/gateway-{triple}[.exe]` → `cd tauri && bun install --frozen-lockfile` → `bun scripts/stamp-version.ts` → `tauri-apps/tauri-action@v0` (build, conditionally upload).
 
 **PR-run behaviour:** `concurrency: cancel-in-progress: true` cancels older runs on the same ref. `if: pull_request.draft == false` skips drafts. Trigger types: `[opened, synchronize, reopened, ready_for_review]` — no fire on title-only edits. Path filter scopes to changes that could plausibly break a Tauri build (`tauri/**`, `cmd/gateway/**`, `ui/**`, `Makefile`, `scripts/stamp-version.ts`, `.github/workflows/*.yml`).
 
@@ -190,9 +190,9 @@ Three workflow files split responsibilities:
 ### Pipeline footguns
 
 - **`tauri-action`'s auto-install is unreliable with `projectPath` set.** It silently skips `bun install` in `tauri/`, leaving `node_modules/.bin/tauri` missing — `bun run tauri build` then fails with "tauri: command not found". Always run `cd tauri && bun install --frozen-lockfile` ourselves before the action.
-- **`build.rs` validates `externalBin` paths at build-script run time.** Any step that compiles the Rust crate (`cargo check`, `cargo build`, `tauri build`) needs the sidecar staged at `binaries/hecate-{triple}[.exe]` first. Stage in this order: `make build` → stage → any Rust compile.
+- **`build.rs` validates `externalBin` paths at build-script run time.** Any step that compiles the Rust crate (`cargo check`, `cargo build`, `tauri build`) needs the sidecar staged at `binaries/gateway-{triple}[.exe]` first. Stage in this order: `make build` → stage → any Rust compile.
 - **Make + Git Bash on Windows runners.** Set `defaults.run.shell: bash` job-wide. Default Windows shell is PowerShell; the Makefile's `SHELL := /bin/sh` and our `cp`/`if` blocks only work in bash. On Windows runners, `bash` resolves to Git Bash.
-- **Go's `-o hecate` extension on Windows shifts across versions.** Stage step tries `hecate.exe` then falls back to `hecate`, fails loudly with `ls -la` if neither exists — silent `cp` of a missing source is the worst failure mode.
+- **Go's `-o gateway` extension on Windows shifts across versions.** Stage step tries `gateway.exe` then falls back to `gateway`, fails loudly with `ls -la` if neither exists — silent `cp` of a missing source is the worst failure mode.
 - **`make build` runs `make ui-build` which checks for `ui/node_modules/@vitejs/plugin-react`.** That's the canary file. CI must run `make ui-install` before `make build`. Goreleaser handles this via its `before:` hook (`bun install --cwd ui --frozen-lockfile`); the Tauri matrix does it explicitly.
 - **`stamp-version.ts` `TAURI_VERSION` env var must not include the `v` prefix.** The script strips it, but only since the recent fix; CI passes the bare semver to be safe. The git-tag fallback path (`gitVersion()`) has always stripped `v`.
 - **Windows MSI rejects pre-release identifiers in the version.** WiX requires a four-part numeric `Major.Minor.Build.Revision` (each ≤ 65535). `0.1.0-alpha.8` fails with "optional pre-release identifier in app version must be numeric-only". `stamp-version.ts` writes a derived four-part version to `bundle.windows.wix.version` (e.g. `0.1.0-alpha.8` → `0.1.0.8`); MSI uses that override, every other bundler still sees the canonical semver. NSIS has no version-override field in Tauri's schema — the matrix is MSI-only on Windows for that reason. If NSIS is ever added, expect the same failure mode and find an upstream fix.
@@ -205,5 +205,5 @@ macOS bundles trigger Gatekeeper on first launch; Windows MSI shows SmartScreen.
 
 - `cargo check` passes with no warnings.
 - `make tauri-dev` launches the window, shows the splash, navigates to the gateway UI, and auto-logs in without a token paste.
-- Closing the window does not leave a `hecate` process running (`pgrep hecate` returns nothing after quit).
+- Closing the window does not leave a `gateway` process running (`pgrep gateway` returns nothing after quit).
 - See [`../../core/verification.md`](../../core/verification.md) for the full ladder.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -27,7 +27,7 @@ the same matrix on PRs touching the desktop pipeline and persists bundles as
 
 What works:
 
-- Sidecar lifecycle (spawn, healthz wait, kill on exit; `pgrep hecate` is
+- Sidecar lifecycle (spawn, healthz wait, kill on exit; `pgrep gateway` is
   empty after `cmd+Q`).
 - Same-origin loopback to the embedded gateway UI; bootstrap-token
   handshake auto-logs in without a token paste.

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 // Package e2e contains true end-to-end tests that build and start the real
-// hecate binary, send real HTTP requests (optionally against real upstream
+// gateway binary, send real HTTP requests (optionally against real upstream
 // providers), and verify the response shape.
 //
 // Run with:
@@ -82,9 +82,9 @@ func moduleRootDir() string {
 	return mod[:strings.LastIndex(mod, string(os.PathSeparator))]
 }
 
-// hecateServer starts the gateway binary on a free port and returns the base
+// gatewayServer starts the gateway binary on a free port and returns the base
 // URL once /healthz responds 200.  The process is killed when the test ends.
-func hecateServer(t *testing.T, extraEnv ...string) string {
+func gatewayServer(t *testing.T, extraEnv ...string) string {
 	t.Helper()
 
 	bin := gatewayBinary(t)
@@ -243,7 +243,7 @@ func readSSE(t *testing.T, resp *http.Response) []sseEvent {
 // the port, and returns 200 on /healthz.
 func TestGatewayStartsAndRespondsHealthy(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	resp, err := http.Get(base + "/healthz")
 	if err != nil {
@@ -264,7 +264,7 @@ func TestGatewayStartsAndRespondsHealthy(t *testing.T) {
 func TestGatewayNoProviderConfiguredReturns502(t *testing.T) {
 	t.Parallel()
 	// No PROVIDER_* env — no providers registered.
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
 	resp := postJSON(t, base+"/v1/chat/completions", body, map[string]string{
@@ -288,7 +288,7 @@ func TestGatewayFakeUpstreamNonStreamingCodex(t *testing.T) {
 	fakeResp := `{"id":"chatcmpl-e2e","object":"chat.completion","created":1700000000,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from fake upstream"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", fakeResp, false)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=gpt-4o-mini",
@@ -328,7 +328,7 @@ func TestGatewayFakeUpstreamStreamingCodex(t *testing.T) {
 
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", "", true)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=gpt-4o-mini",
@@ -370,7 +370,7 @@ func TestGatewayFakeUpstreamClaudeCode(t *testing.T) {
 	fakeResp := `{"id":"chatcmpl-e2e","object":"chat.completion","created":1700000000,"model":"claude-sonnet-4-20250514","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from fake upstream"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", fakeResp, false)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=claude-sonnet-4-20250514",
@@ -413,7 +413,7 @@ func TestGatewayFakeUpstreamClaudeCode(t *testing.T) {
 // TestGatewayMultimodalCodexImageURLPassthrough exercises the
 // full multi-modal pipe end-to-end on the OpenAI route: the
 // caller posts a content array (text + image_url) to the real
-// hecate binary, and the fake upstream must receive the array
+// gateway binary, and the fake upstream must receive the array
 // form on the wire with the image_url block intact.
 //
 // This catches regressions that the unit tests can't: the JSON
@@ -427,7 +427,7 @@ func TestGatewayMultimodalCodexImageURLPassthrough(t *testing.T) {
 	fakeResp := `{"id":"chatcmpl-mm","object":"chat.completion","created":1700000000,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"It's a cat."},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":4,"total_tokens":54}}`
 	upstream, captured := fakeUpstreamCapturing(t, "/v1/chat/completions", fakeResp)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=gpt-4o",
@@ -450,7 +450,7 @@ func TestGatewayMultimodalCodexImageURLPassthrough(t *testing.T) {
 		t.Fatalf("expected 200, got %d — body: %s", resp.StatusCode, readBody(t, resp))
 	}
 
-	// Inspect what hecate forwarded to the upstream.
+	// Inspect what the gateway forwarded to the upstream.
 	upstreamBody := captured.lastBody()
 	if upstreamBody == nil {
 		t.Fatal("upstream received no request body")
@@ -496,7 +496,7 @@ func TestGatewayMultimodalAnthropicImageURLTranslation(t *testing.T) {
 	fakeResp := `{"id":"msg_e2e_mm","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"It's a cat."}],"stop_reason":"end_turn","usage":{"input_tokens":50,"output_tokens":4}}`
 	upstream, captured := fakeUpstreamCapturing(t, "/v1/messages", fakeResp)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_ANTHROPIC_API_KEY=dummy",
 		"PROVIDER_ANTHROPIC_BASE_URL="+upstream,
 		"PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-6",
@@ -559,7 +559,7 @@ func TestGatewayMultimodalAnthropicDataURITranslation(t *testing.T) {
 	fakeResp := `{"id":"msg_e2e_b64","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":80,"output_tokens":1}}`
 	upstream, captured := fakeUpstreamCapturing(t, "/v1/messages", fakeResp)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_ANTHROPIC_API_KEY=dummy",
 		"PROVIDER_ANTHROPIC_BASE_URL="+upstream,
 		"PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-6",
@@ -611,7 +611,7 @@ func TestGatewayRuntimeProviderHeader(t *testing.T) {
 	fakeResp := `{"id":"chatcmpl-e2e","object":"chat.completion","created":1700000000,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", fakeResp, false)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=gpt-4o-mini",
@@ -645,7 +645,7 @@ func TestRealAnthropicClaudeCode(t *testing.T) {
 		t.Skip("PROVIDER_ANTHROPIC_API_KEY not set — skipping real-provider test")
 	}
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_ANTHROPIC_API_KEY="+apiKey,
 		"GATEWAY_DEFAULT_MODEL=claude-haiku-4-5-20251001",
 	)
@@ -683,7 +683,7 @@ func TestRealAnthropicClaudeCodeStreaming(t *testing.T) {
 		t.Skip("PROVIDER_ANTHROPIC_API_KEY not set — skipping real-provider test")
 	}
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_ANTHROPIC_API_KEY="+apiKey,
 		"GATEWAY_DEFAULT_MODEL=claude-haiku-4-5-20251001",
 	)
@@ -728,7 +728,7 @@ func TestRealOpenAICodex(t *testing.T) {
 		t.Skip("PROVIDER_OPENAI_API_KEY not set — skipping real-provider test")
 	}
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_OPENAI_API_KEY="+apiKey,
 		"GATEWAY_DEFAULT_MODEL=gpt-4o-mini",
 	)
@@ -762,7 +762,7 @@ func TestRealOpenAICodexStreaming(t *testing.T) {
 		t.Skip("PROVIDER_OPENAI_API_KEY not set — skipping real-provider test")
 	}
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_OPENAI_API_KEY="+apiKey,
 		"GATEWAY_DEFAULT_MODEL=gpt-4o-mini",
 	)
@@ -797,7 +797,7 @@ func TestRealOpenAICodexStreaming(t *testing.T) {
 // OpenAI-compatible list envelope even when no provider is configured.
 func TestGatewayModelsEndpoint(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/v1/models", nil)
 	if err != nil {
@@ -829,7 +829,7 @@ func TestGatewayModelsEndpoint(t *testing.T) {
 // in single-user admin mode.
 func TestGatewayWhoAmI(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/v1/whoami", nil)
 	if err != nil {
@@ -865,7 +865,7 @@ func TestGatewayWhoAmI(t *testing.T) {
 // the provider-status envelope shape.
 func TestGatewayAdminProviderStatus(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/admin/providers", nil)
 	if err != nil {
@@ -897,7 +897,7 @@ func TestGatewayAdminProviderStatus(t *testing.T) {
 // the runtime-stats envelope shape.
 func TestGatewayAdminRuntimeStats(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/admin/runtime/stats", nil)
 	if err != nil {
@@ -929,7 +929,7 @@ func TestGatewayAdminRuntimeStats(t *testing.T) {
 // non-empty list of built-in provider presets.
 func TestGatewayProviderPresets(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/v1/provider-presets", nil)
 	if err != nil {
@@ -961,7 +961,7 @@ func TestGatewayProviderPresets(t *testing.T) {
 // body to POST /v1/chat/completions results in a 400 Bad Request.
 func TestGatewayInvalidJSONBodyReturns400(t *testing.T) {
 	t.Parallel()
-	base := hecateServer(t)
+	base := gatewayServer(t)
 
 	resp := postJSON(t, base+"/v1/chat/completions", `{not valid json`, map[string]string{
 		"Authorization": "Bearer test-token",
@@ -989,7 +989,7 @@ func TestGatewayRateLimitHeaders(t *testing.T) {
 	fakeResp := `{"id":"chatcmpl-e2e","object":"chat.completion","created":1700000000,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", fakeResp, false)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=gpt-4o-mini",
@@ -1027,7 +1027,7 @@ func TestGatewayFakeUpstreamStreamingClaudeCode(t *testing.T) {
 
 	upstream := fakeOpenAIServer(t, "/v1/chat/completions", "", true)
 
-	base := hecateServer(t,
+	base := gatewayServer(t,
 		"PROVIDER_FAKE_API_KEY=dummy",
 		"PROVIDER_FAKE_BASE_URL="+upstream,
 		"PROVIDER_FAKE_DEFAULT_MODEL=claude-sonnet-4-20250514",
@@ -1174,7 +1174,7 @@ func fakeOpenAIServer(t *testing.T, path, body string, streaming bool) string {
 //   - reuse the same file (and therefore the same token) on a second
 //     start so persisted credentials survive restarts.
 //
-// The standard hecateServer() helper pins both env vars, so this is the
+// The standard gatewayServer() helper pins both env vars, so this is the
 // only test that exercises the auto-generation default-path code in the
 // binary-only suite. The Docker smoke covers the same contract through
 // the `/data` volume; this is the cheap counterpart.

--- a/e2e/ollama_test.go
+++ b/e2e/ollama_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 
 	// ── 4. Gateway binary ─────────────────────────────────────────────────────
 	var err error
-	suiteGateway, err = startHecateProcess(
+	suiteGateway, err = startGatewayProcess(
 		"PROVIDER_OLLAMA_BASE_URL="+suiteOllamaURL,
 		"PROVIDER_OLLAMA_KIND=local",
 		"PROVIDER_OLLAMA_DEFAULT_MODEL="+ollamaModel,
@@ -419,13 +419,13 @@ func (s *otlpSink) waitForMetric(substr string, timeout time.Duration) bool {
 
 // ─── gateway process lifecycle (TestMain-scoped, no *testing.T) ────────────
 
-// startHecateProcess builds the gateway binary once, starts it with the
+// startGatewayProcess builds the gateway binary once, starts it with the
 // given extra env vars plus a fixed admin token (so existing "Bearer
 // test-token" headers in tests authenticate) and a per-process temp data
 // dir for the bootstrap file. Waits for /healthz, returns the base URL.
 // The process is intentionally not tracked for cleanup: it is killed by
 // the OS when the test binary exits.
-func startHecateProcess(extraEnv ...string) (string, error) {
+func startGatewayProcess(extraEnv ...string) (string, error) {
 	bin, err := buildGatewayBin()
 	if err != nil {
 		return "", fmt.Errorf("build: %w", err)

--- a/e2e/sandbox_test.go
+++ b/e2e/sandbox_test.go
@@ -49,7 +49,7 @@ func TestSandboxBundledLayout(t *testing.T) {
 	buildSandboxd(t, gatewayDir)
 
 	workDir := t.TempDir()
-	baseURL := hecateServer(t,
+	baseURL := gatewayServer(t,
 		// Explicitly unset so resolution falls through to the
 		// next-to-executable probe rather than any ambient env var.
 		"SANDBOXD_BIN=",
@@ -77,7 +77,7 @@ func TestSandboxSANDBOXDBINOverride(t *testing.T) {
 	sandboxdBin := buildSandboxd(t, t.TempDir())
 	workDir := t.TempDir()
 
-	baseURL := hecateServer(t,
+	baseURL := gatewayServer(t,
 		"SANDBOXD_BIN="+sandboxdBin,
 		"GATEWAY_TASK_APPROVAL_POLICIES=",
 	)
@@ -103,7 +103,7 @@ func TestSandboxPolicyDeniesNetwork(t *testing.T) {
 	sandboxdBin := buildSandboxd(t, t.TempDir())
 	workDir := t.TempDir()
 
-	baseURL := hecateServer(t,
+	baseURL := gatewayServer(t,
 		"SANDBOXD_BIN="+sandboxdBin,
 		"GATEWAY_TASK_APPROVAL_POLICIES=",
 	)
@@ -123,7 +123,7 @@ func TestSandboxReadOnlyPolicyDeniesWrite(t *testing.T) {
 	sandboxdBin := buildSandboxd(t, t.TempDir())
 	workDir := t.TempDir()
 
-	baseURL := hecateServer(t,
+	baseURL := gatewayServer(t,
 		"SANDBOXD_BIN="+sandboxdBin,
 		"GATEWAY_TASK_APPROVAL_POLICIES=",
 	)


### PR DESCRIPTION
## Summary

Catches up the three [Copilot review comments](https://github.com/chicoxyzzy/hecate/pull/17#pullrequestreview-4212759617) on #17 that were filed and replied to with \`@copilot apply\` but didn't make the merge. Plus a small sweep for stale \`hecate\`-the-binary references the original PR missed.

## Renames

- \`e2e/gateway_test.go\`: \`hecateServer\` → \`gatewayServer\` (function + 22 call sites). Helper builds/starts the \`gateway\` binary; identifier should match. ([Copilot comment](https://github.com/chicoxyzzy/hecate/pull/17#discussion_r3174626560))
- \`e2e/sandbox_test.go\`: same \`hecateServer\` → \`gatewayServer\` at the four call sites here (helper is shared with \`gateway_test.go\`).
- \`e2e/ollama_test.go\`: \`startHecateProcess\` → \`startGatewayProcess\` (definition, doc comment, TestMain call site). ([Copilot comment](https://github.com/chicoxyzzy/hecate/pull/17#discussion_r3174626517))

## Doc fixes for stale binary references

- \`ai/skills/tauri/SKILL.md\`: \`binaries/hecate-{triple}[.exe]\` → \`binaries/gateway-{triple}[.exe]\` in the matrix-step description and the \`build.rs\` externalBin footgun. The workflow YAML already uses \`gateway-{triple}\`; the doc was lying. ([Copilot comment](https://github.com/chicoxyzzy/hecate/pull/17#discussion_r3174626546))
- \`ai/skills/tauri/SKILL.md\`: \"Go's \`-o hecate\` extension on Windows\" footgun → \"Go's \`-o gateway\` extension\"; tries \`gateway.exe\` then \`gateway\`, matching the actual stage step.
- \`ai/skills/tauri/SKILL.md\`: \`make tauri-dev\` note \"(builds hecate first)\" → \"(builds gateway first)\".
- \`ai/skills/tauri/SKILL.md\`: Done criterion \"no orphan \`hecate\` process (\`pgrep hecate\`)\" → \"\`gateway\`\".
- \`docs/desktop-app.md\`: \`pgrep hecate is empty\` → \`pgrep gateway\`.
- \`e2e/gateway_test.go\`: package doc \"real hecate binary\" → \"real gateway binary\"; one inline comment \"Inspect what hecate forwarded\" → \"what the gateway forwarded\".

## Kept unchanged (intentional, matching #17)

- \`github.com/hecate/agent-runtime/...\` Go module path.
- \`ghcr.io/chicoxyzzy/hecate\`, \`com.hecate.app\`, \`hecate-data\`, \`POSTGRES_DB/USER/PASSWORD: hecate\`, \`hecate.db\`, \`hecate.bootstrap.json\`, \`\${TMPDIR}/hecate-workspaces\`, \`hecate_cache_*_idx\`.
- \`HECATE_AUTH_TOKEN\` / \`HECATE_BASE_URL\` env vars (product/auth, not binary).
- \`e2e/docker_test.go\` references to \"hecate\" (docker-compose service id; #17 explicitly kept this as \"product name as service id\").
- MCP \`server.NewServer(\"hecate\", …)\` (logical server name shown to MCP clients).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet -tags 'e2e ollama docker' ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)