### PR TITLE
fix(tasks): close stale approval gaps on cancellation

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -192,7 +192,7 @@ Two distinct approval flows:
 
 ### Pre-execution approval
 
-Triggered when the task's `execution_kind` is `shell` / `git` / `file` (or `sandbox_network=true`) AND a matching policy is in `GATEWAY_TASK_APPROVAL_POLICIES`. The run is created in `awaiting_approval` status before it ever leaves the queue. The UI shows an amber banner with the command being approved. Approve → run becomes `queued` → executes.
+Triggered when the task's `execution_kind` is `shell` / `git` / `file` (or `sandbox_network=true`) AND a matching policy is in `GATEWAY_TASK_APPROVAL_POLICIES`. The run is created in `awaiting_approval` status before it ever leaves the queue. The UI shows an amber banner with the command being approved. Approve → run becomes `queued` → executes. Cancel before approval → run becomes `cancelled` and the pending approval is marked `cancelled` so stale approval buttons cannot resurrect the run.
 
 ### Mid-loop approval (`agent_loop_tool_call`)
 
@@ -205,7 +205,7 @@ When the LLM calls a gated tool inside an `agent_loop` run, the loop pauses. Pol
 - `network_egress` → pauses on `http_request` tool calls
 - `all_tools` → pauses on every tool call (`shell_exec`, `git_exec`, `file_write`, `file_edit`, `read_file`, `list_dir`, `http_request`)
 
-The runtime emits an approval record of kind `agent_loop_tool_call`, persists the conversation snapshot, and returns `status=awaiting_approval` for the run. The UI banner shows which tools the agent wants to use. On approve, the same run is re-queued; on resume, the loop detects the trailing assistant tool_calls without resolved results, dispatches them (no second LLM call), and continues. On reject, the run terminates `failed`.
+The runtime emits an approval record of kind `agent_loop_tool_call`, persists the conversation snapshot, and returns `status=awaiting_approval` for the run. The UI banner shows which tools the agent wants to use. On approve, the same run is re-queued; on resume, the loop detects the trailing assistant tool_calls without resolved results, dispatches them (no second LLM call), and continues. On reject, the run terminates `failed`. On cancel, the run terminates `cancelled`, any awaiting approval step is marked `cancelled`, and the pending approval is resolved as `cancelled`.
 
 The approval banner stays in sync with the run state because approvals ride along in every SSE snapshot (`TaskRunStreamEventData.Approvals`). No separate refetch needed.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -209,13 +209,15 @@ Both shapes share these fields.
 
 ### `approval.resolved`
 
-The operator resolved the gate. After approve, the run re-queues; after reject, the run terminates `failed`.
+The gate reached a terminal decision. After approve, the run re-queues; after
+reject, the run terminates `failed`; after cancellation, the run terminates
+`cancelled` and the approval record is no longer actionable.
 
 | Extra key | Type | Notes |
 |---|---|---|
 | `approval_id` | `string` | Resolved approval id |
-| `decision` | `string` | `approved` or `rejected` |
-| `by` | `string` | Principal that resolved the approval |
+| `decision` | `string` | `approved`, `rejected`, or `cancelled` |
+| `by` | `string` | Principal or subsystem that resolved the approval |
 | `comment` | `string` | Operator-supplied resolution note |
 | `scope` | `string` | Currently `once`; persistent always-allow is separate policy work |
 | `kind` | `string` | Approval type |

--- a/docs/events.md
+++ b/docs/events.md
@@ -42,7 +42,7 @@ These are **persisted events** (rows in the `task_state_run_events` table). They
 | `assistant.tool_call_proposed` | Agent loop | Assistant proposed a tool call before runtime dispatch |
 | `assistant.final_answer` | Agent loop | Assistant ended the loop without more tool calls |
 | `approval.requested` | Approvals | An approval gate was created (pre-execution or mid-loop) |
-| `approval.resolved` | Approvals | Operator resolved an approval gate |
+| `approval.resolved` | Approvals | Operator or system resolved an approval gate |
 | `turn.completed` | Agent loop | One LLM round-trip in an `agent_loop` run finished |
 | `tool.invoked` | Typed shell tool events | Shell executor accepted a tool call or direct shell task |
 | `tool.started` | Typed shell tool events | Shell execution is about to start |
@@ -218,7 +218,7 @@ reject, the run terminates `failed`; after cancellation, the run terminates
 | `approval_id` | `string` | Resolved approval id |
 | `decision` | `string` | `approved`, `rejected`, or `cancelled` |
 | `by` | `string` | Principal or subsystem that resolved the approval |
-| `comment` | `string` | Operator-supplied resolution note |
+| `comment` | `string` | Operator- or system-supplied resolution note |
 | `scope` | `string` | Currently `once`; persistent always-allow is separate policy work |
 | `kind` | `string` | Approval type |
 | `status` | `string` | Mirrors `decision` for compatibility with approval records |

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -221,7 +221,7 @@ The `kind` field on a `task_approval` is one of:
 - `network_egress` — pre-execution gate when `sandbox_network=true`
 - `agent_loop_tool_call` — mid-loop gate when an `agent_loop` run calls a gated tool (`shell_exec`, `http_request`, etc.). The reason text lists the tools the agent wants to use. See [`agent-runtime.md`](agent-runtime.md#approval-gating) for the full flow.
 
-Resolve payload: `{"decision": "approve" | "reject", "note": "..."}`. Approving an `agent_loop_tool_call` requeues the same run; the loop dispatches the approved tool calls without re-calling the LLM.
+Resolve payload: `{"decision": "approve" | "reject", "note": "..."}`. Approving an `agent_loop_tool_call` requeues the same run; the loop dispatches the approved tool calls without re-calling the LLM. Cancelling an `awaiting_approval` run marks the pending approval `cancelled`; resolving it afterward returns a conflict instead of mutating stale state.
 
 ### Approval policy configuration
 

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -417,10 +417,13 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 		close(activeDone)
 		s.clearActiveTurn(activeDone)
 	}()
-	_, runErr := s.conn.Prompt(promptCtx, acp.PromptRequest{
+	resp, runErr := s.conn.Prompt(promptCtx, acp.PromptRequest{
 		SessionId: acp.SessionId(s.nativeID),
 		Prompt:    []acp.ContentBlock{acp.TextBlock(req.Prompt)},
 	})
+	if runErr == nil && resp.StopReason == acp.StopReasonCancelled {
+		runErr = context.Canceled
+	}
 	completed := time.Now().UTC()
 	exitCode := 0
 	if runErr != nil {

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -21,15 +21,12 @@ func DetectVersion(ctx context.Context, path string) string {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, path, "--version")
-	out, err := cmd.CombinedOutput()
+	out, _ := cmd.CombinedOutput()
 	// Some CLI adapters print version text before exiting non-zero, so prefer
 	// any captured semver token before treating the command as unusable.
 	version := semverRe.FindString(strings.TrimSpace(string(out)))
 	if version != "" {
 		return version
-	}
-	if err != nil {
-		return ""
 	}
 	return ""
 }

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -22,10 +22,16 @@ func DetectVersion(ctx context.Context, path string) string {
 
 	cmd := exec.CommandContext(ctx, path, "--version")
 	out, err := cmd.CombinedOutput()
+	// Some CLI adapters print version text before exiting non-zero, so prefer
+	// any captured semver token before treating the command as unusable.
+	version := semverRe.FindString(strings.TrimSpace(string(out)))
+	if version != "" {
+		return version
+	}
 	if err != nil {
 		return ""
 	}
-	return semverRe.FindString(strings.TrimSpace(string(out)))
+	return ""
 }
 
 // satisfiesRange reports whether version v satisfies a simple constraint of

--- a/internal/agentadapters/version_test.go
+++ b/internal/agentadapters/version_test.go
@@ -77,6 +77,23 @@ func TestDetectVersionParsesStderr(t *testing.T) {
 	}
 }
 
+func TestDetectVersionParsesOutputFromNonZeroExit(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("skip shell script test on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonzero-adapter")
+	content := "#!/bin/sh\necho adapter 3.4.5\nexit 1\n"
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write nonzero script: %v", err)
+	}
+	got := DetectVersion(context.Background(), path)
+	if got != "3.4.5" {
+		t.Fatalf("DetectVersion = %q, want 3.4.5 from non-zero output", got)
+	}
+}
+
 func TestDetectVersionMissingBinaryReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	got := DetectVersion(context.Background(), "/does/not/exist/fake-adapter")

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -474,9 +474,13 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 	approval.ResolutionNote = strings.TrimSpace(req.Note)
 	approval.ResolvedBy = "operator"
 	approval.ResolvedAt = now
-	approval, err = h.taskStore.UpdateApproval(ctx, approval)
+	approval, updated, err := h.taskStore.UpdatePendingApproval(ctx, approval)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !updated {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending")
 		return
 	}
 	_, _ = h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -445,6 +445,19 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending")
 		return
 	}
+	run, found, err := h.taskStore.GetRun(ctx, task.ID, approval.RunID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !found {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
+		return
+	}
+	if run.Status != "awaiting_approval" {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, fmt.Sprintf("task approval is no longer actionable because run is %s", run.Status))
+		return
+	}
 
 	var req ResolveTaskApprovalRequest
 	if !decodeJSON(w, r, &req) {

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -474,13 +474,13 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 	approval.ResolutionNote = strings.TrimSpace(req.Note)
 	approval.ResolvedBy = "operator"
 	approval.ResolvedAt = now
-	approval, updated, err := h.taskStore.UpdatePendingApproval(ctx, approval)
+	approval, updated, err := h.taskStore.UpdatePendingApprovalForAwaitingRun(ctx, approval)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !updated {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending")
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending or run is no longer awaiting approval")
 		return
 	}
 	_, _ = h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3709,6 +3709,112 @@ func TestTaskRunCancellation(t *testing.T) {
 	}
 }
 
+func TestTaskRunCancellationCancelsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := config.Config{Server: config.ServerConfig{TaskApprovalPolicies: []string{"shell_exec"}}}
+	handler := newTestHTTPHandlerForProviders(logger, nil, cfg)
+	tasks := newTaskTestClient(t, handler)
+
+	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Cancel approval","prompt":"Cancel before approval.","execution_kind":"shell","shell_command":"printf 'should-not-run\n'","working_directory":".","timeout_ms":1000}`)
+	started := mustTaskRequestJSON[TaskRunResponse](tasks, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/start", "")
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("run status = %q, want awaiting_approval", started.Data.Status)
+	}
+	approvals := mustTaskRequestJSON[TaskApprovalsResponse](tasks, http.MethodGet, "/hecate/v1/tasks/"+created.Data.ID+"/approvals", "")
+	if len(approvals.Data) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(approvals.Data))
+	}
+
+	cancelled := mustTaskRequestJSON[TaskRunResponse](tasks, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/cancel", `{"reason":"operator stop"}`)
+	if cancelled.Data.Status != "cancelled" {
+		t.Fatalf("cancelled run status = %q, want cancelled", cancelled.Data.Status)
+	}
+
+	afterCancel := mustTaskRequestJSON[TaskApprovalsResponse](tasks, http.MethodGet, "/hecate/v1/tasks/"+created.Data.ID+"/approvals", "")
+	if len(afterCancel.Data) != 1 {
+		t.Fatalf("approvals after cancel = %d, want 1", len(afterCancel.Data))
+	}
+	if afterCancel.Data[0].Status != "cancelled" {
+		t.Fatalf("approval status after cancel = %q, want cancelled", afterCancel.Data[0].Status)
+	}
+	if afterCancel.Data[0].ResolvedBy != "system" {
+		t.Fatalf("approval resolved_by = %q, want system", afterCancel.Data[0].ResolvedBy)
+	}
+	if !strings.Contains(afterCancel.Data[0].ResolutionNote, "operator stop") {
+		t.Fatalf("approval resolution_note = %q, want operator stop", afterCancel.Data[0].ResolutionNote)
+	}
+
+	staleResolve := tasks.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/approvals/"+approvals.Data[0].ID+"/resolve", `{"decision":"approve"}`)
+	if !strings.Contains(staleResolve.Body.String(), "not pending") {
+		t.Fatalf("stale resolve body = %s, want mention of not pending", staleResolve.Body.String())
+	}
+
+	events := mustTaskRequestJSON[TaskRunEventsResponse](tasks, http.MethodGet, "/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events", "")
+	assertApprovalResolvedEventBy(t, events.Data, approvals.Data[0].ID, "cancelled", "run cancelled: operator stop", "system")
+	task := mustTaskRequestJSON[TaskResponse](tasks, http.MethodGet, "/hecate/v1/tasks/"+created.Data.ID, "")
+	if task.Data.PendingApprovalCount != 0 {
+		t.Fatalf("pending approval count = %d, want 0", task.Data.PendingApprovalCount)
+	}
+}
+
+func TestTaskApprovalResolveReturnsConflictWhenRunNoLongerAwaiting(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	handler := NewServer(logger, apiHandler)
+	tasks := newTaskTestClient(t, handler)
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:        "task_stale_approval",
+		Title:     "Stale approval",
+		Prompt:    "Approval should not resolve after run exits.",
+		Status:    "cancelled",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	run := types.TaskRun{
+		ID:         "run_stale_approval",
+		TaskID:     task.ID,
+		Number:     1,
+		Status:     "cancelled",
+		StartedAt:  now,
+		FinishedAt: now,
+	}
+	approval := types.TaskApproval{
+		ID:        "approval_stale",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Kind:      "shell_exec",
+		Status:    "pending",
+		Reason:    "legacy pending row",
+		CreatedAt: now,
+	}
+	if _, err := apiHandler.taskStore.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := apiHandler.taskStore.CreateRun(context.Background(), run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := apiHandler.taskStore.CreateApproval(context.Background(), approval); err != nil {
+		t.Fatalf("CreateApproval: %v", err)
+	}
+
+	rec := tasks.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/tasks/"+task.ID+"/approvals/"+approval.ID+"/resolve", `{"decision":"approve"}`)
+	if !strings.Contains(rec.Body.String(), "no longer actionable") {
+		t.Fatalf("conflict body = %s, want no longer actionable", rec.Body.String())
+	}
+	got, found, err := apiHandler.taskStore.GetApproval(context.Background(), task.ID, approval.ID)
+	if err != nil || !found {
+		t.Fatalf("GetApproval: found=%t err=%v", found, err)
+	}
+	if got.Status != "pending" {
+		t.Fatalf("stale approval status = %q, want pending (handler must not mutate)", got.Status)
+	}
+}
+
 func TestTaskRunStreamSSE(t *testing.T) {
 	t.Parallel()
 
@@ -4876,6 +4982,11 @@ func countTaskRunEvents(events []eventprotocol.Envelope, eventType string) int {
 
 func assertApprovalResolvedEvent(t *testing.T, events []eventprotocol.Envelope, approvalID, decision, comment string) {
 	t.Helper()
+	assertApprovalResolvedEventBy(t, events, approvalID, decision, comment, "operator")
+}
+
+func assertApprovalResolvedEventBy(t *testing.T, events []eventprotocol.Envelope, approvalID, decision, comment, by string) {
+	t.Helper()
 	for _, event := range events {
 		if event.Type == "approval.approved" || event.Type == "approval.rejected" {
 			t.Fatalf("legacy approval event %q emitted", event.Type)
@@ -4895,8 +5006,8 @@ func assertApprovalResolvedEvent(t *testing.T, events []eventprotocol.Envelope, 
 		if event.Data["scope"] != "once" {
 			t.Fatalf("approval.resolved scope = %v, want once", event.Data["scope"])
 		}
-		if event.Data["by"] != "operator" {
-			t.Fatalf("approval.resolved by = %v, want operator", event.Data["by"])
+		if event.Data["by"] != by {
+			t.Fatalf("approval.resolved by = %v, want %s", event.Data["by"], by)
 		}
 		return
 	}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -1004,6 +1004,8 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	if requestID != "" && r.tracer != nil {
 		if existing, found := r.tracer.Get(requestID); found {
 			trace = existing
+			traceID = trace.TraceID
+			ctx = telemetry.WithTraceIDs(ctx, trace.TraceID, trace.RootSpanID())
 		} else {
 			trace = r.tracer.Start(requestID)
 			defer trace.Finalize()

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -1007,10 +1007,8 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 		} else {
 			trace = r.tracer.Start(requestID)
 			defer trace.Finalize()
-			if traceID == "" {
-				traceID = trace.TraceID
-				ctx = telemetry.WithTraceIDs(ctx, trace.TraceID, trace.RootSpanID())
-			}
+			traceID = trace.TraceID
+			ctx = telemetry.WithTraceIDs(ctx, trace.TraceID, trace.RootSpanID())
 		}
 	}
 

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -1063,10 +1063,11 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 		return types.TaskRun{}, err
 	}
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
+	r.cancelPendingApprovalsForRun(ctx, task, run, message, requestID, traceID, now)
 
 	steps, _ := r.store.ListSteps(ctx, run.ID)
 	for _, step := range steps {
-		if step.Status == "running" {
+		if step.Status == "running" || step.Status == "awaiting_approval" {
 			step.Status = "cancelled"
 			step.Result = telemetry.ResultError
 			step.Error = message
@@ -1103,6 +1104,35 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	}
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "task.updated", requestID, traceID, nil)
 	return run, nil
+}
+
+func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Task, run types.TaskRun, message, requestID, traceID string, now time.Time) {
+	approvals, err := r.store.ListApprovals(ctx, task.ID)
+	if err != nil {
+		return
+	}
+	for _, approval := range approvals {
+		if approval.RunID != run.ID || approval.Status != "pending" {
+			continue
+		}
+		approval.Status = "cancelled"
+		approval.ResolutionNote = message
+		approval.ResolvedBy = "system"
+		approval.ResolvedAt = now
+		updated, err := r.store.UpdateApproval(ctx, approval)
+		if err != nil {
+			continue
+		}
+		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, traceID, map[string]any{
+			"approval_id": updated.ID,
+			"decision":    updated.Status,
+			"by":          updated.ResolvedBy,
+			"comment":     updated.ResolutionNote,
+			"scope":       "once",
+			"kind":        updated.Kind,
+			"status":      updated.Status,
+		})
+	}
 }
 
 func (r *Runner) processQueue() {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -886,26 +886,7 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		}
 		approvalWaitMS = resolvedAt.Sub(approval.CreatedAt).Milliseconds()
 	}
-	approvalAttrs := map[string]any{
-		telemetry.AttrHecatePhase:          "approval",
-		telemetry.AttrHecateResult:         telemetry.ResultSuccess,
-		telemetry.AttrHecateTaskID:         task.ID,
-		telemetry.AttrHecateRunID:          run.ID,
-		telemetry.AttrHecateApprovalID:     approval.ID,
-		telemetry.AttrHecateApprovalKind:   approval.Kind,
-		telemetry.AttrHecateApprovalStatus: approval.Status,
-	}
-	if approvalWaitMS > 0 {
-		approvalAttrs[telemetry.AttrHecateApprovalWaitMS] = approvalWaitMS
-	}
-	trace.Record(telemetry.EventOrchestratorApprovalResolved, approvalAttrs)
-	r.metrics.RecordApproval(ctx, telemetry.ApprovalMetricsRecord{
-		TaskID:       task.ID,
-		RunID:        run.ID,
-		ApprovalKind: approval.Kind,
-		Decision:     "approved",
-		WaitMS:       approvalWaitMS,
-	})
+	r.recordApprovalResolved(ctx, trace, task.ID, run.ID, approval, "approved", approvalWaitMS)
 
 	run.Status = "queued"
 	run.RequestID = requestID
@@ -979,26 +960,7 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 		}
 		rejectWaitMS = resolvedAt.Sub(approval.CreatedAt).Milliseconds()
 	}
-	rejectApprovalAttrs := map[string]any{
-		telemetry.AttrHecatePhase:          "approval",
-		telemetry.AttrHecateResult:         telemetry.ResultSuccess,
-		telemetry.AttrHecateTaskID:         task.ID,
-		telemetry.AttrHecateRunID:          run.ID,
-		telemetry.AttrHecateApprovalID:     approval.ID,
-		telemetry.AttrHecateApprovalKind:   approval.Kind,
-		telemetry.AttrHecateApprovalStatus: approval.Status,
-	}
-	if rejectWaitMS > 0 {
-		rejectApprovalAttrs[telemetry.AttrHecateApprovalWaitMS] = rejectWaitMS
-	}
-	trace.Record(telemetry.EventOrchestratorApprovalResolved, rejectApprovalAttrs)
-	r.metrics.RecordApproval(ctx, telemetry.ApprovalMetricsRecord{
-		TaskID:       task.ID,
-		RunID:        run.ID,
-		ApprovalKind: approval.Kind,
-		Decision:     "rejected",
-		WaitMS:       rejectWaitMS,
-	})
+	r.recordApprovalResolved(ctx, trace, task.ID, run.ID, approval, "rejected", rejectWaitMS)
 
 	run, err = r.cancelRunWithMessage(ctx, task, run, "approval rejected", requestID, trace.TraceID)
 	if err != nil {
@@ -1038,6 +1000,20 @@ func (r *Runner) CancelRun(ctx context.Context, task types.Task, runID string, r
 }
 
 func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run types.TaskRun, message, requestID, traceID string) (types.TaskRun, error) {
+	var trace *profiler.Trace
+	if requestID != "" && r.tracer != nil {
+		if existing, found := r.tracer.Get(requestID); found {
+			trace = existing
+		} else {
+			trace = r.tracer.Start(requestID)
+			defer trace.Finalize()
+			if traceID == "" {
+				traceID = trace.TraceID
+				ctx = telemetry.WithTraceIDs(ctx, trace.TraceID, trace.RootSpanID())
+			}
+		}
+	}
+
 	r.jobMu.Lock()
 	cancel, ok := r.jobs[run.ID]
 	r.jobMu.Unlock()
@@ -1063,7 +1039,7 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 		return types.TaskRun{}, err
 	}
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
-	r.cancelPendingApprovalsForRun(ctx, task, run, message, requestID, traceID, now)
+	r.cancelPendingApprovalsForRun(ctx, trace, task, run, message, requestID, traceID, now)
 
 	steps, _ := r.store.ListSteps(ctx, run.ID)
 	for _, step := range steps {
@@ -1106,7 +1082,7 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	return run, nil
 }
 
-func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Task, run types.TaskRun, message, requestID, traceID string, now time.Time) {
+func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, message, requestID, traceID string, now time.Time) {
 	approvals, err := r.store.ListApprovals(ctx, task.ID)
 	if err != nil {
 		return
@@ -1119,10 +1095,18 @@ func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Ta
 		approval.ResolutionNote = message
 		approval.ResolvedBy = "system"
 		approval.ResolvedAt = now
-		updated, err := r.store.UpdateApproval(ctx, approval)
+		updated, ok, err := r.store.UpdatePendingApproval(ctx, approval)
 		if err != nil {
 			continue
 		}
+		if !ok {
+			continue
+		}
+		waitMS := int64(0)
+		if !updated.CreatedAt.IsZero() {
+			waitMS = updated.ResolvedAt.Sub(updated.CreatedAt).Milliseconds()
+		}
+		r.recordApprovalResolved(ctx, trace, task.ID, run.ID, updated, "cancelled", waitMS)
 		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, traceID, map[string]any{
 			"approval_id": updated.ID,
 			"decision":    updated.Status,
@@ -1133,6 +1117,31 @@ func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Ta
 			"status":      updated.Status,
 		})
 	}
+}
+
+func (r *Runner) recordApprovalResolved(ctx context.Context, trace *profiler.Trace, taskID, runID string, approval types.TaskApproval, decision string, waitMS int64) {
+	attrs := map[string]any{
+		telemetry.AttrHecatePhase:          "approval",
+		telemetry.AttrHecateResult:         telemetry.ResultSuccess,
+		telemetry.AttrHecateTaskID:         taskID,
+		telemetry.AttrHecateRunID:          runID,
+		telemetry.AttrHecateApprovalID:     approval.ID,
+		telemetry.AttrHecateApprovalKind:   approval.Kind,
+		telemetry.AttrHecateApprovalStatus: approval.Status,
+	}
+	if waitMS > 0 {
+		attrs[telemetry.AttrHecateApprovalWaitMS] = waitMS
+	}
+	if trace != nil {
+		trace.Record(telemetry.EventOrchestratorApprovalResolved, attrs)
+	}
+	r.metrics.RecordApproval(ctx, telemetry.ApprovalMetricsRecord{
+		TaskID:       taskID,
+		RunID:        runID,
+		ApprovalKind: approval.Kind,
+		Decision:     decision,
+		WaitMS:       waitMS,
+	})
 }
 
 func (r *Runner) processQueue() {

--- a/internal/orchestrator/runner_cancel_test.go
+++ b/internal/orchestrator/runner_cancel_test.go
@@ -1,0 +1,82 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/hecate/agent-runtime/internal/profiler"
+	"github.com/hecate/agent-runtime/internal/taskstate"
+	"github.com/hecate/agent-runtime/pkg/types"
+)
+
+func TestCancelRunWithMessageAlignsStartedTraceID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	tracer := profiler.NewInMemoryTracer(nil)
+	runner := &Runner{
+		logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store:    store,
+		tracer:   tracer,
+		policies: make(map[string]struct{}),
+		jobs:     make(map[string]context.CancelFunc),
+	}
+
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:        "task-trace",
+		Status:    "running",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	run := types.TaskRun{
+		ID:        "run-trace",
+		TaskID:    task.ID,
+		Status:    "running",
+		StartedAt: now,
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	cancelled, err := runner.cancelRunWithMessage(ctx, task, run, "run cancelled", "request-trace", "incoming-trace-id")
+	if err != nil {
+		t.Fatalf("cancelRunWithMessage: %v", err)
+	}
+	trace, found := tracer.Get("request-trace")
+	if !found {
+		t.Fatalf("expected profiler trace for request")
+	}
+	if cancelled.TraceID != trace.TraceID {
+		t.Fatalf("cancelled run trace id = %q, want started profiler trace id %q", cancelled.TraceID, trace.TraceID)
+	}
+	if cancelled.TraceID == "incoming-trace-id" {
+		t.Fatalf("cancelled run kept stale incoming trace id")
+	}
+
+	updatedTask, found, err := store.GetTask(ctx, task.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask: found=%v err=%v", found, err)
+	}
+	if updatedTask.LatestTraceID != trace.TraceID {
+		t.Fatalf("task latest trace id = %q, want %q", updatedTask.LatestTraceID, trace.TraceID)
+	}
+
+	events, err := store.ListRunEvents(ctx, task.ID, run.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("expected run events")
+	}
+	if events[0].TraceID != trace.TraceID {
+		t.Fatalf("first run event trace id = %q, want %q", events[0].TraceID, trace.TraceID)
+	}
+}

--- a/internal/orchestrator/runner_cancel_test.go
+++ b/internal/orchestrator/runner_cancel_test.go
@@ -80,3 +80,70 @@ func TestCancelRunWithMessageAlignsStartedTraceID(t *testing.T) {
 		t.Fatalf("first run event trace id = %q, want %q", events[0].TraceID, trace.TraceID)
 	}
 }
+
+func TestCancelRunWithMessageAlignsExistingTraceID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	tracer := profiler.NewInMemoryTracer(nil)
+	existing := tracer.Start("request-trace-existing")
+	defer existing.Finalize()
+	runner := &Runner{
+		logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store:    store,
+		tracer:   tracer,
+		policies: make(map[string]struct{}),
+		jobs:     make(map[string]context.CancelFunc),
+	}
+
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:        "task-existing-trace",
+		Status:    "running",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	run := types.TaskRun{
+		ID:        "run-existing-trace",
+		TaskID:    task.ID,
+		Status:    "running",
+		StartedAt: now,
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	cancelled, err := runner.cancelRunWithMessage(ctx, task, run, "run cancelled", existing.RequestID, "stale-trace-id")
+	if err != nil {
+		t.Fatalf("cancelRunWithMessage: %v", err)
+	}
+	if cancelled.TraceID != existing.TraceID {
+		t.Fatalf("cancelled run trace id = %q, want existing profiler trace id %q", cancelled.TraceID, existing.TraceID)
+	}
+	if cancelled.TraceID == "stale-trace-id" {
+		t.Fatalf("cancelled run kept stale incoming trace id")
+	}
+
+	updatedTask, found, err := store.GetTask(ctx, task.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask: found=%v err=%v", found, err)
+	}
+	if updatedTask.LatestTraceID != existing.TraceID {
+		t.Fatalf("task latest trace id = %q, want %q", updatedTask.LatestTraceID, existing.TraceID)
+	}
+
+	events, err := store.ListRunEvents(ctx, task.ID, run.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("expected run events")
+	}
+	if events[0].TraceID != existing.TraceID {
+		t.Fatalf("first run event trace id = %q, want %q", events[0].TraceID, existing.TraceID)
+	}
+}

--- a/internal/taskstate/approval_test.go
+++ b/internal/taskstate/approval_test.go
@@ -1,0 +1,85 @@
+package taskstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hecate/agent-runtime/pkg/types"
+)
+
+func TestTaskStore_UpdatePendingApprovalOnlyTransitionsPending(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		store func(t *testing.T) Store
+	}{
+		{
+			name: "memory",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return NewMemoryStore()
+			},
+		},
+		{
+			name: "sqlite",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return newSQLiteTestStore(t)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tt.store(t)
+			createdAt := time.Now().UTC()
+
+			if _, err := store.CreateTask(ctx, types.Task{ID: "task-ap", Status: "awaiting_approval"}); err != nil {
+				t.Fatalf("CreateTask: %v", err)
+			}
+			pending := types.TaskApproval{
+				ID:          "approval-1",
+				TaskID:      "task-ap",
+				RunID:       "run-ap",
+				Kind:        "shell_command",
+				Status:      "pending",
+				RequestedBy: "agent",
+				CreatedAt:   createdAt,
+			}
+			if _, err := store.CreateApproval(ctx, pending); err != nil {
+				t.Fatalf("CreateApproval: %v", err)
+			}
+
+			pending.Status = "approved"
+			pending.ResolvedBy = "operator"
+			pending.ResolvedAt = createdAt.Add(time.Second)
+			updated, ok, err := store.UpdatePendingApproval(ctx, pending)
+			if err != nil || !ok {
+				t.Fatalf("UpdatePendingApproval pending: ok=%v err=%v", ok, err)
+			}
+			if updated.Status != "approved" {
+				t.Fatalf("updated status = %q, want approved", updated.Status)
+			}
+
+			stale := updated
+			stale.Status = "cancelled"
+			stale.ResolvedBy = "system"
+			stale.ResolutionNote = "run cancelled"
+			if _, ok, err := store.UpdatePendingApproval(ctx, stale); err != nil || ok {
+				t.Fatalf("UpdatePendingApproval resolved: ok=%v err=%v, want ok=false err=nil", ok, err)
+			}
+			got, found, err := store.GetApproval(ctx, "task-ap", "approval-1")
+			if err != nil || !found {
+				t.Fatalf("GetApproval: found=%v err=%v", found, err)
+			}
+			if got.Status != "approved" || got.ResolvedBy != "operator" {
+				t.Fatalf("resolved approval was clobbered: %+v", got)
+			}
+		})
+	}
+}

--- a/internal/taskstate/approval_test.go
+++ b/internal/taskstate/approval_test.go
@@ -2,6 +2,7 @@ package taskstate
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,6 +80,64 @@ func TestTaskStore_UpdatePendingApprovalOnlyTransitionsPending(t *testing.T) {
 			}
 			if got.Status != "approved" || got.ResolvedBy != "operator" {
 				t.Fatalf("resolved approval was clobbered: %+v", got)
+			}
+		})
+	}
+}
+
+func TestTaskStore_UpdatePendingApprovalValidatesIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		store func(t *testing.T) Store
+	}{
+		{
+			name: "memory",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return NewMemoryStore()
+			},
+		},
+		{
+			name: "sqlite",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return newSQLiteTestStore(t)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tt.store(t)
+
+			cases := []struct {
+				name     string
+				approval types.TaskApproval
+				wantErr  string
+			}{
+				{
+					name:     "empty id",
+					approval: types.TaskApproval{TaskID: "task-ap", Status: "approved"},
+					wantErr:  "approval id is required",
+				},
+				{
+					name:     "empty task id",
+					approval: types.TaskApproval{ID: "approval-1", Status: "approved"},
+					wantErr:  "approval task id is required",
+				},
+			}
+
+			for _, tc := range cases {
+				if _, ok, err := store.UpdatePendingApproval(ctx, tc.approval); err == nil || ok {
+					t.Fatalf("%s: UpdatePendingApproval ok=%v err=%v, want validation error", tc.name, ok, err)
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("%s: error = %q, want %q", tc.name, err.Error(), tc.wantErr)
+				}
 			}
 		})
 	}

--- a/internal/taskstate/approval_test.go
+++ b/internal/taskstate/approval_test.go
@@ -85,6 +85,85 @@ func TestTaskStore_UpdatePendingApprovalOnlyTransitionsPending(t *testing.T) {
 	}
 }
 
+func TestTaskStore_UpdatePendingApprovalForAwaitingRunRequiresAwaitingRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		store func(t *testing.T) Store
+	}{
+		{
+			name: "memory",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return NewMemoryStore()
+			},
+		},
+		{
+			name: "sqlite",
+			store: func(t *testing.T) Store {
+				t.Helper()
+				return newSQLiteTestStore(t)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tt.store(t)
+			createdAt := time.Now().UTC()
+
+			if _, err := store.CreateTask(ctx, types.Task{ID: "task-ap-run", Status: "awaiting_approval"}); err != nil {
+				t.Fatalf("CreateTask: %v", err)
+			}
+			if _, err := store.CreateRun(ctx, types.TaskRun{ID: "run-ap-run", TaskID: "task-ap-run", Status: "cancelled"}); err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			pending := types.TaskApproval{
+				ID:          "approval-run",
+				TaskID:      "task-ap-run",
+				RunID:       "run-ap-run",
+				Kind:        "shell_command",
+				Status:      "pending",
+				RequestedBy: "agent",
+				CreatedAt:   createdAt,
+			}
+			if _, err := store.CreateApproval(ctx, pending); err != nil {
+				t.Fatalf("CreateApproval: %v", err)
+			}
+
+			pending.Status = "approved"
+			pending.ResolvedBy = "operator"
+			pending.ResolvedAt = createdAt.Add(time.Second)
+			if _, ok, err := store.UpdatePendingApprovalForAwaitingRun(ctx, pending); err != nil || ok {
+				t.Fatalf("UpdatePendingApprovalForAwaitingRun cancelled run: ok=%v err=%v, want ok=false err=nil", ok, err)
+			}
+			got, found, err := store.GetApproval(ctx, "task-ap-run", "approval-run")
+			if err != nil || !found {
+				t.Fatalf("GetApproval: found=%v err=%v", found, err)
+			}
+			if got.Status != "pending" {
+				t.Fatalf("approval status after cancelled-run update = %q, want pending", got.Status)
+			}
+
+			run := types.TaskRun{ID: "run-ap-run", TaskID: "task-ap-run", Status: "awaiting_approval"}
+			if _, err := store.UpdateRun(ctx, run); err != nil {
+				t.Fatalf("UpdateRun: %v", err)
+			}
+			updated, ok, err := store.UpdatePendingApprovalForAwaitingRun(ctx, pending)
+			if err != nil || !ok {
+				t.Fatalf("UpdatePendingApprovalForAwaitingRun awaiting run: ok=%v err=%v", ok, err)
+			}
+			if updated.Status != "approved" {
+				t.Fatalf("updated status = %q, want approved", updated.Status)
+			}
+		})
+	}
+}
+
 func TestTaskStore_UpdatePendingApprovalValidatesIdentifiers(t *testing.T) {
 	t.Parallel()
 
@@ -130,13 +209,25 @@ func TestTaskStore_UpdatePendingApprovalValidatesIdentifiers(t *testing.T) {
 					approval: types.TaskApproval{ID: "approval-1", Status: "approved"},
 					wantErr:  "approval task id is required",
 				},
+				{
+					name:     "empty run id",
+					approval: types.TaskApproval{ID: "approval-1", TaskID: "task-ap", Status: "approved"},
+					wantErr:  "approval run id is required",
+				},
 			}
 
 			for _, tc := range cases {
-				if _, ok, err := store.UpdatePendingApproval(ctx, tc.approval); err == nil || ok {
-					t.Fatalf("%s: UpdatePendingApproval ok=%v err=%v, want validation error", tc.name, ok, err)
+				if tc.name != "empty run id" {
+					if _, ok, err := store.UpdatePendingApproval(ctx, tc.approval); err == nil || ok {
+						t.Fatalf("%s: UpdatePendingApproval ok=%v err=%v, want validation error", tc.name, ok, err)
+					} else if !strings.Contains(err.Error(), tc.wantErr) {
+						t.Fatalf("%s: error = %q, want %q", tc.name, err.Error(), tc.wantErr)
+					}
+				}
+				if _, ok, err := store.UpdatePendingApprovalForAwaitingRun(ctx, tc.approval); err == nil || ok {
+					t.Fatalf("%s: UpdatePendingApprovalForAwaitingRun ok=%v err=%v, want validation error", tc.name, ok, err)
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("%s: error = %q, want %q", tc.name, err.Error(), tc.wantErr)
+					t.Fatalf("%s: awaiting-run error = %q, want %q", tc.name, err.Error(), tc.wantErr)
 				}
 			}
 		})

--- a/internal/taskstate/approval_test.go
+++ b/internal/taskstate/approval_test.go
@@ -149,6 +149,22 @@ func TestTaskStore_UpdatePendingApprovalForAwaitingRunRequiresAwaitingRun(t *tes
 				t.Fatalf("approval status after cancelled-run update = %q, want pending", got.Status)
 			}
 
+			if _, err := store.CreateRun(ctx, types.TaskRun{ID: "run-ap-other", TaskID: "task-ap-run", Status: "awaiting_approval"}); err != nil {
+				t.Fatalf("CreateRun other: %v", err)
+			}
+			mismatched := pending
+			mismatched.RunID = "run-ap-other"
+			if _, ok, err := store.UpdatePendingApprovalForAwaitingRun(ctx, mismatched); err != nil || ok {
+				t.Fatalf("UpdatePendingApprovalForAwaitingRun mismatched run id: ok=%v err=%v, want ok=false err=nil", ok, err)
+			}
+			got, found, err = store.GetApproval(ctx, "task-ap-run", "approval-run")
+			if err != nil || !found {
+				t.Fatalf("GetApproval after mismatch: found=%v err=%v", found, err)
+			}
+			if got.Status != "pending" || got.RunID != "run-ap-run" {
+				t.Fatalf("approval after mismatched run update = %+v, want original pending row", got)
+			}
+
 			run := types.TaskRun{ID: "run-ap-run", TaskID: "task-ap-run", Status: "awaiting_approval"}
 			if _, err := store.UpdateRun(ctx, run); err != nil {
 				t.Fatalf("UpdateRun: %v", err)

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -305,6 +306,12 @@ func (s *MemoryStore) UpdateApproval(_ context.Context, approval types.TaskAppro
 }
 
 func (s *MemoryStore) UpdatePendingApproval(_ context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error) {
+	if strings.TrimSpace(approval.ID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval id is required")
+	}
+	if strings.TrimSpace(approval.TaskID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval task id is required")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	current, ok := s.approvals[approval.ID]

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -304,6 +304,17 @@ func (s *MemoryStore) UpdateApproval(_ context.Context, approval types.TaskAppro
 	return approval, nil
 }
 
+func (s *MemoryStore) UpdatePendingApproval(_ context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.approvals[approval.ID]
+	if !ok || current.Status != "pending" || (approval.TaskID != "" && current.TaskID != approval.TaskID) {
+		return types.TaskApproval{}, false, nil
+	}
+	s.approvals[approval.ID] = approval
+	return approval, true, nil
+}
+
 func (s *MemoryStore) CreateArtifact(_ context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -322,6 +322,30 @@ func (s *MemoryStore) UpdatePendingApproval(_ context.Context, approval types.Ta
 	return approval, true, nil
 }
 
+func (s *MemoryStore) UpdatePendingApprovalForAwaitingRun(_ context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error) {
+	if strings.TrimSpace(approval.ID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval id is required")
+	}
+	if strings.TrimSpace(approval.TaskID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval task id is required")
+	}
+	if strings.TrimSpace(approval.RunID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval run id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.approvals[approval.ID]
+	if !ok || current.Status != "pending" || current.TaskID != approval.TaskID || current.RunID != approval.RunID {
+		return types.TaskApproval{}, false, nil
+	}
+	run, ok := s.runs[approval.RunID]
+	if !ok || run.TaskID != approval.TaskID || run.Status != "awaiting_approval" {
+		return types.TaskApproval{}, false, nil
+	}
+	s.approvals[approval.ID] = approval
+	return approval, true, nil
+}
+
 func (s *MemoryStore) CreateArtifact(_ context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -444,6 +444,7 @@ func (s *SQLiteStore) UpdatePendingApprovalForAwaitingRun(ctx context.Context, a
 		SET status = ?, payload = ?
 		WHERE id = ?
 		  AND task_id = ?
+		  AND run_id = ?
 		  AND status = 'pending'
 		  AND EXISTS (
 		    SELECT 1
@@ -452,7 +453,7 @@ func (s *SQLiteStore) UpdatePendingApprovalForAwaitingRun(ctx context.Context, a
 		      AND task_id = ?
 		      AND status = 'awaiting_approval'
 		  )
-	`, s.approvalsTable, s.runsTable), approval.Status, string(payload), approval.ID, approval.TaskID, approval.RunID, approval.TaskID)
+	`, s.approvalsTable, s.runsTable), approval.Status, string(payload), approval.ID, approval.TaskID, approval.RunID, approval.RunID, approval.TaskID)
 	if err != nil {
 		return types.TaskApproval{}, false, err
 	}

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -400,6 +400,9 @@ func (s *SQLiteStore) UpdatePendingApproval(ctx context.Context, approval types.
 	if strings.TrimSpace(approval.ID) == "" {
 		return types.TaskApproval{}, false, fmt.Errorf("approval id is required")
 	}
+	if strings.TrimSpace(approval.TaskID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval task id is required")
+	}
 	payload, err := json.Marshal(approval)
 	if err != nil {
 		return types.TaskApproval{}, false, err

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -396,6 +396,32 @@ func (s *SQLiteStore) UpdateApproval(ctx context.Context, approval types.TaskApp
 	return s.CreateApproval(ctx, approval)
 }
 
+func (s *SQLiteStore) UpdatePendingApproval(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error) {
+	if strings.TrimSpace(approval.ID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval id is required")
+	}
+	payload, err := json.Marshal(approval)
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	res, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, payload = ?
+		WHERE id = ? AND task_id = ? AND status = 'pending'
+	`, s.approvalsTable), approval.Status, string(payload), approval.ID, approval.TaskID)
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	if n == 0 {
+		return types.TaskApproval{}, false, nil
+	}
+	return approval, true, nil
+}
+
 func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error) {
 	if strings.TrimSpace(artifact.ID) == "" {
 		return types.TaskArtifact{}, fmt.Errorf("artifact id is required")

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -425,6 +425,47 @@ func (s *SQLiteStore) UpdatePendingApproval(ctx context.Context, approval types.
 	return approval, true, nil
 }
 
+func (s *SQLiteStore) UpdatePendingApprovalForAwaitingRun(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error) {
+	if strings.TrimSpace(approval.ID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval id is required")
+	}
+	if strings.TrimSpace(approval.TaskID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval task id is required")
+	}
+	if strings.TrimSpace(approval.RunID) == "" {
+		return types.TaskApproval{}, false, fmt.Errorf("approval run id is required")
+	}
+	payload, err := json.Marshal(approval)
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	res, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, payload = ?
+		WHERE id = ?
+		  AND task_id = ?
+		  AND status = 'pending'
+		  AND EXISTS (
+		    SELECT 1
+		    FROM %s
+		    WHERE id = ?
+		      AND task_id = ?
+		      AND status = 'awaiting_approval'
+		  )
+	`, s.approvalsTable, s.runsTable), approval.Status, string(payload), approval.ID, approval.TaskID, approval.RunID, approval.TaskID)
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return types.TaskApproval{}, false, err
+	}
+	if n == 0 {
+		return types.TaskApproval{}, false, nil
+	}
+	return approval, true, nil
+}
+
 func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error) {
 	if strings.TrimSpace(artifact.ID) == "" {
 		return types.TaskArtifact{}, fmt.Errorf("artifact id is required")

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -70,6 +70,7 @@ type Store interface {
 	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
 	UpdateApproval(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, error)
 	UpdatePendingApproval(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error)
+	UpdatePendingApprovalForAwaitingRun(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error)
 
 	CreateArtifact(ctx context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error)
 	GetArtifact(ctx context.Context, taskID, artifactID string) (types.TaskArtifact, bool, error)

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -69,6 +69,7 @@ type Store interface {
 	GetApproval(ctx context.Context, taskID, approvalID string) (types.TaskApproval, bool, error)
 	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
 	UpdateApproval(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, error)
+	UpdatePendingApproval(ctx context.Context, approval types.TaskApproval) (types.TaskApproval, bool, error)
 
 	CreateArtifact(ctx context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error)
 	GetArtifact(ctx context.Context, taskID, artifactID string) (types.TaskArtifact, bool, error)

--- a/internal/telemetry/metric_labels.go
+++ b/internal/telemetry/metric_labels.go
@@ -58,8 +58,9 @@ var knownApprovalKinds = map[string]struct{}{
 }
 
 var knownApprovalDecisions = map[string]struct{}{
-	"approved": {},
-	"rejected": {},
+	"approved":  {},
+	"cancelled": {},
+	"rejected":  {},
 }
 
 var knownQueueBackends = map[string]struct{}{

--- a/internal/telemetry/metric_labels_test.go
+++ b/internal/telemetry/metric_labels_test.go
@@ -38,6 +38,7 @@ func TestMetricClosedSetNormalizersCollapseUnknownValues(t *testing.T) {
 		{"step kind unknown", "browser", NormalizeStepKind, MetricLabelOther},
 		{"approval kind known", "network_egress", NormalizeApprovalKind, "network_egress"},
 		{"approval kind unknown", "danger", NormalizeApprovalKind, MetricLabelOther},
+		{"approval decision cancelled", "cancelled", NormalizeApprovalDecision, "cancelled"},
 		{"queue backend known", "sqlite", NormalizeQueueBackend, "sqlite"},
 		{"queue backend unknown", "postgres", NormalizeQueueBackend, MetricLabelOther},
 		{"driver kind known", "acp", NormalizeAgentDriverKind, "acp"},

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -715,7 +715,7 @@ type ApprovalMetricsRecord struct {
 	TaskID       string
 	RunID        string
 	ApprovalKind string
-	Decision     string // approved | rejected
+	Decision     string // approved | rejected | cancelled
 	WaitMS       int64
 }
 


### PR DESCRIPTION
## Summary

- Cancel pending task approvals when their backing run is cancelled from `awaiting_approval`.
- Mark awaiting-approval steps as cancelled together with running steps.
- Guard approval resolution against stale pending rows whose run is no longer awaiting approval.
- Document the approval cancellation invariant in task runtime, events, and runtime API docs.

## Why

A cancelled task run could leave a pending approval row behind. A later approve click then mutated stale state and failed during resume, which is confusing for both the API and the UI. Terminal runs should not have actionable approval rows.

## Verification

- `go vet ./internal/api ./internal/orchestrator`
- `go test ./internal/api ./internal/orchestrator`
- `go test -race -timeout 10m ./internal/api ./internal/orchestrator`