### PR TITLE
feat(ui): block stale model selections before send

### DIFF
--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -13,6 +13,14 @@ The Chats workspace has two top-level targets: **Hecate Chat** and
 Hecate-owned agent execution: the tools toggle decides whether a prompt stays
 as a direct provider/model turn or enters the native agent task runtime.
 
+Hecate Chat treats model/provider readiness as part of composition, not a
+send-time surprise. If no configured provider has routable models, the empty
+state points at provider setup or local runtime discovery. If models exist but
+the currently selected model is no longer reported by the selected provider
+(for example after changing Ollama models), the composer is blocked with the
+selected model, provider route, discovered-model count, health, and next steps
+before any request is sent.
+
 The operator UI's **Hecate Chat** target now uses **Agent Chat** sessions under
 `/hecate/v1/agent-chat/sessions` for both tools-off direct model turns and tools-on
 Hecate Agent turns. Those records can point at a runtime when tools are enabled,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -204,3 +204,11 @@ diagnostic fields remain available in the provider details disclosure.
 
 Route reports in the trace inspector reuse the same readiness vocabulary when
 they explain why a provider/model candidate was skipped.
+
+The Chats workspace consumes the same readiness model at composition time. A
+provider can be configured and healthy while the selected model is still not
+routable, usually because discovery reports a different local model set or a
+cloud account does not expose that model. In that case Chats blocks the
+composer before sending, shows the selected model, provider route, discovered
+model count, health, and next steps, and links the operator back to Providers
+for the full checklist.

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -175,11 +175,65 @@ describe("ChatView input", () => {
 
     expect(screen.getAllByText("Selected model is not available from this provider").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Ollama is configured, but it does not currently report "llama3.1:8b"/).length).toBeGreaterThan(0);
-    expect(screen.getByText("Selected model")).toBeTruthy();
+    expect(screen.getAllByText("Selected model").length).toBeGreaterThan(0);
     expect(screen.getAllByText("llama3.1:8b").length).toBeGreaterThan(0);
-    expect(screen.getByText("Discovered models")).toBeTruthy();
+    expect(screen.getAllByText("Discovered models").length).toBeGreaterThan(0);
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
+  });
+
+  it("shows stale selected-model readiness on existing transcripts", async () => {
+    const onNavigate = vi.fn();
+    const { state, actions } = setup({
+      chatTarget: "model",
+      providerFilter: "ollama",
+      model: "llama3.1:8b",
+      message: "hello",
+      activeAgentChatSessionID: "chat_1",
+      activeAgentChatSession: {
+        id: "chat_1",
+        title: "Existing chat",
+        runtime_kind: "model",
+        status: "completed",
+        provider: "ollama",
+        model: "llama3.1:8b",
+        messages: [
+          { id: "m1", role: "user", content: "hi", runtime_kind: "model", created_at: "2026-04-20T00:00:00Z" },
+        ],
+      },
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          { id: "ollama", name: "Ollama", preset_id: "ollama", kind: "local", protocol: "openai", base_url: "http://127.0.0.1:11434/v1", credential_configured: false },
+        ],
+        policy_rules: [],
+        pricebook: [],
+        events: [],
+      },
+      providers: [
+        {
+          name: "ollama",
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          base_url: "http://127.0.0.1:11434/v1",
+          models: ["qwen2.5:7b"],
+          model_count: 1,
+        },
+      ],
+      providerScopedModels: [
+        { id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama", provider_kind: "local" } },
+      ],
+    });
+    render(<ChatView state={state} actions={actions} onNavigate={onNavigate} />);
+
+    expect(screen.getByText("Selected model is not available from this provider")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open Providers" })).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Open Providers" }));
+    expect(onNavigate).toHaveBeenCalledWith("providers");
   });
 
   it("opens the shared Add provider modal from the model empty state", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -179,12 +179,16 @@ describe("ChatView input", () => {
     expect(screen.getAllByText(/Ollama is configured, but it does not currently report "llama3.1:8b"/).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Selected model").length).toBeGreaterThan(0);
     expect(screen.getAllByText("llama3.1:8b").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Discovered models").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Health").length).toBeGreaterThan(0);
     expect(screen.getAllByText("degraded").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Blocked by").length).toBeGreaterThan(0);
     expect(screen.getAllByText("no discovered route").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Last error").length).toBeGreaterThan(0);
     expect(screen.getAllByText("model discovery returned no llama3.1:8b").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Start the local provider app or server.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pull or load llama3.1:8b in that provider, or pick one of its discovered models.").length).toBeGreaterThan(0);
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
   });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -161,10 +161,12 @@ describe("ChatView input", () => {
           name: "ollama",
           kind: "local",
           healthy: true,
-          status: "healthy",
+          status: "degraded",
           base_url: "http://127.0.0.1:11434/v1",
           models: ["qwen2.5:7b"],
           model_count: 1,
+          routing_blocked_reason: "no discovered route",
+          last_error: "model discovery returned no llama3.1:8b",
         },
       ],
       providerScopedModels: [
@@ -177,7 +179,12 @@ describe("ChatView input", () => {
     expect(screen.getAllByText(/Ollama is configured, but it does not currently report "llama3.1:8b"/).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Selected model").length).toBeGreaterThan(0);
     expect(screen.getAllByText("llama3.1:8b").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Discovered models").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Health").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("degraded").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Blocked by").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("no discovered route").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Last error").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("model discovery returned no llama3.1:8b").length).toBeGreaterThan(0);
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
   });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -141,6 +141,47 @@ describe("ChatView input", () => {
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
   });
 
+  it("blocks sending when the selected model is not discovered by the selected provider", () => {
+    const { state, actions } = setup({
+      chatTarget: "model",
+      providerFilter: "ollama",
+      model: "llama3.1:8b",
+      message: "hello",
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          { id: "ollama", name: "Ollama", preset_id: "ollama", kind: "local", protocol: "openai", base_url: "http://127.0.0.1:11434/v1", credential_configured: false },
+        ],
+        policy_rules: [],
+        pricebook: [],
+        events: [],
+      },
+      providers: [
+        {
+          name: "ollama",
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          base_url: "http://127.0.0.1:11434/v1",
+          models: ["qwen2.5:7b"],
+          model_count: 1,
+        },
+      ],
+      providerScopedModels: [
+        { id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama", provider_kind: "local" } },
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getAllByText("Selected model is not available from this provider").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ollama is configured, but it does not currently report "llama3.1:8b"/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Selected model")).toBeTruthy();
+    expect(screen.getAllByText("llama3.1:8b").length).toBeGreaterThan(0);
+    expect(screen.getByText("Discovered models")).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
+  });
+
   it("opens the shared Add provider modal from the model empty state", async () => {
     const { state, actions } = setup({
       chatTarget: "model",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2248,7 +2248,7 @@ function SelectedModelReadinessNotice({
         </div>
       )}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8, marginTop: 10 }}>
-        {issue.details.slice(0, compact ? 3 : issue.details.length).map((detail) => (
+        {selectedModelNoticeDetails(issue.details, compact).map((detail) => (
           <InfoChip key={detail.label} label={detail.label} value={detail.value} />
         ))}
       </div>
@@ -2259,6 +2259,18 @@ function SelectedModelReadinessNotice({
       )}
     </div>
   );
+}
+
+function selectedModelNoticeDetails(
+  details: SelectedModelIssue["details"],
+  compact: boolean,
+): SelectedModelIssue["details"] {
+  if (!compact) {
+    return details;
+  }
+  const priorityLabels = new Set(["Selected model", "Provider route", "Health", "Blocked by", "Last error"]);
+  const selected = details.filter((detail) => priorityLabels.has(detail.label));
+  return selected.length > 0 ? selected : details;
 }
 
 function InfoChip({ label, value }: { label: string; value: string }) {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -3,7 +3,9 @@ import type { SyntheticEvent } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
+import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import { describeCredentialState, describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
+import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
 import { CompactProviderReadinessChecks } from "../shared/ProviderReadiness";
 import { AgentAdapterPicker, CodeBlock, Icon, Icons, InlineError, ModelPicker, ProviderPicker } from "../shared/ui";
@@ -234,6 +236,15 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const selectedHecateModelRecord = hecateAgentModelLocked
     ? undefined
     : selectableModels.find((entry) => entry.id === state.model && (!state.providerFilter || state.providerFilter === "auto" || entry.metadata?.provider === state.providerFilter));
+  const selectedModelIssue = !hecateAgentModelLocked && providerConfigLoaded && state.model && selectableModels.length > 0
+    ? buildSelectedModelIssue({
+        model: state.model,
+        providerFilter: state.providerFilter,
+        selectableModels,
+        configuredProvider: selectedConfiguredProvider,
+        runtimeProvider: selectedRuntimeProvider,
+      })
+    : null;
   const selectedModelCapabilities = hecateAgentModelLocked
     ? state.activeAgentChatSession?.capabilities
     : selectedHecateModelRecord?.metadata?.capabilities;
@@ -244,7 +255,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const selectedCapabilityModel = hecateAgentModelLocked ? "" : state.model;
   const hecateChatModelReady = isHecateAgentChat && hecateAgentModelLocked
     ? Boolean(hecateChatModelValue)
-    : Boolean(state.model) && !modelRouteUnavailable;
+    : Boolean(state.model) && !modelRouteUnavailable && !selectedModelIssue;
   const composerVisible = isExternalAgentChat || (isHecateChat && hecateChatModelReady);
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
@@ -252,7 +263,8 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
     || (!agentBusy && streaming)
     || (!isAgentChat && modelRouteUnavailable)
     || (!agentBusy && isExternalAgentChat && (!state.agentWorkspace.trim() || !selectedAgent?.available))
-    || (!agentBusy && isHecateAgentChat && (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel));
+    || (!agentBusy && isHecateAgentChat && (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel))
+    || (!isAgentChat && Boolean(selectedModelIssue));
 
   async function enableToolsForSelectedModel() {
     if (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving) {
@@ -1021,6 +1033,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               isHecateChat={isHecateChat}
               isExternalAgentChat={isExternalAgentChat}
               modelRouteUnavailable={modelRouteUnavailable}
+              selectedModelIssue={selectedModelIssue}
               agentRouteUnavailable={isExternalAgentChat && agentRouteUnavailable}
               nothingRunnable={nothingRunnable}
               agentAdapters={state.agentAdapters}
@@ -1073,6 +1086,11 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                 onOpenTrace={onOpenTrace}
                 diagnostic={chatDiagnostic}
               />
+            </div>
+          )}
+          {isHecateChat && selectedModelIssue && (
+            <div style={{ marginBottom: composerVisible ? 8 : 0 }}>
+              <SelectedModelReadinessNotice issue={selectedModelIssue} onOpenProviders={() => onNavigate?.("providers")} />
             </div>
           )}
           {composerVisible && (
@@ -1967,6 +1985,7 @@ function ChatEmptyState({
   isHecateChat,
   isExternalAgentChat,
   modelRouteUnavailable,
+  selectedModelIssue,
   agentRouteUnavailable,
   nothingRunnable,
   agentAdapters,
@@ -1990,6 +2009,7 @@ function ChatEmptyState({
   isHecateChat: boolean;
   isExternalAgentChat: boolean;
   modelRouteUnavailable: boolean;
+  selectedModelIssue: SelectedModelIssue | null;
   agentRouteUnavailable: boolean;
   nothingRunnable: boolean;
   agentAdapters: AgentAdapterRecord[];
@@ -2009,13 +2029,15 @@ function ChatEmptyState({
   onRefreshQuickLocalProviders: () => void;
   onSwitchTarget: (target: "model" | "agent" | "external_agent") => void;
 }) {
-  const hecateModelUnavailable = isHecateChat && modelRouteUnavailable;
+  const hecateModelUnavailable = isHecateChat && (modelRouteUnavailable || Boolean(selectedModelIssue));
   const title = isAgentChat && selectedAgentUnavailable
       ? `${selectedAgent?.name || "Selected agent"} is unavailable`
       : isExternalAgentChat && agentRouteUnavailable
       ? "No available coding agent"
       : nothingRunnable
         ? "Nothing runnable yet"
+        : selectedModelIssue
+          ? selectedModelIssue.title
         : hecateModelUnavailable
           ? "No routable model"
         : "Start a chat";
@@ -2025,6 +2047,8 @@ function ChatEmptyState({
       ? "Hecate did not find any supported coding-agent CLI or local adapter runner in the known operator locations."
       : nothingRunnable
         ? "Add a model provider or install a supported coding-agent CLI before sending a message."
+        : selectedModelIssue
+          ? selectedModelIssue.message
         : hecateModelUnavailable
           ? "Add a provider with discovered models before sending through Hecate."
         : "Send a message to start this chat.";
@@ -2043,9 +2067,12 @@ function ChatEmptyState({
           runtimeProvider={selectedRuntimeProvider}
         />
       )}
-      {(modelRouteUnavailable || agentRouteUnavailable) && (
+      {isHecateChat && selectedModelIssue && (
+        <SelectedModelReadinessNotice issue={selectedModelIssue} compact />
+      )}
+      {(modelRouteUnavailable || selectedModelIssue || agentRouteUnavailable) && (
         <div style={{ display: "flex", justifyContent: "center", gap: 8, marginTop: 14, flexWrap: "wrap" }}>
-          {modelRouteUnavailable && isHecateChat && (
+          {(modelRouteUnavailable || selectedModelIssue) && isHecateChat && (
             <button
               className="btn btn-primary btn-sm"
               onClick={onAddProvider}
@@ -2181,6 +2208,56 @@ function ModelRouteTroubleshooting({
       <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
         {guidance.map(item => <li key={item}>{item}</li>)}
       </ul>
+    </div>
+  );
+}
+
+function SelectedModelReadinessNotice({
+  issue,
+  compact = false,
+  onOpenProviders,
+}: {
+  issue: SelectedModelIssue;
+  compact?: boolean;
+  onOpenProviders?: () => void;
+}) {
+  return (
+    <div style={{
+      margin: compact ? "14px auto 0" : "0 auto",
+      maxWidth: compact ? 560 : 820,
+      border: "1px solid rgba(245, 191, 79, 0.32)",
+      borderRadius: "var(--radius)",
+      background: "rgba(245, 191, 79, 0.06)",
+      padding: 12,
+      textAlign: "left",
+    }}>
+      {!compact && (
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: "var(--amber)", marginBottom: 4 }}>
+              {issue.title}
+            </div>
+            <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.5 }}>
+              {issue.message}
+            </div>
+          </div>
+          {onOpenProviders && (
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenProviders} style={{ flexShrink: 0 }}>
+              Open Providers
+            </button>
+          )}
+        </div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8, marginTop: 10 }}>
+        {issue.details.slice(0, compact ? 3 : issue.details.length).map((detail) => (
+          <InfoChip key={detail.label} label={detail.label} value={detail.value} />
+        ))}
+      </div>
+      {!compact && (
+        <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
+          {issue.steps.map((step) => <li key={step}>{step}</li>)}
+        </ul>
+      )}
     </div>
   );
 }

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -263,8 +263,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
     || (!agentBusy && streaming)
     || (!isAgentChat && modelRouteUnavailable)
     || (!agentBusy && isExternalAgentChat && (!state.agentWorkspace.trim() || !selectedAgent?.available))
-    || (!agentBusy && isHecateAgentChat && (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel))
-    || (!isAgentChat && Boolean(selectedModelIssue));
+    || (!agentBusy && isHecateAgentChat && (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel));
 
   async function enableToolsForSelectedModel() {
     if (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving) {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2252,7 +2252,11 @@ function SelectedModelReadinessNotice({
           <InfoChip key={detail.label} label={detail.label} value={detail.value} />
         ))}
       </div>
-      {!compact && (
+      {compact ? (
+        <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
+          {issue.steps.slice(0, 2).map((step) => <li key={step}>{step}</li>)}
+        </ul>
+      ) : (
         <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
           {issue.steps.map((step) => <li key={step}>{step}</li>)}
         </ul>
@@ -2268,7 +2272,7 @@ function selectedModelNoticeDetails(
   if (!compact) {
     return details;
   }
-  const priorityLabels = new Set(["Selected model", "Provider route", "Health", "Blocked by", "Last error"]);
+  const priorityLabels = new Set(["Selected model", "Provider route", "Discovered models", "Health", "Blocked by", "Last error"]);
   const selected = details.filter((detail) => priorityLabels.has(detail.label));
   return selected.length > 0 ? selected : details;
 }

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1071,7 +1071,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
         )}
         </div>
 
-        {(composerVisible || state.chatError) && (
+        {(composerVisible || state.chatError || selectedModelIssue) && (
         <form ref={formRef} onSubmit={handleSubmit} style={{ borderTop: "1px solid var(--border)", padding: "10px 12px", background: "var(--bg1)", flexShrink: 0 }}>
           {state.chatError && (
             <div style={{ marginBottom: 8 }}>

--- a/ui/src/lib/provider-issues.test.ts
+++ b/ui/src/lib/provider-issues.test.ts
@@ -100,4 +100,17 @@ describe("buildSelectedModelIssue", () => {
     }));
     expect(issue?.message).toContain("No configured provider currently reports");
   });
+
+  it("uses provider-agnostic repair steps for stale auto-route selections", () => {
+    const issue = buildSelectedModelIssue({
+      model: "llama3.1:8b",
+      providerFilter: "auto",
+      selectableModels: [{ id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama", provider_kind: "local" } }],
+    });
+
+    expect(issue?.steps.join(" ")).toContain("Pick a model that appears in the model picker");
+    expect(issue?.steps.join(" ")).toContain("discovery, health, routing readiness, and credential state");
+    expect(issue?.steps.join(" ")).toContain("If the model should be served locally");
+    expect(issue?.steps.join(" ")).not.toContain("Check provider credentials and account model access");
+  });
 });

--- a/ui/src/lib/provider-issues.test.ts
+++ b/ui/src/lib/provider-issues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildLocalProviderIssue } from "./provider-issues";
+import { buildLocalProviderIssue, buildSelectedModelIssue } from "./provider-issues";
 
 describe("buildLocalProviderIssue", () => {
   it("returns an ollama pull hint when the default local model is missing", () => {
@@ -33,5 +33,71 @@ describe("buildLocalProviderIssue", () => {
     });
 
     expect(issue).toBeNull();
+  });
+});
+
+describe("buildSelectedModelIssue", () => {
+  it("returns null when the selected model is discovered", () => {
+    const issue = buildSelectedModelIssue({
+      model: "llama3.1:8b",
+      providerFilter: "ollama",
+      selectableModels: [{ id: "llama3.1:8b", owned_by: "ollama", metadata: { provider: "ollama" } }],
+      configuredProvider: {
+        id: "ollama",
+        name: "Ollama",
+        kind: "local",
+        protocol: "openai",
+        base_url: "http://127.0.0.1:11434/v1",
+        credential_configured: false,
+      },
+    });
+
+    expect(issue).toBeNull();
+  });
+
+  it("explains a stale local model selection", () => {
+    const issue = buildSelectedModelIssue({
+      model: "llama3.1:8b",
+      providerFilter: "ollama",
+      selectableModels: [{ id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama" } }],
+      configuredProvider: {
+        id: "ollama",
+        name: "Ollama",
+        kind: "local",
+        protocol: "openai",
+        base_url: "http://127.0.0.1:11434/v1",
+        credential_configured: false,
+      },
+      runtimeProvider: {
+        name: "ollama",
+        kind: "local",
+        healthy: true,
+        status: "healthy",
+        models: ["qwen2.5:7b"],
+        model_count: 1,
+      },
+    });
+
+    expect(issue).toEqual(expect.objectContaining({
+      title: "Selected model is not available from this provider",
+      model: "llama3.1:8b",
+      providerLabel: "Ollama",
+    }));
+    expect(issue?.message).toContain("does not currently report");
+    expect(issue?.steps.join(" ")).toContain("Pull or load llama3.1:8b");
+  });
+
+  it("explains a stale auto-route model selection", () => {
+    const issue = buildSelectedModelIssue({
+      model: "gpt-4o-mini",
+      providerFilter: "auto",
+      selectableModels: [{ id: "claude-sonnet-4-6", owned_by: "anthropic", metadata: { provider: "anthropic" } }],
+    });
+
+    expect(issue).toEqual(expect.objectContaining({
+      title: "Selected model is not routable",
+      providerLabel: "All configured providers",
+    }));
+    expect(issue?.message).toContain("No configured provider currently reports");
   });
 });

--- a/ui/src/lib/provider-issues.test.ts
+++ b/ui/src/lib/provider-issues.test.ts
@@ -96,7 +96,7 @@ describe("buildSelectedModelIssue", () => {
 
     expect(issue).toEqual(expect.objectContaining({
       title: "Selected model is not routable",
-      providerLabel: "All configured providers",
+      providerLabel: "All providers",
     }));
     expect(issue?.message).toContain("No configured provider currently reports");
   });

--- a/ui/src/lib/provider-issues.ts
+++ b/ui/src/lib/provider-issues.ts
@@ -57,7 +57,7 @@ export function buildSelectedModelIssue({
   }
 
   const providerLabel = providerFilter === "auto"
-    ? "All configured providers"
+    ? "All providers"
     : configuredProvider?.name || runtimeProvider?.name || providerFilter;
   const isLocal = configuredProvider?.kind === "local" || runtimeProvider?.kind === "local";
   const modelCount = runtimeProvider?.model_count ?? runtimeProvider?.models?.length ?? selectableModels.length;

--- a/ui/src/lib/provider-issues.ts
+++ b/ui/src/lib/provider-issues.ts
@@ -82,7 +82,13 @@ export function buildSelectedModelIssue({
   const message = providerFilter === "auto"
     ? `No configured provider currently reports "${model}". Pick a discovered model or add a provider that serves it.`
     : `${providerLabel} is configured, but it does not currently report "${model}" in model discovery.`;
-  const steps = isLocal
+  const steps = providerFilter === "auto"
+    ? [
+        "Pick a model that appears in the model picker.",
+        "Open Providers to inspect discovery, health, routing readiness, and credential state.",
+        "If the model should be served locally, start the local provider and refresh Providers.",
+      ]
+    : isLocal
     ? [
         "Start the local provider app or server.",
         `Pull or load ${model} in that provider, or pick one of its discovered models.`,

--- a/ui/src/lib/provider-issues.ts
+++ b/ui/src/lib/provider-issues.ts
@@ -1,10 +1,19 @@
-import type { ProviderRecord } from "../types/runtime";
+import type { ConfiguredProviderRecord, ModelRecord, ProviderRecord } from "../types/runtime";
 
 export type LocalProviderIssue = {
   provider: string;
   model: string;
   message: string;
   command?: string;
+};
+
+export type SelectedModelIssue = {
+  title: string;
+  message: string;
+  providerLabel: string;
+  model: string;
+  details: Array<{ label: string; value: string }>;
+  steps: string[];
 };
 
 export function buildLocalProviderIssue(provider: ProviderRecord): LocalProviderIssue | null {
@@ -25,4 +34,65 @@ export function buildLocalProviderIssue(provider: ProviderRecord): LocalProvider
     issue.command = `ollama pull ${provider.default_model}`;
   }
   return issue;
+}
+
+export function buildSelectedModelIssue({
+  model,
+  providerFilter,
+  selectableModels,
+  configuredProvider,
+  runtimeProvider,
+}: {
+  model: string;
+  providerFilter: string;
+  selectableModels: ModelRecord[];
+  configuredProvider?: ConfiguredProviderRecord;
+  runtimeProvider?: ProviderRecord;
+}): SelectedModelIssue | null {
+  if (!model) {
+    return null;
+  }
+  if (selectableModels.some((entry) => entry.id === model)) {
+    return null;
+  }
+
+  const providerLabel = providerFilter === "auto"
+    ? "All configured providers"
+    : configuredProvider?.name || runtimeProvider?.name || providerFilter;
+  const isLocal = configuredProvider?.kind === "local" || runtimeProvider?.kind === "local";
+  const modelCount = runtimeProvider?.model_count ?? runtimeProvider?.models?.length ?? selectableModels.length;
+  const details = [
+    { label: "Selected model", value: model },
+    { label: "Provider route", value: providerLabel },
+    { label: "Discovered models", value: modelCount > 0 ? String(modelCount) : "none" },
+  ];
+  if (runtimeProvider?.status) {
+    details.push({ label: "Health", value: runtimeProvider.status });
+  }
+  if (runtimeProvider?.routing_blocked_reason) {
+    details.push({ label: "Blocked by", value: runtimeProvider.routing_blocked_reason });
+  }
+  if (runtimeProvider?.last_error) {
+    details.push({ label: "Last error", value: runtimeProvider.last_error });
+  }
+
+  const title = providerFilter === "auto"
+    ? "Selected model is not routable"
+    : "Selected model is not available from this provider";
+  const message = providerFilter === "auto"
+    ? `No configured provider currently reports "${model}". Pick a discovered model or add a provider that serves it.`
+    : `${providerLabel} is configured, but it does not currently report "${model}" in model discovery.`;
+  const steps = isLocal
+    ? [
+        "Start the local provider app or server.",
+        `Pull or load ${model} in that provider, or pick one of its discovered models.`,
+        "Refresh Providers to update the discovered model list.",
+      ]
+    : [
+        "Check provider credentials and account model access.",
+        "Pick a model that appears in the model picker, or add a provider that serves this model.",
+        "Open Providers to inspect health, discovery, and routing readiness.",
+      ];
+
+  return { title, message, providerLabel, model, details, steps };
 }


### PR DESCRIPTION
## Summary

- Blocks Hecate Chat sends when the selected model is no longer reported by the selected provider, instead of waiting for the router to reject the request.
- Adds a selected-model readiness helper with provider route, discovered-model count, health, blocked reason, last error, and next-step guidance.
- Shows the readiness notice in both empty chat setup and existing transcript composer areas, with an Open Providers action for deeper diagnostics.
- Updates provider/chat docs to explain chat-side model readiness behavior.

## Verification

- cd ui && bun run typecheck
- cd ui && bun run test -- src/app/runtimeConsoleChatHelpers.test.ts src/app/useRuntimeConsole.test.tsx src/lib/provider-issues.test.ts src/features/chats/ChatView.test.tsx src/features/providers/ProvidersView.test.tsx