### PR TITLE
fix(ui): improve chat run diagnostics

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -158,6 +158,13 @@ artifacts and `tool.shell.output_chunk` events; the event payload includes
 `stream: "stdout" | "stderr"` so tooling can reconstruct or filter either
 stream.
 
+Task Detail still records whether each stream artifact exists. The run output
+header shows stdout size when available, `stderr available` when stderr has
+content, and `stderr empty` when the stderr artifact was created but no bytes
+were captured. Hecate Chat keeps failed-tool diagnostics compact: it links only
+non-empty stdout/stderr artifacts from the chat activity row and leaves the
+empty-stream confirmation to Task Detail.
+
 ### Workspace environment system message
 
 Every fresh `agent_loop` run prepends a machine-generated system message that tells the model where its workspace lives:

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -162,8 +162,9 @@ Task Detail still records whether each stream artifact exists. The run output
 header shows stdout size when available, `stderr available` when stderr has
 content, and `stderr empty` when the stderr artifact was created but no bytes
 were captured. Hecate Chat keeps failed-tool diagnostics compact: it links only
-non-empty stdout/stderr artifacts from the chat activity row and leaves the
-empty-stream confirmation to Task Detail.
+non-empty stdout/stderr artifacts from the chat activity row, shows capped
+inline previews for those streams, and leaves the empty-stream confirmation to
+Task Detail.
 
 ### Workspace environment system message
 

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -74,6 +74,10 @@ conversation stays readable; Task Detail opens the activity section by default
 because that view is already a run-inspection surface. Task Detail can also
 show a per-row **Advanced** disclosure with raw activity metadata such as
 step/artifact/approval ids, tool kind, path, timestamp, and summary payload.
+When a tool row fails, Chats may show its own **Advanced** disclosure with links
+back to the backing Task's non-empty stdout/stderr artifacts. Empty streams stay
+hidden there; open the Task view when you need to confirm whether stderr was
+captured but empty.
 
 ## Mental model
 

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -74,8 +74,9 @@ conversation stays readable; Task Detail opens the activity section by default
 because that view is already a run-inspection surface. Task Detail can also
 show a per-row **Advanced** disclosure with raw activity metadata such as
 step/artifact/approval ids, tool kind, path, timestamp, and summary payload.
-When a tool row fails, Chats may show its own **Advanced** disclosure with links
-back to the backing Task's non-empty stdout/stderr artifacts. Empty streams stay
+When a tool row fails, Chats may show its own **Advanced** disclosure with
+capped previews of the backing Task's non-empty stdout/stderr artifacts plus an
+**Open task output** escape hatch for the full capture. Empty streams stay
 hidden there; open the Task view when you need to confirm whether stderr was
 captured but empty.
 

--- a/e2e/approval_reconcile_test.go
+++ b/e2e/approval_reconcile_test.go
@@ -66,7 +66,7 @@ func TestApprovalReconcilePersistsAndFlipsAcrossRestart(t *testing.T) {
 	if err := cmd1.Start(); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
-	waitHealthy(t, "http://"+addr1, 10*time.Second)
+	waitHealthy(t, "http://"+addr1, gatewayStartupTimeout)
 
 	// Create an agent-chat session via the API so the row we insert
 	// below references a valid session_id (the API list endpoint
@@ -96,7 +96,7 @@ func TestApprovalReconcilePersistsAndFlipsAcrossRestart(t *testing.T) {
 		t.Fatalf("second start: %v", err)
 	}
 	t.Cleanup(func() { _ = cmd2.Process.Kill(); _ = cmd2.Wait() })
-	waitHealthy(t, "http://"+addr2, 10*time.Second)
+	waitHealthy(t, "http://"+addr2, gatewayStartupTimeout)
 
 	// Fetch the row through the public API. It must be terminal, with
 	// the path label that distinguishes reconciled rows from regular
@@ -151,7 +151,7 @@ func TestApprovalGrantPersistsAcrossRestart(t *testing.T) {
 	if err := cmd1.Start(); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
-	waitHealthy(t, "http://"+addr1, 10*time.Second)
+	waitHealthy(t, "http://"+addr1, gatewayStartupTimeout)
 
 	base1 := "http://" + addr1
 	sessionID := mustCreateAgentChatSession(t, base1)
@@ -181,7 +181,7 @@ func TestApprovalGrantPersistsAcrossRestart(t *testing.T) {
 		t.Fatalf("second start: %v", err)
 	}
 	t.Cleanup(func() { _ = cmd2.Process.Kill(); _ = cmd2.Wait() })
-	waitHealthy(t, "http://"+addr2, 10*time.Second)
+	waitHealthy(t, "http://"+addr2, gatewayStartupTimeout)
 
 	grants = mustListGrants(t, "http://"+addr2)
 	if len(grants) != 1 {

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -43,6 +43,47 @@ var (
 	builtBinErr  error
 )
 
+const gatewayStartupTimeout = 30 * time.Second
+
+type tailBuffer struct {
+	mu    sync.Mutex
+	buf   []byte
+	limit int
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	return &tailBuffer{limit: limit}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.limit <= 0 {
+		return len(p), nil
+	}
+	if len(p) >= b.limit {
+		b.buf = append(b.buf[:0], p[len(p)-b.limit:]...)
+		return len(p), nil
+	}
+	b.buf = append(b.buf, p...)
+	if overflow := len(b.buf) - b.limit; overflow > 0 {
+		copy(b.buf, b.buf[overflow:])
+		b.buf = b.buf[:b.limit]
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.buf) == 0 {
+		return "(no gateway output captured)"
+	}
+	return string(b.buf)
+}
+
 // hecateBinary returns the path to the compiled hecate binary.
 // The binary is built exactly once per test-binary execution using sync.Once,
 // so parallel tests don't trigger redundant go build invocations.
@@ -104,8 +145,9 @@ func gatewayServer(t *testing.T, extraEnv ...string) string {
 
 	cmd := exec.Command(bin)
 	cmd.Env = env
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
+	output := newTailBuffer(64 * 1024)
+	cmd.Stdout = output
+	cmd.Stderr = output
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start gateway: %v", err)
@@ -115,7 +157,7 @@ func gatewayServer(t *testing.T, extraEnv ...string) string {
 		_ = cmd.Wait()
 	})
 
-	waitHealthy(t, baseURL, 10*time.Second)
+	waitHealthyProcess(t, baseURL, gatewayStartupTimeout, cmd, output)
 	return baseURL
 }
 
@@ -159,19 +201,45 @@ func autoPreconfiguredEnv(extraEnv []string) []string {
 // waitHealthy polls GET /healthz until it returns 200 or the deadline expires.
 func waitHealthy(t *testing.T, baseURL string, timeout time.Duration) {
 	t.Helper()
+	waitHealthyWithDiagnostics(t, baseURL, timeout, nil, nil)
+}
+
+func waitHealthyProcess(t *testing.T, baseURL string, timeout time.Duration, cmd *exec.Cmd, output *tailBuffer) {
+	t.Helper()
+	waitHealthyWithDiagnostics(t, baseURL, timeout, cmd, output)
+}
+
+func waitHealthyWithDiagnostics(t *testing.T, baseURL string, timeout time.Duration, cmd *exec.Cmd, output *tailBuffer) {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
+	lastProbe := "not attempted"
+	client := &http.Client{Timeout: time.Second}
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(baseURL + "/healthz") //nolint:noctx
+		resp, err := client.Get(baseURL + "/healthz") //nolint:noctx
 		if err == nil && resp.StatusCode == http.StatusOK {
 			resp.Body.Close()
 			return
+		}
+		if err != nil {
+			lastProbe = err.Error()
+		} else {
+			lastProbe = fmt.Sprintf("HTTP %d", resp.StatusCode)
 		}
 		if resp != nil {
 			resp.Body.Close()
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("gateway at %s never became healthy within %s", baseURL, timeout)
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+		if err := cmd.Wait(); err != nil {
+			lastProbe += "; process wait: " + err.Error()
+		}
+	}
+	if output != nil {
+		t.Fatalf("gateway at %s never became healthy within %s (last probe: %s)\n--- gateway output tail ---\n%s", baseURL, timeout, lastProbe, output.String())
+	}
+	t.Fatalf("gateway at %s never became healthy within %s (last probe: %s)", baseURL, timeout, lastProbe)
 }
 
 // freePort asks the OS for an available TCP port.
@@ -1205,7 +1273,7 @@ func TestBootstrapAutoGenerationDefaultPath(t *testing.T) {
 	if err := cmd1.Start(); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
-	waitHealthy(t, "http://"+addr1, 10*time.Second)
+	waitHealthy(t, "http://"+addr1, gatewayStartupTimeout)
 
 	bootstrapPath := filepath.Join(workDir, ".data", "hecate.bootstrap.json")
 	info, err := os.Stat(bootstrapPath)
@@ -1269,7 +1337,7 @@ func TestBootstrapAutoGenerationDefaultPath(t *testing.T) {
 		t.Fatalf("second start: %v", err)
 	}
 	t.Cleanup(func() { _ = cmd2.Process.Kill(); _ = cmd2.Wait() })
-	waitHealthy(t, "http://"+addr2, 10*time.Second)
+	waitHealthy(t, "http://"+addr2, gatewayStartupTimeout)
 
 	resp, err = http.Get("http://" + addr2 + "/v1/models")
 	if err != nil {

--- a/internal/agentchat/store.go
+++ b/internal/agentchat/store.go
@@ -83,9 +83,13 @@ type Activity struct {
 	// ArtifactSizeBytes is populated for task artifact activities.
 	// It lets chat diagnostics hide empty stdout/stderr captures while
 	// still linking useful non-empty run output.
-	ArtifactSizeBytes int64  `json:"artifact_size_bytes,omitempty"`
-	ApprovalID        string `json:"approval_id,omitempty"`
-	NeedsAction       bool   `json:"needs_action,omitempty"`
+	ArtifactSizeBytes int64 `json:"artifact_size_bytes,omitempty"`
+	// ArtifactPreview carries a capped text preview for stdout/stderr-like
+	// artifacts so chat diagnostics can explain a failed tool without forcing
+	// the operator to leave the transcript.
+	ArtifactPreview string `json:"artifact_preview,omitempty"`
+	ApprovalID      string `json:"approval_id,omitempty"`
+	NeedsAction     bool   `json:"needs_action,omitempty"`
 }
 
 type Usage struct {

--- a/internal/agentchat/store.go
+++ b/internal/agentchat/store.go
@@ -72,15 +72,20 @@ type Message struct {
 }
 
 type Activity struct {
-	ID          string    `json:"id,omitempty"`
-	Type        string    `json:"type"`
-	Status      string    `json:"status,omitempty"`
-	Kind        string    `json:"kind,omitempty"`
-	Title       string    `json:"title"`
-	Detail      string    `json:"detail,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	ApprovalID  string    `json:"approval_id,omitempty"`
-	NeedsAction bool      `json:"needs_action,omitempty"`
+	ID         string    `json:"id,omitempty"`
+	Type       string    `json:"type"`
+	Status     string    `json:"status,omitempty"`
+	Kind       string    `json:"kind,omitempty"`
+	Title      string    `json:"title"`
+	Detail     string    `json:"detail,omitempty"`
+	CreatedAt  time.Time `json:"created_at,omitempty"`
+	ArtifactID string    `json:"artifact_id,omitempty"`
+	// ArtifactSizeBytes is populated for task artifact activities.
+	// It lets chat diagnostics hide empty stdout/stderr captures while
+	// still linking useful non-empty run output.
+	ArtifactSizeBytes int64  `json:"artifact_size_bytes,omitempty"`
+	ApprovalID        string `json:"approval_id,omitempty"`
+	NeedsAction       bool   `json:"needs_action,omitempty"`
 }
 
 type Usage struct {

--- a/internal/api/handler_agent_chat_activities.go
+++ b/internal/api/handler_agent_chat_activities.go
@@ -26,6 +26,7 @@ func renderAgentChatActivities(items []agentchat.Activity) []AgentChatActivityIt
 			CreatedAt:         formatOptionalTime(item.CreatedAt),
 			ArtifactID:        item.ArtifactID,
 			ArtifactSizeBytes: item.ArtifactSizeBytes,
+			ArtifactPreview:   item.ArtifactPreview,
 			ApprovalID:        item.ApprovalID,
 			NeedsAction:       item.NeedsAction,
 		})
@@ -82,6 +83,7 @@ func agentChatActivityFromTaskActivity(item TaskActivityItem) agentchat.Activity
 		CreatedAt:         parseAgentChatActivityTime(item.OccurredAt),
 		ArtifactID:        strings.TrimSpace(item.ArtifactID),
 		ArtifactSizeBytes: agentChatTaskArtifactSize(item),
+		ArtifactPreview:   agentChatTaskArtifactPreview(item),
 		ApprovalID:        strings.TrimSpace(item.ApprovalID),
 		NeedsAction:       item.NeedsAction,
 	}
@@ -104,6 +106,14 @@ func agentChatTaskArtifactSize(item TaskActivityItem) int64 {
 	default:
 		return 0
 	}
+}
+
+func agentChatTaskArtifactPreview(item TaskActivityItem) string {
+	if item.Summary == nil {
+		return ""
+	}
+	value, _ := item.Summary["content_preview"].(string)
+	return strings.TrimSpace(value)
 }
 
 func agentChatTaskActivityDetail(item TaskActivityItem) string {
@@ -168,6 +178,15 @@ func mergeAgentChatActivity(items []agentchat.Activity, next agentchat.Activity)
 				}
 				if next.ApprovalID != "" {
 					items[i].ApprovalID = next.ApprovalID
+				}
+				if next.ArtifactID != "" {
+					items[i].ArtifactID = next.ArtifactID
+				}
+				if next.ArtifactSizeBytes != 0 {
+					items[i].ArtifactSizeBytes = next.ArtifactSizeBytes
+				}
+				if next.ArtifactPreview != "" {
+					items[i].ArtifactPreview = next.ArtifactPreview
 				}
 				items[i].NeedsAction = next.NeedsAction
 				items[i].CreatedAt = next.CreatedAt

--- a/internal/api/handler_agent_chat_activities.go
+++ b/internal/api/handler_agent_chat_activities.go
@@ -113,7 +113,7 @@ func agentChatTaskArtifactPreview(item TaskActivityItem) string {
 		return ""
 	}
 	value, _ := item.Summary["content_preview"].(string)
-	return strings.TrimSpace(value)
+	return strings.TrimRight(value, "\r\n")
 }
 
 func agentChatTaskActivityDetail(item TaskActivityItem) string {

--- a/internal/api/handler_agent_chat_activities.go
+++ b/internal/api/handler_agent_chat_activities.go
@@ -17,15 +17,17 @@ func renderAgentChatActivities(items []agentchat.Activity) []AgentChatActivityIt
 	out := make([]AgentChatActivityItem, 0, len(items))
 	for _, item := range items {
 		out = append(out, AgentChatActivityItem{
-			ID:          item.ID,
-			Type:        item.Type,
-			Status:      item.Status,
-			Kind:        item.Kind,
-			Title:       item.Title,
-			Detail:      item.Detail,
-			CreatedAt:   formatOptionalTime(item.CreatedAt),
-			ApprovalID:  item.ApprovalID,
-			NeedsAction: item.NeedsAction,
+			ID:                item.ID,
+			Type:              item.Type,
+			Status:            item.Status,
+			Kind:              item.Kind,
+			Title:             item.Title,
+			Detail:            item.Detail,
+			CreatedAt:         formatOptionalTime(item.CreatedAt),
+			ArtifactID:        item.ArtifactID,
+			ArtifactSizeBytes: item.ArtifactSizeBytes,
+			ApprovalID:        item.ApprovalID,
+			NeedsAction:       item.NeedsAction,
 		})
 	}
 	return out
@@ -71,15 +73,36 @@ func agentChatActivitiesFromTaskActivity(items []TaskActivityItem) []agentchat.A
 func agentChatActivityFromTaskActivity(item TaskActivityItem) agentchat.Activity {
 	title := strings.TrimSpace(firstNonEmpty(item.Title, item.ToolName, item.Path, item.Kind, item.Type))
 	return agentchat.Activity{
-		ID:          strings.TrimSpace("task:" + item.ID),
-		Type:        strings.TrimSpace(item.Type),
-		Status:      strings.TrimSpace(item.Status),
-		Kind:        strings.TrimSpace(firstNonEmpty(item.Kind, item.ToolName)),
-		Title:       title,
-		Detail:      agentChatTaskActivityDetail(item),
-		CreatedAt:   parseAgentChatActivityTime(item.OccurredAt),
-		ApprovalID:  strings.TrimSpace(item.ApprovalID),
-		NeedsAction: item.NeedsAction,
+		ID:                strings.TrimSpace("task:" + item.ID),
+		Type:              strings.TrimSpace(item.Type),
+		Status:            strings.TrimSpace(item.Status),
+		Kind:              strings.TrimSpace(firstNonEmpty(item.Kind, item.ToolName)),
+		Title:             title,
+		Detail:            agentChatTaskActivityDetail(item),
+		CreatedAt:         parseAgentChatActivityTime(item.OccurredAt),
+		ArtifactID:        strings.TrimSpace(item.ArtifactID),
+		ArtifactSizeBytes: agentChatTaskArtifactSize(item),
+		ApprovalID:        strings.TrimSpace(item.ApprovalID),
+		NeedsAction:       item.NeedsAction,
+	}
+}
+
+func agentChatTaskArtifactSize(item TaskActivityItem) int64 {
+	if item.Summary == nil {
+		return 0
+	}
+	switch value := item.Summary["size_bytes"].(type) {
+	case int:
+		return int64(value)
+	case int64:
+		return value
+	case float64:
+		return int64(value)
+	case json.Number:
+		n, _ := value.Int64()
+		return n
+	default:
+		return 0
 	}
 }
 

--- a/internal/api/handler_agent_chat_hecate_test.go
+++ b/internal/api/handler_agent_chat_hecate_test.go
@@ -565,7 +565,8 @@ func TestAgentChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) 
 		ArtifactID: "art_stderr",
 		Kind:       "stderr",
 		Summary: map[string]any{
-			"size_bytes": float64(42),
+			"size_bytes":      float64(42),
+			"content_preview": "fatal: not a git repository",
 		},
 		OccurredAt: "2026-05-03T10:00:00Z",
 	}
@@ -577,6 +578,9 @@ func TestAgentChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) 
 	}
 	if rendered[0].ArtifactID != "art_stderr" || rendered[0].ArtifactSizeBytes != 42 {
 		t.Fatalf("artifact metadata = id %q size %d, want art_stderr/42", rendered[0].ArtifactID, rendered[0].ArtifactSizeBytes)
+	}
+	if rendered[0].ArtifactPreview != "fatal: not a git repository" {
+		t.Fatalf("artifact preview = %q", rendered[0].ArtifactPreview)
 	}
 }
 
@@ -641,6 +645,24 @@ func TestTaskActivityItemsUseResolvedApprovalStatusForStep(t *testing.T) {
 	item := taskActivityByID(items, "step:step_1")
 	if item.Status != "approved" || item.NeedsAction {
 		t.Fatalf("approval activity = status %q needs_action %v, want approved/false", item.Status, item.NeedsAction)
+	}
+}
+
+func TestTaskActivityItemsIncludeOutputArtifactPreview(t *testing.T) {
+	items := buildTaskActivityItems(nil, []TaskArtifactItem{{
+		ID:          "art_stdout",
+		Kind:        "stdout",
+		Name:        "git-stdout.txt",
+		ContentText: "diff --git a/README.md b/README.md\n+hello\n",
+		SizeBytes:   42,
+		Status:      "ready",
+		CreatedAt:   "2026-05-03T10:00:00Z",
+	}}, nil, types.TaskRun{Status: "failed"})
+
+	item := taskActivityByID(items, "artifact:art_stdout")
+	preview, _ := item.Summary["content_preview"].(string)
+	if !strings.Contains(preview, "+hello") {
+		t.Fatalf("content_preview = %q, want stdout preview", preview)
 	}
 }
 

--- a/internal/api/handler_agent_chat_hecate_test.go
+++ b/internal/api/handler_agent_chat_hecate_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hecate/agent-runtime/internal/agentchat"
 	"github.com/hecate/agent-runtime/internal/config"
@@ -663,6 +664,27 @@ func TestTaskActivityItemsIncludeOutputArtifactPreview(t *testing.T) {
 	preview, _ := item.Summary["content_preview"].(string)
 	if !strings.Contains(preview, "+hello") {
 		t.Fatalf("content_preview = %q, want stdout preview", preview)
+	}
+}
+
+func TestTaskActivityArtifactPreviewPreservesLeadingWhitespaceAndCapsBytes(t *testing.T) {
+	content := "  indented output\n" + strings.Repeat("λ", taskActivityArtifactPreviewMaxBytes)
+	preview := taskActivityArtifactContentPreview(TaskArtifactItem{
+		Kind:        "stderr",
+		ContentText: content,
+	})
+
+	if !strings.HasPrefix(preview, "  indented output") {
+		t.Fatalf("preview = %q, want leading whitespace preserved", preview[:min(len(preview), 40)])
+	}
+	if !strings.HasSuffix(preview, taskActivityArtifactPreviewTruncatedSuffix) {
+		t.Fatalf("preview missing truncation suffix")
+	}
+	if len(preview) > taskActivityArtifactPreviewMaxBytes {
+		t.Fatalf("preview length = %d, want <= %d", len(preview), taskActivityArtifactPreviewMaxBytes)
+	}
+	if !utf8.ValidString(preview) {
+		t.Fatalf("preview is not valid UTF-8")
 	}
 }
 

--- a/internal/api/handler_agent_chat_hecate_test.go
+++ b/internal/api/handler_agent_chat_hecate_test.go
@@ -567,7 +567,7 @@ func TestAgentChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) 
 		Kind:       "stderr",
 		Summary: map[string]any{
 			"size_bytes":      float64(42),
-			"content_preview": "fatal: not a git repository",
+			"content_preview": "  fatal: not a git repository\n",
 		},
 		OccurredAt: "2026-05-03T10:00:00Z",
 	}
@@ -580,7 +580,7 @@ func TestAgentChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) 
 	if rendered[0].ArtifactID != "art_stderr" || rendered[0].ArtifactSizeBytes != 42 {
 		t.Fatalf("artifact metadata = id %q size %d, want art_stderr/42", rendered[0].ArtifactID, rendered[0].ArtifactSizeBytes)
 	}
-	if rendered[0].ArtifactPreview != "fatal: not a git repository" {
+	if rendered[0].ArtifactPreview != "  fatal: not a git repository" {
 		t.Fatalf("artifact preview = %q", rendered[0].ArtifactPreview)
 	}
 }

--- a/internal/api/handler_agent_chat_hecate_test.go
+++ b/internal/api/handler_agent_chat_hecate_test.go
@@ -556,6 +556,30 @@ func TestAgentChatActivityFromTaskActivityCarriesApprovalMetadata(t *testing.T) 
 	}
 }
 
+func TestAgentChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) {
+	item := TaskActivityItem{
+		ID:         "artifact:art_stderr",
+		Type:       "artifact",
+		Status:     "ready",
+		Title:      "git-stderr.txt",
+		ArtifactID: "art_stderr",
+		Kind:       "stderr",
+		Summary: map[string]any{
+			"size_bytes": float64(42),
+		},
+		OccurredAt: "2026-05-03T10:00:00Z",
+	}
+
+	activity := agentChatActivityFromTaskActivity(item)
+	rendered := renderAgentChatActivities([]agentchat.Activity{activity})
+	if len(rendered) != 1 {
+		t.Fatalf("rendered activities = %d, want 1", len(rendered))
+	}
+	if rendered[0].ArtifactID != "art_stderr" || rendered[0].ArtifactSizeBytes != 42 {
+		t.Fatalf("artifact metadata = id %q size %d, want art_stderr/42", rendered[0].ArtifactID, rendered[0].ArtifactSizeBytes)
+	}
+}
+
 func TestMergeAgentChatActivityClearsApprovalNeedsAction(t *testing.T) {
 	items := []agentchat.Activity{{
 		ID:          "task:approval:appr_123",

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -1547,29 +1547,40 @@ func buildTaskActivityItems(steps []TaskStepItem, artifacts []TaskArtifactItem, 
 }
 
 const taskActivityArtifactPreviewMaxBytes = 2000
+const taskActivityArtifactPreviewTruncatedSuffix = "\n...[truncated]"
 
 func taskActivityArtifactContentPreview(artifact TaskArtifactItem) string {
 	if artifact.Kind != "stdout" && artifact.Kind != "stderr" {
 		return ""
 	}
-	content := strings.TrimSpace(artifact.ContentText)
+	maxBytes := taskActivityArtifactPreviewMaxBytes
+	content := strings.TrimRight(artifact.ContentText, "\r\n")
 	if content == "" {
 		return ""
 	}
-	if len(content) <= taskActivityArtifactPreviewMaxBytes {
+	if len(content) <= maxBytes {
 		return content
+	}
+	budget := maxBytes - len(taskActivityArtifactPreviewTruncatedSuffix)
+	if budget <= 0 {
+		return taskActivityArtifactPreviewTruncatedSuffix[:maxBytes]
+	}
+	end := truncateStringByteIndex(content, budget)
+	return content[:end] + taskActivityArtifactPreviewTruncatedSuffix
+}
+
+func truncateStringByteIndex(content string, maxBytes int) int {
+	if len(content) <= maxBytes {
+		return len(content)
 	}
 	end := 0
 	for index := range content {
-		if index > taskActivityArtifactPreviewMaxBytes {
+		if index > maxBytes {
 			break
 		}
 		end = index
 	}
-	if end <= 0 {
-		end = taskActivityArtifactPreviewMaxBytes
-	}
-	return content[:end] + "\n...[truncated]"
+	return end
 }
 
 func sortTaskActivityItems(items []TaskActivityItem) {

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -1497,6 +1497,13 @@ func buildTaskActivityItems(steps []TaskStepItem, artifacts []TaskArtifactItem, 
 		case "summary":
 			itemType = "final_answer"
 		}
+		summary := map[string]any{
+			"size_bytes": artifact.SizeBytes,
+			"mime_type":  artifact.MimeType,
+		}
+		if preview := taskActivityArtifactContentPreview(artifact); preview != "" {
+			summary["content_preview"] = preview
+		}
 		items = append(items, TaskActivityItem{
 			ID:         "artifact:" + artifact.ID,
 			Type:       itemType,
@@ -1506,10 +1513,7 @@ func buildTaskActivityItems(steps []TaskStepItem, artifacts []TaskArtifactItem, 
 			ArtifactID: artifact.ID,
 			Kind:       artifact.Kind,
 			Path:       artifact.Path,
-			Summary: map[string]any{
-				"size_bytes": artifact.SizeBytes,
-				"mime_type":  artifact.MimeType,
-			},
+			Summary:    summary,
 			OccurredAt: artifact.CreatedAt,
 			Terminal:   artifact.Status == "ready" || artifact.Status == "applied" || artifact.Status == "reverted",
 		})
@@ -1540,6 +1544,32 @@ func buildTaskActivityItems(steps []TaskStepItem, artifacts []TaskArtifactItem, 
 	}
 	sortTaskActivityItems(items)
 	return items
+}
+
+const taskActivityArtifactPreviewMaxBytes = 2000
+
+func taskActivityArtifactContentPreview(artifact TaskArtifactItem) string {
+	if artifact.Kind != "stdout" && artifact.Kind != "stderr" {
+		return ""
+	}
+	content := strings.TrimSpace(artifact.ContentText)
+	if content == "" {
+		return ""
+	}
+	if len(content) <= taskActivityArtifactPreviewMaxBytes {
+		return content
+	}
+	end := 0
+	for index := range content {
+		if index > taskActivityArtifactPreviewMaxBytes {
+			break
+		}
+		end = index
+	}
+	if end <= 0 {
+		end = taskActivityArtifactPreviewMaxBytes
+	}
+	return content[:end] + "\n...[truncated]"
 }
 
 func sortTaskActivityItems(items []TaskActivityItem) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -779,6 +779,7 @@ type AgentChatActivityItem struct {
 	CreatedAt         string `json:"created_at,omitempty"`
 	ArtifactID        string `json:"artifact_id,omitempty"`
 	ArtifactSizeBytes int64  `json:"artifact_size_bytes,omitempty"`
+	ArtifactPreview   string `json:"artifact_preview,omitempty"`
 	ApprovalID        string `json:"approval_id,omitempty"`
 	NeedsAction       bool   `json:"needs_action,omitempty"`
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -770,15 +770,17 @@ type AgentChatRevertResponse struct {
 }
 
 type AgentChatActivityItem struct {
-	ID          string `json:"id,omitempty"`
-	Type        string `json:"type"`
-	Status      string `json:"status,omitempty"`
-	Kind        string `json:"kind,omitempty"`
-	Title       string `json:"title"`
-	Detail      string `json:"detail,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	ApprovalID  string `json:"approval_id,omitempty"`
-	NeedsAction bool   `json:"needs_action,omitempty"`
+	ID                string `json:"id,omitempty"`
+	Type              string `json:"type"`
+	Status            string `json:"status,omitempty"`
+	Kind              string `json:"kind,omitempty"`
+	Title             string `json:"title"`
+	Detail            string `json:"detail,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"`
+	ArtifactID        string `json:"artifact_id,omitempty"`
+	ArtifactSizeBytes int64  `json:"artifact_size_bytes,omitempty"`
+	ApprovalID        string `json:"approval_id,omitempty"`
+	NeedsAction       bool   `json:"needs_action,omitempty"`
 }
 
 type AgentChatUsageItem struct {

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -266,6 +266,106 @@ test("agent chat renders indented fenced code blocks as code", async ({ page }) 
   await expect(page.locator("code").filter({ hasText: "sh" })).toHaveCount(0);
 });
 
+test("agent chat previews failed tool stdout and stderr in Advanced details", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.agentChatSessionID", "failed-tool-output-e2e");
+  });
+
+  const session = {
+    id: "failed-tool-output-e2e",
+    title: "Failed tool",
+    runtime_kind: "agent",
+    provider: "ollama",
+    model: "qwen2.5-coder",
+    workspace: "/tmp/e2e",
+    status: "completed",
+    message_count: 2,
+    messages: [
+      { id: "m-user", role: "user", content: "why did git fail?", created_at: "2026-04-21T10:00:00Z" },
+      {
+        id: "m-agent",
+        role: "assistant",
+        runtime_kind: "agent",
+        content: "The command failed while inspecting git state.",
+        provider: "ollama",
+        model: "qwen2.5-coder",
+        status: "failed",
+        task_id: "task_failed",
+        run_id: "run_failed",
+        created_at: "2026-04-21T10:00:01Z",
+        activities: [
+          { id: "tool_git", type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
+          {
+            id: "stdout",
+            type: "artifact",
+            title: "git-stdout.txt",
+            status: "ready",
+            artifact_id: "art_stdout",
+            artifact_size_bytes: 41,
+            artifact_preview: "On branch feature/chat-message-queue",
+          },
+          {
+            id: "stderr",
+            type: "artifact",
+            title: "git-stderr.txt",
+            status: "ready",
+            artifact_id: "art_stderr",
+            artifact_size_bytes: 57,
+            artifact_preview: "fatal: not a git repository",
+          },
+          {
+            id: "empty-stderr",
+            type: "artifact",
+            title: "shell-stderr.txt",
+            status: "ready",
+            artifact_id: "art_empty_stderr",
+            artifact_size_bytes: 0,
+          },
+          { id: "terminal", type: "failed", title: "Run failed", status: "failed", terminal: true },
+        ],
+      },
+    ],
+  };
+
+  await page.route("/hecate/v1/agent-chat/sessions", (route) => {
+    if (route.request().method() !== "GET") {
+      void route.fallback();
+      return;
+    }
+    void route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "agent_chat_sessions",
+        data: [{ ...session, messages: undefined }],
+      }),
+    });
+  });
+  await page.route("/hecate/v1/agent-chat/sessions/failed-tool-output-e2e", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ object: "agent_chat_session", data: session }),
+    }),
+  );
+  await page.route("/hecate/v1/agent-chat/sessions/failed-tool-output-e2e/approvals*", route =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ object: "list", data: [] }) }),
+  );
+
+  await page.reload();
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByText(/1 (failed )?tool/).click();
+  await page.getByText("Advanced").first().click();
+
+  await expect(page.getByText(/Preview the related run output/)).toBeVisible();
+  await expect(page.getByText("On branch feature/chat-message-queue")).toBeVisible();
+  await expect(page.getByText("fatal: not a git repository")).toBeVisible();
+  await expect(page.getByText("Open task output")).toBeVisible();
+  await expect(page.getByText("Preview unavailable in this snapshot.")).toHaveCount(0);
+});
+
 test("empty model chat can add all detected local providers in one click", async ({ page }) => {
   await page.unrouteAll({ behavior: "ignoreErrors" });
   await mockGatewayAPIs(page);

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -195,6 +195,77 @@ test("chat error renders inline with the humanized message", async ({ page }) =>
   await expect(page.getByText(/has no API key/i).first()).toBeVisible();
 });
 
+test("agent chat renders indented fenced code blocks as code", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.agentChatSessionID", "markdown-fence-e2e");
+  });
+
+  const session = {
+    id: "markdown-fence-e2e",
+    title: "Markdown fence",
+    runtime_kind: "agent",
+    provider: "ollama",
+    model: "qwen2.5-coder",
+    workspace: "/tmp/e2e",
+    status: "completed",
+    message_count: 2,
+    messages: [
+      { id: "m-user", role: "user", content: "show commands", created_at: "2026-04-21T10:00:00Z" },
+      {
+        id: "m-agent",
+        role: "assistant",
+        content: [
+          "Next steps:",
+          "",
+          "1. Review local changes:",
+          "  ```sh",
+          "git status",
+          "git diff -- README.md",
+          "  ```",
+        ].join("\n"),
+        provider: "ollama",
+        model: "qwen2.5-coder",
+        status: "completed",
+        created_at: "2026-04-21T10:00:01Z",
+      },
+    ],
+  };
+
+  await page.route("/hecate/v1/agent-chat/sessions", (route) => {
+    if (route.request().method() !== "GET") {
+      void route.fallback();
+      return;
+    }
+    void route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "agent_chat_sessions",
+        data: [{ ...session, messages: undefined }],
+      }),
+    });
+  });
+  await page.route("/hecate/v1/agent-chat/sessions/markdown-fence-e2e", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ object: "agent_chat_session", data: session }),
+    }),
+  );
+  await page.route("/hecate/v1/agent-chat/sessions/markdown-fence-e2e/approvals*", route =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ object: "list", data: [] }) }),
+  );
+
+  await page.reload();
+  await page.waitForSelector(".hecate-activitybar");
+
+  const codeBlock = page.locator("pre").filter({ hasText: "git status" });
+  await expect(codeBlock).toBeVisible();
+  await expect(codeBlock).toContainText("git diff -- README.md");
+  await expect(page.locator("code").filter({ hasText: "sh" })).toHaveCount(0);
+});
+
 test("empty model chat can add all detected local providers in one click", async ({ page }) => {
   await page.unrouteAll({ behavior: "ignoreErrors" });
   await mockGatewayAPIs(page);

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -347,6 +347,25 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.queryByText("— stderr —")).toBeNull();
   });
 
+  it("marks object-backed stderr artifacts as available when they have bytes", () => {
+    const { render } = setup({
+      artifacts: [
+        {
+          id: "art-stderr",
+          task_id: "task-1",
+          run_id: "run-1",
+          kind: "stderr",
+          name: "git-stderr.txt",
+          content_text: "",
+          object_ref: "artifact://stderr",
+          size_bytes: 512,
+        } as any,
+      ],
+    });
+    render();
+    expect(screen.getByText("stderr available")).toBeTruthy();
+  });
+
   it("calls onApplyPatch for proposed patch artifacts", async () => {
     const onApplyPatch = vi.fn();
     const { render, user } = setup({ artifacts: [makePatchArtifact()], onApplyPatch });

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -317,6 +317,36 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText(/builtin\.agent_loop/)).not.toBeVisible();
   });
 
+  it("shows when stderr exists but is empty", () => {
+    const { render } = setup({
+      artifacts: [
+        {
+          id: "art-stdout",
+          task_id: "task-1",
+          run_id: "run-1",
+          kind: "stdout",
+          name: "git-stdout.txt",
+          content_text: "diff output",
+          size_bytes: 11,
+        } as any,
+        {
+          id: "art-stderr",
+          task_id: "task-1",
+          run_id: "run-1",
+          kind: "stderr",
+          name: "git-stderr.txt",
+          content_text: "",
+          size_bytes: 0,
+        } as any,
+      ],
+    });
+    render();
+    expect(screen.getByText("run output")).toBeTruthy();
+    expect(screen.getByText("stdout 11b")).toBeTruthy();
+    expect(screen.getByText("stderr empty")).toBeTruthy();
+    expect(screen.queryByText("— stderr —")).toBeNull();
+  });
+
   it("calls onApplyPatch for proposed patch artifacts", async () => {
     const onApplyPatch = vi.fn();
     const { render, user } = setup({ artifacts: [makePatchArtifact()], onApplyPatch });

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -689,11 +689,11 @@ export function TaskDetail({
             {stderrArtifact && (
               <span style={{
                 fontSize: 10,
-                color: stderrArtifact.content_text ? "var(--red)" : "var(--t3)",
+                color: artifactHasBytes(stderrArtifact) ? "var(--red)" : "var(--t3)",
                 fontFamily: "var(--font-mono)",
                 marginLeft: "auto",
               }}>
-                stderr {stderrArtifact.content_text ? "available" : "empty"}
+                stderr {artifactHasBytes(stderrArtifact) ? "available" : "empty"}
               </span>
             )}
           </div>
@@ -958,7 +958,12 @@ function taskActivityArtifactSize(item: TaskActivityRecord): number | undefined 
 
 function taskActivityArtifactPreview(item: TaskActivityRecord): string | undefined {
   const value = item.summary?.content_preview;
-  return typeof value === "string" && value.trim() ? value : undefined;
+  return typeof value === "string" && value.trimEnd() ? value.replace(/[\r\n]+$/, "") : undefined;
+}
+
+function artifactHasBytes(artifact: TaskArtifactRecord): boolean {
+  if (typeof artifact.size_bytes === "number") return artifact.size_bytes > 0;
+  return Boolean(artifact.content_text);
 }
 
 function taskActivityTitle(item: TaskActivityRecord): string {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -944,6 +944,7 @@ function taskActivityToTranscriptActivity(item: TaskActivityRecord): AgentChatAc
     created_at: item.occurred_at,
     artifact_id: item.artifact_id,
     artifact_size_bytes: taskActivityArtifactSize(item),
+    artifact_preview: taskActivityArtifactPreview(item),
     approval_id: item.approval_id,
     needs_action: item.needs_action,
     terminal: item.terminal,
@@ -953,6 +954,11 @@ function taskActivityToTranscriptActivity(item: TaskActivityRecord): AgentChatAc
 function taskActivityArtifactSize(item: TaskActivityRecord): number | undefined {
   const value = item.summary?.size_bytes;
   return typeof value === "number" ? value : undefined;
+}
+
+function taskActivityArtifactPreview(item: TaskActivityRecord): string | undefined {
+  const value = item.summary?.content_preview;
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function taskActivityTitle(item: TaskActivityRecord): string {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -678,11 +678,23 @@ export function TaskDetail({
         <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 180 }}>
           <div style={{ padding: "8px 16px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", gap: 8, background: "var(--bg1)" }}>
             <Icon d={Icons.terminal} size={13} />
-            <span style={{ fontSize: 11, color: "var(--t2)", fontFamily: "var(--font-mono)" }}>stdout</span>
+            <span style={{ fontSize: 11, color: "var(--t2)", fontFamily: "var(--font-mono)" }}>run output</span>
+            {stdoutArtifact && (
+              <span style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
+                stdout{stdoutArtifact.size_bytes ? ` ${stdoutArtifact.size_bytes}b` : ""}
+              </span>
+            )}
             {streamState === "live" && <Dot color="green" pulse />}
             {streamState === "connecting" && <Dot color="amber" pulse />}
-            {stderrArtifact?.content_text && (
-              <span style={{ fontSize: 10, color: "var(--red)", fontFamily: "var(--font-mono)", marginLeft: "auto" }}>stderr available</span>
+            {stderrArtifact && (
+              <span style={{
+                fontSize: 10,
+                color: stderrArtifact.content_text ? "var(--red)" : "var(--t3)",
+                fontFamily: "var(--font-mono)",
+                marginLeft: "auto",
+              }}>
+                stderr {stderrArtifact.content_text ? "available" : "empty"}
+              </span>
             )}
           </div>
           <div ref={termRef} style={{ flex: 1, overflowY: "auto", padding: "10px 16px", background: "var(--bg0)", fontFamily: "var(--font-mono)", fontSize: 12, lineHeight: 1.8 }}>
@@ -930,10 +942,17 @@ function taskActivityToTranscriptActivity(item: TaskActivityRecord): AgentChatAc
     kind: item.kind,
     detail: taskActivitySubtitle(item),
     created_at: item.occurred_at,
+    artifact_id: item.artifact_id,
+    artifact_size_bytes: taskActivityArtifactSize(item),
     approval_id: item.approval_id,
     needs_action: item.needs_action,
     terminal: item.terminal,
   };
+}
+
+function taskActivityArtifactSize(item: TaskActivityRecord): number | undefined {
+  const value = item.summary?.size_bytes;
+  return typeof value === "number" ? value : undefined;
 }
 
 function taskActivityTitle(item: TaskActivityRecord): string {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -124,6 +124,17 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText("git_exec - completed")).toBeNull();
   });
 
+  it("humanizes failed tool titles with status suffixes and marks the summary", () => {
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
+      { type: "completed", title: "Run completed", status: "completed" },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+    expect(screen.getByText(/completed · 1 failed tool/)).toBeInTheDocument();
+    expect(screen.getByText("Ran git")).toBeInTheDocument();
+    expect(screen.queryByText("git_exec - failed")).toBeNull();
+  });
+
   it("includes changed files in the summary and expanded activity list when diffStat is supplied", () => {
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "read_file", status: "completed" },
@@ -208,6 +219,22 @@ describe("TranscriptActivityTimeline", () => {
     const labels = screen.getAllByText(/Starting agent|Backing task|Thinking|Ran shell/)
       .map(node => node.textContent);
     expect(labels).toEqual(["Starting agent", "Backing task", "Thinking", "Ran shell"]);
+  });
+
+  it("uses operator-facing order for Hecate task rows with identical timestamps", () => {
+    const at = "2026-05-07T20:00:00Z";
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed", created_at: at },
+      { type: "thinking", title: "Agent turn 1", status: "completed", detail: "builtin.agent_loop_llm - completed", created_at: at },
+      { type: "task_run", title: "Backing task", status: "failed", detail: "failed", created_at: at },
+      { type: "failed", title: "LLM call failed on turn 2: timeout", status: "failed", terminal: true, created_at: at },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    const labels = screen.getAllByText(/Backing task|Thinking|Ran git/)
+      .map(node => node.textContent);
+    expect(labels).toEqual(["Backing task", "Thinking", "Ran git"]);
+    expect(screen.queryByText(/LLM call failed on turn 2/)).toBeNull();
   });
 
   it("keeps external-agent activity rows chronological too", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -231,10 +231,21 @@ describe("TranscriptActivityTimeline", () => {
     ];
     render(<TranscriptActivityTimeline activities={activities} />);
 
-    const labels = screen.getAllByText(/Backing task|Thinking|Ran git/)
+    const labels = screen.getAllByText(/Backing task|Thinking|Ran git|LLM call failed on turn 2/)
       .map(node => node.textContent);
-    expect(labels).toEqual(["Backing task", "Thinking", "Ran git"]);
-    expect(screen.queryByText(/LLM call failed on turn 2/)).toBeNull();
+    expect(labels).toEqual(["Backing task", "Thinking", "Ran git", "LLM call failed on turn 2: timeout"]);
+  });
+
+  it("hides generic terminal summaries but keeps diagnostic failed rows", () => {
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec", status: "failed", kind: "git" },
+      { type: "failed", title: "Run failed", status: "failed", terminal: true },
+      { type: "run_result", title: "LLM call failed on turn 2: timeout", status: "failed", terminal: true },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.queryByText("Run failed")).toBeNull();
+    expect(screen.getByText("LLM call failed on turn 2: timeout")).toBeInTheDocument();
   });
 
   it("keeps external-agent activity rows chronological too", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -306,7 +306,7 @@ function isTaskRunActivity(activity: AgentChatActivityRecord): boolean {
 function isTerminalRunSummary(activity: AgentChatActivityRecord, totalActivities: number): boolean {
   const terminalTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
   if (!terminalTypes.has(activity.type)) return false;
-  if (totalActivities > 1 && (activity.type === "failed" || activity.type === "cancelled")) return true;
+  void totalActivities;
   return /^run\s+(completed|failed|cancelled)$/i.test(activity.title.trim());
 }
 

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -246,7 +246,7 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
   for (const [index, activity] of activities.entries()) {
     if (hiddenTypes.has(activity.type)) continue;
     if (activity.type === "completed" && activity.title.toLowerCase() === "final answer") continue;
-    if (isTerminalRunSummary(activity, activities.length)) continue;
+    if (isTerminalRunSummary(activity)) continue;
     if (terminal && (activity.type === "started" || activity.type === "running")) continue;
     if (activity.type === "running" && activities.some(item => item.type === "output")) continue;
     if (isTaskRunActivity(activity) && index !== lastTaskRunIndex) continue;
@@ -303,10 +303,9 @@ function isTaskRunActivity(activity: AgentChatActivityRecord): boolean {
   return activity.type === "task_run" || (activity.type.startsWith("task_") && activity.title.startsWith("Task run"));
 }
 
-function isTerminalRunSummary(activity: AgentChatActivityRecord, totalActivities: number): boolean {
+function isTerminalRunSummary(activity: AgentChatActivityRecord): boolean {
   const terminalTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
   if (!terminalTypes.has(activity.type)) return false;
-  void totalActivities;
   return /^run\s+(completed|failed|cancelled)$/i.test(activity.title.trim());
 }
 

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -75,10 +75,15 @@ export function TranscriptActivityTimeline({
 
   const plan = primary.filter(activity => activity.type === "plan");
   const tools = primary.filter(activity => activity.type === "tool_call");
+  const failedTools = tools.filter(activity => activity.status === "failed").length;
   const summary = [
     terminal ? terminalStatusLabel(terminal.status) : hasRunning ? "working" : "details",
     plan.length > 0 ? `${plan.filter(item => item.status === "completed").length}/${plan.length} plan` : "",
-    tools.length > 0 ? `${tools.length} tool${tools.length === 1 ? "" : "s"}` : "",
+    tools.length > 0
+      ? failedTools > 0
+        ? `${failedTools} failed tool${failedTools === 1 ? "" : "s"}`
+        : `${tools.length} tool${tools.length === 1 ? "" : "s"}`
+      : "",
     diffStat ? "files changed" : "",
   ].filter(Boolean).join(" · ");
 
@@ -241,7 +246,7 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
   for (const [index, activity] of activities.entries()) {
     if (hiddenTypes.has(activity.type)) continue;
     if (activity.type === "completed" && activity.title.toLowerCase() === "final answer") continue;
-    if (isTerminalRunSummary(activity)) continue;
+    if (isTerminalRunSummary(activity, activities.length)) continue;
     if (terminal && (activity.type === "started" || activity.type === "running")) continue;
     if (activity.type === "running" && activities.some(item => item.type === "output")) continue;
     if (isTaskRunActivity(activity) && index !== lastTaskRunIndex) continue;
@@ -262,9 +267,10 @@ function compactDetailActivities(activities: AgentChatActivityRecord[], hasDiffS
 
 function orderVisibleActivities(activities: AgentChatActivityRecord[]): AgentChatActivityRecord[] {
   return activities
-    .map((activity, index) => ({ activity, index, time: activitySortTime(activity.created_at) }))
+    .map((activity, index) => ({ activity, index, time: activitySortTime(activity.created_at), phase: activitySortPhase(activity) }))
     .sort((a, b) => {
       if (a.time !== b.time) return a.time - b.time;
+      if (a.phase !== b.phase) return a.phase - b.phase;
       return a.index - b.index;
     })
     .map(({ activity }) => activity);
@@ -297,8 +303,10 @@ function isTaskRunActivity(activity: AgentChatActivityRecord): boolean {
   return activity.type === "task_run" || (activity.type.startsWith("task_") && activity.title.startsWith("Task run"));
 }
 
-function isTerminalRunSummary(activity: AgentChatActivityRecord): boolean {
-  if (activity.type !== "run_result" && activity.type !== "completed") return false;
+function isTerminalRunSummary(activity: AgentChatActivityRecord, totalActivities: number): boolean {
+  const terminalTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
+  if (!terminalTypes.has(activity.type)) return false;
+  if (totalActivities > 1 && (activity.type === "failed" || activity.type === "cancelled")) return true;
   return /^run\s+(completed|failed|cancelled)$/i.test(activity.title.trim());
 }
 
@@ -392,7 +400,7 @@ function activityLinePrefix(activity: AgentChatActivityRecord): string | undefin
 }
 
 function toolActivityTitle(activity: AgentChatActivityRecord): string {
-  const raw = (activity.title || activity.kind || "tool").trim();
+  const raw = stripStatusSuffix(activity.title || activity.kind || "tool").trim();
   const normalized = raw.toLowerCase();
 
   switch (normalized) {
@@ -440,17 +448,26 @@ function cleanApprovalDetail(detail?: string): string | undefined {
 function cleanActivityDetail(activity: AgentChatActivityRecord): string | undefined {
   const detail = activity.detail?.trim();
   if (!detail) return undefined;
+  if (detail.startsWith("builtin.agent_loop_")) return undefined;
 
   const title = activity.title.trim();
+  const baseTitle = stripStatusSuffix(title);
   const status = activity.status?.trim();
   const duplicateForms = [
     title,
+    baseTitle,
     status,
     status ? `${title} - ${status}` : "",
     status ? `${title} · ${status}` : "",
+    status ? `${baseTitle} - ${status}` : "",
+    status ? `${baseTitle} · ${status}` : "",
   ].filter((value): value is string => Boolean(value)).map(value => value.toLowerCase());
 
   return duplicateForms.includes(detail.toLowerCase()) ? undefined : detail;
+}
+
+function stripStatusSuffix(value: string): string {
+  return value.replace(/\s+\((running|completed|failed|cancelled|awaiting_approval|pending|approved|rejected|denied|timed_out)\)$/i, "");
 }
 
 function cleanTaskRunDetail(existingDetail: string, humanStatus: string): string {
@@ -504,6 +521,19 @@ function terminalStatusLabel(status?: string): string {
     default:
       return status || "details";
   }
+}
+
+function activitySortPhase(activity: AgentChatActivityRecord): number {
+  if (activity.type === "started") return 0;
+  if (activity.type === "running") return 1;
+  if (isTaskRunActivity(activity)) return 2;
+  if (activity.type === "plan") return 3;
+  if (activity.type === "thinking" || activity.type === "model_turns") return 4;
+  if (activity.type === "approval") return 5;
+  if (activity.type === "tool_call") return 6;
+  if (activity.type === "files_changed") return 7;
+  if (activity.type === "failed" || activity.type === "cancelled" || activity.type === "completed" || activity.type === "run_result") return 9;
+  return 8;
 }
 
 function activityStatusColor(status?: string) {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import type { AgentChatActivityRecord } from "../../types/runtime";
 
+const terminalRunSummaryTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
+
 export function DiffStatList({ diffStat }: { diffStat: string }) {
   const rows = parseDiffStatRows(diffStat);
   const summary = formatDiffStatSummary(diffStat);
@@ -304,8 +306,7 @@ function isTaskRunActivity(activity: AgentChatActivityRecord): boolean {
 }
 
 function isTerminalRunSummary(activity: AgentChatActivityRecord): boolean {
-  const terminalTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
-  if (!terminalTypes.has(activity.type)) return false;
+  if (!terminalRunSummaryTypes.has(activity.type)) return false;
   return /^run\s+(completed|failed|cancelled)$/i.test(activity.title.trim());
 }
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -159,8 +159,8 @@ describe("TranscriptMessageRow", () => {
     const user = userEvent.setup();
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
-      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42 },
-      { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 19 },
+      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42, artifact_preview: "diff --git a/README.md b/README.md\n+hello" },
+      { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 19, artifact_preview: "fatal: not a git repository" },
       { type: "failed", title: "Run failed", status: "failed", terminal: true },
     ];
 
@@ -174,17 +174,18 @@ describe("TranscriptMessageRow", () => {
 
     await user.click(screen.getByText(/1 failed tool/));
     await user.click(screen.getByText("Advanced"));
-    expect(screen.getByText(/Inspect the related run output/)).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "git-stderr.txt" }));
+    expect(screen.getByText(/Preview the related run output/)).toBeInTheDocument();
+    expect(screen.getByText(/\+hello/)).toBeInTheDocument();
+    expect(screen.getByText("fatal: not a git repository")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Open task output" }));
     expect(onOpenTask).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "git-stdout.txt" })).toBeInTheDocument();
   });
 
   it("does not link empty stderr artifacts from failed tools", async () => {
     const user = userEvent.setup();
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
-      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42 },
+      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42, artifact_preview: "stdout details" },
       { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 0 },
     ];
 
@@ -198,8 +199,8 @@ describe("TranscriptMessageRow", () => {
 
     await user.click(screen.getByText(/1 failed tool/));
     await user.click(screen.getByText("Advanced"));
-    expect(screen.getByRole("button", { name: "git-stdout.txt" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "git-stderr.txt" })).toBeNull();
+    expect(screen.getByText("stdout details")).toBeInTheDocument();
+    expect(screen.queryByText("Preview unavailable in this snapshot.")).toBeNull();
   });
 
   it("renders the diff review section when diff metadata is present", () => {

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -159,12 +159,12 @@ describe("TranscriptMessageRow", () => {
     const user = userEvent.setup();
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
-      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42, artifact_preview: "diff --git a/README.md b/README.md\n+hello" },
+      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42, artifact_preview: "  diff --git a/README.md b/README.md\n+hello\n" },
       { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 19, artifact_preview: "fatal: not a git repository" },
       { type: "failed", title: "Run failed", status: "failed", terminal: true },
     ];
 
-    render(
+    const { container } = render(
       <TranscriptMessageRow
         {...baseProps}
         activities={activities}
@@ -175,6 +175,7 @@ describe("TranscriptMessageRow", () => {
     await user.click(screen.getByText(/1 failed tool/));
     await user.click(screen.getByText("Advanced"));
     expect(screen.getByText(/Preview the related run output/)).toBeInTheDocument();
+    expect([...container.querySelectorAll("pre")].some((node) => node.textContent?.startsWith("  diff --git"))).toBe(true);
     expect(screen.getByText(/\+hello/)).toBeInTheDocument();
     expect(screen.getByText("fatal: not a git repository")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Open task output" }));

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -154,6 +154,54 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText(/2 turns · 1 tool/)).toBeInTheDocument();
   });
 
+  it("links failed tools to related stdout and stderr artifacts", async () => {
+    const onOpenTask = vi.fn();
+    const user = userEvent.setup();
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
+      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42 },
+      { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 19 },
+      { type: "failed", title: "Run failed", status: "failed", terminal: true },
+    ];
+
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        activities={activities}
+        taskLink={{ label: "Task task_123", onClick: onOpenTask }}
+      />,
+    );
+
+    await user.click(screen.getByText(/1 failed tool/));
+    await user.click(screen.getByText("Advanced"));
+    expect(screen.getByText(/Inspect the related run output/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "git-stderr.txt" }));
+    expect(onOpenTask).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "git-stdout.txt" })).toBeInTheDocument();
+  });
+
+  it("does not link empty stderr artifacts from failed tools", async () => {
+    const user = userEvent.setup();
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec (failed)", status: "failed", kind: "git", detail: "git_exec - failed" },
+      { type: "artifact", title: "git-stdout.txt", status: "ready", artifact_id: "artifact_stdout", artifact_size_bytes: 42 },
+      { type: "artifact", title: "git-stderr.txt", status: "ready", artifact_id: "artifact_stderr", artifact_size_bytes: 0 },
+    ];
+
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        activities={activities}
+        taskLink={{ label: "Task task_123", onClick: vi.fn() }}
+      />,
+    );
+
+    await user.click(screen.getByText(/1 failed tool/));
+    await user.click(screen.getByText("Advanced"));
+    expect(screen.getByRole("button", { name: "git-stdout.txt" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "git-stderr.txt" })).toBeNull();
+  });
+
   it("renders the diff review section when diff metadata is present", () => {
     const onListFiles: (sid: string, mid: string) => Promise<AgentChatChangedFileRecord[]> = vi.fn(async () => []);
     const onGetFileDiff: (sid: string, mid: string, p: string) => Promise<AgentChatChangedFileDiffRecord | null> = vi.fn(async () => null);

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -176,7 +176,7 @@ function renderAgentActivityAdvanced(
 
 function OutputArtifactPreview({ artifact }: { artifact: AgentChatActivityRecord }) {
   const isStderr = outputArtifactStream(artifact) === "stderr";
-  const preview = artifact.artifact_preview?.trim();
+  const preview = artifact.artifact_preview?.replace(/[\r\n]+$/, "");
   return (
     <div style={{
       border: `1px solid ${isStderr ? "rgba(239, 95, 95, 0.28)" : "var(--border)"}`,

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -32,6 +32,9 @@ export function TranscriptMessageRow({ id, role, model, content, time, promptTok
     && content.trim() !== ""
     && isLikelyTransientAgentNarration(content)
     && !(activities ?? []).some(activity => activity.type === "tool_call");
+  const renderActivityAdvanced = isAssistant && activities?.length
+    ? (activity: AgentChatActivityRecord) => renderAgentActivityAdvanced(activity, activities, taskLink)
+    : undefined;
 
   return (
     <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
@@ -92,7 +95,11 @@ export function TranscriptMessageRow({ id, role, model, content, time, promptTok
             <TranscriptMarkdown content={content} />
           )}
           {isAssistant && activities && activities.length > 0 && (
-            <TranscriptActivityTimeline activities={activities} diffStat={diffStat} />
+            <TranscriptActivityTimeline
+              activities={activities}
+              diffStat={diffStat}
+              renderAdvancedActivity={renderActivityAdvanced}
+            />
           )}
           {isAssistant && agentTiming && !agentTimingEmpty(agentTiming) && (
             <AgentTiming timing={agentTiming} />
@@ -125,6 +132,62 @@ export function TranscriptMessageRow({ id, role, model, content, time, promptTok
       </div>
     </div>
   );
+}
+
+function renderAgentActivityAdvanced(
+  activity: AgentChatActivityRecord,
+  activities: AgentChatActivityRecord[],
+  taskLink?: { label: string; title?: string; onClick: () => void },
+) {
+  if (activity.type !== "tool_call" || activity.status !== "failed") return null;
+
+  const outputArtifacts = relatedOutputArtifacts(activities);
+  if (outputArtifacts.length === 0) return null;
+
+  return (
+    <div style={{ display: "grid", gap: 7 }}>
+      <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>
+        This tool failed. Inspect the related run output for details.
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {outputArtifacts.map(artifact => (
+          <button
+            key={artifact.artifact_id || artifact.title}
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={taskLink?.onClick}
+            disabled={!taskLink}
+            title={taskLink ? `Open ${taskLink.label} output` : "Open the backing task to inspect this output"}
+            style={{
+              borderColor: artifact.title.toLowerCase().includes("stderr") ? "rgba(239, 95, 95, 0.35)" : "var(--border)",
+              color: artifact.title.toLowerCase().includes("stderr") ? "var(--red)" : "var(--t1)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              padding: "2px 7px",
+            }}
+          >
+            {artifact.title}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function relatedOutputArtifacts(activities: AgentChatActivityRecord[]): AgentChatActivityRecord[] {
+  const seen = new Set<string>();
+  const out: AgentChatActivityRecord[] = [];
+  for (const activity of activities) {
+    if (activity.type !== "artifact") continue;
+    if ((activity.artifact_size_bytes ?? 0) <= 0) continue;
+    const label = `${activity.title} ${activity.detail ?? ""} ${activity.kind ?? ""}`.toLowerCase();
+    if (!/\b(std(out|err)|git-std(out|err))\b/.test(label)) continue;
+    const key = activity.artifact_id || activity.title;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(activity);
+  }
+  return out;
 }
 
 function HeaderMetaButton({

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -147,29 +147,80 @@ function renderAgentActivityAdvanced(
   return (
     <div style={{ display: "grid", gap: 7 }}>
       <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>
-        This tool failed. Inspect the related run output for details.
+        This tool failed. Preview the related run output here, or open the backing task for the full capture.
       </div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+      <div style={{ display: "grid", gap: 7 }}>
         {outputArtifacts.map(artifact => (
-          <button
+          <OutputArtifactPreview
             key={artifact.artifact_id || artifact.title}
-            type="button"
-            className="btn btn-ghost btn-sm"
-            onClick={taskLink?.onClick}
-            disabled={!taskLink}
-            title={taskLink ? `Open ${taskLink.label} output` : "Open the backing task to inspect this output"}
-            style={{
-              borderColor: artifact.title.toLowerCase().includes("stderr") ? "rgba(239, 95, 95, 0.35)" : "var(--border)",
-              color: artifact.title.toLowerCase().includes("stderr") ? "var(--red)" : "var(--t1)",
-              fontFamily: "var(--font-mono)",
-              fontSize: 10,
-              padding: "2px 7px",
-            }}
-          >
-            {artifact.title}
-          </button>
+            artifact={artifact}
+          />
         ))}
       </div>
+      {taskLink && (
+        <div>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={taskLink.onClick}
+            title={`Open ${taskLink.label} output`}
+            style={{ fontSize: 10, padding: "2px 7px" }}
+          >
+            Open task output
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OutputArtifactPreview({ artifact }: { artifact: AgentChatActivityRecord }) {
+  const isStderr = outputArtifactStream(artifact) === "stderr";
+  const preview = artifact.artifact_preview?.trim();
+  return (
+    <div style={{
+      border: `1px solid ${isStderr ? "rgba(239, 95, 95, 0.28)" : "var(--border)"}`,
+      borderRadius: "var(--radius-sm)",
+      background: "var(--bg0)",
+      overflow: "hidden",
+    }}>
+      <div style={{
+        alignItems: "center",
+        borderBottom: "1px solid var(--border)",
+        display: "flex",
+        gap: 8,
+        padding: "4px 7px",
+      }}>
+        <span style={{
+          color: isStderr ? "var(--red)" : "var(--t1)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+        }}>
+          {artifact.title}
+        </span>
+        {artifact.artifact_size_bytes ? (
+          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            {artifact.artifact_size_bytes}b
+          </span>
+        ) : null}
+      </div>
+      {preview ? (
+        <pre style={{
+          color: isStderr ? "var(--red)" : "var(--t1)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          lineHeight: 1.55,
+          margin: 0,
+          maxHeight: 130,
+          overflow: "auto",
+          padding: "7px",
+          whiteSpace: "pre-wrap",
+        }}>{preview}</pre>
+      ) : (
+        <div style={{ color: "var(--t3)", fontSize: 11, padding: "7px" }}>
+          Preview unavailable in this snapshot.
+        </div>
+      )}
     </div>
   );
 }
@@ -188,6 +239,11 @@ function relatedOutputArtifacts(activities: AgentChatActivityRecord[]): AgentCha
     out.push(activity);
   }
   return out;
+}
+
+function outputArtifactStream(activity: AgentChatActivityRecord): "stdout" | "stderr" {
+  const label = `${activity.title} ${activity.detail ?? ""} ${activity.kind ?? ""}`.toLowerCase();
+  return label.includes("stderr") ? "stderr" : "stdout";
 }
 
 function HeaderMetaButton({

--- a/ui/src/lib/markdown.test.ts
+++ b/ui/src/lib/markdown.test.ts
@@ -105,6 +105,14 @@ describe("parseMarkdownBlocks", () => {
     expect(blocks[1]).toEqual({ type: "code", text: "code", lang: "ts" });
   });
 
+  it("stops paragraph accumulation at an indented code fence", () => {
+    const blocks = parseMarkdownBlocks("intro\n  ```sh\ngit status\n  ```");
+    expect(blocks).toEqual([
+      { type: "p", text: "intro" },
+      { type: "code", text: "git status", lang: "sh" },
+    ]);
+  });
+
   it("stops paragraph accumulation at a task list and table", () => {
     const blocks = parseMarkdownBlocks("intro\n- [ ] todo\n\n| A | B |\n| --- | --- |\n| one | two |");
     expect(blocks).toHaveLength(3);

--- a/ui/src/lib/markdown.test.ts
+++ b/ui/src/lib/markdown.test.ts
@@ -13,6 +13,11 @@ describe("parseMarkdownBlocks", () => {
     expect(blocks).toEqual([{ type: "code", text: "const x = 1;", lang: "ts" }]);
   });
 
+  it("parses fenced code blocks with extra info string metadata", () => {
+    const blocks = parseMarkdownBlocks("```sh hl_lines=1\ngit status\n```");
+    expect(blocks).toEqual([{ type: "code", text: "git status", lang: "sh" }]);
+  });
+
   it("parses indented fenced code blocks", () => {
     const blocks = parseMarkdownBlocks("  ```sh\ngit status\n  ```");
     expect(blocks).toEqual([{ type: "code", text: "git status", lang: "sh" }]);
@@ -111,6 +116,11 @@ describe("parseMarkdownBlocks", () => {
       { type: "p", text: "intro" },
       { type: "code", text: "git status", lang: "sh" },
     ]);
+  });
+
+  it("consumes an unmatched fence-looking line instead of looping forever", () => {
+    const blocks = parseMarkdownBlocks("```bad`info");
+    expect(blocks).toEqual([{ type: "p", text: "```bad`info" }]);
   });
 
   it("stops paragraph accumulation at a task list and table", () => {

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -23,7 +23,7 @@ export function parseMarkdownBlocks(content: string): Block[] {
   while (i < lines.length) {
     const line = lines[i];
 
-    const fenceMatch = /^\s*```([^\s`]*)\s*$/.exec(line);
+    const fenceMatch = /^\s*```([^\s`]*)(?:\s+.*)?$/.exec(line);
     if (fenceMatch) {
       const lang = fenceMatch[1];
       const codeLines: string[] = [];
@@ -111,6 +111,10 @@ export function parseMarkdownBlocks(content: string): Block[] {
       !/^\d+\. /.test(lines[i])
     ) {
       paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length === 0) {
+      paraLines.push(line);
       i++;
     }
     blocks.push({ type: "p", text: paraLines.join("\n") });

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -102,7 +102,7 @@ export function parseMarkdownBlocks(content: string): Block[] {
     while (
       i < lines.length &&
       lines[i].trim() !== "" &&
-      !/^```/.test(lines[i]) &&
+      !/^\s*```/.test(lines[i]) &&
       !/^#{1,3} /.test(lines[i]) &&
       !/^(-{3,}|\*{3,}|_{3,})$/.test(lines[i].trim()) &&
       !isTableStart(lines, i) &&

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -352,6 +352,7 @@ export type AgentChatActivityRecord = {
   created_at?: string;
   artifact_id?: string;
   artifact_size_bytes?: number;
+  artifact_preview?: string;
   approval_id?: string;
   needs_action?: boolean;
   terminal?: boolean;

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -350,6 +350,8 @@ export type AgentChatActivityRecord = {
   title: string;
   detail?: string;
   created_at?: string;
+  artifact_id?: string;
+  artifact_size_bytes?: number;
   approval_id?: string;
   needs_action?: boolean;
   terminal?: boolean;


### PR DESCRIPTION
## Summary

This PR tightens the chat/task run diagnostics around Hecate Chat activity, failed tool output, and markdown rendering.

- Fixes chat markdown parsing for indented fenced code blocks so shell snippets render as real code blocks instead of broken inline backticks.
- Cleans up Hecate Chat run activity ordering and labels: high-signal events stay top-to-bottom, duplicate terminal summaries are hidden, failed-tool counts are explicit, and internal builtin details are kept out of the compact view.
- Carries task artifact metadata through agent-chat activities so failed tool rows can expose an Advanced section with capped non-empty stdout/stderr previews plus an Open task output escape hatch.
- Makes Task Detail clearer when stderr was captured but empty: the run output header now shows stdout size, `stderr available`, or `stderr empty` instead of making empty stderr look missing.
- Documents the compact Chat diagnostics vs. canonical Task output/artifact view split.

## Validation

- `go test ./internal/api ./internal/agentchat`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/runs/TaskDetail.test.tsx src/features/transcript/TranscriptMessageRow.test.tsx`
- `cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx src/features/transcript/TranscriptActivityTimeline.test.tsx src/features/chats/ChatView.test.tsx src/app/useRuntimeConsole.test.tsx src/lib/markdown.test.ts`
- `cd ui && bun run test:e2e -- e2e/chat.spec.ts -g "agent chat renders indented fenced code blocks as code"`
- `cd ui && bun run test:e2e -- e2e/chat.spec.ts -g "agent chat previews failed tool stdout and stderr in Advanced details"`
