### PR TITLE
Clean up stale legacy: cmd/gateway, one-binary phrasing, make→just

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ provider credentials. Contributions land easier when they read like that.
 ## Where to start
 
 - **Working with an AI assistant** (Claude Code, Codex, Cursor, etc.): the orientation entry is [`AGENTS.md`](AGENTS.md). The canonical, vendor-neutral instruction layer is [`docs-ai/`](docs-ai/README.md). Tool-specific files ([`CLAUDE.md`](CLAUDE.md), [`.cursor/rules/`](.cursor/rules/)) are thin adapters that point there.
-- **Working without an AI assistant**: read [`AGENTS.md`](AGENTS.md) for the codebase map and runtime invariants, then [`docs/development.md`](docs/development.md) for local build / hot-reload / make targets.
+- **Working without an AI assistant**: read [`AGENTS.md`](AGENTS.md) for the codebase map and runtime invariants, then [`docs/development.md`](docs/development.md) for local build / hot-reload / just targets.
 
 The `docs-ai/` tree mirrors the operating loop:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ provider credentials. Contributions land easier when they read like that.
 ## Where to start
 
 - **Working with an AI assistant** (Claude Code, Codex, Cursor, etc.): the orientation entry is [`AGENTS.md`](AGENTS.md). The canonical, vendor-neutral instruction layer is [`docs-ai/`](docs-ai/README.md). Tool-specific files ([`CLAUDE.md`](CLAUDE.md), [`.cursor/rules/`](.cursor/rules/)) are thin adapters that point there.
-- **Working without an AI assistant**: read [`AGENTS.md`](AGENTS.md) for the codebase map and runtime invariants, then [`docs/development.md`](docs/development.md) for local build / hot-reload / just targets.
+- **Working without an AI assistant**: read [`AGENTS.md`](AGENTS.md) for the codebase map and runtime invariants, then [`docs/development.md`](docs/development.md) for local build / hot-reload / just recipes.
 
 The `docs-ai/` tree mirrors the operating loop:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,10 +59,13 @@ Hecate stores local configuration and operational state on disk.
 
 ## Native app and sidecars
 
-The desktop app is a Tauri shell around the same Hecate gateway binary.
+The desktop app is a Tauri shell that bundles two Hecate binaries: the
+`hecate` gateway it runs as its primary sidecar, and `hecate-acp` for
+editor ACP integrations.
 
 - The app launches `hecate` as a sidecar on a free loopback port.
-- The app bundle also ships `hecate-acp` for editor ACP integrations.
+- The app bundle also ships `hecate-acp` so editors that drive Hecate
+  through the Agent Client Protocol can spawn it directly.
 - Bundles are not yet code-signed, so macOS Gatekeeper and Windows SmartScreen warnings are expected for now.
 - Quitting the app should stop the sidecar; closing a window may not quit the app on every platform.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,11 +61,11 @@ Hecate stores local configuration and operational state on disk.
 
 The desktop app is a Tauri shell that bundles two Hecate binaries: the
 `hecate` gateway it runs as its primary sidecar, and `hecate-acp` for
-editor ACP integrations.
+editor Agent Client Protocol (ACP) integrations.
 
 - The app launches `hecate` as a sidecar on a free loopback port.
 - The app bundle also ships `hecate-acp` so editors that drive Hecate
-  through the Agent Client Protocol can spawn it directly.
+  through ACP can spawn it directly.
 - Bundles are not yet code-signed, so macOS Gatekeeper and Windows SmartScreen warnings are expected for now.
 - Quitting the app should stop the sidecar; closing a window may not quit the app on every platform.
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -118,7 +118,7 @@ type ProviderRuntime interface {
 }
 
 // NewHandler wires the api.Handler from already-constructed dependencies.
-// Storage backends (taskStore, taskQueue) are built by cmd/gateway/main.go
+// Storage backends (taskStore, taskQueue) are built by cmd/hecate/main.go
 // alongside every other backend the gateway uses, so all dispatch lives in
 // one place. taskQueue may be nil — the runner falls back to its default
 // in-process queue, which is what the test fixtures rely on.
@@ -412,7 +412,7 @@ func (h *Handler) rebuildMCPHostFactory() {
 }
 
 // Shutdown stops the underlying task runner and tears down the shared
-// MCP client cache. Bounded by ctx; called from cmd/gateway/main.go on
+// MCP client cache. Bounded by ctx; called from cmd/hecate/main.go on
 // SIGTERM so in-flight agent loops cancel cleanly and any spawned MCP
 // subprocesses don't orphan when the gateway exits.
 //

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -145,7 +145,7 @@ pre { background: #f3f4f6; padding: 1rem; border-radius: 0.5rem; overflow-x: aut
 build the UI before the gateway:</p>
 <pre>make ui-install
 make ui-build
-go build -o gateway ./cmd/gateway</pre>
+go build -o hecate ./cmd/hecate</pre>
 <p class="note">For UI-only iteration, run the dev server:
 <code>make ui-dev</code> opens the React app on
 <code>http://127.0.0.1:5173</code> with API calls proxied to this gateway.</p>

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -142,10 +142,9 @@ pre { background: #f3f4f6; padding: 1rem; border-radius: 0.5rem; overflow-x: aut
 <p>The gateway API is fully functional — try
 <a href="/healthz"><code>GET /healthz</code></a> or
 <a href="/v1/models"><code>GET /v1/models</code></a>. To enable this dashboard,
-build the UI before the gateway:</p>
+build the UI bundle into the binary:</p>
 <pre>just ui-install
-just ui-build
-go build -o hecate ./cmd/hecate</pre>
+just build</pre>
 <p class="note">For UI-only iteration, run the dev server:
 <code>just ui-dev</code> opens the React app on
 <code>http://127.0.0.1:5173</code> with API calls proxied to this gateway.</p>

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -143,11 +143,11 @@ pre { background: #f3f4f6; padding: 1rem; border-radius: 0.5rem; overflow-x: aut
 <a href="/healthz"><code>GET /healthz</code></a> or
 <a href="/v1/models"><code>GET /v1/models</code></a>. To enable this dashboard,
 build the UI before the gateway:</p>
-<pre>make ui-install
-make ui-build
+<pre>just ui-install
+just ui-build
 go build -o hecate ./cmd/hecate</pre>
 <p class="note">For UI-only iteration, run the dev server:
-<code>make ui-dev</code> opens the React app on
+<code>just ui-dev</code> opens the React app on
 <code>http://127.0.0.1:5173</code> with API calls proxied to this gateway.</p>
 </body>
 </html>

--- a/internal/api/static_test.go
+++ b/internal/api/static_test.go
@@ -107,7 +107,7 @@ func TestStaticHandlerDoesNotFallbackForUnknownAPIPath(t *testing.T) {
 }
 
 // TestStaticHandlerServesFallbackWhenUINotBuilt covers the common dev case
-// where the binary was built without first running `make ui-build` — the
+// where the binary was built without first running `just ui-build` — the
 // embedded ui/dist contains only the .gitkeep placeholder. The handler must
 // not 500 or 404; it returns a friendly HTML page that points at the fix.
 func TestStaticHandlerServesFallbackWhenUINotBuilt(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,7 +280,7 @@ type RetentionPolicy struct {
 
 type SQLiteConfig struct {
 	// Path is the on-disk file. Defaults to .data/hecate.db so a fresh
-	// `make dev` plus `GATEWAY_*_BACKEND=sqlite` Just Works without
+	// `just dev` plus `GATEWAY_*_BACKEND=sqlite` Just Works without
 	// extra mkdir or env. Parent directories are auto-created.
 	Path        string
 	TablePrefix string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -518,7 +518,7 @@ func TestLoadFromEnvBootstrapFileDefault(t *testing.T) {
 
 	cfg := LoadFromEnv()
 	if cfg.Server.BootstrapFile != "" {
-		t.Fatalf("BootstrapFile default = %q, want empty (cmd/gateway derives it from DataDir)", cfg.Server.BootstrapFile)
+		t.Fatalf("BootstrapFile default = %q, want empty (cmd/hecate derives it from DataDir)", cfg.Server.BootstrapFile)
 	}
 }
 

--- a/internal/controlplane/env_import.go
+++ b/internal/controlplane/env_import.go
@@ -15,7 +15,7 @@ import (
 // conflict: if a row already exists for the same id we leave it alone and let
 // the operator's admin-panel changes stand.
 //
-// Called once at startup from cmd/gateway/main.go after the provider runtime
+// Called once at startup from cmd/hecate/main.go after the provider runtime
 // reload. Logs each upsert at info level and tolerates per-row failures
 // (logs at warn) so a single bad config can't keep the gateway from booting.
 func AutoImportEnvProviders(ctx context.Context, logger *slog.Logger, store Store, configs []config.OpenAICompatibleProviderConfig) error {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,5 @@
 // Package version exposes the gateway's build version as a single
-// package-level variable so both cmd/gateway and internal/api can read
+// package-level variable so both cmd/hecate and internal/api can read
 // it without an import cycle.
 //
 // Defaults to "dev" for local builds. goreleaser overrides it via


### PR DESCRIPTION
## Summary

A small, mechanical cleanup pass against the legacy items called out in [`docs/beta-roadmap.md`](docs/beta-roadmap.md):

> **Remove stale legacy**: old endpoint names, old \`/gateway\` language, **one-binary claims**, stale screenshots, obsolete scripts, dead fixtures, and duplicate UI rendering paths are removed.

Four narrowly-scoped commits, each one concern. No behavior change.

### `0958db17` — `refactor: update stale cmd/gateway references to cmd/hecate`

Commit `3af790e9 build: rename gateway binary to hecate` renamed the binary's main package from \`cmd/gateway\` to \`cmd/hecate\`. Six references didn't get cleaned up at the time and have been broken ever since:

- `internal/api/static.go:148` — **operator-visible HTML** served when the gateway is built without an embedded UI. It told operators to run \`go build -o gateway ./cmd/gateway\`, which fails because that path no longer exists. This was the worst one.
- `internal/api/handler.go` (×2), `internal/controlplane/env_import.go`, `internal/version/version.go`, `internal/config/config_test.go` — code comments and a test failure message pointing at the dead path.

### `98248699` — `docs(security): clarify desktop app ships hecate and hecate-acp`

`docs/security.md` opened the "Native app and sidecars" section with "The desktop app is a Tauri shell around the same Hecate gateway binary" and then immediately admitted in bullets that the bundle ships **two** binaries (\`hecate\` and \`hecate-acp\`). The header is "sidecars", plural; the opening sentence read as a one-binary claim.

Rewrote the opening to name both binaries up front and expanded the \`hecate-acp\` bullet from "for editor ACP integrations" to say what it actually does (editors that drive Hecate through ACP spawn it directly).

### `1dadee48` — `docs: replace stale 'make ui-*' references with 'just ui-*'`

This repo has no Makefile — the build orchestrator is justfile (recipes \`ui-install\`, \`ui-build\`, \`ui-dev\`, \`build\`). Two operator-facing references kept the old wording:

- `internal/api/static.go` — the same fallback HTML, still telling operators to run \`make ui-install\` / \`make ui-build\` / \`make ui-dev\`. Operators copy-pasting from the page hit "make: no Makefile" before reaching anything Hecate-specific.
- `internal/api/static_test.go` — a doc comment on the corresponding test that referenced \`make ui-build\` for context.

### `c0d5fe93` — `docs: replace remaining stale 'make' references with 'just'`

Two more leftover \`make\` references the prior sweep didn't catch:

- `CONTRIBUTING.md:10` pointed readers at \`docs/development.md\` for "local build / hot-reload / make targets". The doc itself uses \`just\` consistently — only the pointer was stale.
- `internal/config/config.go:283` documents the SQLite default with "\`make dev\` plus \`GATEWAY_*_BACKEND=sqlite\` Just Works without extra mkdir or env." Recipe is \`just dev\`. The "Just Works" pun on \`just\` is now more apt, not less.

## Items I checked and ruled out

I also surveyed for the other roadmap categories. Nothing else to do here:

- **Old endpoint names** — \`/admin/*\` was cleanly removed; no live routes, no UI references. The mention in `internal/api/server.go:163` is a "replaces /admin/control-plane" comment (helpful migration context). The mentions in `docs/rfcs/endpoint-versioning-and-settings-paths.md` are the migration RFC itself (intentional history).
- **Stale screenshots** — refreshed in `098d1f39` (3 commits before this branch).
- **Obsolete scripts** — all six scripts under `scripts/` are actively used.
- **Dead fixtures** — `internal/billing/litellm/testdata/sample.json` is exercised by tests.
- **`hecate-gateway`** appearing in source — that's the OTel `service.name`, a stable identifier; renaming would break operator dashboards.
- **`tauri/src-tauri/binaries/gateway*` ignore rule** — initially flagged this as stale, then re-read the inline comment ("Ignore stale pre-rename sidecars left by older local builds") and realized it's a deliberate cross-version compatibility shim added 5 days ago in `a002ca03`. **Withdrawn** before commit.
- **Duplicate UI rendering paths** (Task Detail vs ChatView transcript convergence) — explicitly called out in the roadmap but a multi-day refactor, out of scope for a sweep.

## Test plan

- [x] \`go build ./...\` — green
- [x] \`go test -race -count=1 -timeout 5m ./...\` — 1721 tests passed across 37 packages
- [x] \`bun run typecheck\` — clean
- [x] \`bun run test\` — 647 UI tests across 29 files
- [x] Spot-check: served the fallback HTML locally and confirmed the build instructions are now copy-paste-runnable