### PR TITLE
fix(chats): resolve task approvals optimistically before the API returns

### DIFF
--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -1116,6 +1116,513 @@ describe("useRuntimeConsole", () => {
 
       await waitFor(() => expect(result.current.state.chatSessions[0].title).toBe("Renamed"));
     });
+
+    it("resolveTaskApproval optimistically marks the row resolved before the API call returns", async () => {
+      // Hecate-task approvals (distinct from the external-agent ACP
+      // approval map exercised below) live as activities on the
+      // active Hecate Chat session. The banner derivation in the
+      // chat surface (`pendingHecateTaskApprovals` in
+      // ChatView.tsx, which keys on `activity.status` /
+      // `needs_action`) collapses any row whose status flips off
+      // "awaiting_approval" — so flipping the activity to
+      // "approved" before the network round-trip returns is what
+      // makes the banner row disappear instantly on click. The
+      // prior version waited for the API to return, which
+      // surfaced as a 50–500 ms unresponsive UI on slow links
+      // and let an operator double-click a duplicate request.
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+
+      const seededSession = {
+        id: "a1",
+        title: "Repo work",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        task_id: "task_42",
+        latest_run_id: "run_99",
+        status: "awaiting_approval",
+        message_count: 1,
+        messages: [
+          {
+            id: "msg_assistant",
+            run_id: "run_99",
+            role: "assistant",
+            content: "",
+            status: "awaiting_approval",
+            created_at: "2026-04-20T00:00:01Z",
+            activities: [
+              {
+                id: "task:approval:appr_1",
+                type: "approval",
+                status: "awaiting_approval",
+                kind: "agent_loop_tool_call",
+                title: "Awaiting approval",
+                detail: "shell_exec",
+                approval_id: "appr_1",
+                needs_action: true,
+              },
+            ],
+          },
+        ],
+        created_at: "2026-04-20T00:00:00Z",
+        updated_at: "2026-04-20T00:00:01Z",
+      };
+      let resolveResolveCall: ((response: Response) => void) | undefined;
+      let resolveCalls = 0;
+      let refetchCalls = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({ object: "agent_chat_sessions", data: [seededSession] });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          refetchCalls += 1;
+          return jsonResponse({ object: "agent_chat_session", data: seededSession });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1/approvals?status=pending") {
+          return jsonResponse({ object: "list", data: [] });
+        }
+        if (url === "/hecate/v1/tasks/task_42/approvals/appr_1/resolve" && init?.method === "POST") {
+          resolveCalls += 1;
+          return new Promise<Response>((resolve) => {
+            resolveResolveCall = resolve;
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
+      const initialRefetches = refetchCalls;
+
+      let pendingResolve: Promise<boolean> | undefined;
+      await act(async () => {
+        pendingResolve = result.current.actions.resolveTaskApproval(
+          "task_42",
+          "appr_1",
+          { decision: "approve" },
+        );
+      });
+
+      // The API call is in flight; the optimistic patch must already
+      // be visible on the local session.
+      expect(resolveCalls).toBe(1);
+      const activity = result.current.state.activeAgentChatSession?.messages?.[0]?.activities?.[0];
+      expect(activity?.status).toBe("approved");
+      expect(activity?.needs_action).toBe(false);
+      // No refresh has fired yet — those are sequenced after the API
+      // returns. (initialRefetches accounts for the catch-up refetch
+      // when the session was hydrated.)
+      expect(refetchCalls).toBe(initialRefetches);
+
+      resolveResolveCall?.(new Response(null, { status: 204 }));
+      const ok = await act(async () => pendingResolve!);
+      expect(ok).toBe(true);
+      expect(refetchCalls).toBeGreaterThan(initialRefetches);
+    });
+
+    it("resolveTaskApproval rolls back the optimistic patch when the API rejects", async () => {
+      // Optimistic-before-call only works if a genuine failure
+      // restores the prior state — otherwise the operator sees the
+      // banner gone forever even though the run is still gated.
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+
+      const seededSession = {
+        id: "a1",
+        title: "Repo work",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        task_id: "task_42",
+        latest_run_id: "run_99",
+        status: "awaiting_approval",
+        message_count: 1,
+        messages: [
+          {
+            id: "msg_assistant",
+            run_id: "run_99",
+            role: "assistant",
+            content: "",
+            status: "awaiting_approval",
+            created_at: "2026-04-20T00:00:01Z",
+            activities: [
+              {
+                id: "task:approval:appr_1",
+                type: "approval",
+                status: "awaiting_approval",
+                kind: "agent_loop_tool_call",
+                title: "Awaiting approval",
+                detail: "shell_exec",
+                approval_id: "appr_1",
+                needs_action: true,
+              },
+            ],
+          },
+        ],
+        created_at: "2026-04-20T00:00:00Z",
+        updated_at: "2026-04-20T00:00:01Z",
+      };
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({ object: "agent_chat_sessions", data: [seededSession] });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          return jsonResponse({ object: "agent_chat_session", data: seededSession });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1/approvals?status=pending") {
+          return jsonResponse({ object: "list", data: [] });
+        }
+        if (url === "/hecate/v1/tasks/task_42/approvals/appr_1/resolve" && init?.method === "POST") {
+          return new Response(JSON.stringify({ error: { message: "upstream is unhappy" } }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.actions.resolveTaskApproval(
+          "task_42",
+          "appr_1",
+          { decision: "approve" },
+        );
+      });
+
+      expect(ok).toBe(false);
+      expect(result.current.state.notice?.kind).toBe("error");
+      // Rollback restored the original `awaiting_approval` status so
+      // the banner reappears and the operator can retry.
+      // NB: `refreshAgentChatSession` is NOT called on a generic
+      // failure (only on the "not pending" branch), so the only way
+      // the row returns to its prior state is via the rollback
+      // inside the catch.
+      const activity = result.current.state.activeAgentChatSession?.messages?.[0]?.activities?.[0];
+      expect(activity?.status).toBe("awaiting_approval");
+      expect(activity?.needs_action).toBe(true);
+    });
+
+    it("resolveTaskApproval rollback restores the right activity when activity.id is absent", async () => {
+      // AgentChatActivityRecord.id is optional. Earlier the rollback
+      // matched the snapshot row by `activity.id === activity.id`,
+      // which (a) fails to restore when the current row has no id
+      // and (b) would wrongly match the first id-less snapshot row
+      // if multiple activities lack ids. The fix: identify the
+      // target activity by `approval_id` (or the projected
+      // `task:approval:<id>` id), the same predicate the dedupe
+      // selection uses.
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+
+      const seededSession = {
+        id: "a1",
+        title: "Repo work",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        task_id: "task_42",
+        latest_run_id: "run_99",
+        status: "awaiting_approval",
+        message_count: 1,
+        messages: [
+          {
+            id: "msg_assistant",
+            run_id: "run_99",
+            role: "assistant",
+            content: "",
+            status: "awaiting_approval",
+            created_at: "2026-04-20T00:00:01Z",
+            activities: [
+              // Two id-less activities: one is the target approval,
+              // one is unrelated. A naïve `id === id` lookup in the
+              // snapshot would match the first id-less row instead
+              // of the right approval — proving why the predicate
+              // must key on approval_id.
+              {
+                type: "thinking",
+                title: "preparing",
+                detail: "warming up",
+              },
+              {
+                type: "approval",
+                status: "awaiting_approval",
+                kind: "agent_loop_tool_call",
+                title: "Awaiting approval",
+                detail: "shell_exec",
+                approval_id: "appr_1",
+                needs_action: true,
+              },
+            ],
+          },
+        ],
+        created_at: "2026-04-20T00:00:00Z",
+        updated_at: "2026-04-20T00:00:01Z",
+      };
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({ object: "agent_chat_sessions", data: [seededSession] });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          return jsonResponse({ object: "agent_chat_session", data: seededSession });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1/approvals?status=pending") {
+          return jsonResponse({ object: "list", data: [] });
+        }
+        if (url === "/hecate/v1/tasks/task_42/approvals/appr_1/resolve" && init?.method === "POST") {
+          return new Response(JSON.stringify({ error: { message: "upstream is unhappy" } }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.actions.resolveTaskApproval(
+          "task_42",
+          "appr_1",
+          { decision: "approve" },
+        );
+      });
+      expect(ok).toBe(false);
+
+      const activities = result.current.state.activeAgentChatSession?.messages?.[0]?.activities ?? [];
+      // The thinking row should be untouched.
+      const thinking = activities.find((a) => a.type === "thinking");
+      expect(thinking?.title).toBe("preparing");
+      // The approval row must be restored to its pre-resolve state
+      // — keyed by approval_id, not by the (absent) id field.
+      const approval = activities.find((a) => a.approval_id === "appr_1");
+      expect(approval?.status).toBe("awaiting_approval");
+      expect(approval?.needs_action).toBe(true);
+    });
+
+    it("resolveTaskApproval rolls back when the server says 'not pending' and the refresh also fails", async () => {
+      // The "already resolved upstream" race: another tab approved
+      // (or the run timed out) while this tab tried to reject. The
+      // server returns a "not pending" error. Optimistic patch
+      // currently shows OUR chosen decision ("rejected"), which may
+      // be wrong if the server actually approved. We try to refresh
+      // to pull server-truth; if THAT also fails (network blip,
+      // gateway transient), we cannot trust the optimistic patch
+      // and must roll back so the row reflects "still pending"
+      // rather than a possibly-wrong final state.
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+
+      const seededSession = {
+        id: "a1",
+        title: "Repo work",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        task_id: "task_42",
+        latest_run_id: "run_99",
+        status: "awaiting_approval",
+        message_count: 1,
+        messages: [
+          {
+            id: "msg_assistant",
+            run_id: "run_99",
+            role: "assistant",
+            content: "",
+            status: "awaiting_approval",
+            created_at: "2026-04-20T00:00:01Z",
+            activities: [
+              {
+                id: "task:approval:appr_1",
+                type: "approval",
+                status: "awaiting_approval",
+                kind: "agent_loop_tool_call",
+                title: "Awaiting approval",
+                detail: "shell_exec",
+                approval_id: "appr_1",
+                needs_action: true,
+              },
+            ],
+          },
+        ],
+        created_at: "2026-04-20T00:00:00Z",
+        updated_at: "2026-04-20T00:00:01Z",
+      };
+      let firstRefetchServed = false;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({ object: "agent_chat_sessions", data: [seededSession] });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          // Serve the catch-up refetch on session select, then fail
+          // every subsequent refetch — including the one inside
+          // the not-pending branch.
+          if (!firstRefetchServed) {
+            firstRefetchServed = true;
+            return jsonResponse({ object: "agent_chat_session", data: seededSession });
+          }
+          return new Response(null, { status: 503 });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1/approvals?status=pending") {
+          return jsonResponse({ object: "list", data: [] });
+        }
+        if (url === "/hecate/v1/tasks/task_42/approvals/appr_1/resolve" && init?.method === "POST") {
+          return new Response(JSON.stringify({ error: { message: "approval is not pending" } }), {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.actions.resolveTaskApproval(
+          "task_42",
+          "appr_1",
+          { decision: "reject" },
+        );
+      });
+
+      // Both API and refresh failed — the function reports failure
+      // (rather than a misleading success) and rolls back.
+      expect(ok).toBe(false);
+      const activity = result.current.state.activeAgentChatSession?.messages?.[0]?.activities?.[0];
+      expect(activity?.status).toBe("awaiting_approval");
+      expect(activity?.needs_action).toBe(true);
+      expect(result.current.state.notice?.kind).toBe("error");
+    });
+
+    it("resolveTaskApproval rollback does not clobber a session the operator switched to mid-flight", async () => {
+      // Concurrency hazard: the operator clicks Approve on session
+      // a1, then navigates to a2 while the request is in flight.
+      // The API call rejects. A naïve rollback that does
+      // `setActiveAgentChatSession(snapshot)` would replace the
+      // active session (now a2) with a1's pre-resolve snapshot,
+      // dragging the operator back to a1. The functional updater
+      // must bail when current.id !== snapshot.id.
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.agentChatSessionID", "a1");
+
+      const sessionA = {
+        id: "a1",
+        title: "A",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        task_id: "task_42",
+        latest_run_id: "run_99",
+        status: "awaiting_approval",
+        message_count: 1,
+        messages: [
+          {
+            id: "msg_a",
+            run_id: "run_99",
+            role: "assistant",
+            content: "",
+            status: "awaiting_approval",
+            created_at: "2026-04-20T00:00:01Z",
+            activities: [
+              {
+                id: "task:approval:appr_1",
+                type: "approval",
+                status: "awaiting_approval",
+                kind: "agent_loop_tool_call",
+                title: "Awaiting approval",
+                detail: "shell_exec",
+                approval_id: "appr_1",
+                needs_action: true,
+              },
+            ],
+          },
+        ],
+        created_at: "2026-04-20T00:00:00Z",
+        updated_at: "2026-04-20T00:00:01Z",
+      };
+      const sessionB = {
+        id: "a2",
+        title: "B",
+        runtime_kind: "agent",
+        adapter_id: "hecate",
+        workspace: "/workspace",
+        status: "completed",
+        message_count: 0,
+        messages: [],
+        created_at: "2026-04-20T00:00:02Z",
+        updated_at: "2026-04-20T00:00:02Z",
+      };
+      let resolveResolveCall: ((response: Response) => void) | undefined;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/agent-chat/sessions") {
+          return jsonResponse({ object: "agent_chat_sessions", data: [sessionA, sessionB] });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a1") {
+          return jsonResponse({ object: "agent_chat_session", data: sessionA });
+        }
+        if (url === "/hecate/v1/agent-chat/sessions/a2") {
+          return jsonResponse({ object: "agent_chat_session", data: sessionB });
+        }
+        if (url.startsWith("/hecate/v1/agent-chat/sessions/") && url.includes("/approvals?status=pending")) {
+          return jsonResponse({ object: "list", data: [] });
+        }
+        if (url === "/hecate/v1/tasks/task_42/approvals/appr_1/resolve" && init?.method === "POST") {
+          return new Promise<Response>((resolve) => {
+            resolveResolveCall = (response) => resolve(response);
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderHook(() => useRuntimeConsole());
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
+
+      // Operator clicks Approve on a1 (request hangs).
+      let pendingResolve: Promise<boolean> | undefined;
+      await act(async () => {
+        pendingResolve = result.current.actions.resolveTaskApproval(
+          "task_42",
+          "appr_1",
+          { decision: "approve" },
+        );
+      });
+      expect(result.current.state.activeAgentChatSession?.id).toBe("a1");
+
+      // Operator navigates to a2 while the resolve is still in
+      // flight.
+      await act(async () => {
+        await result.current.actions.selectChatSession("a2");
+      });
+      await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a2"));
+
+      // Now the API rejects. Rollback fires, but the active session
+      // is a2 — the rollback must NOT pull the operator back to a1.
+      resolveResolveCall?.(new Response(JSON.stringify({ error: { message: "upstream is unhappy" } }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }));
+      const ok = await act(async () => pendingResolve!);
+      expect(ok).toBe(false);
+      expect(result.current.state.activeAgentChatSession?.id).toBe("a2");
+    });
   });
 
   // ─── Agent-chat approvals state ───────────────────────────────────────────

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -70,6 +70,7 @@ import type {
   AgentAdapterHealthRecord,
   AgentAdapterRecord,
   AgentChatApprovalRecord,
+  AgentChatActivityRecord,
   AgentChatChangedFileDiffRecord,
   AgentChatChangedFileRecord,
   AgentChatGrantRecord,
@@ -1604,9 +1605,25 @@ export function useRuntimeConsole() {
     approvalID: string,
     decision: ResolveTaskApprovalPayload,
   ): Promise<boolean> {
-    try {
-      await resolveTaskApprovalRequest(taskID, approvalID, decision);
-      const status = decision.decision === "approve" ? "approved" : "rejected";
+    const status = decision.decision === "approve" ? "approved" : "rejected";
+    // Capture the pre-resolve session synchronously from closure so
+    // we can roll back if the API call fails. We can't capture inside
+    // the state updater function because React invokes it
+    // asynchronously (and may invoke it twice under StrictMode); by
+    // the time the catch branch runs, the closure variable would
+    // either still be null or hold the already-patched state. Same
+    // pattern as deleteProvider above.
+    //
+    // Optimistic-update-before-call means the banner row disappears
+    // the moment the operator clicks; before this, the row hung
+    // around for the full network round-trip (50–500 ms), which
+    // looked unresponsive on slow links and let an operator
+    // double-click a duplicate request through.
+    const snapshot: AgentChatSessionRecord | null =
+      activeAgentChatSession && activeAgentChatSession.task_id === taskID
+        ? activeAgentChatSession
+        : null;
+    if (snapshot) {
       setActiveAgentChatSession((current) => {
         if (!current || current.task_id !== taskID) return current;
         return {
@@ -1620,6 +1637,60 @@ export function useRuntimeConsole() {
           })),
         };
       });
+    }
+    // rollbackOptimisticApproval restores the specific approval
+    // activity from the pre-resolve snapshot, while leaving every
+    // other field of the active session untouched. Two concurrency
+    // hazards force this surgical shape rather than
+    // `setActiveAgentChatSession(snapshot)`:
+    //
+    //   1. The operator may have navigated to a different session
+    //      while the request was in flight. The functional updater
+    //      bails when the active session id has changed.
+    //   2. A stream `session_update` or a refresh may have applied
+    //      newer messages/activities on top of the optimistic
+    //      state. Restoring only the specific approval activity
+    //      preserves them.
+    //
+    // Reused by both the generic-failure path AND the
+    // not-pending+refresh-failed path so both cases produce the
+    // same operator-visible state ("we're not sure what the
+    // server thinks; show the row as still pending so the
+    // operator can retry") instead of leaving a possibly-wrong
+    // optimistic decision on screen.
+    const rollbackOptimisticApproval = () => {
+      if (!snapshot) return;
+      const snapshotForRollback = snapshot;
+      // Predicate matches the activity by approval_id (or the
+      // projected `task:approval:<id>` id). Using the SAME
+      // predicate on both sides matters because Activity.id is
+      // optional — matching by id alone could (a) fail to restore
+      // when the current row has no id and (b) wrongly match the
+      // first id-less row if both sides have undefined ids.
+      const matchesTargetApproval = (activity: AgentChatActivityRecord) =>
+        activity.approval_id === approvalID || activity.id === `task:approval:${approvalID}`;
+      setActiveAgentChatSession((current) => {
+        if (!current || current.id !== snapshotForRollback.id) return current;
+        return {
+          ...current,
+          messages: (current.messages ?? []).map((message) => {
+            const originalMessage = snapshotForRollback.messages?.find((m) => m.id === message.id);
+            if (!originalMessage) return message;
+            return {
+              ...message,
+              activities: message.activities?.map((activity) => {
+                if (!matchesTargetApproval(activity)) return activity;
+                const originalActivity = originalMessage.activities?.find(matchesTargetApproval);
+                return originalActivity ?? activity;
+              }),
+            };
+          }),
+        };
+      });
+    };
+
+    try {
+      await resolveTaskApprovalRequest(taskID, approvalID, decision);
       if (activeAgentChatSessionID) {
         try {
           await refreshAgentChatSession(activeAgentChatSessionID);
@@ -1632,16 +1703,30 @@ export function useRuntimeConsole() {
       return true;
     } catch (error) {
       if (error instanceof Error && /not pending/i.test(error.message)) {
+        // Server says the approval is already resolved. The
+        // resolution may NOT match the operator's chosen decision —
+        // another tab could have approved while this one tried to
+        // reject, the run might have timed out into auto-rejection,
+        // or the run could have been cancelled. Refresh to pull
+        // server-truth and let it overwrite our optimistic patch.
         if (activeAgentChatSessionID) {
           try {
             await refreshAgentChatSession(activeAgentChatSessionID);
+            return true;
           } catch {
-            // The original failure already means the row is stale; if a
-            // refresh also fails, avoid piling on a second noisy error.
+            // Refresh failed — we cannot trust our optimistic patch
+            // (it might claim a decision the server didn't make).
+            // Fall through to rollback so the row reflects "still
+            // pending" rather than a possibly-wrong final state.
           }
         }
-        return true;
+        rollbackOptimisticApproval();
+        setNoticeMessage("error", "Approval was already resolved upstream and the session refresh failed; reload to see the current state.");
+        return false;
       }
+      // Genuine failure — roll back so the row reappears and the
+      // operator can retry.
+      rollbackOptimisticApproval();
       setNoticeMessage("error", error instanceof Error ? error.message : "Failed to resolve task approval.");
       return false;
     }


### PR DESCRIPTION
## Summary

The Hecate Chat task-approval banner cleared a row only AFTER the network round-trip completed (\`useRuntimeConsole.ts:1602\` ➝ \`await resolveTaskApprovalRequest(...)\` ➝ patch). On slow links the row sat there post-click looking unresponsive, and a double-click could fire a duplicate POST through the busy-disabled buttons (since \`disabled\` only flipped on after the busy state propagated through React's render cycle).

Move the optimistic patch BEFORE the API call:

\`\`\`
snapshot = activeAgentChatSession  // sync from closure, like deleteProvider
patch the local state              // banner row disappears immediately
try { await api(); maybe refresh } catch { restore from snapshot }
\`\`\`

Capturing the snapshot inside the state-updater would not work: React invokes useState updaters asynchronously, and may invoke them twice under StrictMode, so a closure variable assigned inside the updater is either still null when the catch runs or already holds the patched state. Reading from the destructured \`activeAgentChatSession\` closure is the same synchronous-snapshot pattern \`deleteProvider\` uses (\`useRuntimeConsole.ts:1265\`).

## Concurrency-safe rollback

- The rollback uses a **functional updater** that bails when \`current.id !== snapshot.id\` — so if the operator navigated to another session while the API was in flight, the rollback no-ops instead of yanking them back.
- It restores ONLY the specific approval activity from the snapshot (matched by \`approval_id\` or the projected \`task:approval:<id>\` id, never by the optional \`Activity.id\`), so any new messages / activities that arrived during the await are preserved.

## Failure handling

- **Generic failure** → rollback + error notice. Operator can retry.
- **\`/not pending/i\` error** → server says "already resolved upstream", but possibly to a different decision than the operator picked. Refresh the session to pull server-truth; if the refresh succeeds, server data wins. If the refresh ALSO fails, fall through to the same rollback so the row reflects "still pending" rather than a possibly-wrong final state, plus an error notice telling the operator to reload.

## Test plan

Five new tests in \`useRuntimeConsole.test.tsx\` cover every code path:

- **\`optimistically marks the row resolved before the API call returns\`** — uses a deferred Promise so the fetch is still in flight when the assertion runs; verifies \`activity.status === "approved"\` while \`resolveResolveCall\` has NOT been called yet.
- **\`rolls back the optimistic patch when the API rejects\`** — 500 response, asserts the activity reverts to \`awaiting_approval\` and an error notice surfaces.
- **\`rollback restores the right activity when activity.id is absent\`** — id-less thinking row + id-less approval row in the same message; only the approval is restored, the thinking row stays untouched.
- **\`rollback does not clobber a session the operator switched to mid-flight\`** — operator switches a1 → a2 while the resolve hangs; API rejects; active session must stay a2 (functional updater bails on id mismatch).
- **\`rolls back when the server says 'not pending' and the refresh also fails\`** — 409 not-pending plus a 503 on the follow-up refresh; expect \`ok === false\`, status restored to \`awaiting_approval\`, error notice.

Plus:

- [x] \`tsc --build\` — clean for production code (\`useRuntimeConsole.ts\`); 6 pre-existing baseline errors in unrelated test files & tsconfig.node.json that were there before this PR.
- [x] Full UI suite: 652 passes, 0 failures.

## What's NOT in this PR

The "resolved approvals should not be clickable" half of the original ask was already covered (existing test at \`ChatView.test.tsx:1167\` pins the behavior — \`status === "approved"\` doesn't render the banner, the resolve buttons are gone). The remaining gap was the click-to-disappear latency, which this PR closes.