### PR TITLE
Env var docs: document 5 missing knobs, drop stale 'make' refs, fix auto-import claim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,12 +39,13 @@ GATEWAY_CONTROL_PLANE_KEY=control-plane
 GATEWAY_CONTROL_PLANE_SECRET_KEY=
 
 # Providers
-# `PROVIDER_<NAME>_*` env vars seed the runtime provider registry so the
-# gateway can route to a provider on boot, but they do NOT auto-add the
-# provider to the Providers tab in the operator UI. To manage a provider
-# from the UI (rotate keys, change base URL, delete), add it explicitly
-# in the Providers tab. Env vars are a deployment-time convenience for
-# first boot; the modal is the source of truth for ongoing changes.
+# `PROVIDER_<NAME>_*` env vars seed the runtime provider registry on
+# boot and are also auto-imported into the persisted Providers tab so
+# operators can see and manage them through the UI. On subsequent
+# boots the auto-import skips any provider already present in the
+# Providers tab, so operator edits made via the UI are never
+# overwritten by environment values. Env vars are a first-boot
+# convenience; the Providers tab is the source of truth thereafter.
 # See docs/providers.md for the full lifecycle.
 #
 # For client integration recipes (Codex / Claude Code), see docs/client-integration.md.

--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,12 @@ GATEWAY_PROVIDER_RETRY_BACKOFF=200ms
 GATEWAY_PROVIDER_FAILOVER_ENABLED=true
 GATEWAY_PROVIDER_HEALTH_FAILURE_THRESHOLD=3
 GATEWAY_PROVIDER_HEALTH_COOLDOWN=30s
+# Mark a provider `degraded` (route diagnostics surface it as
+# `provider_slow`) when successful calls take at-or-above this duration.
+# Degraded providers stay routable but lose to healthy peers in router
+# scoring. 0 disables the latency tier; healthy/unhealthy is then driven
+# only by the failure-threshold + cooldown above. See docs/providers.md.
+GATEWAY_PROVIDER_HEALTH_LATENCY_DEGRADED_THRESHOLD=0
 
 # Provider health history store. Backs the persisted event log behind
 # GET /hecate/v1/providers/history (state transitions: success, slow_success,
@@ -145,6 +151,21 @@ GATEWAY_TASK_RECONCILE_INTERVAL=30s
 GATEWAY_TASK_MAX_CONCURRENT_PER_TENANT=0
 # Cap on agent_loop LLM round-trips per run. Runaway-cost safety net.
 GATEWAY_TASK_AGENT_LOOP_MAX_TURNS=8
+# Cap on how many `mcp_servers` an agent_loop task may declare. Each
+# entry produces one MCP client (subprocess for stdio, persistent
+# connection for http) so this is a per-task resource ceiling, not a
+# global one.
+GATEWAY_TASK_MAX_MCP_SERVERS_PER_TASK=16
+# Shared MCP client cache amortizes subprocess spawn cost across runs
+# that share the same upstream config.
+# _MAX_ENTRIES: distinct cached upstreams the cache holds at once;
+# inserts at-or-over the cap evict the least-recently-used entry.
+# _PING_INTERVAL: how often the cache proactively pings idle entries
+# to detect wedged-but-alive subprocesses; 0 disables the loop.
+# _PING_TIMEOUT: per-ping deadline; failure or timeout evicts.
+GATEWAY_TASK_MCP_CLIENT_CACHE_MAX_ENTRIES=256
+GATEWAY_TASK_MCP_CLIENT_CACHE_PING_INTERVAL=60s
+GATEWAY_TASK_MCP_CLIENT_CACHE_PING_TIMEOUT=5s
 # Global agent_loop system prompt — broadest layer of the three-layer
 # composition (global → workspace CLAUDE.md|AGENTS.md → per-task).
 # Empty disables the global layer; the others still apply.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Hecate runtime
-# Copy to `.env` and keep your real secrets there. `make dev` sources `.env` directly.
+# Copy to `.env` and keep your real secrets there. `just dev` sources `.env` directly.
 
 # Server
 # This is the client-facing gateway address for Codex/Claude-style traffic.
@@ -21,7 +21,7 @@ GATEWAY_ADDRESS=127.0.0.1:8765
 # GATEWAY_BOOTSTRAP_FILE is set explicitly.
 #
 # Leave commented out unless you need to override:
-#   - Local source dev (`make dev`, `make run`): defaults to `.data` —
+#   - Local source dev (`just dev`, `just run`): defaults to `.data` —
 #     relative to the repo root, gitignored.
 #   - Docker (`docker compose up`): the image bakes in `/data` as the
 #     mounted volume; setting this here would override that and break

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -108,9 +108,9 @@ The gateway ships with thirteen provider presets. None of them are auto-added â€
 
 ## Env-configured providers
 
-Setting `PROVIDER_<NAME>_API_KEY`, `PROVIDER_<NAME>_BASE_URL`, or `PROVIDER_<NAME>_DEFAULT_MODEL` in the environment seeds the runtime registry so the provider becomes reachable for routing. Env vars do **not** auto-add the provider to the Providers tab â€” operators who want it visible (and editable) must add it explicitly via the modal. This keeps the UI list a faithful record of operator intent rather than a mirror of every env var that happened to be set on first boot.
+Setting `PROVIDER_<NAME>_API_KEY`, `PROVIDER_<NAME>_BASE_URL`, or `PROVIDER_<NAME>_DEFAULT_MODEL` in the environment seeds the runtime registry so the provider becomes reachable for routing, and is also auto-imported into the persisted Providers tab so operators can see and manage it through the UI. On subsequent boots the auto-import skips any provider that already exists in the Providers tab, so operator edits made via the UI are never overwritten by environment values.
 
-Env vars are convenient for first-run bootstrapping in `.env` / Docker compose; the modal is the source of truth for ongoing changes.
+Env vars are convenient for first-run bootstrapping in `.env` / Docker compose; the Providers tab is the source of truth thereafter.
 
 ```bash
 PROVIDER_ANTHROPIC_API_KEY=sk-ant-...


### PR DESCRIPTION
## Summary

Two narrowly-scoped commits, each one concern. Tail end of the legacy-sweep + a new env-var documentation gap I caught while auditing `.env.example` against `internal/config/config.go`.

### `499e4938` — `docs(env): document 5 undocumented operator-tunable env vars`

Diffed every `getEnv*("GATEWAY_*"...)` call in `internal/config/config.go` (with dynamic constructions in `loadOTelSignalFromEnv` and `loadRetentionPolicyFromEnv` expanded out) against every `GATEWAY_*` line in `.env.example` (active + commented). After accounting for validation-message labels (e.g. `GATEWAY_RETENTION_TRACES`, which gets `_MAX_AGE` / `_MAX_COUNT` appended at error time), five real operator-tunable knobs were genuinely missing from `.env.example`:

| Var | Default | Section |
|---|---|---|
| `GATEWAY_PROVIDER_HEALTH_LATENCY_DEGRADED_THRESHOLD` | `0` (disabled) | Provider execution |
| `GATEWAY_TASK_MAX_MCP_SERVERS_PER_TASK` | `16` | Task runtime |
| `GATEWAY_TASK_MCP_CLIENT_CACHE_MAX_ENTRIES` | `256` | Task runtime |
| `GATEWAY_TASK_MCP_CLIENT_CACHE_PING_INTERVAL` | `60s` | Task runtime |
| `GATEWAY_TASK_MCP_CLIENT_CACHE_PING_TIMEOUT` | `5s` | Task runtime |

Each gets a doc comment that matches the existing style. The latency threshold cross-references `docs/providers.md` where the routing semantics are described in full. The MCP cache vars get one shared block since they configure the same subsystem.

The validation-error message in `config.go:534` already references `GATEWAY_PROVIDER_HEALTH_LATENCY_DEGRADED_THRESHOLD` by name, so the contract was implicit-but-unspelled in the doc surface.

### `e1689977` — `docs(env): replace stale 'make' references in .env.example`

Two `make` references PR #53's grep didn't catch — both inside `.env.example` itself, in comment text:

- Line 1 header: `# Copy to \`.env\` and keep your real secrets there. \`make dev\` sources \`.env\` directly.`
- Line 24, inside the `GATEWAY_DATA_DIR` doc block: `#   - Local source dev (\`make dev\`, \`make run\`): defaults to \`.data\` —`

The repo has no Makefile; both recipes exist as `just dev` and `just run` in the justfile.

## Test plan

- [x] `go test ./internal/config -count=1` — 31 tests pass
- [x] Diff between `getEnv*("GATEWAY_*"...)` calls in `config.go` (including dynamic constructions) and `.env.example` shows zero remaining gaps
- [x] No `make ` references remain in `.env.example`

### `294d04fe` — `docs: correct env-provider auto-import behavior on .env.example and providers.md`

(Added at operator request after the original audit; expands the PR's scope beyond pure env-var-doc gaps.)

Two operator-facing doc surfaces still claim that `PROVIDER_<NAME>_*` env vars do NOT auto-add the provider to the Providers tab:

- `.env.example:43`: *"they do NOT auto-add the provider to the Providers tab in the operator UI"*
- `docs/providers.md:111`: *"Env vars do **not** auto-add the provider to the Providers tab — operators who want it visible (and editable) must add it explicitly via the modal"*

That stopped being true in `1513fc14 chore: post-release cleanup pass` (~10 days ago), which introduced `controlplane.AutoImportEnvProviders` and wired it into `cmd/hecate/main.go:163`. The function mirrors every env-derived `OpenAICompatibleProviderConfig` into the control-plane store; the Providers tab reads from the same store via `HandleSettingsStatus` (`handler_settings.go:41-50`). So env-imported providers have actually been visible in the UI for ~10 days, contrary to the doc claim.

`internal/controlplane/env_import.go:12-16` (the function's own doc comment) describes the new behavior correctly; the operator-facing surfaces just didn't get updated in the same pass.

Rewrote both blocks to:
- State that env vars are auto-imported into the persisted Providers tab (the actual current behavior).
- Spell out the conflict policy: subsequent boots skip any provider already in the Providers tab, so operator edits made via the UI are not overwritten by environment values.
- Keep the *"first-boot convenience; UI is the source of truth thereafter"* framing — always accurate.
- Reword "modal" to "Providers tab" in the closing line for consistency with the rest of the section.
