### PR TITLE
fix(ui): align Task Detail runtime activity with shared transcript copy

### DIFF
--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -242,7 +242,8 @@ describe("TaskDetail runtime activity and patches", () => {
     const { render } = setup({ activity: [makeActivity({ type: "patch", status: "proposed", title: "main.go.patch" })] });
     render();
     expect(screen.getByText(/Runtime activity/i)).toBeTruthy();
-    expect(screen.getByText("main.go.patch")).toBeTruthy();
+    expect(screen.getByText("Patch")).toBeTruthy();
+    expect(screen.getByText("main.go · proposed")).toBeTruthy();
   });
 
   it("uses the shared transcript activity labels and Details grouping", async () => {
@@ -255,6 +256,7 @@ describe("TaskDetail runtime activity and patches", () => {
           step_id: "step-git",
           tool_name: "git_exec",
           kind: "git",
+          path: undefined,
           status: "completed",
           summary: { command: "git status" },
         }),
@@ -273,7 +275,46 @@ describe("TaskDetail runtime activity and patches", () => {
 
     await user.click(screen.getAllByText("Advanced")[0]);
     expect(screen.getByText("step-git")).toBeTruthy();
-    expect(screen.getByText(/git status/)).toBeTruthy();
+    expect(screen.getAllByText(/git status/).length).toBeGreaterThan(0);
+  });
+
+  it("keeps early useful activity rows instead of pre-slicing before compaction", () => {
+    const activity = Array.from({ length: 13 }, (_, index) => makeActivity({
+      id: `activity-${index}`,
+      type: "tool_call",
+      title: "read_file",
+      tool_name: "read_file",
+      path: `file-${index}.ts`,
+      status: "completed",
+    }));
+    const { render } = setup({ activity });
+    render();
+
+    expect(screen.getAllByText("file-0.ts").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("file-12.ts").length).toBeGreaterThan(0);
+  });
+
+  it("renders task approval rows without leaking internal agent-loop markers", () => {
+    const { render } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-approval",
+          type: "approval",
+          status: "approved",
+          title: "builtin.agent_loop_approval",
+          kind: "builtin.agent_loop_approval",
+          approval_id: "approval-1",
+          summary: { reason: "shell_exec" },
+        }),
+      ],
+    });
+    render();
+
+    expect(screen.getByText("Approval granted")).toBeTruthy();
+    expect(screen.getByText("shell_exec")).toBeTruthy();
+    // The raw internal kind is still available in closed Advanced details,
+    // but it should not leak into the primary activity row.
+    expect(screen.getByText(/builtin\.agent_loop/)).not.toBeVisible();
   });
 
   it("calls onApplyPatch for proposed patch artifacts", async () => {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -842,7 +842,7 @@ function StepRowTitle({ step }: { step: TaskStepRecord }) {
 
 function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
   const activityByID = new Map(activity.map(item => [item.id, item]));
-  const rows = activity.slice(-12).map(taskActivityToTranscriptActivity);
+  const rows = activity.map(taskActivityToTranscriptActivity);
   return (
     <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>
       <div className="kicker" style={{ marginBottom: 8 }}>Runtime activity</div>
@@ -937,16 +937,59 @@ function taskActivityToTranscriptActivity(item: TaskActivityRecord): AgentChatAc
 }
 
 function taskActivityTitle(item: TaskActivityRecord): string {
-  return item.title || item.tool_name || item.path || item.type.replaceAll("_", " ");
+  switch (item.type) {
+    case "approval":
+      if (item.needs_action || item.status === "pending" || item.status === "awaiting_approval") return "Waiting for approval";
+      if (item.status === "approved") return "Approval granted";
+      if (item.status === "rejected" || item.status === "denied") return "Approval rejected";
+      return "Approval";
+    case "artifact":
+      return "Artifact";
+    case "changed_files":
+      return "Changed files";
+    case "final_answer":
+      return "Final answer artifact";
+    case "patch":
+      return "Patch";
+    case "tool_call":
+      return item.tool_name || item.title || item.path || "tool";
+    default:
+      return item.title || item.tool_name || item.path || item.type.replaceAll("_", " ");
+  }
 }
 
 function taskActivitySubtitle(item: TaskActivityRecord): string | undefined {
-  const parts = [
-    item.path,
-    item.kind,
-    item.status,
-  ].filter(Boolean);
+  const status = item.status || "";
+  const reason = summaryString(item, "reason");
+  const command = summaryString(item, "command");
+  const filename = item.path || item.title || "";
+  const parts = (() => {
+    switch (item.type) {
+      case "approval":
+        return [reason, nonInternalKind(item.kind)];
+      case "tool_call":
+        return [item.path, command];
+      case "artifact":
+      case "changed_files":
+      case "final_answer":
+        return [filename, status && status !== "ready" ? status : ""];
+      case "patch":
+        return [filename, status && status !== "ready" ? status : ""];
+      default:
+        return [item.path, nonInternalKind(item.kind), status];
+    }
+  })().filter(Boolean);
   return parts.join(" · ") || undefined;
+}
+
+function summaryString(item: TaskActivityRecord, key: string): string {
+  const value = item.summary?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function nonInternalKind(kind?: string): string {
+  const value = kind?.trim() || "";
+  return value.startsWith("builtin.agent_loop_") ? "" : value;
 }
 
 function StepDetail({ step }: { step: TaskStepRecord }) {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -161,6 +161,20 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText("agent-final-answer.txt")).toBeInTheDocument();
   });
 
+  it("hides internal agent-loop approval markers from operator-facing rows", () => {
+    const activities: AgentChatActivityRecord[] = [
+      {
+        type: "approval",
+        title: "builtin.agent_loop_approval",
+        status: "approved",
+        detail: "builtin.agent_loop_approval - approved",
+      },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+    expect(screen.getByText("Approval granted")).toBeInTheDocument();
+    expect(screen.queryByText(/builtin\.agent_loop/)).toBeNull();
+  });
+
   it("summarizes Hecate Agent task internals without duplicate terminal rows", () => {
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "git_exec", status: "completed", kind: "git", detail: "git_exec - completed" },

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -433,6 +433,7 @@ function cleanApprovalDetail(detail?: string): string | undefined {
     ?.replace(/^Agent requested tools that require approval:\s*/i, "")
     .replace(/\s+-\s+(awaiting_approval|pending|approved|rejected|denied|cancelled|timed_out)$/i, "")
     .trim();
+  if (!cleaned || cleaned.startsWith("builtin.agent_loop_")) return undefined;
   return cleaned || undefined;
 }
 


### PR DESCRIPTION
## Summary

Task Detail now feeds the full runtime activity list into the shared `TranscriptActivityTimeline` instead of slicing the last 12 rows before compaction. This keeps early useful actions visible while still letting the shared timeline group low-level artifacts and remove duplicate terminal/status rows.

The Task Detail activity mapper now normalizes operator-facing labels before rows enter the shared timeline: patches render as “Patch”, approvals as “Approval granted” / “Approval rejected” / “Waiting for approval”, artifacts as “Artifact”, changed-file summaries as “Changed files”, and final-answer artifacts as “Final answer artifact”. Tool rows keep their tool identity, but drop duplicate status/kind clutter from the primary row.

Internal `builtin.agent_loop_*` approval markers are hidden from the main transcript row while remaining available in the closed Advanced section for debugging.

## Validation

- `cd ui && bun run test -- src/features/transcript/TranscriptActivityTimeline.test.tsx src/features/runs/TaskDetail.test.tsx`
- `cd ui && bun run typecheck`