### PR TITLE
fix(transcript): dedupe earlier terminal rows on the activity timeline

### DIFF
--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -95,15 +95,17 @@ describe("TranscriptActivityTimeline", () => {
 
   it("dedupes earlier terminal rows when a later terminal row exists", () => {
     // The Hecate Chat run path emits two terminal-shaped rows on a
-    // successful completion: a synced `task_run` mirror that shows
-    // up as `run_result` with title "Run completed", and an
-    // explicit `Activity{Type: status, Title: finalAgentChatActivityTitle(status)}`
+    // successful completion: a synced `task_run` mirror surfacing
+    // as `run_result` (the fixture uses title "Run finished" so it
+    // bypasses isTerminalRunSummary's `/^run (completed|failed|cancelled)$/`
+    // filter, which strips the literal "run completed" titles), and
+    // an explicit `Activity{Type: status, Title: finalAgentChatActivityTitle(status)}`
     // appended by the agent-chat handler at turn end. Without
     // dedupe the operator sees two side-by-side terminal rows for
-    // one run; the timeline should keep only the latest. Earlier
-    // rows that match `isTerminalRunSummary` (title "run X") were
-    // already dropped, but type-only collisions (e.g. type=completed
-    // title="Completed") survived prior to the dedupe rule.
+    // one run; the timeline should keep only one. Earlier
+    // rows that match `isTerminalRunSummary` were already dropped,
+    // but type-only collisions (e.g. type=completed title="Done")
+    // survived prior to the dedupe rule.
     const activities: AgentChatActivityRecord[] = [
       { type: "tool_call", title: "read_file", status: "completed" },
       { type: "run_result", title: "Run finished", status: "completed" },
@@ -112,6 +114,34 @@ describe("TranscriptActivityTimeline", () => {
     render(<TranscriptActivityTimeline activities={activities} />);
     expect(screen.queryByText("Run finished")).toBeNull();
     expect(screen.getAllByText("Done")).toHaveLength(1);
+  });
+
+  it("prefers a terminal=true diagnostic row over a generic terminal row when both are present", () => {
+    // The synced `task_run` mirror carries `terminal: true` AND a
+    // detail like "LLM call failed on turn 3" — informative
+    // diagnostic the operator wants to see. The agent-chat
+    // handler also appends a generic `Activity{Type: "failed",
+    // Title: "Failed"}` at turn end. When both are on the timeline,
+    // the diagnostic row must win — naïvely keeping "the latest
+    // terminal row" would drop it in favour of the bare-bones
+    // generic row that surfaces no useful detail.
+    // Title chosen to avoid `isTerminalRunSummary`'s regex
+    // (`/^run (completed|failed|cancelled)$/i`), which would strip
+    // the row before the dedupe-pick step ran. Real diagnostic rows
+    // typically carry richer titles like "LLM call failed on turn 3"
+    // anyway.
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "shell_exec", status: "failed" },
+      { type: "run_result", title: "LLM call failed on turn 3", status: "failed", terminal: true, detail: "rate limit exceeded" },
+      { type: "failed", title: "Failed", status: "failed" },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+    expect(screen.getByText("LLM call failed on turn 3")).toBeInTheDocument();
+    // The generic "Failed" row title must NOT appear as a timeline row
+    // (the word "failed" still surfaces inside the timeline summary
+    // status text, which is fine — that's not a row).
+    const failedAsRowTitle = screen.queryAllByText("Failed").filter(node => !node.closest("summary"));
+    expect(failedAsRowTitle).toHaveLength(0);
   });
 
   it("renders plan items with their plan-status indicators", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -93,6 +93,27 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText(/completed/).closest("details")?.open).toBe(true);
   });
 
+  it("dedupes earlier terminal rows when a later terminal row exists", () => {
+    // The Hecate Chat run path emits two terminal-shaped rows on a
+    // successful completion: a synced `task_run` mirror that shows
+    // up as `run_result` with title "Run completed", and an
+    // explicit `Activity{Type: status, Title: finalAgentChatActivityTitle(status)}`
+    // appended by the agent-chat handler at turn end. Without
+    // dedupe the operator sees two side-by-side terminal rows for
+    // one run; the timeline should keep only the latest. Earlier
+    // rows that match `isTerminalRunSummary` (title "run X") were
+    // already dropped, but type-only collisions (e.g. type=completed
+    // title="Completed") survived prior to the dedupe rule.
+    const activities: AgentChatActivityRecord[] = [
+      { type: "tool_call", title: "read_file", status: "completed" },
+      { type: "run_result", title: "Run finished", status: "completed" },
+      { type: "completed", title: "Done", status: "completed" },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+    expect(screen.queryByText("Run finished")).toBeNull();
+    expect(screen.getAllByText("Done")).toHaveLength(1);
+  });
+
   it("renders plan items with their plan-status indicators", () => {
     const activities: AgentChatActivityRecord[] = [
       { type: "plan", title: "Step 1", status: "completed" },

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -241,12 +241,7 @@ function ActivityLine({ activity, prefix }: { activity: AgentChatActivityRecord;
 
 function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentChatActivityRecord[] {
   const hiddenTypes = new Set(["artifact", "changed_files", "final_answer", "output"]);
-  const terminal = terminalAgentActivity(activities);
-  // Index of the terminal row we want to keep — the latest one
-  // terminalAgentActivity selects. We use lastIndexOf instead of
-  // findIndex because the helper walks back-to-front; identifying
-  // it by index lets us drop earlier terminal rows by index.
-  const terminalIndex = terminal ? activities.lastIndexOf(terminal) : -1;
+  const terminalIndex = pickTerminalActivityIndex(activities);
   const lastTaskRunIndex = lastIndexOfTaskRunActivity(activities);
   const lastApprovalIndexByID = lastIndexByApprovalID(activities);
   const out: AgentChatActivityRecord[] = [];
@@ -254,14 +249,13 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
     if (hiddenTypes.has(activity.type)) continue;
     if (activity.type === "completed" && activity.title.toLowerCase() === "final answer") continue;
     if (isTerminalRunSummary(activity)) continue;
-    // Drop earlier terminal-typed rows so the timeline never shows
-    // two side-by-side endings (e.g. type="completed" title="Final
-    // answer" emitted by handler_agent_chat alongside a synced
-    // task_run row with type="run_result"). terminalAgentActivity
-    // already picks the latest; everything else with a terminal
-    // shape is redundant for the operator.
+    // Drop terminal-shaped rows that aren't the chosen one. The
+    // chooser prefers a diagnostic `terminal: true` row over a
+    // generic agent-chat-handler row (see pickTerminalActivityIndex)
+    // so an informative "LLM call failed on turn 3" beats a
+    // bare-bones "Failed". When no row is chosen we keep them all.
     if (terminalIndex !== -1 && index !== terminalIndex && isTerminalActivity(activity)) continue;
-    if (terminal && (activity.type === "started" || activity.type === "running")) continue;
+    if (terminalIndex !== -1 && (activity.type === "started" || activity.type === "running")) continue;
     if (activity.type === "running" && activities.some(item => item.type === "output")) continue;
     if (isTaskRunActivity(activity) && index !== lastTaskRunIndex) continue;
     if (activity.type === "approval" && activity.approval_id && lastApprovalIndexByID.get(activity.approval_id) !== index) continue;
@@ -270,8 +264,43 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
   return collapseModelTurnActivities(out);
 }
 
+// isTerminalActivity is the canonical predicate for "this activity
+// represents a terminal status." Used both by the dedupe filter and
+// by pickTerminalActivityIndex so the two cannot disagree on what
+// counts as terminal — an earlier mismatch let `terminalAgentActivity`
+// (which only looked at completed/failed/cancelled+terminal) pick
+// the wrong row when a `run_result`-typed terminal arrived later.
 function isTerminalActivity(activity: AgentChatActivityRecord): boolean {
   return activity.terminal === true || terminalRunSummaryTypes.has(activity.type);
+}
+
+// pickTerminalActivityIndex selects the row that should win on the
+// timeline when several terminal-shaped rows exist for one run.
+// Preference order:
+//
+//   1. The latest row with `terminal: true`. These are explicit
+//      diagnostic rows from the runtime (the synced `task_run`
+//      mirror, kind=run_result with detail like "LLM call failed
+//      on turn 3"). They carry the most useful operator
+//      information; if one exists, it should win.
+//   2. Otherwise, the latest row whose type alone makes it
+//      terminal-shaped (completed/failed/cancelled/run_result
+//      without an explicit `terminal: true` flag). These are the
+//      generic agent-chat-handler rows with titles like "Final
+//      answer" / "Failed" / "Cancelled" — fine when nothing more
+//      informative is available.
+//   3. -1 when no terminal-shaped row exists; the dedupe filter
+//      becomes a no-op and the timeline stays as-is.
+function pickTerminalActivityIndex(activities: AgentChatActivityRecord[]): number {
+  let lastByFlag = -1;
+  let lastByShape = -1;
+  for (let index = 0; index < activities.length; index += 1) {
+    const activity = activities[index];
+    if (activity.terminal === true) lastByFlag = index;
+    if (isTerminalActivity(activity)) lastByShape = index;
+  }
+  if (lastByFlag !== -1) return lastByFlag;
+  return lastByShape;
 }
 
 function compactDetailActivities(activities: AgentChatActivityRecord[], hasDiffStat: boolean): AgentChatActivityRecord[] {
@@ -521,9 +550,18 @@ function approvalActivityTitle(activity: AgentChatActivityRecord): string {
   }
 }
 
+// terminalAgentActivity returns the row that should represent the
+// run's terminal status — the same row pickTerminalActivityIndex
+// selects for the dedupe filter, so the TIMELINE summary (uses
+// this) and the dedupe (uses pickTerminalActivityIndex) cannot
+// disagree about which terminal row to surface. Previously the
+// helper had a narrower set ({completed, failed, cancelled}) and
+// could miss a `run_result`-typed terminal that pickTerminalActivityIndex
+// would correctly pick — leading to the dedupe dropping the row
+// the timeline summary needed.
 function terminalAgentActivity(activities: AgentChatActivityRecord[]): AgentChatActivityRecord | undefined {
-  const terminalTypes = new Set(["completed", "failed", "cancelled"]);
-  return [...activities].reverse().find(activity => activity.terminal || terminalTypes.has(activity.type));
+  const index = pickTerminalActivityIndex(activities);
+  return index === -1 ? undefined : activities[index];
 }
 
 function terminalStatusLabel(status?: string): string {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -242,6 +242,11 @@ function ActivityLine({ activity, prefix }: { activity: AgentChatActivityRecord;
 function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentChatActivityRecord[] {
   const hiddenTypes = new Set(["artifact", "changed_files", "final_answer", "output"]);
   const terminal = terminalAgentActivity(activities);
+  // Index of the terminal row we want to keep — the latest one
+  // terminalAgentActivity selects. We use lastIndexOf instead of
+  // findIndex because the helper walks back-to-front; identifying
+  // it by index lets us drop earlier terminal rows by index.
+  const terminalIndex = terminal ? activities.lastIndexOf(terminal) : -1;
   const lastTaskRunIndex = lastIndexOfTaskRunActivity(activities);
   const lastApprovalIndexByID = lastIndexByApprovalID(activities);
   const out: AgentChatActivityRecord[] = [];
@@ -249,6 +254,13 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
     if (hiddenTypes.has(activity.type)) continue;
     if (activity.type === "completed" && activity.title.toLowerCase() === "final answer") continue;
     if (isTerminalRunSummary(activity)) continue;
+    // Drop earlier terminal-typed rows so the timeline never shows
+    // two side-by-side endings (e.g. type="completed" title="Final
+    // answer" emitted by handler_agent_chat alongside a synced
+    // task_run row with type="run_result"). terminalAgentActivity
+    // already picks the latest; everything else with a terminal
+    // shape is redundant for the operator.
+    if (terminalIndex !== -1 && index !== terminalIndex && isTerminalActivity(activity)) continue;
     if (terminal && (activity.type === "started" || activity.type === "running")) continue;
     if (activity.type === "running" && activities.some(item => item.type === "output")) continue;
     if (isTaskRunActivity(activity) && index !== lastTaskRunIndex) continue;
@@ -256,6 +268,10 @@ function compactAgentActivities(activities: AgentChatActivityRecord[]): AgentCha
     out.push(activity);
   }
   return collapseModelTurnActivities(out);
+}
+
+function isTerminalActivity(activity: AgentChatActivityRecord): boolean {
+  return activity.terminal === true || terminalRunSummaryTypes.has(activity.type);
 }
 
 function compactDetailActivities(activities: AgentChatActivityRecord[], hasDiffStat: boolean): AgentChatActivityRecord[] {


### PR DESCRIPTION
## Summary

A Hecate Chat run that completes successfully emits two terminal-shaped activity rows:
- A synced \`task_run\` mirror surfacing as \`run_result\` with title \"Run finished\".
- An explicit \`Activity{Type: status, Title: finalAgentChatActivityTitle(status)}\` appended by the agent-chat handler at turn end (\`handler_agent_chat.go:635\`).

The existing \`isTerminalRunSummary\` filter only drops rows whose title literally matches \`/^run\\s+(completed|failed|cancelled)$/i\`, so type-only collisions (\`type=\"completed\"\` + \`title=\"Done\"\`, \`type=\"run_result\"\` + \`title=\"Run finished\"\`, …) survive. Operator sees two side-by-side endings for one run.

\`terminalAgentActivity\` already picks the latest terminal-shaped row; everything else with a terminal shape is redundant. New rule in \`compactAgentActivities\`: drop earlier terminal rows by index when a survivor exists.

The line-250 special case (\`type=\"completed\"\` + \`title=\"final answer\"\`) is technically subsumed by the new rule, but it predates this change so I left it untouched — narrower scope.

Closes the \"duplicate completed / run completed rows\" papercut from the Hecate Chat polish list.

## Test plan

- [x] New test pins the regression (\`tool_call\`, \`run_result\`, \`completed\` → only the latest terminal row survives)
- [x] \`npx vitest run src/features/transcript\` — 64 passes, 0 fails
- [x] Full UI suite — 648 passes, 0 fails