### PR TITLE
feat(api): enrich Hecate-native error contracts

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -51,6 +51,27 @@ Hecate-native JSON errors use one stable envelope:
 - `request_id` and `trace_id` are included when the runtime has already created
   trace state. They mirror `X-Request-Id` / `X-Trace-Id` and let clients open
   `GET /hecate/v1/traces?request_id=...` directly from an error surface.
+- Runtime-specific fields may be attached when they help repair the failure.
+  Examples: `task_id`, `latest_run_id`, and `run_status` for a busy Hecate Chat
+  task; `provider`, `model`, and `capabilities` for tool-capability failures;
+  `limit_ms` / `turns_used` for session guardrails.
+
+Common Hecate-native error types:
+
+| Type | Status | Meaning |
+|---|---:|---|
+| `invalid_request` | 400 | Request JSON, query parameters, or required fields are invalid. |
+| `not_found` | 404 | The requested Hecate resource does not exist. |
+| `conflict` | 409 | The resource changed state or the requested transition is not valid now. |
+| `gateway_error` | 500 | Hecate failed before it could classify the failure more specifically. |
+| `rate_limit_exceeded` | 429 | The local gateway rate limiter rejected the request. |
+| `model_not_configured` | 422 | The selected model is stale or not currently reported by the selected provider. |
+| `agent_chat.agent_session_busy` | 409 | A Hecate Chat task-backed loop is queued, running, or awaiting approval. |
+| `agent_chat.model_capability_required` | 422 | Tools are on, but the model is not marked tool-capable. |
+| `agent_chat.workspace_required` | 400 | Hecate Agent or External Agent chat needs a workspace path. |
+| `agent_chat.session_limit_exceeded` | 422 | The chat turn limit was reached. |
+| `agent_chat.session_duration_limit_exceeded` | 422 | The chat wall-clock limit was reached. |
+| `agent_chat.session_idle_timeout` | 422 | The chat was idle beyond the configured timeout. |
 
 OpenAI-compatible and Anthropic-compatible ingress paths keep their protocol
 shape, but gateway-classified failures also include the same

--- a/internal/api/error_mapping.go
+++ b/internal/api/error_mapping.go
@@ -53,7 +53,7 @@ func classifyGatewayError(err error) gatewayHTTPError {
 	if gateway.IsRateLimitedError(err) {
 		return gatewayHTTPError{
 			Status:        http.StatusTooManyRequests,
-			OpenAIType:    "rate_limit_exceeded",
+			OpenAIType:    errCodeRateLimitExceeded,
 			AnthropicType: "rate_limit_error",
 			Message:       err.Error(),
 		}
@@ -226,7 +226,7 @@ func gatewayErrorUserMessage(code string) string {
 		return "No configured provider supports the requested model."
 	case errCodeForbidden:
 		return "The request was blocked by policy."
-	case "rate_limit_exceeded":
+	case errCodeRateLimitExceeded:
 		return "Hecate's local gateway rate limit was exceeded."
 	default:
 		return "Gateway request failed."
@@ -251,7 +251,7 @@ func gatewayErrorAction(code string) string {
 		return "Choose a discovered model for the selected provider, or switch provider routing back to Auto."
 	case errCodeForbidden:
 		return "Review policy rules, provider/model allowlists, and tenant budget settings."
-	case "rate_limit_exceeded":
+	case errCodeRateLimitExceeded:
 		return "Wait for the bucket to refill or adjust the local gateway rate limit."
 	default:
 		return "Open Observability for the request trace and inspect route/provider diagnostics."

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -571,7 +571,7 @@ func (h *Handler) checkRateLimit(w http.ResponseWriter, keyID string) bool {
 	w.Header().Set("X-RateLimit-Remaining", strconv.FormatInt(remaining, 10))
 	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
 	if err != nil {
-		WriteError(w, http.StatusTooManyRequests, "rate_limit_exceeded", err.Error())
+		WriteError(w, http.StatusTooManyRequests, errCodeRateLimitExceeded, err.Error())
 		return false
 	}
 	return true

--- a/internal/api/handler_agent_chat.go
+++ b/internal/api/handler_agent_chat.go
@@ -352,10 +352,8 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 	limits := h.agentChatSnapshotConfig()
 	maxTurns := limits.MaxTurnsPerSession
 	if maxTurns > 0 && session.TurnsUsed >= maxTurns {
-		WriteJSON(w, http.StatusUnprocessableEntity, map[string]any{
-			"error": map[string]any{
-				"type":       errCodeSessionLimitExceeded,
-				"message":    fmt.Sprintf("session has reached the %d-turn limit; start a new session to continue", maxTurns),
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeSessionLimitExceeded, fmt.Sprintf("session has reached the %d-turn limit; start a new session to continue", maxTurns), ErrorDetails{
+			Fields: map[string]any{
 				"limit":      maxTurns,
 				"turns_used": session.TurnsUsed,
 			},
@@ -363,10 +361,8 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if limits.MaxSessionDuration > 0 && !session.CreatedAt.IsZero() && time.Since(session.CreatedAt) >= limits.MaxSessionDuration {
-		WriteJSON(w, http.StatusUnprocessableEntity, map[string]any{
-			"error": map[string]any{
-				"type":       errCodeSessionDurationLimit,
-				"message":    fmt.Sprintf("session has reached the %s wall-clock limit; start a new session to continue", limits.MaxSessionDuration),
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeSessionDurationLimit, fmt.Sprintf("session has reached the %s wall-clock limit; start a new session to continue", limits.MaxSessionDuration), ErrorDetails{
+			Fields: map[string]any{
 				"limit_ms":   limits.MaxSessionDuration.Milliseconds(),
 				"started_at": formatOptionalTime(session.CreatedAt),
 				"turns_used": session.TurnsUsed,
@@ -375,10 +371,8 @@ func (h *Handler) HandleCreateAgentChatMessage(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if limits.IdleTimeout > 0 && !session.UpdatedAt.IsZero() && time.Since(session.UpdatedAt) >= limits.IdleTimeout {
-		WriteJSON(w, http.StatusUnprocessableEntity, map[string]any{
-			"error": map[string]any{
-				"type":       errCodeSessionIdleTimeout,
-				"message":    fmt.Sprintf("session was idle for at least %s; start a new session to continue", limits.IdleTimeout),
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeSessionIdleTimeout, fmt.Sprintf("session was idle for at least %s; start a new session to continue", limits.IdleTimeout), ErrorDetails{
+			Fields: map[string]any{
 				"limit_ms":   limits.IdleTimeout.Milliseconds(),
 				"updated_at": formatOptionalTime(session.UpdatedAt),
 				"turns_used": session.TurnsUsed,

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -77,15 +77,11 @@ func writeAgentChatSessionNotRunning(w http.ResponseWriter) {
 }
 
 func writeHecateAgentBusy(w http.ResponseWriter, session agentchat.Session, runStatus string) {
-	WriteJSON(w, http.StatusConflict, map[string]any{
-		"error": map[string]any{
-			"type":            errCodeAgentSessionBusy,
-			"message":         "Hecate Chat is still working on the current task. Wait for it to finish, resolve the approval, or stop it before sending another message.",
-			"user_message":    "Hecate Chat is still working on this task.",
-			"operator_action": "Open the backing task, resolve the pending approval, or stop the run before sending another message.",
-			"task_id":         session.TaskID,
-			"latest_run_id":   session.LatestRunID,
-			"run_status":      runStatus,
+	WriteErrorDetails(w, http.StatusConflict, errCodeAgentSessionBusy, "Hecate Chat is still working on the current task. Wait for it to finish, resolve the approval, or stop it before sending another message.", ErrorDetails{
+		Fields: map[string]any{
+			"task_id":       session.TaskID,
+			"latest_run_id": session.LatestRunID,
+			"run_status":    runStatus,
 		},
 	})
 }

--- a/internal/api/handler_agent_chat_hecate.go
+++ b/internal/api/handler_agent_chat_hecate.go
@@ -52,15 +52,11 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 		caps = resolved
 	}
 	if !modelcaps.ToolCapable(caps) {
-		WriteJSON(w, http.StatusUnprocessableEntity, map[string]any{
-			"error": map[string]any{
-				"type":            errCodeModelCapability,
-				"message":         "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.",
-				"user_message":    "This model is not marked as tool-capable.",
-				"operator_action": "Turn tools off for direct model chat, test the model, or enable tool support in Settings.",
-				"provider":        session.Provider,
-				"model":           session.Model,
-				"capabilities":    caps,
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.", ErrorDetails{
+			Fields: map[string]any{
+				"provider":     session.Provider,
+				"model":        session.Model,
+				"capabilities": caps,
 			},
 		})
 		return

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 )
 
 const (
@@ -13,6 +14,7 @@ const (
 	errCodeUpstreamError        = "upstream_error"
 	errCodeNotFound             = "not_found"
 	errCodeConflict             = "conflict"
+	errCodeRateLimitExceeded    = "rate_limit_exceeded"
 	errCodeSessionLimitExceeded = "agent_chat.session_limit_exceeded"
 	errCodeSessionDurationLimit = "agent_chat.session_duration_limit_exceeded"
 	errCodeSessionIdleTimeout   = "agent_chat.session_idle_timeout"
@@ -43,9 +45,11 @@ type ErrorDetails struct {
 	OperatorAction string
 	RequestID      string
 	TraceID        string
+	Fields         map[string]any
 }
 
 func WriteErrorDetails(w http.ResponseWriter, status int, code, message string, details ErrorDetails) {
+	details = enrichErrorDetails(code, details)
 	errorObject := map[string]any{
 		"type":    code,
 		"message": message,
@@ -62,5 +66,147 @@ func WriteErrorDetails(w http.ResponseWriter, status int, code, message string, 
 	if details.TraceID != "" {
 		errorObject["trace_id"] = details.TraceID
 	}
+	for key, value := range details.Fields {
+		if key == "" || !isSafeErrorField(value) || isReservedErrorField(key) {
+			continue
+		}
+		errorObject[key] = value
+	}
 	WriteJSON(w, status, map[string]any{"error": errorObject})
+}
+
+func isReservedErrorField(key string) bool {
+	switch key {
+	case "type", "message", "user_message", "operator_action", "request_id", "trace_id":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNilErrorField(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func isSafeErrorField(value any) bool {
+	if isNilErrorField(value) {
+		return false
+	}
+	_, err := json.Marshal(value)
+	return err == nil
+}
+
+func enrichErrorDetails(code string, details ErrorDetails) ErrorDetails {
+	if details.UserMessage == "" {
+		details.UserMessage = defaultErrorUserMessage(code)
+	}
+	if details.OperatorAction == "" {
+		details.OperatorAction = defaultErrorAction(code)
+	}
+	return details
+}
+
+func defaultErrorUserMessage(code string) string {
+	switch code {
+	case errCodeInvalidRequest:
+		return "The request is invalid."
+	case errCodeForbidden:
+		return "The request was blocked."
+	case errCodeUnauthorized:
+		return "Authentication is required."
+	case errCodeGatewayError:
+		return gatewayErrorUserMessage(code)
+	case errCodeBudgetExceeded, errCodePriceMissing, errCodeProviderAuthFailed, errCodeProviderRateLimited,
+		errCodeProviderUnavailable, errCodeRouteImpossible, errCodeUnsupportedModel, errCodeRateLimitExceeded:
+		return gatewayErrorUserMessage(code)
+	case errCodeNotFound:
+		return "The requested resource was not found."
+	case errCodeConflict:
+		return "The requested change conflicts with the current state."
+	case errCodeSessionLimitExceeded:
+		return "This chat has reached its turn limit."
+	case errCodeSessionDurationLimit:
+		return "This chat has reached its wall-clock limit."
+	case errCodeSessionIdleTimeout:
+		return "This chat session expired after being idle."
+	case errCodeAgentSessionBusy:
+		return "Hecate Chat is still working on this task."
+	case errCodeModelCapability:
+		return "This model is not marked as tool-capable."
+	case errCodeModelNotConfigured:
+		return "The selected model is not available from the selected provider."
+	case errCodeWorkspaceRequired:
+		return "Choose a workspace before starting this chat mode."
+	case errCodeModelRequired:
+		return "Choose a model before sending this message."
+	case errCodeRuntimeKindInvalid:
+		return "This chat mode is not supported by the current API."
+	case errCodeRuntimeMismatch:
+		return "This message belongs to a different chat runtime."
+	case errCodeAgentAdapterNotFound:
+		return "The selected external agent is not configured."
+	case errCodeSessionStopping:
+		return "This chat is still stopping."
+	case errCodeSessionNotRunning:
+		return "There is no active run to stop."
+	default:
+		return ""
+	}
+}
+
+func defaultErrorAction(code string) string {
+	switch code {
+	case errCodeInvalidRequest:
+		return "Check the request body and retry."
+	case errCodeForbidden:
+		return "Review policy, same-origin, or permission settings before retrying."
+	case errCodeUnauthorized:
+		return "Provide valid credentials and retry."
+	case errCodeGatewayError:
+		return gatewayErrorAction(code)
+	case errCodeBudgetExceeded, errCodePriceMissing, errCodeProviderAuthFailed, errCodeProviderRateLimited,
+		errCodeProviderUnavailable, errCodeRouteImpossible, errCodeUnsupportedModel, errCodeRateLimitExceeded:
+		return gatewayErrorAction(code)
+	case errCodeNotFound:
+		return "Refresh the view or verify the resource id before retrying."
+	case errCodeConflict:
+		return "Refresh the resource, resolve the active state, then retry."
+	case errCodeSessionLimitExceeded:
+		return "Start a new chat session to continue."
+	case errCodeSessionDurationLimit:
+		return "Start a new chat session to continue."
+	case errCodeSessionIdleTimeout:
+		return "Start a new chat session to continue."
+	case errCodeAgentSessionBusy:
+		return "Open the backing task, resolve the pending approval, or stop the run before sending another message."
+	case errCodeModelCapability:
+		return "Turn tools off for direct model chat, test the model, or enable tool support in Settings."
+	case errCodeModelNotConfigured:
+		return "Choose a discovered model, refresh provider status, or open Providers to fix model discovery."
+	case errCodeWorkspaceRequired:
+		return "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path."
+	case errCodeModelRequired:
+		return "Use the model picker in the chat header, or add a provider that reports at least one model."
+	case errCodeRuntimeKindInvalid:
+		return "Use one of: model, agent, or external_agent."
+	case errCodeRuntimeMismatch:
+		return "Start a new chat or switch back to the runtime that created this session."
+	case errCodeAgentAdapterNotFound:
+		return "Open Settings and test the external agent adapter, or choose another agent."
+	case errCodeSessionStopping:
+		return "Wait a moment, then retry the action."
+	case errCodeSessionNotRunning:
+		return "Send a new message if you want to start another run."
+	default:
+		return ""
+	}
 }

--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteErrorAddsDefaultOperatorMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "invalid request", code: errCodeInvalidRequest},
+		{name: "not found", code: errCodeNotFound},
+		{name: "conflict", code: errCodeConflict},
+		{name: "gateway error", code: errCodeGatewayError},
+		{name: "rate limit", code: errCodeRateLimitExceeded},
+		{name: "chat busy", code: errCodeAgentSessionBusy},
+		{name: "model not configured", code: errCodeModelNotConfigured},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			WriteError(rec, http.StatusBadRequest, tt.code, "runtime detail")
+
+			var payload struct {
+				Error struct {
+					Type           string `json:"type"`
+					Message        string `json:"message"`
+					UserMessage    string `json:"user_message"`
+					OperatorAction string `json:"operator_action"`
+				} `json:"error"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if payload.Error.Type != tt.code {
+				t.Fatalf("error.type = %q, want %q", payload.Error.Type, tt.code)
+			}
+			if payload.Error.Message != "runtime detail" {
+				t.Fatalf("error.message = %q, want runtime detail", payload.Error.Message)
+			}
+			if payload.Error.UserMessage == "" {
+				t.Fatal("error.user_message = empty")
+			}
+			if payload.Error.OperatorAction == "" {
+				t.Fatal("error.operator_action = empty")
+			}
+		})
+	}
+}
+
+func TestWriteErrorDetailsPreservesExplicitMetadataAndFields(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	WriteErrorDetails(rec, http.StatusConflict, errCodeAgentSessionBusy, "busy detail", ErrorDetails{
+		UserMessage:    "Custom user message.",
+		OperatorAction: "Custom action.",
+		RequestID:      "req_123",
+		TraceID:        "trace_456",
+		Fields: map[string]any{
+			"task_id":       "task_123",
+			"latest_run_id": "run_456",
+			"run_status":    "running",
+		},
+	})
+
+	var payload struct {
+		Error struct {
+			Type           string `json:"type"`
+			Message        string `json:"message"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+			RequestID      string `json:"request_id"`
+			TraceID        string `json:"trace_id"`
+			TaskID         string `json:"task_id"`
+			LatestRunID    string `json:"latest_run_id"`
+			RunStatus      string `json:"run_status"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if payload.Error.UserMessage != "Custom user message." {
+		t.Fatalf("error.user_message = %q", payload.Error.UserMessage)
+	}
+	if payload.Error.OperatorAction != "Custom action." {
+		t.Fatalf("error.operator_action = %q", payload.Error.OperatorAction)
+	}
+	if payload.Error.RequestID != "req_123" || payload.Error.TraceID != "trace_456" {
+		t.Fatalf("correlation = request %q trace %q", payload.Error.RequestID, payload.Error.TraceID)
+	}
+	if payload.Error.TaskID != "task_123" || payload.Error.LatestRunID != "run_456" || payload.Error.RunStatus != "running" {
+		t.Fatalf("runtime fields missing: %+v", payload.Error)
+	}
+}
+
+func TestWriteErrorDetailsSkipsReservedRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	WriteErrorDetails(rec, http.StatusConflict, errCodeAgentSessionBusy, "canonical message", ErrorDetails{
+		UserMessage:    "Canonical user message.",
+		OperatorAction: "Canonical action.",
+		RequestID:      "req_123",
+		TraceID:        "trace_456",
+		Fields: map[string]any{
+			"type":            "mutated_type",
+			"message":         "mutated message",
+			"user_message":    "mutated user message",
+			"operator_action": "mutated action",
+			"request_id":      "mutated_req",
+			"trace_id":        "mutated_trace",
+			"task_id":         "task_123",
+		},
+	})
+
+	var payload struct {
+		Error struct {
+			Type           string `json:"type"`
+			Message        string `json:"message"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+			RequestID      string `json:"request_id"`
+			TraceID        string `json:"trace_id"`
+			TaskID         string `json:"task_id"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if payload.Error.Type != errCodeAgentSessionBusy {
+		t.Fatalf("error.type = %q, want %q", payload.Error.Type, errCodeAgentSessionBusy)
+	}
+	if payload.Error.Message != "canonical message" {
+		t.Fatalf("error.message = %q, want canonical message", payload.Error.Message)
+	}
+	if payload.Error.UserMessage != "Canonical user message." {
+		t.Fatalf("error.user_message = %q", payload.Error.UserMessage)
+	}
+	if payload.Error.OperatorAction != "Canonical action." {
+		t.Fatalf("error.operator_action = %q", payload.Error.OperatorAction)
+	}
+	if payload.Error.RequestID != "req_123" || payload.Error.TraceID != "trace_456" {
+		t.Fatalf("correlation fields were overwritten: %+v", payload.Error)
+	}
+	if payload.Error.TaskID != "task_123" {
+		t.Fatalf("non-reserved runtime field was not preserved: %+v", payload.Error)
+	}
+}
+
+func TestWriteErrorDetailsSkipsNilLikeRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	type diagnostic struct {
+		Message string `json:"message"`
+	}
+	var typedPointer *diagnostic
+	var typedMap map[string]string
+	var typedSlice []string
+	var typedInterface any
+
+	rec := httptest.NewRecorder()
+	WriteErrorDetails(rec, http.StatusBadRequest, errCodeInvalidRequest, "invalid", ErrorDetails{
+		Fields: map[string]any{
+			"plain_nil":     nil,
+			"typed_pointer": typedPointer,
+			"typed_map":     typedMap,
+			"typed_slice":   typedSlice,
+			"typed_iface":   typedInterface,
+			"provider":      "ollama",
+		},
+	})
+
+	var payload struct {
+		Error map[string]any `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"plain_nil", "typed_pointer", "typed_map", "typed_slice", "typed_iface"} {
+		if _, ok := payload.Error[key]; ok {
+			t.Fatalf("error.%s should be omitted for nil-like runtime field: %#v", key, payload.Error)
+		}
+	}
+	if payload.Error["provider"] != "ollama" {
+		t.Fatalf("error.provider = %#v, want ollama", payload.Error["provider"])
+	}
+}
+
+func TestWriteErrorDetailsSkipsNonMarshalableRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	WriteErrorDetails(rec, http.StatusBadRequest, errCodeInvalidRequest, "invalid", ErrorDetails{
+		Fields: map[string]any{
+			"callback":      func() {},
+			"events":        make(chan string),
+			"complex_value": complex64(1 + 2i),
+			"nested_bad": map[string]any{
+				"callback": func() {},
+			},
+			"provider": "ollama",
+		},
+	})
+
+	var payload struct {
+		Error map[string]any `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"callback", "events", "complex_value", "nested_bad"} {
+		if _, ok := payload.Error[key]; ok {
+			t.Fatalf("error.%s should be omitted for non-marshalable runtime field: %#v", key, payload.Error)
+		}
+	}
+	if payload.Error["provider"] != "ollama" {
+		t.Fatalf("error.provider = %#v, want ollama", payload.Error["provider"])
+	}
+}
+
+func TestWriteErrorUsesGatewayCanonicalMetadata(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []string{errCodeGatewayError, errCodeRateLimitExceeded} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			WriteError(rec, http.StatusInternalServerError, code, "gateway exploded")
+
+			var payload struct {
+				Error struct {
+					UserMessage    string `json:"user_message"`
+					OperatorAction string `json:"operator_action"`
+				} `json:"error"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if payload.Error.UserMessage != gatewayErrorUserMessage(code) {
+				t.Fatalf("error.user_message = %q, want %q", payload.Error.UserMessage, gatewayErrorUserMessage(code))
+			}
+			if payload.Error.OperatorAction != gatewayErrorAction(code) {
+				t.Fatalf("error.operator_action = %q, want %q", payload.Error.OperatorAction, gatewayErrorAction(code))
+			}
+		})
+	}
+}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hecate/agent-runtime/internal/profiler"
@@ -25,6 +26,8 @@ import (
 // the run is created. Callers should surface this as a client error
 // (HTTP 422) rather than a gateway error (500).
 var ErrAgentLoopMisconfigured = errors.New("agent_loop misconfigured")
+
+var resourceIDCounter atomic.Uint64
 
 var stepTelemetryAttrKeys = []string{
 	telemetry.AttrHecateSandboxWrapperKind,
@@ -2075,7 +2078,9 @@ func defaultResourceID(prefix string) string {
 	if prefix == "" {
 		prefix = "id"
 	}
-	return prefix + "_" + strconv.FormatInt(time.Now().UTC().UnixNano(), 36)
+	now := strconv.FormatInt(time.Now().UTC().UnixNano(), 36)
+	seq := strconv.FormatUint(resourceIDCounter.Add(1), 36)
+	return prefix + "_" + now + "_" + seq
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/orchestrator/runner_helpers_test.go
+++ b/internal/orchestrator/runner_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,6 +48,39 @@ func TestMaxIntFallsBackOnNonPositive(t *testing.T) {
 		if got := maxInt(tc.value, tc.fallback); got != tc.want {
 			t.Errorf("maxInt(%d, %d) = %d, want %d", tc.value, tc.fallback, got, tc.want)
 		}
+	}
+}
+
+func TestDefaultResourceIDIsUniqueUnderConcurrency(t *testing.T) {
+	const workers = 32
+	const perWorker = 512
+
+	ids := make(chan string, workers*perWorker)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWorker; j++ {
+				ids <- defaultResourceID("artifact")
+			}
+		}()
+	}
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[string]struct{}, workers*perWorker)
+	for id := range ids {
+		if !strings.HasPrefix(id, "artifact_") {
+			t.Fatalf("id = %q, want artifact_ prefix", id)
+		}
+		if _, ok := seen[id]; ok {
+			t.Fatalf("duplicate id generated: %s", id)
+		}
+		seen[id] = struct{}{}
+	}
+	if got, want := len(seen), workers*perWorker; got != want {
+		t.Fatalf("ids = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make WriteErrorDetails the shared enrichment point for Hecate-native error responses
- add default user_message and operator_action values for common runtime error codes
- preserve runtime repair fields through ErrorDetails.Fields for busy chat, tool-capability, and session guardrail failures
- promote rate_limit_exceeded into the shared error-code constants and document common Hecate-native error types

## Verification

- git diff HEAD --check
- go test ./internal/api -run 'TestWriteError|TestAgentChat|TestChatCompletions|TestMessages'
- go test ./internal/api -run 'TestWriteError|TestAgentChat|TestChatCompletions|TestMessages|TestClassifyGatewayError'
- go test ./internal/api