### PR TITLE
fix(chat): stabilize readiness error contracts

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1169,7 +1169,15 @@ Hecate Agent-specific errors:
 
 | Status | `error.type` | Meaning |
 |---|---|---|
+| `400` | `agent_chat.workspace_required` | Hecate Agent and External Agent sessions need a selected workspace path before the first turn. |
+| `400` | `agent_chat.model_required` | Hecate Chat needs an explicit selected model before direct model or Hecate Agent turns. |
+| `400` | `agent_chat.runtime_kind_invalid` | The requested chat runtime is not one of `model`, `agent`, or `external_agent`. |
+| `400` | `agent_chat.runtime_mismatch` | The request tried to run a turn through a runtime that does not match the existing session type. |
+| `400` | `agent_chat.adapter_not_found` | The selected external-agent adapter is not registered. |
 | `409` | `agent_chat.agent_session_busy` | The backing task run is queued, running, or awaiting approval. Resolve/cancel the active run before sending another prompt, even for direct model turns in the same Hecate Chat session. |
+| `409` | `agent_chat.session_stopping` | The session is still cancelling or closing; retry after it settles. |
+| `409` | `agent_chat.session_not_running` | A stop request was issued when no run was active. |
+| `422` | `model_not_configured` | The selected model is not currently reported by the selected provider. Choose a discovered model or refresh/fix provider discovery. |
 | `422` | `agent_chat.model_capability_required` | Tools are explicitly disabled for the selected model. Turn tools off for direct model chat or enable tools in Settings. |
 
 Client note: browser/operator clients may queue a prompt locally when they

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -44,10 +44,14 @@ func (h *Handler) HandleCreateAgentChatSession(w http.ResponseWriter, r *http.Re
 		return
 	}
 	runtimeKind := normalizeAgentChatRuntimeKind(req.RuntimeKind, req.AdapterID)
+	if !isValidAgentChatRuntimeKind(runtimeKind) {
+		writeAgentChatRuntimeKindInvalid(w)
+		return
+	}
 	workspace := strings.TrimSpace(req.Workspace)
 	if runtimeKind != "model" {
 		if workspace == "" {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "workspace is required")
+			writeAgentChatWorkspaceRequired(w, runtimeKind)
 			return
 		}
 		var err error
@@ -77,12 +81,12 @@ func (h *Handler) HandleCreateAgentChatSession(w http.ResponseWriter, r *http.Re
 		provider := strings.TrimSpace(req.Provider)
 		model := strings.TrimSpace(req.Model)
 		if model == "" {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "model is required for model chat")
+			writeAgentChatModelRequired(w, "model")
 			return
 		}
 		caps, err := h.resolveModelCapabilities(r.Context(), provider, model)
 		if err != nil {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			writeAgentChatModelResolutionError(w, err)
 			return
 		}
 		if session.Title == "" {
@@ -94,7 +98,7 @@ func (h *Handler) HandleCreateAgentChatSession(w http.ResponseWriter, r *http.Re
 	case "external_agent":
 		adapter, ok := agentadapters.BuiltInByID(strings.TrimSpace(req.AdapterID))
 		if !ok {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("agent adapter %q not found", req.AdapterID))
+			writeAgentChatAdapterNotFound(w, req.AdapterID)
 			return
 		}
 		if session.Title == "" {
@@ -106,12 +110,12 @@ func (h *Handler) HandleCreateAgentChatSession(w http.ResponseWriter, r *http.Re
 		provider := strings.TrimSpace(req.Provider)
 		model := strings.TrimSpace(req.Model)
 		if model == "" {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "model is required for Hecate Agent chat")
+			writeAgentChatModelRequired(w, "agent")
 			return
 		}
 		caps, err := h.resolveModelCapabilities(r.Context(), provider, model)
 		if err != nil {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			writeAgentChatModelResolutionError(w, err)
 			return
 		}
 		if session.Title == "" {
@@ -121,7 +125,7 @@ func (h *Handler) HandleCreateAgentChatSession(w http.ResponseWriter, r *http.Re
 		session.Model = model
 		session.Capabilities = caps
 	default:
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "runtime_kind must be model, agent, or external_agent")
+		writeAgentChatRuntimeKindInvalid(w)
 		return
 	}
 	session, err = h.agentChat.Create(r.Context(), session)
@@ -142,6 +146,15 @@ func normalizeAgentChatRuntimeKind(runtimeKind, adapterID string) string {
 		return "model"
 	default:
 		return runtimeKind
+	}
+}
+
+func isValidAgentChatRuntimeKind(runtimeKind string) bool {
+	switch runtimeKind {
+	case "model", "agent", "external_agent":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -230,7 +243,7 @@ func (h *Handler) HandleDeleteAgentChatSession(w http.ResponseWriter, r *http.Re
 	settled := h.agentChatLive.cancelRunAndWait(cancelCtx, sessionID)
 	cancel()
 	if !settled {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is still stopping")
+		writeAgentChatSessionStopping(w)
 		return
 	}
 	if h.agentChatRunner != nil {
@@ -272,13 +285,13 @@ func (h *Handler) HandleCancelAgentChatSession(w http.ResponseWriter, r *http.Re
 				}
 			}
 			if err != nil && !strings.Contains(err.Error(), "already terminal") {
-				WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+				WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
 				return
 			}
 		}
 	}
 	if !h.agentChatLive.cancelRun(session.ID) {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is not running")
+		writeAgentChatSessionNotRunning(w)
 		return
 	}
 	WriteJSON(w, http.StatusAccepted, AgentChatSessionResponse{Object: "agent_chat_session", Data: renderAgentChatSession(session, h.agentChatSnapshotConfig())})
@@ -298,7 +311,7 @@ func (h *Handler) HandleCloseAgentChatSession(w http.ResponseWriter, r *http.Req
 	settled := h.agentChatLive.cancelRunAndWait(cancelCtx, session.ID)
 	cancel()
 	if !settled {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is still stopping")
+		writeAgentChatSessionStopping(w)
 		return
 	}
 	if h.agentChatRunner != nil {
@@ -380,24 +393,24 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		return
 	case "agent":
 		if renderAgentChatRuntimeKind(session) == "external_agent" {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "external agent sessions cannot run Hecate Agent turns")
+			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Agent turns")
 			return
 		}
 		h.handleCreateHecateAgentChatMessage(w, r, session, req)
 		return
 	case "external_agent":
 		if renderAgentChatRuntimeKind(session) != "external_agent" {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "Hecate Chat sessions cannot run external-agent turns")
+			writeAgentChatRuntimeMismatch(w, "Hecate Chat sessions cannot run external-agent turns")
 			return
 		}
 	default:
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "runtime_kind must be model, agent, or external_agent")
+		writeAgentChatRuntimeKindInvalid(w)
 		return
 	}
 
 	adapter, ok := agentadapters.BuiltInByID(session.AdapterID)
 	if !ok {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("agent adapter %q not found", session.AdapterID))
+		writeAgentChatAdapterNotFound(w, session.AdapterID)
 		return
 	}
 	assistantID := newAgentChatID("msg")
@@ -408,7 +421,10 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 	runCtx, cancel := context.WithTimeout(traceCtx, agentChatTimeout)
 	if !h.agentChatLive.registerRun(session.ID, cancel) {
 		cancel()
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "agent chat session is already running")
+		WriteErrorDetails(w, http.StatusConflict, errCodeAgentSessionBusy, "agent chat session is already running", ErrorDetails{
+			UserMessage:    "This chat is already running.",
+			OperatorAction: "Wait for the active run to finish or stop it before sending another message.",
+		})
 		return
 	}
 	defer h.agentChatLive.clearRun(session.ID)
@@ -678,12 +694,12 @@ func (h *Handler) handleCreateModelAgentChatMessage(w http.ResponseWriter, r *ht
 		model = session.Model
 	}
 	if model == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "model is required for model chat")
+		writeAgentChatModelRequired(w, "model")
 		return
 	}
 	caps, err := h.resolveModelCapabilities(r.Context(), provider, model)
 	if err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		writeAgentChatModelResolutionError(w, err)
 		return
 	}
 	content := strings.TrimSpace(req.Content)
@@ -693,7 +709,10 @@ func (h *Handler) handleCreateModelAgentChatMessage(w http.ResponseWriter, r *ht
 	runCtx, cancel := context.WithTimeout(r.Context(), agentChatTimeout)
 	if !h.agentChatLive.registerRun(session.ID, cancel) {
 		cancel()
-		WriteError(w, http.StatusConflict, errCodeAgentSessionBusy, "chat session is already running")
+		WriteErrorDetails(w, http.StatusConflict, errCodeAgentSessionBusy, "chat session is already running", ErrorDetails{
+			UserMessage:    "This chat is already running.",
+			OperatorAction: "Wait for the active run to finish or stop it before sending another message.",
+		})
 		return
 	}
 	defer h.agentChatLive.clearRun(session.ID)

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -27,7 +27,11 @@ func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
 		return
 	}
 	message := err.Error()
-	if strings.Contains(message, "not available") || strings.Contains(message, "not configured") || strings.Contains(message, "model is required") {
+	if strings.Contains(message, "model is required") {
+		writeAgentChatModelRequired(w, "model")
+		return
+	}
+	if strings.Contains(message, "not available") || strings.Contains(message, "not configured") {
 		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, message, ErrorDetails{
 			UserMessage:    "The selected model is not available from the selected provider.",
 			OperatorAction: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hecate/agent-runtime/internal/agentchat"
+)
+
+func writeAgentChatWorkspaceRequired(w http.ResponseWriter, runtimeKind string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeWorkspaceRequired, fmt.Sprintf("workspace is required for %s chat", agentChatRuntimeLabel(runtimeKind)), ErrorDetails{
+		UserMessage:    "Choose a workspace before starting this chat mode.",
+		OperatorAction: "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path.",
+	})
+}
+
+func writeAgentChatModelRequired(w http.ResponseWriter, runtimeKind string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeModelRequired, fmt.Sprintf("model is required for %s chat", agentChatRuntimeLabel(runtimeKind)), ErrorDetails{
+		UserMessage:    "Choose a model before sending this message.",
+		OperatorAction: "Use the model picker in the chat header, or add a provider that reports at least one model.",
+	})
+}
+
+func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	message := err.Error()
+	if strings.Contains(message, "not available") || strings.Contains(message, "not configured") || strings.Contains(message, "model is required") {
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, message, ErrorDetails{
+			UserMessage:    "The selected model is not available from the selected provider.",
+			OperatorAction: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",
+		})
+		return
+	}
+	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, message)
+}
+
+func writeAgentChatRuntimeKindInvalid(w http.ResponseWriter) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeRuntimeKindInvalid, "runtime_kind must be model, agent, or external_agent", ErrorDetails{
+		UserMessage:    "This chat mode is not supported by the current API.",
+		OperatorAction: "Use one of: model, agent, or external_agent.",
+	})
+}
+
+func writeAgentChatRuntimeMismatch(w http.ResponseWriter, message string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeRuntimeMismatch, message, ErrorDetails{
+		UserMessage:    "This message belongs to a different chat runtime.",
+		OperatorAction: "Start a new chat or switch back to the runtime that created this session.",
+	})
+}
+
+func writeAgentChatAdapterNotFound(w http.ResponseWriter, adapterID string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeAgentAdapterNotFound, fmt.Sprintf("agent adapter %q not found", adapterID), ErrorDetails{
+		UserMessage:    "The selected external agent is not configured.",
+		OperatorAction: "Open Settings and test the external agent adapter, or choose another agent.",
+	})
+}
+
+func writeAgentChatSessionStopping(w http.ResponseWriter) {
+	WriteErrorDetails(w, http.StatusConflict, errCodeSessionStopping, "agent chat session is still stopping", ErrorDetails{
+		UserMessage:    "This chat is still stopping.",
+		OperatorAction: "Wait a moment, then retry the action.",
+	})
+}
+
+func writeAgentChatSessionNotRunning(w http.ResponseWriter) {
+	WriteErrorDetails(w, http.StatusConflict, errCodeSessionNotRunning, "agent chat session is not running", ErrorDetails{
+		UserMessage:    "There is no active run to stop.",
+		OperatorAction: "Send a new message if you want to start another run.",
+	})
+}
+
+func writeHecateAgentBusy(w http.ResponseWriter, session agentchat.Session, runStatus string) {
+	WriteJSON(w, http.StatusConflict, map[string]any{
+		"error": map[string]any{
+			"type":            errCodeAgentSessionBusy,
+			"message":         "Hecate Chat is still working on the current task. Wait for it to finish, resolve the approval, or stop it before sending another message.",
+			"user_message":    "Hecate Chat is still working on this task.",
+			"operator_action": "Open the backing task, resolve the pending approval, or stop the run before sending another message.",
+			"task_id":         session.TaskID,
+			"latest_run_id":   session.LatestRunID,
+			"run_status":      runStatus,
+		},
+	})
+}
+
+func agentChatRuntimeLabel(runtimeKind string) string {
+	switch runtimeKind {
+	case "agent":
+		return "Hecate Agent"
+	case "external_agent":
+		return "External Agent"
+	default:
+		return "model"
+	}
+}

--- a/internal/api/handler_agent_chat_hecate.go
+++ b/internal/api/handler_agent_chat_hecate.go
@@ -32,7 +32,7 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 		session.WorkspaceBranch = workspaceGitBranch(resolved)
 	}
 	if strings.TrimSpace(session.Workspace) == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "workspace is required for Hecate Agent chat")
+		writeAgentChatWorkspaceRequired(w, "agent")
 		return
 	}
 	if provider := strings.TrimSpace(req.Provider); provider != "" {
@@ -46,7 +46,7 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 	if !modelcaps.ToolCapable(caps) {
 		resolved, err := h.resolveModelCapabilities(r.Context(), session.Provider, session.Model)
 		if err != nil {
-			WriteError(w, http.StatusUnprocessableEntity, errCodeModelCapability, err.Error())
+			writeAgentChatModelResolutionError(w, err)
 			return
 		}
 		caps = resolved
@@ -54,11 +54,13 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 	if !modelcaps.ToolCapable(caps) {
 		WriteJSON(w, http.StatusUnprocessableEntity, map[string]any{
 			"error": map[string]any{
-				"type":         errCodeModelCapability,
-				"message":      "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.",
-				"provider":     session.Provider,
-				"model":        session.Model,
-				"capabilities": caps,
+				"type":            errCodeModelCapability,
+				"message":         "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.",
+				"user_message":    "This model is not marked as tool-capable.",
+				"operator_action": "Turn tools off for direct model chat, test the model, or enable tool support in Settings.",
+				"provider":        session.Provider,
+				"model":           session.Model,
+				"capabilities":    caps,
 			},
 		})
 		return
@@ -80,7 +82,10 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 	runCtx, cancel := context.WithTimeout(traceCtx, agentChatTimeout)
 	if !h.agentChatLive.registerRun(session.ID, cancel) {
 		cancel()
-		WriteError(w, http.StatusConflict, errCodeAgentSessionBusy, "agent chat session is already running")
+		WriteErrorDetails(w, http.StatusConflict, errCodeAgentSessionBusy, "agent chat session is already running", ErrorDetails{
+			UserMessage:    "This chat is already running.",
+			OperatorAction: "Wait for the active run to finish or stop it before sending another message.",
+		})
 		return
 	}
 	defer h.agentChatLive.clearRun(session.ID)
@@ -345,18 +350,6 @@ func (h *Handler) hecateAgentSessionBusy(ctx context.Context, session agentchat.
 		return false, ""
 	}
 	return !types.IsTerminalTaskRunStatus(run.Status), run.Status
-}
-
-func writeHecateAgentBusy(w http.ResponseWriter, session agentchat.Session, runStatus string) {
-	WriteJSON(w, http.StatusConflict, map[string]any{
-		"error": map[string]any{
-			"type":          errCodeAgentSessionBusy,
-			"message":       "Hecate Chat is still working on the current task. Wait for it to finish, resolve the approval, or stop it before sending another message.",
-			"task_id":       session.TaskID,
-			"latest_run_id": session.LatestRunID,
-			"run_status":    runStatus,
-		},
-	})
 }
 
 func shouldStartNewHecateAgentSegment(session agentchat.Session, provider, model string) bool {

--- a/internal/api/handler_agent_chat_hecate_test.go
+++ b/internal/api/handler_agent_chat_hecate_test.go
@@ -880,20 +880,24 @@ func TestHecateAgentChatRejectsBusyBackingRun(t *testing.T) {
 		`{"content":"new turn"}`)
 	var payload struct {
 		Error struct {
-			Type        string `json:"type"`
-			Message     string `json:"message"`
-			TaskID      string `json:"task_id"`
-			LatestRunID string `json:"latest_run_id"`
-			RunStatus   string `json:"run_status"`
+			Type           string `json:"type"`
+			Message        string `json:"message"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+			TaskID         string `json:"task_id"`
+			LatestRunID    string `json:"latest_run_id"`
+			RunStatus      string `json:"run_status"`
 		} `json:"error"`
 	}
 	payload = decodeRecorder[struct {
 		Error struct {
-			Type        string `json:"type"`
-			Message     string `json:"message"`
-			TaskID      string `json:"task_id"`
-			LatestRunID string `json:"latest_run_id"`
-			RunStatus   string `json:"run_status"`
+			Type           string `json:"type"`
+			Message        string `json:"message"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+			TaskID         string `json:"task_id"`
+			LatestRunID    string `json:"latest_run_id"`
+			RunStatus      string `json:"run_status"`
 		} `json:"error"`
 	}](t, recorder)
 	if payload.Error.Type != errCodeAgentSessionBusy {
@@ -901,6 +905,9 @@ func TestHecateAgentChatRejectsBusyBackingRun(t *testing.T) {
 	}
 	if !strings.Contains(payload.Error.Message, "still working on the current task") {
 		t.Fatalf("message = %q", payload.Error.Message)
+	}
+	if payload.Error.UserMessage == "" || payload.Error.OperatorAction == "" {
+		t.Fatalf("operator metadata missing from busy payload: %+v", payload.Error)
 	}
 	if payload.Error.TaskID != task.ID || payload.Error.LatestRunID != run.ID || payload.Error.RunStatus != "running" {
 		t.Fatalf("busy payload = %+v", payload.Error)

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -18,6 +18,14 @@ const (
 	errCodeSessionIdleTimeout   = "agent_chat.session_idle_timeout"
 	errCodeAgentSessionBusy     = "agent_chat.agent_session_busy"
 	errCodeModelCapability      = "agent_chat.model_capability_required"
+	errCodeModelNotConfigured   = "model_not_configured"
+	errCodeWorkspaceRequired    = "agent_chat.workspace_required"
+	errCodeModelRequired        = "agent_chat.model_required"
+	errCodeRuntimeKindInvalid   = "agent_chat.runtime_kind_invalid"
+	errCodeRuntimeMismatch      = "agent_chat.runtime_mismatch"
+	errCodeAgentAdapterNotFound = "agent_chat.adapter_not_found"
+	errCodeSessionStopping      = "agent_chat.session_stopping"
+	errCodeSessionNotRunning    = "agent_chat.session_not_running"
 )
 
 func WriteJSON(w http.ResponseWriter, status int, payload any) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1702,6 +1702,34 @@ func TestAgentChatCreateUsesStableErrorContracts(t *testing.T) {
 	}
 }
 
+func TestAgentChatModelResolutionRequiredErrorUsesValidationContract(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeAgentChatModelResolutionError(rec, errors.New("model is required"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Type           string `json:"type"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+		} `json:"error"`
+	}
+	payload = decodeRecorder[struct {
+		Error struct {
+			Type           string `json:"type"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+		} `json:"error"`
+	}](t, rec)
+	if payload.Error.Type != errCodeModelRequired {
+		t.Fatalf("error.type = %q, want %q", payload.Error.Type, errCodeModelRequired)
+	}
+	if payload.Error.UserMessage == "" || payload.Error.OperatorAction == "" {
+		t.Fatalf("error missing operator metadata: %+v", payload.Error)
+	}
+}
+
 func TestAgentChatStoreAttachReconcilesInterruptedRun(t *testing.T) {
 	store := agentchat.NewMemoryStore()
 	ctx := context.Background()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1638,6 +1638,70 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 	}
 }
 
+func TestAgentChatCreateUsesStableErrorContracts(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
+	client := newAPITestClient(t, handler)
+
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		wantType   string
+	}{
+		{
+			name:       "workspace required for external agent",
+			body:       `{"runtime_kind":"external_agent","adapter_id":"codex"}`,
+			statusCode: http.StatusBadRequest,
+			wantType:   errCodeWorkspaceRequired,
+		},
+		{
+			name:       "model required for model chat",
+			body:       `{"runtime_kind":"model"}`,
+			statusCode: http.StatusBadRequest,
+			wantType:   errCodeModelRequired,
+		},
+		{
+			name:       "adapter not found",
+			body:       fmt.Sprintf(`{"runtime_kind":"external_agent","adapter_id":"missing","workspace":%q}`, t.TempDir()),
+			statusCode: http.StatusBadRequest,
+			wantType:   errCodeAgentAdapterNotFound,
+		},
+		{
+			name:       "runtime kind invalid",
+			body:       `{"runtime_kind":"bogus"}`,
+			statusCode: http.StatusBadRequest,
+			wantType:   errCodeRuntimeKindInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := client.mustRequestStatus(tt.statusCode, http.MethodPost, "/hecate/v1/agent-chat/sessions", tt.body)
+			var payload struct {
+				Error struct {
+					Type           string `json:"type"`
+					UserMessage    string `json:"user_message"`
+					OperatorAction string `json:"operator_action"`
+				} `json:"error"`
+			}
+			payload = decodeRecorder[struct {
+				Error struct {
+					Type           string `json:"type"`
+					UserMessage    string `json:"user_message"`
+					OperatorAction string `json:"operator_action"`
+				} `json:"error"`
+			}](t, rec)
+			if payload.Error.Type != tt.wantType {
+				t.Fatalf("error.type = %q, want %q", payload.Error.Type, tt.wantType)
+			}
+			if payload.Error.UserMessage == "" || payload.Error.OperatorAction == "" {
+				t.Fatalf("error missing operator metadata: %+v", payload.Error)
+			}
+		})
+	}
+}
+
 func TestAgentChatStoreAttachReconcilesInterruptedRun(t *testing.T) {
 	store := agentchat.NewMemoryStore()
 	ctx := context.Background()

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -197,8 +197,10 @@ describe("ChatView input", () => {
     expect(screen.getByText("Provider is configured")).toBeTruthy();
     expect(screen.getAllByText("Ollama").length).toBeGreaterThan(0);
     expect(screen.getByText("none discovered")).toBeTruthy();
-    expect(screen.getByText("Credentials")).toBeTruthy();
+    expect(screen.getAllByText("Credentials").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Models").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Routing").length).toBeGreaterThan(0);
+    expect(screen.getByText("Discovery")).toBeTruthy();
     expect(screen.getByText("Routing is blocked because no models are available.")).toBeTruthy();
     expect(screen.getByText(/Start the local provider app/)).toBeTruthy();
     expect(screen.queryByText("Detected locally")).toBeNull();

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -3,7 +3,7 @@ import type { SyntheticEvent } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
-import { describeRoutingBlockedReason } from "../../lib/runtime-utils";
+import { describeCredentialState, describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import type { AgentAdapterRecord, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
 import { CompactProviderReadinessChecks } from "../shared/ProviderReadiness";
 import { AgentAdapterPicker, CodeBlock, Icon, Icons, InlineError, ModelPicker, ProviderPicker } from "../shared/ui";
@@ -2103,6 +2103,22 @@ function ModelRouteTroubleshooting({
   const modelCount = runtimeProvider?.model_count ?? runtimeProvider?.models?.length ?? 0;
   const blockedReason = runtimeProvider?.routing_blocked_reason ? describeRoutingBlockedReason(runtimeProvider.routing_blocked_reason) : "";
   const lastError = runtimeProvider?.last_error || "";
+  const lastErrorClass = runtimeProvider?.last_error_class ? describeHealthErrorClass(runtimeProvider.last_error_class) : "";
+  const discoverySource = runtimeProvider?.discovery_source || "";
+  const rawCredentialState = runtimeProvider?.credential_state
+    ?? (configuredProvider?.kind === "local"
+      ? "not_required"
+      : configuredProvider?.credential_configured
+        ? "configured"
+        : configuredProvider
+          ? "missing"
+          : undefined);
+  const credentialState = describeCredentialState(rawCredentialState);
+  const routingState = runtimeProvider?.routing_ready === false
+    ? (blockedReason || "Blocked")
+    : runtimeProvider?.routing_ready === true
+      ? "Ready"
+      : "Unknown";
 
   const guidance = isLocal
     ? [
@@ -2139,13 +2155,27 @@ function ModelRouteTroubleshooting({
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 8, marginTop: 10 }}>
         <InfoChip label="Endpoint" value={endpoint || "not reported"} />
+        <InfoChip label="Credentials" value={credentialState} />
         <InfoChip label="Models" value={modelCount > 0 ? String(modelCount) : "none discovered"} />
+        <InfoChip label="Routing" value={routingState} />
         <InfoChip label="Health" value={runtimeProvider?.status || "pending probe"} />
+        <InfoChip label="Discovery" value={discoverySource || "pending"} />
       </div>
       <CompactProviderReadinessChecks checks={runtimeProvider?.readiness_checks ?? []} />
-      {(blockedReason || lastError) && (
-        <div style={{ marginTop: 10, fontSize: 11, color: "var(--amber)", lineHeight: 1.45 }}>
-          {blockedReason || lastError}
+      {(blockedReason || lastError || lastErrorClass) && (
+        <div style={{
+          marginTop: 10,
+          border: "1px solid var(--amber-border)",
+          borderRadius: "var(--radius-sm)",
+          background: "var(--amber-bg)",
+          padding: "8px 9px",
+          fontSize: 11,
+          color: "var(--amber)",
+          lineHeight: 1.45,
+        }}>
+          {blockedReason && <div>Route: {blockedReason}</div>}
+          {lastErrorClass && <div>Error class: {lastErrorClass}</div>}
+          {lastError && <div style={{ color: "var(--t2)", marginTop: 3, overflowWrap: "anywhere" }}>{lastError}</div>}
         </div>
       )}
       <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>

--- a/ui/src/lib/error-diagnostics.test.ts
+++ b/ui/src/lib/error-diagnostics.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { describeGatewayError, formatErrorCode } from "./error-diagnostics";
+
+describe("describeGatewayError", () => {
+  it("labels stable Hecate Chat error contracts", () => {
+    expect(describeGatewayError("agent_chat.agent_session_busy")?.title).toBe("Chat is still working");
+    expect(describeGatewayError("agent_chat.model_capability_required")?.title).toBe("Tools unavailable for this model");
+    expect(describeGatewayError("agent_chat.workspace_required")?.action).toContain("Choose a workspace");
+    expect(describeGatewayError("model_not_configured")?.title).toBe("Selected model is unavailable");
+  });
+
+  it("keeps HTTP status fallbacks for non-Hecate errors", () => {
+    expect(describeGatewayError(undefined, 429)?.title).toBe("Gateway rate limit exceeded");
+    expect(describeGatewayError(undefined, 502)?.title).toBe("Gateway or upstream failed");
+  });
+});
+
+describe("formatErrorCode", () => {
+  it("combines status and stable code", () => {
+    expect(formatErrorCode("agent_chat.agent_session_busy", 409)).toBe("409 · agent_chat.agent_session_busy");
+  });
+});

--- a/ui/src/lib/error-diagnostics.ts
+++ b/ui/src/lib/error-diagnostics.ts
@@ -50,6 +50,56 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
     action: "Review tenant key scope, provider/model allowlists, and policy rules.",
     tone: "warning",
   },
+  "agent_chat.workspace_required": {
+    title: "Workspace required",
+    action: "Choose a workspace before using Hecate Agent or External Agent.",
+    tone: "warning",
+  },
+  "agent_chat.model_required": {
+    title: "Model required",
+    action: "Choose a model from the chat header, or add a provider that reports models.",
+    tone: "warning",
+  },
+  model_not_configured: {
+    title: "Selected model is unavailable",
+    action: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",
+    tone: "warning",
+  },
+  "agent_chat.model_capability_required": {
+    title: "Tools unavailable for this model",
+    action: "Turn tools off for direct model chat, test the model, or enable tool support in Settings.",
+    tone: "warning",
+  },
+  "agent_chat.agent_session_busy": {
+    title: "Chat is still working",
+    action: "Open the backing task, resolve the approval, or stop the run before sending another message.",
+    tone: "warning",
+  },
+  "agent_chat.runtime_mismatch": {
+    title: "Wrong chat runtime",
+    action: "Start a new chat or switch back to the runtime that created this session.",
+    tone: "warning",
+  },
+  "agent_chat.runtime_kind_invalid": {
+    title: "Unsupported chat runtime",
+    action: "Use one of the supported chat modes: model, agent, or external_agent.",
+    tone: "warning",
+  },
+  "agent_chat.adapter_not_found": {
+    title: "External agent is unavailable",
+    action: "Open Settings and test the external agent adapter, or choose another agent.",
+    tone: "warning",
+  },
+  "agent_chat.session_stopping": {
+    title: "Chat is stopping",
+    action: "Wait a moment, then retry the action.",
+    tone: "warning",
+  },
+  "agent_chat.session_not_running": {
+    title: "No active run",
+    action: "Send a new message if you want to start another run.",
+    tone: "warning",
+  },
 };
 
 export function describeGatewayError(code?: string, status?: number): GatewayErrorDiagnostic | null {


### PR DESCRIPTION
## Summary

- promote common Hecate Chat failures from generic invalid_request strings to stable error.type values with user_message and operator_action metadata
- preserve Hecate Agent busy-session task/run fields while adding operator-facing guidance for the UI
- improve the Chats no-route troubleshooting card with credential state, routing state, discovery source, health, model count, error class, and last provider error
- document the expanded Hecate Chat error contract in runtime API docs

## Verification

- go test ./internal/api
- cd ui && bun run typecheck
- cd ui && bun run test -- src/lib/error-diagnostics.test.ts src/features/chats/ChatView.test.tsx src/app/runtimeConsoleChatHelpers.test.ts