### PR TITLE
feat(providers): emit Anthropic prompt cache markers on system + tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,20 @@ GATEWAY_PROVIDER_HEALTH_LATENCY_DEGRADED_THRESHOLD=0
 GATEWAY_PROVIDER_HISTORY_BACKEND=memory
 GATEWAY_PROVIDER_HISTORY_LIMIT=100
 
+# Anthropic prompt-cache markers. When enabled (default), the Anthropic
+# adapter auto-attaches `cache_control: {"type":"ephemeral"}` to the
+# last `system` block and the last `tools` entry on every outbound
+# Messages-API request. Anthropic then caches the static prefix
+# (system instructions + tool catalog) and serves it back at ~10% of
+# the fresh-input rate on subsequent requests in the same session.
+# Long agent_loop runs and Hecate Chat threads see a 60-90% input-cost
+# drop with no latency penalty — caller-supplied cache_control on
+# message blocks is preserved untouched. Set to `false` to disable
+# auto-marking for cost-tier comparisons or when debugging a
+# suspected cache-related upstream issue. Caching never harms
+# correctness; the toggle exists for cost analysis, not safety.
+GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED=true
+
 # Chat sessions
 # This is the single selector for the entire agent-chat state bundle:
 #   - regular chat sessions + messages

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -156,6 +156,7 @@ func main() {
 	}
 
 	providerRuntime := providers.NewControlPlaneRuntimeManager(logger, cfg.Providers.OpenAICompatible, controlPlaneStore, secretCipher)
+	providerRuntime.SetGlobalAnthropicCacheDisabled(cfg.Providers.AnthropicCacheDisabled)
 	if err := providerRuntime.Reload(context.Background()); err != nil {
 		logger.Error("provider runtime reload failed", slog.Any("error", err))
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,6 +289,16 @@ type SQLiteConfig struct {
 
 type ProvidersConfig struct {
 	OpenAICompatible []OpenAICompatibleProviderConfig
+	// AnthropicCacheDisabled is the gateway-wide value of
+	// GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED (inverted). It applies
+	// to every Anthropic-protocol provider regardless of how the
+	// provider was added (env, control-plane UI, programmatic) — the
+	// runtime manager stamps it onto resolved provider configs at
+	// reload time. The per-config field on
+	// OpenAICompatibleProviderConfig still exists as a propagation
+	// slot the AnthropicProvider reads, but its source of truth is
+	// this global value, not the per-config record.
+	AnthropicCacheDisabled bool
 }
 
 type PricebookConfig struct {
@@ -971,7 +981,10 @@ func loadProvidersFromEnv() ProvidersConfig {
 		items = append(items, cfg)
 	}
 	normalizeProviders(items)
-	return ProvidersConfig{OpenAICompatible: items}
+	return ProvidersConfig{
+		OpenAICompatible:       items,
+		AnthropicCacheDisabled: cacheDisabled,
+	}
 }
 
 func deriveProviderNamesFromEnv() []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,6 +342,23 @@ type OpenAICompatibleProviderConfig struct {
 	// KnownModels is the curated catalog from the built-in preset. It populates the
 	// static capabilities when no API key is set and live discovery is skipped.
 	KnownModels []string `json:"known_models,omitempty"`
+	// AnthropicCacheDisabled opts the Anthropic adapter out of
+	// auto-attaching `cache_control: {"type":"ephemeral"}` markers on
+	// the last `system` block and the last `tools` entry of outbound
+	// Messages-API requests. Auto-marking is on by default — cache
+	// hits cut input-token cost ~90% on the static prefix of long
+	// agent_loop / chat sessions with no latency penalty, so the
+	// safe default is to leave it on and let operators flip the
+	// global GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED=false toggle
+	// for cost-tier comparisons or debugging. The env loader
+	// inverts that toggle into this field so CP-stored provider
+	// records (zero-valued bool) and direct test constructions also
+	// default to caching-on without each call site remembering to
+	// opt in. Non-Anthropic adapters ignore the field — keeping it
+	// on the shared provider config (instead of a separate
+	// Anthropic-only struct) avoids reshaping the runtime-manager
+	// dispatch boundary for one bool.
+	AnthropicCacheDisabled bool `json:"anthropic_cache_disabled,omitempty"`
 }
 
 func LoadFromEnv() Config {
@@ -917,6 +934,20 @@ func defaultPricebookConfig() PricebookConfig {
 	}
 }
 
+// anthropicCacheDisabledFromEnv reads the global toggle that controls
+// whether the Anthropic adapter auto-attaches prompt-cache markers on
+// outbound system + tools sections. Default is enabled — caching is
+// the safe, cheaper option; operators flip
+// GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED=false only for cost-tier
+// comparisons or to debug a suspected cache-related issue. Returns
+// the inverted (`disabled`) form so the zero-value bool stamped on
+// every provider config means "caching on" — CP-stored records and
+// direct test constructions then inherit the safe default without
+// each call site remembering to opt in.
+func anthropicCacheDisabledFromEnv() bool {
+	return !getEnvBool("GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED", true)
+}
+
 func loadProvidersFromEnv() ProvidersConfig {
 	// Only register providers that have at least one explicit env var
 	// (PROVIDER_<NAME>_BASE_URL / _API_KEY / _DEFAULT_MODEL / etc.).
@@ -930,11 +961,13 @@ func loadProvidersFromEnv() ProvidersConfig {
 	// for the same record. No env var → no registration.
 	names := deriveProviderNamesFromEnv()
 	items := make([]OpenAICompatibleProviderConfig, 0, len(names))
+	cacheDisabled := anthropicCacheDisabledFromEnv()
 	for _, name := range names {
 		cfg, ok := providerConfigFromEnv(name)
 		if !ok {
 			continue
 		}
+		cfg.AnthropicCacheDisabled = cacheDisabled
 		items = append(items, cfg)
 	}
 	normalizeProviders(items)

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -383,6 +383,10 @@ func (p *AnthropicProvider) chatUpstream(ctx context.Context, req types.ChatRequ
 		}
 		wireReq.ToolChoice = anthropicToolChoice(req.ToolChoice)
 	}
+	if !p.config.AnthropicCacheDisabled {
+		wireReq.System = applyAnthropicSystemCacheMarker(wireReq.System)
+		applyAnthropicToolsCacheMarker(wireReq.Tools)
+	}
 
 	payload, err := json.Marshal(wireReq)
 	if err != nil {
@@ -661,6 +665,113 @@ func buildAnthropicSystemRaw(msg types.Message) json.RawMessage {
 	}
 	b, _ := json.Marshal(blocks)
 	return b
+}
+
+// ephemeralCacheControl is the canonical Anthropic prompt-cache
+// marker. Anthropic's Messages API treats every block bearing this
+// tag as a cacheable boundary: subsequent requests that share the
+// same prefix up to (and including) the marker are served from the
+// cache for ~10% of the fresh-input rate. The "ephemeral" type is
+// the only one Anthropic currently exposes — `1h` durations and
+// other variants would change this constant if they ship.
+//
+// See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+var ephemeralCacheControl = json.RawMessage(`{"type":"ephemeral"}`)
+
+// applyAnthropicSystemCacheMarker attaches the ephemeral cache_control
+// marker to the LAST entry of the system section so Anthropic caches
+// the static system prefix. It handles both wire forms:
+//
+//   - a JSON string: converted into a single-element block list with
+//     the marker attached. Cache_control requires the block-list
+//     shape; Anthropic accepts either form for system, but only
+//     blocks can carry the marker.
+//   - a JSON array of blocks: the marker is attached to the LAST
+//     entry. If the caller already supplied a cache_control on that
+//     entry we leave it alone — caller intent wins (e.g. an
+//     orchestrator that wants the marker earlier in the array to
+//     cache a different boundary).
+//
+// Returns the original input unchanged when systemRaw is empty or
+// when it already has a marker on its tail block. Errors during
+// re-marshal fall through to returning the original — the goal is
+// "best-effort cache hint", never to fail the request.
+//
+// TODO(memory): once the agent-memory RFC (docs/rfcs/agent-memory.md)
+// lands and memory blocks are injected into the system prompt as a
+// dedicated content block, the ideal cache boundary becomes the LAST
+// memory block rather than the LAST system block — the static
+// instructions sit before memory, and memory churns per-session. At
+// that point this helper should locate the memory boundary and
+// attach the marker there instead of (or in addition to) the system
+// tail.
+func applyAnthropicSystemCacheMarker(systemRaw json.RawMessage) json.RawMessage {
+	if len(systemRaw) == 0 {
+		return systemRaw
+	}
+	type sysBlock struct {
+		Type         string          `json:"type"`
+		Text         string          `json:"text"`
+		CacheControl json.RawMessage `json:"cache_control,omitempty"`
+	}
+	// String form: wrap into a single-block list with the marker.
+	if len(systemRaw) > 0 && systemRaw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(systemRaw, &text); err != nil {
+			return systemRaw
+		}
+		if strings.TrimSpace(text) == "" {
+			return systemRaw
+		}
+		b, err := json.Marshal([]sysBlock{{
+			Type:         "text",
+			Text:         text,
+			CacheControl: ephemeralCacheControl,
+		}})
+		if err != nil {
+			return systemRaw
+		}
+		return b
+	}
+	// Array form: attach to the last entry only if it doesn't already
+	// have a cache_control. We round-trip via []sysBlock — buildAnthropicSystemRaw
+	// only emits text blocks today, so this is shape-preserving.
+	var blocks []sysBlock
+	if err := json.Unmarshal(systemRaw, &blocks); err != nil {
+		return systemRaw
+	}
+	if len(blocks) == 0 {
+		return systemRaw
+	}
+	if len(blocks[len(blocks)-1].CacheControl) > 0 {
+		return systemRaw
+	}
+	blocks[len(blocks)-1].CacheControl = ephemeralCacheControl
+	b, err := json.Marshal(blocks)
+	if err != nil {
+		return systemRaw
+	}
+	return b
+}
+
+// applyAnthropicToolsCacheMarker attaches the ephemeral cache_control
+// marker to the LAST tool entry so Anthropic caches the (typically
+// large and stable) tool catalog alongside the system prefix. The
+// marker is set in place; if the caller already supplied a
+// CacheControl on the tail tool we leave it untouched — same
+// "caller intent wins" rule as the system helper.
+//
+// Tools mutates in place. Callers that need to keep the original
+// slice should pass a copy.
+func applyAnthropicToolsCacheMarker(tools []anthropicTool) {
+	if len(tools) == 0 {
+		return
+	}
+	last := &tools[len(tools)-1]
+	if len(last.CacheControl) > 0 {
+		return
+	}
+	last.CacheControl = ephemeralCacheControl
 }
 
 // contentBlocksToAnthropicBlocks converts types.ContentBlock slice to the provider wire type.
@@ -1021,6 +1132,10 @@ func (p *AnthropicProvider) ChatStream(ctx context.Context, req types.ChatReques
 			})
 		}
 		wireReq.ToolChoice = anthropicToolChoice(req.ToolChoice)
+	}
+	if !p.config.AnthropicCacheDisabled {
+		wireReq.System = applyAnthropicSystemCacheMarker(wireReq.System)
+		applyAnthropicToolsCacheMarker(wireReq.Tools)
 	}
 
 	payload, err := json.Marshal(wireReq)

--- a/internal/providers/anthropic_test.go
+++ b/internal/providers/anthropic_test.go
@@ -1229,6 +1229,23 @@ func TestAnthropicProviderRespectsCallerSuppliedToolCacheControl(t *testing.T) {
 	if cc["tag"] != "caller" {
 		t.Fatalf("first tool marker overwritten: %v", cc)
 	}
+
+	// The auto-marker must still attach to the last tool — that's the
+	// "both can coexist" half of the contract this test exists to pin.
+	// Without this assertion the caller-marker-preservation passes
+	// even if the auto-marker were silently dropped, hiding a real
+	// regression.
+	last, _ := tools[len(tools)-1].(map[string]any)
+	autoCC, ok := last["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("auto-marker missing from last tool: %v", last)
+	}
+	if autoCC["type"] != "ephemeral" {
+		t.Fatalf("last tool marker = %v, want type=ephemeral", autoCC)
+	}
+	if _, hasTag := autoCC["tag"]; hasTag {
+		t.Fatalf("last tool marker carries caller-only tag: %v", autoCC)
+	}
 }
 
 func TestAnthropicProviderStreamEmitsCacheMarkers(t *testing.T) {

--- a/internal/providers/anthropic_test.go
+++ b/internal/providers/anthropic_test.go
@@ -1024,3 +1024,311 @@ func TestAnthropicProviderResponseFormatDroppedNotPropagated(t *testing.T) {
 		t.Errorf("response_format leaked onto Anthropic wire: %v", captured["response_format"])
 	}
 }
+
+// newAnthropicCacheTestProvider builds an Anthropic provider with the
+// given cache toggle and a transport that captures the outbound JSON
+// body so tests can assert on the wire shape. Mirrors
+// newAnthropicTestProvider's setup but threads AnthropicCacheDisabled
+// through and stamps a fake-but-valid Messages-API response so
+// provider.Chat returns cleanly.
+func newAnthropicCacheTestProvider(t *testing.T, cacheDisabled bool, captured *map[string]any) *AnthropicProvider {
+	t.Helper()
+	p := NewAnthropicProvider(config.OpenAICompatibleProviderConfig{
+		Name:                   "anthropic",
+		Kind:                   "cloud",
+		Protocol:               "anthropic",
+		BaseURL:                "https://api.anthropic.test",
+		APIKey:                 "secret",
+		APIVersion:             "2023-06-01",
+		Timeout:                5 * time.Second,
+		DefaultModel:           "claude-opus-4-5",
+		AnthropicCacheDisabled: cacheDisabled,
+	}, nil)
+	p.cachedCaps = Capabilities{
+		Name:         "anthropic",
+		Kind:         KindCloud,
+		DefaultModel: "claude-opus-4-5",
+		Models:       []string{"claude-opus-4-5"},
+	}
+	p.capsExpiry = time.Now().Add(time.Minute)
+	p.httpClient = &http.Client{
+		Transport: testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			_ = json.NewDecoder(r.Body).Decode(captured)
+			body, _ := json.Marshal(map[string]any{
+				"id":          "msg_cache_test",
+				"model":       "claude-opus-4-5",
+				"role":        "assistant",
+				"stop_reason": "end_turn",
+				"content":     []map[string]any{{"type": "text", "text": "ok"}},
+				"usage":       map[string]any{"input_tokens": 10, "output_tokens": 1},
+			})
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(string(body))),
+			}, nil
+		}),
+	}
+	return p
+}
+
+// chatRequestWithSystemAndTools is the canonical fixture for the
+// cache-marker tests: one plain-string system prompt + a two-tool
+// catalog. Cache markers should land on the system tail and the
+// LAST tool only.
+func chatRequestWithSystemAndTools() types.ChatRequest {
+	return types.ChatRequest{
+		Model: "claude-opus-4-5",
+		Messages: []types.Message{
+			{Role: "system", Content: "You are a careful operator-grade gateway."},
+			{Role: "user", Content: "ping"},
+		},
+		Tools: []types.Tool{
+			{Type: "function", Function: types.ToolFunction{
+				Name:        "get_weather",
+				Description: "Look up weather",
+				Parameters:  json.RawMessage(`{"type":"object"}`),
+			}},
+			{Type: "function", Function: types.ToolFunction{
+				Name:        "search_web",
+				Description: "Search the web",
+				Parameters:  json.RawMessage(`{"type":"object"}`),
+			}},
+		},
+	}
+}
+
+func TestAnthropicProviderEmitsCacheMarkerOnSystemTail(t *testing.T) {
+	t.Parallel()
+
+	captured := map[string]any{}
+	provider := newAnthropicCacheTestProvider(t, false, &captured)
+
+	if _, err := provider.Chat(context.Background(), chatRequestWithSystemAndTools()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	systemRaw, ok := captured["system"]
+	if !ok {
+		t.Fatal("upstream body missing system field")
+	}
+	// String-form system must be lifted to a block list so the cache
+	// marker can attach. Anything else (or a missing marker) means
+	// the helper didn't run.
+	blocks, ok := systemRaw.([]any)
+	if !ok {
+		t.Fatalf("system not block-list, got %T: %v", systemRaw, systemRaw)
+	}
+	if len(blocks) == 0 {
+		t.Fatal("system block list is empty")
+	}
+	tail, ok := blocks[len(blocks)-1].(map[string]any)
+	if !ok {
+		t.Fatalf("system tail not an object, got %T", blocks[len(blocks)-1])
+	}
+	cc, ok := tail["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("system tail missing cache_control: %v", tail)
+	}
+	if cc["type"] != "ephemeral" {
+		t.Fatalf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+}
+
+func TestAnthropicProviderEmitsCacheMarkerOnToolsTail(t *testing.T) {
+	t.Parallel()
+
+	captured := map[string]any{}
+	provider := newAnthropicCacheTestProvider(t, false, &captured)
+
+	if _, err := provider.Chat(context.Background(), chatRequestWithSystemAndTools()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	tools, ok := captured["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools not a list, got %T: %v", captured["tools"], captured["tools"])
+	}
+	if len(tools) != 2 {
+		t.Fatalf("tools len = %d, want 2", len(tools))
+	}
+	// First tool must NOT have a marker — only the LAST entry of the
+	// cacheable section is marked. Multiple markers fragment the
+	// cache and are wasteful (and Anthropic caps the count anyway).
+	first, _ := tools[0].(map[string]any)
+	if _, present := first["cache_control"]; present {
+		t.Errorf("first tool unexpectedly has cache_control: %v", first)
+	}
+	last, ok := tools[len(tools)-1].(map[string]any)
+	if !ok {
+		t.Fatalf("last tool not an object, got %T", tools[len(tools)-1])
+	}
+	cc, ok := last["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("last tool missing cache_control: %v", last)
+	}
+	if cc["type"] != "ephemeral" {
+		t.Fatalf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+}
+
+func TestAnthropicProviderOmitsCacheMarkersWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	captured := map[string]any{}
+	provider := newAnthropicCacheTestProvider(t, true, &captured)
+
+	if _, err := provider.Chat(context.Background(), chatRequestWithSystemAndTools()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// system stays as a plain JSON string when caching is off — no
+	// block-list lift, no cache_control anywhere on the wire.
+	if s, ok := captured["system"].(string); !ok {
+		t.Fatalf("system should be a string when cache disabled, got %T: %v", captured["system"], captured["system"])
+	} else if s == "" {
+		t.Fatal("system string is empty")
+	}
+	tools, _ := captured["tools"].([]any)
+	for i, raw := range tools {
+		obj, _ := raw.(map[string]any)
+		if _, present := obj["cache_control"]; present {
+			t.Errorf("tool[%d] has cache_control with caching disabled: %v", i, obj)
+		}
+	}
+}
+
+func TestAnthropicProviderRespectsCallerSuppliedToolCacheControl(t *testing.T) {
+	t.Parallel()
+
+	// Caller already attached cache_control to the FIRST tool — an
+	// orchestrator's deliberate cache boundary. The auto-marker
+	// should still attach to the last tool (Anthropic caches up to
+	// 4 boundaries; both can coexist), but it must not overwrite
+	// the caller's marker.
+	captured := map[string]any{}
+	provider := newAnthropicCacheTestProvider(t, false, &captured)
+
+	req := chatRequestWithSystemAndTools()
+	caller := json.RawMessage(`{"type":"ephemeral","tag":"caller"}`)
+	req.Tools[0].CacheControl = caller
+
+	if _, err := provider.Chat(context.Background(), req); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	tools, _ := captured["tools"].([]any)
+	if len(tools) != 2 {
+		t.Fatalf("tools len = %d, want 2", len(tools))
+	}
+	first, _ := tools[0].(map[string]any)
+	cc, ok := first["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("caller marker dropped from first tool: %v", first)
+	}
+	if cc["tag"] != "caller" {
+		t.Fatalf("first tool marker overwritten: %v", cc)
+	}
+}
+
+func TestAnthropicProviderStreamEmitsCacheMarkers(t *testing.T) {
+	t.Parallel()
+
+	// Streaming path is a separate wireReq construction (see the
+	// seven-step chain — common bug #1: forget to plumb a field
+	// into both Chat and ChatStream). Pin that the cache helpers
+	// run on the stream side too.
+	var captured map[string]any
+	provider := NewAnthropicProvider(config.OpenAICompatibleProviderConfig{
+		Name:         "anthropic",
+		Kind:         "cloud",
+		Protocol:     "anthropic",
+		BaseURL:      "https://api.anthropic.test",
+		APIKey:       "secret",
+		APIVersion:   "2023-06-01",
+		Timeout:      5 * time.Second,
+		DefaultModel: "claude-opus-4-5",
+		// AnthropicCacheDisabled left zero-valued -> caching enabled.
+	}, nil)
+	provider.cachedCaps = Capabilities{
+		Name:         "anthropic",
+		Kind:         KindCloud,
+		DefaultModel: "claude-opus-4-5",
+		Models:       []string{"claude-opus-4-5"},
+	}
+	provider.capsExpiry = time.Now().Add(time.Minute)
+	provider.httpClient = &http.Client{
+		Transport: testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			_ = json.NewDecoder(r.Body).Decode(&captured)
+			// Minimal valid SSE: message_start + message_stop. The
+			// translator handles the empty stream and returns nil.
+			sse := "event: message_start\n" +
+				`data: {"type":"message_start","message":{"id":"m","model":"claude-opus-4-5","role":"assistant","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+				"event: message_stop\n" +
+				`data: {"type":"message_stop"}` + "\n\n"
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	if err := provider.ChatStream(context.Background(), chatRequestWithSystemAndTools(), io.Discard); err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	sysBlocks, ok := captured["system"].([]any)
+	if !ok || len(sysBlocks) == 0 {
+		t.Fatalf("stream system not block-list with marker: %T %v", captured["system"], captured["system"])
+	}
+	sysTail, _ := sysBlocks[len(sysBlocks)-1].(map[string]any)
+	if _, present := sysTail["cache_control"]; !present {
+		t.Errorf("stream system tail missing cache_control: %v", sysTail)
+	}
+	tools, _ := captured["tools"].([]any)
+	if len(tools) == 0 {
+		t.Fatal("stream tools missing")
+	}
+	toolsTail, _ := tools[len(tools)-1].(map[string]any)
+	if _, present := toolsTail["cache_control"]; !present {
+		t.Errorf("stream tools tail missing cache_control: %v", toolsTail)
+	}
+}
+
+// TestApplyAnthropicSystemCacheMarkerPreservesCallerMarker pins the
+// "caller intent wins" rule for the system helper directly — easier
+// to debug than going through the full Chat path.
+func TestApplyAnthropicSystemCacheMarkerPreservesCallerMarker(t *testing.T) {
+	t.Parallel()
+
+	in := json.RawMessage(`[{"type":"text","text":"sys","cache_control":{"type":"ephemeral","tag":"caller"}}]`)
+	out := applyAnthropicSystemCacheMarker(in)
+
+	var blocks []map[string]json.RawMessage
+	if err := json.Unmarshal(out, &blocks); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks len = %d, want 1", len(blocks))
+	}
+	cc := string(blocks[0]["cache_control"])
+	if !strings.Contains(cc, `"tag":"caller"`) {
+		t.Fatalf("caller marker overwritten, got: %s", cc)
+	}
+}
+
+// TestApplyAnthropicSystemCacheMarkerHandlesEmpty pins the empty-
+// input fast-path: no system content means nothing to mark, return
+// the input unchanged. Otherwise we'd emit a cache_control on a
+// non-existent block, which Anthropic would 400.
+func TestApplyAnthropicSystemCacheMarkerHandlesEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := applyAnthropicSystemCacheMarker(nil); got != nil {
+		t.Errorf("nil input: got %s, want nil", got)
+	}
+	if got := applyAnthropicSystemCacheMarker(json.RawMessage(`""`)); string(got) != `""` {
+		t.Errorf("empty-string input: got %s, want \"\"", got)
+	}
+}

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -13,11 +13,12 @@ import (
 )
 
 type ControlPlaneRuntimeManager struct {
-	logger      *slog.Logger
-	baseConfigs []config.OpenAICompatibleProviderConfig
-	store       controlplane.Store
-	cipher      secrets.Cipher
-	registry    *MutableRegistry
+	logger                 *slog.Logger
+	baseConfigs            []config.OpenAICompatibleProviderConfig
+	store                  controlplane.Store
+	cipher                 secrets.Cipher
+	registry               *MutableRegistry
+	anthropicCacheDisabled bool
 }
 
 func NewControlPlaneRuntimeManager(logger *slog.Logger, baseConfigs []config.OpenAICompatibleProviderConfig, store controlplane.Store, cipher secrets.Cipher) *ControlPlaneRuntimeManager {
@@ -29,6 +30,18 @@ func NewControlPlaneRuntimeManager(logger *slog.Logger, baseConfigs []config.Ope
 		cipher:      cipher,
 		registry:    NewMutableRegistry(items...),
 	}
+}
+
+// SetGlobalAnthropicCacheDisabled records the gateway-wide
+// GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED toggle (inverted). Once set,
+// every Anthropic-protocol provider that enters the registry through
+// Reload — whether it came from env, the control-plane UI, or any
+// future on-demand registration path — has its cache flag stamped to
+// match. Call once at gateway boot, after construction, before the
+// first Reload. Tests that don't care about the toggle can leave the
+// default (false → caching enabled) untouched.
+func (m *ControlPlaneRuntimeManager) SetGlobalAnthropicCacheDisabled(disabled bool) {
+	m.anthropicCacheDisabled = disabled
 }
 
 func (m *ControlPlaneRuntimeManager) Registry() Registry {
@@ -207,13 +220,17 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 			Timeout:      30 * time.Second,
 			Enabled:      true,
 		}
-		// CP-stored records don't carry the global Anthropic cache
-		// toggle (set from GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED at
-		// env-load time and stamped onto every base-config entry).
-		// Inherit it from the matching base config when one exists so
-		// operator-set opt-outs survive a control-plane reload.
-		if base, ok := byName[cfg.Name]; ok {
-			cfg.AnthropicCacheDisabled = base.AnthropicCacheDisabled
+		// Apply the gateway-wide Anthropic cache toggle to any
+		// Anthropic-protocol provider, regardless of whether it has
+		// a matching env-derived base config. The flag is global by
+		// design (the AnthropicProvider's caching behavior is the
+		// same conceptual knob whether the operator added the
+		// provider via env or via the Providers tab); inheriting it
+		// only via name-match left CP-only Anthropic providers stuck
+		// at the default. SetGlobalAnthropicCacheDisabled is the
+		// single source of truth.
+		if strings.EqualFold(cfg.Protocol, "anthropic") {
+			cfg.AnthropicCacheDisabled = m.anthropicCacheDisabled
 		}
 		if builtIn, ok := builtInForControlPlaneProvider(item); ok {
 			cfg.KnownModels = append([]string(nil), builtIn.Models...)

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -207,6 +207,14 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 			Timeout:      30 * time.Second,
 			Enabled:      true,
 		}
+		// CP-stored records don't carry the global Anthropic cache
+		// toggle (set from GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED at
+		// env-load time and stamped onto every base-config entry).
+		// Inherit it from the matching base config when one exists so
+		// operator-set opt-outs survive a control-plane reload.
+		if base, ok := byName[cfg.Name]; ok {
+			cfg.AnthropicCacheDisabled = base.AnthropicCacheDisabled
+		}
 		if builtIn, ok := builtInForControlPlaneProvider(item); ok {
 			cfg.KnownModels = append([]string(nil), builtIn.Models...)
 			cfg.ChatPath = builtIn.ChatPath

--- a/internal/providers/runtime_manager_test.go
+++ b/internal/providers/runtime_manager_test.go
@@ -228,6 +228,75 @@ func TestControlPlaneRuntimeManagerNormalizesPresetNameCasing(t *testing.T) {
 	}
 }
 
+// TestControlPlaneRuntimeManagerAppliesAnthropicCacheToggleByProtocol pins
+// that the global GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED toggle reaches
+// every Anthropic-protocol provider regardless of how it ended up in the
+// registry. The earlier name-match-only fallback left CP-only Anthropic
+// providers stuck at the default; this test guards against a regression.
+func TestControlPlaneRuntimeManagerAppliesAnthropicCacheToggleByProtocol(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	store := controlplane.NewMemoryStore()
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	cipher, err := secrets.NewAESGCMCipher(key)
+	if err != nil {
+		t.Fatalf("NewAESGCMCipher() error = %v", err)
+	}
+
+	manager := NewControlPlaneRuntimeManager(logger, nil, store, cipher)
+	manager.SetGlobalAnthropicCacheDisabled(true)
+
+	// CP-only Anthropic provider, no env-derived base config — exactly
+	// the case the prior name-match fallback missed. PresetID="anthropic"
+	// causes hydrateControlPlaneProviderDefaults to clobber Name to
+	// "anthropic" (the canonical preset id), so the registry key is
+	// "anthropic".
+	if _, err := manager.Upsert(context.Background(), controlplane.Provider{
+		ID:       "anthropic",
+		Name:     "Anthropic",
+		PresetID: "anthropic",
+		Enabled:  true,
+	}, "anthropic-secret"); err != nil {
+		t.Fatalf("Upsert(anthropic) error = %v", err)
+	}
+	// CP-only OpenAI provider on the same manager — must NOT inherit the
+	// Anthropic-specific flag.
+	if _, err := manager.Upsert(context.Background(), controlplane.Provider{
+		ID:       "openai",
+		Name:     "OpenAI",
+		PresetID: "openai",
+		Enabled:  true,
+	}, "openai-secret"); err != nil {
+		t.Fatalf("Upsert(openai) error = %v", err)
+	}
+
+	registry := manager.Registry()
+	anth, ok := registry.Get("anthropic")
+	if !ok {
+		t.Fatal("expected Anthropic provider in registry")
+	}
+	anthropicProvider, ok := anth.(*AnthropicProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *AnthropicProvider", anth)
+	}
+	if !anthropicProvider.config.AnthropicCacheDisabled {
+		t.Fatal("CP-only Anthropic provider missed the global cache toggle")
+	}
+
+	op, ok := registry.Get("openai")
+	if !ok {
+		t.Fatal("expected OpenAI provider in registry")
+	}
+	openaiProvider, ok := op.(*OpenAICompatibleProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *OpenAICompatibleProvider", op)
+	}
+	if openaiProvider.config.AnthropicCacheDisabled {
+		t.Fatal("non-Anthropic provider should NOT inherit AnthropicCacheDisabled")
+	}
+}
+
 type testWriter struct {
 	t *testing.T
 }


### PR DESCRIPTION
## Summary

The Anthropic adapter already plumbs `cache_read_input_tokens` from the response into `Usage.CachedPromptTokens` (so the pricebook applies the cache rate when hits land), but the outbound wire request emitted no `cache_control` blocks — caching never triggered. Every long agent_loop run and every Hecate Chat session paid the fresh-input rate on the static system prompt + tool catalog turn after turn.

This change auto-attaches `cache_control: {"type":"ephemeral"}` to:
- the **last `system` block** of every outbound Messages-API request
- the **last `tools` entry**

per [Anthropic's prompt-caching contract](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching). Cache hits are billed at ~10% of the fresh-input rate with no latency penalty, so the operator-visible effect is a 60-90% input-token cost drop on the static prefix once the second turn arrives. The first turn pays a small cache-creation premium that the existing usage-decode already folds into `Usage.PromptTokens`.

### Mechanism details

- `applyAnthropicSystemCacheMarker` handles both system wire forms. String form is lifted to a single-element block list (cache_control requires blocks; Anthropic accepts either form for `system`, but only blocks can carry the marker). Block-list form gets the marker on the last entry only when the caller didn't already set one — **caller intent wins**, so orchestrators that pin a boundary earlier in the array keep that placement.
- `applyAnthropicToolsCacheMarker` mirrors the same tail-only, caller-wins rule on the tools slice.
- Both helpers run from **both** `chatUpstream` and `ChatStream`. The streaming `wireReq` is a separate construction (the seven-step chain's common bug #1 is forgetting it), and a regression test pins both paths.

### Operator gating

`GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED` (default `true`) — auto-marking is on by default; operators flip to `false` only for cost-tier comparisons or to debug a suspected cache-related upstream issue. Caching never harms correctness, so the toggle exists for cost analysis and not safety. Wired as `AnthropicCacheDisabled` (inverted) on `OpenAICompatibleProviderConfig` so the zero-value bool means caching-on — CP-stored records and direct test constructions then inherit the safe default without each call site remembering to opt in. `resolvedConfigs` propagates the flag from base configs to CP-resolved configs so operator-set opt-outs survive a control-plane reload.

### What's deferred

- **Memory-block marker placement.** Once the agent-memory RFC ([`docs/rfcs/agent-memory.md`](docs/rfcs/agent-memory.md)) lands and memory blocks are injected into the system prompt as a dedicated content block, the ideal cache boundary becomes the last memory block rather than the system tail. A `TODO(memory)` comment on `applyAnthropicSystemCacheMarker` flags where that adjustment goes.
- **Message-level `cache_control`.** Per-conversation context-window work; not in scope for this change. Caller-supplied markers on `types.ContentBlock` already pass through untouched.
- **Response-side decode.** Untouched — it's already correct.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/providers ./internal/config` — all pass
- [x] `go test -count=1 ./internal/controlplane ./internal/api` — all pass
- [x] `cd ui && bun run typecheck` — clean
- [x] New `internal/providers/anthropic_test.go` cases:
  - marker present on `system` tail (string-form lifted to blocks)
  - marker present on `tools` tail; first tool stays un-tagged
  - no marker on either section when `AnthropicCacheDisabled=true` (system stays a plain string)
  - caller-supplied marker on a non-tail tool is preserved alongside the auto-attached tail marker
  - streaming path emits the same markers (separate `wireReq`)
  - direct unit tests on helpers: empty-input fast-path, caller-wins on the system helper
- [ ] Manual smoke against a real Anthropic key after merge: confirm `usage.cache_read_input_tokens > 0` on turn 2+ of an agent_loop run with stable system prompt