### PR TITLE
feat(providers): add readiness repair actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Full standards: [`docs-ai/core/engineering-standards.md`](docs-ai/core/engineeri
 Full ladder: [`docs-ai/core/verification.md`](docs-ai/core/verification.md).
 
 - **Race suite is the floor for runtime/backend changes**: `go test -race -timeout 10m ./...` (or `/race`). Race builds are large; if your default `$GOCACHE` is on a small volume, point it at the repo: `GOCACHE="$(pwd)/.gocache" go test -race ...`.
+- **Vet Go changes**: run `go vet` on touched packages during iteration; use `go vet ./...` for broad backend changes or release prep.
 - **Iteration**: `/test-affected` for narrow runs.
 - **E2E**: `go test -tags e2e ./e2e/...`. Build tag `e2e` always required; sub-tags `ollama`, `docker` opt in. `PROVIDER_FAKE_KIND=local` skips pricebook preflight on synthetic models.
 - **UI**: `cd ui && bun run typecheck` then `bun run test`. Never `bun test` (skips testing-library DOM setup).

--- a/docs-ai/core/verification.md
+++ b/docs-ai/core/verification.md
@@ -7,9 +7,15 @@ How "done" is determined. Treat the floors as floors, not nice-to-haves.
 | Step | Command | When |
 |---|---|---|
 | Build | `go build ./...` | Always, before claiming done |
+| Vet | `go vet ./...` or targeted packages | Go backend/runtime changes; use targeted vet during iteration |
 | Focused tests | `/test-affected` (or `go test -race -count=1 ./<package>/...`) | During iteration |
 | Race suite | `go test -race -timeout 10m ./...` (or `/race`) | **Floor** for runtime/backend changes |
 | E2E | `go test -tags e2e ./e2e/...` | When the change crosses the api → orchestrator → providers/sandbox/mcp chain |
+
+Run `go vet` for Go changes before claiming done. Targeted vet is fine while
+iterating, for example `go vet ./internal/api ./internal/gateway`; use
+`go vet ./...` for broad refactors, release prep, or changes that cross many
+packages.
 
 The race suite is the floor — not a nice-to-have — for any change that touches `internal/gateway`, `internal/router`, `internal/providers`, `internal/orchestrator`, `internal/sandbox`, retention/state wiring, or other request execution paths.
 
@@ -38,6 +44,7 @@ Full matrix in [`../skills/tester/SKILL.md`](../skills/tester/SKILL.md).
 ## Done criteria — backend
 
 - Build passes (`go build ./...`).
+- Vet passes for touched Go packages, or `go vet ./...` for broad changes.
 - Race suite passes for runtime/backend work.
 - Inbound and outbound wire shapes are tested independently.
 - New env knobs documented in `.env.example` AND the relevant `docs/<feature>.md`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -191,16 +191,23 @@ returns:
 - `credential_ready` — whether credentials are configured or not required
 - `routing_ready` — whether the router can currently send traffic to it
 - `routing_blocked_reason` — stable reason when routing is blocked, such as `credential_missing`, `provider_disabled`, `provider_rate_limited`, `circuit_open`, `provider_unhealthy`, or `no_models`
-- `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, and an operator-facing `message`. Non-routing checks can use scoped reasons such as `default_model_only`, `discovery_failed`, `self_referential`, or `provider_slow`.
+- `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, an operator-facing `message`, and an optional `operator_action` repair step. Non-routing checks can use scoped reasons such as `default_model_only`, `discovery_failed`, `self_referential`, or `provider_slow`.
 - `model_count`, `discovery_source`, `last_checked_at`, and `last_error` for model-discovery freshness and failure context
 - `last_error_class`, `open_until`, `last_latency_ms`, `consecutive_failures`, `timeouts`, `server_errors`, `rate_limits`, `total_successes`, and `total_failures` for richer health debugging
 
-The UI keeps the checklist message verbatim and adds a short **Next** hint from
-the stable `reason` value. That means `credential_missing` points directly at
-credential setup, `no_models` points at starting/pulling a local model,
-`self_referential` points at fixing a base URL that loops back to Hecate, and
-`provider_rate_limited` points at waiting or routing elsewhere. The raw
-diagnostic fields remain available in the provider details disclosure.
+The UI keeps the checklist message verbatim and shows `operator_action` as the
+short **Next** hint when the backend provides one. That means
+`credential_missing` points directly at credential setup, `no_models` points at
+starting/pulling a local model, `self_referential` points at fixing a base URL
+that loops back to Hecate, and `provider_rate_limited` points at waiting or
+routing elsewhere. The raw diagnostic fields remain available in the provider
+details disclosure.
+
+For stale selected models, Hecate Chat returns
+`422 model_not_configured` with the same readiness vocabulary: the selected
+provider/model, a stable reason such as `provider_missing`,
+`provider_not_ready`, or `model_not_discovered`, suggested replacement models,
+and an `operator_action` that can be shown directly in the UI.
 
 Route reports in the trace inspector reuse the same readiness vocabulary when
 they explain why a provider/model candidate was skipped.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -488,10 +488,12 @@ clients from guessing readiness by combining unrelated raw fields. Check names
 are currently `credentials`, `models`, `health`, and `routing`; statuses are
 `ok`, `warning`, `blocked`, or `unknown`. `reason` is stable enough for UI
 branching, while `message` is safe to show directly to the operator.
-Clients can layer concise next-step copy on top of `reason` without parsing
-`message`; for example `credential_missing` means "add or rotate credentials",
-`no_models` means "start the provider and load at least one model", and
-`provider_rate_limited` means "wait for cooldown or route elsewhere".
+When a check needs operator action, `operator_action` carries the canonical
+repair step; clients should prefer it over deriving their own copy from
+`reason`. For example `credential_missing` includes "add or rotate
+credentials", `no_models` includes "start the provider and load at least one
+model", and `provider_rate_limited` includes "wait for cooldown or route
+elsewhere".
 
 `routing_ready=false` means the router currently skips the provider. The
 matching `routing_blocked_reason` and the `reason` on the
@@ -1063,15 +1065,11 @@ prompt cannot drain into a different transcript after the operator switches
 sessions. That queue is intentionally not durable until each prompt is
 submitted.
 
-Clients should also treat model/provider readiness as a preflight concern.
-Before sending Hecate Chat turns, compare the selected model against
-`GET /v1/models` and the provider readiness snapshot from
-`GET /hecate/v1/providers/status`. If the selected model is stale or no longer
-reported by the selected provider route, block the composer and show the
-selected model, provider route, discovered-model count, health, blocked-by,
-last-error, and remediation steps. The server still returns
-`422 model_not_configured` as the authoritative contract when a stale selection
-slips through.
+Clients can block obvious stale selections by combining `/v1/models` with
+`/hecate/v1/providers/status`, but the server remains authoritative. If a stale
+provider/model selection slips through, Hecate Chat returns
+`422 model_not_configured` with provider readiness fields, suggested replacement
+models, and an `operator_action` repair hint in the error details.
 
 The response returns after the backing turn finishes, times out, is cancelled,
 or fails. For live output while the turn is running, subscribe to the session

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -85,10 +85,11 @@ func renderProviderReadinessChecks(checks []types.ProviderReadinessCheck) []Prov
 	out := make([]ProviderReadinessCheckResponseItem, 0, len(checks))
 	for _, check := range checks {
 		out = append(out, ProviderReadinessCheckResponseItem{
-			Name:    check.Name,
-			Status:  check.Status,
-			Reason:  check.Reason,
-			Message: check.Message,
+			Name:           check.Name,
+			Status:         check.Status,
+			Reason:         check.Reason,
+			Message:        check.Message,
+			OperatorAction: check.OperatorAction,
 		})
 	}
 	return out

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/hecate/agent-runtime/internal/agentchat"
+	"github.com/hecate/agent-runtime/internal/gateway"
 )
 
 func writeAgentChatWorkspaceRequired(w http.ResponseWriter, runtimeKind string) {
@@ -32,13 +34,53 @@ func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
 		return
 	}
 	if strings.Contains(message, "not available") || strings.Contains(message, "not configured") {
-		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, message, ErrorDetails{
+		details := ErrorDetails{
 			UserMessage:    "The selected model is not available from the selected provider.",
 			OperatorAction: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",
+		}
+		var readinessErr modelReadinessError
+		if asModelReadinessError(err, &readinessErr) {
+			details = modelReadinessErrorDetails(readinessErr.readiness)
+		}
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, message, ErrorDetails{
+			UserMessage:    details.UserMessage,
+			OperatorAction: details.OperatorAction,
+			Fields:         details.Fields,
 		})
 		return
 	}
 	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, message)
+}
+
+func asModelReadinessError(err error, target *modelReadinessError) bool {
+	if err == nil {
+		return false
+	}
+	return errors.As(err, target)
+}
+
+func modelReadinessErrorDetails(readiness gateway.ProviderModelReadiness) ErrorDetails {
+	details := ErrorDetails{
+		UserMessage:    "The selected model is not ready for this chat.",
+		OperatorAction: readiness.OperatorAction,
+		Fields: map[string]any{
+			"provider":                readiness.Provider,
+			"matched_provider":        readiness.MatchedProvider,
+			"model":                   readiness.Model,
+			"reason":                  readiness.Reason,
+			"routing_ready":           readiness.RoutingReady,
+			"provider_status":         readiness.ProviderStatus,
+			"provider_blocked_reason": readiness.ProviderBlockedReason,
+			"suggested_models":        readiness.SuggestedModels,
+		},
+	}
+	if readiness.Message != "" {
+		details.UserMessage = readiness.Message
+	}
+	if details.OperatorAction == "" {
+		details.OperatorAction = "Choose a discovered model, refresh provider status, or open Providers to fix model discovery."
+	}
+	return details
 }
 
 func writeAgentChatRuntimeKindInvalid(w http.ResponseWriter) {

--- a/internal/api/model_capabilities.go
+++ b/internal/api/model_capabilities.go
@@ -5,9 +5,26 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hecate/agent-runtime/internal/gateway"
 	"github.com/hecate/agent-runtime/internal/modelcaps"
 	"github.com/hecate/agent-runtime/pkg/types"
 )
+
+type modelReadinessError struct {
+	err       error
+	readiness gateway.ProviderModelReadiness
+}
+
+func (e modelReadinessError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e modelReadinessError) Unwrap() error {
+	return e.err
+}
 
 func (h *Handler) resolveModelCapabilities(ctx context.Context, provider, model string) (types.ModelCapabilities, error) {
 	model = strings.TrimSpace(model)
@@ -35,7 +52,20 @@ func (h *Handler) resolveModelCapabilities(ctx context.Context, provider, model 
 		return modelcaps.Resolve(item.Provider, item.Kind, item.ID, item.DiscoverySource, state), nil
 	}
 	if provider == "" {
-		return types.ModelCapabilities{}, fmt.Errorf("model %q is not available from any configured provider", model)
+		err := fmt.Errorf("model %q is not available from any configured provider", model)
+		return types.ModelCapabilities{}, h.withModelReadiness(ctx, provider, model, err)
 	}
-	return types.ModelCapabilities{}, fmt.Errorf("model %q is not available from provider %q", model, provider)
+	err = fmt.Errorf("model %q is not available from provider %q", model, provider)
+	return types.ModelCapabilities{}, h.withModelReadiness(ctx, provider, model, err)
+}
+
+func (h *Handler) withModelReadiness(ctx context.Context, provider, model string, err error) error {
+	if err == nil || h.service == nil {
+		return err
+	}
+	result, readinessErr := h.service.ProviderModelReadiness(ctx, provider, model)
+	if readinessErr != nil {
+		return err
+	}
+	return modelReadinessError{err: err, readiness: result.Readiness}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -522,10 +522,11 @@ type ProviderStatusResponseItem struct {
 }
 
 type ProviderReadinessCheckResponseItem struct {
-	Name    string `json:"name"`
-	Status  string `json:"status"`
-	Reason  string `json:"reason,omitempty"`
-	Message string `json:"message,omitempty"`
+	Name           string `json:"name"`
+	Status         string `json:"status"`
+	Reason         string `json:"reason,omitempty"`
+	Message        string `json:"message,omitempty"`
+	OperatorAction string `json:"operator_action,omitempty"`
 }
 
 type ProviderHealthHistoryResponseItem struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -606,6 +606,9 @@ func assertProviderReadinessCheck(t *testing.T, item ProviderStatusResponseItem,
 		if check.Message == "" {
 			t.Fatalf("%s readiness check %q message is empty", item.Name, name)
 		}
+		if check.Status != "ok" && check.OperatorAction == "" {
+			t.Fatalf("%s readiness check %q operator_action is empty for status %q", item.Name, name, check.Status)
+		}
 		return
 	}
 	t.Fatalf("%s missing readiness check %q in %#v", item.Name, name, item.ReadinessChecks)
@@ -1727,6 +1730,58 @@ func TestAgentChatModelResolutionRequiredErrorUsesValidationContract(t *testing.
 	}
 	if payload.Error.UserMessage == "" || payload.Error.OperatorAction == "" {
 		t.Fatalf("error missing operator metadata: %+v", payload.Error)
+	}
+}
+
+func TestAgentChatModelResolutionErrorIncludesReadinessFields(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeAgentChatModelResolutionError(rec, fmt.Errorf("resolve model: %w", modelReadinessError{
+		err: errors.New("model \"gpt-5.4-mini\" is not available from provider \"ollama\""),
+		readiness: gateway.ProviderModelReadiness{
+			Provider:              "ollama",
+			MatchedProvider:       "ollama",
+			Model:                 "gpt-5.4-mini",
+			Reason:                "model_not_discovered",
+			Message:               "Provider \"ollama\" does not report model \"gpt-5.4-mini\".",
+			OperatorAction:        "Pull or load the model locally.",
+			RoutingReady:          true,
+			ProviderStatus:        "healthy",
+			ProviderBlockedReason: "",
+			SuggestedModels:       []string{"llama3.1:8b"},
+		},
+	}))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Type            string   `json:"type"`
+			UserMessage     string   `json:"user_message"`
+			OperatorAction  string   `json:"operator_action"`
+			Reason          string   `json:"reason"`
+			SuggestedModels []string `json:"suggested_models"`
+		} `json:"error"`
+	}
+	payload = decodeRecorder[struct {
+		Error struct {
+			Type            string   `json:"type"`
+			UserMessage     string   `json:"user_message"`
+			OperatorAction  string   `json:"operator_action"`
+			Reason          string   `json:"reason"`
+			SuggestedModels []string `json:"suggested_models"`
+		} `json:"error"`
+	}](t, rec)
+	if payload.Error.Type != errCodeModelNotConfigured {
+		t.Fatalf("error.type = %q, want %q", payload.Error.Type, errCodeModelNotConfigured)
+	}
+	if payload.Error.OperatorAction != "Pull or load the model locally." {
+		t.Fatalf("operator_action = %q", payload.Error.OperatorAction)
+	}
+	if payload.Error.Reason != "model_not_discovered" {
+		t.Fatalf("error.reason = %q, want model_not_discovered", payload.Error.Reason)
+	}
+	if len(payload.Error.SuggestedModels) != 1 || payload.Error.SuggestedModels[0] != "llama3.1:8b" {
+		t.Fatalf("error.suggested_models = %#v, want llama3.1:8b", payload.Error.SuggestedModels)
 	}
 }
 

--- a/internal/gateway/provider_model_readiness.go
+++ b/internal/gateway/provider_model_readiness.go
@@ -1,0 +1,201 @@
+package gateway
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hecate/agent-runtime/internal/catalog"
+	"github.com/hecate/agent-runtime/internal/providers"
+)
+
+type ProviderModelReadiness struct {
+	Provider              string
+	MatchedProvider       string
+	Model                 string
+	Ready                 bool
+	Reason                string
+	Message               string
+	OperatorAction        string
+	RoutingReady          bool
+	ProviderStatus        string
+	ProviderBlockedReason string
+	SuggestedModels       []string
+}
+
+func providerModelReadiness(entries []catalog.Entry, provider, model string) ProviderModelReadiness {
+	entries = sortedCatalogEntries(entries)
+	out := ProviderModelReadiness{
+		Provider: provider,
+		Model:    model,
+	}
+	if model == "" {
+		if provider == "" {
+			out.Provider = "auto"
+		}
+		out.Reason = "model_required"
+		out.Message = "No model is selected."
+		out.OperatorAction = "Choose a discovered model before sending a chat message."
+		out.SuggestedModels = suggestedModels(entries, provider)
+		return out
+	}
+	if provider != "" {
+		for _, entry := range entries {
+			if strings.EqualFold(entry.Name, provider) {
+				return providerModelReadinessForEntry(entry, entry.Name, model)
+			}
+		}
+		out.Reason = "provider_missing"
+		out.Message = fmt.Sprintf("Provider %q is not configured.", provider)
+		out.OperatorAction = "Choose Auto routing, select a configured provider, or add this provider in Settings."
+		out.SuggestedModels = suggestedModels(entries, "")
+		return out
+	}
+
+	var blocked []catalog.Entry
+	for _, entry := range entries {
+		if !providerModelAvailable(entry, model) {
+			continue
+		}
+		if reason := providerRoutingBlockedReason(entry); reason != "" {
+			blocked = append(blocked, entry)
+			continue
+		}
+		out.Provider = "auto"
+		out.MatchedProvider = entry.Name
+		out.Ready = true
+		out.Reason = "auto_route_available"
+		out.Message = fmt.Sprintf("Auto routing can use provider %q for model %q.", entry.Name, model)
+		out.RoutingReady = true
+		out.ProviderStatus = entry.Status
+		return out
+	}
+	if len(blocked) > 0 {
+		entry := blocked[0]
+		reason := providerRoutingBlockedReason(entry)
+		out.Provider = "auto"
+		out.MatchedProvider = entry.Name
+		out.Reason = "provider_not_ready"
+		out.Message = fmt.Sprintf("Provider %q has model %q but is not routable.", entry.Name, model)
+		out.OperatorAction = providerModelReadinessOperatorAction(entry, reason, model)
+		out.ProviderStatus = entry.Status
+		out.ProviderBlockedReason = reason
+		out.SuggestedModels = suggestedModels(entries, "")
+		return out
+	}
+	out.Provider = "auto"
+	out.Reason = "model_not_discovered"
+	out.Message = fmt.Sprintf("No routable provider reports model %q.", model)
+	out.OperatorAction = "Pick one of the discovered models, refresh provider discovery, or load this model in a local provider."
+	out.SuggestedModels = suggestedModels(entries, "")
+	return out
+}
+
+func providerModelReadinessForEntry(entry catalog.Entry, provider, model string) ProviderModelReadiness {
+	out := ProviderModelReadiness{
+		Provider:        provider,
+		MatchedProvider: entry.Name,
+		Model:           model,
+		ProviderStatus:  entry.Status,
+	}
+	if reason := providerRoutingBlockedReason(entry); reason != "" {
+		out.Reason = "provider_not_ready"
+		out.Message = fmt.Sprintf("Provider %q is not routable for model %q.", entry.Name, model)
+		out.OperatorAction = providerModelReadinessOperatorAction(entry, reason, model)
+		out.ProviderBlockedReason = reason
+		out.SuggestedModels = suggestedModels([]catalog.Entry{entry}, "")
+		return out
+	}
+	out.RoutingReady = true
+	if providerModelAvailable(entry, model) {
+		out.Ready = true
+		out.Reason = "model_available"
+		out.Message = fmt.Sprintf("Provider %q reports model %q.", entry.Name, model)
+		return out
+	}
+	out.Reason = "model_not_discovered"
+	out.Message = fmt.Sprintf("Provider %q does not report model %q.", entry.Name, model)
+	out.OperatorAction = providerModelReadinessOperatorAction(entry, out.Reason, model)
+	out.SuggestedModels = suggestedModels([]catalog.Entry{entry}, "")
+	return out
+}
+
+func providerModelAvailable(entry catalog.Entry, model string) bool {
+	for _, candidate := range entry.Models {
+		if strings.EqualFold(candidate, model) {
+			return true
+		}
+	}
+	return false
+}
+
+func suggestedModels(entries []catalog.Entry, provider string) []string {
+	out := make([]string, 0, 8)
+	for _, entry := range entries {
+		if provider != "" && !strings.EqualFold(entry.Name, provider) {
+			continue
+		}
+		out = appendUniqueStrings(out, entry.Models...)
+		if len(out) >= 5 {
+			break
+		}
+	}
+	if len(out) > 5 {
+		out = out[:5]
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedCatalogEntries(entries []catalog.Entry) []catalog.Entry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := append([]catalog.Entry(nil), entries...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out
+}
+
+func appendUniqueStrings(out []string, values ...string) []string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		exists := false
+		for _, existing := range out {
+			if strings.EqualFold(existing, value) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func providerModelReadinessOperatorAction(entry catalog.Entry, reason, model string) string {
+	switch reason {
+	case "provider_disabled":
+		return "Enable this provider or choose Auto routing."
+	case "credential_missing":
+		return "Add or rotate this provider's API key, then retry this model."
+	case "provider_rate_limited":
+		return "Wait for cooldown, switch provider, or choose Auto routing."
+	case "circuit_open", "provider_unhealthy":
+		return "Inspect provider health, fix the upstream issue, then refresh provider status."
+	case "no_models":
+		return "Start the provider and pull or load at least one model."
+	case "model_not_discovered":
+		if entry.Kind == providers.KindLocal {
+			return fmt.Sprintf("Pull or load %q locally, refresh provider status, or pick a discovered model.", model)
+		}
+		return "Pick a discovered model or confirm this account can access the requested model."
+	default:
+		return providerReadinessOperatorAction("routing", reason)
+	}
+}

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -87,6 +87,10 @@ type ProviderStatusResult struct {
 	Providers []types.ProviderStatus
 }
 
+type ProviderModelReadinessResult struct {
+	Readiness ProviderModelReadiness
+}
+
 type ProviderHealthHistoryResult struct {
 	Entries []types.ProviderHealthHistoryEntry
 }
@@ -788,6 +792,16 @@ func (s *Service) ProviderStatus(ctx context.Context) (*ProviderStatusResult, er
 	return &ProviderStatusResult{Providers: statuses}, nil
 }
 
+func (s *Service) ProviderModelReadiness(ctx context.Context, provider, model string) (*ProviderModelReadinessResult, error) {
+	model = strings.TrimSpace(model)
+	provider = strings.TrimSpace(provider)
+	if strings.EqualFold(provider, "auto") {
+		provider = ""
+	}
+	readiness := providerModelReadiness(s.catalog.Snapshot(ctx), provider, model)
+	return &ProviderModelReadinessResult{Readiness: readiness}, nil
+}
+
 func (s *Service) ProviderHealthHistory(ctx context.Context, provider string, limit int) (*ProviderHealthHistoryResult, error) {
 	if s.providerHistory == nil {
 		return &ProviderHealthHistoryResult{}, nil
@@ -1039,10 +1053,50 @@ func providerRoutingBlockedMessage(reason string) string {
 
 func providerReadinessCheck(name, status, reason, message string) types.ProviderReadinessCheck {
 	return types.ProviderReadinessCheck{
-		Name:    name,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Name:           name,
+		Status:         status,
+		Reason:         reason,
+		Message:        message,
+		OperatorAction: providerReadinessOperatorAction(name, reason),
+	}
+}
+
+func providerReadinessOperatorAction(name, reason string) string {
+	switch reason {
+	case "configured", "not_required", "healthy", "routable", "models_discovered":
+		return ""
+	case "credential_missing":
+		return "Add or rotate this provider's API key, then refresh provider status."
+	case "provider_disabled":
+		if name == "models" {
+			return "Enable the provider before model discovery can run."
+		}
+		return "Enable the provider when you want Hecate to route to it."
+	case "self_referential":
+		return "Change the base URL so it points at the provider, not Hecate."
+	case "discovery_failed":
+		return "Check the endpoint and refresh provider status after the server is reachable."
+	case "default_model_only":
+		return "Send a test request or refresh discovery to confirm the default model is real."
+	case "no_models":
+		return "Start the provider and pull or load at least one model."
+	case "provider_slow":
+		return "Keep this provider enabled if the latency is acceptable, or route to a faster provider."
+	case "provider_rate_limited":
+		return "Wait for cooldown or temporarily route to another provider."
+	case "provider_unhealthy":
+		return "Inspect the latest health error and provider server logs, then refresh provider status."
+	case "circuit_open":
+		return "Wait for recovery or test the provider after fixing the upstream issue."
+	case "recovery_probe":
+		return "Retry once the half-open probe succeeds."
+	case "health_pending", "unknown":
+		return "Refresh provider status after configuration or startup settles."
+	default:
+		if name == "routing" {
+			return "Open Providers to inspect readiness checks and repair the blocked dependency."
+		}
+		return ""
 	}
 }
 

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -142,6 +142,7 @@ func TestProviderModelDiscoveryCheckDistinguishesSkippedDiscovery(t *testing.T) 
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,6 +194,7 @@ func TestProviderHealthCheckTreatsRoutableDegradedProvidersAsWarnings(t *testing
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -311,6 +313,7 @@ func TestProviderModelReadiness(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -198,6 +199,183 @@ func TestProviderHealthCheckTreatsRoutableDegradedProvidersAsWarnings(t *testing
 			got := providerHealthCheck(tt.entry)
 			assertReadinessCheck(t, got, "health", tt.wantStatus, tt.wantReason)
 		})
+	}
+}
+
+func TestProviderModelReadiness(t *testing.T) {
+	t.Parallel()
+
+	entries := []catalog.Entry{
+		{
+			Name:            "ollama",
+			Kind:            providers.KindLocal,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "not_required",
+			Models:          []string{"llama3.1:8b", "mistral:latest"},
+		},
+		{
+			Name:            "anthropic",
+			Kind:            providers.KindCloud,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "missing",
+			Models:          []string{"claude-sonnet-4-5"},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		provider            string
+		model               string
+		wantReady           bool
+		wantProvider        string
+		wantReason          string
+		wantMatchedProvider string
+		wantBlockedReason   string
+		wantSuggestions     bool
+		rejectSuggestion    string
+	}{
+		{
+			name:                "explicit provider reports model",
+			provider:            "ollama",
+			model:               "llama3.1:8b",
+			wantReady:           true,
+			wantProvider:        "ollama",
+			wantReason:          "model_available",
+			wantMatchedProvider: "ollama",
+		},
+		{
+			name:                "explicit provider match returns canonical id",
+			provider:            "Ollama",
+			model:               "llama3.1:8b",
+			wantReady:           true,
+			wantProvider:        "ollama",
+			wantReason:          "model_available",
+			wantMatchedProvider: "ollama",
+		},
+		{
+			name:                "explicit provider missing selected model",
+			provider:            "ollama",
+			model:               "gpt-5.4-mini",
+			wantProvider:        "ollama",
+			wantReason:          "model_not_discovered",
+			wantMatchedProvider: "ollama",
+		},
+		{
+			name:                "explicit provider blocked before model use",
+			provider:            "anthropic",
+			model:               "claude-sonnet-4-5",
+			wantProvider:        "anthropic",
+			wantReason:          "provider_not_ready",
+			wantMatchedProvider: "anthropic",
+			wantBlockedReason:   "credential_missing",
+			wantSuggestions:     true,
+		},
+		{
+			name:         "missing provider",
+			provider:     "missing",
+			model:        "llama3.1:8b",
+			wantProvider: "missing",
+			wantReason:   "provider_missing",
+		},
+		{
+			name:                "auto finds routable provider",
+			model:               "mistral:latest",
+			wantReady:           true,
+			wantProvider:        "auto",
+			wantReason:          "auto_route_available",
+			wantMatchedProvider: "ollama",
+		},
+		{
+			name:            "auto cannot find selected model",
+			model:           "gpt-5.4-mini",
+			wantProvider:    "auto",
+			wantReason:      "model_not_discovered",
+			wantSuggestions: true,
+		},
+		{
+			name:             "explicit provider model required",
+			provider:         "ollama",
+			wantProvider:     "ollama",
+			wantReason:       "model_required",
+			wantSuggestions:  true,
+			rejectSuggestion: "claude-sonnet-4-5",
+		},
+		{
+			name:            "auto model required",
+			wantProvider:    "auto",
+			wantReason:      "model_required",
+			wantSuggestions: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerModelReadiness(entries, tt.provider, tt.model)
+			if got.Ready != tt.wantReady {
+				t.Fatalf("ready = %v, want %v", got.Ready, tt.wantReady)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tt.wantReason)
+			}
+			if got.Provider != tt.wantProvider {
+				t.Fatalf("provider = %q, want %q", got.Provider, tt.wantProvider)
+			}
+			if got.MatchedProvider != tt.wantMatchedProvider {
+				t.Fatalf("matched_provider = %q, want %q", got.MatchedProvider, tt.wantMatchedProvider)
+			}
+			if got.ProviderBlockedReason != tt.wantBlockedReason {
+				t.Fatalf("provider_blocked_reason = %q, want %q", got.ProviderBlockedReason, tt.wantBlockedReason)
+			}
+			if !got.Ready && got.OperatorAction == "" {
+				t.Fatalf("operator_action is empty for blocked readiness: %#v", got)
+			}
+			if got.Ready && len(got.SuggestedModels) > 0 {
+				t.Fatalf("suggested_models = %#v for ready response, want none", got.SuggestedModels)
+			}
+			if tt.wantSuggestions && len(got.SuggestedModels) == 0 {
+				t.Fatalf("suggested_models is empty, want repair suggestions")
+			}
+			for _, suggestion := range got.SuggestedModels {
+				if strings.EqualFold(suggestion, tt.rejectSuggestion) {
+					t.Fatalf("suggested_models = %#v includes rejected suggestion %q", got.SuggestedModels, tt.rejectSuggestion)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderModelReadinessAutoSelectionIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	entries := []catalog.Entry{
+		{
+			Name:            "zeta",
+			Kind:            providers.KindLocal,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "not_required",
+			Models:          []string{"shared-model"},
+		},
+		{
+			Name:            "alpha",
+			Kind:            providers.KindLocal,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "not_required",
+			Models:          []string{"shared-model"},
+		},
+	}
+
+	got := providerModelReadiness(entries, "", "shared-model")
+	if !got.Ready {
+		t.Fatalf("ready = false, want true: %#v", got)
+	}
+	if got.MatchedProvider != "alpha" {
+		t.Fatalf("matched_provider = %q, want alpha", got.MatchedProvider)
 	}
 }
 

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -255,10 +255,11 @@ type ProviderStatus struct {
 }
 
 type ProviderReadinessCheck struct {
-	Name    string
-	Status  string
-	Reason  string
-	Message string
+	Name           string
+	Status         string
+	Reason         string
+	Message        string
+	OperatorAction string
 }
 
 type ProviderHealthHistoryEntry struct {

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -670,7 +670,13 @@ describe("ProvidersView table renders", () => {
           readiness_checks: [
             { name: "credentials", status: "ok", reason: "not_required", message: "No credentials are required for this provider." },
             { name: "models", status: "ok", reason: "models_discovered", message: "1 model discovered." },
-            { name: "health", status: "blocked", reason: "provider_rate_limited", message: "Provider is cooling down after an upstream rate limit." },
+            {
+              name: "health",
+              status: "blocked",
+              reason: "provider_rate_limited",
+              message: "Provider is cooling down after an upstream rate limit.",
+              operator_action: "Use the backend-provided repair action.",
+            },
             { name: "routing", status: "blocked", reason: "provider_rate_limited", message: "Routing is blocked while the provider cools down after a rate limit." },
           ],
           discovery_source: "live",
@@ -699,6 +705,7 @@ describe("ProvidersView table renders", () => {
     expect(screen.getAllByText("Health").length).toBeGreaterThan(0);
     expect(screen.getByText("Routing")).toBeTruthy();
     expect(screen.getByText("Routing is blocked while the provider cools down after a rate limit.")).toBeTruthy();
+    expect(screen.getByText("Next: Use the backend-provided repair action.")).toBeTruthy();
     expect(screen.getAllByText(/Next: wait for cooldown or temporarily route to another provider/).length).toBeGreaterThan(0);
     expect(screen.getByText("Diagnostics")).toBeTruthy();
     expect(screen.getByText("connect: connection refused")).toBeTruthy();

--- a/ui/src/features/shared/ProviderReadiness.tsx
+++ b/ui/src/features/shared/ProviderReadiness.tsx
@@ -132,6 +132,8 @@ export function CompactProviderReadinessChecks({ checks }: { checks: ProviderRea
 }
 
 export function readinessRecommendation(check: ProviderReadinessCheckRecord): string {
+  if (check.operator_action) return check.operator_action;
+
   switch (check.reason) {
     case "credential_missing":
       return "add or rotate this provider's API key.";

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -180,6 +180,7 @@ export type ProviderReadinessCheckRecord = {
   status: ProviderReadinessStatus;
   reason?: string;
   message?: string;
+  operator_action?: string;
 };
 
 export type ProviderStatusResponse = {


### PR DESCRIPTION
## Summary

This PR keeps the provider-readiness work focused on the reliability contract we need now:

- Adds backend-authored `operator_action` hints to provider readiness checks returned by `/hecate/v1/providers/status`.
- Adds an internal provider/model readiness evaluator used only to enrich Hecate Chat `422 model_not_configured` errors when a stale selected model reaches the server.
- Updates the Providers UI checklist to prefer the backend-provided repair hint when present.
- Updates provider/runtime docs and agent verification guidance.

## Scope intentionally removed

This no longer adds a public `model-readiness` endpoint, chat-side readiness preflight, provider modal readiness panel, or observability UI expansion. The server remains authoritative: clients may use `/v1/models` and `/hecate/v1/providers/status` for obvious stale selections, but failed sends are still repaired through the enriched `model_not_configured` error contract.

## Verification

- `go vet ./internal/gateway ./internal/api`
- `go test ./internal/gateway ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- ProvidersView`