### PR TITLE
perf(ui): code-split workspace views via React.lazy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -121,13 +121,12 @@ ui-dev: _ui-deps
 	cd ui && bun run dev
 
 # Build the React UI bundle.
+# `.gitkeep` is preserved by the `preserve-dist-gitkeep` Vite
+# plugin (ui/vite.config.ts) — it's emitted as a build asset so
+# any caller (just, bare `bun run build`, IDE, CI without just)
+# leaves the worktree clean.
 ui-build: _ui-deps
 	cd ui && bun run build
-	# Vite empties ui/dist before building, which deletes the tracked
-	# .gitkeep placeholder. Restore it exactly as git has it so the next
-	# `git status` stays clean. Fall back to touch outside a git repo
-	# (CI build steps, fresh checkouts before the first commit).
-	git restore ui/dist/.gitkeep 2>/dev/null || touch ui/dist/.gitkeep
 
 # Run UI unit tests.
 ui-test: _ui-deps

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -37,7 +37,7 @@ describe("ConsoleShell loading state", () => {
 });
 
 describe("ConsoleShell navigation", () => {
-  it("keeps Chats available when no providers are configured", () => {
+  it("keeps Chats available when no providers are configured", async () => {
     const state = createRuntimeConsoleFixture({
       chatTarget: "model",
       settingsConfig: { backend: "memory", providers: [], pricebook: [], policy_rules: [], events: [] },
@@ -51,9 +51,14 @@ describe("ConsoleShell navigation", () => {
       />,
     );
 
+    // The Chats workspace is a `lazy()` chunk per AppShell.tsx;
+    // assert workspace content asynchronously so the assertion
+    // waits for the dynamic import to resolve. Shell chrome
+    // (workspace nav buttons, statusbar) is not lazy and can
+    // still be queried synchronously.
     expect(screen.getByRole("button", { name: /Chats \(1\)/ })).toBeEnabled();
+    expect(await screen.findByText(/Nothing runnable yet/i)).toBeInTheDocument();
     expect(screen.queryByText(/No providers configured/i)).toBeNull();
-    expect(screen.getByText(/Nothing runnable yet/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Add provider/i })).toBeInTheDocument();
   });
 

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -1,11 +1,34 @@
-import { useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 
-import { SettingsView } from "../features/settings/SettingsView";
-import { CostsView } from "../features/costs/CostsView";
-import { ObservabilityView } from "../features/overview/ObservabilityView";
-import { ChatView } from "../features/chats/ChatView";
-import { ProvidersView } from "../features/providers/ProvidersView";
-import { TasksView } from "../features/runs/TasksView";
+// Each workspace view is its own dynamic chunk so the initial
+// page load only ships the shell + active workspace, not all six.
+// Vite splits each `lazy(() => import(...))` into a separate
+// chunk under `dist/assets/`. Runtime cost: a one-time fetch +
+// parse the first time the operator visits a workspace; on
+// localhost this is sub-100 ms and invisible. Build cost: each
+// `<Suspense>` boundary needs a fallback (handled by
+// `WorkspaceFallback` below). Test cost: tests that assert on
+// workspace content must use `findBy*` (async) instead of
+// `getBy*` (sync) to wait for the lazy chunk to resolve.
+const SettingsView = lazy(() =>
+  import("../features/settings/SettingsView").then(m => ({ default: m.SettingsView })),
+);
+const CostsView = lazy(() =>
+  import("../features/costs/CostsView").then(m => ({ default: m.CostsView })),
+);
+const ObservabilityView = lazy(() =>
+  import("../features/overview/ObservabilityView").then(m => ({ default: m.ObservabilityView })),
+);
+const ChatView = lazy(() =>
+  import("../features/chats/ChatView").then(m => ({ default: m.ChatView })),
+);
+const ProvidersView = lazy(() =>
+  import("../features/providers/ProvidersView").then(m => ({ default: m.ProvidersView })),
+);
+const TasksView = lazy(() =>
+  import("../features/runs/TasksView").then(m => ({ default: m.TasksView })),
+);
+
 import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
 import type { AgentChatUsageRecord } from "../types/runtime";
 
@@ -92,6 +115,30 @@ export function ConsoleShell({
       state={state}
       actions={actions}
     />
+  );
+}
+
+// WorkspaceFallback fills the content area for the brief moment a
+// lazily-loaded workspace chunk is being fetched. Uses the same
+// muted style as AuthLoadingShell so a workspace switch reads as
+// "still booting that surface" rather than as a separate loading
+// state. On localhost the fallback is rarely visible — the chunk
+// arrives in <50ms — but it prevents layout flash on slower links
+// or the cold cache after a deploy.
+function WorkspaceFallback() {
+  return (
+    <div
+      style={{
+        padding: 16,
+        fontSize: 11,
+        color: "var(--t3)",
+        fontFamily: "var(--font-mono)",
+        letterSpacing: "0.06em",
+        textTransform: "uppercase",
+      }}
+    >
+      Loading…
+    </div>
   );
 }
 
@@ -192,12 +239,14 @@ function AuthenticatedShell({
         <main className="hecate-content">
           {state.error && <div className="page-banner page-banner--error">{state.error}</div>}
           <div className={`console-content${isBare ? " console-content--bare" : ""}`}>
-            {activeWorkspace === "overview"   && <ObservabilityView actions={actions} state={state} onNavigate={onSelectWorkspace} focusRequest={traceFocusRequest} />}
-            {activeWorkspace === "chats" && <ChatView actions={actions} state={state} onNavigate={onSelectWorkspace} onOpenTask={openTaskFromChat} onOpenTrace={openTraceFromChat} />}
-            {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} />}
-            {activeWorkspace === "providers"     && <ProvidersView actions={actions} state={state} />}
-            {activeWorkspace === "costs"         && <CostsView actions={actions} state={state} />}
-            {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} />}
+            <Suspense fallback={<WorkspaceFallback />}>
+              {activeWorkspace === "overview"   && <ObservabilityView actions={actions} state={state} onNavigate={onSelectWorkspace} focusRequest={traceFocusRequest} />}
+              {activeWorkspace === "chats" && <ChatView actions={actions} state={state} onNavigate={onSelectWorkspace} onOpenTask={openTaskFromChat} onOpenTrace={openTraceFromChat} />}
+              {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} />}
+              {activeWorkspace === "providers"     && <ProvidersView actions={actions} state={state} />}
+              {activeWorkspace === "costs"         && <CostsView actions={actions} state={state} />}
+              {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} />}
+            </Suspense>
           </div>
         </main>
       </div>

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -1,5 +1,8 @@
 import { Suspense, lazy, useEffect, useState } from "react";
 
+import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
+import type { AgentChatUsageRecord } from "../types/runtime";
+
 // Each workspace view is its own dynamic chunk so the initial
 // page load only ships the shell + active workspace, not all six.
 // Vite splits each `lazy(() => import(...))` into a separate
@@ -28,9 +31,6 @@ const ProvidersView = lazy(() =>
 const TasksView = lazy(() =>
   import("../features/runs/TasksView").then(m => ({ default: m.TasksView })),
 );
-
-import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
-import type { AgentChatUsageRecord } from "../types/runtime";
 
 export type WorkspaceID = "overview" | "runs" | "chats" | "providers" | "costs" | "settings";
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,8 +1,56 @@
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// preloadLikelyFirstWorkspace injects a `<link rel="modulepreload">`
+// for the chunk we expect the operator to need first, so the browser
+// fetches and parses it in parallel with the initial entry chunk
+// instead of waiting until React.lazy resolves on first render.
+//
+// The "likely first workspace" is Chats — it's the runtime console's
+// default landing surface for new operators, the most-used surface
+// for repeat operators, and (incidentally) the largest workspace
+// chunk (~91 KB / ~23 KB gzipped). Preloading any other workspace
+// would help in narrower scenarios; preloading Chats is the broadest
+// hit-rate.
+//
+// Cost when the operator's last-active workspace is something else
+// (the app remembers via localStorage): ~23 KB gzipped of wasted
+// bandwidth. On localhost / LAN — Hecate's deployment shape — this
+// is invisible. On a hypothetical remote install it would be
+// notable, but Hecate isn't deployed that way today.
+//
+// Browsers automatically follow the import graph for modulepreloaded
+// chunks (Chrome, Firefox, Safari all do this), so ChatView's shared
+// dependencies (AddProviderModal, TranscriptActivityTimeline, ui)
+// get pulled along without explicit tags.
+function preloadLikelyFirstWorkspace(): Plugin {
+  return {
+    name: "preload-likely-first-workspace",
+    apply: "build",
+    enforce: "post",
+    transformIndexHtml: {
+      order: "post",
+      handler(_html, { bundle }) {
+        if (!bundle) return;
+        for (const fileName of Object.keys(bundle)) {
+          if (/^assets\/ChatView-.*\.js$/.test(fileName)) {
+            return [
+              {
+                tag: "link",
+                attrs: { rel: "modulepreload", href: `/${fileName}` },
+                injectTo: "head",
+              },
+            ];
+          }
+        }
+      },
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), preloadLikelyFirstWorkspace()],
   server: {
     port: 5173,
     proxy: {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,6 +2,35 @@ import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// preserveDistGitkeep emits ui/dist/.gitkeep alongside the build
+// output. The file is the placeholder that lets
+// `//go:embed all:ui/dist` (embed.go in the module root) compile
+// against a fresh clone where `bun run build` hasn't run yet —
+// without a file inside ui/dist/, Go's embed directive fails with
+// "pattern all:ui/dist: no matching files found".
+//
+// Vite's default `emptyOutDir: true` wipes the directory before
+// writing, so a tracked `.gitkeep` would disappear on every build
+// and the worktree would show a phantom deletion. Emitting via
+// Rollup's `emitFile` API runs as part of the normal bundle output,
+// after empty-out-dir, so the file always lands in dist regardless
+// of who invoked the build (Justfile, `bun run build` directly,
+// CI without just, an IDE-triggered build). The Justfile used to
+// restore it as a post-step; that's no longer needed.
+function preserveDistGitkeep(): Plugin {
+  return {
+    name: "preserve-dist-gitkeep",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: ".gitkeep",
+        source: "",
+      });
+    },
+  };
+}
+
 // preloadLikelyFirstWorkspace injects a `<link rel="modulepreload">`
 // for the chunk we expect the operator to need first, so the browser
 // fetches and parses it in parallel with the initial entry chunk
@@ -50,7 +79,7 @@ function preloadLikelyFirstWorkspace(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [react(), preloadLikelyFirstWorkspace()],
+  plugins: [react(), preloadLikelyFirstWorkspace(), preserveDistGitkeep()],
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

Vite has been warning about a >500 KB chunk for a while. The fix is the textbook one Vite itself suggests in the warning: each of the six workspace views (Chats, Providers, Tasks, Observability, Costs, Settings) becomes its own lazy chunk, plus a build-time `<link rel="modulepreload">` for the most-likely-first workspace so the parallel-load benefit isn't lost on the default landing surface.

| | Before | After |
|---|---|---|
| Initial JS | 561.84 KB | **259.02 KB** |
| Initial gzipped | 149.43 KB | **80.19 KB** |
| Largest chunk after | — | ChatView 91.71 KB / 23.44 KB gz |
| Vite `>500KB` warning | yes | gone |

**Reduction: -54% raw / -46% gzipped on the initial bundle.** Workspace chunks fetch on first visit (sub-100 ms on localhost, invisible in practice).

Vite also auto-extracted three shared chunks because multiple lazy components consume them: `AddProviderModal-*.js` (15 KB), `TranscriptActivityTimeline-*.js` (11 KB), `ui-*.js` (22 KB). Those load alongside whichever workspace needs them first, then are cached for the others.

## Implementation

- The 6 `import { XView } from "..."` lines in `AppShell.tsx` become `const XView = lazy(() => import("..."))`.
- The conditional render block in `AuthenticatedShell` is wrapped in a single `<Suspense>` with a muted `<WorkspaceFallback />` ("Loading…" in the same monospaced style as the boot splash, so a workspace switch reads as "still booting that surface" rather than as a jarring spinner).
- One AppShell test that asserted on lazy ChatView content via synchronous `getByText` switches to `await findByText` — the standard pattern for components inside Suspense. Shell chrome (workspace nav buttons, statusbar) stays sync because it's not lazy.

## Modulepreload for ChatView

Inline Vite plugin `preloadLikelyFirstWorkspace` runs at build-time, finds the hashed `assets/ChatView-*.js` filename in the bundle map, and injects a single `<link rel="modulepreload" href="...">` into the built `index.html`. The browser fetches + parses ChatView in parallel with the entry chunk so first-paint of Chats happens with the chunk already warm.

Why ChatView specifically:
- Default landing surface for new operators (no localStorage workspace preference yet).
- Most-used surface for repeat operators.
- Incidentally the largest workspace chunk; the parallel-load win scales with chunk size.

Modern browsers follow the import graph for modulepreloaded chunks, so the shared dependencies (AddProviderModal, TranscriptActivityTimeline, ui) get pulled along without explicit tags.

Cost when the operator's last-active workspace is something else: ~23 KB gzipped of wasted bandwidth, fetched once. On localhost / LAN — Hecate's deployment shape — invisible.

## Gitkeep preservation

Side fix: `//go:embed all:ui/dist` (in the module root's `embed.go`) requires `ui/dist/` to be a non-empty directory at compile time, otherwise Go fails with "pattern all:ui/dist: no matching files found". The placeholder is a tracked `.gitkeep`. Vite's `emptyOutDir: true` wipes it on every build, leaving a phantom deletion in `git status` until something restores it. The Justfile used to do this restore as a post-step, which only worked when callers went through `just ui-build` — bare `bun run build`, IDE-triggered builds, or CI invoking bun directly all left the worktree dirty.

New `preserve-dist-gitkeep` plugin emits `.gitkeep` as a build asset via Rollup's `emitFile` API. Empty-out-dir runs before `generateBundle`, so the emitted asset always lands in the output regardless of who invoked the build. The Justfile's post-step is gone, replaced with a comment pointing at the plugin.

## Test plan

- [x] `tsc --build`: clean.
- [x] Production build: clean, no `>500KB` warning.
- [x] Built `index.html` contains `<link rel="modulepreload" href="/assets/ChatView-*.js">` in `<head>`.
- [x] `.gitkeep` survives 3 consecutive `rm -f ui/dist/.gitkeep && just ui-build` cycles, worktree stays clean.
- [x] Full UI suite: 5 consecutive runs all green (29 files, 654 tests).
- [x] Bundle inspection: 11 chunks total, all under 260 KB; per-workspace sizes match expectations.

## Risk

- **First-visit-per-workspace latency** adds a fetch+parse for the chunk. On localhost (and the desktop app's embedded webview, which is also localhost-equivalent), this is sub-100 ms. The fallback prevents layout flash.
- **Service worker / cache invalidation** behavior unchanged — Vite handles chunk hashing automatically.
- **Tauri bundle** picks up the multi-file dist transparently via `//go:embed all:ui/dist`. No goreleaser or release-pipeline changes needed.