### PR TITLE
docs: drop stale RFC TODOs, capture send-side cache-marker behavior

### DIFF
--- a/docs-ai/skills/providers/SKILL.md
+++ b/docs-ai/skills/providers/SKILL.md
@@ -81,6 +81,17 @@ The Anthropic adapter centralizes warn-and-drop in `warnUnsupportedFieldsDropped
 
 ## Prompt caching (Anthropic-specific)
 
+### Send side — automatic `cache_control` markers
+
+The Anthropic adapter auto-attaches `cache_control: {"type":"ephemeral"}` markers so the static prefix (system prompt + tools catalog) is reused across turns. Two helpers — `applyAnthropicSystemCacheMarker` and `applyAnthropicToolsCacheMarker` in `anthropic.go` — run during request preparation:
+
+- The `system` field's last block and the last entry in `tools` each get a marker, but **only if the tail entry doesn't already carry caller-supplied `cache_control`**. Caller intent wins on the tail; earlier caller markers anywhere else in the same section are preserved unchanged.
+- Anthropic caps requests at four `cache_control` breakpoints. The adapter does not currently count or enforce that limit — auto-attach can contribute up to two markers on top of whatever the caller set. A caller already placing three or more markers can exceed the cap and be rejected upstream. If we add cross-provider request-shaping helpers later, this is where to put a breakpoint counter.
+- Globally toggleable via `GATEWAY_PROVIDER_ANTHROPIC_CACHE_ENABLED` (default `true`). Applied uniformly by `Protocol == "anthropic"` regardless of how the provider was added (env, Providers tab, programmatic). The runtime manager exposes `SetGlobalAnthropicCacheDisabled` for tests.
+- Operator-facing doc: [`docs/providers.md`](../../../docs/providers.md#anthropic-prompt-caching). Keep it in sync if you change the helpers' contract.
+
+### Response side — three-bucket usage
+
 `anthropicUsage` captures three buckets:
 
 - `input_tokens` — fresh tokens.

--- a/docs/rfcs/agent-memory.md
+++ b/docs/rfcs/agent-memory.md
@@ -241,9 +241,13 @@ boundary in trace inspectors.
 For both paths, when the request goes to Anthropic the memory
 block is wrapped in a `cache_control` marker. Memory changes
 infrequently and is identical across runs that share the same
-scope, so cache hits are high. Pairs with the planned
-context-window-management RFC (TODO: link once that file lands;
-the cache-marker mechanics live in that companion RFC).
+scope, so cache hits are high. The marker mechanics for the
+`system` prompt and `tools` catalog already shipped (PR #59) and
+are documented in [`docs/providers.md`](../providers.md#anthropic-prompt-caching);
+this RFC extends them by wrapping the memory block. The
+[LLM context window management RFC](llm-context-window-management.md)'s
+[Cache marker integration](llm-context-window-management.md#cache-marker-integration)
+section anticipates the same hookup.
 
 When the request goes elsewhere, no markers — the block is just
 text.
@@ -414,16 +418,21 @@ When this RFC is implemented:
 
 ## Cross-reference
 
-The companion RFC for **LLM context window management** (not yet
-written) handles token estimation, soft thresholds, hard caps,
-truncation, and Anthropic prompt caching. Memory entries inflate
-context, so:
+The companion RFC, [**LLM context window management**](llm-context-window-management.md),
+handles token estimation, soft thresholds, hard caps, and
+truncation. Anthropic prompt-cache markers for the `system`
+prompt and `tools` catalog shipped separately via PR #59 and
+are documented in [`docs/providers.md`](../providers.md#anthropic-prompt-caching).
+Memory entries inflate context, so:
 
 - The token estimator MUST count memory contributions in its
   pre-flight estimate.
-- The Anthropic cache-marker piece in the context-management RFC
-  SHOULD wrap the memory block when caching is on, since memory
-  changes infrequently relative to conversation turns.
+- The Anthropic adapter SHOULD wrap the memory block in the same
+  `cache_control: {"type":"ephemeral"}` marker when caching is on,
+  since memory changes infrequently relative to conversation turns.
+  The system-prompt and tools wrappers are already in place; the
+  memory-block wrapper lands with this RFC.
 
-These two features are designed to compose cleanly. Either can ship
-first; the other gains its hook on top.
+These features are designed to compose cleanly. The cache-marker
+plumbing already exists; the context-window RFC and this one each
+gain their hook on top.


### PR DESCRIPTION
## Summary

Now that PRs #59 (cache markers), #60 (context-window RFC), and #62 (operator docs) are merged, two doc surfaces are out of sync.

- **`docs/rfcs/agent-memory.md`** — two stale references to the context-window RFC: a `TODO: link once that file lands` and a `(not yet written)`. The RFC is in tree as `llm-context-window-management.md`. Both replaced with proper links and the cache-marker discussion re-anchored: system+tools markers shipped via PR #59 and live in `docs/providers.md`; the memory-block wrapper is what the agent-memory RFC adds on top.
- **`docs-ai/skills/providers/SKILL.md`** — covered the response-side three-bucket usage but said nothing about the send-side auto-attach helpers PR #59 introduced (`applyAnthropicSystemCacheMarker`, `applyAnthropicToolsCacheMarker`). Added a "Send side" subsection covering caller-wins-on-the-tail semantics, Anthropic's four-breakpoint cap (the adapter does not count or enforce it — known footgun for callers placing 3+ markers), the global toggle, and the operator-facing doc cross-link so future contributors keep the two in sync.

No code changes; docs only.

## Test plan

- [x] Links resolve (relative paths checked)
- [x] No code touched; CI is doc-link checks only