### PR TITLE
fix(chats): treat ACP progress narration as transient

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -171,6 +171,9 @@ On Hecate shutdown, active Agent Chat turns are cancelled first. Hecate waits
 briefly for the ACP turn to drain, asks the native ACP session to close, and
 then kills the owned adapter process group if it is still alive. This keeps app
 quit / restart from leaving Codex, Claude, or Cursor adapter processes behind.
+Operators can also close an Agent Chat session manually to release the external
+adapter process while keeping the Hecate chat history. Deleting a chat performs
+the same release step and then removes the persisted history.
 
 Every prompt also gets OTel-shaped observability. The message response includes
 `request_id`, `trace_id`, and `span_id`, and `GET

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -167,6 +167,11 @@ captures ACP updates with an output cap, and records Git diff / diff stat after
 each turn. External agent adapters are still trusted subprocesses in the
 selected workspace; this is not equivalent to the task runtime sandbox.
 
+On Hecate shutdown, active Agent Chat turns are cancelled first. Hecate waits
+briefly for the ACP turn to drain, asks the native ACP session to close, and
+then kills the owned adapter process group if it is still alive. This keeps app
+quit / restart from leaving Codex, Claude, or Cursor adapter processes behind.
+
 Every prompt also gets OTel-shaped observability. The message response includes
 `request_id`, `trace_id`, and `span_id`, and `GET
 /v1/traces?request_id=<request_id>` shows the `agent_chat.run` span with adapter

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -592,6 +592,12 @@ POST /v1/agent-chat/sessions/agent_chat_.../cancel
 Returns `202` when a running turn was signalled. If the session is not
 currently running, the endpoint returns `409 invalid_request`.
 
+### `POST /v1/agent-chat/sessions/{id}/close`
+
+Closes the native ACP adapter session while keeping the Hecate chat history.
+If a turn is currently running, Hecate cancels and waits briefly before closing
+the external session.
+
 ### `DELETE /v1/agent-chat/sessions/{id}`
 
 Deletes an Agent Chat session from the configured chat-session backend.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -595,6 +595,8 @@ currently running, the endpoint returns `409 invalid_request`.
 ### `DELETE /v1/agent-chat/sessions/{id}`
 
 Deletes an Agent Chat session from the configured chat-session backend.
+If the session has an active native ACP adapter process, Hecate closes the
+native session and terminates the owned process as part of deletion.
 
 ### `POST /v1/workspace-dialog`
 

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -280,6 +280,7 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 
 	started := time.Now().UTC()
 	turn := newACPTurn(req.MaxOutputBytes, req.OnOutput)
+	turn.setActivityCallback(req.OnActivity)
 	s.client.setTurn(turn)
 	defer s.client.clearTurn(turn)
 
@@ -478,6 +479,7 @@ type acpTurn struct {
 	usage          Usage
 	agentMessageID string
 	onOutput       func(string)
+	onActivity     func(Activity)
 
 	mu sync.Mutex
 }
@@ -492,6 +494,12 @@ func newACPTurn(maxOutput int64, onOutput func(string)) *acpTurn {
 	return turn
 }
 
+func (t *acpTurn) setActivityCallback(onActivity func(Activity)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.onActivity = onActivity
+}
+
 func (t *acpTurn) recordUpdate(params acp.SessionNotification) {
 	raw, _ := json.Marshal(params)
 	if len(raw) > 0 {
@@ -501,6 +509,12 @@ func (t *acpTurn) recordUpdate(params acp.SessionNotification) {
 	switch {
 	case update.AgentMessageChunk != nil:
 		t.appendAgentMessageChunk(update.AgentMessageChunk)
+	case update.ToolCall != nil:
+		t.recordToolCall(update.ToolCall)
+	case update.ToolCallUpdate != nil:
+		t.recordToolCallUpdate(update.ToolCallUpdate)
+	case update.Plan != nil:
+		t.recordPlan(update.Plan)
 	case update.UsageUpdate != nil:
 		t.recordUsage(update.UsageUpdate)
 	}
@@ -537,6 +551,165 @@ func (t *acpTurn) appendAgentMessageChunk(update *acp.SessionUpdateAgentMessageC
 	if t.onOutput != nil {
 		t.onOutput(snapshot)
 	}
+}
+
+func (t *acpTurn) recordToolCall(update *acp.SessionUpdateToolCall) {
+	if update == nil {
+		return
+	}
+	t.emitActivity(Activity{
+		ID:     "tool:" + string(update.ToolCallId),
+		Type:   "tool_call",
+		Status: acpToolStatus(string(update.Status)),
+		Kind:   string(update.Kind),
+		Title:  firstNonEmpty(update.Title, string(update.ToolCallId)),
+		Detail: toolCallDetail(update.Kind, update.Locations, update.Content),
+	})
+}
+
+func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
+	if update == nil {
+		return
+	}
+	title := ""
+	if update.Title != nil {
+		title = *update.Title
+	}
+	status := ""
+	if update.Status != nil {
+		status = string(*update.Status)
+	}
+	kind := ""
+	if update.Kind != nil {
+		kind = string(*update.Kind)
+	}
+	t.emitActivity(Activity{
+		ID:     "tool:" + string(update.ToolCallId),
+		Type:   "tool_call",
+		Status: acpToolStatus(status),
+		Kind:   kind,
+		Title:  title,
+		Detail: toolCallDetail(acp.ToolKind(""), update.Locations, update.Content),
+	})
+}
+
+func (t *acpTurn) recordPlan(update *acp.SessionUpdatePlan) {
+	if update == nil {
+		return
+	}
+	for index, entry := range update.Entries {
+		t.emitActivity(Activity{
+			ID:     fmt.Sprintf("plan:%d:%s", index, entry.Content),
+			Type:   "plan",
+			Status: string(entry.Status),
+			Kind:   string(entry.Priority),
+			Title:  entry.Content,
+			Detail: string(entry.Priority),
+		})
+	}
+}
+
+func (t *acpTurn) emitActivity(activity Activity) {
+	if strings.TrimSpace(activity.ID) == "" && strings.TrimSpace(activity.Title) == "" {
+		return
+	}
+	t.mu.Lock()
+	onActivity := t.onActivity
+	t.mu.Unlock()
+	if onActivity != nil {
+		onActivity(activity)
+	}
+}
+
+func acpToolStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case string(acp.ToolCallStatusPending):
+		return "pending"
+	case string(acp.ToolCallStatusInProgress):
+		return "running"
+	case string(acp.ToolCallStatusCompleted):
+		return "completed"
+	case string(acp.ToolCallStatusFailed):
+		return "failed"
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func toolCallDetail(kind acp.ToolKind, locations []acp.ToolCallLocation, content []acp.ToolCallContent) string {
+	parts := make([]string, 0, 3)
+	if kind != "" {
+		parts = append(parts, string(kind))
+	}
+	if len(locations) > 0 {
+		parts = append(parts, summarizeToolLocations(locations))
+	}
+	if len(content) > 0 {
+		if summary := summarizeToolContent(content); summary != "" {
+			parts = append(parts, summary)
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func summarizeToolLocations(locations []acp.ToolCallLocation) string {
+	const maxLocations = 3
+	parts := make([]string, 0, min(len(locations), maxLocations))
+	for i, location := range locations {
+		if i >= maxLocations {
+			break
+		}
+		if location.Line != nil && *location.Line > 0 {
+			parts = append(parts, fmt.Sprintf("%s:%d", location.Path, *location.Line))
+			continue
+		}
+		parts = append(parts, location.Path)
+	}
+	if len(locations) > maxLocations {
+		parts = append(parts, fmt.Sprintf("+%d more", len(locations)-maxLocations))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func summarizeToolContent(content []acp.ToolCallContent) string {
+	var diffs, terminals, text int
+	for _, item := range content {
+		switch {
+		case item.Diff != nil:
+			diffs++
+		case item.Terminal != nil:
+			terminals++
+		case item.Content != nil:
+			text++
+		}
+	}
+	parts := make([]string, 0, 3)
+	if diffs > 0 {
+		parts = append(parts, pluralize(diffs, "diff"))
+	}
+	if terminals > 0 {
+		parts = append(parts, pluralize(terminals, "terminal"))
+	}
+	if text > 0 {
+		parts = append(parts, pluralize(text, "output"))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func pluralize(count int, singular string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %ss", count, singular)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (t *acpTurn) recordUsage(update *acp.SessionUsageUpdate) {

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -81,13 +81,14 @@ func (m *SessionManager) Run(ctx context.Context, req RunRequest) (RunResult, er
 	if req.MaxOutputBytes <= 0 {
 		req.MaxOutputBytes = 1024 * 1024
 	}
-	session, started, resumed, err := m.session(ctx, adapter, req)
+	session, started, resumed, recovery, err := m.session(ctx, adapter, req)
 	if err != nil {
 		return RunResult{}, err
 	}
 	result, err := session.RunTurn(ctx, req)
 	result.SessionStarted = started
 	result.SessionResumed = resumed
+	result.SessionRecovery = recovery
 	return result, err
 }
 
@@ -96,17 +97,17 @@ type sessionStart struct {
 	cancel context.CancelFunc
 }
 
-func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRequest) (*acpSession, bool, bool, error) {
+func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRequest) (*acpSession, bool, bool, string, error) {
 	for {
 		m.mu.Lock()
 		if m.closed {
 			m.mu.Unlock()
-			return nil, false, false, fmt.Errorf("agent session manager is shut down")
+			return nil, false, false, "", fmt.Errorf("agent session manager is shut down")
 		}
 		existing := m.sessions[req.SessionID]
 		if existing != nil && existing.adapter.ID == adapter.ID && existing.workspace == req.Workspace {
 			m.mu.Unlock()
-			return existing, false, false, nil
+			return existing, false, false, "", nil
 		}
 		if start := m.starts[req.SessionID]; start != nil {
 			done := start.done
@@ -115,7 +116,7 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 			case <-done:
 				continue
 			case <-ctx.Done():
-				return nil, false, false, ctx.Err()
+				return nil, false, false, "", ctx.Err()
 			}
 		}
 		if m.starts == nil {
@@ -127,7 +128,7 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		logger := m.logger
 		m.mu.Unlock()
 
-		started, resumed, err := startACPSession(startCtx, adapter, req.Workspace, req.PreviousNativeSessionID, logger)
+		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.Workspace, req.PreviousNativeSessionID, logger)
 		startCancel()
 
 		var previous *acpSession
@@ -137,7 +138,7 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 			close(start.done)
 			m.mu.Unlock()
 			_ = started.Close(context.Background())
-			return nil, false, false, fmt.Errorf("agent session manager is shut down")
+			return nil, false, false, "", fmt.Errorf("agent session manager is shut down")
 		}
 		if err == nil {
 			previous = m.sessions[req.SessionID]
@@ -150,9 +151,9 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 			_ = previous.Close(context.Background())
 		}
 		if err != nil {
-			return nil, false, false, err
+			return nil, false, false, "", err
 		}
-		return started, true, resumed, nil
+		return started, true, resumed, recovery, nil
 	}
 }
 
@@ -224,10 +225,10 @@ type acpSession struct {
 	activeDone   chan struct{}
 }
 
-func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNativeSessionID string, logger *slog.Logger) (*acpSession, bool, error) {
+func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNativeSessionID string, logger *slog.Logger) (*acpSession, bool, string, error) {
 	command, err := resolveExecutable(adapter, exec.LookPath)
 	if err != nil {
-		return nil, false, err
+		return nil, false, "", err
 	}
 	args := append([]string(nil), adapter.Args...)
 	cmd := exec.CommandContext(context.Background(), command, args...)
@@ -237,18 +238,18 @@ func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNa
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, false, fmt.Errorf("create ACP stdin pipe: %w", err)
+		return nil, false, "", fmt.Errorf("create ACP stdin pipe: %w", err)
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, false, fmt.Errorf("create ACP stdout pipe: %w", err)
+		return nil, false, "", fmt.Errorf("create ACP stdout pipe: %w", err)
 	}
 	var stderr limitedBuffer
 	stderr.limit = 256 * 1024
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		return nil, false, fmt.Errorf("start ACP adapter %q: %w", adapter.ID, err)
+		return nil, false, "", fmt.Errorf("start ACP adapter %q: %w", adapter.ID, err)
 	}
 
 	client := &acpChatClient{workspace: workspace}
@@ -274,11 +275,12 @@ func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNa
 	})
 	if err != nil {
 		terminateProcess(cmd)
-		return nil, false, fmt.Errorf("initialize ACP adapter %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
+		return nil, false, "", fmt.Errorf("initialize ACP adapter %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 	}
 
 	nativeID := ""
 	resumed := false
+	recovery := ""
 	previousNativeSessionID = strings.TrimSpace(previousNativeSessionID)
 	if previousNativeSessionID != "" && initResp.AgentCapabilities.LoadSession {
 		loadCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
@@ -291,6 +293,8 @@ func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNa
 		if err == nil {
 			nativeID = previousNativeSessionID
 			resumed = true
+		} else {
+			recovery = fmt.Sprintf("could not restore ACP session %s: %v", previousNativeSessionID, err)
 		}
 	}
 	if nativeID == "" {
@@ -302,7 +306,7 @@ func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNa
 		cancel()
 		if err != nil {
 			terminateProcess(cmd)
-			return nil, false, fmt.Errorf("create ACP session for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
+			return nil, false, "", fmt.Errorf("create ACP session for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 		}
 		nativeID = string(created.SessionId)
 	}
@@ -313,7 +317,7 @@ func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNa
 		conn:      conn,
 		client:    client,
 		nativeID:  nativeID,
-	}, resumed, nil
+	}, resumed, recovery, nil
 }
 
 func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -575,6 +575,8 @@ type acpTurn struct {
 	raw            limitedBuffer
 	usage          Usage
 	agentMessageID string
+	toolSeen       bool
+	postToolText   bool
 	onOutput       func(string)
 	onActivity     func(Activity)
 
@@ -628,6 +630,10 @@ func (t *acpTurn) appendAgentMessageChunk(update *acp.SessionUpdateAgentMessageC
 
 	var snapshot string
 	t.mu.Lock()
+	if t.toolSeen && !t.postToolText && isLikelyProgressNarration(t.output.String()) {
+		t.output.Buffer.Reset()
+		t.postToolText = true
+	}
 	if update.MessageId != nil {
 		nextID := strings.TrimSpace(*update.MessageId)
 		if nextID != "" {
@@ -654,6 +660,7 @@ func (t *acpTurn) recordToolCall(update *acp.SessionUpdateToolCall) {
 	if update == nil {
 		return
 	}
+	t.markToolSeen()
 	t.emitActivity(Activity{
 		ID:     "tool:" + string(update.ToolCallId),
 		Type:   "tool_call",
@@ -668,6 +675,7 @@ func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
 	if update == nil {
 		return
 	}
+	t.markToolSeen()
 	title := ""
 	if update.Title != nil {
 		title = *update.Title
@@ -688,6 +696,50 @@ func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
 		Title:  title,
 		Detail: toolCallDetail(acp.ToolKind(""), update.Locations, update.Content),
 	})
+}
+
+func (t *acpTurn) markToolSeen() {
+	var snapshot *string
+	t.mu.Lock()
+	t.toolSeen = true
+	if !t.postToolText && t.output.Len() > 0 && isLikelyProgressNarration(t.output.String()) {
+		t.output.Buffer.Reset()
+		empty := ""
+		snapshot = &empty
+	}
+	onOutput := t.onOutput
+	t.mu.Unlock()
+	if snapshot != nil && onOutput != nil {
+		onOutput(*snapshot)
+	}
+}
+
+func isLikelyProgressNarration(text string) bool {
+	text = strings.TrimSpace(strings.ToLower(text))
+	if text == "" {
+		return false
+	}
+	prefixes := []string{
+		"i'll ",
+		"i’ll ",
+		"i will ",
+		"i'm going to ",
+		"i’m going to ",
+		"i’m checking ",
+		"i'm checking ",
+		"i’ll check ",
+		"i'll check ",
+		"i’ll inspect ",
+		"i'll inspect ",
+		"let me ",
+		"checking ",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(text, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *acpTurn) recordPlan(update *acp.SessionUpdatePlan) {

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -473,9 +473,11 @@ func (c *acpChatClient) workspacePath(path string) (string, error) {
 }
 
 type acpTurn struct {
-	output limitedBuffer
-	raw    limitedBuffer
-	usage  Usage
+	output         limitedBuffer
+	raw            limitedBuffer
+	usage          Usage
+	agentMessageID string
+	onOutput       func(string)
 
 	mu sync.Mutex
 }
@@ -484,9 +486,8 @@ func newACPTurn(maxOutput int64, onOutput func(string)) *acpTurn {
 	if maxOutput <= 0 {
 		maxOutput = 1024 * 1024
 	}
-	turn := &acpTurn{}
+	turn := &acpTurn{onOutput: onOutput}
 	turn.output.limit = maxOutput
-	turn.output.onWrite = onOutput
 	turn.raw.limit = maxOutput
 	return turn
 }
@@ -499,9 +500,42 @@ func (t *acpTurn) recordUpdate(params acp.SessionNotification) {
 	update := params.Update
 	switch {
 	case update.AgentMessageChunk != nil:
-		t.appendText("agent_message_chunk", contentBlockText(update.AgentMessageChunk.Content))
+		t.appendAgentMessageChunk(update.AgentMessageChunk)
 	case update.UsageUpdate != nil:
 		t.recordUsage(update.UsageUpdate)
+	}
+}
+
+func (t *acpTurn) appendAgentMessageChunk(update *acp.SessionUpdateAgentMessageChunk) {
+	if update == nil {
+		return
+	}
+	text := contentBlockText(update.Content)
+	if text == "" {
+		return
+	}
+
+	var snapshot string
+	t.mu.Lock()
+	if update.MessageId != nil {
+		nextID := strings.TrimSpace(*update.MessageId)
+		if nextID != "" {
+			// ACP messageId is unstable but specifically exists to mark message
+			// boundaries. Codex sends short progress narration as one assistant
+			// message and the actual answer as another; when the id changes, the
+			// transcript should follow the latest visible assistant message.
+			if t.agentMessageID != "" && t.agentMessageID != nextID {
+				t.output.Buffer.Reset()
+			}
+			t.agentMessageID = nextID
+		}
+	}
+	_, _ = t.output.Write([]byte(text))
+	snapshot = t.output.String()
+	t.mu.Unlock()
+
+	if t.onOutput != nil {
+		t.onOutput(snapshot)
 	}
 }
 
@@ -520,15 +554,6 @@ func (t *acpTurn) recordUsage(update *acp.SessionUsageUpdate) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.usage = usage
-}
-
-func (t *acpTurn) appendText(_ string, text string) {
-	if text == "" {
-		return
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	_, _ = t.output.Write([]byte(text))
 }
 
 func (t *acpTurn) appendRaw(data []byte) {

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -19,6 +19,11 @@ import (
 
 const DriverKindACP = "acp"
 
+const (
+	acpShutdownCancelTimeout = 2 * time.Second
+	acpShutdownCloseTimeout  = 2 * time.Second
+)
+
 type Runner interface {
 	Run(context.Context, RunRequest) (RunResult, error)
 	CloseSession(context.Context, string) error
@@ -30,6 +35,7 @@ type SessionManager struct {
 	sessions map[string]*acpSession
 	starts   map[string]*sessionStart
 	logger   *slog.Logger
+	closed   bool
 }
 
 func NewSessionManager() *SessionManager {
@@ -86,12 +92,17 @@ func (m *SessionManager) Run(ctx context.Context, req RunRequest) (RunResult, er
 }
 
 type sessionStart struct {
-	done chan struct{}
+	done   chan struct{}
+	cancel context.CancelFunc
 }
 
 func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRequest) (*acpSession, bool, bool, error) {
 	for {
 		m.mu.Lock()
+		if m.closed {
+			m.mu.Unlock()
+			return nil, false, false, fmt.Errorf("agent session manager is shut down")
+		}
 		existing := m.sessions[req.SessionID]
 		if existing != nil && existing.adapter.ID == adapter.ID && existing.workspace == req.Workspace {
 			m.mu.Unlock()
@@ -110,16 +121,24 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		if m.starts == nil {
 			m.starts = make(map[string]*sessionStart)
 		}
-		start := &sessionStart{done: make(chan struct{})}
+		startCtx, startCancel := context.WithCancel(ctx)
+		start := &sessionStart{done: make(chan struct{}), cancel: startCancel}
 		m.starts[req.SessionID] = start
 		logger := m.logger
 		m.mu.Unlock()
 
-		started, resumed, err := startACPSession(ctx, adapter, req.Workspace, req.PreviousNativeSessionID, logger)
+		started, resumed, err := startACPSession(startCtx, adapter, req.Workspace, req.PreviousNativeSessionID, logger)
+		startCancel()
 
 		var previous *acpSession
 		m.mu.Lock()
 		delete(m.starts, req.SessionID)
+		if err == nil && m.closed {
+			close(start.done)
+			m.mu.Unlock()
+			_ = started.Close(context.Background())
+			return nil, false, false, fmt.Errorf("agent session manager is shut down")
+		}
 		if err == nil {
 			previous = m.sessions[req.SessionID]
 			m.sessions[req.SessionID] = started
@@ -161,7 +180,26 @@ func (m *SessionManager) Shutdown(ctx context.Context) error {
 		items = append(items, session)
 		delete(m.sessions, id)
 	}
+	starts := make([]*sessionStart, 0, len(m.starts))
+	for _, start := range m.starts {
+		starts = append(starts, start)
+	}
+	m.closed = true
 	m.mu.Unlock()
+
+	for _, start := range starts {
+		if start.cancel != nil {
+			start.cancel()
+		}
+	}
+	for _, start := range starts {
+		select {
+		case <-start.done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	var firstErr error
 	for _, session := range items {
 		if err := session.Close(ctx); err != nil && firstErr == nil {
@@ -180,6 +218,10 @@ type acpSession struct {
 	nativeID  string
 
 	turnMu sync.Mutex
+
+	activeMu     sync.Mutex
+	activeCancel context.CancelFunc
+	activeDone   chan struct{}
 }
 
 func startACPSession(ctx context.Context, adapter Adapter, workspace, previousNativeSessionID string, logger *slog.Logger) (*acpSession, bool, error) {
@@ -284,8 +326,16 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 	s.client.setTurn(turn)
 	defer s.client.clearTurn(turn)
 
-	promptCtx, cancel := context.WithTimeout(ctx, req.Timeout)
-	defer cancel()
+	promptBaseCtx, timeoutCancel := context.WithTimeout(ctx, req.Timeout)
+	promptCtx, activeCancel := context.WithCancel(promptBaseCtx)
+	activeDone := make(chan struct{})
+	s.setActiveTurn(activeCancel, activeDone)
+	defer func() {
+		activeCancel()
+		timeoutCancel()
+		close(activeDone)
+		s.clearActiveTurn(activeDone)
+	}()
 	_, runErr := s.conn.Prompt(promptCtx, acp.PromptRequest{
 		SessionId: acp.SessionId(s.nativeID),
 		Prompt:    []acp.ContentBlock{acp.TextBlock(req.Prompt)},
@@ -315,8 +365,11 @@ func (s *acpSession) Close(ctx context.Context) error {
 	if s == nil {
 		return nil
 	}
+	cancelCtx, cancel := context.WithTimeout(ctx, acpShutdownCancelTimeout)
+	_ = s.cancelActiveTurn(cancelCtx)
+	cancel()
 	if s.conn != nil && s.nativeID != "" {
-		closeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		closeCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
 		_, _ = s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)})
 		cancel()
 	}
@@ -324,6 +377,46 @@ func (s *acpSession) Close(ctx context.Context) error {
 		terminateProcess(s.cmd)
 	}
 	return nil
+}
+
+func (s *acpSession) setActiveTurn(cancel context.CancelFunc, done chan struct{}) {
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	s.activeCancel = cancel
+	s.activeDone = done
+}
+
+func (s *acpSession) clearActiveTurn(done chan struct{}) {
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeDone == done {
+		s.activeCancel = nil
+		s.activeDone = nil
+	}
+}
+
+func (s *acpSession) cancelActiveTurn(ctx context.Context) error {
+	s.activeMu.Lock()
+	cancel := s.activeCancel
+	done := s.activeDone
+	conn := s.conn
+	nativeID := s.nativeID
+	s.activeMu.Unlock()
+	if done == nil {
+		return nil
+	}
+	if conn != nil && nativeID != "" {
+		_ = conn.Cancel(ctx, acp.CancelNotification{SessionId: acp.SessionId(nativeID)})
+	}
+	if cancel != nil {
+		cancel()
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func captureACPTurnResult(ctx context.Context, adapter Adapter, req RunRequest, nativeSessionID, output, rawOutput string, usage Usage, exitCode int, started, completed time.Time, runErr error) (RunResult, error) {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -207,6 +207,120 @@ func TestSessionManagerCancelsACPPrompt(t *testing.T) {
 	}
 }
 
+func TestSessionManagerShutdownCancelsActiveACPPrompt(t *testing.T) {
+	installFakeACPExecutable(t, "codex-acp")
+	workspace := t.TempDir()
+
+	manager := NewSessionManager()
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	var once sync.Once
+	go func() {
+		_, err := manager.Run(context.Background(), RunRequest{
+			SessionID:      "chat_shutdown_cancel",
+			AdapterID:      "codex",
+			Workspace:      workspace,
+			Prompt:         "wait",
+			Timeout:        30 * time.Second,
+			MaxOutputBytes: 64 * 1024,
+			OnOutput: func(chunk string) {
+				if strings.Contains(chunk, "waiting") {
+					once.Do(func() { close(ready) })
+				}
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for ACP prompt to start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := manager.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("Run error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for active ACP prompt cancellation")
+	}
+}
+
+func TestSessionManagerShutdownKillsStubbornACPProcess(t *testing.T) {
+	installFakeACPExecutable(t, "codex-acp")
+	workspace := t.TempDir()
+
+	manager := NewSessionManager()
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	var once sync.Once
+	go func() {
+		_, err := manager.Run(context.Background(), RunRequest{
+			SessionID:      "chat_shutdown_kill",
+			AdapterID:      "codex",
+			Workspace:      workspace,
+			Prompt:         "ignore_cancel",
+			Timeout:        30 * time.Second,
+			MaxOutputBytes: 64 * 1024,
+			OnOutput: func(chunk string) {
+				if strings.Contains(chunk, "waiting") {
+					once.Do(func() { close(ready) })
+				}
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for stubborn ACP prompt to start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	if err := manager.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("Run error = nil, want process termination error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for stubborn ACP process termination")
+	}
+}
+
+func TestSessionManagerRejectsRunsAfterShutdown(t *testing.T) {
+	installFakeACPExecutable(t, "codex-acp")
+	manager := NewSessionManager()
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	_, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      "chat_after_shutdown",
+		AdapterID:      "codex",
+		Workspace:      t.TempDir(),
+		Prompt:         "hello",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err == nil || !strings.Contains(err.Error(), "shut down") {
+		t.Fatalf("Run error = %v, want shut down error", err)
+	}
+}
+
 func TestACPTurnIgnoresBookkeepingUpdatesInTranscript(t *testing.T) {
 	turn := newACPTurn(64*1024, nil)
 	sessionID := acp.SessionId("session_1")
@@ -494,6 +608,15 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 		}
 		<-turnCtx.Done()
 		return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
+	}
+	if prompt == "ignore_cancel" {
+		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update:    acp.UpdateAgentMessageText("waiting"),
+		}); err != nil {
+			return acp.PromptResponse{}, err
+		}
+		select {}
 	}
 
 	if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -268,6 +268,73 @@ func TestACPTurnIgnoresBookkeepingUpdatesInTranscript(t *testing.T) {
 	}
 }
 
+func TestACPTurnReplacesProgressNarrationWhenAgentMessageIDChanges(t *testing.T) {
+	var snapshots []string
+	turn := newACPTurn(64*1024, func(text string) {
+		snapshots = append(snapshots, text)
+	})
+	sessionID := acp.SessionId("session_1")
+	progressID := "019df226-progress"
+	finalID := "019df226-final"
+
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("I’ll inspect the current git diff and summarize it."),
+				MessageId: &progressID,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("There’s no current tracked-file diff."),
+				MessageId: &finalID,
+			},
+		},
+	})
+
+	output, _, _ := turn.snapshot()
+	if output != "There’s no current tracked-file diff." {
+		t.Fatalf("output = %q, want latest agent message only", output)
+	}
+	if len(snapshots) != 2 || snapshots[0] != "I’ll inspect the current git diff and summarize it." || snapshots[1] != output {
+		t.Fatalf("snapshots = %#v, want progress then replacement final", snapshots)
+	}
+}
+
+func TestACPTurnConcatenatesChunksWithSameAgentMessageID(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	sessionID := acp.SessionId("session_1")
+	messageID := "019df226-final"
+
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("There’s no "),
+				MessageId: &messageID,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("current diff."),
+				MessageId: &messageID,
+			},
+		},
+	})
+
+	output, _, _ := turn.snapshot()
+	if output != "There’s no current diff." {
+		t.Fatalf("output = %q, want same-message chunks concatenated", output)
+	}
+}
+
 func TestACPTurnCapturesUsageUpdate(t *testing.T) {
 	turn := newACPTurn(64*1024, nil)
 	turn.recordUpdate(acp.SessionNotification{

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -361,6 +361,54 @@ func TestACPTurnCapturesUsageUpdate(t *testing.T) {
 	}
 }
 
+func TestACPTurnEmitsToolAndPlanActivities(t *testing.T) {
+	var activities []Activity
+	turn := newACPTurn(64*1024, nil)
+	turn.setActivityCallback(func(activity Activity) {
+		activities = append(activities, activity)
+	})
+	sessionID := acp.SessionId("session_1")
+	line := 42
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				SessionUpdate: "tool_call",
+				ToolCallId:    acp.ToolCallId("call_1"),
+				Title:         "git diff --stat",
+				Status:        acp.ToolCallStatusInProgress,
+				Kind:          acp.ToolKindExecute,
+				Locations:     []acp.ToolCallLocation{{Path: "README.md", Line: &line}},
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			Plan: &acp.SessionUpdatePlan{
+				SessionUpdate: "plan",
+				Entries: []acp.PlanEntry{
+					{Content: "Inspect changes", Status: acp.PlanEntryStatusCompleted, Priority: acp.PlanEntryPriorityHigh},
+					{Content: "Summarize result", Status: acp.PlanEntryStatusInProgress, Priority: acp.PlanEntryPriorityMedium},
+				},
+			},
+		},
+	})
+
+	if len(activities) != 3 {
+		t.Fatalf("activities = %#v, want 3", activities)
+	}
+	if got := activities[0]; got.ID != "tool:call_1" || got.Type != "tool_call" || got.Status != "running" || got.Kind != "execute" || got.Title != "git diff --stat" || !strings.Contains(got.Detail, "README.md:42") {
+		t.Fatalf("tool activity = %#v", got)
+	}
+	if got := activities[1]; got.Type != "plan" || got.Status != "completed" || got.Kind != "high" || got.Title != "Inspect changes" {
+		t.Fatalf("first plan activity = %#v", got)
+	}
+	if got := activities[2]; got.Type != "plan" || got.Status != "in_progress" || got.Kind != "medium" || got.Title != "Summarize result" {
+		t.Fatalf("second plan activity = %#v", got)
+	}
+}
+
 func installFakeACPExecutable(t *testing.T, name string) {
 	t.Helper()
 	bin := filepath.Join(t.TempDir(), "bin")

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -76,8 +76,8 @@ func TestSessionManagerRunsTurnsThroughACP(t *testing.T) {
 }
 
 func TestSessionManagerSerializesConcurrentSessionStart(t *testing.T) {
-	installFakeACPExecutable(t, "codex-acp")
 	t.Setenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY", "100ms")
+	installFakeACPExecutable(t, "codex-acp")
 	workspace := t.TempDir()
 	manager := NewSessionManager()
 
@@ -170,6 +170,38 @@ func TestSessionManagerLoadsPersistedNativeSession(t *testing.T) {
 	}
 	if !second.SessionStarted || !second.SessionResumed {
 		t.Fatalf("session flags = started:%v resumed:%v, want both true", second.SessionStarted, second.SessionResumed)
+	}
+}
+
+func TestSessionManagerStartsFreshWhenPersistedNativeSessionIsStale(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL", "1")
+	installFakeACPExecutable(t, "codex-acp")
+	workspace := t.TempDir()
+
+	manager := NewSessionManager()
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:               "chat_stale",
+		AdapterID:               "codex",
+		Workspace:               workspace,
+		PreviousNativeSessionID: "fake_session_stale",
+		Prompt:                  "fresh turn",
+		Timeout:                 5 * time.Second,
+		MaxOutputBytes:          64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.NativeSessionID == "" || run.NativeSessionID == "fake_session_stale" {
+		t.Fatalf("native session id = %q, want fresh id", run.NativeSessionID)
+	}
+	if !run.SessionStarted || run.SessionResumed {
+		t.Fatalf("session flags = started:%v resumed:%v, want started fresh", run.SessionStarted, run.SessionResumed)
+	}
+	if !strings.Contains(run.SessionRecovery, "fake_session_stale") {
+		t.Fatalf("session recovery = %q, want stale id", run.SessionRecovery)
+	}
+	if !strings.Contains(run.Output, "fresh turn") {
+		t.Fatalf("output = %q, want fresh turn", run.Output)
 	}
 }
 
@@ -530,7 +562,12 @@ func installFakeACPExecutable(t *testing.T, name string) {
 		t.Fatalf("mkdir fake bin: %v", err)
 	}
 	exe := filepath.Join(bin, name)
-	script := fmt.Sprintf("#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 exec %q -test.run '^TestFakeACPAgentProcess$'\n", os.Args[0])
+	script := fmt.Sprintf(
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
+		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
+		os.Args[0],
+	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ACP executable: %v", err)
 	}
@@ -579,6 +616,9 @@ func (a *fakeACPAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.N
 }
 
 func (a *fakeACPAgent) LoadSession(_ context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	if os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL") == "1" {
+		return acp.LoadSessionResponse{}, fmt.Errorf("fake persisted session %s not found", params.SessionId)
+	}
 	a.mu.Lock()
 	a.sessions[string(params.SessionId)] = &fakeACPSession{}
 	a.mu.Unlock()

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -451,6 +451,64 @@ func TestACPTurnReplacesProgressNarrationWhenAgentMessageIDChanges(t *testing.T)
 	}
 }
 
+func TestACPTurnReplacesPreToolNarrationWhenAnswerContinuesSameMessage(t *testing.T) {
+	var snapshots []string
+	turn := newACPTurn(64*1024, func(text string) {
+		snapshots = append(snapshots, text)
+	})
+	sessionID := acp.SessionId("session_1")
+	messageID := "019df226-same-message"
+
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("I’ll check the current worktree diff and summarize the changed files plus the important hunks."),
+				MessageId: &messageID,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				SessionUpdate: "tool_call",
+				ToolCallId:    acp.ToolCallId("call_diff"),
+				Title:         "git diff --stat",
+				Status:        acp.ToolCallStatusInProgress,
+				Kind:          acp.ToolKindExecute,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:   acp.TextBlock("There are 11 modified files."),
+				MessageId: &messageID,
+			},
+		},
+	})
+
+	output, _, _ := turn.snapshot()
+	if output != "There are 11 modified files." {
+		t.Fatalf("output = %q, want final answer without pre-tool narration", output)
+	}
+	wantSnapshots := []string{
+		"I’ll check the current worktree diff and summarize the changed files plus the important hunks.",
+		"",
+		"There are 11 modified files.",
+	}
+	if len(snapshots) != len(wantSnapshots) {
+		t.Fatalf("snapshots = %#v, want %#v", snapshots, wantSnapshots)
+	}
+	for i := range wantSnapshots {
+		if snapshots[i] != wantSnapshots[i] {
+			t.Fatalf("snapshots[%d] = %q, want %q in %#v", i, snapshots[i], wantSnapshots[i], snapshots)
+		}
+	}
+}
+
 func TestACPTurnConcatenatesChunksWithSameAgentMessageID(t *testing.T) {
 	turn := newACPTurn(64*1024, nil)
 	sessionID := acp.SessionId("session_1")

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -72,6 +72,7 @@ type RunResult struct {
 	NativeSessionID string
 	SessionStarted  bool
 	SessionResumed  bool
+	SessionRecovery string
 	Output          string
 	RawOutput       string
 	ExitCode        int

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -63,6 +63,7 @@ type RunRequest struct {
 	Timeout                 time.Duration
 	MaxOutputBytes          int64
 	OnOutput                func(string)
+	OnActivity              func(Activity)
 }
 
 type RunResult struct {
@@ -86,6 +87,15 @@ type Usage struct {
 	ContextUsed          int
 	ReportedCostAmount   string
 	ReportedCostCurrency string
+}
+
+type Activity struct {
+	ID     string
+	Type   string
+	Status string
+	Kind   string
+	Title  string
+	Detail string
 }
 
 func (u Usage) Empty() bool {

--- a/internal/agentchat/sqlite_test.go
+++ b/internal/agentchat/sqlite_test.go
@@ -32,6 +32,11 @@ func TestSQLiteStoreLifecycle(t *testing.T) {
 	runStoreLifecycle(t, newSQLiteTestStore(t))
 }
 
+func TestSQLiteStoreReconcileInterruptedRuns(t *testing.T) {
+	t.Parallel()
+	runStoreReconcileInterruptedRuns(t, newSQLiteTestStore(t))
+}
+
 func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/agentchat/store.go
+++ b/internal/agentchat/store.go
@@ -52,8 +52,10 @@ type Message struct {
 }
 
 type Activity struct {
+	ID        string    `json:"id,omitempty"`
 	Type      string    `json:"type"`
 	Status    string    `json:"status,omitempty"`
+	Kind      string    `json:"kind,omitempty"`
 	Title     string    `json:"title"`
 	Detail    string    `json:"detail,omitempty"`
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/internal/agentchat/store.go
+++ b/internal/agentchat/store.go
@@ -83,6 +83,75 @@ type Store interface {
 	UpdateMessage(ctx context.Context, sessionID string, messageID string, update func(*Message)) (Session, error)
 }
 
+func ReconcileInterruptedRuns(ctx context.Context, store Store, now time.Time) (int, error) {
+	if store == nil {
+		return 0, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sessions, err := store.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	reconciled := 0
+	for _, summary := range sessions {
+		session, ok, err := store.Get(ctx, summary.ID)
+		if err != nil {
+			return reconciled, err
+		}
+		if !ok {
+			continue
+		}
+		sessionReconciled := false
+		for _, message := range session.Messages {
+			if message.Role != "assistant" || message.Status != "running" {
+				continue
+			}
+			if _, err := store.UpdateMessage(ctx, session.ID, message.ID, func(item *Message) {
+				item.Status = "cancelled"
+				item.ExitCode = 1
+				item.CompletedAt = now
+				item.Error = "interrupted by Hecate restart"
+				if item.Content == "" {
+					item.Content = "Agent run interrupted by Hecate restart."
+				}
+				if !activityTypeExists(item.Activities, "interrupted") {
+					item.Activities = append(item.Activities, Activity{
+						Type:      "interrupted",
+						Status:    "cancelled",
+						Title:     "Interrupted by restart",
+						Detail:    "Hecate restarted before this agent run finished.",
+						CreatedAt: now,
+					})
+				}
+			}); err != nil {
+				return reconciled, err
+			}
+			reconciled++
+			sessionReconciled = true
+		}
+		if !sessionReconciled && session.Status == "running" {
+			if _, err := store.UpdateSession(ctx, session.ID, func(item *Session) {
+				item.Status = "cancelled"
+			}); err != nil {
+				return reconciled, err
+			}
+			reconciled++
+		}
+	}
+	return reconciled, nil
+}
+
+func activityTypeExists(items []Activity, typ string) bool {
+	for _, item := range items {
+		if item.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
 type MemoryStore struct {
 	mu       sync.Mutex
 	sessions map[string]Session

--- a/internal/agentchat/store_test.go
+++ b/internal/agentchat/store_test.go
@@ -11,6 +11,11 @@ func TestMemoryStoreLifecycle(t *testing.T) {
 	runStoreLifecycle(t, NewMemoryStore())
 }
 
+func TestMemoryStoreReconcileInterruptedRuns(t *testing.T) {
+	t.Parallel()
+	runStoreReconcileInterruptedRuns(t, NewMemoryStore())
+}
+
 func runStoreLifecycle(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()
@@ -130,5 +135,79 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	}
 	if ok {
 		t.Fatal("Get after delete: ok = true, want false")
+	}
+}
+
+func runStoreReconcileInterruptedRuns(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := store.Create(ctx, Session{
+		ID:        "agent_chat_interrupted",
+		Title:     "Interrupted",
+		AdapterID: "codex",
+		Workspace: "/tmp/hecate",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := store.AppendMessage(ctx, created.ID, Message{
+		ID:        "msg_user",
+		Role:      "user",
+		Content:   "keep going",
+		CreatedAt: time.Now().UTC().Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("AppendMessage(user): %v", err)
+	}
+	if _, err := store.AppendMessage(ctx, created.ID, Message{
+		ID:          "msg_assistant",
+		RunID:       "agent_run_interrupted",
+		Role:        "assistant",
+		Content:     "partial answer",
+		AdapterID:   "codex",
+		AdapterName: "Codex",
+		Status:      "running",
+		CostMode:    "external",
+		Workspace:   "/tmp/hecate",
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+		Activities: []Activity{
+			{Type: "running", Status: "running", Title: "Running"},
+		},
+	}); err != nil {
+		t.Fatalf("AppendMessage(assistant): %v", err)
+	}
+
+	now := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	count, err := ReconcileInterruptedRuns(ctx, store, now)
+	if err != nil {
+		t.Fatalf("ReconcileInterruptedRuns: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("reconciled count = %d, want 1", count)
+	}
+
+	got, ok, err := store.Get(ctx, created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.Status != "cancelled" {
+		t.Fatalf("session status = %q, want cancelled", got.Status)
+	}
+	assistant := got.Messages[1]
+	if assistant.Status != "cancelled" || assistant.Error != "interrupted by Hecate restart" || !assistant.CompletedAt.Equal(now) {
+		t.Fatalf("assistant after reconcile = %+v", assistant)
+	}
+	if assistant.Content != "partial answer" {
+		t.Fatalf("assistant content = %q, want preserved partial answer", assistant.Content)
+	}
+	if !activityTypeExists(assistant.Activities, "interrupted") {
+		t.Fatalf("activities = %+v, want interrupted activity", assistant.Activities)
+	}
+
+	count, err = ReconcileInterruptedRuns(ctx, store, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("ReconcileInterruptedRuns second call: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("second reconciled count = %d, want 0", count)
 	}
 }

--- a/internal/api/agent_chat_live.go
+++ b/internal/api/agent_chat_live.go
@@ -10,13 +10,18 @@ import (
 type agentChatLive struct {
 	mu          sync.Mutex
 	subscribers map[string]map[chan AgentChatSessionResponse]struct{}
-	running     map[string]context.CancelFunc
+	running     map[string]agentChatRunControl
+}
+
+type agentChatRunControl struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func newAgentChatLive() *agentChatLive {
 	return &agentChatLive{
 		subscribers: make(map[string]map[chan AgentChatSessionResponse]struct{}),
-		running:     make(map[string]context.CancelFunc),
+		running:     make(map[string]agentChatRunControl),
 	}
 }
 
@@ -72,23 +77,42 @@ func (l *agentChatLive) registerRun(sessionID string, cancel context.CancelFunc)
 	if _, exists := l.running[sessionID]; exists {
 		return false
 	}
-	l.running[sessionID] = cancel
+	l.running[sessionID] = agentChatRunControl{cancel: cancel, done: make(chan struct{})}
 	return true
 }
 
 func (l *agentChatLive) clearRun(sessionID string) {
 	l.mu.Lock()
-	delete(l.running, sessionID)
+	run, ok := l.running[sessionID]
+	if ok {
+		delete(l.running, sessionID)
+		close(run.done)
+	}
 	l.mu.Unlock()
 }
 
 func (l *agentChatLive) cancelRun(sessionID string) bool {
 	l.mu.Lock()
-	cancel, ok := l.running[sessionID]
+	run, ok := l.running[sessionID]
 	l.mu.Unlock()
 	if !ok {
 		return false
 	}
-	cancel()
+	run.cancel()
+	return true
+}
+
+func (l *agentChatLive) cancelRunAndWait(ctx context.Context, sessionID string) bool {
+	l.mu.Lock()
+	run, ok := l.running[sessionID]
+	l.mu.Unlock()
+	if !ok {
+		return false
+	}
+	run.cancel()
+	select {
+	case <-run.done:
+	case <-ctx.Done():
+	}
 	return true
 }

--- a/internal/api/agent_chat_live.go
+++ b/internal/api/agent_chat_live.go
@@ -107,12 +107,13 @@ func (l *agentChatLive) cancelRunAndWait(ctx context.Context, sessionID string) 
 	run, ok := l.running[sessionID]
 	l.mu.Unlock()
 	if !ok {
-		return false
+		return true
 	}
 	run.cancel()
 	select {
 	case <-run.done:
+		return true
 	case <-ctx.Done():
+		return false
 	}
-	return true
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -206,6 +206,7 @@ func (h *Handler) SetAgentChatStore(store agentchat.Store) {
 		return
 	}
 	h.agentChat = store
+	h.reconcileAgentChatStore(context.Background())
 }
 
 func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {
@@ -213,6 +214,20 @@ func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {
 		return
 	}
 	h.agentChatRunner = runner
+}
+
+func (h *Handler) reconcileAgentChatStore(ctx context.Context) {
+	if h.agentChat == nil {
+		return
+	}
+	count, err := agentchat.ReconcileInterruptedRuns(ctx, h.agentChat, time.Now().UTC())
+	if err != nil {
+		h.logger.Warn("agent chat reconciliation failed", slog.Any("error", err))
+		return
+	}
+	if count > 0 {
+		h.logger.Info("agent chat reconciliation completed", slog.Int("interrupted_runs", count))
+	}
 }
 
 // SetSecretCipher wires the control-plane AES-GCM cipher into the

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -142,6 +142,9 @@ func (h *Handler) HandleAgentChatSessionStream(w http.ResponseWriter, r *http.Re
 
 func (h *Handler) HandleDeleteAgentChatSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
+	cancelCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	_ = h.agentChatLive.cancelRunAndWait(cancelCtx, sessionID)
+	cancel()
 	if h.agentChatRunner != nil {
 		_ = h.agentChatRunner.CloseSession(r.Context(), sessionID)
 	}

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -295,12 +295,9 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		Timeout:                 agentChatTimeout,
 		MaxOutputBytes:          agentChatMaxOutputBytes,
 		OnOutput: func(display string) {
-			if display == "" {
-				return
-			}
 			updated, updateErr := h.agentChat.UpdateMessage(runCtx, session.ID, assistantID, func(message *agentchat.Message) {
 				message.Content = display
-				if !outputSeen {
+				if strings.TrimSpace(display) != "" && !outputSeen {
 					message.Activities = append(message.Activities, newAgentChatActivity("output", "running", "ACP output", "Streaming normalized transcript"))
 					trace.Record(telemetry.EventAgentChatOutputStarted, agentChatTraceAttrs(session, adapter, runID, assistantID, map[string]any{
 						telemetry.AttrHecateRunStatus:        "running",

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -354,7 +354,7 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 	trace.Record(agentChatTerminalEvent(status), terminalAttrs)
 
 	updated, err = h.agentChat.UpdateMessage(r.Context(), session.ID, assistantID, func(message *agentchat.Message) {
-		if strings.TrimSpace(message.Content) == "" || runErr != nil {
+		if output != "" {
 			message.Content = output
 		}
 		message.RawOutput = result.RawOutput

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -143,8 +143,12 @@ func (h *Handler) HandleAgentChatSessionStream(w http.ResponseWriter, r *http.Re
 func (h *Handler) HandleDeleteAgentChatSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	cancelCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
-	_ = h.agentChatLive.cancelRunAndWait(cancelCtx, sessionID)
+	settled := h.agentChatLive.cancelRunAndWait(cancelCtx, sessionID)
 	cancel()
+	if !settled {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is still stopping")
+		return
+	}
 	if h.agentChatRunner != nil {
 		_ = h.agentChatRunner.CloseSession(r.Context(), sessionID)
 	}
@@ -183,18 +187,21 @@ func (h *Handler) HandleCloseAgentChatSession(w http.ResponseWriter, r *http.Req
 		return
 	}
 	cancelCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
-	_ = h.agentChatLive.cancelRunAndWait(cancelCtx, session.ID)
+	settled := h.agentChatLive.cancelRunAndWait(cancelCtx, session.ID)
 	cancel()
+	if !settled {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is still stopping")
+		return
+	}
 	if h.agentChatRunner != nil {
 		_ = h.agentChatRunner.CloseSession(r.Context(), session.ID)
 	}
-	updated, found, err := h.agentChat.Get(r.Context(), session.ID)
+	updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *agentchat.Session) {
+		item.DriverKind = ""
+		item.NativeSessionID = ""
+	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
-		return
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
 		return
 	}
 	WriteJSON(w, http.StatusOK, AgentChatSessionResponse{Object: "agent_chat_session", Data: renderAgentChatSession(updated)})

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -282,6 +282,14 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 				h.agentChatLive.publish(updated)
 			}
 		},
+		OnActivity: func(activity agentadapters.Activity) {
+			updated, updateErr := h.agentChat.UpdateMessage(runCtx, session.ID, assistantID, func(message *agentchat.Message) {
+				message.Activities = mergeAgentChatActivity(message.Activities, agentChatActivityFromAdapter(activity))
+			})
+			if updateErr == nil {
+				h.agentChatLive.publish(updated)
+			}
+		},
 	})
 	status := "completed"
 	if runErr != nil {
@@ -530,8 +538,10 @@ func renderAgentChatActivities(items []agentchat.Activity) []AgentChatActivityIt
 	out := make([]AgentChatActivityItem, 0, len(items))
 	for _, item := range items {
 		out = append(out, AgentChatActivityItem{
+			ID:        item.ID,
 			Type:      item.Type,
 			Status:    item.Status,
+			Kind:      item.Kind,
 			Title:     item.Title,
 			Detail:    item.Detail,
 			CreatedAt: formatOptionalTime(item.CreatedAt),
@@ -548,6 +558,48 @@ func newAgentChatActivity(kind, status, title, detail string) agentchat.Activity
 		Detail:    strings.TrimSpace(detail),
 		CreatedAt: time.Now().UTC(),
 	}
+}
+
+func agentChatActivityFromAdapter(activity agentadapters.Activity) agentchat.Activity {
+	return agentchat.Activity{
+		ID:        strings.TrimSpace(activity.ID),
+		Type:      strings.TrimSpace(activity.Type),
+		Status:    strings.TrimSpace(activity.Status),
+		Kind:      strings.TrimSpace(activity.Kind),
+		Title:     strings.TrimSpace(activity.Title),
+		Detail:    strings.TrimSpace(activity.Detail),
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func mergeAgentChatActivity(items []agentchat.Activity, next agentchat.Activity) []agentchat.Activity {
+	if next.Type == "" || (next.ID == "" && next.Title == "") {
+		return items
+	}
+	if next.ID != "" {
+		for i := range items {
+			if items[i].ID == next.ID {
+				if next.Status != "" {
+					items[i].Status = next.Status
+				}
+				if next.Kind != "" {
+					items[i].Kind = next.Kind
+				}
+				if next.Title != "" {
+					items[i].Title = next.Title
+				}
+				if next.Detail != "" {
+					items[i].Detail = next.Detail
+				}
+				items[i].CreatedAt = next.CreatedAt
+				return items
+			}
+		}
+	}
+	if next.Title == "" {
+		return items
+	}
+	return append(items, next)
 }
 
 func finalAgentChatActivityTitle(status string) string {

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -172,6 +172,34 @@ func (h *Handler) HandleCancelAgentChatSession(w http.ResponseWriter, r *http.Re
 	WriteJSON(w, http.StatusAccepted, AgentChatSessionResponse{Object: "agent_chat_session", Data: renderAgentChatSession(session)})
 }
 
+func (h *Handler) HandleCloseAgentChatSession(w http.ResponseWriter, r *http.Request) {
+	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		return
+	}
+	cancelCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	_ = h.agentChatLive.cancelRunAndWait(cancelCtx, session.ID)
+	cancel()
+	if h.agentChatRunner != nil {
+		_ = h.agentChatRunner.CloseSession(r.Context(), session.ID)
+	}
+	updated, found, err := h.agentChat.Get(r.Context(), session.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		return
+	}
+	if !found {
+		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, AgentChatSessionResponse{Object: "agent_chat_session", Data: renderAgentChatSession(updated)})
+}
+
 func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Request) {
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -263,22 +263,17 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		Prompt:                  content,
 		Timeout:                 agentChatTimeout,
 		MaxOutputBytes:          agentChatMaxOutputBytes,
-		OnOutput: func(chunk string) {
-			if chunk == "" {
+		OnOutput: func(display string) {
+			if display == "" {
 				return
 			}
 			updated, updateErr := h.agentChat.UpdateMessage(runCtx, session.ID, assistantID, func(message *agentchat.Message) {
-				message.RawOutput += chunk
-				normalized := agentadapters.NormalizeOutput(adapter.ID, message.RawOutput)
-				if strings.TrimSpace(normalized) == "" {
-					normalized = message.RawOutput
-				}
-				message.Content = normalized
+				message.Content = display
 				if !outputSeen {
 					message.Activities = append(message.Activities, newAgentChatActivity("output", "running", "ACP output", "Streaming normalized transcript"))
 					trace.Record(telemetry.EventAgentChatOutputStarted, agentChatTraceAttrs(session, adapter, runID, assistantID, map[string]any{
-						telemetry.AttrHecateRunStatus:           "running",
-						telemetry.AttrHecateAgentRawOutputBytes: int64(len(message.RawOutput)),
+						telemetry.AttrHecateRunStatus:        "running",
+						telemetry.AttrHecateAgentOutputBytes: int64(len(display)),
 					}))
 					outputSeen = true
 				}

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -405,7 +405,11 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		if result.SessionResumed {
 			message.Activities = append([]agentchat.Activity{newAgentChatActivity("resumed", "completed", "Resumed external session", adapter.Name+" restored "+result.NativeSessionID)}, message.Activities...)
 		} else if result.SessionStarted {
-			message.Activities = append([]agentchat.Activity{newAgentChatActivity("started", "completed", "Starting external agent", adapter.Name+" in "+session.Workspace)}, message.Activities...)
+			activities := []agentchat.Activity{newAgentChatActivity("started", "completed", "Starting external agent", adapter.Name+" in "+session.Workspace)}
+			if result.SessionRecovery != "" {
+				activities = append(activities, newAgentChatActivity("recovered", "completed", "Started fresh external session", result.SessionRecovery))
+			}
+			message.Activities = append(activities, message.Activities...)
 		}
 		if result.DiffStat != "" {
 			message.Activities = append(message.Activities, newAgentChatActivity("files_changed", "completed", "Files changed", result.DiffStat))

--- a/internal/api/handler_shutdown_test.go
+++ b/internal/api/handler_shutdown_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hecate/agent-runtime/internal/orchestrator"
 	"github.com/hecate/agent-runtime/internal/profiler"
 	"github.com/hecate/agent-runtime/internal/taskstate"
+	"github.com/hecate/agent-runtime/pkg/types"
 )
 
 // newShutdownTestRunner builds a minimal *orchestrator.Runner suitable
@@ -40,6 +41,17 @@ func newShutdownTestCache() *mcpclient.SharedClientCache {
 		Name:    "hecate-handler-shutdown-test",
 		Version: "0",
 	})
+}
+
+type blockingShutdownExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingShutdownExecutor) Execute(context.Context, orchestrator.ExecutionSpec) (*orchestrator.ExecutionResult, error) {
+	close(e.started)
+	<-e.release
+	return &orchestrator.ExecutionResult{Status: "cancelled"}, nil
 }
 
 // TestHandler_Shutdown_ClosesBothRunnerAndCache pins the headline
@@ -192,31 +204,54 @@ func TestHandler_Shutdown_RunnerBeforeCache(t *testing.T) {
 // orphan subprocesses on top of a wedged runner.
 func TestHandler_Shutdown_RunnerErrorPropagated(t *testing.T) {
 	t.Parallel()
-	runner := newShutdownTestRunner(t)
+	store := taskstate.NewMemoryStore()
+	runner := orchestrator.NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		profiler.NewInMemoryTracer(nil),
+		orchestrator.Config{QueueWorkers: 1},
+	)
 	cache := newShutdownTestCache()
+	blocker := &blockingShutdownExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	runner.SetExecutor(blocker)
 	h := &Handler{
 		taskRunner:     runner,
 		mcpClientCache: cache,
 	}
 
-	// Park a goroutine that ignores cancellation so runner.Shutdown
-	// can't drain. We can't reach runner.workerWg from this package,
-	// so we drive the failure via a tight ctx deadline against an
-	// otherwise-empty runner — but with no in-flight work the runner
-	// would drain instantly. The deterministic error signal we have
-	// is: pass an ALREADY-cancelled context to Shutdown.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// With an already-cancelled ctx, runner.Shutdown's wait path
-	// returns ctx.Err() (context.Canceled). Handler.Shutdown should
-	// propagate that, AND still close the cache.
-	err := h.Shutdown(ctx)
-	if err == nil {
-		t.Fatal("expected Shutdown error from cancelled ctx, got nil")
+	task, err := store.CreateTask(context.Background(), types.Task{
+		ID:     "task_shutdown_error",
+		Status: "created",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
 	}
-	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "canceled") {
-		t.Errorf("Shutdown err = %v, want context.Canceled or wrapped", err)
+	if _, err := runner.StartTask(context.Background(), task, func(prefix string) string { return prefix + "_shutdown" }); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	select {
+	case <-blocker.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("executor did not start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err = h.Shutdown(ctx)
+	if err == nil {
+		t.Fatal("expected Shutdown error from timed-out ctx, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "deadline") {
+		t.Errorf("Shutdown err = %v, want context deadline exceeded or wrapped", err)
+	}
+	close(blocker.release)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer drainCancel()
+	if err := runner.Shutdown(drainCtx); err != nil {
+		t.Fatalf("second runner shutdown after release: %v", err)
 	}
 
 	// Cache must still have been closed despite the runner error.

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -622,8 +622,10 @@ type AgentChatMessageItem struct {
 }
 
 type AgentChatActivityItem struct {
+	ID        string `json:"id,omitempty"`
 	Type      string `json:"type"`
 	Status    string `json:"status,omitempty"`
+	Kind      string `json:"kind,omitempty"`
 	Title     string `json:"title"`
 	Detail    string `json:"detail,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,7 @@ func NewServer(logger *slog.Logger, handler *Handler) http.Handler {
 	mux.HandleFunc("DELETE /v1/agent-chat/sessions/{id}", handler.HandleDeleteAgentChatSession)
 	mux.HandleFunc("GET /v1/agent-chat/sessions/{id}/stream", handler.HandleAgentChatSessionStream)
 	mux.HandleFunc("POST /v1/agent-chat/sessions/{id}/cancel", handler.HandleCancelAgentChatSession)
+	mux.HandleFunc("POST /v1/agent-chat/sessions/{id}/close", handler.HandleCloseAgentChatSession)
 	mux.HandleFunc("POST /v1/agent-chat/sessions/{id}/messages", handler.HandleCreateAgentChatMessage)
 	mux.HandleFunc("POST /v1/workspace-dialog", handler.HandleWorkspaceDialog)
 	mux.HandleFunc("GET /v1/provider-presets", handler.HandleProviderPresets)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1157,6 +1157,24 @@ func TestAgentChatMergesAdapterActivityUpdates(t *testing.T) {
 	}
 }
 
+func TestAgentChatFinalOutputReplacesStreamedNarration(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithControlPlane(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{
+		chunks:      []string{"I will inspect the diff first."},
+		finalOutput: "There is no current diff.",
+	})
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	created := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	updated := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions/"+created.Data.ID+"/messages", `{"content":"show diff"}`)
+	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
+	if assistant.Content != "There is no current diff." {
+		t.Fatalf("assistant content = %q, want final output replacing streamed narration", assistant.Content)
+	}
+}
+
 func TestAgentChatPassesPersistedNativeSessionForResume(t *testing.T) {
 	dir := t.TempDir()
 	store := agentchat.NewMemoryStore()
@@ -1249,6 +1267,7 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 
 type fakeAgentChatRunner struct {
 	output          string
+	finalOutput     string
 	chunks          []string
 	activities      []agentadapters.Activity
 	delay           time.Duration
@@ -1303,6 +1322,9 @@ func (r *fakeAgentChatRunner) Run(ctx context.Context, req agentadapters.RunRequ
 	}
 	if r.err != nil {
 		return r.result(req, output, started, 1), r.err
+	}
+	if r.finalOutput != "" {
+		output = r.finalOutput
 	}
 	return r.result(req, output, started, 0), nil
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1215,6 +1215,37 @@ func TestAgentChatPassesPersistedNativeSessionForResume(t *testing.T) {
 	}
 }
 
+func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
+	dir := t.TempDir()
+	store := agentchat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	apiHandler := newTestAPIHandlerWithControlPlane(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{
+		output:          "recovered",
+		nativeSessionID: "native_fresh",
+		sessionStarted:  true,
+		sessionRecovery: "could not restore ACP session native_stale: not found",
+	})
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	created := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	if _, err := store.UpdateSession(context.Background(), created.Data.ID, func(item *agentchat.Session) {
+		item.NativeSessionID = "native_stale"
+	}); err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+	updated := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions/"+created.Data.ID+"/messages", `{"content":"second"}`)
+	if updated.Data.NativeSessionID != "native_fresh" {
+		t.Fatalf("native session = %q, want fresh session", updated.Data.NativeSessionID)
+	}
+	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
+	if !agentChatActivitiesContain(assistant.Activities, "recovered") {
+		t.Fatalf("activities = %+v, want recovered activity", assistant.Activities)
+	}
+}
+
 func TestAgentChatHumanizesAdapterJSONRPCBillingError(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
@@ -1265,6 +1296,47 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 	}
 }
 
+func TestAgentChatStoreAttachReconcilesInterruptedRun(t *testing.T) {
+	store := agentchat.NewMemoryStore()
+	ctx := context.Background()
+	created, err := store.Create(ctx, agentchat.Session{
+		ID:        "agent_chat_restart",
+		Title:     "Restart",
+		AdapterID: "codex",
+		Workspace: t.TempDir(),
+		Status:    "running",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := store.AppendMessage(ctx, created.ID, agentchat.Message{
+		ID:        "msg_running",
+		Role:      "assistant",
+		Status:    "running",
+		Content:   "working",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendMessage: %v", err)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	apiHandler.SetAgentChatStore(store)
+	handler := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, handler)
+
+	got := mustRequestJSON[AgentChatSessionResponse](client, http.MethodGet, "/v1/agent-chat/sessions/"+created.ID, "")
+	if got.Data.Status != "cancelled" {
+		t.Fatalf("session status = %q, want cancelled", got.Data.Status)
+	}
+	if got.Data.Messages[0].Status != "cancelled" || got.Data.Messages[0].Error != "interrupted by Hecate restart" {
+		t.Fatalf("message = %+v, want interrupted cancellation", got.Data.Messages[0])
+	}
+	if !agentChatActivitiesContain(got.Data.Messages[0].Activities, "interrupted") {
+		t.Fatalf("activities = %+v, want interrupted activity", got.Data.Messages[0].Activities)
+	}
+}
+
 type fakeAgentChatRunner struct {
 	output          string
 	finalOutput     string
@@ -1275,6 +1347,7 @@ type fakeAgentChatRunner struct {
 	nativeSessionID string
 	sessionStarted  bool
 	sessionResumed  bool
+	sessionRecovery string
 	seenPreviousID  string
 	usage           agentadapters.Usage
 	err             error
@@ -1342,6 +1415,7 @@ func (r *fakeAgentChatRunner) result(req agentadapters.RunRequest, output string
 		NativeSessionID: nativeSessionID,
 		SessionStarted:  r.sessionStarted,
 		SessionResumed:  r.sessionResumed,
+		SessionRecovery: r.sessionRecovery,
 		Output:          output,
 		RawOutput:       output,
 		ExitCode:        exitCode,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1278,6 +1278,7 @@ type fakeAgentChatRunner struct {
 	seenPreviousID  string
 	usage           agentadapters.Usage
 	err             error
+	closedSessions  []string
 }
 
 func (r *fakeAgentChatRunner) Run(ctx context.Context, req agentadapters.RunRequest) (agentadapters.RunResult, error) {
@@ -1350,7 +1351,10 @@ func (r *fakeAgentChatRunner) result(req agentadapters.RunRequest, output string
 	}
 }
 
-func (r *fakeAgentChatRunner) CloseSession(context.Context, string) error { return nil }
+func (r *fakeAgentChatRunner) CloseSession(_ context.Context, sessionID string) error {
+	r.closedSessions = append(r.closedSessions, sessionID)
+	return nil
+}
 
 func (r *fakeAgentChatRunner) Shutdown(context.Context) error { return nil }
 
@@ -1463,6 +1467,58 @@ func TestAgentChatCancelsExternalAdapter(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatalf("timed out waiting for cancelled message POST")
+	}
+}
+
+func TestAgentChatDeleteCancelsRunBeforeDeletingSession(t *testing.T) {
+	dir := t.TempDir()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithControlPlane(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	runner := &fakeAgentChatRunner{waitForCancel: true}
+	apiHandler.SetAgentChatRunner(runner)
+	handler := NewServer(logger, apiHandler)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	created := requestJSONToURL[AgentChatSessionResponse](t, http.MethodPost, server.URL+"/v1/agent-chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	done := make(chan AgentChatSessionResponse, 1)
+	go func() {
+		done <- requestJSONToURL[AgentChatSessionResponse](t, http.MethodPost, server.URL+"/v1/agent-chat/sessions/"+created.Data.ID+"/messages", `{"content":"please wait"}`)
+	}()
+
+	waitForAgentChatStatus(t, server.URL, created.Data.ID, "running")
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/v1/agent-chat/sessions/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete status = %d, want 204, body=%s", resp.StatusCode, string(body))
+	}
+	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.Data.ID {
+		t.Fatalf("closed sessions = %#v, want %q", runner.closedSessions, created.Data.ID)
+	}
+	select {
+	case updated := <-done:
+		if got := updated.Data.Status; got != "cancelled" {
+			t.Fatalf("post status = %q, want cancelled", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for cancelled message POST")
+	}
+	getResp, err := http.Get(server.URL + "/v1/agent-chat/sessions/" + created.Data.ID)
+	if err != nil {
+		t.Fatalf("get deleted session: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("deleted session status = %d, want 404", getResp.StatusCode)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1617,9 +1617,37 @@ func TestAgentChatCloseKeepsHistoryAndClosesNativeSession(t *testing.T) {
 	if len(closed.Data.Messages) != 2 {
 		t.Fatalf("closed session messages = %d, want preserved history", len(closed.Data.Messages))
 	}
+	if closed.Data.DriverKind != "" || closed.Data.NativeSessionID != "" {
+		t.Fatalf("closed session ACP metadata = kind %q native %q, want cleared", closed.Data.DriverKind, closed.Data.NativeSessionID)
+	}
 	got := mustRequestJSON[AgentChatSessionResponse](client, http.MethodGet, "/v1/agent-chat/sessions/"+created.Data.ID, "")
 	if len(got.Data.Messages) != 2 {
 		t.Fatalf("reloaded messages = %d, want preserved history", len(got.Data.Messages))
+	}
+	if got.Data.DriverKind != "" || got.Data.NativeSessionID != "" {
+		t.Fatalf("reloaded closed session ACP metadata = kind %q native %q, want cleared", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+}
+
+func TestAgentChatLiveCancelRunAndWaitTimesOutUntilRunDone(t *testing.T) {
+	live := newAgentChatLive()
+	cancelled := false
+	if ok := live.registerRun("session_1", func() { cancelled = true }); !ok {
+		t.Fatal("registerRun = false, want true")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	if live.cancelRunAndWait(ctx, "session_1") {
+		t.Fatal("cancelRunAndWait = true before run done, want false")
+	}
+	if !cancelled {
+		t.Fatal("cancel callback was not called")
+	}
+
+	live.clearRun("session_1")
+	if !live.cancelRunAndWait(context.Background(), "session_1") {
+		t.Fatal("cancelRunAndWait without active run = false, want true")
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1118,6 +1118,45 @@ func TestAgentChatOmitsStartedActivityWhenNativeSessionReused(t *testing.T) {
 	}
 }
 
+func TestAgentChatMergesAdapterActivityUpdates(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithControlPlane(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{
+		output: "done",
+		activities: []agentadapters.Activity{
+			{ID: "tool:call_1", Type: "tool_call", Status: "running", Kind: "execute", Title: "git status", Detail: "README.md"},
+			{ID: "tool:call_1", Type: "tool_call", Status: "completed", Kind: "execute", Title: "git status", Detail: "README.md"},
+			{ID: "plan:0:Inspect", Type: "plan", Status: "completed", Kind: "high", Title: "Inspect"},
+		},
+	})
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	created := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	updated := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
+	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
+
+	var toolCount int
+	var sawPlan bool
+	for _, activity := range assistant.Activities {
+		if activity.ID == "tool:call_1" {
+			toolCount++
+			if activity.Status != "completed" || activity.Kind != "execute" || activity.Detail != "README.md" {
+				t.Fatalf("tool activity = %#v", activity)
+			}
+		}
+		if activity.ID == "plan:0:Inspect" && activity.Type == "plan" && activity.Status == "completed" && activity.Kind == "high" {
+			sawPlan = true
+		}
+	}
+	if toolCount != 1 {
+		t.Fatalf("tool activity count = %d, want 1 in %#v", toolCount, assistant.Activities)
+	}
+	if !sawPlan {
+		t.Fatalf("plan activity missing in %#v", assistant.Activities)
+	}
+}
+
 func TestAgentChatPassesPersistedNativeSessionForResume(t *testing.T) {
 	dir := t.TempDir()
 	store := agentchat.NewMemoryStore()
@@ -1211,6 +1250,7 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 type fakeAgentChatRunner struct {
 	output          string
 	chunks          []string
+	activities      []agentadapters.Activity
 	delay           time.Duration
 	waitForCancel   bool
 	nativeSessionID string
@@ -1225,6 +1265,11 @@ func (r *fakeAgentChatRunner) Run(ctx context.Context, req agentadapters.RunRequ
 	started := time.Now().UTC()
 	r.seenPreviousID = req.PreviousNativeSessionID
 	output := r.output
+	for _, activity := range r.activities {
+		if req.OnActivity != nil {
+			req.OnActivity(activity)
+		}
+	}
 	for _, chunk := range r.chunks {
 		select {
 		case <-ctx.Done():

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1522,6 +1522,33 @@ func TestAgentChatDeleteCancelsRunBeforeDeletingSession(t *testing.T) {
 	}
 }
 
+func TestAgentChatCloseKeepsHistoryAndClosesNativeSession(t *testing.T) {
+	dir := t.TempDir()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithControlPlane(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	runner := &fakeAgentChatRunner{output: "done", nativeSessionID: "native_close_1", sessionStarted: true}
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	created := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	updated := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
+	if len(updated.Data.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(updated.Data.Messages))
+	}
+	closed := mustRequestJSON[AgentChatSessionResponse](client, http.MethodPost, "/v1/agent-chat/sessions/"+created.Data.ID+"/close", `{}`)
+	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.Data.ID {
+		t.Fatalf("closed sessions = %#v, want %q", runner.closedSessions, created.Data.ID)
+	}
+	if len(closed.Data.Messages) != 2 {
+		t.Fatalf("closed session messages = %d, want preserved history", len(closed.Data.Messages))
+	}
+	got := mustRequestJSON[AgentChatSessionResponse](client, http.MethodGet, "/v1/agent-chat/sessions/"+created.Data.ID, "")
+	if len(got.Data.Messages) != 2 {
+		t.Fatalf("reloaded messages = %d, want preserved history", len(got.Data.Messages))
+	}
+}
+
 func TestAgentChatWorkspaceGitBranch(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -18,7 +18,13 @@ test.beforeEach(async ({ page }) => {
   await page.waitForSelector(".hecate-activitybar");
 });
 
+async function switchToModel(page: Page) {
+  await page.getByRole("button", { name: "Model", exact: true }).click();
+}
+
 test("renders the message textarea and send button", async ({ page }) => {
+  await expect(page.getByRole("button", { name: "Agent", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Model", exact: true })).toBeVisible();
   await expect(page.locator("textarea")).toBeVisible();
   await expect(page.locator("button[type='submit']")).toBeVisible();
 });
@@ -29,11 +35,13 @@ test("send button is disabled when message is empty", async ({ page }) => {
 });
 
 test("send button becomes enabled when message has content", async ({ page }) => {
+  await switchToModel(page);
   await page.locator("textarea").fill("Hello");
   await expect(page.locator("button[type='submit']")).toBeEnabled();
 });
 
 test("model picker opens and lists models from mock data", async ({ page }) => {
+  await switchToModel(page);
   // Wait for models to load, then open the picker
   const modelBtn = page.getByRole("button", { name: /model picker/i });
   await modelBtn.click();
@@ -44,6 +52,7 @@ test("model picker opens and lists models from mock data", async ({ page }) => {
 });
 
 test("model picker filters by search input", async ({ page }) => {
+  await switchToModel(page);
   const modelBtn = page.getByRole("button", { name: /model picker/i });
   await modelBtn.click();
 
@@ -55,6 +64,7 @@ test("model picker filters by search input", async ({ page }) => {
 });
 
 test("selecting a model closes the picker and updates the button label", async ({ page }) => {
+  await switchToModel(page);
   const modelBtn = page.getByRole("button", { name: /model picker/i });
   await modelBtn.click();
 
@@ -65,6 +75,7 @@ test("selecting a model closes the picker and updates the button label", async (
 });
 
 test("provider picker shows healthy providers", async ({ page }) => {
+  await switchToModel(page);
   const healthyProviders = MOCK_PROVIDERS.filter(p => p.healthy);
   const providerBtn = page.locator("button", { hasText: /all providers/i });
   await providerBtn.click();
@@ -76,6 +87,7 @@ test("provider picker shows healthy providers", async ({ page }) => {
 });
 
 test("New chat button clears the active conversation", async ({ page }) => {
+  await switchToModel(page);
   // Fill the message box so we can verify the state resets
   await page.locator("textarea").fill("some prior message");
   await page.getByRole("button", { name: /new chat/i }).click();
@@ -86,6 +98,7 @@ test("New chat button clears the active conversation", async ({ page }) => {
 });
 
 test("system prompt editor opens and closes", async ({ page }) => {
+  await switchToModel(page);
   const systemBtn = page.locator("button", { hasText: /system/i });
   await systemBtn.click();
   await expect(page.getByText("SYSTEM PROMPT")).toBeVisible();
@@ -133,6 +146,7 @@ test("workspace selection persists across reload", async ({ page }) => {
 // required for cloud provider X" wire message is humanized into "X has no
 // API key. Open the Providers tab and add one." before reaching the DOM.
 test("chat error renders inline with the humanized message", async ({ page }) => {
+  await switchToModel(page);
   await page.route("/v1/chat/sessions", r =>
     r.fulfill({
       status: 200,

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { installTauriEditShortcutFallback } from "./App";
+
+describe("installTauriEditShortcutFallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+    Reflect.deleteProperty(document, "execCommand");
+    document.body.innerHTML = "";
+  });
+
+  it("does not intercept browser shortcuts outside Tauri", () => {
+    Object.defineProperty(document, "execCommand", { configurable: true, value: vi.fn(() => true) });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+    const cleanup = installTauriEditShortcutFallback();
+    const input = document.createElement("input");
+    input.value = "hello";
+    document.body.append(input);
+    input.focus();
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "c", ctrlKey: true, bubbles: true }));
+
+    expect(execCommand).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("forwards native copy shortcuts to focused editable fields inside Tauri", () => {
+    Reflect.set(window, "__TAURI_INTERNALS__", {});
+    Object.defineProperty(document, "execCommand", { configurable: true, value: vi.fn(() => true) });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+    const cleanup = installTauriEditShortcutFallback();
+    const input = document.createElement("input");
+    input.value = "hello";
+    document.body.append(input);
+    input.focus();
+    input.select();
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "c", ctrlKey: true, bubbles: true }));
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    cleanup();
+  });
+});

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -41,4 +41,22 @@ describe("installTauriEditShortcutFallback", () => {
     expect(execCommand).toHaveBeenCalledWith("copy");
     cleanup();
   });
+
+  it("does not intercept non-text input shortcuts inside Tauri", () => {
+    Reflect.set(window, "__TAURI_INTERNALS__", {});
+    Object.defineProperty(document, "execCommand", { configurable: true, value: vi.fn(() => true) });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+    const cleanup = installTauriEditShortcutFallback();
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    document.body.append(checkbox);
+    checkbox.focus();
+    const event = new KeyboardEvent("keydown", { key: "c", ctrlKey: true, bubbles: true, cancelable: true });
+
+    checkbox.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(execCommand).not.toHaveBeenCalled();
+    cleanup();
+  });
 });

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, type WorkspaceID } from "./AppShell";
 import { useRuntimeConsole } from "./useRuntimeConsole";
@@ -21,5 +21,63 @@ export default function App() {
     setPreferredWorkspace(id);
   }
 
+  useEffect(() => {
+    return installTauriEditShortcutFallback();
+  }, []);
+
   return <ConsoleShell actions={actions} activeWorkspace={activeWorkspace} onSelectWorkspace={handleSelectWorkspace} state={state} />;
+}
+
+export function installTauriEditShortcutFallback(): () => void {
+  if (!isTauriRuntime()) return () => undefined;
+  const handler = (event: KeyboardEvent) => {
+    const editable = editableTarget(event.target);
+    if (!editable) return;
+    const isMac = /mac/i.test(navigator.platform);
+    const modPressed = isMac ? event.metaKey : event.ctrlKey;
+    if (!modPressed || event.altKey) return;
+
+    const key = event.key.toLowerCase();
+    if (key === "a") {
+      event.preventDefault();
+      editable.select();
+      return;
+    }
+    if (key === "c" || key === "x") {
+      event.preventDefault();
+      document.execCommand(key === "c" ? "copy" : "cut");
+      return;
+    }
+    if (key === "v") {
+      event.preventDefault();
+      void pasteIntoEditable(editable);
+    }
+  };
+  window.addEventListener("keydown", handler);
+  return () => window.removeEventListener("keydown", handler);
+}
+
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined"
+    && (Object.prototype.hasOwnProperty.call(window, "__TAURI_INTERNALS__")
+      || Object.prototype.hasOwnProperty.call(window, "__TAURI__"));
+}
+
+function editableTarget(target: EventTarget | null): HTMLInputElement | HTMLTextAreaElement | null {
+  if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+    return null;
+  }
+  if (target.disabled || target.readOnly) {
+    return null;
+  }
+  return target;
+}
+
+async function pasteIntoEditable(target: HTMLInputElement | HTMLTextAreaElement) {
+  const text = await navigator.clipboard?.readText().catch(() => "");
+  if (!text) return;
+  const start = target.selectionStart ?? target.value.length;
+  const end = target.selectionEnd ?? target.value.length;
+  target.setRangeText(text, start, end, "end");
+  target.dispatchEvent(new Event("input", { bubbles: true }));
 }

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -64,20 +64,39 @@ function isTauriRuntime(): boolean {
 }
 
 function editableTarget(target: EventTarget | null): HTMLInputElement | HTMLTextAreaElement | null {
-  if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+  if (target instanceof HTMLTextAreaElement) {
+    if (target.disabled || target.readOnly) {
+      return null;
+    }
+    return target;
+  }
+  if (!(target instanceof HTMLInputElement) || !isTextInput(target)) {
     return null;
   }
-  if (target.disabled || target.readOnly) {
-    return null;
-  }
+  if (target.disabled || target.readOnly) return null;
   return target;
 }
 
+function isTextInput(input: HTMLInputElement): boolean {
+  return [
+    "",
+    "email",
+    "password",
+    "search",
+    "tel",
+    "text",
+    "url",
+  ].includes(input.type);
+}
+
 async function pasteIntoEditable(target: HTMLInputElement | HTMLTextAreaElement) {
+  if (target.selectionStart === null || target.selectionEnd === null) {
+    return;
+  }
   const text = await navigator.clipboard?.readText().catch(() => "");
   if (!text) return;
-  const start = target.selectionStart ?? target.value.length;
-  const end = target.selectionEnd ?? target.value.length;
+  const start = target.selectionStart;
+  const end = target.selectionEnd;
   target.setRangeText(text, start, end, "end");
   target.dispatchEvent(new Event("input", { bubbles: true }));
 }

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -39,6 +39,7 @@ describe("ConsoleShell loading state", () => {
 describe("ConsoleShell navigation", () => {
   it("keeps Chats available when no providers are configured", () => {
     const state = createRuntimeConsoleFixture({
+      chatTarget: "model",
       controlPlaneConfig: { backend: "memory", providers: [], pricebook: [], policy_rules: [], events: [] },
     });
     render(

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -68,6 +68,23 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatTarget).toBe("model");
   });
 
+  it("keeps the active agent chat selection when session refresh fails transiently", async () => {
+    window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+    fetchMock.mockImplementation(defaultBackendMock({
+      "/v1/agent-chat/sessions": () => jsonResponse({
+        object: "agent_chat_sessions",
+        data: [{ id: "a1", title: "Still exists", adapter_id: "codex", status: "running", message_count: 2 }],
+      }),
+      "/v1/agent-chat/sessions/a1": () => jsonResponse({ error: { type: "gateway_error", message: "temporary failure" } }, 500),
+    }));
+
+    const { result } = renderHook(() => useRuntimeConsole());
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    expect(result.current.state.activeAgentChatSessionID).toBe("a1");
+    expect(window.localStorage.getItem("hecate.agentChatSessionID")).toBe("a1");
+  });
+
   it("settles into a Local session after the dashboard loads", async () => {
     const { result } = renderHook(() => useRuntimeConsole());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
@@ -460,9 +477,9 @@ describe("humanizeChatError", () => {
   });
 });
 
-function jsonResponse(payload: unknown): Response {
+function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
-    status: 200,
+    status,
     headers: { "Content-Type": "application/json" },
   });
 }

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -55,6 +55,19 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.message).toBe("");
   });
 
+  it("defaults to Agent chat when no chat target preference exists", async () => {
+    const { result } = renderHook(() => useRuntimeConsole());
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+    expect(result.current.state.chatTarget).toBe("agent");
+  });
+
+  it("preserves the saved chat target preference", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "model");
+    const { result } = renderHook(() => useRuntimeConsole());
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+    expect(result.current.state.chatTarget).toBe("model");
+  });
+
   it("settles into a Local session after the dashboard loads", async () => {
     const { result } = renderHook(() => useRuntimeConsole());
     await waitFor(() => expect(result.current.state.loading).toBe(false));
@@ -303,6 +316,10 @@ describe("useRuntimeConsole", () => {
 
   // ─── chat session actions ──────────────────────────────────────────────────
   describe("chat session actions", () => {
+    beforeEach(() => {
+      window.localStorage.setItem("hecate.chatTarget", "model");
+    });
+
     function withSessions(sessions: Array<{ id: string; title: string }>, routes: Record<string, () => Response> = {}) {
       return defaultBackendMock({
         "/v1/chat/sessions?limit=20": () => {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -83,18 +83,28 @@ type NoticeState = {
   message: string;
 };
 
+function readLocalStorage(key: string): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.localStorage.getItem(key) ?? "";
+}
+
 export function useRuntimeConsole() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [models, setModels] = useState<ModelResponse["data"]>([]);
   const [providers, setProviders] = useState<ProviderStatusResponse["data"]>([]);
   const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
   const [agentAdapters, setAgentAdapters] = useState<AgentAdapterRecord[]>([]);
-  const [chatTarget, setChatTarget] = useState<"model" | "agent">("agent");
-  const [agentAdapterID, setAgentAdapterID] = useState("codex");
-  const [agentWorkspace, setAgentWorkspace] = useState("");
+  const [chatTarget, setChatTarget] = useState<"model" | "agent">(() => {
+    const stored = readLocalStorage("hecate.chatTarget");
+    return stored === "model" ? "model" : "agent";
+  });
+  const [agentAdapterID, setAgentAdapterID] = useState(() => readLocalStorage("hecate.agentAdapterID") || "codex");
+  const [agentWorkspace, setAgentWorkspace] = useState(() => readLocalStorage("hecate.agentWorkspace"));
   const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");
   const [agentChatSessions, setAgentChatSessions] = useState<AgentChatSessionsResponse["data"]>([]);
-  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = useState("");
+  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = useState(() => readLocalStorage("hecate.agentChatSessionID"));
   const [activeAgentChatSession, setActiveAgentChatSession] = useState<AgentChatSessionRecord | null>(null);
   const [budget, setBudget] = useState<BudgetStatusResponse["data"] | null>(null);
   const [accountSummary, setAccountSummary] = useState<AccountSummaryResponse["data"] | null>(null);
@@ -605,9 +615,9 @@ export function useRuntimeConsole() {
 
       let sessionID = activeAgentChatSessionID;
       if (sessionID && !activeAgentChatSession) {
-        // Agent Chat history is memory-backed in the MVP. After a gateway
-        // restart, localStorage can point at a session the server no longer
-        // knows about; start a fresh session instead of surfacing a stale 404.
+        // The server owns chat persistence. If localStorage points at a
+        // deleted or unavailable session, start clean instead of making the
+        // next prompt fail with a stale 404.
         sessionID = "";
         setActiveAgentChatSessionID("");
       }
@@ -1731,7 +1741,7 @@ async function resolveAgentChatDashboardState(args: {
     const sessionResult = await getAgentChatSession(activeSessionID);
     return { sessions, activeSessionID, activeSession: sessionResult.data };
   } catch {
-    return { sessions, activeSessionID, activeSession: null };
+    return { sessions, activeSessionID: "", activeSession: null };
   }
 }
 

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1740,7 +1740,10 @@ async function resolveAgentChatDashboardState(args: {
   try {
     const sessionResult = await getAgentChatSession(activeSessionID);
     return { sessions, activeSessionID, activeSession: sessionResult.data };
-  } catch {
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 404) {
+      return { sessions, activeSessionID, activeSession: args.previousActiveSession };
+    }
     return { sessions, activeSessionID: "", activeSession: null };
   }
 }

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -89,7 +89,7 @@ export function useRuntimeConsole() {
   const [providers, setProviders] = useState<ProviderStatusResponse["data"]>([]);
   const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
   const [agentAdapters, setAgentAdapters] = useState<AgentAdapterRecord[]>([]);
-  const [chatTarget, setChatTarget] = useState<"model" | "agent">("model");
+  const [chatTarget, setChatTarget] = useState<"model" | "agent">("agent");
   const [agentAdapterID, setAgentAdapterID] = useState("codex");
   const [agentWorkspace, setAgentWorkspace] = useState("");
   const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -107,6 +107,7 @@ export function useRuntimeConsole() {
   const [message, setMessage] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [chatLoading, setChatLoading] = useState(false);
+  const [agentChatCancelling, setAgentChatCancelling] = useState(false);
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
   const [chatResult, setChatResult] = useState<ChatResponse | null>(null);
   // pendingToolCalls: model responded with tool_calls; waiting for user to fill results.
@@ -201,6 +202,12 @@ export function useRuntimeConsole() {
     void loadDashboard();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!chatLoading) {
+      setAgentChatCancelling(false);
+    }
+  }, [chatLoading]);
 
   useEffect(() => {
     if (model) {
@@ -668,13 +675,15 @@ export function useRuntimeConsole() {
   }
 
   async function cancelAgentChat() {
-    if (!activeAgentChatSessionID) {
+    if (!activeAgentChatSessionID || agentChatCancelling) {
       return;
     }
+    setAgentChatCancelling(true);
+    setStreamingContent("Stopping external agent...");
     try {
       await cancelAgentChatSessionRequest(activeAgentChatSessionID);
-      setStreamingContent("Stopping external agent...");
     } catch (error) {
+      setAgentChatCancelling(false);
       setChatError(error instanceof Error ? error.message : "failed to cancel agent chat");
       setChatErrorCode(error instanceof ApiError ? error.code : "");
       setChatErrorStatus(error instanceof ApiError ? error.status : null);
@@ -1171,6 +1180,7 @@ export function useRuntimeConsole() {
       accountSummary,
       agentAdapterID,
       agentAdapters,
+      agentChatCancelling,
       agentChatSessions,
       agentWorkspace,
       agentWorkspaceBranch,

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -95,6 +95,12 @@ describe("ChatView Enter switch", () => {
 });
 
 describe("ChatView chats sidebar", () => {
+  function daysAgo(days: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    return date.toISOString();
+  }
+
   it("shows 'No chats yet' when chatSessions is empty", () => {
     const { state, actions } = setup({ chatTarget: "model", chatSessions: [] });
     render(<ChatView state={state} actions={actions} />);
@@ -105,13 +111,45 @@ describe("ChatView chats sidebar", () => {
     const { state, actions } = setup({
       chatTarget: "model",
       chatSessions: [
-        { id: "s1", title: "First chat", message_count: 4, provider_call_count: 2, updated_at: "2026-04-25T00:00:00Z" } as any,
-        { id: "s2", title: "Second chat", message_count: 2, provider_call_count: 1, updated_at: "2026-04-25T01:00:00Z" } as any,
+        { id: "s1", title: "First chat", message_count: 4, provider_call_count: 2, updated_at: daysAgo(0) } as any,
+        { id: "s2", title: "Second chat", message_count: 2, provider_call_count: 1, updated_at: daysAgo(10) } as any,
       ],
     });
     render(<ChatView state={state} actions={actions} />);
+    expect(screen.getByText("Today")).toBeTruthy();
+    expect(screen.getByText("Older")).toBeTruthy();
     expect(screen.getByText("First chat")).toBeTruthy();
     expect(screen.getByText("Second chat")).toBeTruthy();
+  });
+
+  it("filters chat history by title and route metadata", async () => {
+    const { state, actions } = setup({
+      chatTarget: "model",
+      chatSessions: [
+        { id: "s1", title: "Budget check", message_count: 4, provider_call_count: 2, last_provider: "anthropic", updated_at: daysAgo(0) } as any,
+        { id: "s2", title: "Draft release notes", message_count: 2, provider_call_count: 1, last_provider: "openai", updated_at: daysAgo(0) } as any,
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Search chats"), "anthropic");
+    expect(screen.getByText("Budget check")).toBeTruthy();
+    expect(screen.queryByText("Draft release notes")).toBeNull();
+  });
+
+  it("filters agent history by adapter and status metadata", async () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      agentChatSessions: [
+        { id: "a1", title: "Codex refactor", adapter_id: "codex", status: "completed", message_count: 4, updated_at: daysAgo(0) } as any,
+        { id: "a2", title: "Cursor repro", adapter_id: "cursor_agent", status: "failed", message_count: 2, updated_at: daysAgo(0) } as any,
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Search chats"), "failed");
+    expect(screen.getByText("Cursor repro")).toBeTruthy();
+    expect(screen.queryByText("Codex refactor")).toBeNull();
   });
 
   it("calls selectChatSession when clicking a chat row", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -489,6 +489,25 @@ describe("ChatView agent target", () => {
 });
 
 describe("ChatView model target", () => {
+  it("announces markdown task-list checkbox state", () => {
+    const { state, actions } = setup({
+      chatTarget: "model",
+      activeChatSessionID: "s1",
+      activeChatSession: {
+        id: "s1",
+        title: "Tasks",
+        messages: [
+          { id: "m1", sequence: 1, role: "assistant", content: "- [x] done\n- [ ] todo" },
+        ],
+        provider_calls: [],
+      } as any,
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByRole("img", { name: "Completed task" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Incomplete task" })).toBeTruthy();
+  });
+
   it("keeps provider and model pickers editable for an active model chat", async () => {
     const setProviderFilter = vi.fn();
     const setModel = vi.fn();
@@ -644,6 +663,23 @@ describe("ChatView history pagination", () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Load earlier chats" }));
+    expect(loadMoreChatSessions).toHaveBeenCalled();
+  });
+
+  it("keeps a load-earlier action available while searching model chat history", async () => {
+    const loadMoreChatSessions = vi.fn(async () => undefined);
+    const { state, actions } = setup({
+      chatTarget: "model",
+      chatSessionsHasMore: true,
+      chatSessions: [
+        { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
+      ],
+    }, { loadMoreChatSessions });
+    render(<ChatView state={state} actions={actions} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole("textbox", { name: "Search chats" }), "older match");
+    await user.click(screen.getByRole("button", { name: "Search earlier chats" }));
     expect(loadMoreChatSessions).toHaveBeenCalled();
   });
 });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -323,6 +323,34 @@ describe("ChatView agent target", () => {
     expect(screen.getByText("run running")).toBeTruthy();
   });
 
+  it("disables stop and shows cancelling feedback after stop is requested", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      chatLoading: true,
+      agentChatCancelling: true,
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
+      ],
+      activeAgentChatSessionID: "a1",
+      activeAgentChatSession: {
+        id: "a1",
+        title: "Stopping work",
+        adapter_id: "codex",
+        driver_kind: "acp",
+        workspace: "/tmp/hecate",
+        status: "running",
+        messages: [],
+      } as any,
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    const stop = screen.getByRole("button", { name: "Stop agent" }) as HTMLButtonElement;
+    expect(stop.disabled).toBe(true);
+    expect(stop.title).toBe("Stopping agent...");
+    expect(screen.getByText("Stopping external agent...")).toBeTruthy();
+  });
+
   it("renders failed agent runs as an error notice with raw diagnostics separate", () => {
     const { state, actions } = setup({
       chatTarget: "agent",

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -245,13 +245,13 @@ describe("ChatView agent target", () => {
     expect(screen.getAllByText(/ACP native_codex/).length).toBeGreaterThan(0);
     expect(screen.getByText(/trace 01234567/)).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();
-    expect(screen.getByText("run completed · session started · 1/2 plan · 1 tool · files changed")).toBeTruthy();
+    expect(screen.getByText("run completed · 1/2 plan · 1 tool · files changed")).toBeTruthy();
     expect(screen.getByText("Inspect changes")).toBeTruthy();
     expect(screen.getByText("Summarize result")).toBeTruthy();
     expect(screen.getByText("git diff --stat")).toBeTruthy();
     expect(screen.getByText("README.md:12")).toBeTruthy();
     expect(screen.getByText("files changed · 1 file changed")).toBeTruthy();
-    expect(screen.getByText("raw adapter output")).toBeTruthy();
+    expect(screen.getByText("raw adapter output · 1 line")).toBeTruthy();
     expect(screen.getByText("completed")).toBeTruthy();
     const user = userEvent.setup();
     const adapterPicker = screen.getByRole("button", { name: "External agent adapter" }) as HTMLButtonElement;
@@ -321,6 +321,48 @@ describe("ChatView agent target", () => {
 
     expect(screen.getByText("Waiting for agent output...")).toBeTruthy();
     expect(screen.getByText("run running")).toBeTruthy();
+  });
+
+  it("renders failed agent runs as an error notice with raw diagnostics separate", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        { id: "claude_code", name: "Claude Code", kind: "acp", command: "claude-agent-acp", available: true, status: "available", cost_mode: "external" },
+      ],
+      activeAgentChatSessionID: "a1",
+      activeAgentChatSession: {
+        id: "a1",
+        title: "Failed work",
+        adapter_id: "claude_code",
+        driver_kind: "acp",
+        workspace: "/tmp/hecate",
+        status: "failed",
+        messages: [
+          { id: "m1", role: "user", content: "status", created_at: "2026-05-03T10:00:00Z" },
+          {
+            id: "m2",
+            role: "assistant",
+            content: "Claude Code usage limit: credit balance is too low",
+            raw_output: `{"code":-32603,"message":"Internal error: Credit balance is too low"}`,
+            error: "Claude Code usage limit: credit balance is too low",
+            adapter_id: "claude_code",
+            adapter_name: "Claude Code",
+            status: "failed",
+            created_at: "2026-05-03T10:00:01Z",
+            activities: [
+              { type: "failed", status: "failed", title: "Failed", detail: "Claude Code usage limit: credit balance is too low" },
+            ],
+          },
+        ],
+      } as any,
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByText("agent run failed")).toBeTruthy();
+    expect(screen.getAllByText("Claude Code usage limit: credit balance is too low").length).toBeGreaterThan(0);
+    expect(screen.getByText("raw adapter output · 1 line")).toBeTruthy();
+    expect(screen.getByText("run failed")).toBeTruthy();
   });
 
   it("opens the workspace picker action from the folder button", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -222,7 +222,7 @@ describe("ChatView agent target", () => {
             native_session_id: "native_codex_1",
             status: "completed",
             cost_mode: "external",
-            diff_stat: "1 file changed",
+            diff_stat: "README.md | 2 +-\nui/src/features/chats/ChatView.tsx | 12 +++++++---\n2 files changed, 10 insertions(+), 4 deletions(-)",
             diff: "diff --git a/README.md b/README.md",
             created_at: "2026-05-03T10:00:01Z",
             activities: [
@@ -245,12 +245,16 @@ describe("ChatView agent target", () => {
     expect(screen.getAllByText(/ACP native_codex/).length).toBeGreaterThan(0);
     expect(screen.getByText(/trace 01234567/)).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();
-    expect(screen.getByText("run completed · 1/2 plan · 1 tool · files changed")).toBeTruthy();
+    expect(screen.getByText("completed · 1/2 plan · 1 tool · files changed")).toBeTruthy();
     expect(screen.getByText("Inspect changes")).toBeTruthy();
     expect(screen.getByText("Summarize result")).toBeTruthy();
     expect(screen.getByText("git diff --stat")).toBeTruthy();
     expect(screen.getByText("README.md:12")).toBeTruthy();
-    expect(screen.getByText("files changed · 1 file changed")).toBeTruthy();
+    expect(screen.getByText("files changed · 2 files changed, 10 insertions(+), 4 deletions(-)")).toBeTruthy();
+    expect(screen.getByText("README.md")).toBeTruthy();
+    expect(screen.getByText("2 +-")).toBeTruthy();
+    expect(screen.getByText("ui/src/features/chats/ChatView.tsx")).toBeTruthy();
+    expect(screen.getByText("12 +++++++---")).toBeTruthy();
     expect(screen.getByText("raw adapter output · 1 line")).toBeTruthy();
     expect(screen.getByText("completed")).toBeTruthy();
     const user = userEvent.setup();
@@ -320,7 +324,46 @@ describe("ChatView agent target", () => {
     render(<ChatView state={state} actions={actions} />);
 
     expect(screen.getByText("Waiting for agent output...")).toBeTruthy();
-    expect(screen.getByText("run running")).toBeTruthy();
+    expect(screen.getAllByText("running").length).toBeGreaterThan(0);
+  });
+
+  it("shows transient agent narration as live assistant text while a run is active", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
+      ],
+      activeAgentChatSessionID: "a1",
+      activeAgentChatSession: {
+        id: "a1",
+        title: "Inspect diff",
+        adapter_id: "codex",
+        driver_kind: "acp",
+        workspace: "/tmp/hecate",
+        status: "running",
+        messages: [
+          { id: "m1", role: "user", content: "show diff", created_at: "2026-05-03T10:00:00Z" },
+          {
+            id: "m2",
+            role: "assistant",
+            content: "I’ll check the current worktree diff and summarize the changed files plus the important hunks.",
+            adapter_id: "codex",
+            adapter_name: "Codex",
+            status: "running",
+            created_at: "2026-05-03T10:00:01Z",
+            activities: [
+              { type: "running", status: "running", title: "Running", detail: "Waiting for ACP output" },
+            ],
+          },
+        ],
+      } as any,
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByText("I’ll check the current worktree diff and summarize the changed files plus the important hunks.")).toBeTruthy();
+    expect(screen.getByText("I’ll check the current worktree diff and summarize the changed files plus the important hunks.").parentElement?.querySelector("[aria-hidden='true']")).toBeTruthy();
+    expect(screen.queryByText("Waiting for agent output...")).toBeNull();
   });
 
   it("disables stop and shows cancelling feedback after stop is requested", () => {
@@ -390,7 +433,7 @@ describe("ChatView agent target", () => {
     expect(screen.getByText("agent run failed")).toBeTruthy();
     expect(screen.getAllByText("Claude Code usage limit: credit balance is too low").length).toBeGreaterThan(0);
     expect(screen.getByText("raw adapter output · 1 line")).toBeTruthy();
-    expect(screen.getByText("run failed")).toBeTruthy();
+    expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
   });
 
   it("opens the workspace picker action from the folder button", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -227,6 +227,9 @@ describe("ChatView agent target", () => {
             created_at: "2026-05-03T10:00:01Z",
             activities: [
               { type: "started", status: "completed", title: "Starting external agent", detail: "Codex ACP session started" },
+              { id: "plan:0:Inspect", type: "plan", status: "completed", kind: "high", title: "Inspect changes" },
+              { id: "plan:1:Summarize", type: "plan", status: "in_progress", kind: "medium", title: "Summarize result" },
+              { id: "tool:call_1", type: "tool_call", status: "completed", kind: "execute", title: "git diff --stat", detail: "README.md:12" },
               { type: "completed", status: "completed", title: "Final answer" },
             ],
           },
@@ -242,6 +245,11 @@ describe("ChatView agent target", () => {
     expect(screen.getAllByText(/ACP native_codex/).length).toBeGreaterThan(0);
     expect(screen.getByText(/trace 01234567/)).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();
+    expect(screen.getByText("run completed · session started · 1/2 plan · 1 tool · files changed")).toBeTruthy();
+    expect(screen.getByText("Inspect changes")).toBeTruthy();
+    expect(screen.getByText("Summarize result")).toBeTruthy();
+    expect(screen.getByText("git diff --stat")).toBeTruthy();
+    expect(screen.getByText("README.md:12")).toBeTruthy();
     expect(screen.getByText("files changed · 1 file changed")).toBeTruthy();
     expect(screen.getByText("raw adapter output")).toBeTruthy();
     expect(screen.getByText("completed")).toBeTruthy();

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -17,6 +17,14 @@ function setup(stateOverrides = {}, actionOverrides = {}) {
 }
 
 describe("ChatView input", () => {
+  it("renders Agent as the first and active chat target by default", () => {
+    const { state, actions } = setup();
+    render(<ChatView state={state} actions={actions} />);
+    const targetButtons = screen.getAllByRole("button", { name: /^(Agent|Model)$/ });
+    expect(targetButtons.map((button) => button.textContent)).toEqual(["Agent", "Model"]);
+    expect(targetButtons[0]).toHaveStyle({ color: "var(--teal)" });
+  });
+
   it("disables the send button when message is empty", () => {
     const { state, actions } = setup({ message: "" });
     render(<ChatView state={state} actions={actions} />);
@@ -25,7 +33,7 @@ describe("ChatView input", () => {
   });
 
   it("enables the send button when message has content", () => {
-    const { state, actions } = setup({ message: "hello" });
+    const { state, actions } = setup({ chatTarget: "model", message: "hello" });
     render(<ChatView state={state} actions={actions} />);
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(false);
@@ -33,6 +41,7 @@ describe("ChatView input", () => {
 
   it("disables model send when no provider is configured", () => {
     const { state, actions } = setup({
+      chatTarget: "model",
       message: "hello",
       controlPlaneConfig: { backend: "memory", providers: [], policy_rules: [], pricebook: [], events: [] },
       agentAdapters: [
@@ -48,6 +57,7 @@ describe("ChatView input", () => {
 
   it("shows a first-run setup state when providers and agents are unavailable", () => {
     const { state, actions } = setup({
+      chatTarget: "model",
       message: "hello",
       controlPlaneConfig: { backend: "memory", providers: [], policy_rules: [], pricebook: [], events: [] },
       agentAdapters: [
@@ -63,7 +73,7 @@ describe("ChatView input", () => {
   it("calls setMessage as user types", async () => {
     const setMessage = vi.fn();
     // Start with empty message so the assertion sees only what we typed.
-    const { state, actions } = setup({ message: "" }, { setMessage });
+    const { state, actions } = setup({ chatTarget: "model", message: "" }, { setMessage });
     render(<ChatView state={state} actions={actions} />);
     const ta = screen.getByPlaceholderText(/Message/i) as HTMLTextAreaElement;
     const user = userEvent.setup();
@@ -86,13 +96,14 @@ describe("ChatView Enter switch", () => {
 
 describe("ChatView chats sidebar", () => {
   it("shows 'No chats yet' when chatSessions is empty", () => {
-    const { state, actions } = setup({ chatSessions: [] });
+    const { state, actions } = setup({ chatTarget: "model", chatSessions: [] });
     render(<ChatView state={state} actions={actions} />);
     expect(screen.getByText(/No chats yet/i)).toBeTruthy();
   });
 
   it("renders one row per chat with title", () => {
     const { state, actions } = setup({
+      chatTarget: "model",
       chatSessions: [
         { id: "s1", title: "First chat", message_count: 4, provider_call_count: 2, updated_at: "2026-04-25T00:00:00Z" } as any,
         { id: "s2", title: "Second chat", message_count: 2, provider_call_count: 1, updated_at: "2026-04-25T01:00:00Z" } as any,
@@ -106,6 +117,7 @@ describe("ChatView chats sidebar", () => {
   it("calls selectChatSession when clicking a chat row", async () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup({
+      chatTarget: "model",
       chatSessions: [{ id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any],
     }, { selectChatSession });
     render(<ChatView state={state} actions={actions} />);
@@ -349,13 +361,14 @@ describe("ChatView error display", () => {
 
 describe("ChatView session title", () => {
   it("shows 'New chat' when no chats and no active chat", () => {
-    const { state, actions } = setup({ chatSessions: [], activeChatSession: null });
+    const { state, actions } = setup({ chatTarget: "model", chatSessions: [], activeChatSession: null });
     render(<ChatView state={state} actions={actions} />);
     expect(screen.getAllByText("New chat").length).toBeGreaterThan(0);
   });
 
   it("shows the active session's title", () => {
     const { state, actions } = setup({
+      chatTarget: "model",
       activeChatSession: { id: "s1", title: "Hello world", messages: [], provider_calls: [] } as any,
     });
     render(<ChatView state={state} actions={actions} />);
@@ -389,6 +402,7 @@ describe("ChatView session focus", () => {
     // (e2e regression — see shell.spec.ts shortcut tests).
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup({
+      chatTarget: "model",
       chatSessions: [{ id: "s2", title: "Pick me", message_count: 0, provider_call_count: 0 } as any],
     }, { selectChatSession });
     const user = userEvent.setup();
@@ -407,7 +421,7 @@ describe("ChatView session focus", () => {
   it("does NOT focus the textarea when activeChatSessionID changes from data-load", async () => {
     // Initial-load and API-driven session arrivals must not steal
     // focus — page-level shortcuts depend on it. Asserts the negative.
-    const { state, actions } = setup({ activeChatSessionID: "" });
+    const { state, actions } = setup({ chatTarget: "model", activeChatSessionID: "" });
     const { rerender } = render(<ChatView state={state} actions={actions} />);
     const closeBtn = screen.getByTitle("Close");
     closeBtn.focus();

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -239,11 +239,11 @@ describe("ChatView agent target", () => {
     expect(screen.getByRole("button", { name: /workspace/i })).toBeTruthy();
     expect(screen.getAllByText("Codex work").length).toBeGreaterThan(0);
     expect(screen.getByText("Looks good.")).toBeTruthy();
-    expect(screen.getByText(/ACP native_codex/)).toBeTruthy();
+    expect(screen.getAllByText(/ACP native_codex/).length).toBeGreaterThan(0);
     expect(screen.getByText(/trace 01234567/)).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();
     expect(screen.getByText("files changed · 1 file changed")).toBeTruthy();
-    expect(screen.getByText("raw ACP diagnostics")).toBeTruthy();
+    expect(screen.getByText("raw adapter output")).toBeTruthy();
     expect(screen.getByText("completed")).toBeTruthy();
     const user = userEvent.setup();
     const adapterPicker = screen.getByRole("button", { name: "External agent adapter" }) as HTMLButtonElement;
@@ -275,6 +275,44 @@ describe("ChatView agent target", () => {
     await user.click(screen.getByRole("button", { name: "External agent adapter" }));
     await user.click(screen.getByText("Claude Code"));
     expect(setAgentAdapterID).toHaveBeenCalledWith("claude_code");
+  });
+
+  it("shows a waiting state for a running agent before transcript output arrives", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
+      ],
+      activeAgentChatSessionID: "a1",
+      activeAgentChatSession: {
+        id: "a1",
+        title: "Running work",
+        adapter_id: "codex",
+        driver_kind: "acp",
+        workspace: "/tmp/hecate",
+        status: "running",
+        messages: [
+          { id: "m1", role: "user", content: "status", created_at: "2026-05-03T10:00:00Z" },
+          {
+            id: "m2",
+            role: "assistant",
+            content: "",
+            adapter_id: "codex",
+            adapter_name: "Codex",
+            status: "running",
+            created_at: "2026-05-03T10:00:01Z",
+            activities: [
+              { type: "running", status: "running", title: "Running", detail: "Waiting for ACP output" },
+            ],
+          },
+        ],
+      } as any,
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByText("Waiting for agent output...")).toBeTruthy();
+    expect(screen.getByText("run running")).toBeTruthy();
   });
 
   it("opens the workspace picker action from the folder button", async () => {
@@ -468,5 +506,23 @@ describe("ChatView session focus", () => {
     // Focus must STAY on the close button — the effect should not have
     // jumped to the textarea on a programmatic ID transition.
     expect(document.activeElement).toBe(closeBtn);
+  });
+});
+
+describe("ChatView history pagination", () => {
+  it("shows an explicit load-earlier action for model chat history", async () => {
+    const loadMoreChatSessions = vi.fn(async () => undefined);
+    const { state, actions } = setup({
+      chatTarget: "model",
+      chatSessionsHasMore: true,
+      chatSessions: [
+        { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
+      ],
+    }, { loadMoreChatSessions });
+    render(<ChatView state={state} actions={actions} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Load earlier chats" }));
+    expect(loadMoreChatSessions).toHaveBeenCalled();
   });
 });

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -30,6 +30,7 @@ type VisibleChatMessage = {
   raw_output?: string;
   activities?: AgentChatActivityRecord[];
   duration_ms?: number;
+  error?: string;
 };
 
 type SidebarSession = {
@@ -103,6 +104,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
         raw_output: m.raw_output,
         activities: m.activities,
         duration_ms: m.duration_ms,
+        error: m.error,
       }))
     : (state.activeChatSession?.messages ?? []).map((m) => ({
         id: m.id,
@@ -589,6 +591,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
                 diffStat={isAgentChat && role === "assistant" ? m.diff_stat : undefined}
                 diff={isAgentChat && role === "assistant" ? m.diff : undefined}
                 rawOutput={isAgentChat && role === "assistant" ? m.raw_output : undefined}
+                error={isAgentChat && role === "assistant" ? m.error : undefined}
                 onCopy={copyMsg}
                 copied={copiedMsgId === m.id}
               />
@@ -1075,11 +1078,11 @@ function formatDuration(durationMS: number): string {
 // needs to pick a model with type-to-filter + disabled-provider
 // awareness.)
 
-function MessageRow({ id, role, model, content, time, promptTokens, completionTokens, costUsd, badge, runtimeMeta, activities, diffStat, diff, rawOutput, onCopy, copied }: {
+function MessageRow({ id, role, model, content, time, promptTokens, completionTokens, costUsd, badge, runtimeMeta, activities, diffStat, diff, rawOutput, error, onCopy, copied }: {
   id: string; role: "user" | "assistant"; model?: string; content: string;
   time: string; promptTokens?: number; completionTokens?: number; costUsd?: string;
   badge?: string; runtimeMeta?: string;
-  activities?: AgentChatActivityRecord[]; diffStat?: string; diff?: string; rawOutput?: string;
+  activities?: AgentChatActivityRecord[]; diffStat?: string; diff?: string; rawOutput?: string; error?: string;
   onCopy: (id: string, text: string) => void; copied: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
@@ -1087,6 +1090,8 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
   const hasTokenData = isAssistant && (promptTokens ?? 0) > 0;
   const showRawOutput = isAssistant && rawOutput && rawOutput.trim() && rawOutput.trim() !== content.trim();
   const waitingForAgentOutput = isAssistant && !content.trim() && activities?.some(activity => activity.status === "running");
+  const failed = isAssistant && badge === "failed";
+  const cancelled = isAssistant && badge === "cancelled";
 
   return (
     <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
@@ -1128,13 +1133,18 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
               </button>
             </div>
           </div>
-          {waitingForAgentOutput ? (
+          {failed || cancelled ? (
+            <AgentRunNotice status={failed ? "failed" : "cancelled"} message={error || content} />
+          ) : waitingForAgentOutput ? (
             <div style={{ alignItems: "center", color: "var(--t2)", display: "flex", fontSize: 13, gap: 8, lineHeight: 1.7 }}>
               <span style={{ background: "var(--teal)", borderRadius: 999, display: "inline-block", height: 6, opacity: 0.8, width: 6 }} />
               Waiting for agent output...
             </div>
           ) : (
             <Markdown content={content} />
+          )}
+          {isAssistant && activities && activities.length > 0 && (
+            <ActivityTimeline activities={activities} diffStat={diffStat} />
           )}
           {isAssistant && diff && (
             <details style={{ marginTop: 8 }}>
@@ -1149,18 +1159,37 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
           {showRawOutput && (
             <details style={{ marginTop: 8 }}>
               <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>
-                raw adapter output
+                raw adapter output{rawOutput ? ` · ${formatLineCount(rawOutput)}` : ""}
               </summary>
               <div style={{ marginTop: 6 }}>
                 <CodeBlock code={rawOutput} lang="text" />
               </div>
             </details>
           )}
-          {isAssistant && activities && activities.length > 0 && (
-            <ActivityTimeline activities={activities} diffStat={diffStat} />
-          )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function AgentRunNotice({ status, message }: { status: "failed" | "cancelled"; message: string }) {
+  const color = status === "failed" ? "var(--red)" : "var(--amber)";
+  return (
+    <div style={{
+      border: "1px solid var(--border)",
+      borderLeft: `3px solid ${color}`,
+      borderRadius: "var(--radius-sm)",
+      background: "var(--bg2)",
+      padding: "9px 10px",
+    }}>
+      <div style={{ color, fontFamily: "var(--font-mono)", fontSize: 11, marginBottom: 4 }}>
+        agent run {status}
+      </div>
+      {message && (
+        <div style={{ color: "var(--t0)", fontSize: 13, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+          {message}
+        </div>
+      )}
     </div>
   );
 }
@@ -1170,13 +1199,11 @@ function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActiv
   if (visible.length === 0) return null;
   const terminal = terminalAgentActivity(activities);
   const hasRunning = !terminal && activities.some(activity => activity.status === "running");
-  const lifecycle = activities.find(activity => activity.type === "resumed" || activity.type === "started");
   const plan = visible.filter(activity => activity.type === "plan");
   const tools = visible.filter(activity => activity.type === "tool_call");
   const other = visible.filter(activity => activity.type !== "plan" && activity.type !== "tool_call");
   const summary = [
     terminal ? `run ${terminal.status}` : hasRunning ? "run running" : "run details",
-    lifecycle?.type === "resumed" ? "session resumed" : lifecycle?.type === "started" ? "session started" : "",
     plan.length > 0 ? `${plan.filter(item => item.status === "completed").length}/${plan.length} plan` : "",
     tools.length > 0 ? `${tools.length} tool${tools.length === 1 ? "" : "s"}` : "",
     diffStat ? "files changed" : "",
@@ -1295,6 +1322,13 @@ function activityStatusColor(status?: string) {
   default:
     return "var(--green)";
   }
+}
+
+function formatLineCount(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "0 lines";
+  const count = trimmed.split(/\r?\n/).length;
+  return `${count} line${count === 1 ? "" : "s"}`;
 }
 
 function Markdown({ content }: { content: string }) {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -771,6 +771,10 @@ export function ChatView({ state, actions, onNavigate }: Props) {
       <style>{`
         .cursor-blink { color: var(--teal); }
         @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+        @keyframes hecate-live-caret {
+          0%, 100% { opacity: 0.25; transform: translateY(-1px) scale(0.85); }
+          50% { opacity: 0.9; transform: translateY(-1px) scale(1.15); }
+        }
       `}</style>
     </div>
   );
@@ -1098,6 +1102,11 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
   const waitingForAgentOutput = isAssistant && !content.trim() && activities?.some(activity => activity.status === "running");
   const failed = isAssistant && badge === "failed";
   const cancelled = isAssistant && badge === "cancelled";
+  const thinkingForAgent = isAssistant
+    && badge === "running"
+    && content.trim() !== ""
+    && isLikelyTransientAgentNarration(content)
+    && !(activities ?? []).some(activity => activity.type === "tool_call");
 
   return (
     <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
@@ -1141,6 +1150,8 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
           </div>
           {failed || cancelled ? (
             <AgentRunNotice status={failed ? "failed" : "cancelled"} message={error || content} />
+          ) : thinkingForAgent ? (
+            <AgentLiveText content={content} />
           ) : waitingForAgentOutput ? (
             <div style={{ alignItems: "center", color: "var(--t2)", display: "flex", fontSize: 13, gap: 8, lineHeight: 1.7 }}>
               <span style={{ background: "var(--teal)", borderRadius: 999, display: "inline-block", height: 6, opacity: 0.8, width: 6 }} />
@@ -1152,13 +1163,14 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
           {isAssistant && activities && activities.length > 0 && (
             <ActivityTimeline activities={activities} diffStat={diffStat} />
           )}
-          {isAssistant && diff && (
+          {isAssistant && (diff || diffStat) && (
             <details style={{ marginTop: 8 }}>
               <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>
-                files changed{diffStat ? ` · ${diffStat}` : ""}
+                files changed{diffStat ? ` · ${formatDiffStatSummary(diffStat)}` : ""}
               </summary>
-              <div style={{ marginTop: 6 }}>
-                <CodeBlock code={diff} lang="diff" />
+              <div style={{ display: "grid", gap: 6, marginTop: 6 }}>
+                {diffStat && <DiffStatList diffStat={diffStat} />}
+                {diff && <CodeBlock code={diff} lang="diff" />}
               </div>
             </details>
           )}
@@ -1176,6 +1188,26 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
       </div>
     </div>
   );
+}
+
+function isLikelyTransientAgentNarration(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return false;
+  return [
+    "i'll ",
+    "i’ll ",
+    "i will ",
+    "i'm going to ",
+    "i’m going to ",
+    "i'm checking ",
+    "i’m checking ",
+    "i'll check ",
+    "i’ll check ",
+    "i'll inspect ",
+    "i’ll inspect ",
+    "let me ",
+    "checking ",
+  ].some(prefix => normalized.startsWith(prefix));
 }
 
 function AgentRunNotice({ status, message }: { status: "failed" | "cancelled"; message: string }) {
@@ -1200,6 +1232,89 @@ function AgentRunNotice({ status, message }: { status: "failed" | "cancelled"; m
   );
 }
 
+function AgentLiveText({ content }: { content: string }) {
+  return (
+    <div style={{ alignItems: "baseline", display: "flex", gap: 6, minWidth: 0 }}>
+      <div style={{ color: "var(--t0)", flex: "0 1 auto", fontSize: 13, lineHeight: 1.7, minWidth: 0, whiteSpace: "pre-wrap" }}>
+        {content}
+      </div>
+      <span
+        aria-hidden="true"
+        style={{
+          animation: "hecate-live-caret 1.1s ease-in-out infinite",
+          background: "var(--teal)",
+          borderRadius: 999,
+          display: "inline-block",
+          flexShrink: 0,
+          height: 5,
+          opacity: 0.75,
+          transform: "translateY(-1px)",
+          width: 5,
+        }}
+      />
+    </div>
+  );
+}
+
+function DiffStatList({ diffStat }: { diffStat: string }) {
+  const rows = parseDiffStatRows(diffStat);
+  const summary = formatDiffStatSummary(diffStat);
+
+  if (rows.length === 0) {
+    return (
+      <div style={{ color: "var(--t2)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
+        {summary}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      display: "grid",
+      gap: 5,
+      padding: "8px 10px",
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-sm)",
+      background: "var(--bg2)",
+    }}>
+      {rows.map(row => (
+        <div key={row.path} style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) auto", gap: 10, alignItems: "baseline" }}>
+          <span style={{ color: "var(--t1)", fontFamily: "var(--font-mono)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {row.path}
+          </span>
+          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 11, whiteSpace: "nowrap" }}>
+            {row.change}
+          </span>
+        </div>
+      ))}
+      {summary && (
+        <div style={{ borderTop: "1px solid var(--border)", color: "var(--t2)", fontFamily: "var(--font-mono)", fontSize: 11, marginTop: 2, paddingTop: 6 }}>
+          {summary}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function parseDiffStatRows(diffStat: string): Array<{ path: string; change: string }> {
+  return diffStat
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .filter(line => !/\bfiles? changed\b/.test(line))
+    .map(line => {
+      const match = line.match(/^(.+?)\s+\|\s+(.+)$/);
+      if (!match) return null;
+      return { path: match[1].trim(), change: match[2].trim() };
+    })
+    .filter((row): row is { path: string; change: string } => row !== null);
+}
+
+function formatDiffStatSummary(diffStat: string): string {
+  const lines = diffStat.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  return lines.find(line => /\bfiles? changed\b/.test(line)) || lines[0] || "";
+}
+
 function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActivityRecord[]; diffStat?: string }) {
   const visible = compactAgentActivities(activities);
   if (visible.length === 0) return null;
@@ -1209,7 +1324,7 @@ function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActiv
   const tools = visible.filter(activity => activity.type === "tool_call");
   const other = visible.filter(activity => activity.type !== "plan" && activity.type !== "tool_call");
   const summary = [
-    terminal ? `run ${terminal.status}` : hasRunning ? "run running" : "run details",
+    terminal ? terminal.status : hasRunning ? "running" : "details",
     plan.length > 0 ? `${plan.filter(item => item.status === "completed").length}/${plan.length} plan` : "",
     tools.length > 0 ? `${tools.length} tool${tools.length === 1 ? "" : "s"}` : "",
     diffStat ? "files changed" : "",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -3,7 +3,7 @@ import type { SyntheticEvent } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { parseInlineNodes, parseMarkdownBlocks } from "../../lib/markdown";
-import type { AgentAdapterRecord, AgentChatActivityRecord } from "../../types/runtime";
+import type { AgentAdapterRecord, AgentChatActivityRecord, AgentChatSessionRecord } from "../../types/runtime";
 import { AgentAdapterPicker, CodeBlock, Icon, Icons, InlineError, ModelPicker, ProviderPicker } from "../shared/ui";
 
 type Props = {
@@ -273,7 +273,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
             </button>
           </div>
           <div style={{ padding: "8px 12px 4px", fontFamily: "var(--font-mono)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
-            Chats
+            Chats{sessions.length > 0 ? ` · ${filteredSessions.length}${filteredSessions.length === sessions.length ? "" : `/${sessions.length}`}` : ""}
           </div>
           <div style={{ padding: "4px 8px 8px" }}>
             <input
@@ -366,6 +366,13 @@ export function ChatView({ state, actions, onNavigate }: Props) {
             {!isAgentChat && state.chatSessionsLoadingMore && (
               <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--t3)", textAlign: "center" }}>Loading chats…</div>
             )}
+            {!isAgentChat && !sidebarQuery.trim() && state.chatSessionsHasMore && !state.chatSessionsLoadingMore && (
+              <div style={{ padding: "8px 12px" }}>
+                <button className="btn btn-ghost btn-sm" onClick={() => void actions.loadMoreChatSessions()} style={{ width: "100%", justifyContent: "center" }} type="button">
+                  Load earlier chats
+                </button>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -400,6 +407,14 @@ export function ChatView({ state, actions, onNavigate }: Props) {
           <span style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {activeTitle || (sessions.length === 0 ? "New chat" : "Select a chat")}
           </span>
+          {isAgentChat && (
+            <span
+              title={formatAgentSessionTitle(state.activeAgentChatSession, selectedAgent)}
+              style={{ flexShrink: 0, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", maxWidth: 260, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            >
+              {formatAgentSessionLabel(state.activeAgentChatSession, selectedAgent)}
+            </span>
+          )}
           {isAgentChat ? (
             <>
               <AgentAdapterPicker
@@ -999,6 +1014,32 @@ function agentReadyLabel(adapter: AgentAdapterRecord): string {
   return `Ready at ${adapter.path || adapter.command}`;
 }
 
+function formatAgentSessionLabel(session: AgentChatSessionRecord | null, adapter?: AgentAdapterRecord): string {
+  if (!session) {
+    return adapter?.available ? "new agent session" : "agent not ready";
+  }
+  const driver = (session.driver_kind || "agent").toUpperCase();
+  if (session.native_session_id) {
+    return `${driver} ${session.native_session_id.slice(0, 12)} · ${session.status}`;
+  }
+  return `${driver} session · ${session.status}`;
+}
+
+function formatAgentSessionTitle(session: AgentChatSessionRecord | null, adapter?: AgentAdapterRecord): string {
+  if (!session) {
+    return adapter?.available
+      ? `A new ${adapter.name} session will be created on send.`
+      : "Install or authenticate an agent adapter before sending.";
+  }
+  const parts = [
+    `${session.title || "Agent chat"} is backed by a persistent ${session.driver_kind || "agent"} session.`,
+    session.native_session_id ? `Native session: ${session.native_session_id}.` : "",
+    session.workspace ? `Workspace: ${session.workspace}.` : "",
+    session.workspace_branch ? `Branch: ${session.workspace_branch}.` : "",
+  ].filter(Boolean);
+  return parts.join(" ");
+}
+
 function formatAgentRuntimeMeta(runID?: string, durationMS?: number, traceID?: string, nativeSessionID?: string): string {
   const parts: string[] = [];
   if (nativeSessionID) {
@@ -1045,6 +1086,7 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
   const isAssistant = role === "assistant";
   const hasTokenData = isAssistant && (promptTokens ?? 0) > 0;
   const showRawOutput = isAssistant && rawOutput && rawOutput.trim() && rawOutput.trim() !== content.trim();
+  const waitingForAgentOutput = isAssistant && !content.trim() && activities?.some(activity => activity.status === "running");
 
   return (
     <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
@@ -1086,7 +1128,14 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
               </button>
             </div>
           </div>
-          <Markdown content={content} />
+          {waitingForAgentOutput ? (
+            <div style={{ alignItems: "center", color: "var(--t2)", display: "flex", fontSize: 13, gap: 8, lineHeight: 1.7 }}>
+              <span style={{ background: "var(--teal)", borderRadius: 999, display: "inline-block", height: 6, opacity: 0.8, width: 6 }} />
+              Waiting for agent output...
+            </div>
+          ) : (
+            <Markdown content={content} />
+          )}
           {isAssistant && diff && (
             <details style={{ marginTop: 8 }}>
               <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>
@@ -1100,7 +1149,7 @@ function MessageRow({ id, role, model, content, time, promptTokens, completionTo
           {showRawOutput && (
             <details style={{ marginTop: 8 }}>
               <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>
-                raw ACP diagnostics
+                raw adapter output
               </summary>
               <div style={{ marginTop: 6 }}>
                 <CodeBlock code={rawOutput} lang="text" />
@@ -1121,9 +1170,10 @@ function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActiv
   if (visible.length === 0) return null;
   const terminal = terminalAgentActivity(activities);
   const hasRunning = !terminal && activities.some(activity => activity.status === "running");
+  const lifecycle = visible.find(activity => activity.type === "resumed" || activity.type === "started");
   const summary = [
-    "run details",
-    terminal?.status,
+    terminal ? `run ${terminal.status}` : hasRunning ? "run running" : "run details",
+    lifecycle?.type === "resumed" ? "session resumed" : lifecycle?.type === "started" ? "session started" : "",
     diffStat ? "files changed" : "",
   ].filter(Boolean).join(" · ");
 

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -725,7 +725,8 @@ export function ChatView({ state, actions, onNavigate }: Props) {
               <button type="button"
                 className="btn btn-danger"
                 aria-label="Stop agent"
-                title="Stop agent"
+                disabled={state.agentChatCancelling}
+                title={state.agentChatCancelling ? "Stopping agent..." : "Stop agent"}
                 onClick={actions.cancelAgentChat}
                 style={{
                   position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
@@ -751,6 +752,11 @@ export function ChatView({ state, actions, onNavigate }: Props) {
               </button>
             )}
           </div>
+          {isAgentChat && state.agentChatCancelling && (
+            <div style={{ maxWidth: 820, margin: "6px auto 0", color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
+              Stopping external agent...
+            </div>
+          )}
           <div style={{ maxWidth: 820, margin: "3px auto 0", display: "flex", justifyContent: "flex-end" }}>
             <button type="button" onClick={toggleModEnterMode} style={{
               fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -32,6 +32,17 @@ type VisibleChatMessage = {
   duration_ms?: number;
 };
 
+type SidebarSession = {
+  id: string;
+  title?: string;
+  message_count: number;
+  provider_call_count: number;
+  last_provider?: string;
+  last_model?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
 export function ChatView({ state, actions, onNavigate }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [syspromptOpen, setSyspromptOpen] = useState(false);
@@ -42,6 +53,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
   const [atBottom, setAtBottom] = useState(true);
   const [workspaceEntryOpen, setWorkspaceEntryOpen] = useState(false);
   const [workspacePathValue, setWorkspacePathValue] = useState("");
+  const [sidebarQuery, setSidebarQuery] = useState("");
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";
   const [modEnterMode, setModEnterMode] = useState(
@@ -55,7 +67,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
   const userScrolledRef = useRef(false);
 
   const isAgentChat = state.chatTarget === "agent";
-  const sessions = isAgentChat
+  const sessions: SidebarSession[] = isAgentChat
     ? (state.agentChatSessions ?? []).map((s) => ({
         id: s.id,
         title: s.title,
@@ -67,6 +79,8 @@ export function ChatView({ state, actions, onNavigate }: Props) {
         updated_at: s.updated_at,
       }))
     : (state.chatSessions ?? []);
+  const filteredSessions = filterSidebarSessions(sessions, sidebarQuery);
+  const groupedSessions = groupSidebarSessions(filteredSessions);
   const activeSessionID = isAgentChat ? state.activeAgentChatSessionID : state.activeChatSessionID;
   const activeTitle = isAgentChat
     ? state.activeAgentChatSession?.title
@@ -176,7 +190,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
 
   function handleSidebarScroll() {
     const el = sidebarScrollRef.current;
-    if (isAgentChat || !el || !state.chatSessionsHasMore || state.chatSessionsLoadingMore) return;
+    if (isAgentChat || sidebarQuery.trim() || !el || !state.chatSessionsHasMore || state.chatSessionsLoadingMore) return;
     const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
     if (nearBottom) {
       void actions.loadMoreChatSessions();
@@ -261,72 +275,92 @@ export function ChatView({ state, actions, onNavigate }: Props) {
           <div style={{ padding: "8px 12px 4px", fontFamily: "var(--font-mono)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
             Chats
           </div>
+          <div style={{ padding: "4px 8px 8px" }}>
+            <input
+              aria-label="Search chats"
+              className="input"
+              onChange={(e) => setSidebarQuery(e.target.value)}
+              placeholder="Search chats"
+              style={{ height: 28, fontSize: 12, padding: "0 8px" }}
+              value={sidebarQuery}
+            />
+          </div>
           <div ref={sidebarScrollRef} onScroll={handleSidebarScroll} style={{ flex: 1, overflowY: "auto", padding: "2px 0 6px" }}>
             {sessions.length === 0 && (
               <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No chats yet</div>
             )}
-            {sessions.map(s => (
-              <div key={s.id}
-                onClick={() => {
-                  if (renamingId === s.id) return;
-                  void actions.selectChatSession(s.id);
-                  textareaRef.current?.focus();
-                }}
-                onMouseEnter={() => setHoveredChatId(s.id)}
-                onMouseLeave={() => setHoveredChatId(null)}
-                style={{
-                  padding: "8px 12px", cursor: "pointer",
-                  background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
-                  borderLeft: activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
-                  transition: "background 0.1s",
-                }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 2, height: 18 }}>
-                  {renamingId === s.id ? (
-                    <input
-                      autoFocus
-                      value={renameValue}
-                      onChange={e => setRenameValue(e.target.value)}
-                      onClick={e => e.stopPropagation()}
-                      onKeyDown={e => {
-                        if (e.key === "Enter") { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }
-                        if (e.key === "Escape") setRenamingId(null);
-                      }}
-                      onBlur={() => { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }}
-                      style={{ flex: 1, minWidth: 0, height: 18, boxSizing: "border-box", fontSize: 12, background: "var(--bg3)", border: "1px solid var(--teal)", borderRadius: "var(--radius-sm)", color: "var(--t0)", padding: "0 4px", outline: "none", fontFamily: "var(--font-sans)", lineHeight: "16px" }}
-                    />
-                  ) : (
-                    <>
-                      <div style={{ flex: 1, minWidth: 0, fontSize: 12, lineHeight: "18px", color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)", fontWeight: activeSessionID === s.id ? 500 : 400, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {s.title || "Untitled"}
-                      </div>
-                      <div style={{ display: "flex", gap: 1, opacity: hoveredChatId === s.id ? 1 : 0, transition: "opacity 0.15s", flexShrink: 0 }}>
-                        {!isAgentChat && (
-                          <button
-                            className="btn btn-ghost btn-sm"
-                            onClick={e => { e.stopPropagation(); setRenamingId(s.id); setRenameValue(s.title || ""); }}
-                            style={{ padding: "1px 3px" }}
-                            title="Rename"
-                          >
-                            <Icon d={Icons.edit} size={10} />
-                          </button>
-                        )}
-                        <button
-                          className="btn btn-ghost btn-sm"
-                          onClick={e => { e.stopPropagation(); void actions.deleteChatSession(s.id); }}
-                          style={{ padding: "1px 3px", color: "var(--red)" }}
-                          title="Delete"
-                        >
-                          <Icon d={Icons.trash} size={10} />
-                        </button>
-                      </div>
-                    </>
-                  )}
+            {sessions.length > 0 && filteredSessions.length === 0 && (
+              <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No matching chats</div>
+            )}
+            {groupedSessions.map((group) => (
+              <div key={group.label}>
+                <div style={{ padding: "8px 12px 3px", fontFamily: "var(--font-mono)", fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
+                  {group.label}
                 </div>
-                <div style={{ fontSize: 10, color: "var(--t3)", marginTop: 1, fontFamily: "var(--font-mono)" }}>
-                  {isAgentChat
-                    ? `${s.message_count} msg${s.last_provider ? ` · ${s.last_provider}` : ""}${s.last_model ? ` · ${s.last_model}` : ""}`
-                    : `${s.message_count} msg · ${s.provider_call_count} call${s.provider_call_count === 1 ? "" : "s"}${s.last_provider ? ` · ${s.last_provider}` : ""}`}
-                </div>
+                {group.sessions.map(s => (
+                  <div key={s.id}
+                    onClick={() => {
+                      if (renamingId === s.id) return;
+                      void actions.selectChatSession(s.id);
+                      textareaRef.current?.focus();
+                    }}
+                    onMouseEnter={() => setHoveredChatId(s.id)}
+                    onMouseLeave={() => setHoveredChatId(null)}
+                    style={{
+                      padding: "8px 12px", cursor: "pointer",
+                      background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
+                      borderLeft: activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
+                      transition: "background 0.1s",
+                    }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 2, height: 18 }}>
+                      {renamingId === s.id ? (
+                        <input
+                          autoFocus
+                          value={renameValue}
+                          onChange={e => setRenameValue(e.target.value)}
+                          onClick={e => e.stopPropagation()}
+                          onKeyDown={e => {
+                            if (e.key === "Enter") { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }
+                            if (e.key === "Escape") setRenamingId(null);
+                          }}
+                          onBlur={() => { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }}
+                          style={{ flex: 1, minWidth: 0, height: 18, boxSizing: "border-box", fontSize: 12, background: "var(--bg3)", border: "1px solid var(--teal)", borderRadius: "var(--radius-sm)", color: "var(--t0)", padding: "0 4px", outline: "none", fontFamily: "var(--font-sans)", lineHeight: "16px" }}
+                        />
+                      ) : (
+                        <>
+                          <div style={{ flex: 1, minWidth: 0, fontSize: 12, lineHeight: "18px", color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)", fontWeight: activeSessionID === s.id ? 500 : 400, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {s.title || "Untitled"}
+                          </div>
+                          <div style={{ display: "flex", gap: 1, opacity: hoveredChatId === s.id ? 1 : 0, transition: "opacity 0.15s", flexShrink: 0 }}>
+                            {!isAgentChat && (
+                              <button
+                                className="btn btn-ghost btn-sm"
+                                onClick={e => { e.stopPropagation(); setRenamingId(s.id); setRenameValue(s.title || ""); }}
+                                style={{ padding: "1px 3px" }}
+                                title="Rename"
+                              >
+                                <Icon d={Icons.edit} size={10} />
+                              </button>
+                            )}
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              onClick={e => { e.stopPropagation(); void actions.deleteChatSession(s.id); }}
+                              style={{ padding: "1px 3px", color: "var(--red)" }}
+                              title="Delete"
+                            >
+                              <Icon d={Icons.trash} size={10} />
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 10, color: "var(--t3)", marginTop: 1, fontFamily: "var(--font-mono)" }}>
+                      {isAgentChat
+                        ? `${s.message_count} msg${s.last_provider ? ` · ${s.last_provider}` : ""}${s.last_model ? ` · ${s.last_model}` : ""}`
+                        : `${s.message_count} msg · ${s.provider_call_count} call${s.provider_call_count === 1 ? "" : "s"}${s.last_provider ? ` · ${s.last_provider}` : ""}`}
+                    </div>
+                  </div>
+                ))}
               </div>
             ))}
             {!isAgentChat && state.chatSessionsLoadingMore && (
@@ -716,6 +750,45 @@ export function ChatView({ state, actions, onNavigate }: Props) {
       `}</style>
     </div>
   );
+}
+
+function filterSidebarSessions(sessions: SidebarSession[], query: string): SidebarSession[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return sessions;
+  return sessions.filter((session) => {
+    const searchable = [
+      session.title,
+      session.last_provider,
+      session.last_model,
+    ].filter(Boolean).join(" ").toLowerCase();
+    return searchable.includes(needle);
+  });
+}
+
+function groupSidebarSessions(sessions: SidebarSession[]): Array<{ label: string; sessions: SidebarSession[] }> {
+  const groups = new Map<string, SidebarSession[]>();
+  for (const session of sessions) {
+    const label = sidebarDateGroup(session.updated_at || session.created_at);
+    const group = groups.get(label) ?? [];
+    group.push(session);
+    groups.set(label, group);
+  }
+  return ["Today", "This week", "Older", "No date"]
+    .map((label) => ({ label, sessions: groups.get(label) ?? [] }))
+    .filter((group) => group.sessions.length > 0);
+}
+
+function sidebarDateGroup(value?: string): string {
+  if (!value) return "No date";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "No date";
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const chatDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const ageDays = Math.floor((today.getTime() - chatDay.getTime()) / 86_400_000);
+  if (ageDays <= 0) return "Today";
+  if (ageDays < 7) return "This week";
+  return "Older";
 }
 
 function ChatErrorPanel({

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -346,7 +346,7 @@ export function ChatView({ state, actions, onNavigate }: Props) {
             </button>
           )}
           <div style={{ display: "flex", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", overflow: "hidden", flexShrink: 0 }}>
-            {(["model", "agent"] as const).map((target) => (
+            {(["agent", "model"] as const).map((target) => (
               <button
                 key={target}
                 className="btn btn-ghost btn-sm"

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1231,6 +1231,64 @@ function Markdown({ content }: { content: string }) {
             </ol>
           );
         }
+        if (block.type === "task") {
+          return (
+            <ul key={i} style={{ display: "grid", gap: 4, listStyle: "none", margin: "6px 0", padding: 0 }}>
+              {block.tasks!.map((task, j) => (
+                <li key={j} style={{ alignItems: "flex-start", display: "flex", gap: 8 }}>
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      alignItems: "center",
+                      background: task.checked ? "var(--teal-soft)" : "var(--bg3)",
+                      border: `1px solid ${task.checked ? "var(--teal-border)" : "var(--border)"}`,
+                      borderRadius: 4,
+                      color: task.checked ? "var(--teal)" : "transparent",
+                      display: "inline-flex",
+                      flex: "0 0 auto",
+                      fontSize: 10,
+                      height: 14,
+                      justifyContent: "center",
+                      marginTop: 4,
+                      width: 14,
+                    }}
+                  >
+                    x
+                  </span>
+                  <span>{renderInline(task.text)}</span>
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        if (block.type === "table") {
+          return (
+            <div key={i} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", margin: "8px 0", overflowX: "auto" }}>
+              <table style={{ borderCollapse: "collapse", minWidth: "100%", fontSize: 12 }}>
+                <thead>
+                  <tr>
+                    {block.table!.headers.map((header, j) => (
+                      <th key={j} style={{ background: "var(--bg3)", borderBottom: "1px solid var(--border)", color: "var(--t1)", fontWeight: 600, padding: "6px 8px", textAlign: "left", whiteSpace: "nowrap" }}>
+                        {renderInline(header)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {block.table!.rows.map((row, j) => (
+                    <tr key={j}>
+                      {block.table!.headers.map((_, k) => (
+                        <td key={k} style={{ borderTop: j === 0 ? "none" : "1px solid var(--border)", color: "var(--t0)", padding: "6px 8px", verticalAlign: "top" }}>
+                          {renderInline(row[k] ?? "")}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          );
+        }
         if (block.type === "hr") {
           return <hr key={i} style={{ border: "none", borderTop: "1px solid var(--border)", margin: "10px 0" }} />;
         }

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1170,10 +1170,15 @@ function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActiv
   if (visible.length === 0) return null;
   const terminal = terminalAgentActivity(activities);
   const hasRunning = !terminal && activities.some(activity => activity.status === "running");
-  const lifecycle = visible.find(activity => activity.type === "resumed" || activity.type === "started");
+  const lifecycle = activities.find(activity => activity.type === "resumed" || activity.type === "started");
+  const plan = visible.filter(activity => activity.type === "plan");
+  const tools = visible.filter(activity => activity.type === "tool_call");
+  const other = visible.filter(activity => activity.type !== "plan" && activity.type !== "tool_call");
   const summary = [
     terminal ? `run ${terminal.status}` : hasRunning ? "run running" : "run details",
     lifecycle?.type === "resumed" ? "session resumed" : lifecycle?.type === "started" ? "session started" : "",
+    plan.length > 0 ? `${plan.filter(item => item.status === "completed").length}/${plan.length} plan` : "",
+    tools.length > 0 ? `${tools.length} tool${tools.length === 1 ? "" : "s"}` : "",
     diffStat ? "files changed" : "",
   ].filter(Boolean).join(" · ");
 
@@ -1191,27 +1196,72 @@ function ActivityTimeline({ activities, diffStat }: { activities: AgentChatActiv
         borderRadius: "var(--radius-sm)",
         background: "var(--bg2)",
       }}>
-        {visible.map((activity, index) => (
-          <div key={`${activity.type}-${activity.created_at ?? index}`} style={{ display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
-            <span style={{
-              width: 7,
-              height: 7,
-              borderRadius: 999,
-              background: activityStatusColor(activity.status),
-              flexShrink: 0,
-            }} />
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t1)", whiteSpace: "nowrap" }}>
-              {activity.title}
-            </span>
-            {activity.detail && (
-              <span style={{ fontSize: 11, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {activity.detail}
-              </span>
-            )}
-          </div>
+        {plan.length > 0 && <PlanActivityList items={plan} />}
+        {tools.length > 0 && <ToolActivityList items={tools} />}
+        {other.map((activity, index) => (
+          <ActivityLine key={activity.id || `${activity.type}-${activity.created_at ?? index}`} activity={activity} />
         ))}
       </div>
     </details>
+  );
+}
+
+function PlanActivityList({ items }: { items: AgentChatActivityRecord[] }) {
+  return (
+    <div style={{ display: "grid", gap: 5 }}>
+      {items.map((activity, index) => (
+        <div key={activity.id || `${activity.title}-${index}`} style={{ display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
+          <span style={{ color: activity.status === "completed" ? "var(--green)" : activity.status === "in_progress" ? "var(--teal)" : "var(--t3)", flexShrink: 0, fontFamily: "var(--font-mono)", fontSize: 11 }}>
+            {activity.status === "completed" ? "x" : activity.status === "in_progress" ? ">" : "-"}
+          </span>
+          <span style={{ color: "var(--t1)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {activity.title}
+          </span>
+          {activity.kind && (
+            <span style={{ color: "var(--t3)", flexShrink: 0, fontFamily: "var(--font-mono)", fontSize: 10 }}>
+              {activity.kind}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ToolActivityList({ items }: { items: AgentChatActivityRecord[] }) {
+  return (
+    <div style={{ display: "grid", gap: 5 }}>
+      {items.map((activity, index) => (
+        <ActivityLine key={activity.id || `${activity.type}-${activity.created_at ?? index}`} activity={activity} prefix={activity.kind || "tool"} />
+      ))}
+    </div>
+  );
+}
+
+function ActivityLine({ activity, prefix }: { activity: AgentChatActivityRecord; prefix?: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
+      <span style={{
+        width: 7,
+        height: 7,
+        borderRadius: 999,
+        background: activityStatusColor(activity.status),
+        flexShrink: 0,
+      }} />
+      {prefix && (
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", whiteSpace: "nowrap" }}>
+          {prefix}
+        </span>
+      )}
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t1)", whiteSpace: "nowrap" }}>
+        {activity.title}
+      </span>
+      {activity.detail && (
+        <span style={{ fontSize: 11, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {activity.detail}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -368,10 +368,10 @@ export function ChatView({ state, actions, onNavigate }: Props) {
             {!isAgentChat && state.chatSessionsLoadingMore && (
               <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--t3)", textAlign: "center" }}>Loading chats…</div>
             )}
-            {!isAgentChat && !sidebarQuery.trim() && state.chatSessionsHasMore && !state.chatSessionsLoadingMore && (
+            {!isAgentChat && state.chatSessionsHasMore && !state.chatSessionsLoadingMore && (
               <div style={{ padding: "8px 12px" }}>
                 <button className="btn btn-ghost btn-sm" onClick={() => void actions.loadMoreChatSessions()} style={{ width: "100%", justifyContent: "center" }} type="button">
-                  Load earlier chats
+                  {sidebarQuery.trim() ? "Search earlier chats" : "Load earlier chats"}
                 </button>
               </div>
             )}
@@ -1492,7 +1492,8 @@ function Markdown({ content }: { content: string }) {
               {block.tasks!.map((task, j) => (
                 <li key={j} style={{ alignItems: "flex-start", display: "flex", gap: 8 }}>
                   <span
-                    aria-hidden="true"
+                    aria-label={task.checked ? "Completed task" : "Incomplete task"}
+                    role="img"
                     style={{
                       alignItems: "center",
                       background: task.checked ? "var(--teal-soft)" : "var(--bg3)",

--- a/ui/src/lib/markdown.test.ts
+++ b/ui/src/lib/markdown.test.ts
@@ -38,6 +38,34 @@ describe("parseMarkdownBlocks", () => {
     expect(blocks).toEqual([{ type: "ol", text: "", items: ["first", "second"] }]);
   });
 
+  it("parses task list items", () => {
+    const blocks = parseMarkdownBlocks("- [x] done\n- [ ] todo\n* [X] shipped");
+    expect(blocks).toEqual([{
+      type: "task",
+      text: "",
+      tasks: [
+        { checked: true, text: "done" },
+        { checked: false, text: "todo" },
+        { checked: true, text: "shipped" },
+      ],
+    }]);
+  });
+
+  it("parses pipe tables", () => {
+    const blocks = parseMarkdownBlocks("| File | Status |\n| --- | --- |\n| README.md | updated |\n| docs.md | skipped |");
+    expect(blocks).toEqual([{
+      type: "table",
+      text: "",
+      table: {
+        headers: ["File", "Status"],
+        rows: [
+          ["README.md", "updated"],
+          ["docs.md", "skipped"],
+        ],
+      },
+    }]);
+  });
+
   it("parses horizontal rule", () => {
     expect(parseMarkdownBlocks("---")).toEqual([{ type: "hr", text: "" }]);
     expect(parseMarkdownBlocks("***")).toEqual([{ type: "hr", text: "" }]);
@@ -62,6 +90,14 @@ describe("parseMarkdownBlocks", () => {
     expect(blocks).toHaveLength(2);
     expect(blocks[0]).toEqual({ type: "p", text: "intro" });
     expect(blocks[1]).toEqual({ type: "code", text: "code", lang: "ts" });
+  });
+
+  it("stops paragraph accumulation at a task list and table", () => {
+    const blocks = parseMarkdownBlocks("intro\n- [ ] todo\n\n| A | B |\n| --- | --- |\n| one | two |");
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toEqual({ type: "p", text: "intro" });
+    expect(blocks[1].type).toBe("task");
+    expect(blocks[2].type).toBe("table");
   });
 });
 

--- a/ui/src/lib/markdown.test.ts
+++ b/ui/src/lib/markdown.test.ts
@@ -66,6 +66,14 @@ describe("parseMarkdownBlocks", () => {
     }]);
   });
 
+  it("does not treat a bare horizontal rule as a table separator", () => {
+    const blocks = parseMarkdownBlocks("a | b\n---");
+    expect(blocks).toEqual([
+      { type: "p", text: "a | b" },
+      { type: "hr", text: "" },
+    ]);
+  });
+
   it("parses horizontal rule", () => {
     expect(parseMarkdownBlocks("---")).toEqual([{ type: "hr", text: "" }]);
     expect(parseMarkdownBlocks("***")).toEqual([{ type: "hr", text: "" }]);

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -1,9 +1,11 @@
 export type Block = {
-  type: "code" | "heading" | "ul" | "ol" | "hr" | "p";
+  type: "code" | "heading" | "ul" | "ol" | "task" | "table" | "hr" | "p";
   text: string;
   lang?: string;
   level?: number;
   items?: string[];
+  tasks?: Array<{ checked: boolean; text: string }>;
+  table?: { headers: string[]; rows: string[][] };
 };
 
 export type InlineNode =
@@ -48,6 +50,29 @@ export function parseMarkdownBlocks(content: string): Block[] {
       continue;
     }
 
+    if (isTableStart(lines, i)) {
+      const headers = splitTableRow(lines[i]);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && isTableRow(lines[i])) {
+        rows.push(splitTableRow(lines[i]));
+        i++;
+      }
+      blocks.push({ type: "table", text: "", table: { headers, rows } });
+      continue;
+    }
+
+    if (/^[-*] \[[ xX]\] /.test(line)) {
+      const tasks: Array<{ checked: boolean; text: string }> = [];
+      while (i < lines.length && /^[-*] \[[ xX]\] /.test(lines[i])) {
+        const match = /^[-*] \[([ xX])\] (.*)/.exec(lines[i]);
+        if (match) tasks.push({ checked: match[1].toLowerCase() === "x", text: match[2] });
+        i++;
+      }
+      blocks.push({ type: "task", text: "", tasks });
+      continue;
+    }
+
     if (/^[-*] /.test(line)) {
       const items: string[] = [];
       while (i < lines.length && /^[-*] /.test(lines[i])) {
@@ -79,6 +104,8 @@ export function parseMarkdownBlocks(content: string): Block[] {
       lines[i].trim() !== "" &&
       !/^```/.test(lines[i]) &&
       !/^#{1,3} /.test(lines[i]) &&
+      !isTableStart(lines, i) &&
+      !/^[-*] \[[ xX]\] /.test(lines[i]) &&
       !/^[-*] /.test(lines[i]) &&
       !/^\d+\. /.test(lines[i])
     ) {
@@ -89,6 +116,28 @@ export function parseMarkdownBlocks(content: string): Block[] {
   }
 
   return blocks;
+}
+
+function isTableStart(lines: string[], index: number): boolean {
+  return isTableRow(lines[index]) && isTableSeparator(lines[index + 1] ?? "");
+}
+
+function isTableRow(line: string): boolean {
+  return line.includes("|") && line.trim().replace(/\|/g, "").trim() !== "";
+}
+
+function isTableSeparator(line: string): boolean {
+  const cells = splitTableRow(line);
+  return cells.length > 0 && cells.every(cell => /^:?-{3,}:?$/.test(cell.trim()));
+}
+
+function splitTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map(cell => cell.trim());
 }
 
 export function parseInlineNodes(text: string): InlineNode[] {

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -104,6 +104,7 @@ export function parseMarkdownBlocks(content: string): Block[] {
       lines[i].trim() !== "" &&
       !/^```/.test(lines[i]) &&
       !/^#{1,3} /.test(lines[i]) &&
+      !/^(-{3,}|\*{3,}|_{3,})$/.test(lines[i].trim()) &&
       !isTableStart(lines, i) &&
       !/^[-*] \[[ xX]\] /.test(lines[i]) &&
       !/^[-*] /.test(lines[i]) &&
@@ -127,6 +128,7 @@ function isTableRow(line: string): boolean {
 }
 
 function isTableSeparator(line: string): boolean {
+  if (!line.includes("|")) return false;
   const cells = splitTableRow(line);
   return cells.length > 0 && cells.every(cell => /^:?-{3,}:?$/.test(cell.trim()));
 }

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -15,6 +15,7 @@ export function createRuntimeConsoleFixture(
     activeChatSessionID: "",
     agentAdapterID: "codex",
     agentAdapters: [],
+    agentChatCancelling: false,
     agentChatSessions: [],
     agentWorkspace: "",
     agentWorkspaceBranch: "",

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -24,7 +24,7 @@ export function createRuntimeConsoleFixture(
     chatLoading: false,
     streamingContent: null,
     chatResult: null,
-    chatTarget: "model",
+    chatTarget: "agent",
     pendingToolCalls: [],
     chatSessions: [],
     cloudModels: [],

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -242,8 +242,10 @@ export type AgentChatUsageRecord = {
 };
 
 export type AgentChatActivityRecord = {
+  id?: string;
   type: string;
   status?: string;
+  kind?: string;
   title: string;
   detail?: string;
   created_at?: string;


### PR DESCRIPTION
## Summary

- Show short ACP narration such as "I'll inspect..." as live assistant text while an agent run is active.
- Clear transient pre-tool narration once tool activity or real answer output begins so it does not leak into the final transcript.
- Render git diffstat as structured rows inside the files-changed disclosure instead of collapsing long file lists into one summary line.
- Tighten agent activity wording from labels like `run running` to simpler `running` / `completed` / `failed`.

## Validation

- `cd ui && bun run typecheck`
- `cd ui && bun run test -- ChatView.test.tsx`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
