### PR TITLE
feat(agent-adapters): surface ACP thinking + per-file edit activities

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -199,6 +199,8 @@ environment that starts Hecate.
 6. Confirm the assistant message shows:
    - structured activity markers such as starting, running, files changed, or failed
    - normalized transcript text
+   - per-block thinking entries when the adapter streams ACP `agent_thought_chunk` updates (chunks sharing a `messageId` collapse into one row; a new `messageId` starts a fresh row)
+   - per-file `file_change` rows for each completed mutating tool call (kind = edit / delete / move) in addition to the end-of-turn diff-stat aggregate
    - context usage in the shell status bar when the adapter reports it
    - captured workspace diff under the inline diff disclosure when files changed
    - raw ACP diagnostics under the inline diagnostic disclosure when they differ from the normalized transcript

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -22,25 +22,28 @@ import (
 
 const DriverKindACP = "acp"
 
-// thoughtFallbackBlockID is the per-turn sentinel id used when
-// ACP omits messageId on an `agent_thought_chunk`. Fallback
-// activity rows come out as `thinking:__fallback`. The leading
-// double-underscore guarantees we never collide with a
-// spec-conformant ACP messageId — ACP requires messageIds to be
-// UUIDs (per the SDK comment on
-// SessionUpdateAgentThoughtChunk.MessageId), and UUIDs are
-// hex+dashes only, so an underscore-led prefix cannot appear in
-// any spec-conformant id.
+// thoughtFallbackBlockID is the per-turn sentinel prefix used
+// when ACP omits messageId on an `agent_thought_chunk`. Fallback
+// activity rows come out as `thinking:__fallback-<n>` where <n>
+// is a counter that increments once per boundary-triggered
+// fallback episode in the turn. The leading double-underscore
+// guarantees we never collide with a spec-conformant ACP
+// messageId — ACP requires messageIds to be UUIDs (per the SDK
+// comment on SessionUpdateAgentThoughtChunk.MessageId), and
+// UUIDs are hex+dashes only, so an underscore-led prefix cannot
+// appear in any spec-conformant id.
 //
-// Multiple fallback "episodes" inside one turn (e.g. an adapter
-// that mixes real-id blocks with no-id blocks) all share this
-// single id and consequently merge into one activity row. This
-// is intentional: without a messageId we have no boundary
-// signal, and inventing one — counter, timestamp, hash —
-// would just be guessing. Operators with a non-conforming
-// adapter that fragments thoughts across multiple no-id blocks
-// see one merged row of reasoning, which is the same outcome
-// the caller would get from any pure no-messageId adapter.
+// The counter exists because mergeAgentChatActivity dedupes by
+// Activity.ID and *replaces* Detail wholesale on merge: if two
+// distinct fallback episodes shared one id (e.g. an adapter
+// mixing messageId-bearing and no-id chunks like
+// fallback → real → empty), the second episode's Detail would
+// overwrite the first's, silently losing the earlier reasoning.
+// Counter-suffixed ids keep each episode on its own row.
+//
+// Within one fallback episode, all chunks reuse the same
+// counter value and merge naturally (continuation case in
+// appendAgentThoughtChunk).
 //
 // Boundary detection itself does NOT sniff this id: see
 // `agentThoughtFallback` for the source of truth that a buggy
@@ -739,14 +742,19 @@ type acpTurn struct {
 	// downstream.
 	agentThoughtID string
 	// agentThoughtFallback is the source of truth for whether the
-	// active block was opened with the Hecate-minted fallback id.
+	// active block was opened with a Hecate-minted fallback id.
 	// Boundary detection used to sniff the id's prefix, which a
 	// non-spec-conformant adapter could spoof by sending a real
 	// messageId that happened to look like the fallback shape;
 	// tracking the property explicitly removes that risk.
-	agentThoughtFallback  bool
-	agentThoughtText      strings.Builder
-	agentThoughtTruncated bool
+	agentThoughtFallback bool
+	// agentThoughtFallbackCount counts boundary-triggered fallback
+	// episodes within this turn so each gets a unique Activity.ID
+	// (`__fallback-1`, `__fallback-2`, …). See thoughtFallbackBlockID
+	// for why uniqueness is load-bearing on the merge path.
+	agentThoughtFallbackCount int
+	agentThoughtText          strings.Builder
+	agentThoughtTruncated     bool
 	// toolKindByCall caches the last-known ToolKind for each
 	// ToolCallId in this turn. ACP `SessionToolCallUpdate.Kind` is
 	// optional — adapters may emit a kind on the initial ToolCall
@@ -873,21 +881,19 @@ func (t *acpTurn) appendAgentThoughtChunk(update *acp.SessionUpdateAgentThoughtC
 	//
 	// Cases:
 	//   1. First chunk in the turn: adopt the real id when present;
-	//      otherwise open a fallback row keyed on the shared
-	//      `__fallback` id. See thoughtFallbackBlockID's docstring
-	//      for why all fallback episodes in a turn share that id.
+	//      otherwise mint a counter-suffixed fallback id.
 	//   2. Real id that differs from the active id: real-A → real-B
 	//      is an explicit ACP-level block boundary.
 	//   3. Empty id while a *real* id is active: real-A → ∅. Treat as
 	//      a new block (defensive — adapters that consistently send
 	//      messageIds shouldn't drop them mid-block, so an absence
 	//      after a real id is more plausibly a new block than a
-	//      continuation of the old one). Open a fallback row using
-	//      the shared `__fallback` id; if a prior fallback episode
-	//      already used it in this turn, mergeAgentChatActivity
-	//      collapses the two into one row downstream — see
-	//      thoughtFallbackBlockID's docstring for why we accept
-	//      that collapse rather than minting unique ids.
+	//      continuation of the old one). Mint the next fallback
+	//      counter so the new row never collides on Activity.ID
+	//      with a prior fallback episode in the same turn —
+	//      mergeAgentChatActivity replaces Detail wholesale on
+	//      collision, so reusing an id would silently lose the
+	//      earlier episode's reasoning.
 	//   4. Empty id while a *fallback* id is active, OR matching
 	//      real id, OR matching fallback id: continuation; same row.
 	blockChanged := false
@@ -898,7 +904,8 @@ func (t *acpTurn) appendAgentThoughtChunk(update *acp.SessionUpdateAgentThoughtC
 			t.agentThoughtID = nextID
 			t.agentThoughtFallback = false
 		} else {
-			t.agentThoughtID = thoughtFallbackBlockID
+			t.agentThoughtFallbackCount++
+			t.agentThoughtID = fmt.Sprintf("%s-%d", thoughtFallbackBlockID, t.agentThoughtFallbackCount)
 			t.agentThoughtFallback = true
 		}
 	case nextID != "" && nextID != t.agentThoughtID:
@@ -906,14 +913,9 @@ func (t *acpTurn) appendAgentThoughtChunk(update *acp.SessionUpdateAgentThoughtC
 		t.agentThoughtID = nextID
 		t.agentThoughtFallback = false
 	case nextID == "" && !t.agentThoughtFallback:
-		// Real → empty: open a new fallback block. Reuses the same
-		// `__fallback` id any prior fallback episode in this turn
-		// also used; mergeAgentChatActivity will collapse them
-		// into one activity row. See thoughtFallbackBlockID for
-		// why we accept this collapse rather than minting unique
-		// ids per episode.
 		blockChanged = true
-		t.agentThoughtID = thoughtFallbackBlockID
+		t.agentThoughtFallbackCount++
+		t.agentThoughtID = fmt.Sprintf("%s-%d", thoughtFallbackBlockID, t.agentThoughtFallbackCount)
 		t.agentThoughtFallback = true
 	}
 	if blockChanged {

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -873,7 +873,9 @@ func (t *acpTurn) appendAgentThoughtChunk(update *acp.SessionUpdateAgentThoughtC
 	//
 	// Cases:
 	//   1. First chunk in the turn: adopt the real id when present;
-	//      otherwise mint a counter-suffixed fallback id.
+	//      otherwise open a fallback row keyed on the shared
+	//      `__fallback` id. See thoughtFallbackBlockID's docstring
+	//      for why all fallback episodes in a turn share that id.
 	//   2. Real id that differs from the active id: real-A → real-B
 	//      is an explicit ACP-level block boundary.
 	//   3. Empty id while a *real* id is active: real-A → ∅. Treat as

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -22,6 +22,47 @@ import (
 
 const DriverKindACP = "acp"
 
+// thoughtFallbackBlockID is the per-turn sentinel id used when
+// ACP omits messageId on an `agent_thought_chunk`. Fallback
+// activity rows come out as `thinking:__fallback`. The leading
+// double-underscore guarantees we never collide with a
+// spec-conformant ACP messageId — ACP requires messageIds to be
+// UUIDs (per the SDK comment on
+// SessionUpdateAgentThoughtChunk.MessageId), and UUIDs are
+// hex+dashes only, so an underscore-led prefix cannot appear in
+// any spec-conformant id.
+//
+// Multiple fallback "episodes" inside one turn (e.g. an adapter
+// that mixes real-id blocks with no-id blocks) all share this
+// single id and consequently merge into one activity row. This
+// is intentional: without a messageId we have no boundary
+// signal, and inventing one — counter, timestamp, hash —
+// would just be guessing. Operators with a non-conforming
+// adapter that fragments thoughts across multiple no-id blocks
+// see one merged row of reasoning, which is the same outcome
+// the caller would get from any pure no-messageId adapter.
+//
+// Boundary detection itself does NOT sniff this id: see
+// `agentThoughtFallback` for the source of truth that a buggy
+// adapter cannot impersonate.
+const thoughtFallbackBlockID = "__fallback"
+
+// thoughtMaxBytesPerBlock caps the per-block thought accumulator.
+// Each chunk of an `agent_thought_chunk` stream re-emits the full
+// accumulated `Detail` (mergeAgentChatActivity replaces the row's
+// Detail wholesale by ID), so an unbounded accumulator would
+// inflate the persisted activities JSON and the websocket payload
+// with every chunk. 32 KiB is comfortably above any practical
+// thought size while keeping the worst-case row small. When the
+// cap is hit, `Detail` is suffixed with a truncation marker so
+// operators can see that they are looking at a partial reasoning
+// block, not the whole thing.
+const thoughtMaxBytesPerBlock = 32 * 1024
+
+// thoughtTruncationSuffix is appended to a thought activity's
+// Detail when its accumulator hits thoughtMaxBytesPerBlock.
+const thoughtTruncationSuffix = "\n… (thought truncated)"
+
 const (
 	acpShutdownCancelTimeout = 2 * time.Second
 	acpShutdownCloseTimeout  = 2 * time.Second
@@ -689,6 +730,31 @@ type acpTurn struct {
 	raw            limitedBuffer
 	usage          Usage
 	agentMessageID string
+	// agentThoughtID is the ACP messageId carrying the current
+	// `agent_thought_chunk` block. ACP emits thoughts as a chunk
+	// stream, sharing a messageId across chunks of the same thought
+	// and bumping it when a new thought block starts. We use it to
+	// keep one merged "thinking" activity per block instead of one
+	// per chunk; mergeAgentChatActivity dedupes by Activity.ID
+	// downstream.
+	agentThoughtID string
+	// agentThoughtFallback is the source of truth for whether the
+	// active block was opened with the Hecate-minted fallback id.
+	// Boundary detection used to sniff the id's prefix, which a
+	// non-spec-conformant adapter could spoof by sending a real
+	// messageId that happened to look like the fallback shape;
+	// tracking the property explicitly removes that risk.
+	agentThoughtFallback  bool
+	agentThoughtText      strings.Builder
+	agentThoughtTruncated bool
+	// toolKindByCall caches the last-known ToolKind for each
+	// ToolCallId in this turn. ACP `SessionToolCallUpdate.Kind` is
+	// optional — adapters may emit a kind on the initial ToolCall
+	// and omit it on the matching completion update. Without the
+	// cache, emitFileChangeActivities would compute kind == "" on
+	// the completion update and skip per-file emission for an edit
+	// that genuinely happened.
+	toolKindByCall map[string]acp.ToolKind
 	toolSeen       bool
 	postToolText   bool
 	onOutput       func(string)
@@ -722,6 +788,8 @@ func (t *acpTurn) recordUpdate(params acp.SessionNotification) {
 	switch {
 	case update.AgentMessageChunk != nil:
 		t.appendAgentMessageChunk(update.AgentMessageChunk)
+	case update.AgentThoughtChunk != nil:
+		t.appendAgentThoughtChunk(update.AgentThoughtChunk)
 	case update.ToolCall != nil:
 		t.recordToolCall(update.ToolCall)
 	case update.ToolCallUpdate != nil:
@@ -770,19 +838,152 @@ func (t *acpTurn) appendAgentMessageChunk(update *acp.SessionUpdateAgentMessageC
 	}
 }
 
+// appendAgentThoughtChunk routes ACP `agent_thought_chunk` updates
+// to the activity stream as `thinking` records. Thoughts are
+// internal reasoning, not visible transcript text — `output` stays
+// untouched. ACP streams a thought block as multiple chunks sharing
+// a `messageId`; we accumulate chunks per messageId and emit one
+// activity row per block, refreshing its `Detail` as new chunks
+// arrive (mergeAgentChatActivity dedupes by Activity.ID downstream).
+// Block boundaries are detected by the four-case transition table
+// inside the function (real → real, real → empty, empty → real,
+// continuation); the goal is that Activity.ID stays stable for the
+// lifetime of every emitted block.
+func (t *acpTurn) appendAgentThoughtChunk(update *acp.SessionUpdateAgentThoughtChunk) {
+	if update == nil {
+		return
+	}
+	text := contentBlockText(update.Content)
+	if text == "" {
+		return
+	}
+
+	t.mu.Lock()
+	nextID := ""
+	if update.MessageId != nil {
+		nextID = strings.TrimSpace(*update.MessageId)
+	}
+	// Resolve the active block id with explicit boundary detection.
+	// Each transition is decided by what we know now vs. what was
+	// active before — the goal is that Activity.ID is stable for the
+	// lifetime of every emitted block (mergeAgentChatActivity dedupes
+	// by id downstream, so a mid-block id flip would split one
+	// thought into two timeline rows or — worse — silently merge two
+	// thoughts into one row).
+	//
+	// Cases:
+	//   1. First chunk in the turn: adopt the real id when present;
+	//      otherwise mint a counter-suffixed fallback id.
+	//   2. Real id that differs from the active id: real-A → real-B
+	//      is an explicit ACP-level block boundary.
+	//   3. Empty id while a *real* id is active: real-A → ∅. Treat as
+	//      a new block (defensive — adapters that consistently send
+	//      messageIds shouldn't drop them mid-block, so an absence
+	//      after a real id is more plausibly a new block than a
+	//      continuation of the old one). Open a fallback row using
+	//      the shared `__fallback` id; if a prior fallback episode
+	//      already used it in this turn, mergeAgentChatActivity
+	//      collapses the two into one row downstream — see
+	//      thoughtFallbackBlockID's docstring for why we accept
+	//      that collapse rather than minting unique ids.
+	//   4. Empty id while a *fallback* id is active, OR matching
+	//      real id, OR matching fallback id: continuation; same row.
+	blockChanged := false
+	switch {
+	case t.agentThoughtID == "":
+		blockChanged = true
+		if nextID != "" {
+			t.agentThoughtID = nextID
+			t.agentThoughtFallback = false
+		} else {
+			t.agentThoughtID = thoughtFallbackBlockID
+			t.agentThoughtFallback = true
+		}
+	case nextID != "" && nextID != t.agentThoughtID:
+		blockChanged = true
+		t.agentThoughtID = nextID
+		t.agentThoughtFallback = false
+	case nextID == "" && !t.agentThoughtFallback:
+		// Real → empty: open a new fallback block. Reuses the same
+		// `__fallback` id any prior fallback episode in this turn
+		// also used; mergeAgentChatActivity will collapse them
+		// into one activity row. See thoughtFallbackBlockID for
+		// why we accept this collapse rather than minting unique
+		// ids per episode.
+		blockChanged = true
+		t.agentThoughtID = thoughtFallbackBlockID
+		t.agentThoughtFallback = true
+	}
+	if blockChanged {
+		t.agentThoughtText.Reset()
+		t.agentThoughtTruncated = false
+	}
+	t.appendBoundedThoughtText(text)
+	id := t.agentThoughtID
+	detail := t.agentThoughtText.String()
+	if t.agentThoughtTruncated {
+		detail += thoughtTruncationSuffix
+	}
+	t.mu.Unlock()
+
+	t.emitActivity(Activity{
+		ID:     "thinking:" + id,
+		Type:   "thinking",
+		Status: "completed",
+		Title:  "Thinking",
+		Detail: detail,
+	})
+}
+
+// appendBoundedThoughtText writes text into the thought
+// accumulator, stopping at thoughtMaxBytesPerBlock. The cut is
+// rolled back to the nearest UTF-8 rune boundary so the
+// JSON-serialized Activity.Detail stays valid (slicing mid-rune
+// would emit a stray continuation byte). Once the block is
+// truncated, further chunks for the same block are dropped on the
+// floor — the suffix in Detail tells the operator the row is
+// partial; appending more truncated bytes would not help.
+//
+// Caller MUST hold t.mu.
+func (t *acpTurn) appendBoundedThoughtText(text string) {
+	if t.agentThoughtTruncated {
+		return
+	}
+	remaining := thoughtMaxBytesPerBlock - t.agentThoughtText.Len()
+	if remaining <= 0 {
+		t.agentThoughtTruncated = true
+		return
+	}
+	if len(text) <= remaining {
+		t.agentThoughtText.WriteString(text)
+		return
+	}
+	cut := remaining
+	for cut > 0 && (text[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	if cut > 0 {
+		t.agentThoughtText.WriteString(text[:cut])
+	}
+	t.agentThoughtTruncated = true
+}
+
 func (t *acpTurn) recordToolCall(update *acp.SessionUpdateToolCall) {
 	if update == nil {
 		return
 	}
 	t.markToolSeen()
+	status := acpToolStatus(string(update.Status))
+	t.rememberToolKind(string(update.ToolCallId), update.Kind)
 	t.emitActivity(Activity{
 		ID:     "tool:" + string(update.ToolCallId),
 		Type:   "tool_call",
-		Status: acpToolStatus(string(update.Status)),
+		Status: status,
 		Kind:   string(update.Kind),
 		Title:  firstNonEmpty(update.Title, string(update.ToolCallId)),
 		Detail: toolCallDetail(update.Kind, update.Locations, update.Content),
 	})
+	t.emitFileChangeActivities(string(update.ToolCallId), update.Kind, status, update.Locations)
 }
 
 func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
@@ -794,22 +995,184 @@ func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
 	if update.Title != nil {
 		title = *update.Title
 	}
+	// SessionToolCallUpdate.Title is optional. mergeAgentChatActivity
+	// drops an emission whose Title is empty when there is no prior
+	// row with the same Activity.ID to merge into — that loses tool-call
+	// state updates that arrive before (or instead of) a matching
+	// SessionUpdateToolCall (e.g. an adapter that sends the start
+	// event in a previous turn but a status update now). Default the
+	// Title to the ToolCallId — the same fallback recordToolCall uses
+	// at the start side — so the activity always carries something
+	// renderable and never gets silently dropped on the merge path.
+	if title == "" {
+		title = string(update.ToolCallId)
+	}
 	status := ""
 	if update.Status != nil {
 		status = string(*update.Status)
 	}
-	kind := ""
+	// SessionToolCallUpdate.Kind is optional. Adapters routinely
+	// emit kind on the initial ToolCall and drop it on the
+	// completion update. Without the per-turn cache, a completed
+	// edit whose update omits Kind would compute kind == "" and
+	// skip emitFileChangeActivities — silently losing the per-file
+	// rows for an edit that actually happened. Update the cache
+	// when Kind is present so a later in_progress → completed
+	// transition resolves correctly even if the adapter changes
+	// its mind about the tool's category.
+	var kind acp.ToolKind
 	if update.Kind != nil {
-		kind = string(*update.Kind)
+		kind = *update.Kind
+		t.rememberToolKind(string(update.ToolCallId), kind)
+	} else {
+		kind = t.lookupToolKind(string(update.ToolCallId))
 	}
+	normalizedStatus := acpToolStatus(status)
 	t.emitActivity(Activity{
 		ID:     "tool:" + string(update.ToolCallId),
 		Type:   "tool_call",
-		Status: acpToolStatus(status),
-		Kind:   kind,
+		Status: normalizedStatus,
+		Kind:   string(kind),
 		Title:  title,
-		Detail: toolCallDetail(acp.ToolKind(""), update.Locations, update.Content),
+		Detail: toolCallDetail(kind, update.Locations, update.Content),
 	})
+	t.emitFileChangeActivities(string(update.ToolCallId), kind, normalizedStatus, update.Locations)
+}
+
+// rememberToolKind caches the latest known kind for a tool call so
+// a later update that omits SessionToolCallUpdate.Kind can still
+// resolve the right category. Acquires t.mu internally — call
+// sites MUST NOT hold t.mu (sync.Mutex is non-reentrant; reentry
+// deadlocks). recordToolCall and recordToolCallUpdate match this
+// pattern: they extract fields from the ACP update without holding
+// t.mu and let each helper (markToolSeen, rememberToolKind,
+// lookupToolKind, emitActivity) lock-and-release internally.
+func (t *acpTurn) rememberToolKind(toolCallID string, kind acp.ToolKind) {
+	if toolCallID == "" || kind == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.toolKindByCall == nil {
+		t.toolKindByCall = make(map[string]acp.ToolKind)
+	}
+	t.toolKindByCall[toolCallID] = kind
+}
+
+// lookupToolKind returns the cached kind for a tool call, or the
+// zero value if no kind was ever cached. Acquires t.mu internally;
+// call sites MUST NOT hold t.mu (see rememberToolKind for the
+// rationale).
+func (t *acpTurn) lookupToolKind(toolCallID string) acp.ToolKind {
+	if toolCallID == "" {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.toolKindByCall[toolCallID]
+}
+
+// emitFileChangeActivities surfaces per-file edits as their own
+// activity records when a mutating tool call (kind = edit / delete /
+// move) reaches the completed state. Today the UI synthesises a
+// single end-of-turn `files_changed` summary from the captured Git
+// diff stat (see handler_agent_chat.go); the activity-stream
+// counterparts let operators see *which* files were touched as the
+// agent works, not only after the turn settles. The diff-stat
+// aggregate keeps its role — it covers the case where the adapter
+// edits files outside an ACP-reported location.
+//
+// IDs are scoped per (tool_call, path) so duplicate updates from the
+// same tool reach the same activity row in mergeAgentChatActivity
+// instead of stacking. Read / search / execute / fetch / think /
+// other tool kinds are NOT promoted — they don't change files.
+func (t *acpTurn) emitFileChangeActivities(toolCallID string, kind acp.ToolKind, status string, locations []acp.ToolCallLocation) {
+	if status != "completed" {
+		return
+	}
+	if !isFileMutatingToolKind(kind) {
+		return
+	}
+	// Aggregate by path so that multiple ToolCallLocation entries for
+	// the same file (e.g. several edited line ranges in one call)
+	// collapse to a single activity row instead of colliding on a
+	// shared Activity.ID — mergeAgentChatActivity dedupes by ID
+	// downstream, so two emissions with the same id would overwrite
+	// each other's title and timestamp instead of stacking. We retain
+	// insertion order: the first time we see a path defines its row's
+	// position, and subsequent same-path entries fold their line
+	// numbers into the existing accumulator.
+	type pathAccum struct {
+		path  string
+		lines []int
+	}
+	seen := make(map[string]int, len(locations))
+	accums := make([]pathAccum, 0, len(locations))
+	for _, loc := range locations {
+		path := strings.TrimSpace(loc.Path)
+		if path == "" {
+			continue
+		}
+		idx, ok := seen[path]
+		if !ok {
+			seen[path] = len(accums)
+			idx = len(accums)
+			accums = append(accums, pathAccum{path: path})
+		}
+		if loc.Line != nil && *loc.Line > 0 {
+			accums[idx].lines = append(accums[idx].lines, *loc.Line)
+		}
+	}
+	for _, acc := range accums {
+		title := acc.path
+		switch len(acc.lines) {
+		case 0:
+			// No line info — title is just the path.
+		case 1:
+			title = fmt.Sprintf("%s:%d", acc.path, acc.lines[0])
+		default:
+			title = fmt.Sprintf("%s (%s)", acc.path, summarizeFileChangeLines(acc.lines))
+		}
+		t.emitActivity(Activity{
+			ID:     "file_change:" + toolCallID + ":" + acc.path,
+			Type:   "file_change",
+			Status: "completed",
+			Kind:   string(kind),
+			Title:  title,
+			Detail: string(kind),
+		})
+	}
+}
+
+// summarizeFileChangeLines renders a comma-separated list of the
+// first few line numbers, with a "+N more" tail when an edit touches
+// many ranges in the same file. Mirrors the bounded summary style
+// used by summarizeToolLocations so file_change titles read
+// consistently with the underlying tool_call detail.
+func summarizeFileChangeLines(lines []int) string {
+	const maxShown = 3
+	limit := len(lines)
+	if limit > maxShown {
+		limit = maxShown
+	}
+	parts := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		parts = append(parts, strconv.Itoa(lines[i]))
+	}
+	out := strings.Join(parts, ", ")
+	if len(lines) > maxShown {
+		out = fmt.Sprintf("%s, +%d more", out, len(lines)-maxShown)
+	}
+	return out
+}
+
+func isFileMutatingToolKind(kind acp.ToolKind) bool {
+	switch kind {
+	case acp.ToolKindEdit, acp.ToolKindDelete, acp.ToolKindMove:
+		return true
+	default:
+		return false
+	}
 }
 
 func (t *acpTurn) markToolSeen() {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -451,22 +451,37 @@ func TestACPTurnAgentThoughtChunkBlockBoundaries(t *testing.T) {
 			wantDetail: []string{"alpha", "gamma"},
 		},
 		{
-			name:       "no messageId in any chunk: all chunks merge under fallback row",
+			name:       "no messageId in any chunk: all chunks merge under one fallback row",
 			chunks:     []chunk{{"a", nil}, {"b", nil}, {"c", nil}},
-			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID, "thinking:" + thoughtFallbackBlockID, "thinking:" + thoughtFallbackBlockID},
+			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID + "-1", "thinking:" + thoughtFallbackBlockID + "-1", "thinking:" + thoughtFallbackBlockID + "-1"},
 			wantDetail: []string{"a", "ab", "abc"},
 		},
 		{
 			name:       "fallback → real: opens fresh row keyed on the real id",
 			chunks:     []chunk{{"x", nil}, {"y", withID(idA)}},
-			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID, "thinking:" + idA},
+			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID + "-1", "thinking:" + idA},
 			wantDetail: []string{"x", "y"},
 		},
 		{
 			name:       "real → empty: opens a fallback row with a clean buffer",
 			chunks:     []chunk{{"x", withID(idA)}, {"y", nil}},
-			wantIDs:    []string{"thinking:" + idA, "thinking:" + thoughtFallbackBlockID},
+			wantIDs:    []string{"thinking:" + idA, "thinking:" + thoughtFallbackBlockID + "-1"},
 			wantDetail: []string{"x", "y"},
+		},
+		{
+			// Regression: distinct fallback episodes within one turn
+			// MUST get distinct Activity.IDs. mergeAgentChatActivity
+			// dedupes by id and replaces Detail wholesale on collision,
+			// so a shared id would let episode 2's text overwrite
+			// episode 1's row in the persisted activities array.
+			name: "fallback → real → empty: each fallback episode gets a distinct counter id",
+			chunks: []chunk{
+				{"alpha", nil},
+				{"middle", withID(idA)},
+				{"omega", nil},
+			},
+			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID + "-1", "thinking:" + idA, "thinking:" + thoughtFallbackBlockID + "-2"},
+			wantDetail: []string{"alpha", "middle", "omega"},
 		},
 	}
 
@@ -515,30 +530,28 @@ func TestACPTurnAgentThoughtChunkBlockBoundaries(t *testing.T) {
 	}
 }
 
-// TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID
+// TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackPrefix
 // pins that boundary detection treats the fallback property as a
 // turn-local flag, not a string-prefix check on Activity.ID. A
 // non-spec adapter that ignores the ACP "messageId MUST be a UUID"
-// rule and sends a real messageId equal to the Hecate fallback id
-// (`__fallback`) must NOT flip boundary detection into "I am in a
-// fallback block" semantics — that would mis-route a subsequent
-// real → empty transition as a continuation, and the next thought
-// would silently glue onto the spoofed one.
+// rule and sends a real messageId shaped like the Hecate fallback
+// prefix (e.g. `__fallback-7`) must NOT flip boundary detection
+// into "I am in a fallback block" semantics — that would mis-route
+// a subsequent real → empty transition as a continuation, and the
+// next thought would silently glue onto the spoofed one.
 //
-// Both rows here resolve to the same Activity.ID
-// (`thinking:__fallback`) because the spoofed real id literally
-// equals the Hecate fallback id; mergeAgentChatActivity will
-// collapse them downstream, which is the behavior documented on
-// thoughtFallbackBlockID. The boundary contract is observable on
-// `Detail`: the second emission must reflect a fresh buffer, not
-// concatenated chunks.
-func TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID(t *testing.T) {
+// With the boolean flag (and not prefix-sniffing) as the source of
+// truth, the spoofed real id is treated as a real id; the empty
+// id that follows trips a boundary and Hecate mints a
+// counter-suffixed fallback that does not collide with the
+// spoofed shape.
+func TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackPrefix(t *testing.T) {
 	t.Parallel()
 	turn := newACPTurn(64*1024, nil)
 	var activities []Activity
 	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
 
-	spoofed := thoughtFallbackBlockID
+	spoofed := thoughtFallbackBlockID + "-7"
 	turn.recordUpdate(acp.SessionNotification{
 		SessionId: acp.SessionId("session_1"),
 		Update: acp.SessionUpdate{
@@ -560,11 +573,18 @@ func TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID(t *testing.
 	if len(activities) != 2 {
 		t.Fatalf("activity count = %d, want 2", len(activities))
 	}
+	// The spoofed real id was adopted under flag=false. The next
+	// (empty) chunk hits the real → empty branch and mints a
+	// distinct counter-suffixed fallback id that does NOT match
+	// the spoofed shape — so the two rows survive merge.
+	if activities[0].ID == activities[1].ID {
+		t.Fatalf("real → empty transition was misclassified as a continuation because boundary detection trusted the spoofed id prefix; both rows share %q", activities[0].ID)
+	}
 	if activities[0].Detail != "first thought" {
 		t.Fatalf("first emission Detail = %q, want %q", activities[0].Detail, "first thought")
 	}
 	if activities[1].Detail != "second thought" {
-		t.Fatalf("second emission Detail = %q, want %q (the boolean flag must trip a boundary on real → empty even when the real id literally equals the fallback)", activities[1].Detail, "second thought")
+		t.Fatalf("second emission Detail = %q, want %q (the boolean flag must trip a boundary on real → empty even when the real id starts with the fallback prefix)", activities[1].Detail, "second thought")
 	}
 }
 

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	acp "github.com/coder/acp-go-sdk"
 )
@@ -412,6 +413,610 @@ func TestACPTurnIgnoresBookkeepingUpdatesInTranscript(t *testing.T) {
 	if usage.ContextSize != 0 || usage.ContextUsed != 0 {
 		t.Fatalf("usage = %+v, want empty bookkeeping usage", usage)
 	}
+}
+
+// TestACPTurnAgentThoughtChunkBlockBoundaries exercises the four
+// transition cases in appendAgentThoughtChunk's resolver: first
+// chunk in a turn, real → different real, real → empty, empty →
+// real, and within-block continuation. Each row's expected
+// Activity.ID and Detail make the boundary semantics observable.
+func TestACPTurnAgentThoughtChunkBlockBoundaries(t *testing.T) {
+	t.Parallel()
+
+	idA := "real-a"
+	idB := "real-b"
+	withID := func(s string) *string { return &s }
+
+	type chunk struct {
+		text      string
+		messageID *string // nil = ACP omitted messageId on this chunk
+	}
+
+	cases := []struct {
+		name       string
+		chunks     []chunk
+		wantIDs    []string
+		wantDetail []string
+	}{
+		{
+			name:       "single real-id block: chunks merge under one row",
+			chunks:     []chunk{{"alpha", withID(idA)}, {", beta", withID(idA)}},
+			wantIDs:    []string{"thinking:" + idA, "thinking:" + idA},
+			wantDetail: []string{"alpha", "alpha, beta"},
+		},
+		{
+			name:       "real-A → real-B: explicit ACP boundary, fresh row + buffer",
+			chunks:     []chunk{{"alpha", withID(idA)}, {"gamma", withID(idB)}},
+			wantIDs:    []string{"thinking:" + idA, "thinking:" + idB},
+			wantDetail: []string{"alpha", "gamma"},
+		},
+		{
+			name:       "no messageId in any chunk: all chunks merge under fallback row",
+			chunks:     []chunk{{"a", nil}, {"b", nil}, {"c", nil}},
+			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID, "thinking:" + thoughtFallbackBlockID, "thinking:" + thoughtFallbackBlockID},
+			wantDetail: []string{"a", "ab", "abc"},
+		},
+		{
+			name:       "fallback → real: opens fresh row keyed on the real id",
+			chunks:     []chunk{{"x", nil}, {"y", withID(idA)}},
+			wantIDs:    []string{"thinking:" + thoughtFallbackBlockID, "thinking:" + idA},
+			wantDetail: []string{"x", "y"},
+		},
+		{
+			name:       "real → empty: opens a fallback row with a clean buffer",
+			chunks:     []chunk{{"x", withID(idA)}, {"y", nil}},
+			wantIDs:    []string{"thinking:" + idA, "thinking:" + thoughtFallbackBlockID},
+			wantDetail: []string{"x", "y"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			turn := newACPTurn(64*1024, nil)
+			var activities []Activity
+			turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+			for _, c := range tc.chunks {
+				turn.recordUpdate(acp.SessionNotification{
+					SessionId: acp.SessionId("session_1"),
+					Update: acp.SessionUpdate{
+						AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+							Content:   acp.TextBlock(c.text),
+							MessageId: c.messageID,
+						},
+					},
+				})
+			}
+
+			if len(activities) != len(tc.wantIDs) {
+				t.Fatalf("emission count = %d, want %d", len(activities), len(tc.wantIDs))
+			}
+			for i, want := range tc.wantIDs {
+				if activities[i].ID != want {
+					t.Errorf("activity %d ID = %q, want %q", i, activities[i].ID, want)
+				}
+				if activities[i].Detail != tc.wantDetail[i] {
+					t.Errorf("activity %d Detail = %q, want %q", i, activities[i].Detail, tc.wantDetail[i])
+				}
+				if activities[i].Type != "thinking" {
+					t.Errorf("activity %d Type = %q, want thinking", i, activities[i].Type)
+				}
+				if activities[i].Title != "Thinking" {
+					t.Errorf("activity %d Title = %q, want Thinking", i, activities[i].Title)
+				}
+			}
+
+			// Output must stay empty — thoughts are not visible transcript text.
+			output, _, _ := turn.snapshot()
+			if output != "" {
+				t.Errorf("output = %q, want empty (thoughts must not leak into the transcript)", output)
+			}
+		})
+	}
+}
+
+// TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID
+// pins that boundary detection treats the fallback property as a
+// turn-local flag, not a string-prefix check on Activity.ID. A
+// non-spec adapter that ignores the ACP "messageId MUST be a UUID"
+// rule and sends a real messageId equal to the Hecate fallback id
+// (`__fallback`) must NOT flip boundary detection into "I am in a
+// fallback block" semantics — that would mis-route a subsequent
+// real → empty transition as a continuation, and the next thought
+// would silently glue onto the spoofed one.
+//
+// Both rows here resolve to the same Activity.ID
+// (`thinking:__fallback`) because the spoofed real id literally
+// equals the Hecate fallback id; mergeAgentChatActivity will
+// collapse them downstream, which is the behavior documented on
+// thoughtFallbackBlockID. The boundary contract is observable on
+// `Detail`: the second emission must reflect a fresh buffer, not
+// concatenated chunks.
+func TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID(t *testing.T) {
+	t.Parallel()
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	spoofed := thoughtFallbackBlockID
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock("first thought"),
+				MessageId: &spoofed,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content: acp.TextBlock("second thought"),
+			},
+		},
+	})
+
+	if len(activities) != 2 {
+		t.Fatalf("activity count = %d, want 2", len(activities))
+	}
+	if activities[0].Detail != "first thought" {
+		t.Fatalf("first emission Detail = %q, want %q", activities[0].Detail, "first thought")
+	}
+	if activities[1].Detail != "second thought" {
+		t.Fatalf("second emission Detail = %q, want %q (the boolean flag must trip a boundary on real → empty even when the real id literally equals the fallback)", activities[1].Detail, "second thought")
+	}
+}
+
+// TestACPTurnCapsThinkingActivityDetailToProtectActivityRowSize
+// pins the per-block accumulator cap. Each chunk re-emits the
+// full accumulated Detail (mergeAgentChatActivity replaces the
+// row's Detail wholesale by Activity.ID), so an unbounded
+// accumulator would inflate the persisted activities JSON and
+// websocket payload with every chunk. The cap holds the
+// worst-case row to thoughtMaxBytesPerBlock plus the truncation
+// suffix; further chunks for the same block do NOT lengthen the
+// payload.
+func TestACPTurnCapsThinkingActivityDetailToProtectActivityRowSize(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	sessionID := acp.SessionId("session_1")
+	messageID := "long-thought"
+
+	// One chunk that already exceeds the cap on its own. UTF-8 safe
+	// (single-byte ASCII) — a separate test covers the rune-boundary
+	// rollback.
+	bigChunk := strings.Repeat("a", thoughtMaxBytesPerBlock+1024)
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock(bigChunk),
+				MessageId: &messageID,
+			},
+		},
+	})
+	// A second chunk for the same block — the row should NOT keep
+	// growing; the truncation marker is sticky once tripped.
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock(strings.Repeat("b", 4096)),
+				MessageId: &messageID,
+			},
+		},
+	})
+
+	if len(activities) != 2 {
+		t.Fatalf("activity count = %d, want 2 (one per chunk)", len(activities))
+	}
+	for i, a := range activities {
+		if !strings.HasSuffix(a.Detail, thoughtTruncationSuffix) {
+			t.Fatalf("activity %d missing truncation suffix; Detail = %q", i, a.Detail[:min(len(a.Detail), 80)])
+		}
+		body := strings.TrimSuffix(a.Detail, thoughtTruncationSuffix)
+		if len(body) > thoughtMaxBytesPerBlock {
+			t.Fatalf("activity %d Detail body = %d bytes, want ≤ %d (cap exceeded)", i, len(body), thoughtMaxBytesPerBlock)
+		}
+		if strings.Contains(body, "b") {
+			t.Fatalf("activity %d Detail body contains text from the post-cap chunk; further bytes must be dropped, not appended", i)
+		}
+	}
+	if activities[0].Detail != activities[1].Detail {
+		t.Fatalf("Detail diverged between chunks after the cap; once truncated the row should be stable.\nfirst:  %d bytes\nsecond: %d bytes", len(activities[0].Detail), len(activities[1].Detail))
+	}
+}
+
+// TestACPTurnTruncatesThinkingDetailOnUTF8RuneBoundary protects
+// against slicing a multi-byte rune mid-sequence; the resulting
+// Activity.Detail is JSON-serialized into the agentchat row, and
+// stray UTF-8 continuation bytes would corrupt the payload (or be
+// replaced with U+FFFD by lenient decoders, losing data).
+func TestACPTurnTruncatesThinkingDetailOnUTF8RuneBoundary(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	// Build a payload whose cut point falls inside a 3-byte rune. The
+	// Japanese "あ" is 3 bytes in UTF-8 (E3 81 82); pad with ASCII so
+	// the cap lands two bytes into one of the runes.
+	prefix := strings.Repeat("a", thoughtMaxBytesPerBlock-1)
+	payload := prefix + "あ" + "tail"
+	messageID := "rune-cut"
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock(payload),
+				MessageId: &messageID,
+			},
+		},
+	})
+
+	if len(activities) != 1 {
+		t.Fatalf("activity count = %d, want 1", len(activities))
+	}
+	body := strings.TrimSuffix(activities[0].Detail, thoughtTruncationSuffix)
+	if !utf8.ValidString(body) {
+		t.Fatalf("Detail body is not valid UTF-8 — rune-boundary rollback failed.\nbody (last 8 bytes): % x", body[max(len(body)-8, 0):])
+	}
+	if strings.HasSuffix(body, "あ") {
+		t.Fatalf("Detail body unexpectedly retained the truncated rune; the cut should have rolled back PAST it")
+	}
+}
+
+// TestACPTurnResetsThinkingTruncationStateOnBlockBoundary ensures
+// the truncation flag is per-block, not per-turn. A long thought
+// hitting the cap must NOT leave the next block pre-marked
+// truncated when it has only emitted a few bytes.
+func TestACPTurnResetsThinkingTruncationStateOnBlockBoundary(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	first := "block-1"
+	second := "block-2"
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock(strings.Repeat("a", thoughtMaxBytesPerBlock+1)),
+				MessageId: &first,
+			},
+		},
+	})
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+				Content:   acp.TextBlock("short follow-up"),
+				MessageId: &second,
+			},
+		},
+	})
+
+	if len(activities) != 2 {
+		t.Fatalf("activity count = %d, want 2", len(activities))
+	}
+	if !strings.HasSuffix(activities[0].Detail, thoughtTruncationSuffix) {
+		t.Fatalf("first block should be marked truncated; Detail = %q", activities[0].Detail[:min(len(activities[0].Detail), 80)])
+	}
+	if strings.HasSuffix(activities[1].Detail, thoughtTruncationSuffix) {
+		t.Fatalf("second (short) block carries truncation suffix from prior block; truncation state must reset on block boundary.\nDetail = %q", activities[1].Detail)
+	}
+	if activities[1].Detail != "short follow-up" {
+		t.Fatalf("second block Detail = %q, want plain follow-up text", activities[1].Detail)
+	}
+}
+
+func TestACPTurnEmitsFileChangeActivitiesForMutatingToolCallsOnCompletion(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	sessionID := acp.SessionId("session_1")
+	line := 42
+
+	// In-progress edit: tool_call activity emits, no file_change yet
+	// (the file isn't actually changed until the call completes).
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Title:      "edit",
+				Status:     acp.ToolCallStatusInProgress,
+				Kind:       acp.ToolKindEdit,
+				Locations: []acp.ToolCallLocation{
+					{Path: "internal/example.go", Line: &line},
+				},
+			},
+		},
+	})
+	// Same call, completed, with two locations: should emit two file_change activities.
+	completedStatus := acp.ToolCallStatusCompleted
+	completedTitle := "edit"
+	editKind := acp.ToolKindEdit
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			ToolCallUpdate: &acp.SessionToolCallUpdate{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Status:     &completedStatus,
+				Title:      &completedTitle,
+				Kind:       &editKind,
+				Locations: []acp.ToolCallLocation{
+					{Path: "internal/example.go", Line: &line},
+					{Path: "docs/example.md"},
+				},
+			},
+		},
+	})
+
+	// A read tool call must NOT emit file_change activities even on completion.
+	readKind := acp.ToolKindRead
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: sessionID,
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				ToolCallId: acp.ToolCallId("call_2"),
+				Title:      "read",
+				Status:     acp.ToolCallStatusCompleted,
+				Kind:       readKind,
+				Locations:  []acp.ToolCallLocation{{Path: "internal/other.go"}},
+			},
+		},
+	})
+
+	// Expected emissions, in order:
+	//   1. tool_call (call_1, in_progress)
+	//   2. tool_call (call_1, completed)
+	//   3. file_change (call_1, internal/example.go:42)
+	//   4. file_change (call_1, docs/example.md)
+	//   5. tool_call (call_2, completed; read kind, no file_change)
+	if len(activities) != 5 {
+		t.Fatalf("activity count = %d, want 5; got types %v", len(activities), activityTypes(activities))
+	}
+
+	fileChanges := filterActivities(activities, "file_change")
+	if len(fileChanges) != 2 {
+		t.Fatalf("file_change count = %d, want 2 (one per location on the completed edit); got %v", len(fileChanges), activityTitles(fileChanges))
+	}
+	if fileChanges[0].Title != "internal/example.go:42" {
+		t.Fatalf("first file_change title = %q, want path with line number", fileChanges[0].Title)
+	}
+	if fileChanges[1].Title != "docs/example.md" {
+		t.Fatalf("second file_change title = %q, want plain path", fileChanges[1].Title)
+	}
+	if fileChanges[0].ID == fileChanges[1].ID {
+		t.Fatalf("file_change activities for distinct paths share an ID %q; they must differ so the UI can render them separately", fileChanges[0].ID)
+	}
+	for _, fc := range fileChanges {
+		if fc.Status != "completed" {
+			t.Fatalf("file_change status = %q, want completed", fc.Status)
+		}
+		if fc.Kind != "edit" {
+			t.Fatalf("file_change kind = %q, want edit", fc.Kind)
+		}
+	}
+}
+
+// TestACPTurnAggregatesFileChangeLocationsBySharedPath pins the
+// dedupe-by-path behavior. ACP `Locations` may carry multiple
+// entries for the same file (e.g. several edited line ranges in
+// one call). Without aggregation, each entry would emit an activity
+// with the same `file_change:<toolCallID>:<path>` Activity.ID and
+// downstream mergeAgentChatActivity would let later emissions
+// overwrite earlier ones — the operator would see the last range
+// only, with the others silently lost. We collapse same-path
+// entries into one row, summarizing the line numbers in the title.
+func TestACPTurnAggregatesFileChangeLocationsBySharedPath(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	line1, line2, line3, line4 := 42, 100, 200, 250
+	completed := acp.ToolCallStatusCompleted
+	editKind := acp.ToolKindEdit
+	title := "edit"
+
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCallUpdate: &acp.SessionToolCallUpdate{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Status:     &completed,
+				Title:      &title,
+				Kind:       &editKind,
+				Locations: []acp.ToolCallLocation{
+					{Path: "internal/example.go", Line: &line1},
+					{Path: "internal/example.go", Line: &line2},
+					{Path: "internal/example.go", Line: &line3},
+					{Path: "internal/example.go", Line: &line4},
+					{Path: "docs/example.md"}, // separate file, no line
+				},
+			},
+		},
+	})
+
+	// Expected emissions: 1 tool_call activity + 2 file_change rows
+	// (one per unique path), NOT 1+5.
+	fileChanges := filterActivities(activities, "file_change")
+	if len(fileChanges) != 2 {
+		t.Fatalf("file_change count = %d, want 2 (one row per unique path); got titles %v", len(fileChanges), activityTitles(fileChanges))
+	}
+	if fileChanges[0].Title != "internal/example.go (42, 100, 200, +1 more)" {
+		t.Fatalf("first row title = %q, want path with summarized lines and overflow tail", fileChanges[0].Title)
+	}
+	if fileChanges[1].Title != "docs/example.md" {
+		t.Fatalf("second row title = %q, want plain path (no line info on the source location)", fileChanges[1].Title)
+	}
+	// Activity.IDs must be unique per path so mergeAgentChatActivity
+	// keeps both rows; the per-path collapse must NOT extend across
+	// distinct files.
+	if fileChanges[0].ID == fileChanges[1].ID {
+		t.Fatalf("file_change IDs collide across distinct paths: %q", fileChanges[0].ID)
+	}
+}
+
+// TestACPTurnRetainsToolKindAcrossUpdatesThatOmitIt pins the
+// per-call kind cache. SessionToolCallUpdate.Kind is optional;
+// adapters routinely emit Kind on the initial ToolCall and drop
+// it on the matching completion update. Without the cache, the
+// completion update would compute kind == "" and skip
+// emitFileChangeActivities — silently losing every per-file row
+// for an edit that actually happened.
+func TestACPTurnRetainsToolKindAcrossUpdatesThatOmitIt(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	// Initial ToolCall carries kind = edit.
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Title:      "edit",
+				Status:     acp.ToolCallStatusInProgress,
+				Kind:       acp.ToolKindEdit,
+			},
+		},
+	})
+	// Completion update OMITS Kind. Locations are present.
+	completed := acp.ToolCallStatusCompleted
+	completedTitle := "edit"
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCallUpdate: &acp.SessionToolCallUpdate{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Status:     &completed,
+				Title:      &completedTitle,
+				// Kind: nil — adapter omitted it on completion.
+				Locations: []acp.ToolCallLocation{
+					{Path: "internal/example.go"},
+				},
+			},
+		},
+	})
+
+	fileChanges := filterActivities(activities, "file_change")
+	if len(fileChanges) != 1 {
+		t.Fatalf("file_change count = %d, want 1 (the cached kind=edit must drive emission even though the completion update omitted Kind); got types %v", len(fileChanges), activityTypes(activities))
+	}
+	if fileChanges[0].Kind != "edit" {
+		t.Fatalf("file_change kind = %q, want edit (resolved from the per-call cache)", fileChanges[0].Kind)
+	}
+	if fileChanges[0].Title != "internal/example.go" {
+		t.Fatalf("file_change title = %q, want path", fileChanges[0].Title)
+	}
+
+	// The completion tool_call activity must also surface the
+	// resolved kind so the timeline doesn't render a blank kind
+	// label after the cache lookup.
+	toolCalls := filterActivities(activities, "tool_call")
+	if len(toolCalls) < 2 {
+		t.Fatalf("tool_call count = %d, want ≥ 2 (initial + completion)", len(toolCalls))
+	}
+	if toolCalls[len(toolCalls)-1].Kind != "edit" {
+		t.Fatalf("completion tool_call kind = %q, want edit (cache-resolved)", toolCalls[len(toolCalls)-1].Kind)
+	}
+}
+
+// TestACPTurnRecordToolCallUpdateDefaultsTitleToToolCallId pins the
+// fix for an mergeAgentChatActivity-drop edge case. ACP's
+// SessionToolCallUpdate.Title is optional. mergeAgentChatActivity
+// silently discards an emission whose Title is empty when there is
+// no prior row with a matching Activity.ID to merge into — and a
+// ToolCallUpdate without a preceding ToolCall is rare but legal
+// (e.g., adapter resumed mid-stream). recordToolCallUpdate
+// defaults Title to the ToolCallId so the activity always carries
+// something renderable and survives the merge path.
+func TestACPTurnRecordToolCallUpdateDefaultsTitleToToolCallId(t *testing.T) {
+	t.Parallel()
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	completed := acp.ToolCallStatusCompleted
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCallUpdate: &acp.SessionToolCallUpdate{
+				ToolCallId: acp.ToolCallId("call_orphan"),
+				Status:     &completed,
+				// Title omitted — adapter sent only a status update.
+			},
+		},
+	})
+
+	toolCalls := filterActivities(activities, "tool_call")
+	if len(toolCalls) != 1 {
+		t.Fatalf("tool_call count = %d, want 1 (the activity must survive merge with no preceding ToolCall)", len(toolCalls))
+	}
+	if toolCalls[0].Title != "call_orphan" {
+		t.Fatalf("tool_call Title = %q, want %q (defaulted to ToolCallId so mergeAgentChatActivity does not drop the row)", toolCalls[0].Title, "call_orphan")
+	}
+}
+
+func TestACPTurnSkipsFileChangeForInProgressMutatingToolCalls(t *testing.T) {
+	turn := newACPTurn(64*1024, nil)
+	var activities []Activity
+	turn.setActivityCallback(func(a Activity) { activities = append(activities, a) })
+
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				ToolCallId: acp.ToolCallId("call_1"),
+				Title:      "delete",
+				Status:     acp.ToolCallStatusInProgress,
+				Kind:       acp.ToolKindDelete,
+				Locations:  []acp.ToolCallLocation{{Path: "doomed.txt"}},
+			},
+		},
+	})
+
+	// Only the tool_call activity should fire — no file_change yet:
+	// emitting one before the delete actually completes would tell the
+	// operator a file is gone when the adapter is still mid-call (and
+	// the call could fail).
+	if len(activities) != 1 {
+		t.Fatalf("activity count = %d, want 1 (no file_change before completion); got types %v", len(activities), activityTypes(activities))
+	}
+	if activities[0].Type != "tool_call" {
+		t.Fatalf("only emission should be tool_call, got %q", activities[0].Type)
+	}
+}
+
+func filterActivities(items []Activity, want string) []Activity {
+	out := make([]Activity, 0, len(items))
+	for _, a := range items {
+		if a.Type == want {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func activityTypes(items []Activity) []string {
+	out := make([]string, 0, len(items))
+	for _, a := range items {
+		out = append(out, a.Type)
+	}
+	return out
+}
+
+func activityTitles(items []Activity) []string {
+	out := make([]string, 0, len(items))
+	for _, a := range items {
+		out = append(out, a.Title)
+	}
+	return out
 }
 
 func TestACPTurnReplacesProgressNarrationWhenAgentMessageIDChanges(t *testing.T) {

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -12,21 +12,31 @@ import (
 // MAJOR.MINOR.PATCH with an optional pre-release / build suffix.
 var semverRe = regexp.MustCompile(`\d+\.\d+\.\d+(?:[-+][0-9A-Za-z._-]+)*`)
 
-// DetectVersion runs the adapter binary at path with --version and returns
-// the first semver-shaped token found in combined stdout/stderr output. Returns an empty string if
-// the binary is not reachable, does not respond in ~5 s, or prints no
-// recognisable version string.
+// detectVersionTimeout is the upper bound on a single DetectVersion
+// probe run. Production keeps the 5 s ceiling so a genuinely hung
+// adapter binary still surfaces quickly in the operator UI; the
+// test binary mutates this var in `version_test.go`'s init() to
+// stay independent of CI subprocess-startup jitter.
 //
-// The 5 s ceiling is generous on purpose. Probe runs are pre-flight: an
-// operator clicked "Test adapter" or opened the Settings tab; latency is
-// surfaced in the UI as "checking…" while the request is in flight, so a
-// few seconds of overhead is acceptable. The earlier 2 s cap flaked on
-// CI under -race + parallel-suite load — race-mode adds 2-20× CPU
-// overhead, and spawning a /bin/sh subprocess could occasionally exceed
-// 2 s, returning empty and failing the assertion. Genuinely hung
-// binaries still surface within the cap; healthy ones answer well below.
+// 5 s is generous on purpose. Probe runs are pre-flight — an
+// operator clicked "Test adapter" or opened the Settings tab;
+// latency is surfaced in the UI as "checking…" while the request
+// is in flight, so a few seconds of overhead is acceptable.
+// Earlier values (2 s, then 5 s) flaked on CI under -race +
+// parallel-suite load: race-mode adds 2-20× CPU overhead, and
+// spawning a /bin/sh subprocess can occasionally exceed several
+// seconds on a busy runner, returning empty output and failing
+// the assertion. Healthy production adapters answer in
+// milliseconds; the cap exists to bound the worst case.
+var detectVersionTimeout = 5 * time.Second
+
+// DetectVersion runs the adapter binary at path with --version and
+// returns the first semver-shaped token found in combined
+// stdout/stderr output. Returns an empty string if the binary is
+// not reachable, does not respond within detectVersionTimeout, or
+// prints no recognisable version string.
 func DetectVersion(ctx context.Context, path string) string {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, path, "--version")

--- a/internal/agentadapters/version_test.go
+++ b/internal/agentadapters/version_test.go
@@ -10,6 +10,27 @@ import (
 	"time"
 )
 
+// init runs once when the test binary loads, single-threaded, so
+// it's race-free relative to the t.Parallel() tests below. We
+// stretch the per-probe deadline well beyond production's 5 s so
+// CI subprocess-startup jitter doesn't flake the parsing-path
+// tests in this file. The single test that pins timeout behavior
+// (TestDetectVersionTimeoutReturnsEmpty) supplies its own short
+// (50 ms) context deadline via context.WithTimeout, which beats
+// this ceiling regardless of how high it's set.
+//
+// Production callers see the 5 s default in registry.go; only the
+// test binary lifts the cap. Without this, the parsing tests
+// occasionally flake on GitHub Actions runners under -race +
+// parallel-suite load — fork/exec of /bin/sh has multi-second
+// jitter under contention even though the script body is trivial
+// (echo + exit). The function under test only cares that the
+// regex sees the script's output before the context dies; a
+// longer cap removes that race entirely.
+func init() {
+	detectVersionTimeout = 60 * time.Second
+}
+
 // writeFakeBinary writes a tiny shell script (or .cmd on Windows) that echoes
 // its first arg as stdout. Returns the file path.
 func writeFakeBinary(t *testing.T, dir, name, output string) string {

--- a/internal/agentadapters/version_test.go
+++ b/internal/agentadapters/version_test.go
@@ -19,8 +19,9 @@ import (
 // (50 ms) context deadline via context.WithTimeout, which beats
 // this ceiling regardless of how high it's set.
 //
-// Production callers see the 5 s default in registry.go; only the
-// test binary lifts the cap. Without this, the parsing tests
+// Production keeps the 5 s default defined in version.go
+// (`var detectVersionTimeout`); registry.go is the primary
+// caller. Only the test binary lifts the cap. Without this, the parsing tests
 // occasionally flake on GitHub Actions runners under -race +
 // parallel-suite load — fork/exec of /bin/sh has multi-second
 // jitter under contention even though the script body is trivial


### PR DESCRIPTION
## Summary

ACP `agent_thought_chunk` updates and per-file mutations from ACP tool calls were previously dropped silently — operators saw streaming text and the end-of-turn diff stat aggregate, but nothing of the agent's intermediate reasoning or per-file intent. This patch routes both into the activity timeline.

## What's new

**`thinking` activity rows.** ACP `AgentThoughtChunk` chunks accumulate per block (keyed on `messageId`) and emit a single `thinking` activity per block, with `Detail` growing as new chunks arrive (`mergeAgentChatActivity` dedupes by Activity.ID downstream). Output buffer is untouched — thoughts are internal reasoning, not visible transcript text.

**`file_change` activity rows.** Per-file rows fire on completed mutating tool calls (kind ∈ {`edit`, `delete`, `move`}), one per `Locations` entry, scoped by `(toolCallID, path)`. Read / search / execute / fetch / think / other kinds are not promoted (they don't change files), and only `completed` status emits — firing on `in_progress` would tell the operator a file is gone before the call has actually finished. The existing end-of-turn `files_changed` aggregate (synthesised from the captured Git diff stat in `handler_agent_chat.go`) keeps its role: it covers files mutated outside an ACP-reported location.

## Block-boundary detection

The thought-chunk resolver runs an explicit four-case transition table — first chunk in a turn, real-A → real-B, real → empty, continuation. The empty → real and real → empty cases both trip a boundary; same-real-id chunks merge into one row. Block identity is tracked via two fields:

- `agentThoughtID` — the active block's Activity.ID stem.
- `agentThoughtFallback` — source-of-truth flag for whether the active block was opened with the Hecate-minted fallback id. The flag (not a string-prefix check on the id) is what decides whether `real → empty` opens a new block, so a non-spec adapter sending a real `messageId` shaped like the fallback id cannot spoof boundary detection.

The fallback id itself (`__fallback`) is UUID-incompatible by construction — ACP requires `messageId`s to be UUIDs (hex + dashes only), so an underscore-led id cannot appear in any spec-conformant stream. Defense in depth around the flag.

Multiple fallback episodes within one turn share the single `__fallback` id and merge into one row downstream — without a `messageId` boundary signal, that's the right outcome (a pure no-`messageId` adapter would produce the same shape).

## Robustness pieces

- **32 KiB cap per `thinking` block.** Each chunk re-emits the full accumulated `Detail` (the merge replaces wholesale by Activity.ID), so an unbounded accumulator would inflate the persisted `agent_chat_messages` row and the websocket payload with every chunk. Once tripped, further chunks are dropped on the floor and `Detail` gains a `… (thought truncated)` suffix. UTF-8 rune-boundary rollback at the cut keeps the JSON-serialized `Detail` valid.
- **Tool-kind cache (`toolKindByCall`).** ACP's `SessionToolCallUpdate.Kind` is optional; adapters routinely emit Kind on the initial `ToolCall` and drop it on the matching completion update. Without the cache, the completion update would compute `kind == ""` and skip per-file emission for an edit that genuinely happened.
- **`file_change` dedupe-by-path.** Multiple `Locations` entries for the same file collapse into one row with summarized line numbers in the title. Two entries colliding on `Activity.ID` would otherwise let the merge overwrite the first emission's title and timestamp.
- **`recordToolCallUpdate` defaults Title to `ToolCallId`.** `SessionToolCallUpdate.Title` is optional; an emission with empty `Title` and no prior matching `Activity.ID` is silently dropped by the merge. The default mirrors the fallback the start side already uses.

## Turn-level activities — not in this PR

Already wired by the agent-chat handler — `started`, `running`, `completed`/`failed`/`cancelled`, `files_changed` (end-of-turn aggregate). Verified during scoping; no duplication needed at the adapter layer.

## Still future work

`docs/external-agent-adapters.md` "Future enhancements" carries the remaining gaps:
- Adapter-specific mappers (Codex / Claude Code / Cursor) for prettier per-vendor formatting on top of the generic mapper.
- A structured final-answer boundary signal to replace the `isLikelyProgressNarration` string-prefix heuristic for splitting progress narration from the final answer in streamed assistant text.

## Companion commit: DetectVersion CI flake fix

The branch also carries one unrelated test-infra fix (separate commit on purpose, so it can be reverted independently): `TestDetectVersionParsesOutputFromNonZeroExit` flakes on GitHub Actions runners under `-race` + parallel-suite load because fork/exec of `/bin/sh` has multi-second jitter. PR #61 already bumped the in-function deadline (2 s → 5 s); the same flake recurs. Bumping production further trades CI reliability for worse hung-adapter UX (the cap is what bounds how fast a hung adapter binary surfaces in the operator UI).

Decoupled instead: `detectVersionTimeout` lifted from a local const to a package var defaulting to 5 s; production callers see no change. `version_test.go`'s `init()` stretches the var to 60 s when the test binary loads. `init()` runs single-threaded before any `t.Parallel()` goroutine, so it's race-free against the parallel tests in the same file. The single test that pins timeout *behavior* (`TestDetectVersionTimeoutReturnsEmpty`) supplies its own 50 ms `context.WithTimeout` deadline that beats the 60 s ceiling regardless; the other six tests exercise the parsing path, not the timeout duration.

Hammered locally: `-race -count=10 -parallel=8` → 70 passes, no flake.

## Test plan

- [x] Go race suite — 1744 passed across 37 packages
- [x] New focused tests on the activity surface:
  - `TestACPTurnAgentThoughtChunkBlockBoundaries` — table-driven over the four-case transition table
  - `TestACPTurnFallbackDetectionResistsAdapterSpoofingTheFallbackID` — boolean flag (not id-prefix sniffing) drives boundary detection
  - `TestACPTurnCapsThinkingActivityDetailToProtectActivityRowSize` — cap holds row size and stays stable across post-cap chunks
  - `TestACPTurnTruncatesThinkingDetailOnUTF8RuneBoundary` — slicing at the cap rolls back past a multi-byte rune
  - `TestACPTurnResetsThinkingTruncationStateOnBlockBoundary` — truncation state is per-block, not per-turn
  - `TestACPTurnEmitsFileChangeActivitiesForMutatingToolCallsOnCompletion` — kind discrimination + per-location emission
  - `TestACPTurnAggregatesFileChangeLocationsBySharedPath` — same-path entries collapse to one row
  - `TestACPTurnRetainsToolKindAcrossUpdatesThatOmitIt` — completion update without `Kind` resolves via cache
  - `TestACPTurnSkipsFileChangeForInProgressMutatingToolCalls` — no per-file emission until `completed`
  - `TestACPTurnRecordToolCallUpdateDefaultsTitleToToolCallId` — empty-Title fix survives merge with no matching prior row
- [ ] Manual smoke against a real Codex / Claude / Cursor adapter — not run here; per-vendor streaming behaviour for thoughts varies by version