### PR TITLE
docs(providers): document Anthropic prompt caching support

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -14,6 +14,7 @@ Hecate uses a vendor-neutral provider layer at the runtime boundary. It treats O
 - [Env-configured providers](#env-configured-providers)
 - [Settings API](#settings-api)
 - [Health and circuit breaking](#health-and-circuit-breaking)
+- [Anthropic prompt caching](#anthropic-prompt-caching)
 
 ## Providers vs. clients
 
@@ -139,11 +140,14 @@ applied to:
   requires the block shape)
 - the last entry in `tools`
 
-Caller-supplied `cache_control` is preserved — operators or
-upstream orchestrators that set their own cache boundaries
-keep them, and the auto-attached marker on the last entry of
-each section coexists alongside (Anthropic accepts up to four
-cache breakpoints).
+Caller intent wins on the tail: when the last block of `system`
+or the last entry in `tools` already carries a caller-supplied
+`cache_control`, Hecate skips the auto-marker for that section
+and leaves the caller's boundary in place. Earlier caller-supplied
+markers elsewhere in the same section are always preserved
+unchanged, so an operator who has placed their own breakpoints
+keeps them either way (Anthropic accepts up to four cache
+breakpoints per request).
 
 Hits show up in the response as non-zero `cache_read_input_tokens`,
 which Hecate plumbs through as `Usage.CachedPromptTokens` and

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -126,6 +126,37 @@ provider-specific endpoint layout: Hecate sends chat traffic to
 fields such as `citations` and `search_results` are not forwarded yet; the
 normalized assistant text, model, and token usage are.
 
+## Anthropic prompt caching
+
+Hecate automatically attaches `cache_control: {"type":"ephemeral"}`
+markers to outbound Anthropic Messages API requests so the static
+prefix (system prompt + tools catalog) is reused across turns and
+billed at Anthropic's discounted cache-read rate. Markers are
+applied to:
+
+- the last block of the `system` field (lifted to a block list
+  when the caller sends a string system prompt — `cache_control`
+  requires the block shape)
+- the last entry in `tools`
+
+Caller-supplied `cache_control` is preserved — operators or
+upstream orchestrators that set their own cache boundaries
+keep them, and the auto-attached marker on the last entry of
+each section coexists alongside (Anthropic accepts up to four
+cache breakpoints).
+
+Hits show up in the response as non-zero `cache_read_input_tokens`,
+which Hecate plumbs through as `Usage.CachedPromptTokens` and
+prices via the cache-read rate when the pricebook has one.
+
+The behavior is controlled by `GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED`
+(default `true`). The toggle is global — every Anthropic-protocol
+provider, however it was added (env, Providers tab, programmatic),
+inherits the same value. Operators flip it to `false` for cost-tier
+comparisons or to debug a suspected cache-related issue. The
+Anthropic adapter is the only place this knob applies; non-Anthropic
+providers are unaffected.
+
 ## Settings API
 
 Every UI action maps to a Hecate-native settings endpoint:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,9 +12,9 @@ Hecate uses a vendor-neutral provider layer at the runtime boundary. It treats O
 - [Adding a provider](#adding-a-provider)
 - [Built-in presets](#built-in-presets)
 - [Env-configured providers](#env-configured-providers)
+- [Anthropic prompt caching](#anthropic-prompt-caching)
 - [Settings API](#settings-api)
 - [Health and circuit breaking](#health-and-circuit-breaking)
-- [Anthropic prompt caching](#anthropic-prompt-caching)
 
 ## Providers vs. clients
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -131,9 +131,13 @@ normalized assistant text, model, and token usage are.
 
 Hecate automatically attaches `cache_control: {"type":"ephemeral"}`
 markers to outbound Anthropic Messages API requests so the static
-prefix (system prompt + tools catalog) is reused across turns and
-billed at Anthropic's discounted cache-read rate. Markers are
-applied to:
+prefix (system prompt + tools catalog) is reused across turns. The
+billing impact is asymmetric: the first turn writes the cache and
+Anthropic returns those tokens as `cache_creation_input_tokens`
+(charged at ~1.25× the base input rate); subsequent turns reuse
+the prefix and Anthropic returns them as `cache_read_input_tokens`
+(charged at ~0.1× the base rate). The win lands on turn 2 onwards.
+Markers are applied to:
 
 - the last block of the `system` field (lifted to a block list
   when the caller sends a string system prompt — `cache_control`
@@ -146,12 +150,25 @@ or the last entry in `tools` already carries a caller-supplied
 and leaves the caller's boundary in place. Earlier caller-supplied
 markers elsewhere in the same section are always preserved
 unchanged, so an operator who has placed their own breakpoints
-keeps them either way (Anthropic accepts up to four cache
-breakpoints per request).
+keeps them either way.
 
-Hits show up in the response as non-zero `cache_read_input_tokens`,
-which Hecate plumbs through as `Usage.CachedPromptTokens` and
-prices via the cache-read rate when the pricebook has one.
+Anthropic accepts up to four `cache_control` breakpoints per
+request, and Hecate does not currently count or enforce that
+limit — its auto-attach can contribute up to two markers (one
+on the `system` tail, one on the `tools` tail) on top of whatever
+the caller already set. Callers placing three or more of their
+own markers should either leave room for the auto-markers or
+place a `cache_control` on the `system` and `tools` tails to
+suppress Hecate's auto-attach for those sections.
+
+Reads show up in the response as non-zero
+`cache_read_input_tokens`, which Hecate plumbs through as
+`Usage.CachedPromptTokens` and prices via the cache-read rate
+when the pricebook has one. Cache writes
+(`cache_creation_input_tokens`) currently fold into
+`Usage.PromptTokens` at the fresh-input rate; the pricebook
+doesn't yet have a separate cache-write rate, so first-turn cost
+is undercounted by ~20% per cache-write token until that lands.
 
 The behavior is controlled by `GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED`
 (default `true`). The toggle is global — every Anthropic-protocol


### PR DESCRIPTION
## Summary

PR #59 (merged) wired Anthropic prompt-cache markers into outbound Messages API requests, plus a global toggle `GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED`. The `.env.example` block landed with that PR; `docs/providers.md` — the canonical provider-behavior reference — didn't get the matching prose. An operator looking at the docs today has no signal that caching exists or how to control it.

This PR adds the missing section.

## What's in the new section

Between "Env-configured providers" and "Settings API":

- What Hecate auto-attaches to outbound requests (cache_control on the last system block + last tool entry; string system prompts lifted to block-list form because cache_control requires the block shape).
- Caller-supplied `cache_control` coexistence — operators or upstream orchestrators that already attach markers keep their boundaries alongside Hecate's auto-marker (Anthropic allows up to four cache breakpoints).
- Where the operator sees cache hits — non-zero `cache_read_input_tokens` in the response, plumbed to `Usage.CachedPromptTokens`, priced at the cache-read rate when the pricebook has one.
- The global toggle `GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED` (default `true`), explicitly noting it's gateway-wide and not per-provider.

## Other surfaces checked and not modified

- `docs/known-limitations.md` — had no caching limitation entry to remove or amend.
- `docs/agent-runtime.md` — cost-tracking section text doesn't claim caching is absent; existing description still reads correctly.
- `README.md` — the "cache metadata" mention there refers to request-cache, a different subsystem.

## Test plan

- [x] Single-file change, +31/-0
- [x] No code touched → no test runs