### PR TITLE
docs(agent-runtime): spell out the one-active-loop chat invariant

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -23,13 +23,14 @@ Hecate Chat session can carry an arbitrary history of segments — alternating
 tools-on and tools-off — in one continuous transcript. Within that transcript
 **at most one task-backed loop is active at a time.** Each tools-on segment
 maps to exactly one backing task; while that task's latest run is non-terminal
-(`pending`, `running`, `awaiting_approval`), the chat is "busy" and the
-composer rejects further prompts (the composer itself blocks send and surfaces
-"Hecate Chat is still working on this task" with `Open task` / `Stop`; the
-backend returns `409 agent_chat.agent_session_busy` if a client bypasses the
-UI). Once the active run reaches a terminal state, the next tools-on prompt
-either continues the same task with a new run or — if tools have been toggled
-off and on in the meantime — starts a fresh task-backed segment. Historical
+(`queued`, `running`, `awaiting_approval`), the chat is "busy" — the
+composer's send button flips into `Stop active task`, a yellow banner links
+the backing task and offers `Open task` / `Stop`, and operator-typed
+messages queue locally rather than POSTing. The backend returns
+`409 agent_chat.agent_session_busy` if a client bypasses the UI. Once the
+active run reaches a terminal state, the next tools-on prompt either
+continues the same task with a new run or — if tools have been toggled off
+and on in the meantime — starts a fresh task-backed segment. Historical
 segments persist for transcript context but never resume execution; the only
 loop the runtime drives forward is the active one.
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -23,16 +23,26 @@ Hecate Chat session can carry an arbitrary history of segments — alternating
 tools-on and tools-off — in one continuous transcript. Within that transcript
 **at most one task-backed loop is active at a time.** Each tools-on segment
 maps to exactly one backing task; while that task's latest run is non-terminal
-(`queued`, `running`, `awaiting_approval`), the chat is "busy" — the
-composer's send button flips into `Stop active task`, a yellow banner links
-the backing task and offers `Open task` / `Stop`, and operator-typed
-messages queue locally rather than POSTing. The backend returns
-`409 agent_chat.agent_session_busy` if a client bypasses the UI. Once the
-active run reaches a terminal state, the next tools-on prompt either
-continues the same task with a new run or — if tools have been toggled off
-and on in the meantime — starts a fresh task-backed segment. Historical
-segments persist for transcript context but never resume execution; the only
-loop the runtime drives forward is the active one.
+(`queued`, `running`, `awaiting_approval`), the chat is "busy" and the
+composer's submit control reflects three states:
+
+- **idle** — the regular `Send message` button (`aria-label="Send message"`).
+- **busy with empty composer** — a red icon button labelled
+  `Stop current run` that cancels the active run.
+- **busy with a typed prompt** — a `Queue message` button that buffers
+  the text locally and replays it automatically once the active run
+  finishes.
+
+A yellow banner under the composer surfaces a queueing notice plus an
+`Open task` link to the backing task in the Tasks workspace and a `Stop`
+button (`aria-label="Stop active task"`) that also cancels the run. The
+backend returns `409 agent_chat.agent_session_busy` if a client bypasses
+the UI. Once the active run reaches a terminal state, the next tools-on
+prompt either continues the same task with a new run or — if tools have
+been toggled off and on in the meantime — starts a fresh task-backed
+segment. Historical segments persist for transcript context but never
+resume execution; the only loop the runtime drives forward is the active
+one.
 
 The Tasks workspace in the operator UI is the human entry point — create a task, watch its run state, approve or retry, and inspect streamed output:
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -18,6 +18,21 @@ streams assistant text into the conversation artifact during the model turn so
 Chats can show the answer before the task run reaches a terminal state.
 Providers without streaming fall back to the normal non-streaming chat call.
 
+**Invariant: one chat, many segments, one active task-backed loop.** A single
+Hecate Chat session can carry an arbitrary history of segments — alternating
+tools-on and tools-off — in one continuous transcript. Within that transcript
+**at most one task-backed loop is active at a time.** Each tools-on segment
+maps to exactly one backing task; while that task's latest run is non-terminal
+(`pending`, `running`, `awaiting_approval`), the chat is "busy" and the
+composer rejects further prompts (the composer itself blocks send and surfaces
+"Hecate Chat is still working on this task" with `Open task` / `Stop`; the
+backend returns `409 agent_chat.agent_session_busy` if a client bypasses the
+UI). Once the active run reaches a terminal state, the next tools-on prompt
+either continues the same task with a new run or — if tools have been toggled
+off and on in the meantime — starts a fresh task-backed segment. Historical
+segments persist for transcript context but never resume execution; the only
+loop the runtime drives forward is the active one.
+
 The Tasks workspace in the operator UI is the human entry point — create a task, watch its run state, approve or retry, and inspect streamed output:
 
 ![Tasks workspace — task list with run state and approval queue](screenshots/tasks.png)


### PR DESCRIPTION
## Summary

Hecate Chat enforces a structural rule that wasn't spelled out in \`docs/agent-runtime.md\`: **one chat session can carry an arbitrary history of tools-on / tools-off segments, but at most one task-backed loop is active at a time.** The composer's busy state (yellow \"Hecate Chat is still working\" banner + Stop button + \`409 agent_chat.agent_session_busy\` at the API gate) is the visible enforcement.

The doc covered the per-segment story but left the invariant implicit, which made it harder to reason about why the busy-send block exists, why historical segments don't resume on refresh, and why \"tools on → tools off → tools on\" starts a fresh task instead of reusing the prior one. New paragraph names the invariant explicitly and links to the operator-visible UX.

The companion E2E for busy-send prevention already lives at \`ui/e2e/chat.spec.ts:791\` (\"Hecate Chat rehydrates an active task and blocks direct sends after refresh\") — it queues the second prompt locally and asserts \`messagePosts === 0\`, so this PR is docs-only.

\`[skip ci]\` on the commit since there's no source diff for the race suite or lint to catch.

## Test plan

- [x] Existing busy-send-prevention E2E covers the runtime side (verified, line 791).
- [x] Doc renders cleanly in the Markdown preview (no broken anchors / lists).