### PR TITLE
feat(chats): make queued prompts editable and improve task diagnostics

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -141,7 +141,9 @@ by default because it is a run-inspection view. Chats keeps it quieter so the
 conversation remains the primary surface. Task Detail may additionally expose a
 per-row **Advanced** disclosure with raw activity metadata for debugging:
 activity id/type/status, step/artifact/approval ids, tool kind, path, timestamp,
-and summary payload.
+and summary payload. Failed tool rows additionally preview related stdout/stderr
+artifacts there, so the common "why did this command fail?" path is answerable
+without leaving the activity row.
 
 ## Output and stderr in the UI
 
@@ -161,8 +163,10 @@ stream.
 Task Detail still records whether each stream artifact exists. The run output
 header shows stdout size when available, `stderr available` when stderr has
 content, and `stderr empty` when the stderr artifact was created but no bytes
-were captured. Hecate Chat keeps failed-tool diagnostics compact: it links only
-non-empty stdout/stderr artifacts from the chat activity row, shows capped
+were captured. Failed tool rows in Task Detail's **Advanced** disclosure preview
+stdout/stderr artifacts and keep empty stderr discoverable as "No bytes captured
+for this stream." Hecate Chat keeps failed-tool diagnostics compact: it links
+only non-empty stdout/stderr artifacts from the chat activity row, shows capped
 inline previews for those streams, and leaves the empty-stream confirmation to
 Task Detail.
 

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -50,7 +50,8 @@ but they can also store direct model segments:
   the originating chat session plus the selected runtime/model/workspace
   snapshot from the moment they were queued, so switching to another chat cannot
   drain a prompt into the wrong transcript. They can be edited or removed while
-  waiting, and they are not persisted until submitted.
+  waiting. They are persisted in browser-local operator storage until submitted,
+  removed, or pruned because the backing chat session was deleted.
   Chats projects the backing run activity into the transcript, links each
   assistant turn back to its backing Task/run, and can approve/reject pending
   task approvals inline. Low-level artifacts stay under transcript **Details**,

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -49,8 +49,8 @@ but they can also store direct model segments:
   after the run or approval reaches a terminal state. Queued prompts preserve
   the originating chat session plus the selected runtime/model/workspace
   snapshot from the moment they were queued, so switching to another chat cannot
-  drain a prompt into the wrong transcript. They are not persisted until
-  submitted.
+  drain a prompt into the wrong transcript. They can be edited or removed while
+  waiting, and they are not persisted until submitted.
   Chats projects the backing run activity into the transcript, links each
   assistant turn back to its backing Task/run, and can approve/reject pending
   task approvals inline. Low-level artifacts stay under transcript **Details**,
@@ -88,6 +88,9 @@ conversation stays readable; Task Detail opens the activity section by default
 because that view is already a run-inspection surface. Task Detail can also
 show a per-row **Advanced** disclosure with raw activity metadata such as
 step/artifact/approval ids, tool kind, path, timestamp, and summary payload.
+For failed tool rows, Task Detail also previews related stdout/stderr artifacts
+inside that disclosure, including an explicit empty-stream note when stderr was
+captured but contained no bytes.
 When a tool row fails, Chats may show its own **Advanced** disclosure with
 capped previews of the backing Task's non-empty stdout/stderr artifacts plus an
 **Open task output** escape hatch for the full capture. Empty streams stay

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -895,7 +895,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
   await expect(page.getByRole("button", { name: "Queue message" })).toBeVisible();
   await page.getByRole("button", { name: "Queue message" }).click();
   await expect(page.getByLabel("Queued messages")).toBeVisible();
-  await expect(page.getByText("try direct while busy")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Queued message 1" })).toHaveValue("try direct while busy");
   expect(messagePosts).toBe(0);
 });
 

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -636,6 +636,57 @@ describe("useRuntimeConsole", () => {
       });
     });
 
+    it("keeps queued prompt edits usable when browser storage writes fail", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+      window.localStorage.setItem("hecate.queuedChatMessages", JSON.stringify([
+        {
+          id: "queued_restore",
+          session_id: "a1",
+          content: "keep this after refresh",
+          runtime_kind: "agent",
+          provider_filter: "auto",
+          model: "ministral-3:latest",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:01Z",
+        },
+      ]));
+      const originalSetItem = Storage.prototype.setItem;
+      const storageSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key, value) {
+        if (key === "hecate.queuedChatMessages") {
+          throw new DOMException("quota exceeded", "QuotaExceededError");
+        }
+        return originalSetItem.call(this, key, value);
+      });
+      fetchMock.mockImplementation(defaultBackendMock({
+        "/hecate/v1/agent-chat/sessions": () => jsonResponse({
+          object: "agent_chat_sessions",
+          data: [{ id: "a1", title: "Agent", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 }],
+        }),
+        "/hecate/v1/agent-chat/sessions/a1": () => jsonResponse({
+          object: "agent_chat_session",
+          data: { id: "a1", title: "Agent", runtime_kind: "agent", status: "running", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
+        }),
+      }));
+
+      try {
+        const { result } = renderHook(() => useRuntimeConsole());
+        await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+        act(() => {
+          result.current.actions.updateQueuedChatMessage("queued_restore", "edited in memory");
+        });
+
+        await waitFor(() => expect(storageSpy).toHaveBeenCalledWith("hecate.queuedChatMessages", expect.any(String)));
+        expect(result.current.state.queuedChatMessages[0].content).toBe("edited in memory");
+      } finally {
+        storageSpy.mockRestore();
+      }
+    });
+
     it("prunes stored queued prompts for sessions that no longer exist", async () => {
       window.localStorage.setItem("hecate.queuedChatMessages", JSON.stringify([
         {

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -674,8 +674,10 @@ describe("useRuntimeConsole", () => {
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await waitFor(() => expect(result.current.state.queuedChatMessages.map((item) => item.id)).toEqual(["queued_keep"]));
-      const stored = JSON.parse(window.localStorage.getItem("hecate.queuedChatMessages") ?? "[]");
-      expect(stored.map((item: { id: string }) => item.id)).toEqual(["queued_keep"]);
+      await waitFor(() => {
+        const stored = JSON.parse(window.localStorage.getItem("hecate.queuedChatMessages") ?? "[]");
+        expect(stored.map((item: { id: string }) => item.id)).toEqual(["queued_keep"]);
+      });
     });
 
     it("does not drain a queued prompt into a different selected chat", async () => {

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -592,6 +592,92 @@ describe("useRuntimeConsole", () => {
       await waitFor(() => expect(result.current.state.queuedChatMessages).toHaveLength(0));
     });
 
+    it("restores queued prompts from local storage and persists edits", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+      window.localStorage.setItem("hecate.queuedChatMessages", JSON.stringify([
+        {
+          id: "queued_restore",
+          session_id: "a1",
+          content: "keep this after refresh",
+          runtime_kind: "agent",
+          provider_filter: "auto",
+          model: "ministral-3:latest",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:01Z",
+        },
+      ]));
+      fetchMock.mockImplementation(defaultBackendMock({
+        "/hecate/v1/agent-chat/sessions": () => jsonResponse({
+          object: "agent_chat_sessions",
+          data: [{ id: "a1", title: "Agent", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 }],
+        }),
+        "/hecate/v1/agent-chat/sessions/a1": () => jsonResponse({
+          object: "agent_chat_session",
+          data: { id: "a1", title: "Agent", runtime_kind: "agent", status: "running", workspace: "/workspace", messages: [], created_at: "2026-04-20T00:00:00Z", updated_at: "2026-04-20T00:00:00Z" },
+        }),
+      }));
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      expect(result.current.state.queuedChatMessages).toHaveLength(1);
+      expect(result.current.state.queuedChatMessages[0].content).toBe("keep this after refresh");
+
+      act(() => {
+        result.current.actions.updateQueuedChatMessage("queued_restore", "edited after refresh");
+      });
+
+      await waitFor(() => {
+        const stored = JSON.parse(window.localStorage.getItem("hecate.queuedChatMessages") ?? "[]");
+        expect(stored[0].content).toBe("edited after refresh");
+      });
+    });
+
+    it("prunes stored queued prompts for sessions that no longer exist", async () => {
+      window.localStorage.setItem("hecate.queuedChatMessages", JSON.stringify([
+        {
+          id: "queued_keep",
+          session_id: "a1",
+          content: "keep",
+          runtime_kind: "agent",
+          provider_filter: "auto",
+          model: "ministral-3:latest",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:01Z",
+        },
+        {
+          id: "queued_drop",
+          session_id: "missing",
+          content: "drop",
+          runtime_kind: "agent",
+          provider_filter: "auto",
+          model: "ministral-3:latest",
+          workspace: "/workspace",
+          system_prompt: "",
+          adapter_id: "codex",
+          created_at: "2026-04-20T00:00:02Z",
+        },
+      ]));
+      fetchMock.mockImplementation(defaultBackendMock({
+        "/hecate/v1/agent-chat/sessions": () => jsonResponse({
+          object: "agent_chat_sessions",
+          data: [{ id: "a1", title: "Agent", runtime_kind: "agent", status: "running", workspace: "/workspace", message_count: 0 }],
+        }),
+      }));
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+      await waitFor(() => expect(result.current.state.queuedChatMessages.map((item) => item.id)).toEqual(["queued_keep"]));
+      const stored = JSON.parse(window.localStorage.getItem("hecate.queuedChatMessages") ?? "[]");
+      expect(stored.map((item: { id: string }) => item.id)).toEqual(["queued_keep"]);
+    });
+
     it("does not drain a queued prompt into a different selected chat", async () => {
       window.localStorage.setItem("hecate.chatTarget", "agent");
       window.localStorage.setItem("hecate.agentChatSessionID", "a1");

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -174,11 +174,16 @@ function writeStoredQueuedChatMessages(items: QueuedChatMessage[]) {
   if (typeof window === "undefined") {
     return;
   }
-  if (items.length === 0) {
-    window.localStorage.removeItem(queuedChatMessagesStorageKey);
-    return;
+  try {
+    if (items.length === 0) {
+      window.localStorage.removeItem(queuedChatMessagesStorageKey);
+      return;
+    }
+    window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(items));
+  } catch {
+    // Browser storage can be disabled, private, or quota-limited. Queued
+    // prompts remain usable in memory even when draft persistence is unavailable.
   }
-  window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(items));
 }
 
 function readStoredChatTargetsBySessionID(): Map<string, HecateChatTarget> {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -114,6 +114,8 @@ type QueuedChatMessage = {
   created_at: string;
 };
 
+const queuedChatMessagesStorageKey = "hecate.queuedChatMessages";
+
 function normalizeStoredChatTarget(value: string): ChatTarget {
   switch (value) {
     case "model":
@@ -132,6 +134,39 @@ function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
       return value;
     default:
       return "";
+  }
+}
+
+function readStoredQueuedChatMessages(): QueuedChatMessage[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(queuedChatMessagesStorageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item): QueuedChatMessage[] => {
+      if (!item || typeof item !== "object") return [];
+      const id = typeof item.id === "string" ? item.id : "";
+      const sessionID = typeof item.session_id === "string" ? item.session_id : "";
+      const content = typeof item.content === "string" ? item.content : "";
+      if (!id || !sessionID || !content.trim()) return [];
+      return [{
+        id,
+        session_id: sessionID,
+        content,
+        runtime_kind: normalizeStoredChatTarget(typeof item.runtime_kind === "string" ? item.runtime_kind : ""),
+        provider_filter: typeof item.provider_filter === "string" ? item.provider_filter as ProviderFilter : "auto",
+        model: typeof item.model === "string" ? item.model : "",
+        workspace: typeof item.workspace === "string" ? item.workspace : "",
+        system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
+        adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
+        created_at: typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
+      }];
+    });
+  } catch {
+    return [];
   }
 }
 
@@ -264,7 +299,7 @@ export function useRuntimeConsole() {
 
   const [model, setModel] = useState("");
   const [message, setMessage] = useState("");
-  const [queuedChatMessages, setQueuedChatMessages] = useState<QueuedChatMessage[]>([]);
+  const [queuedChatMessages, setQueuedChatMessages] = useState<QueuedChatMessage[]>(() => readStoredQueuedChatMessages());
   const [systemPrompt, setSystemPrompt] = useState("");
   const [chatLoading, setChatLoading] = useState(false);
   const [agentChatCancelling, setAgentChatCancelling] = useState(false);
@@ -432,6 +467,14 @@ export function useRuntimeConsole() {
     }
     window.localStorage.removeItem("hecate.agentChatSessionID");
   }, [activeAgentChatSessionID]);
+
+  useEffect(() => {
+    if (queuedChatMessages.length === 0) {
+      window.localStorage.removeItem(queuedChatMessagesStorageKey);
+      return;
+    }
+    window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(queuedChatMessages));
+  }, [queuedChatMessages]);
 
   useEffect(() => {
     if (!notice) {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -170,6 +170,17 @@ function readStoredQueuedChatMessages(): QueuedChatMessage[] {
   }
 }
 
+function writeStoredQueuedChatMessages(items: QueuedChatMessage[]) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (items.length === 0) {
+    window.localStorage.removeItem(queuedChatMessagesStorageKey);
+    return;
+  }
+  window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(items));
+}
+
 function readStoredChatTargetsBySessionID(): Map<string, HecateChatTarget> {
   if (typeof window === "undefined") {
     return new Map();
@@ -300,6 +311,7 @@ export function useRuntimeConsole() {
   const [model, setModel] = useState("");
   const [message, setMessage] = useState("");
   const [queuedChatMessages, setQueuedChatMessages] = useState<QueuedChatMessage[]>(() => readStoredQueuedChatMessages());
+  const queuedChatMessagesRef = useRef(queuedChatMessages);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [chatLoading, setChatLoading] = useState(false);
   const [agentChatCancelling, setAgentChatCancelling] = useState(false);
@@ -469,12 +481,21 @@ export function useRuntimeConsole() {
   }, [activeAgentChatSessionID]);
 
   useEffect(() => {
-    if (queuedChatMessages.length === 0) {
-      window.localStorage.removeItem(queuedChatMessagesStorageKey);
-      return;
-    }
-    window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(queuedChatMessages));
+    queuedChatMessagesRef.current = queuedChatMessages;
+    const timeout = window.setTimeout(() => {
+      writeStoredQueuedChatMessages(queuedChatMessages);
+    }, 200);
+    return () => window.clearTimeout(timeout);
   }, [queuedChatMessages]);
+
+  useEffect(() => {
+    const flushQueuedMessages = () => writeStoredQueuedChatMessages(queuedChatMessagesRef.current);
+    window.addEventListener("pagehide", flushQueuedMessages);
+    return () => {
+      window.removeEventListener("pagehide", flushQueuedMessages);
+      flushQueuedMessages();
+    };
+  }, []);
 
   useEffect(() => {
     if (!notice) {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -655,6 +655,12 @@ export function useRuntimeConsole() {
     setQueuedChatMessages((current) => current.filter((item) => item.id !== id));
   }
 
+  function updateQueuedChatMessage(id: string, content: string) {
+    setQueuedChatMessages((current) => current.map((item) => (
+      item.id === id ? { ...item, content } : item
+    )));
+  }
+
   function pruneQueuedChatMessagesForSessions(sessionIDs: Iterable<string>) {
     const valid = new Set(sessionIDs);
     setQueuedChatMessages((current) => current.filter((item) => valid.has(item.session_id)));
@@ -937,6 +943,10 @@ export function useRuntimeConsole() {
     }
     const next = queuedChatMessages.find((item) => item.session_id === activeAgentChatSessionID);
     if (!next) {
+      return;
+    }
+    if (!next.content.trim()) {
+      setQueuedChatMessages((current) => current.filter((item) => item.id !== next.id));
       return;
     }
     setQueuedChatMessages((current) => current.filter((item) => item.id !== next.id));
@@ -1794,6 +1804,7 @@ export function useRuntimeConsole() {
       setChatTarget,
       setMessage,
       removeQueuedChatMessage,
+      updateQueuedChatMessage,
       setSystemPrompt,
       setModel,
       setModelFilter,

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -780,6 +780,7 @@ describe("ChatView input", () => {
 
   it("renders queued messages with a remove action", async () => {
     const removeQueuedChatMessage = vi.fn();
+    const updateQueuedChatMessage = vi.fn();
     const user = userEvent.setup();
     const { state, actions } = setup({
       activeAgentChatSessionID: "agent_chat_1",
@@ -797,12 +798,15 @@ describe("ChatView input", () => {
           created_at: "2026-04-20T00:00:00Z",
         },
       ],
-    }, { removeQueuedChatMessage });
+    }, { removeQueuedChatMessage, updateQueuedChatMessage });
 
     render(<ChatView state={state} actions={actions} />);
 
     expect(screen.getByLabelText("Queued messages")).toBeTruthy();
-    expect(screen.getByText("run tests after this")).toBeTruthy();
+    const queuedInput = screen.getByLabelText("Queued message 1");
+    expect(queuedInput).toHaveValue("run tests after this");
+    fireEvent.change(queuedInput, { target: { value: "run unit tests after this" } });
+    expect(updateQueuedChatMessage).toHaveBeenLastCalledWith("queued_1", "run unit tests after this");
     await user.click(screen.getByRole("button", { name: "Remove queued message 1" }));
     expect(removeQueuedChatMessage).toHaveBeenCalledWith("queued_1");
   });
@@ -841,8 +845,8 @@ describe("ChatView input", () => {
     render(<ChatView state={state} actions={actions} />);
 
     expect(screen.getByLabelText("Queued messages")).toBeTruthy();
-    expect(screen.getByText("send this here")).toBeTruthy();
-    expect(screen.queryByText("not in this chat")).toBeNull();
+    expect(screen.getByLabelText("Queued message 1")).toHaveValue("send this here");
+    expect(screen.queryByDisplayValue("not in this chat")).toBeNull();
   });
 
   it("shows the Hecate Agent sandbox reminder only when tools are enabled", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1183,9 +1183,33 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                   <span style={{ color: "var(--teal)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
                     #{index + 1}
                   </span>
-                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {queued.content}
-                  </span>
+                  <input
+                    aria-label={`Queued message ${index + 1}`}
+                    value={queued.content}
+                    onChange={(event) => actions.updateQueuedChatMessage(queued.id, event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") event.preventDefault();
+                    }}
+                    style={{
+                      minWidth: 0,
+                      width: "100%",
+                      border: "1px solid transparent",
+                      borderRadius: "var(--radius-sm)",
+                      background: "transparent",
+                      color: "var(--t0)",
+                      font: "inherit",
+                      padding: "3px 6px",
+                      outline: "none",
+                    }}
+                    onFocus={(event) => {
+                      event.currentTarget.style.borderColor = "var(--border)";
+                      event.currentTarget.style.background = "var(--bg3)";
+                    }}
+                    onBlur={(event) => {
+                      event.currentTarget.style.borderColor = "transparent";
+                      event.currentTarget.style.background = "transparent";
+                    }}
+                  />
                   <button
                     type="button"
                     className="btn btn-ghost btn-sm"

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1183,16 +1183,18 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                   <span style={{ color: "var(--teal)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
                     #{index + 1}
                   </span>
-                  <input
+                  <textarea
                     aria-label={`Queued message ${index + 1}`}
                     value={queued.content}
                     onChange={(event) => actions.updateQueuedChatMessage(queued.id, event.target.value)}
                     onKeyDown={(event) => {
-                      if (event.key === "Enter") event.preventDefault();
+                      if (event.key === "Enter" && !event.shiftKey) event.preventDefault();
                     }}
+                    rows={Math.min(4, Math.max(1, queued.content.split("\n").length))}
                     style={{
                       minWidth: 0,
                       width: "100%",
+                      resize: "vertical",
                       border: "1px solid transparent",
                       borderRadius: "var(--radius-sm)",
                       background: "transparent",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1185,6 +1185,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                   </span>
                   <textarea
                     aria-label={`Queued message ${index + 1}`}
+                    className="queued-chat-message-input"
                     value={queued.content}
                     onChange={(event) => actions.updateQueuedChatMessage(queued.id, event.target.value)}
                     onKeyDown={(event) => {
@@ -1195,21 +1196,11 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                       minWidth: 0,
                       width: "100%",
                       resize: "vertical",
-                      border: "1px solid transparent",
                       borderRadius: "var(--radius-sm)",
-                      background: "transparent",
                       color: "var(--t0)",
                       font: "inherit",
                       padding: "3px 6px",
                       outline: "none",
-                    }}
-                    onFocus={(event) => {
-                      event.currentTarget.style.borderColor = "var(--border)";
-                      event.currentTarget.style.background = "var(--bg3)";
-                    }}
-                    onBlur={(event) => {
-                      event.currentTarget.style.borderColor = "transparent";
-                      event.currentTarget.style.background = "transparent";
                     }}
                   />
                   <button

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -317,6 +317,108 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText(/builtin\.agent_loop/)).not.toBeVisible();
   });
 
+  it("previews related stdout and stderr on failed tool advanced details", async () => {
+    const { render, user } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-tool",
+          type: "tool_call",
+          title: "git_exec",
+          step_id: "step-git",
+          tool_name: "git_exec",
+          kind: "git",
+          status: "failed",
+          summary: { command: "git status" },
+        }),
+        makeActivity({
+          id: "activity-stdout",
+          type: "artifact",
+          title: "git-stdout.txt",
+          step_id: "step-git",
+          artifact_id: "art-stdout",
+          kind: "stdout",
+          status: "ready",
+          summary: {
+            size_bytes: 41,
+            content_preview: "On branch feature/task-debug\nnothing to commit",
+          },
+        }),
+        makeActivity({
+          id: "activity-stderr",
+          type: "artifact",
+          title: "git-stderr.txt",
+          step_id: "step-git",
+          artifact_id: "art-stderr",
+          kind: "stderr",
+          status: "ready",
+          summary: {
+            size_bytes: 57,
+            content_preview: "fatal: not a git repository",
+          },
+        }),
+      ],
+    });
+    render();
+
+    expect(screen.getByText("Details · 2 items")).toBeTruthy();
+    await user.click(screen.getAllByText("Advanced")[0]);
+
+    expect(screen.getByText(/This tool failed/)).toBeTruthy();
+    expect(screen.getByText("git-stdout.txt")).toBeTruthy();
+    expect(screen.getAllByText(/On branch feature\/task-debug/)[0]).toBeVisible();
+    expect(screen.getAllByText(/nothing to commit/)[0]).toBeVisible();
+    expect(screen.getByText("git-stderr.txt")).toBeTruthy();
+    expect(screen.getByText("fatal: not a git repository")).toBeTruthy();
+  });
+
+  it("keeps empty stderr discoverable for failed tool diagnostics", async () => {
+    const { render, user } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-tool",
+          type: "tool_call",
+          title: "shell_exec",
+          step_id: "step-shell",
+          tool_name: "shell_exec",
+          kind: "shell",
+          status: "failed",
+        }),
+        makeActivity({
+          id: "activity-stdout",
+          type: "artifact",
+          title: "shell-stdout.txt",
+          step_id: "step-shell",
+          artifact_id: "art-stdout",
+          kind: "stdout",
+          status: "ready",
+          summary: {
+            size_bytes: 12,
+            content_preview: "stdout notes",
+          },
+        }),
+        makeActivity({
+          id: "activity-stderr",
+          type: "artifact",
+          title: "shell-stderr.txt",
+          step_id: "step-shell",
+          artifact_id: "art-stderr",
+          kind: "stderr",
+          status: "ready",
+          summary: {
+            size_bytes: 0,
+          },
+        }),
+      ],
+    });
+    render();
+
+    await user.click(screen.getAllByText("Advanced")[0]);
+
+    expect(screen.getByText("stdout notes")).toBeTruthy();
+    expect(screen.getByText("shell-stderr.txt")).toBeTruthy();
+    expect(screen.getByText("No bytes captured for this stream.")).toBeTruthy();
+  });
+
   it("shows when stderr exists but is empty", () => {
     const { render } = setup({
       artifacts: [

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -328,7 +328,7 @@ describe("TaskDetail runtime activity and patches", () => {
           tool_name: "git_exec",
           kind: "git",
           status: "failed",
-          summary: { command: "git status" },
+          summary: { command: "git status", exit_code: 128, stdout_bytes: 41, stderr_bytes: 57 },
         }),
         makeActivity({
           id: "activity-stdout",
@@ -364,6 +364,14 @@ describe("TaskDetail runtime activity and patches", () => {
     await user.click(screen.getAllByText("Advanced")[0]);
 
     expect(screen.getByText(/This tool failed/)).toBeTruthy();
+    expect(screen.getByText("command")).toBeTruthy();
+    expect(screen.getByText("git status")).toBeTruthy();
+    expect(screen.getByText("exit")).toBeTruthy();
+    expect(screen.getByText("128")).toBeTruthy();
+    expect(screen.getAllByText("stdout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("41b").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("stderr").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("57b").length).toBeGreaterThan(0);
     expect(screen.getByText("git-stdout.txt")).toBeTruthy();
     expect(screen.getAllByText(/On branch feature\/task-debug/)[0]).toBeVisible();
     expect(screen.getAllByText(/nothing to commit/)[0]).toBeVisible();
@@ -417,6 +425,66 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText("stdout notes")).toBeTruthy();
     expect(screen.getByText("shell-stderr.txt")).toBeTruthy();
     expect(screen.getByText("No bytes captured for this stream.")).toBeTruthy();
+  });
+
+  it("shows missing output streams for failed tool diagnostics", async () => {
+    const { render, user } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-tool",
+          type: "tool_call",
+          title: "git_exec",
+          step_id: "step-git",
+          tool_name: "git_exec",
+          kind: "git",
+          status: "failed",
+          summary: { command: "git status", exit_code: 128, stdout_bytes: 0, stderr_bytes: 0 },
+        }),
+      ],
+    });
+    render();
+
+    await user.click(screen.getAllByText("Advanced")[0]);
+
+    expect(screen.getByText("git status")).toBeTruthy();
+    expect(screen.getByText("128")).toBeTruthy();
+    expect(screen.getByText("No stdout or stderr artifacts were captured for this tool.")).toBeTruthy();
+  });
+
+  it("shows when a failed tool has stdout but no stderr artifact", async () => {
+    const { render, user } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-tool",
+          type: "tool_call",
+          title: "git_exec",
+          step_id: "step-git",
+          tool_name: "git_exec",
+          kind: "git",
+          status: "failed",
+          summary: { command: "git status", exit_code: 128, stdout_bytes: 14 },
+        }),
+        makeActivity({
+          id: "activity-stdout",
+          type: "artifact",
+          title: "git-stdout.txt",
+          step_id: "step-git",
+          artifact_id: "art-stdout",
+          kind: "stdout",
+          status: "ready",
+          summary: {
+            size_bytes: 14,
+            content_preview: "stdout only",
+          },
+        }),
+      ],
+    });
+    render();
+
+    await user.click(screen.getAllByText("Advanced")[0]);
+
+    expect(screen.getByText("stdout only")).toBeTruthy();
+    expect(screen.getByText("stderr artifact was not captured for this tool.")).toBeTruthy();
   });
 
   it("shows when stderr exists but is empty", () => {

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -451,6 +451,42 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText("No stdout or stderr artifacts were captured for this tool.")).toBeTruthy();
   });
 
+  it("does not show output from another step when a failed tool has no matching artifacts", async () => {
+    const { render, user } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-tool",
+          type: "tool_call",
+          title: "git_exec",
+          step_id: "step-git",
+          tool_name: "git_exec",
+          kind: "git",
+          status: "failed",
+          summary: { command: "git status", exit_code: 128 },
+        }),
+        makeActivity({
+          id: "activity-other-stdout",
+          type: "artifact",
+          title: "other-stdout.txt",
+          step_id: "step-other",
+          artifact_id: "art-other-stdout",
+          kind: "stdout",
+          status: "ready",
+          summary: {
+            size_bytes: 24,
+            content_preview: "unrelated output",
+          },
+        }),
+      ],
+    });
+    render();
+
+    await user.click(screen.getAllByText("Advanced")[0]);
+
+    expect(screen.getByText("No stdout or stderr artifacts were captured for this tool.")).toBeTruthy();
+    expect(screen.queryByText("unrelated output")).toBeNull();
+  });
+
   it("shows when a failed tool has stdout but no stderr artifact", async () => {
     const { render, user } = setup({
       activity: [

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -862,46 +862,159 @@ function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
         activities={rows}
         defaultOpen
         renderAdvancedActivity={(item) => item.id
-          ? <TaskActivityAdvancedDetails activity={activityByID.get(item.id)} />
+          ? <TaskActivityAdvancedDetails activity={activityByID.get(item.id)} allActivity={activity} />
           : null}
       />
     </div>
   );
 }
 
-function TaskActivityAdvancedDetails({ activity }: { activity?: TaskActivityRecord }) {
+function TaskActivityAdvancedDetails({ activity, allActivity }: { activity?: TaskActivityRecord; allActivity: TaskActivityRecord[] }) {
   if (!activity) return null;
   const rows = taskActivityAdvancedRows(activity);
-  if (rows.length === 0) return null;
+  const diagnostics = failedToolOutputArtifacts(activity, allActivity);
+  if (rows.length === 0 && diagnostics.length === 0) return null;
 
   return (
     <div style={{ display: "grid", gap: 5 }}>
-      {rows.map(row => (
-        <div
-          key={row.label}
-          style={{
-            display: "grid",
-            gridTemplateColumns: "92px minmax(0, 1fr)",
-            gap: 8,
-            alignItems: "baseline",
-          }}
-        >
-          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-            {row.label}
-          </span>
-          <span style={{
-            color: "var(--t1)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 10,
-            overflowWrap: "anywhere",
-            whiteSpace: row.multiline ? "pre-wrap" : "normal",
-          }}>
-            {row.value}
-          </span>
-        </div>
-      ))}
+      {diagnostics.length > 0 && (
+        <TaskActivityOutputDiagnostics artifacts={diagnostics} />
+      )}
+      {rows.length > 0 && (
+        <details open={diagnostics.length === 0}>
+          <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+            Raw metadata
+          </summary>
+          <div style={{ display: "grid", gap: 5, marginTop: 6 }}>
+            {rows.map(row => (
+              <div
+                key={row.label}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "92px minmax(0, 1fr)",
+                  gap: 8,
+                  alignItems: "baseline",
+                }}
+              >
+                <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+                  {row.label}
+                </span>
+                <span style={{
+                  color: "var(--t1)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  overflowWrap: "anywhere",
+                  whiteSpace: row.multiline ? "pre-wrap" : "normal",
+                }}>
+                  {row.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
+}
+
+function TaskActivityOutputDiagnostics({ artifacts }: { artifacts: TaskActivityRecord[] }) {
+  return (
+    <div style={{ display: "grid", gap: 7 }}>
+      <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>
+        This tool failed. Related run output is previewed here; the full stdout/stderr capture remains in run output.
+      </div>
+      <div style={{ display: "grid", gap: 7 }}>
+        {artifacts.map(artifact => (
+          <TaskActivityOutputPreview
+            key={artifact.artifact_id || artifact.id}
+            artifact={artifact}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord }) {
+  const stream = outputActivityStream(artifact);
+  const isStderr = stream === "stderr";
+  const preview = taskActivityArtifactPreview(artifact);
+  const size = taskActivityArtifactSize(artifact);
+  return (
+    <div style={{
+      border: `1px solid ${isStderr ? "rgba(239, 95, 95, 0.28)" : "var(--border)"}`,
+      borderRadius: "var(--radius-sm)",
+      background: "var(--bg0)",
+      overflow: "hidden",
+    }}>
+      <div style={{
+        alignItems: "center",
+        borderBottom: "1px solid var(--border)",
+        display: "flex",
+        gap: 8,
+        padding: "4px 7px",
+      }}>
+        <span style={{
+          color: isStderr ? "var(--red)" : "var(--t1)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+        }}>
+          {artifact.title || stream}
+        </span>
+        <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+          {size ? `${size}b` : "empty"}
+        </span>
+      </div>
+      {preview ? (
+        <pre style={{
+          color: isStderr ? "var(--red)" : "var(--t1)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          lineHeight: 1.55,
+          margin: 0,
+          maxHeight: 130,
+          overflow: "auto",
+          padding: "7px",
+          whiteSpace: "pre-wrap",
+        }}>{preview}</pre>
+      ) : (
+        <div style={{ color: "var(--t3)", fontSize: 11, padding: "7px" }}>
+          {size ? "Preview unavailable in this snapshot." : "No bytes captured for this stream."}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function failedToolOutputArtifacts(activity: TaskActivityRecord, allActivity: TaskActivityRecord[]): TaskActivityRecord[] {
+  if (activity.type !== "tool_call" || activity.status !== "failed") return [];
+  const seen = new Set<string>();
+  const matchingStep = activity.step_id || "";
+  const related = allActivity.filter(item => {
+    if (item.type !== "artifact" || !isOutputArtifactActivity(item)) return false;
+    if (matchingStep && item.step_id && item.step_id !== matchingStep) return false;
+    return true;
+  });
+  const scoped = matchingStep && related.some(item => item.step_id === matchingStep)
+    ? related.filter(item => item.step_id === matchingStep)
+    : related;
+  return scoped.filter(item => {
+    const key = item.artifact_id || item.id;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function isOutputArtifactActivity(activity: TaskActivityRecord): boolean {
+  return outputActivityStream(activity) !== "";
+}
+
+function outputActivityStream(activity: TaskActivityRecord): "stdout" | "stderr" | "" {
+  const label = `${activity.kind ?? ""} ${activity.title ?? ""} ${activity.path ?? ""}`.toLowerCase();
+  if (label.includes("stderr")) return "stderr";
+  if (label.includes("stdout")) return "stdout";
+  return "";
 }
 
 function taskActivityAdvancedRows(activity: TaskActivityRecord): Array<{ label: string; value: string; multiline?: boolean }> {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentChatActivityRecord, TaskActivityRecord, TaskApprovalRecord, TaskArtifactRecord, TaskRecord, TaskRunEventRecord, TaskRunRecord, TaskStepRecord } from "../../types/runtime";
 import { Badge, Dot, Icon, Icons, Modal } from "../shared/ui";
 import { TranscriptActivityTimeline } from "../transcript/TranscriptActivityTimeline";
@@ -854,6 +854,7 @@ function StepRowTitle({ step }: { step: TaskStepRecord }) {
 
 function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
   const activityByID = new Map(activity.map(item => [item.id, item]));
+  const outputArtifacts = useMemo(() => buildOutputActivityIndex(activity), [activity]);
   const rows = activity.map(taskActivityToTranscriptActivity);
   return (
     <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>
@@ -862,17 +863,22 @@ function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
         activities={rows}
         defaultOpen
         renderAdvancedActivity={(item) => item.id
-          ? <TaskActivityAdvancedDetails activity={activityByID.get(item.id)} allActivity={activity} />
+          ? <TaskActivityAdvancedDetails activity={activityByID.get(item.id)} outputArtifacts={outputArtifacts} />
           : null}
       />
     </div>
   );
 }
 
-function TaskActivityAdvancedDetails({ activity, allActivity }: { activity?: TaskActivityRecord; allActivity: TaskActivityRecord[] }) {
+type OutputActivityIndex = {
+  all: TaskActivityRecord[];
+  byStepID: Map<string, TaskActivityRecord[]>;
+};
+
+function TaskActivityAdvancedDetails({ activity, outputArtifacts }: { activity?: TaskActivityRecord; outputArtifacts: OutputActivityIndex }) {
   if (!activity) return null;
   const rows = taskActivityAdvancedRows(activity);
-  const diagnostics = failedToolOutputArtifacts(activity, allActivity);
+  const diagnostics = failedToolOutputArtifacts(activity, outputArtifacts);
   const isFailedTool = activity.type === "tool_call" && activity.status === "failed";
   if (rows.length === 0 && diagnostics.length === 0 && !isFailedTool) return null;
 
@@ -1056,24 +1062,31 @@ function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord 
   );
 }
 
-function failedToolOutputArtifacts(activity: TaskActivityRecord, allActivity: TaskActivityRecord[]): TaskActivityRecord[] {
-  if (activity.type !== "tool_call" || activity.status !== "failed") return [];
+function buildOutputActivityIndex(activity: TaskActivityRecord[]): OutputActivityIndex {
+  const all: TaskActivityRecord[] = [];
+  const byStepID = new Map<string, TaskActivityRecord[]>();
   const seen = new Set<string>();
-  const matchingStep = activity.step_id || "";
-  const related = allActivity.filter(item => {
-    if (item.type !== "artifact" || !isOutputArtifactActivity(item)) return false;
-    if (matchingStep && item.step_id && item.step_id !== matchingStep) return false;
-    return true;
-  });
-  const scoped = matchingStep && related.some(item => item.step_id === matchingStep)
-    ? related.filter(item => item.step_id === matchingStep)
-    : related;
-  return scoped.filter(item => {
+  for (const item of activity) {
+    if (item.type !== "artifact" || !isOutputArtifactActivity(item)) continue;
     const key = item.artifact_id || item.id;
-    if (seen.has(key)) return false;
+    if (seen.has(key)) continue;
     seen.add(key);
-    return true;
-  });
+    all.push(item);
+    if (item.step_id) {
+      const scoped = byStepID.get(item.step_id) ?? [];
+      scoped.push(item);
+      byStepID.set(item.step_id, scoped);
+    }
+  }
+  return { all, byStepID };
+}
+
+function failedToolOutputArtifacts(activity: TaskActivityRecord, outputArtifacts: OutputActivityIndex): TaskActivityRecord[] {
+  if (activity.type !== "tool_call" || activity.status !== "failed") return [];
+  const matchingStep = activity.step_id || "";
+  return matchingStep && outputArtifacts.byStepID.has(matchingStep)
+    ? outputArtifacts.byStepID.get(matchingStep) ?? []
+    : outputArtifacts.all;
 }
 
 function isOutputArtifactActivity(activity: TaskActivityRecord): boolean {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -873,15 +873,16 @@ function TaskActivityAdvancedDetails({ activity, allActivity }: { activity?: Tas
   if (!activity) return null;
   const rows = taskActivityAdvancedRows(activity);
   const diagnostics = failedToolOutputArtifacts(activity, allActivity);
-  if (rows.length === 0 && diagnostics.length === 0) return null;
+  const isFailedTool = activity.type === "tool_call" && activity.status === "failed";
+  if (rows.length === 0 && diagnostics.length === 0 && !isFailedTool) return null;
 
   return (
     <div style={{ display: "grid", gap: 5 }}>
-      {diagnostics.length > 0 && (
-        <TaskActivityOutputDiagnostics artifacts={diagnostics} />
+      {isFailedTool && (
+        <TaskActivityFailureDiagnostics activity={activity} artifacts={diagnostics} />
       )}
       {rows.length > 0 && (
-        <details open={diagnostics.length === 0}>
+        <details open={!isFailedTool}>
           <summary style={{ cursor: "pointer", fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
             Raw metadata
           </summary>
@@ -917,20 +918,83 @@ function TaskActivityAdvancedDetails({ activity, allActivity }: { activity?: Tas
   );
 }
 
-function TaskActivityOutputDiagnostics({ artifacts }: { artifacts: TaskActivityRecord[] }) {
+function TaskActivityFailureDiagnostics({ activity, artifacts }: { activity: TaskActivityRecord; artifacts: TaskActivityRecord[] }) {
+  const command = summaryString(activity, "command");
+  const exitCode = summaryNumber(activity, "exit_code");
+  const stdoutBytes = summaryNumber(activity, "stdout_bytes");
+  const stderrBytes = summaryNumber(activity, "stderr_bytes");
+  const hasStdout = artifacts.some(artifact => outputActivityStream(artifact) === "stdout");
+  const hasStderr = artifacts.some(artifact => outputActivityStream(artifact) === "stderr");
+  const facts = [
+    command ? { label: "command", value: command } : null,
+    exitCode !== undefined ? { label: "exit", value: String(exitCode) } : null,
+    stdoutBytes !== undefined ? { label: "stdout", value: `${stdoutBytes}b` } : null,
+    stderrBytes !== undefined ? { label: "stderr", value: `${stderrBytes}b` } : null,
+  ].filter((item): item is { label: string; value: string } => Boolean(item));
+
   return (
     <div style={{ display: "grid", gap: 7 }}>
       <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>
-        This tool failed. Related run output is previewed here; the full stdout/stderr capture remains in run output.
+        This tool failed. The summary below shows what Hecate captured for the tool call; full streams remain in run output when artifacts exist.
       </div>
+      {facts.length > 0 && (
+        <div style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 6,
+        }}>
+          {facts.map(fact => (
+            <span
+              key={fact.label}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 999,
+                color: "var(--t2)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                padding: "3px 7px",
+              }}
+            >
+              <span style={{ color: "var(--t3)" }}>{fact.label}</span>{" "}
+              <span style={{ color: fact.label === "exit" && fact.value !== "0" ? "var(--red)" : "var(--t1)" }}>
+                {fact.value}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
       <div style={{ display: "grid", gap: 7 }}>
-        {artifacts.map(artifact => (
-          <TaskActivityOutputPreview
-            key={artifact.artifact_id || artifact.id}
-            artifact={artifact}
-          />
-        ))}
+        {artifacts.length > 0 ? (
+          artifacts.map(artifact => (
+            <TaskActivityOutputPreview
+              key={artifact.artifact_id || artifact.id}
+              artifact={artifact}
+            />
+          ))
+        ) : (
+          <TaskActivityMissingOutput message="No stdout or stderr artifacts were captured for this tool." />
+        )}
+        {!hasStdout && artifacts.length > 0 && (
+          <TaskActivityMissingOutput message="stdout artifact was not captured for this tool." />
+        )}
+        {!hasStderr && artifacts.length > 0 && (
+          <TaskActivityMissingOutput message="stderr artifact was not captured for this tool." />
+        )}
       </div>
+    </div>
+  );
+}
+
+function TaskActivityMissingOutput({ message }: { message: string }) {
+  return (
+    <div style={{
+      border: "1px dashed var(--border)",
+      borderRadius: "var(--radius-sm)",
+      color: "var(--t3)",
+      fontSize: 11,
+      padding: "7px",
+    }}>
+      {message}
     </div>
   );
 }
@@ -1134,6 +1198,11 @@ function taskActivitySubtitle(item: TaskActivityRecord): string | undefined {
 function summaryString(item: TaskActivityRecord, key: string): string {
   const value = item.summary?.[key];
   return typeof value === "string" ? value.trim() : "";
+}
+
+function summaryNumber(item: TaskActivityRecord, key: string): number | undefined {
+  const value = item.summary?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function nonInternalKind(kind?: string): string {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -940,6 +940,12 @@ function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord 
   const isStderr = stream === "stderr";
   const preview = taskActivityArtifactPreview(artifact);
   const size = taskActivityArtifactSize(artifact);
+  const sizeLabel = size === undefined ? "unknown size" : size === 0 ? "empty" : `${size}b`;
+  const emptyMessage = size === undefined
+    ? "Preview unavailable in this snapshot."
+    : size === 0
+      ? "No bytes captured for this stream."
+      : "Preview unavailable in this snapshot.";
   return (
     <div style={{
       border: `1px solid ${isStderr ? "rgba(239, 95, 95, 0.28)" : "var(--border)"}`,
@@ -962,7 +968,7 @@ function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord 
           {artifact.title || stream}
         </span>
         <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-          {size ? `${size}b` : "empty"}
+          {sizeLabel}
         </span>
       </div>
       {preview ? (
@@ -979,7 +985,7 @@ function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord 
         }}>{preview}</pre>
       ) : (
         <div style={{ color: "var(--t3)", fontSize: 11, padding: "7px" }}>
-          {size ? "Preview unavailable in this snapshot." : "No bytes captured for this stream."}
+          {emptyMessage}
         </div>
       )}
     </div>

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1084,9 +1084,10 @@ function buildOutputActivityIndex(activity: TaskActivityRecord[]): OutputActivit
 function failedToolOutputArtifacts(activity: TaskActivityRecord, outputArtifacts: OutputActivityIndex): TaskActivityRecord[] {
   if (activity.type !== "tool_call" || activity.status !== "failed") return [];
   const matchingStep = activity.step_id || "";
-  return matchingStep && outputArtifacts.byStepID.has(matchingStep)
-    ? outputArtifacts.byStepID.get(matchingStep) ?? []
-    : outputArtifacts.all;
+  if (matchingStep) {
+    return outputArtifacts.byStepID.get(matchingStep) ?? [];
+  }
+  return outputArtifacts.all;
 }
 
 function isOutputArtifactActivity(activity: TaskActivityRecord): boolean {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -177,6 +177,16 @@ button, input, select, textarea { font: inherit; }
 .input:focus-visible { box-shadow: 0 0 0 1px var(--teal-border); }
 .input::placeholder { color: var(--t3); }
 
+.queued-chat-message-input {
+  background: transparent;
+  border: 1px solid transparent;
+}
+.queued-chat-message-input:focus,
+.queued-chat-message-input:focus-visible {
+  background: var(--bg3);
+  border-color: var(--border);
+}
+
 .select {
   background: var(--bg3); border: 1px solid var(--border); border-radius: var(--radius-sm);
   color: var(--t0); font-family: var(--font-sans); font-size: 12px;

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -96,6 +96,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleViewModel["actions"
     setChatTarget: () => undefined,
     setMessage: () => undefined,
     removeQueuedChatMessage: () => undefined,
+    updateQueuedChatMessage: () => undefined,
     setSystemPrompt: () => undefined,
     setModel: () => undefined,
     setModelFilter: () => undefined,


### PR DESCRIPTION
## Summary

- Make queued Hecate Chat prompts editable while they wait behind an active task-backed run.
- Drop cleared queued prompts before dispatch so an empty queued item cannot send later by accident.
- Improve Task Detail failed-tool diagnostics by previewing related stdout/stderr artifacts in the Advanced disclosure and explicitly showing empty stderr captures.
- Update chat/session and agent-runtime docs to describe editable queues and failed-tool diagnostic behavior.

## Why

Hecate Chat already supports queuing prompts while a task-backed loop is busy, but queued text was previously fixed once submitted. That made small corrections awkward and forced operators to remove/retype prompts. Separately, failed tool rows in Task Detail exposed raw metadata, but did not make the common “what did stdout/stderr say?” path easy enough to inspect.

## Validation

- cd ui && bun run typecheck
- cd ui && bun run test -- ChatView.test.tsx TaskDetail.test.tsx useRuntimeConsole.test.tsx