### PR TITLE
fix(security): harden workspace provisioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@ Open-source AI gateway and agent-task runtime. The gateway mediates
 OpenAI- and Anthropic-shaped client traffic to upstream providers, runs
 queued `agent_loop` tasks behind policy and approval gates, and emits
 OpenTelemetry traces. Gateway-local, deny-by-default, storage-tiered
-(memory / sqlite). Binds to 127.0.0.1 by default; no built-in auth
-layer. The React operator UI is embedded via `//go:embed ui/dist`.
+(memory / sqlite). Binds to 127.0.0.1 by default and is intended to run as
+a local operator console. The React operator UI is embedded via
+`//go:embed ui/dist`.
 
 This file is the orientation entry — the codebase map, the runtime
 invariants, and the gotchas that bite often. It is what an agent
@@ -67,7 +68,7 @@ internal/
   retention/            retention worker (subsystems: traces, budget, audit, provider_history, turn_events)
   mcp/                  stdio MCP server (read tools + write tools)
   controlplane/         providers, pricing, settings (admin surface state)
-  auth/                 local operator principal / no-auth request context
+  auth/                 local operator principal request context
   ratelimit/            per-key request limits
   requestscope/         per-request principal + tracing context
   config/, bootstrap/   env-driven config + startup wiring
@@ -96,7 +97,7 @@ When adding a new persisted thing, mirror both.
 Non-negotiable rules of the system. Read them before writing code that
 touches request handling, persistence, or tool execution.
 
-- **No auth layer.** Every request is processed as the operator. The gateway binds to `127.0.0.1` by default; bind elsewhere only behind a reverse proxy or firewall.
+- **Local operator boundary.** Every request is processed as the operator. The gateway binds to `127.0.0.1` by default; bind elsewhere only behind a reverse proxy, firewall, or equivalent access control.
 - **Sandbox is per-call subprocess, applied inline.** Shell, file, and git tool calls spawn a fresh `sh` from inside the gateway after policy validation + env sanitisation + output cap + wall-clock timeout. On Linux with `bwrap` installed and on macOS, the call is additionally wrapped by `bwrap` / `sandbox-exec` for filesystem and network confinement (auto-detected at startup). No separate sandbox daemon, no per-call rlimits (those would shrink the long-running gateway). New tools follow the same pattern.
 - **Approvals are blocking.** Pre-execution and mid-loop approvals halt the run; the run record persists in `awaiting_approval` until resolved. New gates use the `TaskApproval` shape.
 - **Events are appended, not mutated.** Every state transition writes a `run_event` with a monotonic sequence. The SSE stream replays from `after_sequence`. New event types must follow the event-protocol v1 taxonomy (`run.*`, `turn.*`, `tool.*`, `policy.*`, `gap.*`, `error.*`) and be documented in `docs/events.md`.
@@ -159,6 +160,7 @@ Full ladder: [`docs-ai/core/verification.md`](docs-ai/core/verification.md).
 | [`docs/runtime-api.md`](docs/runtime-api.md) | Task / run / step / approval endpoints, queue + lease |
 | [`docs/events.md`](docs/events.md) | Every event type at `/v1/events` with payload shapes |
 | [`docs/telemetry.md`](docs/telemetry.md) | OTel spans + metrics, OTLP wiring, status & gaps |
+| [`docs/security.md`](docs/security.md) | Local-first threat model, workspace safety, approvals, secrets, advisories |
 | [`docs/providers.md`](docs/providers.md) | Provider catalog, configuration |
 | [`docs/mcp.md`](docs/mcp.md) | MCP server: tools, transport, configure |
 | [`docs/external-agent-adapters.md`](docs/external-agent-adapters.md) | Hecate as an ACP client/operator: Chats runs Codex, Claude Code, and Cursor Agent |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker run --rm -p 127.0.0.1:8765:8765 -v hecate-data:/data \
 
 Open `http://127.0.0.1:8765`. The UI loads with no further setup.
 
-> The container intentionally publishes only on `127.0.0.1`. Hecate has no built-in auth layer; same-origin checks protect browser traffic, but they are not a network security boundary. Do not expose it to the network without your own auth, firewall, or reverse proxy in front.
+> The container intentionally publishes only on `127.0.0.1`. Hecate is designed as a local-first operator console, not as a directly exposed network service. If you bind it beyond loopback, put your own access controls, firewall, or reverse proxy in front. See [Security](docs/security.md) for the current threat model.
 
 Pinned image tags, binary tarballs (linux/darwin × amd64/arm64), checksums, compose examples, and storage notes live in [`docs/deployment.md`](docs/deployment.md). Local development setup lives in [`docs/development.md`](docs/development.md).
 
@@ -231,6 +231,7 @@ Full index lives at [`docs/README.md`](docs/README.md), organized by reader role
 **Observability and internals**
 
 - [Telemetry](docs/telemetry.md) — OTLP traces / metrics / logs, response headers, local trace view.
+- [Security](docs/security.md) — local-first threat model, workspace safety, approvals, secrets, and advisory handling.
 - [Architecture](docs/architecture.md) — gateway request flow, task-runtime queue / lease / sandbox boundary.
 - [Development](docs/development.md) — source-build toolchain, local dev, the test ladder, screenshot tooling.
 - [Release](docs/release.md) — cutting a tag, verification gate, recovery if CI fails.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Pick the path closest to what you are doing.
 
 | You are... | Read in this order |
 |---|---|
-| Running Hecate locally | [Desktop app](desktop-app.md), [Deployment](deployment.md), [Providers](providers.md), [Chat sessions](chat-sessions.md), [Known limitations](known-limitations.md) |
+| Running Hecate locally | [Desktop app](desktop-app.md), [Deployment](deployment.md), [Security](security.md), [Providers](providers.md), [Chat sessions](chat-sessions.md), [Known limitations](known-limitations.md) |
 | Calling Hecate from a client | [Runtime API](runtime-api.md), [Chat sessions](chat-sessions.md), [Agent runtime](agent-runtime.md), [Events](events.md) |
 | Building or using coding-agent integrations | [External agent adapters](external-agent-adapters.md), [ACP bridge](acp.md), [Runtime API](runtime-api.md), [Events](events.md), [MCP integration](mcp.md) |
 | Changing the codebase | [Architecture](architecture.md), [Development](development.md), [`docs-ai/`](../docs-ai/README.md), [Release](release.md) |
@@ -22,6 +22,7 @@ Pick the path closest to what you are doing.
 |---|---|
 | [Deployment](deployment.md) | Docker, binary install, image pinning, storage backends, rate limits, lost-token recovery. |
 | [Desktop app](desktop-app.md) | Native bundles, first-launch warnings, platform data dirs, sidecar lifecycle, roadmap. |
+| [Security](security.md) | Local-first threat model, runtime boundaries, workspace safety, approvals, secrets, and advisory handling. |
 | [Providers](providers.md) | Built-in provider presets, OpenAI-compatible custom endpoints, credentials, model discovery, health, circuit breaking. |
 | [Chat sessions](chat-sessions.md) | Hecate Chat transcript segments, tools on/off behavior, task-backed turns, queued prompts, approvals in Chats, and shared activity rendering. |
 | [Known limitations](known-limitations.md) | The honest alpha boundary: API/schema stability, sandbox limits, desktop gaps, deployment scope. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ flowchart TD
 
 Key invariants:
 
-- **No built-in auth.** Hecate defaults to `127.0.0.1:8765` and rejects cross-origin browser requests. That same-origin check is browser protection, not a network security boundary. If you bind the gateway beyond the local machine, put your own auth, firewall, or reverse proxy in front.
+- **Local operator boundary.** Hecate defaults to `127.0.0.1:8765` and rejects cross-origin browser requests. That same-origin check is browser protection, not a network security boundary. If you bind the gateway beyond the local machine, put your own access controls, firewall, or reverse proxy in front.
 - **Policy/budget can deny without an upstream call.** A budget-exceeded request returns `402` with the gateway's own body — no provider tokens are spent.
 - **Cost calculation is deterministic.** Pricebook is read after the provider returns usage; the same `(provider, model, usage)` tuple always produces the same cost in micros USD.
 - **CheckRoute is read-not-reservation.** Two concurrent requests can both pass when balance covers each individually but not their sum — the budget can briefly go negative under contention. Pinned in [tests](../internal/governor/governor_test.go) so a "fix" doesn't silently introduce write contention.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 The [Quick Start](../README.md#quick-start) covers `docker run` end-to-end. This page is the reference for everything past the first run: pinning images, the compose profile, the binary install, storage tiers, and rate limits.
 
-Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests; there is no built-in auth layer. If you change `GATEWAY_ADDRESS` to expose Hecate beyond the local machine, put your own auth, firewall, or reverse proxy in front.
+Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests, but same-origin is not a network security boundary. If you change `GATEWAY_ADDRESS` to expose Hecate beyond the local machine, put your own access controls, firewall, or reverse proxy in front. The current security model is documented in [Security](security.md).
 
 ## Contents
 

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -183,6 +183,8 @@ environment passed to the ACP adapter process, applies timeout/cancel behavior,
 captures ACP updates with an output cap, and records Git diff / diff stat after
 each turn. External agent adapters are still trusted subprocesses in the
 selected workspace; this is not equivalent to the task runtime sandbox.
+Read [Security](security.md) for the full runtime-boundary and workspace-safety
+model.
 
 On Hecate shutdown, active Agent Chat turns are cancelled first. Hecate waits
 briefly for the ACP turn to drain, asks the native ACP session to close, and

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -8,9 +8,10 @@ operators should not assume yet.
 - Public APIs are designed to be stable, but pre-1.0 changes are still possible.
 - Persisted SQLite schemas are young. Back up data before upgrading.
 - There is not yet a dedicated migration CLI or rollback workflow.
-- The gateway defaults to `127.0.0.1:8765`, enforces same-origin browser
-  requests, and has no built-in auth layer. If you bind it beyond the local
-  machine, bring your own auth, firewall, or reverse proxy.
+- The gateway defaults to `127.0.0.1:8765` and enforces same-origin browser
+  requests, but same-origin is not a network security boundary. If you bind it
+  beyond the local machine, bring your own access controls, firewall, or reverse
+  proxy. The practical threat model lives in [Security](security.md).
 
 ## Provider Lifecycle
 

--- a/docs/rfcs/external-adapter-approvals-v1.md
+++ b/docs/rfcs/external-adapter-approvals-v1.md
@@ -199,8 +199,9 @@ the action." The adapter is free to retry the action on the next prompt.
 ## API surface
 
 All endpoints are served by the gateway and covered by Hecate's existing access
-model: loopback by default, same-origin checks for browser requests, and no
-built-in auth boundary if the operator binds the gateway elsewhere.
+model: loopback by default and same-origin checks for browser requests. If the
+operator binds the gateway elsewhere, they must provide the network access
+controls around it.
 
 ### Pending list
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,88 @@
+# Security
+
+Hecate is local-first, single-operator software. This page documents the security model that exists today, what Hecate tries to protect, and what remains the operator's responsibility.
+
+## Threat model
+
+Hecate assumes the operator trusts their own machine, local user account, and selected workspaces.
+
+- The gateway binds to `127.0.0.1:8765` by default.
+- Browser requests are same-origin checked, but same-origin is not a network security boundary.
+- Hecate is not designed to be exposed directly on a network.
+- If you bind Hecate to anything other than loopback, put your own firewall, reverse proxy, or access-control layer in front.
+- Do not run Hecate on a shared host where untrusted local users can access the gateway port or data directory.
+
+## Runtime boundaries
+
+Hecate has two different execution surfaces with different trust levels.
+
+| Surface | Boundary |
+|---|---|
+| Hecate Chat with tools on / native `agent_loop` tasks | Hecate owns the task loop. Tool calls run as per-call subprocesses with env sanitisation, output caps, timeouts, policy checks, approvals, and `bwrap` / `sandbox-exec` wrappers where available. This is not a VM or container boundary. |
+| External Agent adapters | Codex, Claude Code, Cursor Agent, and similar adapters run as trusted local subprocesses in the selected workspace. Hecate supervises lifecycle, approvals, diagnostics, and Git diffs, but it does not sandbox the adapter's internal runtime. |
+
+If you need a hard isolation boundary, run Hecate and its workspaces inside a VM, container, or dedicated OS user that you are comfortable letting tools modify.
+
+## Workspaces
+
+Hecate supports isolated generated workspaces and opt-in in-place workspaces.
+
+- Isolated native task runs create workspaces under a Hecate-managed root from validated task/run IDs.
+- In isolated mode, when the task source is a Git repository, Hecate clones it with `git clone --no-hardlinks -- <source> <workspace>`.
+- In isolated mode, when the task source is a plain directory, Hecate copies it into the generated workspace.
+- Generated workspace paths reject traversal and existing symlink components before Hecate creates files.
+- Operator-selected source directories are canonicalized. Symlinked source repos/folders are allowed by design, because operators may intentionally select them.
+- `workspace_mode=in_place` skips clone/copy and runs tools directly in the selected source directory. Treat it as destructive.
+- Adding or selecting a workspace in the UI does not clone it. Clone/copy happens only when a native task run provisions an isolated workspace.
+
+Git is used for workspace setup and change review, not as a security boundary. Hecate also uses Git status/diff information to show branch state, changed files, and revertable workspace changes.
+
+## Approvals
+
+Approvals are safety gates, not a sandbox.
+
+- Native task approvals block the run until the operator approves or rejects.
+- External-agent approvals are prompt-first by default when the adapter asks for permission.
+- Durable external-agent grants can be reviewed and revoked from Settings.
+- Auto-approval modes are dangerous for interactive use because they let tool requests proceed without operator review.
+
+Review broad grants carefully, especially workspace-wide or adapter-wide grants for file writes, shell commands, Git commands, and network access.
+
+## Secrets and local state
+
+Hecate stores local configuration and operational state on disk.
+
+- Provider credentials and settings are local to the gateway data directory / desktop app data directory.
+- Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
+- External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own those accounts.
+- If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach the gateway may be able to spend those credentials.
+
+## Native app and sidecars
+
+The desktop app is a Tauri shell around the same Hecate gateway binary.
+
+- The app launches `hecate` as a sidecar on a free loopback port.
+- The app bundle also ships `hecate-acp` for editor ACP integrations.
+- Bundles are not yet code-signed, so macOS Gatekeeper and Windows SmartScreen warnings are expected for now.
+- Quitting the app should stop the sidecar; closing a window may not quit the app on every platform.
+
+## Dependency and advisory handling
+
+Hecate uses GitHub Dependabot and CodeQL to catch dependency and code-scanning issues.
+
+- Fixable advisories should be handled by updating dependencies or hardening the relevant code path.
+- Some transitive advisories can be upstream-blocked. For example, the current Tauri Linux stack still depends on `gtk ^0.18`, which requires `glib ^0.18`; `glib >=0.20` cannot be forced safely until the Tauri/GTK stack moves.
+- Upstream-blocked alerts should be documented in the relevant PR or release notes, then revisited when upstream releases a compatible fix.
+
+## Operator checklist
+
+- Keep the default loopback bind unless you add your own network protection.
+- Use trusted workspaces, especially for in-place mode and External Agent sessions.
+- Prefer prompt-mode approvals for interactive use.
+- Revoke durable grants you no longer need.
+- Keep Hecate, the desktop app, and external agent CLIs updated.
+- Run high-risk workflows under a dedicated OS user, VM, or container.
+
+## Reporting vulnerabilities
+
+If GitHub private vulnerability reporting is enabled for the repository, use it. Otherwise, open a minimal public issue that asks for a private security contact and avoid posting exploit details publicly.

--- a/internal/orchestrator/workspace.go
+++ b/internal/orchestrator/workspace.go
@@ -21,6 +21,10 @@ func NewWorkspaceManager(root string) *WorkspaceManager {
 	if strings.TrimSpace(root) == "" {
 		root = filepath.Join(os.TempDir(), "hecate-workspaces")
 	}
+	root = filepath.Clean(root)
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
 	return &WorkspaceManager{root: root}
 }
 
@@ -43,11 +47,30 @@ func (m *WorkspaceManager) Provision(ctx context.Context, task types.Task, run t
 		}
 		return source.path, nil
 	}
-	workspacePath := filepath.Join(m.root, task.ID, run.ID)
+	workspacePath, err := m.workspacePath(task.ID, run.ID)
+	if err != nil {
+		return "", err
+	}
 	if err := provisionWorkspaceSource(ctx, workspacePath, source); err != nil {
 		return "", err
 	}
 	return workspacePath, nil
+}
+
+func (m *WorkspaceManager) workspacePath(taskID, runID string) (string, error) {
+	root, err := canonicalWorkspaceRoot(m.root)
+	if err != nil {
+		return "", err
+	}
+	taskSegment, err := workspacePathSegment("task id", taskID)
+	if err != nil {
+		return "", err
+	}
+	runSegment, err := workspacePathSegment("run id", runID)
+	if err != nil {
+		return "", err
+	}
+	return safeJoinWithinRoot(root, filepath.Join(taskSegment, runSegment))
 }
 
 type workspaceSourceSpec struct {
@@ -57,12 +80,8 @@ type workspaceSourceSpec struct {
 
 func workspaceSource(task types.Task) workspaceSourceSpec {
 	for _, candidate := range []string{task.WorkingDirectory, task.Repo} {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || !filepath.IsAbs(candidate) {
-			continue
-		}
-		info, err := os.Stat(candidate)
-		if err != nil || !info.IsDir() {
+		candidate, ok := canonicalWorkspaceDir(candidate)
+		if !ok {
 			continue
 		}
 		if isGitRepository(candidate) {
@@ -88,7 +107,7 @@ func provisionGitWorkspace(ctx context.Context, sourcePath, workspacePath string
 	if err := ensureWorkspaceParent(workspacePath); err != nil {
 		return err
 	}
-	if output, err := exec.CommandContext(ctx, "git", "clone", "--quiet", "--no-hardlinks", sourcePath, workspacePath).CombinedOutput(); err != nil {
+	if output, err := exec.CommandContext(ctx, "git", "clone", "--quiet", "--no-hardlinks", "--", sourcePath, workspacePath).CombinedOutput(); err != nil {
 		return fmt.Errorf("clone workspace: %w: %s", err, string(output))
 	}
 	return nil
@@ -110,7 +129,11 @@ func ensureWorkspaceRoot(workspacePath string) error {
 }
 
 func isGitRepository(path string) bool {
-	info, err := os.Stat(filepath.Join(path, ".git"))
+	gitDir, err := safeJoinWithinRoot(path, ".git")
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(gitDir)
 	return err == nil && info.IsDir()
 }
 
@@ -127,7 +150,10 @@ func copyDirectory(sourcePath, destinationPath string) error {
 		if err != nil {
 			return err
 		}
-		targetPath := filepath.Join(destinationPath, relativePath)
+		targetPath, err := safeJoinWithinRoot(destinationPath, relativePath)
+		if err != nil {
+			return err
+		}
 
 		info, err := entry.Info()
 		if err != nil {
@@ -149,6 +175,109 @@ func copyDirectory(sourcePath, destinationPath string) error {
 		}
 		return copyFile(path, targetPath, info.Mode())
 	})
+}
+
+func canonicalWorkspaceDir(candidate string) (string, bool) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || !filepath.IsAbs(candidate) {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(candidate))
+	if err != nil {
+		return "", false
+	}
+	root, err := os.OpenRoot(resolved)
+	if err != nil {
+		return "", false
+	}
+	defer root.Close()
+	info, err := root.Stat(".")
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return resolved, true
+}
+
+func canonicalWorkspaceRoot(root string) (string, error) {
+	root = filepath.Clean(root)
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("workspace root %q resolves to a symlink", root)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace root %q is not a directory", root)
+	}
+	return resolved, nil
+}
+
+func workspacePathSegment(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("invalid workspace %s: empty path segment", field)
+	}
+	if value == "." || value == ".." || strings.ContainsAny(value, `/\`) || value != filepath.Base(value) || !filepath.IsLocal(value) {
+		return "", fmt.Errorf("invalid workspace %s %q: must be a single local path segment", field, value)
+	}
+	return value, nil
+}
+
+func safeJoinWithinRoot(root, relativePath string) (string, error) {
+	if !filepath.IsLocal(relativePath) {
+		return "", fmt.Errorf("unsafe relative workspace path %q", relativePath)
+	}
+	root = filepath.Clean(root)
+	target := filepath.Clean(filepath.Join(root, relativePath))
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("workspace path escapes root: %q", relativePath)
+	}
+	if err := rejectExistingSymlinkComponents(root, rel); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func rejectExistingSymlinkComponents(root, relativePath string) error {
+	rootDir, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer rootDir.Close()
+
+	current := "."
+	for _, segment := range strings.Split(relativePath, string(os.PathSeparator)) {
+		if segment == "" || segment == "." {
+			continue
+		}
+		current = filepath.Join(current, segment)
+		info, err := rootDir.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("workspace path uses symlink component %q", filepath.Join(root, current))
+		}
+	}
+	return nil
 }
 
 func copyFile(sourcePath, destinationPath string, mode fs.FileMode) error {

--- a/internal/orchestrator/workspace_test.go
+++ b/internal/orchestrator/workspace_test.go
@@ -47,8 +47,9 @@ func TestWorkspaceSourcePrefersWorkingDirectoryOverRepo(t *testing.T) {
 	}
 
 	got := workspaceSource(types.Task{WorkingDirectory: wd, Repo: repo})
-	if got.path != wd {
-		t.Errorf("path = %q, want %q (working directory should win)", got.path, wd)
+	wantPath := canonicalTestPath(t, wd)
+	if got.path != wantPath {
+		t.Errorf("path = %q, want %q (working directory should win)", got.path, wantPath)
 	}
 	if got.kind != "directory" {
 		t.Errorf("kind = %q, want %q", got.kind, "directory")
@@ -65,8 +66,27 @@ func TestWorkspaceSourceClassifiesGitRepo(t *testing.T) {
 	if got.kind != "git" {
 		t.Errorf("kind = %q, want %q", got.kind, "git")
 	}
-	if got.path != repo {
-		t.Errorf("path = %q, want %q", got.path, repo)
+	wantPath := canonicalTestPath(t, repo)
+	if got.path != wantPath {
+		t.Errorf("path = %q, want %q", got.path, wantPath)
+	}
+}
+
+func TestWorkspaceSourceCanonicalizesSymlinkedSource(t *testing.T) {
+	source := t.TempDir()
+	parent := t.TempDir()
+	link := filepath.Join(parent, "workspace-link")
+	if err := os.Symlink(source, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	got := workspaceSource(types.Task{WorkingDirectory: link})
+	wantPath := canonicalTestPath(t, source)
+	if got.path != wantPath {
+		t.Errorf("path = %q, want resolved source %q", got.path, wantPath)
+	}
+	if got.kind != "directory" {
+		t.Errorf("kind = %q, want %q", got.kind, "directory")
 	}
 }
 
@@ -110,8 +130,9 @@ func TestWorkspaceManager_InPlaceModeReturnsSourcePathWithoutCloning(t *testing.
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	if got != source {
-		t.Errorf("workspace path = %q, want source %q (in_place must NOT clone)", got, source)
+	wantSource := canonicalTestPath(t, source)
+	if got != wantSource {
+		t.Errorf("workspace path = %q, want source %q (in_place must NOT clone)", got, wantSource)
 	}
 	// And the temp root should NOT have a copy under task-1/run-1.
 	cloned := filepath.Join(root, "task-1", "run-1")
@@ -146,6 +167,36 @@ func TestWorkspaceManager_InPlaceWithoutValidSourceFails(t *testing.T) {
 	}
 }
 
+func TestWorkspaceManagerRejectsUnsafeTaskAndRunIDs(t *testing.T) {
+	mgr := NewWorkspaceManager(t.TempDir())
+	source := t.TempDir()
+	cases := []struct {
+		name string
+		task types.Task
+		run  types.TaskRun
+	}{
+		{"empty task id", types.Task{ID: "", WorkingDirectory: source}, types.TaskRun{ID: "run-1"}},
+		{"empty run id", types.Task{ID: "task-1", WorkingDirectory: source}, types.TaskRun{ID: ""}},
+		{"task path traversal", types.Task{ID: "../task-1", WorkingDirectory: source}, types.TaskRun{ID: "run-1"}},
+		{"run path traversal", types.Task{ID: "task-1", WorkingDirectory: source}, types.TaskRun{ID: "../run-1"}},
+		{"task nested segment", types.Task{ID: "task/nested", WorkingDirectory: source}, types.TaskRun{ID: "run-1"}},
+		{"run windows separator", types.Task{ID: "task-1", WorkingDirectory: source}, types.TaskRun{ID: `run\nested`}},
+		{"dot segment", types.Task{ID: ".", WorkingDirectory: source}, types.TaskRun{ID: "run-1"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mgr.Provision(context.Background(), tc.task, tc.run)
+			if err == nil {
+				t.Fatal("expected unsafe id to be rejected")
+			}
+			if !strings.Contains(err.Error(), "path segment") {
+				t.Errorf("error = %q, want path segment validation", err.Error())
+			}
+		})
+	}
+}
+
 func TestWorkspaceManager_DefaultModeStillClones(t *testing.T) {
 	// Default workspace mode (empty / persistent / ephemeral) must
 	// keep the existing isolated-clone behavior so the safety
@@ -162,13 +213,97 @@ func TestWorkspaceManager_DefaultModeStillClones(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	want := filepath.Join(root, "task-x", "run-x")
+	want := filepath.Join(canonicalTestPath(t, root), "task-x", "run-x")
 	if got != want {
 		t.Errorf("workspace path = %q, want %q (cloned under temp root)", got, want)
 	}
 	// And the marker copied across.
 	if _, err := os.Stat(filepath.Join(want, "marker.txt")); err != nil {
 		t.Errorf("marker not copied to clone: %v", err)
+	}
+}
+
+func TestWorkspaceManagerCanonicalizesConfiguredRootSymlink(t *testing.T) {
+	actualRoot := t.TempDir()
+	parent := t.TempDir()
+	rootLink := filepath.Join(parent, "workspace-root")
+	if err := os.Symlink(actualRoot, rootLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	mgr := NewWorkspaceManager(rootLink)
+	got, err := mgr.workspacePath("task-1", "run-1")
+	if err != nil {
+		t.Fatalf("workspacePath: %v", err)
+	}
+	want := filepath.Join(canonicalTestPath(t, actualRoot), "task-1", "run-1")
+	if got != want {
+		t.Errorf("workspace path = %q, want resolved root path %q", got, want)
+	}
+}
+
+func TestSafeJoinWithinRootRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	cases := []string{
+		"../outside",
+		filepath.Join("..", "outside"),
+		filepath.Clean(filepath.Join("nested", "..", "..", "outside")),
+	}
+	for _, relativePath := range cases {
+		t.Run(relativePath, func(t *testing.T) {
+			if _, err := safeJoinWithinRoot(root, relativePath); err == nil {
+				t.Fatal("expected escaping path to be rejected")
+			}
+		})
+	}
+}
+
+func TestSafeJoinWithinRootRejectsExistingSymlinkComponents(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if _, err := safeJoinWithinRoot(root, filepath.Join("linked", "file.txt")); err == nil {
+		t.Fatal("expected symlink component to be rejected")
+	}
+}
+
+func TestCopyDirectoryRejectsDestinationSymlinkComponents(t *testing.T) {
+	source := t.TempDir()
+	if err := os.Mkdir(filepath.Join(source, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir source nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "nested", "file.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	destination := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(destination, "nested")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := copyDirectory(source, destination)
+	if err == nil {
+		t.Fatal("expected copy into symlinked destination component to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink component") {
+		t.Errorf("error = %q, want symlink component rejection", err.Error())
+	}
+}
+
+func TestSafeJoinWithinRootAllowsNestedLocalPaths(t *testing.T) {
+	root := t.TempDir()
+	got, err := safeJoinWithinRoot(root, filepath.Join("nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("safeJoinWithinRoot: %v", err)
+	}
+	want := filepath.Join(root, "nested", "file.txt")
+	if got != want {
+		t.Errorf("joined path = %q, want %q", got, want)
 	}
 }
 
@@ -182,4 +317,13 @@ func TestWorkspaceSourceRejectsRegularFiles(t *testing.T) {
 	if got.path != "" || got.kind != "" {
 		t.Errorf("workspaceSource(regular file) = %+v, want zero spec", got)
 	}
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve %q: %v", path, err)
+	}
+	return resolved
 }

--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -584,7 +584,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -752,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2247,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2326,22 +2326,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
@@ -2351,18 +2341,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2372,20 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2394,20 +2361,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -2616,7 +2574,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2639,7 +2597,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2665,21 +2623,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2689,14 +2638,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2907,7 +2850,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2964,7 +2907,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3105,7 +3048,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -3463,7 +3406,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -3473,8 +3416,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -3626,9 +3569,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3677,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3698,9 +3641,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3725,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3824,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -3849,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -3875,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
@@ -3891,7 +3834,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
  "plist",
  "proc-macro2",
  "quote",
@@ -3932,7 +3875,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4619,7 +4562,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -4745,7 +4688,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5293,9 +5236,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.55.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3013fd6116aac351dd2e18f349b28b2cfef3a5ff3253a9d0ce2d7193bb1b4429"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",


### PR DESCRIPTION
## Summary

- Harden task workspace provisioning against unsafe task/run path segments and lexical root escapes.
- Resolve the configured Hecate workspace root before deriving generated task workspaces.
- Reject pre-existing symlink components in Hecate-owned destination paths before creating copied directories, symlinks, or files.
- Canonicalize operator-provided workspace source directories and verify them with `os.OpenRoot` before in-place or clone/copy provisioning.
- Pass `--` to `git clone` so a source path cannot be interpreted as a flag.
- Bump the Tauri lockfile to `tauri 2.11.1` and `wry 0.55.1`.
- Add `docs/security.md` as the canonical local-first security model and link it from the README, docs index, deployment docs, architecture docs, external-agent docs, known limitations, and agent orientation.

## Security alerts covered

- CodeQL `go/path-injection` in `internal/orchestrator/workspace.go` for generated workspace paths and source directory validation.
- CodeQL `go/command-injection` in `internal/orchestrator/workspace.go` for `git clone` arguments.
- Dependabot `tauri` advisory fixed by `2.11.1`.

## Design notes

Hecate is documented as a local-first operator console rather than a directly exposed network service. The docs now focus on the actual security boundary: loopback by default, same-origin browser checks, and operator-provided network access controls if Hecate is bound beyond the local machine.

The Copilot symlink concern is valid for Hecate-owned destination paths: a stale symlink under the generated workspace root could otherwise redirect later copy/create operations. The fix rejects those symlink components before file creation.

Operator-selected source workspaces intentionally still support symlinks after canonicalization. That preserves the product behavior where a user can select a symlinked repo or folder as the task workspace source; Hecate resolves it before provisioning rather than treating the symlink path itself as the sandbox/root identity.

Adding or selecting a workspace in the UI does not clone it. Clone/copy happens only when a native task run provisions an isolated workspace. In-place task runs, Hecate Chat tools-on sessions, and External Agent sessions run directly in the selected workspace.

## Security documentation

`docs/security.md` now captures the practical security contract in one place: local operator boundary, loopback-by-default behavior, task-runtime versus external-agent boundaries, workspace safety, approvals, secrets/local state, native app sidecars, dependency advisory handling, operator checklist, and vulnerability-reporting guidance.

## Remaining upstream constraint

The `glib` Dependabot alert remains in the Linux Tauri dependency tree because the latest available Tauri 2 release (`2.11.1`) still depends on `gtk ^0.18`, which requires `glib ^0.18`. A direct `cargo update -p glib --precise 0.20.0` is rejected by Cargo for that reason. This needs an upstream Tauri/GTK stack update before it can be fixed safely in this repo.

## Verification

- `go test ./internal/orchestrator -run 'Test(Workspace|SafeJoin|CopyDirectory|IsGit)'`
- `go test ./internal/orchestrator`
- `cargo check --manifest-path tauri/src-tauri/Cargo.toml`
- `git diff --check`
- Confirmed `cargo update -p glib --precise 0.20.0` is blocked by `gtk ^0.18` from current Tauri.
