### PR TITLE
feat(providers): add readiness checklist diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Stability stages:
 | Area | State | Notes |
 |---|---|---|
 | Model gateway | Alpha-ready | OpenAI-compatible Chat Completions, Anthropic-shaped Messages, streaming, vision, model discovery, failover, budgets, rate limits, pricebook, and custom endpoints. |
-| Providers | Alpha-ready | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health, credentials, and routing readiness. |
+| Providers | Alpha-ready | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health, credentials, and checklist-style routing readiness diagnostics. |
 | Hecate Chat | Alpha-ready | Direct model turns and tools-on task-backed `agent_loop` segments in one transcript, streamed assistant text, task/trace links, local busy-prompt queueing, and inline task approvals. Workspace modes and agent profiles are still future work. |
 | External Agent | Alpha-ready | Codex, Claude Code, and Cursor Agent discovery, long-lived ACP sessions, prompt-first approvals, grants, health/version checks, cancel, guardrails, raw diagnostics, and Git diff inspect/revert. Runs as trusted subprocesses. |
 | Task runtime | Alpha-ready | Queue/lease execution, approvals, resumable `agent_loop`, MCP integration, streamed output, artifacts, and stale-run recovery. Broader lifecycle hardening is still ongoing. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -191,6 +191,7 @@ returns:
 - `credential_ready` — whether credentials are configured or not required
 - `routing_ready` — whether the router can currently send traffic to it
 - `routing_blocked_reason` — stable reason when routing is blocked, such as `credential_missing`, `provider_disabled`, `provider_rate_limited`, `circuit_open`, `provider_unhealthy`, or `no_models`
+- `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, and an operator-facing `message`.
 - `model_count`, `discovery_source`, `last_checked_at`, and `last_error` for model-discovery freshness and failure context
 - `last_error_class`, `open_until`, `last_latency_ms`, `consecutive_failures`, `timeouts`, `server_errors`, `rate_limits`, `total_successes`, and `total_failures` for richer health debugging
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -191,7 +191,7 @@ returns:
 - `credential_ready` — whether credentials are configured or not required
 - `routing_ready` — whether the router can currently send traffic to it
 - `routing_blocked_reason` — stable reason when routing is blocked, such as `credential_missing`, `provider_disabled`, `provider_rate_limited`, `circuit_open`, `provider_unhealthy`, or `no_models`
-- `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, and an operator-facing `message`.
+- `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, and an operator-facing `message`. Non-routing checks can use scoped reasons such as `default_model_only`, `discovery_failed`, `self_referential`, or `provider_slow`.
 - `model_count`, `discovery_source`, `last_checked_at`, and `last_error` for model-discovery freshness and failure context
 - `last_error_class`, `open_until`, `last_latency_ms`, `consecutive_failures`, `timeouts`, `server_errors`, `rate_limits`, `total_successes`, and `total_failures` for richer health debugging
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -441,8 +441,10 @@ matching `routing_blocked_reason` and the `reason` on the
 route diagnostics: `credential_missing`, `provider_disabled`,
 `provider_rate_limited`, `circuit_open`, `provider_unhealthy`, and `no_models`.
 Other checks use reason values scoped to that check, such as
-`default_model_only` for model-discovery fallback or `not_required` for local
-providers that do not need credentials.
+`default_model_only` for model-discovery fallback, `discovery_failed` when the
+provider could not return a model list, `self_referential` when a provider URL
+points back to Hecate, `provider_slow` when a latency-degraded provider remains
+routable, or `not_required` for local providers that do not need credentials.
 
 ### `GET /hecate/v1/settings/providers/local-discovery`
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -436,10 +436,13 @@ are currently `credentials`, `models`, `health`, and `routing`; statuses are
 branching, while `message` is safe to show directly to the operator.
 
 `routing_ready=false` means the router currently skips the provider. The
-matching `routing_blocked_reason` and `readiness_checks[].reason` values use the
-same vocabulary as route diagnostics: `credential_missing`,
-`provider_disabled`, `provider_rate_limited`, `circuit_open`,
-`provider_unhealthy`, and `no_models`.
+matching `routing_blocked_reason` and the `reason` on the
+`readiness_checks[]` item whose `name` is `routing` use the same vocabulary as
+route diagnostics: `credential_missing`, `provider_disabled`,
+`provider_rate_limited`, `circuit_open`, `provider_unhealthy`, and `no_models`.
+Other checks use reason values scoped to that check, such as
+`default_model_only` for model-discovery fallback or `not_required` for local
+providers that do not need credentials.
 
 ### `GET /hecate/v1/settings/providers/local-discovery`
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -375,6 +375,72 @@ GET /hecate/v1/providers/presets
 
 The list is built from `config.BuiltInProviders()` — see [`docs/providers.md`](providers.md) for the full catalog and OpenAI-compatible custom-endpoint flow.
 
+### `GET /hecate/v1/providers/status`
+
+Runtime provider readiness snapshot. The UI uses this endpoint to explain
+whether a configured provider can receive traffic right now and why it may be
+skipped by routing.
+
+```json
+GET /hecate/v1/providers/status
+→ 200
+{
+  "object": "provider_status",
+  "data": [
+    {
+      "name": "ollama",
+      "kind": "local",
+      "status": "healthy",
+      "healthy": true,
+      "base_url": "http://127.0.0.1:11434/v1",
+      "models": ["llama3.1:8b"],
+      "model_count": 1,
+      "credential_state": "not_required",
+      "credential_ready": true,
+      "routing_ready": true,
+      "readiness_checks": [
+        {
+          "name": "credentials",
+          "status": "ok",
+          "reason": "not_required",
+          "message": "No credentials are required for this provider."
+        },
+        {
+          "name": "models",
+          "status": "ok",
+          "reason": "models_discovered",
+          "message": "1 model discovered."
+        },
+        {
+          "name": "health",
+          "status": "ok",
+          "reason": "healthy",
+          "message": "Provider health checks are passing."
+        },
+        {
+          "name": "routing",
+          "status": "ok",
+          "reason": "routable",
+          "message": "Provider is eligible for routing."
+        }
+      ]
+    }
+  ]
+}
+```
+
+`readiness_checks` is the canonical operator-facing checklist. It prevents
+clients from guessing readiness by combining unrelated raw fields. Check names
+are currently `credentials`, `models`, `health`, and `routing`; statuses are
+`ok`, `warning`, `blocked`, or `unknown`. `reason` is stable enough for UI
+branching, while `message` is safe to show directly to the operator.
+
+`routing_ready=false` means the router currently skips the provider. The
+matching `routing_blocked_reason` and `readiness_checks[].reason` values use the
+same vocabulary as route diagnostics: `credential_missing`,
+`provider_disabled`, `provider_rate_limited`, `circuit_open`,
+`provider_unhealthy`, and `no_models`.
+
 ### `GET /hecate/v1/settings/providers/local-discovery`
 
 Advisory discovery for the Providers tab's **Add provider → Local** catalog.

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -58,6 +58,7 @@ func (h *Handler) HandleProviderStatus(w http.ResponseWriter, r *http.Request) {
 			Timeouts:            provider.Timeouts,
 			ServerErrors:        provider.ServerErrors,
 			RateLimits:          provider.RateLimits,
+			ReadinessChecks:     renderProviderReadinessChecks(provider.ReadinessChecks),
 		}
 		if !provider.RefreshedAt.IsZero() {
 			item.RefreshedAt = provider.RefreshedAt.UTC().Format(time.RFC3339)
@@ -75,6 +76,22 @@ func (h *Handler) HandleProviderStatus(w http.ResponseWriter, r *http.Request) {
 		Object: "provider_status",
 		Data:   data,
 	})
+}
+
+func renderProviderReadinessChecks(checks []types.ProviderReadinessCheck) []ProviderReadinessCheckResponseItem {
+	if len(checks) == 0 {
+		return nil
+	}
+	out := make([]ProviderReadinessCheckResponseItem, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, ProviderReadinessCheckResponseItem{
+			Name:    check.Name,
+			Status:  check.Status,
+			Reason:  check.Reason,
+			Message: check.Message,
+		})
+	}
+	return out
 }
 
 func (h *Handler) HandleProviderHealthHistory(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -493,31 +493,39 @@ type TraceEventRecord struct {
 }
 
 type ProviderStatusResponseItem struct {
-	Name                string   `json:"name"`
-	Kind                string   `json:"kind"`
-	BaseURL             string   `json:"base_url,omitempty"`
-	CredentialState     string   `json:"credential_state,omitempty"`
-	CredentialReady     bool     `json:"credential_ready"`
-	Healthy             bool     `json:"healthy"`
-	Status              string   `json:"status"`
-	RoutingReady        bool     `json:"routing_ready"`
-	RoutingBlocked      string   `json:"routing_blocked_reason,omitempty"`
-	DefaultModel        string   `json:"default_model,omitempty"`
-	Models              []string `json:"models,omitempty"`
-	ModelCount          int      `json:"model_count"`
-	DiscoverySource     string   `json:"discovery_source,omitempty"`
-	RefreshedAt         string   `json:"refreshed_at,omitempty"`
-	LastCheckedAt       string   `json:"last_checked_at,omitempty"`
-	LastError           string   `json:"last_error,omitempty"`
-	LastErrorClass      string   `json:"last_error_class,omitempty"`
-	OpenUntil           string   `json:"open_until,omitempty"`
-	LastLatencyMS       int64    `json:"last_latency_ms,omitempty"`
-	ConsecutiveFailures int      `json:"consecutive_failures,omitempty"`
-	TotalSuccesses      int64    `json:"total_successes,omitempty"`
-	TotalFailures       int64    `json:"total_failures,omitempty"`
-	Timeouts            int64    `json:"timeouts,omitempty"`
-	ServerErrors        int64    `json:"server_errors,omitempty"`
-	RateLimits          int64    `json:"rate_limits,omitempty"`
+	Name                string                               `json:"name"`
+	Kind                string                               `json:"kind"`
+	BaseURL             string                               `json:"base_url,omitempty"`
+	CredentialState     string                               `json:"credential_state,omitempty"`
+	CredentialReady     bool                                 `json:"credential_ready"`
+	Healthy             bool                                 `json:"healthy"`
+	Status              string                               `json:"status"`
+	RoutingReady        bool                                 `json:"routing_ready"`
+	RoutingBlocked      string                               `json:"routing_blocked_reason,omitempty"`
+	DefaultModel        string                               `json:"default_model,omitempty"`
+	Models              []string                             `json:"models,omitempty"`
+	ModelCount          int                                  `json:"model_count"`
+	DiscoverySource     string                               `json:"discovery_source,omitempty"`
+	RefreshedAt         string                               `json:"refreshed_at,omitempty"`
+	LastCheckedAt       string                               `json:"last_checked_at,omitempty"`
+	LastError           string                               `json:"last_error,omitempty"`
+	LastErrorClass      string                               `json:"last_error_class,omitempty"`
+	OpenUntil           string                               `json:"open_until,omitempty"`
+	LastLatencyMS       int64                                `json:"last_latency_ms,omitempty"`
+	ConsecutiveFailures int                                  `json:"consecutive_failures,omitempty"`
+	TotalSuccesses      int64                                `json:"total_successes,omitempty"`
+	TotalFailures       int64                                `json:"total_failures,omitempty"`
+	Timeouts            int64                                `json:"timeouts,omitempty"`
+	ServerErrors        int64                                `json:"server_errors,omitempty"`
+	RateLimits          int64                                `json:"rate_limits,omitempty"`
+	ReadinessChecks     []ProviderReadinessCheckResponseItem `json:"readiness_checks,omitempty"`
+}
+
+type ProviderReadinessCheckResponseItem struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 type ProviderHealthHistoryResponseItem struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -520,6 +520,10 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if !item.RoutingReady {
 				t.Fatalf("openai routing_ready = false, reason = %q", item.RoutingBlocked)
 			}
+			assertProviderReadinessCheck(t, item, "credentials", "ok", "configured")
+			assertProviderReadinessCheck(t, item, "models", "ok", "models_discovered")
+			assertProviderReadinessCheck(t, item, "health", "ok", "healthy")
+			assertProviderReadinessCheck(t, item, "routing", "ok", "routable")
 			foundHealthy = true
 		}
 		if item.Name == "ollama" && !item.Healthy && item.Status == "degraded" && item.LastError != "" {
@@ -532,6 +536,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.RoutingBlocked != "provider_unhealthy" {
 				t.Fatalf("ollama routing_blocked_reason = %q, want provider_unhealthy", item.RoutingBlocked)
 			}
+			assertProviderReadinessCheck(t, item, "credentials", "ok", "not_required")
+			assertProviderReadinessCheck(t, item, "health", "blocked", "provider_unhealthy")
+			assertProviderReadinessCheck(t, item, "routing", "blocked", "provider_unhealthy")
 			foundDegraded = true
 		}
 		if item.Name == "anthropic" {
@@ -544,6 +551,8 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.RoutingBlocked != "credential_missing" {
 				t.Fatalf("anthropic routing_blocked_reason = %q, want credential_missing", item.RoutingBlocked)
 			}
+			assertProviderReadinessCheck(t, item, "credentials", "blocked", "credential_missing")
+			assertProviderReadinessCheck(t, item, "routing", "blocked", "credential_missing")
 			foundCredentialBlocked = true
 		}
 	}
@@ -556,6 +565,26 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 	if !foundCredentialBlocked {
 		t.Fatalf("missing credential-blocked provider entry: %#v", response.Data)
 	}
+}
+
+func assertProviderReadinessCheck(t *testing.T, item ProviderStatusResponseItem, name, status, reason string) {
+	t.Helper()
+	for _, check := range item.ReadinessChecks {
+		if check.Name != name {
+			continue
+		}
+		if check.Status != status {
+			t.Fatalf("%s readiness check %q status = %q, want %q", item.Name, name, check.Status, status)
+		}
+		if check.Reason != reason {
+			t.Fatalf("%s readiness check %q reason = %q, want %q", item.Name, name, check.Reason, reason)
+		}
+		if check.Message == "" {
+			t.Fatalf("%s readiness check %q message is empty", item.Name, name)
+		}
+		return
+	}
+	t.Fatalf("%s missing readiness check %q in %#v", item.Name, name, item.ReadinessChecks)
 }
 
 func TestProviderStatusReturnsRateLimitedRoutingBlockReason(t *testing.T) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -469,8 +469,17 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			DiscoverySource: "config_unconfigured",
 		},
 	}
+	defaultOnlyProvider := &fakeProvider{
+		name: "openrouter",
+		capabilities: providers.Capabilities{
+			Name:            "openrouter",
+			Kind:            providers.KindCloud,
+			DefaultModel:    "openrouter-default",
+			DiscoverySource: "provider_default",
+		},
+	}
 
-	registry := providers.NewRegistry(healthyProvider, degradedProvider, missingCredentialProvider)
+	registry := providers.NewRegistry(healthyProvider, degradedProvider, missingCredentialProvider, defaultOnlyProvider)
 	providerCatalog := catalog.NewRegistryCatalog(registry, nil)
 	budgetStore := governor.NewMemoryBudgetStore()
 	service := gateway.NewService(gateway.Dependencies{
@@ -493,13 +502,14 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 	if response.Object != "provider_status" {
 		t.Fatalf("object = %q, want provider_status", response.Object)
 	}
-	if len(response.Data) != 3 {
-		t.Fatalf("provider count = %d, want 3", len(response.Data))
+	if len(response.Data) != 4 {
+		t.Fatalf("provider count = %d, want 4", len(response.Data))
 	}
 
 	foundHealthy := false
 	foundDegraded := false
 	foundCredentialBlocked := false
+	foundDefaultOnly := false
 	for _, item := range response.Data {
 		if item.Name == "openai" && item.Healthy && item.RefreshedAt != "" {
 			if item.BaseURL == "" {
@@ -555,6 +565,17 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			assertProviderReadinessCheck(t, item, "routing", "blocked", "credential_missing")
 			foundCredentialBlocked = true
 		}
+		if item.Name == "openrouter" {
+			if item.ModelCount != 1 {
+				t.Fatalf("openrouter model_count = %d, want 1 default-model fallback", item.ModelCount)
+			}
+			if !item.RoutingReady {
+				t.Fatalf("openrouter routing_ready = false, reason = %q", item.RoutingBlocked)
+			}
+			assertProviderReadinessCheck(t, item, "models", "warning", "default_model_only")
+			assertProviderReadinessCheck(t, item, "routing", "ok", "routable")
+			foundDefaultOnly = true
+		}
 	}
 	if !foundHealthy {
 		t.Fatalf("missing healthy provider entry: %#v", response.Data)
@@ -564,6 +585,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 	}
 	if !foundCredentialBlocked {
 		t.Fatalf("missing credential-blocked provider entry: %#v", response.Data)
+	}
+	if !foundDefaultOnly {
+		t.Fatalf("missing default-only provider entry: %#v", response.Data)
 	}
 }
 
@@ -634,6 +658,8 @@ func TestProviderStatusReturnsRateLimitedRoutingBlockReason(t *testing.T) {
 	if item.RoutingBlocked != "provider_rate_limited" {
 		t.Fatalf("routing_blocked_reason = %q, want provider_rate_limited", item.RoutingBlocked)
 	}
+	assertProviderReadinessCheck(t, item, "health", "blocked", "provider_rate_limited")
+	assertProviderReadinessCheck(t, item, "routing", "blocked", "provider_rate_limited")
 	if item.LastErrorClass != "rate_limit" {
 		t.Fatalf("last_error_class = %q, want rate_limit", item.LastErrorClass)
 	}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -7,29 +7,30 @@ import (
 )
 
 type Entry struct {
-	Provider            providers.Provider
-	Name                string
-	Kind                providers.Kind
-	BaseURL             string
-	CredentialState     string
-	DefaultModel        string
-	Models              []string
-	DiscoverySource     string
-	RefreshedAt         string
-	LastCheckedAt       string
-	LastError           string
-	HealthReason        string
-	OpenUntil           string
-	LastLatencyMS       int64
-	ConsecutiveFailures int
-	TotalSuccesses      int64
-	TotalFailures       int64
-	Timeouts            int64
-	ServerErrors        int64
-	RateLimits          int64
-	Healthy             bool
-	Status              string
-	Error               string
+	Provider             providers.Provider
+	Name                 string
+	Kind                 providers.Kind
+	BaseURL              string
+	CredentialState      string
+	DefaultModel         string
+	Models               []string
+	DiscoveredModelCount int
+	DiscoverySource      string
+	RefreshedAt          string
+	LastCheckedAt        string
+	LastError            string
+	HealthReason         string
+	OpenUntil            string
+	LastLatencyMS        int64
+	ConsecutiveFailures  int
+	TotalSuccesses       int64
+	TotalFailures        int64
+	Timeouts             int64
+	ServerErrors         int64
+	RateLimits           int64
+	Healthy              bool
+	Status               string
+	Error                string
 }
 
 type Catalog interface {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -46,4 +46,40 @@ func TestRegistryCatalogSnapshotIncludesHealthAndCapabilities(t *testing.T) {
 	if entries[0].DiscoverySource != "upstream_v1_models" {
 		t.Fatalf("discovery source = %q, want upstream_v1_models", entries[0].DiscoverySource)
 	}
+	if entries[0].DiscoveredModelCount != 2 {
+		t.Fatalf("discovered model count = %d, want 2", entries[0].DiscoveredModelCount)
+	}
+}
+
+func TestRegistryCatalogSnapshotTracksDefaultModelFallbackSeparately(t *testing.T) {
+	t.Parallel()
+
+	registry := providers.NewRegistry(
+		&fakeProvider{
+			name:         "openai",
+			kind:         providers.KindCloud,
+			defaultModel: "gpt-4o-mini",
+			caps: providers.Capabilities{
+				Name:            "openai",
+				Kind:            providers.KindCloud,
+				DefaultModel:    "gpt-4o-mini",
+				DiscoverySource: "provider_default",
+			},
+		},
+	)
+
+	cat := NewRegistryCatalog(registry, nil)
+	entries := cat.Snapshot(context.Background())
+	if len(entries) != 1 {
+		t.Fatalf("Snapshot() len = %d, want 1", len(entries))
+	}
+	if entries[0].DiscoveredModelCount != 0 {
+		t.Fatalf("discovered model count = %d, want 0", entries[0].DiscoveredModelCount)
+	}
+	if got := len(entries[0].Models); got != 1 {
+		t.Fatalf("models len = %d, want default-model fallback", got)
+	}
+	if entries[0].Models[0] != "gpt-4o-mini" {
+		t.Fatalf("fallback model = %q, want gpt-4o-mini", entries[0].Models[0])
+	}
 }

--- a/internal/catalog/registry.go
+++ b/internal/catalog/registry.go
@@ -89,6 +89,7 @@ func (c *RegistryCatalog) entryForProvider(ctx context.Context, provider provide
 	}
 
 	models := append([]string(nil), caps.Models...)
+	discoveredModelCount := len(models)
 	if len(models) == 0 && defaultModel != "" {
 		models = []string{defaultModel}
 	}
@@ -99,17 +100,18 @@ func (c *RegistryCatalog) entryForProvider(ctx context.Context, provider provide
 	}
 
 	entry := Entry{
-		Provider:        provider,
-		Name:            provider.Name(),
-		Kind:            provider.Kind(),
-		BaseURL:         baseURL,
-		CredentialState: credentialState,
-		DefaultModel:    defaultModel,
-		Models:          models,
-		DiscoverySource: discoverySource,
-		Healthy:         err == nil,
-		Status:          "healthy",
-		LastError:       caps.LastError,
+		Provider:             provider,
+		Name:                 provider.Name(),
+		Kind:                 provider.Kind(),
+		BaseURL:              baseURL,
+		CredentialState:      credentialState,
+		DefaultModel:         defaultModel,
+		Models:               models,
+		DiscoveredModelCount: discoveredModelCount,
+		DiscoverySource:      discoverySource,
+		Healthy:              err == nil,
+		Status:               "healthy",
+		LastError:            caps.LastError,
 	}
 	if !caps.RefreshedAt.IsZero() {
 		refreshedAt := caps.RefreshedAt.UTC().Format(time.RFC3339)

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -911,12 +911,21 @@ func providerCredentialCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 }
 
 func providerModelDiscoveryCheck(entry catalog.Entry) types.ProviderReadinessCheck {
+	switch {
+	case entry.Status == "disabled":
+		return providerReadinessCheck("models", "blocked", "provider_disabled", "Model discovery is skipped while this provider is disabled.")
+	case entry.DiscoverySource == "self_referential":
+		return providerReadinessCheck("models", "blocked", "self_referential", "Model discovery is skipped because this provider points back to Hecate.")
+	}
+
 	count := entry.DiscoveredModelCount
 	switch {
 	case count > 0:
 		return providerReadinessCheck("models", "ok", "models_discovered", fmt.Sprintf("%d model%s discovered.", count, pluralS(count)))
 	case entry.DefaultModel != "":
 		return providerReadinessCheck("models", "warning", "default_model_only", fmt.Sprintf("No models were discovered; Hecate can still try the configured default model %q.", entry.DefaultModel))
+	case entry.LastError != "" || entry.Error != "":
+		return providerReadinessCheck("models", "unknown", "discovery_failed", fmt.Sprintf("Model discovery failed before returning a model list: %s", firstNonEmpty(entry.LastError, entry.Error)))
 	default:
 		return providerReadinessCheck("models", "blocked", "no_models", "No models were discovered and no default model is configured.")
 	}
@@ -930,6 +939,9 @@ func providerHealthCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 		}
 		return providerReadinessCheck("health", "unknown", providerReadinessHealthReason(entry.HealthReason), providerHealthPendingMessage(entry.HealthReason))
 	case "degraded":
+		if entry.Healthy {
+			return providerReadinessCheck("health", "warning", providerReadinessHealthReason(entry.HealthReason), providerHealthDegradedMessage(entry.HealthReason))
+		}
 		if entry.HealthReason == "rate_limit" {
 			return providerReadinessCheck("health", "blocked", "provider_rate_limited", "Provider is cooling down after an upstream rate limit.")
 		}
@@ -978,6 +990,17 @@ func providerHealthFailureMessage(reason string) string {
 		return "Provider health checks are failing."
 	default:
 		return fmt.Sprintf("Provider health checks are failing with error class %q.", reason)
+	}
+}
+
+func providerHealthDegradedMessage(reason string) string {
+	switch reason {
+	case "latency":
+		return "Provider is routable but slower than the configured degraded-latency threshold."
+	case "":
+		return "Provider is routable but currently degraded."
+	default:
+		return fmt.Sprintf("Provider is routable but degraded after error class %q.", reason)
 	}
 }
 

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -911,7 +911,7 @@ func providerCredentialCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 }
 
 func providerModelDiscoveryCheck(entry catalog.Entry) types.ProviderReadinessCheck {
-	count := len(entry.Models)
+	count := entry.DiscoveredModelCount
 	switch {
 	case count > 0:
 		return providerReadinessCheck("models", "ok", "models_discovered", fmt.Sprintf("%d model%s discovered.", count, pluralS(count)))

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -906,10 +906,7 @@ func providerCredentialCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 	case "", "unknown":
 		return providerReadinessCheck("credentials", "unknown", "unknown", "Hecate could not determine credential state yet.")
 	default:
-		if providerCredentialReady(entry.CredentialState) {
-			return providerReadinessCheck("credentials", "unknown", entry.CredentialState, "Hecate does not recognize this credential state.")
-		}
-		return providerReadinessCheck("credentials", "blocked", entry.CredentialState, "Credential state blocks routing.")
+		return providerReadinessCheck("credentials", "blocked", "credential_missing", fmt.Sprintf("Credential state %q blocks routing.", entry.CredentialState))
 	}
 }
 

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -765,6 +765,7 @@ func (s *Service) ProviderStatus(ctx context.Context) (*ProviderStatusResult, er
 			ServerErrors:        entry.ServerErrors,
 			RateLimits:          entry.RateLimits,
 			Error:               entry.Error,
+			ReadinessChecks:     providerReadinessChecks(entry),
 		}
 		if entry.RefreshedAt != "" {
 			if ts, err := time.Parse(time.RFC3339, entry.RefreshedAt); err == nil {
@@ -883,6 +884,118 @@ func providerRoutingBlockedReason(entry catalog.Entry) string {
 		return "no_models"
 	}
 	return ""
+}
+
+func providerReadinessChecks(entry catalog.Entry) []types.ProviderReadinessCheck {
+	return []types.ProviderReadinessCheck{
+		providerCredentialCheck(entry),
+		providerModelDiscoveryCheck(entry),
+		providerHealthCheck(entry),
+		providerRoutingCheck(entry),
+	}
+}
+
+func providerCredentialCheck(entry catalog.Entry) types.ProviderReadinessCheck {
+	switch entry.CredentialState {
+	case "configured":
+		return providerReadinessCheck("credentials", "ok", "configured", "Credentials are configured.")
+	case "not_required":
+		return providerReadinessCheck("credentials", "ok", "not_required", "No credentials are required for this provider.")
+	case "missing":
+		return providerReadinessCheck("credentials", "blocked", "credential_missing", "Add credentials before Hecate can route requests to this provider.")
+	case "", "unknown":
+		return providerReadinessCheck("credentials", "unknown", "unknown", "Hecate could not determine credential state yet.")
+	default:
+		if providerCredentialReady(entry.CredentialState) {
+			return providerReadinessCheck("credentials", "unknown", entry.CredentialState, "Hecate does not recognize this credential state.")
+		}
+		return providerReadinessCheck("credentials", "blocked", entry.CredentialState, "Credential state blocks routing.")
+	}
+}
+
+func providerModelDiscoveryCheck(entry catalog.Entry) types.ProviderReadinessCheck {
+	count := len(entry.Models)
+	switch {
+	case count > 0:
+		return providerReadinessCheck("models", "ok", "models_discovered", fmt.Sprintf("%d model%s discovered.", count, pluralS(count)))
+	case entry.DefaultModel != "":
+		return providerReadinessCheck("models", "warning", "default_model_only", fmt.Sprintf("No models were discovered; Hecate can still try the configured default model %q.", entry.DefaultModel))
+	default:
+		return providerReadinessCheck("models", "blocked", "no_models", "No models were discovered and no default model is configured.")
+	}
+}
+
+func providerHealthCheck(entry catalog.Entry) types.ProviderReadinessCheck {
+	switch entry.Status {
+	case "healthy":
+		if entry.Healthy {
+			return providerReadinessCheck("health", "ok", "healthy", "Provider health checks are passing.")
+		}
+		return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.HealthReason, "health_pending"), "Provider health is still settling.")
+	case "degraded":
+		if entry.HealthReason == "rate_limit" {
+			return providerReadinessCheck("health", "blocked", "provider_rate_limited", "Provider is cooling down after an upstream rate limit.")
+		}
+		return providerReadinessCheck("health", "blocked", "provider_unhealthy", "Provider is degraded after recent failures.")
+	case "half_open":
+		return providerReadinessCheck("health", "warning", "recovery_probe", "Circuit is half-open; Hecate is testing recovery.")
+	case "open":
+		if entry.HealthReason == "rate_limit" {
+			return providerReadinessCheck("health", "blocked", "provider_rate_limited", "Provider is cooling down after an upstream rate limit.")
+		}
+		return providerReadinessCheck("health", "blocked", "circuit_open", "Provider circuit is open after recent failures.")
+	case "unhealthy":
+		return providerReadinessCheck("health", "blocked", firstNonEmpty(entry.HealthReason, "provider_unhealthy"), "Provider health checks are failing.")
+	case "disabled":
+		return providerReadinessCheck("health", "blocked", "provider_disabled", "Provider is disabled.")
+	default:
+		if !entry.Healthy {
+			return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.HealthReason, "unknown"), "Provider health has not been established yet.")
+		}
+		return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.Status, "unknown"), "Provider health has not been checked yet.")
+	}
+}
+
+func providerRoutingCheck(entry catalog.Entry) types.ProviderReadinessCheck {
+	if reason := providerRoutingBlockedReason(entry); reason != "" {
+		return providerReadinessCheck("routing", "blocked", reason, providerRoutingBlockedMessage(reason))
+	}
+	return providerReadinessCheck("routing", "ok", "routable", "Provider is eligible for routing.")
+}
+
+func providerRoutingBlockedMessage(reason string) string {
+	switch reason {
+	case "credential_missing":
+		return "Routing is blocked until credentials are configured."
+	case "provider_disabled":
+		return "Routing is blocked because this provider is disabled."
+	case "provider_rate_limited":
+		return "Routing is blocked while the provider cools down after a rate limit."
+	case "circuit_open":
+		return "Routing is blocked while the provider circuit is open."
+	case "provider_unhealthy":
+		return "Routing is blocked because provider health checks are failing."
+	case "no_models":
+		return "Routing is blocked because no models are available."
+	default:
+		return "Routing is blocked."
+	}
+}
+
+func providerReadinessCheck(name, status, reason, message string) types.ProviderReadinessCheck {
+	return types.ProviderReadinessCheck{
+		Name:    name,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func pluralS(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func (s *Service) BudgetStatus(ctx context.Context, key string) (*BudgetStatusResult, error) {

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -928,7 +928,7 @@ func providerHealthCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 		if entry.Healthy {
 			return providerReadinessCheck("health", "ok", "healthy", "Provider health checks are passing.")
 		}
-		return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.HealthReason, "health_pending"), "Provider health is still settling.")
+		return providerReadinessCheck("health", "unknown", providerReadinessHealthReason(entry.HealthReason), providerHealthPendingMessage(entry.HealthReason))
 	case "degraded":
 		if entry.HealthReason == "rate_limit" {
 			return providerReadinessCheck("health", "blocked", "provider_rate_limited", "Provider is cooling down after an upstream rate limit.")
@@ -942,15 +942,50 @@ func providerHealthCheck(entry catalog.Entry) types.ProviderReadinessCheck {
 		}
 		return providerReadinessCheck("health", "blocked", "circuit_open", "Provider circuit is open after recent failures.")
 	case "unhealthy":
-		return providerReadinessCheck("health", "blocked", firstNonEmpty(entry.HealthReason, "provider_unhealthy"), "Provider health checks are failing.")
+		return providerReadinessCheck("health", "blocked", providerReadinessHealthReason(entry.HealthReason), providerHealthFailureMessage(entry.HealthReason))
 	case "disabled":
 		return providerReadinessCheck("health", "blocked", "provider_disabled", "Provider is disabled.")
 	default:
 		if !entry.Healthy {
-			return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.HealthReason, "unknown"), "Provider health has not been established yet.")
+			return providerReadinessCheck("health", "unknown", providerReadinessHealthReason(entry.HealthReason), providerHealthPendingMessage(entry.HealthReason))
 		}
 		return providerReadinessCheck("health", "unknown", firstNonEmpty(entry.Status, "unknown"), "Provider health has not been checked yet.")
 	}
+}
+
+func providerReadinessHealthReason(reason string) string {
+	switch reason {
+	case "rate_limit":
+		return "provider_rate_limited"
+	case "latency":
+		return "provider_slow"
+	case "timeout", "server_error", "other":
+		return "provider_unhealthy"
+	case "":
+		return "health_pending"
+	default:
+		return "provider_unhealthy"
+	}
+}
+
+func providerHealthFailureMessage(reason string) string {
+	switch reason {
+	case "rate_limit":
+		return "Provider is cooling down after an upstream rate limit."
+	case "latency":
+		return "Provider is slower than the configured degraded-latency threshold."
+	case "":
+		return "Provider health checks are failing."
+	default:
+		return fmt.Sprintf("Provider health checks are failing with error class %q.", reason)
+	}
+}
+
+func providerHealthPendingMessage(reason string) string {
+	if reason == "" {
+		return "Provider health is still settling."
+	}
+	return fmt.Sprintf("Provider health is still settling after error class %q.", reason)
 }
 
 func providerRoutingCheck(entry catalog.Entry) types.ProviderReadinessCheck {

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hecate/agent-runtime/internal/billing"
+	"github.com/hecate/agent-runtime/internal/catalog"
 	"github.com/hecate/agent-runtime/internal/config"
 	"github.com/hecate/agent-runtime/internal/governor"
 	"github.com/hecate/agent-runtime/internal/profiler"
@@ -84,5 +85,134 @@ func TestServiceHandleChatFallsBackWhenPrimaryPriceMissing(t *testing.T) {
 	}
 	if result.Metadata.FallbackFromProvider != "openai" {
 		t.Fatalf("fallback_from_provider = %q, want openai", result.Metadata.FallbackFromProvider)
+	}
+}
+
+func TestProviderModelDiscoveryCheckDistinguishesSkippedDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		entry      catalog.Entry
+		wantStatus string
+		wantReason string
+	}{
+		{
+			name: "disabled provider",
+			entry: catalog.Entry{
+				Status: "disabled",
+			},
+			wantStatus: "blocked",
+			wantReason: "provider_disabled",
+		},
+		{
+			name: "self referential provider",
+			entry: catalog.Entry{
+				DiscoverySource: "self_referential",
+				Status:          "degraded",
+			},
+			wantStatus: "blocked",
+			wantReason: "self_referential",
+		},
+		{
+			name: "discovery error without fallback",
+			entry: catalog.Entry{
+				Status:    "degraded",
+				LastError: "dial tcp: connection refused",
+			},
+			wantStatus: "unknown",
+			wantReason: "discovery_failed",
+		},
+		{
+			name: "configured fallback remains warning",
+			entry: catalog.Entry{
+				DefaultModel: "llama3.1:8b",
+				LastError:    "dial tcp: connection refused",
+			},
+			wantStatus: "warning",
+			wantReason: "default_model_only",
+		},
+		{
+			name:       "empty successful discovery",
+			entry:      catalog.Entry{},
+			wantStatus: "blocked",
+			wantReason: "no_models",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerModelDiscoveryCheck(tt.entry)
+			assertReadinessCheck(t, got, "models", tt.wantStatus, tt.wantReason)
+		})
+	}
+}
+
+func TestProviderHealthCheckTreatsRoutableDegradedProvidersAsWarnings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		entry      catalog.Entry
+		wantStatus string
+		wantReason string
+	}{
+		{
+			name: "latency degraded but healthy",
+			entry: catalog.Entry{
+				Status:       "degraded",
+				Healthy:      true,
+				HealthReason: "latency",
+			},
+			wantStatus: "warning",
+			wantReason: "provider_slow",
+		},
+		{
+			name: "degraded and unavailable",
+			entry: catalog.Entry{
+				Status:       "degraded",
+				Healthy:      false,
+				HealthReason: "timeout",
+			},
+			wantStatus: "blocked",
+			wantReason: "provider_unhealthy",
+		},
+		{
+			name: "rate limited and unavailable",
+			entry: catalog.Entry{
+				Status:       "degraded",
+				Healthy:      false,
+				HealthReason: "rate_limit",
+			},
+			wantStatus: "blocked",
+			wantReason: "provider_rate_limited",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerHealthCheck(tt.entry)
+			assertReadinessCheck(t, got, "health", tt.wantStatus, tt.wantReason)
+		})
+	}
+}
+
+func assertReadinessCheck(t *testing.T, got types.ProviderReadinessCheck, wantName, wantStatus, wantReason string) {
+	t.Helper()
+	if got.Name != wantName {
+		t.Fatalf("Name = %q, want %q", got.Name, wantName)
+	}
+	if got.Status != wantStatus {
+		t.Fatalf("Status = %q, want %q", got.Status, wantStatus)
+	}
+	if got.Reason != wantReason {
+		t.Fatalf("Reason = %q, want %q", got.Reason, wantReason)
+	}
+	if got.Message == "" {
+		t.Fatal("Message is empty")
 	}
 }

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -251,6 +251,14 @@ type ProviderStatus struct {
 	ServerErrors        int64
 	RateLimits          int64
 	Error               string
+	ReadinessChecks     []ProviderReadinessCheck
+}
+
+type ProviderReadinessCheck struct {
+	Name    string
+	Status  string
+	Reason  string
+	Message string
 }
 
 type ProviderHealthHistoryEntry struct {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -172,7 +172,20 @@ describe("ChatView input", () => {
         events: [],
       },
       providers: [
-        { name: "ollama", kind: "local", healthy: true, status: "healthy", base_url: "http://127.0.0.1:11434/v1", models: [], model_count: 0 },
+        {
+          name: "ollama",
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          base_url: "http://127.0.0.1:11434/v1",
+          models: [],
+          model_count: 0,
+          readiness_checks: [
+            { name: "credentials", status: "ok", reason: "not_required", message: "No credentials are required for this provider." },
+            { name: "models", status: "blocked", reason: "no_models", message: "No models were discovered and no default model is configured." },
+            { name: "routing", status: "blocked", reason: "no_models", message: "Routing is blocked because no models are available." },
+          ],
+        },
       ],
       providerScopedModels: [],
       agentAdapters: [
@@ -184,6 +197,9 @@ describe("ChatView input", () => {
     expect(screen.getByText("Provider is configured")).toBeTruthy();
     expect(screen.getAllByText("Ollama").length).toBeGreaterThan(0);
     expect(screen.getByText("none discovered")).toBeTruthy();
+    expect(screen.getByText("Credentials")).toBeTruthy();
+    expect(screen.getAllByText("Models").length).toBeGreaterThan(0);
+    expect(screen.getByText("Routing is blocked because no models are available.")).toBeTruthy();
     expect(screen.getByText(/Start the local provider app/)).toBeTruthy();
     expect(screen.queryByText("Detected locally")).toBeNull();
     expect(screen.queryByRole("button", { name: /Add detected provider/i })).toBeNull();

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -5,6 +5,7 @@ import { discoverLocalProviders } from "../../lib/api";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import type { AgentAdapterRecord, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
+import { CompactProviderReadinessChecks } from "../shared/ProviderReadiness";
 import { AgentAdapterPicker, CodeBlock, Icon, Icons, InlineError, ModelPicker, ProviderPicker } from "../shared/ui";
 import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
 import { AgentApprovalAutoModeBanner, AgentApprovalsBanner } from "./AgentApprovalBanner";
@@ -2091,6 +2092,7 @@ function ModelRouteTroubleshooting({
         <InfoChip label="Models" value={modelCount > 0 ? String(modelCount) : "none discovered"} />
         <InfoChip label="Health" value={runtimeProvider?.status || "pending probe"} />
       </div>
+      <CompactProviderReadinessChecks checks={runtimeProvider?.readiness_checks ?? []} />
       {(blockedReason || lastError) && (
         <div style={{ marginTop: 10, fontSize: 11, color: "var(--amber)", lineHeight: 1.45 }}>
           {blockedReason || lastError}

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -667,6 +667,12 @@ describe("ProvidersView table renders", () => {
           credential_state: "not_required",
           routing_ready: false,
           routing_blocked_reason: "provider_rate_limited",
+          readiness_checks: [
+            { name: "credentials", status: "ok", reason: "not_required", message: "No credentials are required for this provider." },
+            { name: "models", status: "ok", reason: "models_discovered", message: "1 model discovered." },
+            { name: "health", status: "blocked", reason: "provider_rate_limited", message: "Provider is cooling down after an upstream rate limit." },
+            { name: "routing", status: "blocked", reason: "provider_rate_limited", message: "Routing is blocked while the provider cools down after a rate limit." },
+          ],
           discovery_source: "live",
           last_checked_at: "2026-04-29T10:00:00Z",
           open_until: "2026-04-29T10:01:00Z",
@@ -687,6 +693,12 @@ describe("ProvidersView table renders", () => {
     await user.click(screen.getByText("Ollama"));
 
     expect(screen.getByText(/Circuit open/)).toBeTruthy();
+    expect(screen.getByText("Readiness")).toBeTruthy();
+    expect(screen.getAllByText("Credentials").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Models").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Health").length).toBeGreaterThan(0);
+    expect(screen.getByText("Routing")).toBeTruthy();
+    expect(screen.getByText("Routing is blocked while the provider cools down after a rate limit.")).toBeTruthy();
     expect(screen.getByText("Diagnostics")).toBeTruthy();
     expect(screen.getByText("connect: connection refused")).toBeTruthy();
     expect(screen.getAllByText("Not required").length).toBeGreaterThan(0);

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { providerIconColor, resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
+import { ProviderReadinessChecklist } from "../shared/ProviderReadiness";
 import { Badge, ConfirmModal, Icon, Icons, Modal } from "../shared/ui";
 import { AddProviderModal } from "./AddProviderModal";
 
@@ -455,6 +456,8 @@ export function ProvidersView({ state, actions }: Props) {
                 </div>
               ))}
             </div>
+
+            <ProviderReadinessChecklist checks={selectedStatus?.readiness_checks ?? []} />
 
             {/* Editable Name — only for custom providers (no preset_id);
                 preset providers keep the catalog name and reach for the

--- a/ui/src/features/shared/ProviderReadiness.tsx
+++ b/ui/src/features/shared/ProviderReadiness.tsx
@@ -20,7 +20,7 @@ export function ProviderReadinessChecklist({ checks }: { checks: ProviderReadine
       <div style={{ display: "flex", flexDirection: "column" }}>
         {checks.map((check, index) => (
           <div
-            key={`${check.name}-${index}`}
+            key={check.name}
             style={{
               display: "grid",
               gridTemplateColumns: "120px minmax(0, 1fr)",
@@ -85,7 +85,7 @@ export function CompactProviderReadinessChecks({ checks }: { checks: ProviderRea
     <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8, marginTop: 10 }}>
       {checks.map(check => (
         <div
-          key={`${check.name}-${check.reason ?? check.status}`}
+          key={check.name}
           title={check.message}
           style={{
             border: "1px solid var(--border)",

--- a/ui/src/features/shared/ProviderReadiness.tsx
+++ b/ui/src/features/shared/ProviderReadiness.tsx
@@ -1,0 +1,161 @@
+import type { ProviderReadinessCheckRecord } from "../../types/runtime";
+
+export function ProviderReadinessChecklist({ checks }: { checks: ProviderReadinessCheckRecord[] }) {
+  if (checks.length === 0) return null;
+
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", overflow: "hidden" }}>
+      <div style={{
+        padding: "7px 10px",
+        borderBottom: "1px solid var(--border)",
+        background: "var(--bg2)",
+        fontSize: 10,
+        color: "var(--t3)",
+        fontFamily: "var(--font-mono)",
+        textTransform: "uppercase",
+        letterSpacing: "0.04em",
+      }}>
+        Readiness
+      </div>
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {checks.map((check, index) => (
+          <div
+            key={`${check.name}-${index}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "120px minmax(0, 1fr)",
+              gap: 10,
+              padding: "8px 10px",
+              borderBottom: index === checks.length - 1 ? undefined : "1px solid var(--border)",
+              alignItems: "start",
+            }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+              <span style={{
+                width: 7,
+                height: 7,
+                borderRadius: 999,
+                background: readinessColor(check.status),
+                boxShadow: check.status === "ok" ? "0 0 10px rgba(96, 199, 112, 0.35)" : undefined,
+                flexShrink: 0,
+              }} />
+              <span style={{
+                fontSize: 11,
+                color: "var(--t1)",
+                fontFamily: "var(--font-mono)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}>
+                {titleizeReadinessName(check.name)}
+              </span>
+            </div>
+            <div style={{ minWidth: 0 }}>
+              <div style={{
+                fontSize: 11,
+                color: readinessTextColor(check.status),
+                lineHeight: 1.45,
+              }}>
+                {check.message || describeReadinessStatus(check.status)}
+              </div>
+              {check.reason && (
+                <div style={{
+                  marginTop: 2,
+                  fontSize: 10,
+                  color: "var(--t3)",
+                  fontFamily: "var(--font-mono)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}>
+                  {check.reason}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CompactProviderReadinessChecks({ checks }: { checks: ProviderReadinessCheckRecord[] }) {
+  if (checks.length === 0) return null;
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8, marginTop: 10 }}>
+      {checks.map(check => (
+        <div
+          key={`${check.name}-${check.reason ?? check.status}`}
+          title={check.message}
+          style={{
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--bg3)",
+            padding: "7px 8px",
+            minWidth: 0,
+          }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{
+              width: 7,
+              height: 7,
+              borderRadius: 999,
+              background: readinessColor(check.status),
+              flexShrink: 0,
+            }} />
+            <span style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              {titleizeReadinessName(check.name)}
+            </span>
+          </div>
+          <div style={{ marginTop: 4, fontSize: 11, color: readinessTextColor(check.status), overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {check.message || check.reason || check.status}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function readinessColor(status?: string): string {
+  switch (status) {
+    case "ok":
+      return "var(--green)";
+    case "warning":
+      return "var(--amber)";
+    case "blocked":
+      return "var(--red)";
+    default:
+      return "var(--t3)";
+  }
+}
+
+function readinessTextColor(status?: string): string {
+  switch (status) {
+    case "blocked":
+      return "var(--red)";
+    case "warning":
+      return "var(--amber)";
+    default:
+      return "var(--t2)";
+  }
+}
+
+function describeReadinessStatus(status?: string): string {
+  switch (status) {
+    case "ok":
+      return "Ready";
+    case "warning":
+      return "Needs attention";
+    case "blocked":
+      return "Blocked";
+    default:
+      return "Unknown";
+  }
+}
+
+function titleizeReadinessName(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -170,6 +170,14 @@ export type ProviderRecord = {
   timeouts?: number;
   server_errors?: number;
   rate_limits?: number;
+  readiness_checks?: ProviderReadinessCheckRecord[];
+};
+
+export type ProviderReadinessCheckRecord = {
+  name: string;
+  status: "ok" | "warning" | "blocked" | "unknown" | string;
+  reason?: string;
+  message?: string;
 };
 
 export type ProviderStatusResponse = {

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -173,9 +173,11 @@ export type ProviderRecord = {
   readiness_checks?: ProviderReadinessCheckRecord[];
 };
 
+export type ProviderReadinessStatus = "ok" | "warning" | "blocked" | "unknown";
+
 export type ProviderReadinessCheckRecord = {
   name: string;
-  status: "ok" | "warning" | "blocked" | "unknown" | string;
+  status: ProviderReadinessStatus;
   reason?: string;
   message?: string;
 };


### PR DESCRIPTION
## Summary

Adds a canonical provider readiness checklist to GET /hecate/v1/providers/status. Each provider now reports four operator-facing checks: credentials, model discovery, health, and routing. Every check includes a stable status, reason, and display-ready message, so the UI no longer has to infer readiness by combining raw credential, model, health, and routing fields.

## Changes

- Adds readiness_checks to provider status API responses.
- Builds readiness checks in the gateway service for credentials, models, health, and routing.
- Documents the new response shape in docs/runtime-api.md and docs/providers.md.
- Updates the README provider status wording to mention checklist-style diagnostics.
- Adds a shared React readiness component used by both Providers and Chats.
- Shows the full checklist in the Providers detail panel.
- Shows compact readiness cards in the Chat no-routable-model troubleshooting panel.

## Validation

- go test ./internal/api ./internal/gateway -count=1
- go test ./internal/api ./internal/gateway -run TestProviderStatusReturnsHealthAndDiscoveryFreshness -count=1
- cd ui && bun run typecheck
- cd ui && bun run test
- git diff --check