### PR TITLE
chore(website): update Pages actions and dependency lock

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -10,7 +10,6 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "@typescript/native-preview": "beta",
-        "typescript": "6.0.0-beta",
       },
     },
   },

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "@typescript/native-preview": "beta",
-    "typescript": "6.0.0-beta"
+    "@typescript/native-preview": "beta"
   }
 }


### PR DESCRIPTION
## Summary

Update the website deployment workflow to use `actions/upload-pages-artifact@v5` and `actions/deploy-pages@v5` so the GitHub Pages pipeline follows the current action majors.

Remove the direct TypeScript beta dependency from the website package. The website already uses the native TypeScript preview package for `tsgo`, and Astro/check continue to resolve correctly without listing TypeScript directly.

Refresh the Bun lockfile after the package metadata change.

## Validation

- `cd website && bun install`
- `cd website && bun run check`
- `cd website && bun run build`