### PR TITLE
docs: add alpha-to-beta roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,12 @@ sneaks into a refactor, split. State the verification you ran in the
 description — see [`docs-ai/tasks/code-review.md`](docs-ai/tasks/code-review.md)
 for the rubric reviewers will apply.
 
+Beta-scope work starts from current `master` on a feature/refactor/docs branch
+and lands through a reviewed PR. Do not implement beta features directly on
+`master`; reserve direct `master` commits for release mechanics or urgent tiny
+corrections that a maintainer explicitly requests. The current beta gate lives
+in [`docs/beta-roadmap.md`](docs/beta-roadmap.md).
+
 ## Repo policy
 
 Shared agent guidance is repository-owned and committed. There is no

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Full index lives at [`docs/README.md`](docs/README.md), organized by reader role
 - [Desktop app](docs/desktop-app.md) — native bundles, first-launch footguns, platform data dirs, roadmap.
 - [Providers](docs/providers.md) — preset catalog, OpenAI-compatible custom endpoints, credentials, health, circuit breaking.
 - [Known limitations](docs/known-limitations.md) — plain-language list of what's still alpha.
+- [Alpha-to-beta roadmap](docs/beta-roadmap.md) — core gates, UX polish order, cleanup/refactoring, and branch/release workflow.
 
 **Building against Hecate**
 
@@ -235,6 +236,7 @@ Full index lives at [`docs/README.md`](docs/README.md), organized by reader role
 - [Architecture](docs/architecture.md) — gateway request flow, task-runtime queue / lease / sandbox boundary.
 - [Development](docs/development.md) — source-build toolchain, local dev, website work, the test ladder, screenshot tooling.
 - [Release](docs/release.md) — cutting a tag, verification gate, recovery if CI fails.
+- [Alpha-to-beta roadmap](docs/beta-roadmap.md) — what must be true before the first beta tag.
 
 First-run environment knobs live in [`.env.example`](.env.example).
 

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -60,3 +60,6 @@ commit question.
 - **No plan labels** (`Phase 1`, `P0`, `#15`, `Milestone N`) in commit messages or code comments.
 - **Probe before assuming paths.** `grep`, `ls`, `go build` before writing file paths from memory. Wrong paths compound.
 - **Build early, build often.** `go build ./...` before the first edit (confirm the tree is clean) and after each logical step.
+- **Beta-scope work gets a branch.** Start from current `master`, use a
+  feature/refactor/docs branch, and land through PR. Direct `master` commits are
+  for release mechanics or explicitly requested urgent corrections only.

--- a/docs-ai/core/workflow.md
+++ b/docs-ai/core/workflow.md
@@ -53,6 +53,13 @@ If a refactor is the right move, split it into its own change first and rebuild 
 - The verification scope balloons (e.g. needs both UI typecheck/test and backend race suite for behavior the operator will see in stages).
 - A behavior change is sneaking into a refactor.
 
+## Branch discipline
+
+Beta-scope work starts from current `master` on a feature/refactor/docs branch
+and lands through PR. Do not implement beta features directly on `master`.
+Reserve direct `master` commits for release mechanics or urgent tiny
+corrections that the operator explicitly requests.
+
 ## Commit etiquette
 
 **Don't auto-commit.** After every change, propose a Conventional Commits message in a fenced code block; the operator merges. This is a default behavior, not an opt-in.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Pick the path closest to what you are doing.
 | Running Hecate locally | [Desktop app](desktop-app.md), [Deployment](deployment.md), [Security](security.md), [Providers](providers.md), [Chat sessions](chat-sessions.md), [Known limitations](known-limitations.md) |
 | Calling Hecate from a client | [Runtime API](runtime-api.md), [Chat sessions](chat-sessions.md), [Agent runtime](agent-runtime.md), [Events](events.md) |
 | Building or using coding-agent integrations | [External agent adapters](external-agent-adapters.md), [ACP bridge](acp.md), [Runtime API](runtime-api.md), [Events](events.md), [MCP integration](mcp.md) |
-| Changing the codebase | [Architecture](architecture.md), [Development](development.md), [`docs-ai/`](../docs-ai/README.md), [Release](release.md) |
+| Changing the codebase | [Architecture](architecture.md), [Development](development.md), [Alpha-to-beta roadmap](beta-roadmap.md), [`docs-ai/`](../docs-ai/README.md), [Release](release.md) |
 | Working as an AI agent | [`AGENTS.md`](../AGENTS.md), [`docs-ai/README.md`](../docs-ai/README.md), then the relevant `docs-ai/skills/*/SKILL.md` |
 
 ## Operator Docs
@@ -53,6 +53,7 @@ Pick the path closest to what you are doing.
 | [Architecture](architecture.md) | Gateway flow, orchestrator responsibilities, task-runtime queue/lease model, agent turn cycle, storage tiers. |
 | [Development](development.md) | Go + Bun + just + Rust/Cargo setup, local dev, test ladder, screenshot tooling, package map. |
 | [Release](release.md) | Versioning, verification gate, release script, image build, recovery, release-note shape. |
+| [Alpha-to-beta roadmap](beta-roadmap.md) | Beta gate, core runtime work, view-by-view UX order, cleanup/refactoring, and branch/release workflow. |
 | [`docs-ai/`](../docs-ai/README.md) | Vendor-neutral agent guidance: workflow, verification, skills, task recipes. |
 
 ## Candidate Contracts

--- a/docs/beta-roadmap.md
+++ b/docs/beta-roadmap.md
@@ -1,0 +1,117 @@
+# Alpha-to-beta roadmap
+
+Hecate keeps shipping `v0.1.0-alpha.N` releases while beta work lands
+incrementally. Beta is not the next release by default; it is the quality gate
+after core runtime contracts, view-by-view UX polish, and cleanup/refactoring
+are complete.
+
+`master` stays the protected integration and release branch. Beta-scope work
+happens on feature branches forked from current `master`, lands through PRs, and
+is released in alpha tags only after it merges.
+
+## Core Runtime First
+
+| Area | Beta bar |
+|---|---|
+| Error contracts | Hecate-native errors across gateway, model chat, Hecate Chat, External Agent, Tasks, approvals, storage, retention, and provider readiness return stable `type` values, correct HTTP statuses, trace IDs when available, friendly operator messages, and raw details. |
+| Provider/model readiness | Provider readiness is the canonical setup contract: credential state, discovery state, discovered model count, selected-model validity, route blocking reason, tool capability, pricebook status, last probe/result, and repair action. |
+| Routing explainability | Route reports persist and expose selected route, skipped candidates, skip reasons, failover path, cache path, budget/policy decision, pricebook source, provider latency/error state, and final error. |
+| Task runtime hardening | Queue, lease, running, awaiting approval, approved/rejected, cancelled, failed, completed, retry, resume, stale worker recovery, and shutdown behavior are audited and tested. |
+| Storage and retention | Memory/SQLite parity is verified for providers, chats, tasks, approvals, grants, model capabilities, retention pruning, startup reconcile, and schema migration safety. |
+| OpenTelemetry | Route choice/skip, provider failure, cache hit/miss, task lifecycle, approval lifecycle, chat segment lifecycle, external adapter behavior, retention, rate limits, and readiness probes emit useful spans, metrics, or logs. |
+| Endpoint stability | Hecate-native endpoints stay under `/hecate/v1/*`; provider-compatible endpoints stay under `/v1/*`; tests and docs checks prevent old `/admin/*` and accidental Hecate-native `/v1/*` routes from returning. |
+
+## UX By View
+
+| View | Beta bar |
+|---|---|
+| Chats | Hecate Chat, External Agent, and direct model chat have clear segment boundaries, queued prompts, busy state, task/trace/run links, approvals, markdown/code rendering, run activity grouping, changed-files review, model/tool capability state, stale-model repair, and refresh/resume accuracy. |
+| Providers | Provider setup is self-explanatory: readiness cards, discovered/running/installed states, credential repair, duplicate endpoint handling, route blocking reasons, model discovery failures, local provider discovery, and optimistic edits/deletes where safe. |
+| Tasks | Task Detail is the canonical deep-debug view: clear run timeline, grouped advanced activity, approval cards, stdout/stderr/artifacts, retry/resume/cancel explanations, patch review, and chat-origin links. |
+| Observability | The UI answers "what happened?" without JSON archaeology: request ledger, route report, trace viewer, skipped providers, policy/budget denial, cost calculation, cache path, provider failure, and final outcome. |
+| Settings | Settings stays focused on pricebook, retention, model capability overrides/probes, External Agent readiness/grants, and OTel/export knobs when needed. |
+| Costs | Costs clearly separates enforced gateway cost from adapter-reported usage. External Agent usage remains labelled as reported by adapter and not enforced by Hecate. |
+| Desktop app | Before beta, decide whether unsigned desktop bundles are acceptable. If not, complete signing/notarization or clearly keep desktop labelled alpha while the rest of Hecate enters beta. |
+
+## Cleanup And Refactoring
+
+- **Shared transcript/activity primitives**: model chat, Hecate Chat, External
+  Agent chat, and Task Detail converge on one shared transcript/activity
+  component family.
+- **Canonical readiness model**: one provider/model readiness type feeds API,
+  UI, docs, tests, and trace/telemetry labels.
+- **Task/chat boundaries**: Tasks remain canonical for full run history and
+  patch review; Hecate Chat projections stay accurate and linked. One chat can
+  have many historical segments but only one active task-backed loop.
+- **Docs structure**: user docs, runtime/API docs, RFCs, and `docs-ai` guidance
+  describe the same product and same caveats.
+- **Remove stale legacy**: old endpoint names, old `/gateway` language,
+  one-binary claims, stale screenshots, obsolete scripts, dead fixtures, and
+  duplicate UI rendering paths are removed.
+- **Release automation**: alpha releases stay boring: docs drift checks,
+  screenshots, links, Docker/native/binary parity, Tauri version stamp,
+  release-doc refresh, and recovery instructions.
+
+## Branching And Release Workflow
+
+- Create a feature branch from current `master` for every beta-scope slice, for
+  example `feature/provider-readiness-contracts` or
+  `refactor/shared-transcript-activity`.
+- Rebase feature branches onto `origin/master` before opening or updating PRs.
+- Merge only reviewed PRs into `master`; do not implement beta features
+  directly on `master`.
+- Use direct `master` commits only for release mechanics or urgent tiny
+  corrections that are explicitly requested, such as version stamps,
+  release-reference docs, or failed-release recovery.
+- Cut alpha releases from `master` after completed PR slices merge and
+  `just verify` passes.
+- Do not create a long-lived beta branch unless beta stabilization later needs a
+  freeze window. Until then, `master` remains the alpha release train and
+  integration branch.
+- The first beta tag should be `v0.1.0-beta.1` after the beta gate passes.
+
+## Beta Gate
+
+Hecate can move from alpha releases to a beta tag only when all of these are
+true:
+
+- Runtime errors are stable and friendly across the main surfaces.
+- Provider/model readiness can explain and repair common setup failures.
+- Routing decisions are inspectable in traces/UI.
+- Hecate Chat supports mixed direct/model and tools-on task-backed segments
+  reliably.
+- External Agent sessions have approvals, readiness, diagnostics, guardrails,
+  diff inspect/revert, and trusted-subprocess warnings.
+- Task runtime lifecycle is tested for approval, cancel, retry/resume, stale
+  worker recovery, and shutdown.
+- Memory/SQLite persistence and retention boundaries are tested and documented.
+- OTel covers the important runtime decisions.
+- UI polish passes are complete for Chats, Providers, Tasks, Observability, and
+  Settings.
+- README, known limitations, runtime API docs, release docs, screenshots, and
+  `docs-ai` guidance all describe the same product.
+- Latest alpha release passes `just verify`, release workflow, links workflow,
+  and desktop release matrix.
+
+## Test Plan
+
+| Layer | Coverage |
+|---|---|
+| Go unit/API tests | Error contracts, provider readiness, route reports, task lifecycle, storage parity, retention, model capabilities, approvals, endpoint namespace checks. |
+| Go e2e tests | Docker startup, OTLP smoke, ACP smoke, approval persistence/reconcile, provider readiness scenarios, task retry/resume/cancel, release-critical startup paths. |
+| UI unit tests | Shared transcript components, friendly errors, readiness cards, chat segment state, queued prompts, approvals, task links, provider repair states. |
+| Playwright e2e | First-run provider onboarding, stale selected model repair, Hecate Chat tools on/off/on, task approval in Chats, refresh during running/awaiting approval, External Agent approval + diff inspect/revert, provider readiness repair, trace/task links. |
+| Release checks | `just verify`, links, screenshots, Docker image pull/run, release asset presence, Tauri matrix, README release links. |
+
+## Assumptions
+
+- Alpha releases continue normally while this work is in progress.
+- Beta is a quality gate, not a marketing rename for the next release.
+- No feature work lands directly on `master`; work is done in feature branches
+  and merged through PRs.
+- No compatibility shims are required for alpha-only endpoint/API changes unless
+  explicitly decided later.
+- Hecate remains local-first and single-operator shaped for beta; multi-node and
+  hosted deployments stay out of scope.
+- External Agent CLIs remain trusted subprocesses for beta; Hecate supervises
+  and warns, but does not sandbox their internals.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -3,6 +3,10 @@
 Hecate is public-alpha software. This page is the plain-language list of what
 operators should not assume yet.
 
+The current quality gate for leaving alpha is tracked in the
+[alpha-to-beta roadmap](beta-roadmap.md). Until that gate closes, Hecate keeps
+shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
+
 ## API And Schema Stability
 
 - Public APIs are designed to be stable, but pre-1.0 changes are still possible.

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,6 +14,9 @@ what is alpha-grade versus production-shaped.
   `v0.1.0-alpha.2`, `v0.1.0-rc.1`. Goreleaser and tauri-action handle them
   the same as stable tags; consumers can opt out via semver tooling that
   recognizes pre-release tags.
+- Keep shipping `v0.1.0-alpha.N` while the
+  [alpha-to-beta roadmap](beta-roadmap.md) is open. The first beta tag is a
+  quality gate (`v0.1.0-beta.1`), not the next release by default.
 - Do not publish a release from a dirty worktree.
 
 ## What a release produces


### PR DESCRIPTION
## Summary

- add a repo-owned alpha-to-beta roadmap that keeps alpha releases as the active train and defines beta as a quality gate
- document the core runtime, view-by-view UX, cleanup/refactoring, beta gate, and test-plan scope
- mirror the new branch discipline in README/docs index/release/known-limitations, contributor docs, and agent workflow guidance

## Verification

- rtk git diff HEAD --check