### PR TITLE
fix(ui): scope queued chat prompts to their session

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Chats is the primary day-to-day surface. It explains missing setup before you se
 
 ![Agent approval modal with ACP options, scope choices, and audit note](docs/screenshots/chat-agent-approval-modal.png)
 
-Hecate Chat preserves runtime boundaries inside the transcript: tools-off turns keep route/cost/cache metadata, tools-on turns link to their backing Task/run, and every assistant turn can link to its trace. If a task-backed run is busy, the composer queues the next prompt locally and sends it when the run settles. The Tasks workspace remains canonical for full run history, advanced activity details, artifacts, retry/resume, and patch review. See [Chat sessions](docs/chat-sessions.md), [Agent runtime](docs/agent-runtime.md), and [External agent adapters](docs/external-agent-adapters.md) for the deeper contracts.
+Hecate Chat preserves runtime boundaries inside the transcript: tools-off turns keep route/cost/cache metadata, tools-on turns link to their backing Task/run, and every assistant turn can link to its trace. If a task-backed run is busy, the composer queues the next prompt locally for that chat and sends it when the run settles. The Tasks workspace remains canonical for full run history, advanced activity details, artifacts, retry/resume, and patch review. See [Chat sessions](docs/chat-sessions.md), [Agent runtime](docs/agent-runtime.md), and [External agent adapters](docs/external-agent-adapters.md) for the deeper contracts.
 
 ## Architecture
 

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -33,8 +33,10 @@ but they can also store direct model segments:
   If the operator submits another prompt while the active run is still busy,
   the UI keeps it in a local **Queued next** FIFO and submits it automatically
   after the run or approval reaches a terminal state. Queued prompts preserve
-  the selected runtime/model/workspace snapshot from the moment they were
-  queued, but they are not persisted until submitted.
+  the originating chat session plus the selected runtime/model/workspace
+  snapshot from the moment they were queued, so switching to another chat cannot
+  drain a prompt into the wrong transcript. They are not persisted until
+  submitted.
   Chats projects the backing run activity into the transcript, links each
   assistant turn back to its backing Task/run, and can approve/reject pending
   task approvals inline. Low-level artifacts stay under transcript **Details**,

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1037,7 +1037,10 @@ task to finish, resolve the pending approval, or cancel/stop the active run
 before sending another prompt. The operator UI layers a local composer queue on
 top of that API contract: prompts submitted while a run is busy are held in a
 client-side FIFO and posted only after the active task reaches a terminal
-state. That queue is intentionally not durable until each prompt is submitted.
+state. Queue entries are scoped to the chat session that created them so a
+prompt cannot drain into a different transcript after the operator switches
+sessions. That queue is intentionally not durable until each prompt is
+submitted.
 
 The response returns after the backing turn finishes, times out, is cancelled,
 or fails. For live output while the turn is running, subscribe to the session

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -788,6 +788,55 @@ describe("useRuntimeConsole", () => {
       expect(result.current.state.notice?.message).toBe("Agent chat deleted.");
     });
 
+    it("deleteChatSession removes queued prompts for the deleted session", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "sess_b");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+      let deleteCalls = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({
+            object: "agent_chat_sessions",
+            data: [
+              { id: "sess_a", title: "Keep", runtime_kind: "agent", status: "completed", workspace: "/workspace", message_count: 0 },
+              { id: "sess_b", title: "Delete me", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/sess_b" && init?.method === "DELETE") {
+          deleteCalls += 1;
+          return new Response(null, { status: 204 });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/sess_b") {
+          return jsonResponse({
+            object: "agent_chat_session",
+            data: { id: "sess_b", title: "Delete me", runtime_kind: "agent", status: "running", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("sess_b"));
+
+      act(() => {
+        result.current.actions.setMessage("do this later");
+      });
+      await act(async () => {
+        await result.current.actions.submitChat({ preventDefault: vi.fn() } as any);
+      });
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+
+      await act(async () => {
+        await result.current.actions.deleteChatSession("sess_b");
+      });
+
+      expect(deleteCalls).toBe(1);
+      expect(result.current.state.queuedChatMessages).toHaveLength(0);
+      expect(result.current.state.activeAgentChatSessionID).toBe("");
+    });
+
     it("renameChatSession patches the title in the sidebar", async () => {
       fetchMock.mockImplementation(async (input, init) => {
         const url = String(input);

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -580,6 +580,7 @@ describe("useRuntimeConsole", () => {
       expect(messagePostCount).toBe(0);
       expect(result.current.state.message).toBe("");
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
+      expect(result.current.state.queuedChatMessages[0].session_id).toBe("a1");
       expect(result.current.state.queuedChatMessages[0].content).toBe("after this");
 
       sessionStatus = "completed";
@@ -589,6 +590,64 @@ describe("useRuntimeConsole", () => {
 
       await waitFor(() => expect(messagePostCount).toBe(1));
       await waitFor(() => expect(result.current.state.queuedChatMessages).toHaveLength(0));
+    });
+
+    it("does not drain a queued prompt into a different selected chat", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+      let messagePostCount = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({
+            object: "agent_chat_sessions",
+            data: [
+              { id: "a1", title: "Busy chat", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 },
+              { id: "a2", title: "Idle chat", runtime_kind: "agent", status: "completed", workspace: "/workspace", message_count: 0 },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          return jsonResponse({
+            object: "agent_chat_session",
+            data: { id: "a1", title: "Busy chat", runtime_kind: "agent", status: "running", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
+          });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a2") {
+          return jsonResponse({
+            object: "agent_chat_session",
+            data: { id: "a2", title: "Idle chat", runtime_kind: "agent", status: "completed", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
+          });
+        }
+        if (url.endsWith("/messages")) {
+          messagePostCount += 1;
+          void init;
+          return jsonResponse({ object: "agent_chat_session", data: {} });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
+
+      act(() => {
+        result.current.actions.setMessage("keep this with a1");
+      });
+      await act(async () => {
+        await result.current.actions.submitChat({ preventDefault: vi.fn() } as any);
+      });
+
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+      await act(async () => {
+        await result.current.actions.selectChatSession("a2");
+      });
+
+      await waitFor(() => expect(result.current.state.activeAgentChatSessionID).toBe("a2"));
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+      expect(result.current.state.queuedChatMessages[0].session_id).toBe("a1");
+      expect(messagePostCount).toBe(0);
     });
 
     it("keeps the tools toggle scoped to the selected Hecate chat", async () => {

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -597,6 +597,10 @@ describe("useRuntimeConsole", () => {
       window.localStorage.setItem("hecate.agentChatSessionID", "a1");
       window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
       let messagePostCount = 0;
+      let resolveA2: (() => void) | undefined;
+      const a2Gate = new Promise<void>((resolve) => {
+        resolveA2 = resolve;
+      });
       fetchMock.mockImplementation(async (input, init) => {
         const url = String(input);
         if (url === "/hecate/v1/agent-chat/sessions") {
@@ -615,6 +619,7 @@ describe("useRuntimeConsole", () => {
           });
         }
         if (url === "/hecate/v1/agent-chat/sessions/a2") {
+          await a2Gate;
           return jsonResponse({
             object: "agent_chat_session",
             data: { id: "a2", title: "Idle chat", runtime_kind: "agent", status: "completed", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
@@ -640,14 +645,119 @@ describe("useRuntimeConsole", () => {
       });
 
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
-      await act(async () => {
-        await result.current.actions.selectChatSession("a2");
+      let selectPromise!: Promise<void>;
+      act(() => {
+        selectPromise = result.current.actions.selectChatSession("a2");
       });
 
       await waitFor(() => expect(result.current.state.activeAgentChatSessionID).toBe("a2"));
+      expect(result.current.state.activeAgentChatSession?.id).toBe("a1");
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
       expect(result.current.state.queuedChatMessages[0].session_id).toBe("a1");
       expect(messagePostCount).toBe(0);
+      resolveA2?.();
+      await act(async () => {
+        await selectPromise;
+      });
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a2"));
+      expect(messagePostCount).toBe(0);
+    });
+
+    it("waits for the selected chat record before draining a queued prompt", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a2");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+
+      let messagePostCount = 0;
+      let a2FetchCount = 0;
+      let resolveA2Refresh: (() => void) | undefined;
+      const a2RefreshGate = new Promise<void>((resolve) => {
+        resolveA2Refresh = resolve;
+      });
+      const session = (id: string, status: string) => ({
+        object: "agent_chat_session",
+        data: {
+          id,
+          title: id,
+          runtime_kind: "agent",
+          status,
+          workspace: "/workspace",
+          messages: [],
+          created_at: "2026-04-20T00:00:00Z",
+          updated_at: "2026-04-20T00:00:00Z",
+        },
+      });
+
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({
+            object: "agent_chat_sessions",
+            data: [
+              { id: "a1", title: "Idle chat", runtime_kind: "agent", status: "completed", workspace: "/workspace", message_count: 0 },
+              { id: "a2", title: "Busy chat", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          return jsonResponse(session("a1", "completed"));
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a2") {
+          a2FetchCount += 1;
+          if (a2FetchCount > 1) {
+            await a2RefreshGate;
+            return jsonResponse(session("a2", "completed"));
+          }
+          return jsonResponse(session("a2", "running"));
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a2/messages") {
+          messagePostCount += 1;
+          void init;
+          return jsonResponse(session("a2", "completed"));
+        }
+        if (url.endsWith("/messages")) {
+          throw new Error(`unexpected message post: ${url}`);
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a2"));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.status).toBe("running"));
+
+      act(() => {
+        result.current.actions.setMessage("drain only after a2 loads");
+      });
+      await act(async () => {
+        await result.current.actions.submitChat({ preventDefault: vi.fn() } as any);
+      });
+
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+
+      await act(async () => {
+        await result.current.actions.selectChatSession("a1");
+      });
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
+
+      let selectA2Promise!: Promise<void>;
+      act(() => {
+        selectA2Promise = result.current.actions.selectChatSession("a2");
+      });
+
+      await waitFor(() => expect(result.current.state.activeAgentChatSessionID).toBe("a2"));
+      expect(result.current.state.activeAgentChatSession?.id).toBe("a1");
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+      expect(messagePostCount).toBe(0);
+
+      resolveA2Refresh?.();
+      await act(async () => {
+        await selectA2Promise;
+      });
+
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a2"));
+      await waitFor(() => expect(messagePostCount).toBe(1));
+      await waitFor(() => expect(result.current.state.queuedChatMessages).toHaveLength(0));
     });
 
     it("keeps the tools toggle scoped to the selected Hecate chat", async () => {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -103,6 +103,7 @@ type ChatTarget = "model" | "agent" | "external_agent";
 type HecateChatTarget = "model" | "agent";
 type QueuedChatMessage = {
   id: string;
+  session_id: string;
   content: string;
   runtime_kind: ChatTarget;
   provider_filter: ProviderFilter;
@@ -653,9 +654,10 @@ export function useRuntimeConsole() {
     setQueuedChatMessages((current) => current.filter((item) => item.id !== id));
   }
 
-  function buildQueuedChatMessage(content: string, runtimeKind: ChatTarget): QueuedChatMessage {
+  function buildQueuedChatMessage(content: string, runtimeKind: ChatTarget, sessionID: string): QueuedChatMessage {
     return {
       id: `queued-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      session_id: sessionID,
       content,
       runtime_kind: runtimeKind,
       provider_filter: providerFilter,
@@ -667,8 +669,8 @@ export function useRuntimeConsole() {
     };
   }
 
-  function queueChatMessage(content: string, runtimeKind: ChatTarget) {
-    setQueuedChatMessages((current) => [...current, buildQueuedChatMessage(content, runtimeKind)]);
+  function queueChatMessage(content: string, runtimeKind: ChatTarget, sessionID: string) {
+    setQueuedChatMessages((current) => [...current, buildQueuedChatMessage(content, runtimeKind, sessionID)]);
     setMessage("");
   }
 
@@ -787,7 +789,7 @@ export function useRuntimeConsole() {
 
     const turnRuntimeKind = queued?.runtime_kind ?? (chatTarget === "external_agent" ? "external_agent" : chatTarget === "agent" ? "agent" : "model");
     if (!queued && activeAgentChatSessionID && agentChatSessionIsBusy(activeAgentChatSession)) {
-      queueChatMessage(content, turnRuntimeKind);
+      queueChatMessage(content, turnRuntimeKind, activeAgentChatSessionID);
       return;
     }
 
@@ -811,7 +813,7 @@ export function useRuntimeConsole() {
         return;
       }
 
-      let sessionID = activeAgentChatSessionID;
+      let sessionID = queued?.session_id ?? activeAgentChatSessionID;
       if (sessionID && !activeAgentChatSession) {
         // The server owns chat persistence. If localStorage points at a
         // deleted or unavailable session, start clean instead of making the
@@ -921,7 +923,13 @@ export function useRuntimeConsole() {
     if (agentChatSessionIsBusy(activeAgentChatSession)) {
       return;
     }
-    const next = queuedChatMessages[0];
+    if (!activeAgentChatSessionID) {
+      return;
+    }
+    const next = queuedChatMessages.find((item) => item.session_id === activeAgentChatSessionID);
+    if (!next) {
+      return;
+    }
     setQueuedChatMessages((current) => current.filter((item) => item.id !== next.id));
     void submitAgentChat(next);
   // submitAgentChat deliberately stays out of the dependency list: it
@@ -931,6 +939,7 @@ export function useRuntimeConsole() {
     activeAgentChatSession?.latest_run_id,
     activeAgentChatSession?.status,
     activeAgentChatSession?.updated_at,
+    activeAgentChatSessionID,
     agentChatCancelling,
     chatLoading,
     queuedChatMessages,

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -932,6 +932,9 @@ export function useRuntimeConsole() {
     if (!activeAgentChatSessionID) {
       return;
     }
+    if (activeAgentChatSession?.id !== activeAgentChatSessionID) {
+      return;
+    }
     const next = queuedChatMessages.find((item) => item.session_id === activeAgentChatSessionID);
     if (!next) {
       return;
@@ -942,6 +945,7 @@ export function useRuntimeConsole() {
   // reads the queued snapshot passed above, not the live composer state.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    activeAgentChatSession?.id,
     activeAgentChatSession?.latest_run_id,
     activeAgentChatSession?.status,
     activeAgentChatSession?.updated_at,

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -598,6 +598,7 @@ export function useRuntimeConsole() {
       setActiveChatSessionID(snapshot.activeChatSessionID);
       setActiveChatSession(snapshot.activeChatSession);
       setAgentChatSessions(snapshot.agentChatSessions);
+      pruneQueuedChatMessagesForSessions(snapshot.agentChatSessions.map((session) => session.id));
       setActiveAgentChatSessionID(snapshot.activeAgentChatSessionID);
       setActiveAgentChatSession(snapshot.activeAgentChatSession);
       setRequestLedger(snapshot.requestLedger);
@@ -652,6 +653,11 @@ export function useRuntimeConsole() {
 
   function removeQueuedChatMessage(id: string) {
     setQueuedChatMessages((current) => current.filter((item) => item.id !== id));
+  }
+
+  function pruneQueuedChatMessagesForSessions(sessionIDs: Iterable<string>) {
+    const valid = new Set(sessionIDs);
+    setQueuedChatMessages((current) => current.filter((item) => valid.has(item.session_id)));
   }
 
   function buildQueuedChatMessage(content: string, runtimeKind: ChatTarget, sessionID: string): QueuedChatMessage {
@@ -1431,6 +1437,9 @@ export function useRuntimeConsole() {
   }
 
   function startNewChat() {
+    if (activeAgentChatSessionID) {
+      setQueuedChatMessages((current) => current.filter((item) => item.session_id !== activeAgentChatSessionID));
+    }
     setActiveAgentChatSessionID("");
     setActiveAgentChatSession(null);
     setAgentWorkspaceBranch("");
@@ -1446,6 +1455,7 @@ export function useRuntimeConsole() {
     try {
       await deleteAgentChatSessionRequest(id);
       setAgentChatSessions((current) => current.filter((s) => s.id !== id));
+      setQueuedChatMessages((current) => current.filter((item) => item.session_id !== id));
       setChatTargetBySessionID((current) => {
         if (!current.has(id)) return current;
         const next = new Map(current);

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -674,9 +674,11 @@ describe("ChatView input", () => {
     const removeQueuedChatMessage = vi.fn();
     const user = userEvent.setup();
     const { state, actions } = setup({
+      activeAgentChatSessionID: "agent_chat_1",
       queuedChatMessages: [
         {
           id: "queued_1",
+          session_id: "agent_chat_1",
           content: "run tests after this",
           runtime_kind: "agent",
           provider_filter: "ollama",
@@ -695,6 +697,44 @@ describe("ChatView input", () => {
     expect(screen.getByText("run tests after this")).toBeTruthy();
     await user.click(screen.getByRole("button", { name: "Remove queued message 1" }));
     expect(removeQueuedChatMessage).toHaveBeenCalledWith("queued_1");
+  });
+
+  it("only renders queued messages for the active agent chat", () => {
+    const { state, actions } = setup({
+      activeAgentChatSessionID: "agent_chat_active",
+      queuedChatMessages: [
+        {
+          id: "queued_active",
+          session_id: "agent_chat_active",
+          content: "send this here",
+          runtime_kind: "agent",
+          provider_filter: "ollama",
+          model: "qwen2.5-coder",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:00Z",
+        },
+        {
+          id: "queued_other",
+          session_id: "agent_chat_other",
+          content: "not in this chat",
+          runtime_kind: "agent",
+          provider_filter: "ollama",
+          model: "qwen2.5-coder",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:00Z",
+        },
+      ],
+    });
+
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByLabelText("Queued messages")).toBeTruthy();
+    expect(screen.getByText("send this here")).toBeTruthy();
+    expect(screen.queryByText("not in this chat")).toBeNull();
   });
 
   it("shows the Hecate Agent sandbox reminder only when tools are enabled", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -125,6 +125,9 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const filteredSessions = filterSidebarSessions(sessions, sidebarQuery);
   const groupedSessions = groupSidebarSessions(filteredSessions);
   const activeSessionID = isAgentChat ? state.activeAgentChatSessionID : state.activeChatSessionID;
+  const activeQueuedChatMessages = isAgentChat && activeSessionID
+    ? state.queuedChatMessages.filter((queued) => queued.session_id === activeSessionID)
+    : [];
   const activeTitle = isAgentChat
     ? state.activeAgentChatSession?.title
     : state.activeChatSession?.title;
@@ -1126,7 +1129,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               </button>
             </div>
           )}
-          {state.queuedChatMessages.length > 0 && (
+          {activeQueuedChatMessages.length > 0 && (
             <div
               aria-label="Queued messages"
               style={{
@@ -1148,7 +1151,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                   will send when the active run finishes
                 </span>
               </div>
-              {state.queuedChatMessages.map((queued, index) => (
+              {activeQueuedChatMessages.map((queued, index) => (
                 <div
                   key={queued.id}
                   style={{


### PR DESCRIPTION
## Summary

This PR tightens the local queued-prompt behavior in Hecate Chat.

Before this change, queued prompts lived in one local FIFO. The happy path worked, but there was a cross-session edge case: queue a prompt while Chat A is busy, switch to idle Chat B, and the queue effect could drain that prompt into the currently selected chat instead of the chat that created it.

Now each queued prompt records its originating agent-chat session id. The UI renders only queued prompts for the active chat, and the drain effect only submits prompts whose session id matches the selected session. The prompt still preserves the runtime/model/workspace snapshot captured when it was queued.

Docs were updated to clarify that the queue is session-scoped and still intentionally non-durable until submission.

## Tests

- cd ui && bun run typecheck
- cd ui && bun run test -- src/app/useRuntimeConsole.test.tsx src/features/chats/ChatView.test.tsx