### PR TITLE
chore(ui): close TS baseline errors and fix ProvidersView focus-race flake

### DIFF
--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -481,6 +481,16 @@ describe("ProvidersView table renders", () => {
     expect(screen.getByText(/Add a custom name/)).toBeTruthy();
     expect(screen.getAllByText("Add provider").pop()).toBeDisabled();
 
+    // The form's mount-time effect schedules `requestAnimationFrame(
+    // () => target?.focus())` to move focus to the URL input
+    // (AddProviderModal.tsx:58-69). Under full-suite parallel load
+    // that rAF can fire mid-`user.type` and redirect some keystrokes
+    // away from the custom-name field, leaving form.custom_name
+    // shorter than "Dev" — the duplicate check still matches and the
+    // warning persists. Awaiting one rAF tick proves the effect has
+    // already run, so the upcoming typing reaches the right input.
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
     await user.type(screen.getByPlaceholderText(/Prod, Dev, Staging/i), "Dev");
 
     expect(screen.queryByText(/llama\.cpp is already configured/)).toBeNull();

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -481,14 +481,14 @@ describe("ProvidersView table renders", () => {
     expect(screen.getByText(/Add a custom name/)).toBeTruthy();
     expect(screen.getAllByText("Add provider").pop()).toBeDisabled();
 
-    // The form's mount-time effect schedules `requestAnimationFrame(
-    // () => target?.focus())` to move focus to the URL input
-    // (AddProviderModal.tsx:58-69). Under full-suite parallel load
-    // that rAF can fire mid-`user.type` and redirect some keystrokes
-    // away from the custom-name field, leaving form.custom_name
-    // shorter than "Dev" — the duplicate check still matches and the
-    // warning persists. Awaiting one rAF tick proves the effect has
-    // already run, so the upcoming typing reaches the right input.
+    // The form's mount-time effect in `AddProviderModal` schedules
+    // `requestAnimationFrame(() => target?.focus())` to move focus to
+    // the URL input. Under full-suite parallel load that rAF can fire
+    // mid-`user.type` and redirect some keystrokes away from the
+    // custom-name field, leaving form.custom_name shorter than "Dev"
+    // — the duplicate check still matches and the warning persists.
+    // Awaiting one rAF tick proves the effect has already run, so the
+    // upcoming typing reaches the right input.
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
     await user.type(screen.getByPlaceholderText(/Prod, Dev, Staging/i), "Dev");

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": false,
     "resolveJsonModule": true,

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -3,6 +3,7 @@
     "composite": true,
     "noEmit": true,
     "skipLibCheck": true,
+    "module": "ESNext",
     "moduleResolution": "Bundler"
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
Two pre-existing TS-side debt items I noticed during the recent PR/release work and deliberately left out of scope at the time. Now paying them down so future \`tsc --build\` and full-suite vitest runs are deterministic.

## Commit 1 — \`chore(ui): close 6 TypeScript baseline errors via tsconfig\`

\`tsc --build\` surfaced six errors that root \`tsc --noEmit\` missed because of the project-references layout (root \`tsconfig.json\` is \`{ files: [], references: [...] }\`). All six are config-shape issues, not source bugs:

| Code | Count | Where |
|---|---|---|
| TS5095 | 1 | tsconfig.node.json — \`Bundler\` resolution requires modern \`module\` |
| TS1323 | 4 | useRuntimeConsole.test.tsx — dynamic \`import()\` requires modern \`module\` |
| TS2488 | 1 | TranscriptMessageRow.test.tsx — \`[...querySelectorAll(...)]\` spread needs \`DOM.Iterable\` |

Two-line fix: both tsconfigs gain \`"module": "ESNext"\`; \`tsconfig.app.json\`'s \`lib\` adds \`"DOM.Iterable"\`. No source changes.

This was discovered during the v0.1.0-alpha.22 release-CI failure where a missing import slipped past the local \`tsc --noEmit\` but broke CI's \`tsc --build\`. Closing the baseline noise means \`tsc --build\` is usable as a local pre-commit gate going forward.

## Commit 2 — \`test(providers): wait for the focus-stealing rAF before typing\`

The \"asks for a custom name when the selected preset id already configured\" test flaked ~25% of full-suite runs (2/8 sampled) under vitest's parallel-worker load. Standalone-file runs never reproduced.

Root cause is focus stealing, not state propagation. \`AddProviderModal.tsx:58–69\` schedules \`requestAnimationFrame(() => target?.focus())\` to move focus to the URL input on preset selection. Under stress the rAF can fire mid-\`user.type\`, redirecting some keystrokes from the custom-name field to the URL field — \`form.custom_name\` ends up shorter than \"Dev\", the slug check still matches the configured \"llama-cpp\", warning persists. \`waitFor\` doesn't help: the DOM truly does still hold the warning row.

Fix: \`await new Promise(resolve => requestAnimationFrame(resolve))\` before \`user.type\`. By the time the resolver fires, any rAF-queued focus shift has already happened, and the typing reaches a stable target.

## Test plan

- [x] \`npx tsc --build\` → No errors found (was: 6 errors).
- [x] \`npx vitest run\` (full suite) → 654/654 passing on the first commit.
- [x] **10/10 full-suite runs** clean after the second commit (was: ~25% failure rate on the same hardware/config).
- [x] \`bun run build\` (production) → builds clean.

## What's NOT in this PR

The \`tsc --build\` run still flags 4 dynamic-\`import()\` errors in \`useRuntimeConsole.test.tsx\` — those are part of a separate test that uses runtime imports for module-mocking; the fix here makes them legal under the new \`module: "ESNext"\` setting, so they go from errors to clean. No source changes needed there.