### PR TITLE
fix(tasks): prevent duplicate active task runs

### DIFF
--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -272,8 +272,11 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
 		return
 	}
-	if task.Status == "running" {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "cannot delete a running task; cancel it first")
+	if active, err := taskHasActiveRun(ctx, h.taskStore, task); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "cannot delete a task with an active run; cancel it first")
 		return
 	}
 
@@ -305,7 +308,10 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if taskHasActiveRun(task) {
+	if active, err := taskHasActiveRun(ctx, h.taskStore, task); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has an active run")
 		return
 	}
@@ -334,11 +340,26 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func taskHasActiveRun(task types.Task) bool {
-	if strings.TrimSpace(task.LatestRunID) == "" {
-		return false
+func taskHasActiveRun(ctx context.Context, store taskstate.Store, task types.Task) (bool, error) {
+	latestRunID := strings.TrimSpace(task.LatestRunID)
+	if latestRunID != "" && store != nil {
+		run, found, err := store.GetRun(ctx, task.ID, latestRunID)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return !types.IsTerminalTaskRunStatus(run.Status), nil
+		}
 	}
-	return !types.IsTerminalTaskRunStatus(task.Status)
+	return latestRunID != "" && !types.IsTerminalTaskRunStatus(task.Status), nil
+}
+
+func taskHasOtherActiveRun(ctx context.Context, store taskstate.Store, task types.Task, currentRunID string) (bool, error) {
+	latestRunID := strings.TrimSpace(task.LatestRunID)
+	if latestRunID == "" || latestRunID == strings.TrimSpace(currentRunID) {
+		return false, nil
+	}
+	return taskHasActiveRun(ctx, store, task)
 }
 
 func (h *Handler) HandleTaskApprovals(w http.ResponseWriter, r *http.Request) {
@@ -1243,6 +1264,13 @@ func (h *Handler) HandleRetryTaskRun(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "run is not retryable until it reaches a terminal state")
 		return
 	}
+	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
+		return
+	}
 	result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -1267,6 +1295,13 @@ func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
 	}
 	if run.Status != "failed" && run.Status != "cancelled" {
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "run is not resumable")
+		return
+	}
+	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
 		return
 	}
 	// Optional ceiling raise — used by the "Raise ceiling and
@@ -1311,6 +1346,13 @@ func (h *Handler) HandleContinueTaskRun(w http.ResponseWriter, r *http.Request) 
 	}
 	var req ContinueTaskRunRequest
 	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
 		return
 	}
 	result, err := h.taskRunner.ContinueAgentTask(ctx, task, run, req.Prompt, newOpaqueTaskResourceID)
@@ -1360,6 +1402,13 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 	}
 	if req.Turn < 1 {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "turn must be >= 1")
+		return
+	}
+	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if active {
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
 		return
 	}
 	result, err := h.taskRunner.RetryTaskFromTurn(ctx, task, run, req.Turn, strings.TrimSpace(req.Reason), newOpaqueTaskResourceID)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4370,6 +4370,42 @@ func TestTaskStartReturnsConflictWhileRunActive(t *testing.T) {
 	}
 }
 
+func TestTaskStartAndDeleteCheckLatestRunWhenTaskSummaryIsStale(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := config.Config{Server: config.ServerConfig{TaskApprovalPolicies: []string{"shell_exec"}}}
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, cfg, nil)
+	handler := NewServer(logger, apiHandler)
+	tasks := newTaskTestClient(t, handler)
+
+	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Stale summary","prompt":"Leave this run awaiting approval.","execution_kind":"shell","shell_command":"printf 'active\n'","working_directory":".","timeout_ms":1000}`)
+	started := mustTaskRequestJSON[TaskRunResponse](tasks, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/start", "")
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("run status = %q, want awaiting_approval", started.Data.Status)
+	}
+
+	staleTask, found, err := apiHandler.taskStore.GetTask(context.Background(), created.Data.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask: found=%t err=%v", found, err)
+	}
+	staleTask.Status = "completed"
+	staleTask.FinishedAt = time.Now().UTC()
+	if _, err := apiHandler.taskStore.UpdateTask(context.Background(), staleTask); err != nil {
+		t.Fatalf("UpdateTask stale summary: %v", err)
+	}
+
+	startAgain := tasks.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/start", "")
+	if !strings.Contains(startAgain.Body.String(), "active run") {
+		t.Fatalf("start error body = %s, want mention of active run", startAgain.Body.String())
+	}
+
+	deleteActive := tasks.mustRequestStatus(http.StatusConflict, http.MethodDelete, "/hecate/v1/tasks/"+created.Data.ID, "")
+	if !strings.Contains(deleteActive.Body.String(), "active run") {
+		t.Fatalf("delete error body = %s, want mention of active run", deleteActive.Body.String())
+	}
+}
+
 func TestTaskRunRetryReturnsConflictForActiveRun(t *testing.T) {
 	t.Parallel()
 
@@ -4411,6 +4447,87 @@ func TestTaskRunResumeReturnsConflictForActiveRun(t *testing.T) {
 	rec := tasks.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/resume", `{}`)
 	if !strings.Contains(rec.Body.String(), "not resumable") {
 		t.Fatalf("error body = %s, want mention of not resumable", rec.Body.String())
+	}
+}
+
+func TestTaskRunMutationsReturnConflictWhenAnotherLatestRunActive(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	handler := NewServer(logger, apiHandler)
+	tasks := newTaskTestClient(t, handler)
+	now := time.Now().UTC()
+
+	task := types.Task{
+		ID:            "task-other-active-run",
+		Title:         "other active run",
+		Prompt:        "old run should not fork while latest is active",
+		ExecutionKind: "agent_loop",
+		Status:        "completed", // Deliberately stale; latest run row is authoritative.
+		LatestRunID:   "run-active-latest",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if _, err := apiHandler.taskStore.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	oldRun := types.TaskRun{
+		ID:         "run-old-terminal",
+		TaskID:     task.ID,
+		Number:     1,
+		Status:     "failed",
+		StartedAt:  now.Add(-2 * time.Minute),
+		FinishedAt: now.Add(-time.Minute),
+	}
+	if _, err := apiHandler.taskStore.CreateRun(context.Background(), oldRun); err != nil {
+		t.Fatalf("CreateRun(old): %v", err)
+	}
+	activeRun := types.TaskRun{
+		ID:        task.LatestRunID,
+		TaskID:    task.ID,
+		Number:    2,
+		Status:    "awaiting_approval",
+		StartedAt: now,
+	}
+	if _, err := apiHandler.taskStore.CreateRun(context.Background(), activeRun); err != nil {
+		t.Fatalf("CreateRun(active): %v", err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "retry",
+			path: "/hecate/v1/tasks/" + task.ID + "/runs/" + oldRun.ID + "/retry",
+			body: `{}`,
+		},
+		{
+			name: "resume",
+			path: "/hecate/v1/tasks/" + task.ID + "/runs/" + oldRun.ID + "/resume",
+			body: `{}`,
+		},
+		{
+			name: "continue",
+			path: "/hecate/v1/tasks/" + task.ID + "/runs/" + oldRun.ID + "/continue",
+			body: `{"prompt":"continue anyway"}`,
+		},
+		{
+			name: "retry from turn",
+			path: "/hecate/v1/tasks/" + task.ID + "/runs/" + oldRun.ID + "/retry-from-turn",
+			body: `{"turn":1}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tasks.mustRequestStatus(http.StatusConflict, http.MethodPost, tc.path, tc.body)
+			if !strings.Contains(rec.Body.String(), "another active run") {
+				t.Fatalf("error body = %s, want mention of another active run", rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -555,6 +555,9 @@ func (r *Runner) reconcileStaleRuns(ctx context.Context, staleThreshold time.Dur
 		if ctx.Err() != nil {
 			return nil
 		}
+		if r.hasInFlightJob(run.ID) {
+			continue
+		}
 		if run.StartedAt.IsZero() || run.StartedAt.After(cutoff) {
 			continue
 		}
@@ -1384,6 +1387,13 @@ func (r *Runner) unregisterJob(runID string) {
 	r.jobMu.Lock()
 	defer r.jobMu.Unlock()
 	delete(r.jobs, runID)
+}
+
+func (r *Runner) hasInFlightJob(runID string) bool {
+	r.jobMu.Lock()
+	defer r.jobMu.Unlock()
+	_, ok := r.jobs[runID]
+	return ok
 }
 
 func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, requestID string, resumeCheckpoint *ResumeCheckpoint) (*StartTaskResult, error) {

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -166,6 +166,76 @@ func TestStartReconcileLoop_SkipsFreshRunningRun(t *testing.T) {
 	}
 }
 
+// TestStartReconcileLoop_SkipsLocalInflightRun verifies that periodic
+// stale-run reconciliation does not duplicate work the current runner still
+// owns. A long-running task can legitimately outlive the conservative
+// StartedAt-based stale threshold; if it is registered in r.jobs, Shutdown and
+// explicit CancelRun can still reach it, so requeueing would create a second
+// worker for the same run.
+func TestStartReconcileLoop_SkipsLocalInflightRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	queue := &recordingQueue{}
+
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{
+			QueueWorkers:      0,
+			QueueLeaseSeconds: 1, // stale threshold = 3s
+			ReconcileInterval: 20 * time.Millisecond,
+		},
+	)
+	runner.SetQueue(queue)
+
+	task := types.Task{
+		ID:        "task-inflight",
+		Status:    "running",
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{
+		ID:        "run-inflight",
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "running",
+		StartedAt: time.Now().UTC().Add(-10 * time.Second),
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	cancelled := false
+	runner.registerJob(run.ID, func() { cancelled = true })
+	defer runner.unregisterJob(run.ID)
+	runner.StartReconcileLoop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = runner.Shutdown(shutdownCtx)
+
+	gotRun, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%t err=%v", found, err)
+	}
+	if gotRun.Status != "running" {
+		t.Fatalf("in-flight run status = %q, want running", gotRun.Status)
+	}
+	if len(queue.enqueued) != 0 {
+		t.Fatalf("in-flight run was unexpectedly requeued (%d jobs)", len(queue.enqueued))
+	}
+	if !cancelled {
+		t.Fatal("Shutdown did not cancel the registered in-flight job")
+	}
+}
+
 // TestStartReconcileLoop_StopsOnShutdown verifies that the reconcile goroutine
 // joins the worker wait-group and exits when Shutdown is called. If it leaked,
 // Shutdown would block until its context deadline.


### PR DESCRIPTION
## Summary

Tightens the task-runtime single-active-run invariant after the approval-cancellation hardening landed.

- Periodic stale-run reconciliation now skips runs that are still registered as in-flight by the current runner. A long-running task can legitimately outlive the conservative StartedAt-based stale threshold; if the current runner still owns the run, requeueing would create a duplicate worker.
- Task start/delete now use the latest run row as the source of truth instead of trusting only the task summary status. This prevents stale task summaries from starting a second run or deleting active runtime state.
- Retry, resume, continue, and retry-from-turn now reject attempts to fork an older terminal run while another latest run is active.

## Tests

- go test ./internal/orchestrator ./internal/api
- go vet ./internal/orchestrator ./internal/api
