### PR TITLE
docs(known-limitations): correct env-import auto-add claim

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -19,8 +19,11 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
 
 ## Provider Lifecycle
 
-- Operators add providers explicitly from the built-in preset catalog (or an
-  OpenAI-compatible custom endpoint flow); none are auto-added.
+- Operators add providers from the built-in preset catalog or an
+  OpenAI-compatible custom endpoint flow. `PROVIDER_<NAME>_*` env vars
+  also auto-import into the Providers tab on first boot; subsequent
+  boots leave operator UI edits untouched. See [providers.md](providers.md)
+  for the full env-vs-UI lifecycle.
 - Credentials, base URLs, defaults, and pricebook entries are managed through
   the persisted settings store. Taking a provider out of rotation is done by
   deleting it — there is no enable/disable toggle.


### PR DESCRIPTION
## Summary

One-commit follow-up to PR #54. Same `1513fc14`-era doc drift, third operator-facing surface — separate from PR #54 because it's a separate file with its own framing.

`docs/known-limitations.md`'s "Provider Lifecycle" section asserted:

> Operators add providers explicitly from the built-in preset catalog (or an OpenAI-compatible custom endpoint flow); none are auto-added.

The "none are auto-added" clause is wrong. `controlplane.AutoImportEnvProviders` (introduced in `1513fc14 chore: post-release cleanup pass`, ~10 days ago) auto-imports `PROVIDER_<NAME>_*` env vars into the Providers tab on first boot. PR #54 corrects the matching drift in `.env.example` and `docs/providers.md`; this PR closes the third surface.

`docs/known-limitations.md` is the most operator-impactful surface of the three because it's the canonical "what should you NOT assume" page — telling operators "none are auto-added" sets exactly the wrong expectation.

Rewrite the bullet to match the same wording used in `.env.example` and `providers.md` (env vars seed + auto-import on first boot; subsequent boots leave UI edits untouched) and cross-link to `providers.md` for the full lifecycle.

## Verification

- [x] No remaining `none are auto-added` / `do(es) not auto-add` claims anywhere in `docs/`, `.env.example`, `README.md`, or `CONTRIBUTING.md`
- [x] Cross-link target (`docs/providers.md`'s env-vs-UI section) was already fixed in PR #54

## Stacking

This PR is independent of PR #54 — different file, mergeable in either order. If PR #54 lands first, no rebase needed. If this lands first, PR #54 still applies cleanly.