### PR TITLE
fix(ui): trustworthy span waterfall rendering

### DIFF
--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -170,6 +170,22 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   const [traceDetail, setTraceDetail] = useState<TraceResponse["data"] | null>(null);
   const [traceFetching, setTraceFetching] = useState(false);
   const traceRetryRef = useRef<ReturnType<typeof window.setInterval> | null>(null);
+  // Trace-detail polling fires every 2s while waiting for spans. We cap
+  // attempts so a trace that's been retention-pruned, dropped by the OTel
+  // buffer, or otherwise will-never-arrive doesn't poll forever — at one
+  // request per 2s it's not load-bearing for the gateway, but it produces
+  // a steady drip of 200-with-empty-spans responses an operator can't
+  // see and can't stop. We mirror traceDetail to a ref so the interval
+  // callback can read the latest value without smuggling side effects
+  // through a state updater (which StrictMode double-invokes for
+  // debugging — the previous shape over-counted attempts in dev).
+  const traceRetryAttemptsRef = useRef(0);
+  const traceDetailRef = useRef<TraceResponse["data"] | null>(null);
+  // Counts retries only — the initial fetch when the drawer opens
+  // is separate. Total network calls in the worst case: 1 initial
+  // + TRACE_RETRY_LIMIT retries. With TRACE_RETRY_LIMIT=5 that's 6
+  // fetches total, the last firing ~10s after the drawer opened.
+  const TRACE_RETRY_LIMIT = 5;
 
   // Pick the layout mode once on mount. A live resize listener would
   // make the layout reactive but it'd also rip the drawer out from
@@ -247,8 +263,14 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   const fetchTraceDetail = useCallback((reqId: string) => {
     setTraceFetching(true);
     getTrace(reqId)
-      .then(res => setTraceDetail(res.data))
-      .catch(() => setTraceDetail(null))
+      .then(res => {
+        traceDetailRef.current = res.data;
+        setTraceDetail(res.data);
+      })
+      .catch(() => {
+        traceDetailRef.current = null;
+        setTraceDetail(null);
+      })
       .finally(() => setTraceFetching(false));
   }, []);
 
@@ -259,18 +281,36 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
       window.clearInterval(traceRetryRef.current);
       traceRetryRef.current = null;
     }
-    if (!drawerOpen || !selectedID) { setTraceDetail(null); return; }
+    if (!drawerOpen || !selectedID) {
+      traceDetailRef.current = null;
+      setTraceDetail(null);
+      return;
+    }
+    traceDetailRef.current = null;
     setTraceDetail(null);
+    traceRetryAttemptsRef.current = 0;
     fetchTraceDetail(selectedID);
     traceRetryRef.current = window.setInterval(() => {
-      setTraceDetail(prev => {
-        if (prev?.spans?.length) {
-          if (traceRetryRef.current) window.clearInterval(traceRetryRef.current);
-          return prev;
+      // Side effects live outside any state updater so StrictMode's
+      // double-invoke doesn't double-count attempts. Reads traceDetail
+      // via the ref so we don't depend on closing over stale state.
+      const current = traceDetailRef.current;
+      if (current?.spans?.length) {
+        if (traceRetryRef.current) {
+          window.clearInterval(traceRetryRef.current);
+          traceRetryRef.current = null;
         }
-        fetchTraceDetail(selectedID);
-        return prev;
-      });
+        return;
+      }
+      if (traceRetryAttemptsRef.current >= TRACE_RETRY_LIMIT) {
+        if (traceRetryRef.current) {
+          window.clearInterval(traceRetryRef.current);
+          traceRetryRef.current = null;
+        }
+        return;
+      }
+      traceRetryAttemptsRef.current += 1;
+      fetchTraceDetail(selectedID);
     }, 2000);
     return () => {
       if (traceRetryRef.current) window.clearInterval(traceRetryRef.current);
@@ -884,13 +924,28 @@ function SpanWaterfall({
         )}
       </div>
 
-      {/* Sticky ruler */}
+      {/* Sticky ruler. Three things needed for it to render reliably
+        on top of subsequent span rows:
+         - `bg2` (not `bg1`) so the ruler has visible contrast against
+           the surrounding card and so its background actually
+           occludes the row that scrolls under it. `bg1` is the same
+           color as the card it's sitting in.
+         - `isolation: isolate` creates a stacking context so the
+           absolute-positioned bar children inside SpanRow can't
+           paint above the sticky ruler. Without it, a high-z-index
+           descendant of a sibling could land on top.
+         - `marginBottom: 6` separates the ruler from the first span
+           row — without it, the row's amber critical-path border
+           visually merges with the ruler's own bottom border. */}
       <div style={{
-        position: "sticky", top: 0, zIndex: 1, background: "var(--bg1)",
+        position: "sticky", top: 0, zIndex: 5,
+        background: "var(--bg2)",
+        isolation: "isolate",
         display: "grid",
         gridTemplateColumns: "240px 1fr 60px",
         gap: 8,
-        padding: "4px 0",
+        padding: "6px 0",
+        marginBottom: 6,
         borderBottom: "1px solid var(--border)",
       }}>
         <div />
@@ -904,7 +959,7 @@ function SpanWaterfall({
                 transform: i === 0 ? "translateX(0)" : i === ticks.length - 1 ? "translateX(-100%)" : "translateX(-50%)",
                 fontFamily: "var(--font-mono)",
                 fontSize: 10,
-                color: "var(--t3)",
+                color: "var(--t2)",
               }}>{t}ms</span>
           ))}
         </div>
@@ -937,12 +992,25 @@ function SpanRow({
   isDimmed: boolean;
   onToggle: () => void;
 }) {
-  const leftPct = (ws.startMs / totalMs) * 100;
-  const widthPct = Math.max((ws.durMs / totalMs) * 100, 0.5);
+  // unknownTiming: span had missing/unparseable timestamps. We render
+  // a tiny 1%-wide indicator at left:0 (not a meaningful position —
+  // see the comment in runtime-trace.ts) plus a "?" duration label,
+  // so the row is visible without silently misleading the operator
+  // about position or width.
+  // negativeDuration: both timestamps parsed but end < start (clock
+  // skew or partial trace). The bar IS positioned at the span's
+  // real start but the duration label is "?" rather than a
+  // misleading "-50ms" or a silently-clamped 1ms tick.
+  const leftPct = ws.unknownTiming ? 0 : (ws.startMs / totalMs) * 100;
+  const widthPct = ws.unknownTiming || ws.negativeDuration
+    ? 1
+    : Math.max((ws.durMs / totalMs) * 100, 0.5);
   const color = phaseColor(ws.phase, ws.span);
   const opacity = isDimmed ? 0.3 : 1;
   // Duration label inside the bar when wide enough, otherwise to its right.
-  const labelInside = widthPct > 12;
+  const labelInside = widthPct > 12 && !ws.unknownTiming && !ws.negativeDuration;
+  const durLabel = ws.unknownTiming || ws.negativeDuration ? "?" : `${Math.max(ws.durMs, 0).toFixed(0)}ms`;
+  const barTone = ws.unknownTiming || ws.negativeDuration ? "var(--t3)" : (ws.hasError ? "var(--red)" : color);
 
   return (
     <div>
@@ -1004,7 +1072,7 @@ function SpanRow({
               width: `${widthPct}%`,
               minWidth: 2,
               height: "100%",
-              background: ws.hasError ? "var(--red)" : color,
+              background: barTone,
               borderRadius: 2,
               display: "flex",
               alignItems: "center",
@@ -1014,22 +1082,28 @@ function SpanRow({
             }}>
             {labelInside && (
               <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t0)" }}>
-                {ws.durMs}ms
+                {durLabel}
               </span>
             )}
           </div>
         </div>
 
         {/* Right-side label */}
-        <div style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: 10,
-          color: "var(--t1)",
-          textAlign: "right",
-          whiteSpace: "nowrap",
-        }}>
-          {labelInside ? "" : `${ws.durMs}ms`}
-          {ws.hasError ? " · CRIT" : ""}
+        <div
+          title={ws.unknownTiming
+            ? "missing or unparseable timestamps"
+            : ws.negativeDuration
+              ? "end_time is before start_time (clock skew or partial trace)"
+              : undefined}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: ws.unknownTiming || ws.negativeDuration ? "var(--amber)" : "var(--t1)",
+            textAlign: "right",
+            whiteSpace: "nowrap",
+          }}>
+          {labelInside ? "" : durLabel}
+          {ws.hasError ? " · ERR" : ""}
         </div>
       </div>
 

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSpanWaterfall } from "./runtime-trace";
+import type { TraceSpanRecord } from "../types/runtime";
+
+// Helpers for the synthetic-trace fixtures. `at(ms)` returns an ISO
+// string `ms` after the trace anchor; `span(...)` builds a minimal
+// TraceSpanRecord. The bug-shaped tests intentionally feed bad data
+// (unparseable starts, end-before-start, multiple roots, cycles) and
+// assert the waterfall renders something sensible rather than blowing
+// the whole picture apart on a single bad row.
+
+const T0 = "2026-04-21T10:00:00.000Z";
+const at = (ms: number) => new Date(Date.parse(T0) + ms).toISOString();
+
+function span(p: Partial<TraceSpanRecord> & Pick<TraceSpanRecord, "span_id" | "name">): TraceSpanRecord {
+  return {
+    trace_id: "t",
+    span_id: p.span_id,
+    name: p.name,
+    start_time: p.start_time,
+    end_time: p.end_time,
+    parent_span_id: p.parent_span_id,
+    status_code: p.status_code,
+    attributes: p.attributes,
+    events: p.events,
+    kind: p.kind,
+  };
+}
+
+describe("buildSpanWaterfall", () => {
+  it("returns an empty waterfall for empty input", () => {
+    const wf = buildSpanWaterfall([]);
+    expect(wf.spans).toEqual([]);
+    expect(wf.totalMs).toBe(0);
+    expect(wf.phases).toEqual([]);
+  });
+
+  it("emits spans in pre-order DFS so children always follow their parent", () => {
+    // Tree:
+    //   root (0..400)
+    //     ├─ A (10..200)
+    //     │   └─ A1 (50..150)
+    //     └─ B (220..380)
+    // Expected order: root, A, A1, B
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "B", name: "gateway.usage", parent_span_id: "root", start_time: at(220), end_time: at(380) }),
+      span({ span_id: "A", name: "provider.openai", parent_span_id: "root", start_time: at(10), end_time: at(200) }),
+      span({ span_id: "A1", name: "provider.openai.parse", parent_span_id: "A", start_time: at(50), end_time: at(150) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.spans.map((s) => s.span.span_id)).toEqual(["root", "A", "A1", "B"]);
+  });
+
+  it("emits a child after its parent in DFS order even when clock skew puts the child's start earlier", () => {
+    // Even though A's start (-50) is earlier than root's (0), A must
+    // still render below root because of the parent→child relationship.
+    // The previous (startMs, depth) sort orphaned A above its parent.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "A", name: "provider.openai", parent_span_id: "root", start_time: at(-50), end_time: at(380) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.spans.map((s) => s.span.span_id)).toEqual(["root", "A"]);
+  });
+
+  it("does not let one unparseable timestamp blow up t0/totalMs for all other spans", () => {
+    // The previous implementation defaulted bad start_time to 0, then
+    // Math.min(...) picked 0 as t0. Every other span's startMs became
+    // ~1.7e12 — sub-pixel everywhere except the bad span's own row.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "good", name: "provider.openai", parent_span_id: "root", start_time: at(50), end_time: at(380) }),
+      span({ span_id: "bad", name: "tool.shell", parent_span_id: "root", start_time: "not-a-date", end_time: "also-not" }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.totalMs).toBe(400);
+    const good = wf.spans.find((s) => s.span.span_id === "good")!;
+    expect(good.startMs).toBe(50);
+    expect(good.durMs).toBe(330);
+    expect(good.unknownTiming).toBe(false);
+    const bad = wf.spans.find((s) => s.span.span_id === "bad")!;
+    expect(bad.unknownTiming).toBe(true);
+    expect(Number.isNaN(bad.startMs)).toBe(true);
+  });
+
+  it("flags spans with valid start but unparseable end as unknownTiming, not 0ms", () => {
+    // The previous code defaulted endRaw to startRaw when the
+    // end_time string was bad, silently producing a 0ms span. The
+    // doc comment said "missing/unparseable start_time *or*
+    // end_time" should be flagged — code now matches doc. Both
+    // startMs and durMs are NaN so a caller that forgets to check
+    // unknownTiming can't accidentally position a bar at a known
+    // start with an unknown width.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "halfBad", name: "tool.shell", parent_span_id: "root", start_time: at(50), end_time: "garbage" }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const halfBad = wf.spans.find((s) => s.span.span_id === "halfBad")!;
+    expect(halfBad.unknownTiming).toBe(true);
+    expect(Number.isNaN(halfBad.startMs)).toBe(true);
+    expect(Number.isNaN(halfBad.durMs)).toBe(true);
+  });
+
+  it("includes negative-duration span starts in totalMs so they don't render off-scale", () => {
+    // Without including starts in totalMs, a clock-skew span with
+    // start=200ms and end=150ms in a trace whose latest valid end is
+    // 150ms would render at leftPct=200/150=133% — past the right
+    // edge of the bar column. totalMs covers max(starts, ends) so
+    // the renderer always has a valid range for any span's position.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(150) }),
+      span({ span_id: "skewLate", name: "tool.shell", parent_span_id: "root", start_time: at(200), end_time: at(150) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.totalMs).toBe(200);
+    const skewLate = wf.spans.find((s) => s.span.span_id === "skewLate")!;
+    expect(skewLate.startMs).toBe(200);
+    expect(skewLate.negativeDuration).toBe(true);
+  });
+
+  it("flags negative-duration spans rather than silently clamping to 1ms", () => {
+    // Codex-like sidecar with subprocess clock drift can emit
+    // end_time < start_time. The previous code clamped this to a
+    // 1ms tick visually indistinguishable from a real one.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "skewed", name: "tool.shell", parent_span_id: "root", start_time: at(100), end_time: at(50) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const skewed = wf.spans.find((s) => s.span.span_id === "skewed")!;
+    expect(skewed.negativeDuration).toBe(true);
+    expect(skewed.durMs).toBe(-50);
+    expect(skewed.unknownTiming).toBe(false);
+  });
+
+  it("computes critical path via longest-descent DP, not longest single child", () => {
+    // root has two children:
+    //   short_with_long_chain: 60ms own, descendant chain adds 200ms (260ms total)
+    //   long_alone:            80ms own, no descendants            (80ms total)
+    //
+    // The previous "longest single child" heuristic picked
+    // long_alone (80 > 60). The DP picks short_with_long_chain
+    // (260 > 80). The critical chain runs through that branch.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "short_with_long_chain", name: "router.select", parent_span_id: "root", start_time: at(0), end_time: at(60) }),
+      span({ span_id: "deep1", name: "provider.openai", parent_span_id: "short_with_long_chain", start_time: at(10), end_time: at(200) }),
+      span({ span_id: "deep2", name: "provider.openai.parse", parent_span_id: "deep1", start_time: at(20), end_time: at(190) }),
+      span({ span_id: "long_alone", name: "gateway.usage", parent_span_id: "root", start_time: at(60), end_time: at(140) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const critIDs = wf.spans.filter((s) => s.critical).map((s) => s.span.span_id).sort();
+    expect(critIDs).toEqual(["deep1", "deep2", "root", "short_with_long_chain"].sort());
+  });
+
+  it("highlights the critical path of every root in a multi-root trace", () => {
+    // Two unrelated subtrees (retention pruned the common ancestor).
+    // Both their longest-descent chains must be marked, not just the
+    // first root's.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "rootA", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "A1", name: "provider.openai", parent_span_id: "rootA", start_time: at(10), end_time: at(380) }),
+      span({ span_id: "rootB", name: "gateway.request", start_time: at(500), end_time: at(900) }),
+      span({ span_id: "B1", name: "provider.anthropic", parent_span_id: "rootB", start_time: at(510), end_time: at(880) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const critIDs = new Set(wf.spans.filter((s) => s.critical).map((s) => s.span.span_id));
+    expect(critIDs.has("rootA")).toBe(true);
+    expect(critIDs.has("A1")).toBe(true);
+    expect(critIDs.has("rootB")).toBe(true);
+    expect(critIDs.has("B1")).toBe(true);
+  });
+
+  it("treats spans with a missing parent in the visible set as roots", () => {
+    // The parent span was pruned by retention or never sampled. Its
+    // children should still render rather than disappear.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "orphan", name: "provider.openai", parent_span_id: "missing", start_time: at(10), end_time: at(380) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.spans).toHaveLength(1);
+    expect(wf.spans[0].depth).toBe(0);
+    expect(wf.spans[0].critical).toBe(true); // sole root
+  });
+
+  it("survives a parent_span_id cycle without infinite recursion", () => {
+    // Corrupt-data guard. Two spans claiming each other as parent.
+    // The cycle guards in depthOf and descent should clamp gracefully
+    // and let buildSpanWaterfall return.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "A", name: "spanA", parent_span_id: "B", start_time: at(0), end_time: at(100) }),
+      span({ span_id: "B", name: "spanB", parent_span_id: "A", start_time: at(0), end_time: at(100) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.spans).toHaveLength(2);
+    // Depth assignment under a cycle is "best effort, don't loop"; we
+    // just assert it terminated and produced finite depths.
+    for (const s of wf.spans) {
+      expect(Number.isFinite(s.depth)).toBe(true);
+    }
+  });
+
+  it("falls back to a 1ms total when every span has unparseable timestamps", () => {
+    // Edge case: trace store mangled every ISO timestamp. We don't
+    // throw, we don't divide-by-zero — we render a degenerate
+    // waterfall that at least lists the spans.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "A", name: "spanA", start_time: "garbage", end_time: "garbage" }),
+      span({ span_id: "B", name: "spanB", parent_span_id: "A", start_time: "garbage", end_time: "garbage" }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.totalMs).toBe(1);
+    expect(wf.spans).toHaveLength(2);
+    for (const s of wf.spans) {
+      expect(s.unknownTiming).toBe(true);
+      expect(Number.isNaN(s.startMs)).toBe(true);
+    }
+  });
+
+  it("preserves the existing 'long span on root's longest descent is critical' contract", () => {
+    // Sanity: the basic three-span shape from runtime-utils.test.ts
+    // keeps working — root + a long provider call + a short usage
+    // call, only the long one is critical.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(400) }),
+      span({ span_id: "long", name: "provider.openai", parent_span_id: "root", start_time: at(50), end_time: at(380) }),
+      span({ span_id: "short", name: "gateway.usage", parent_span_id: "root", start_time: at(385), end_time: at(395) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const long = wf.spans.find((s) => s.span.span_id === "long")!;
+    const short = wf.spans.find((s) => s.span.span_id === "short")!;
+    expect(long.critical).toBe(true);
+    expect(short.critical).toBe(false);
+  });
+});

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -35,7 +35,16 @@ export type TraceTimelineItem = {
 // WaterfallSpan annotates a span with the data the drawer renders:
 // startMs/durMs are normalized to the trace start; depth is computed
 // from the parent_span_id chain (purely UI-side); critical = on the
-// longest single child chain rooted at the trace root.
+// longest descent path from this span's root (DP over child chains,
+// summing own duration with the longest descent under any child).
+//
+// unknownTiming / negativeDuration mark spans whose timestamps were
+// missing/unparseable or whose end_time is before start_time (clock
+// skew or partial trace). The renderer must handle these explicitly:
+// `startMs` and `durMs` are NaN for unknownTiming, and `durMs` is
+// preserved as-is (possibly negative or zero) for negativeDuration so
+// the UI can render a "?" marker rather than silently showing a 1ms
+// dot indistinguishable from a real one.
 export type WaterfallSpan = {
   span: TraceSpanRecord;
   startMs: number;
@@ -44,6 +53,8 @@ export type WaterfallSpan = {
   phase: TraceTimelineItem["phase"];
   hasError: boolean;
   critical: boolean;
+  unknownTiming: boolean;
+  negativeDuration: boolean;
 };
 
 export type TraceWaterfall = {
@@ -162,23 +173,120 @@ export function tracePhaseFromSpan(name: string): TraceTimelineItem["phase"] {
 }
 
 // buildSpanWaterfall computes the data shape the drawer's waterfall
-// renders. Spans are ordered by start_offset_ms; depth comes from the
-// parent_span_id chain (root = depth 0). The critical-path is the
-// longest single child chain by duration starting at the root.
+// renders. Spans are emitted in pre-order DFS (parent immediately
+// followed by descendants, siblings sorted by start time) so the
+// nested visual hierarchy survives clock skew that would otherwise
+// place a child ahead of its parent under a (startMs, depth) sort.
+//
+// `critical` marks the longest-descent chain from each root, computed
+// via DP: descent(node) = ownDur + max(descent(child)). This handles
+// the case the previous "longest single child by duration" heuristic
+// got wrong — a shorter child whose subtree contains a longer chain.
+//
+// Spans with unparseable start_time or end_time are flagged
+// `unknownTiming: true` (NaN startMs/durMs) and excluded from t0 /
+// totalMs so a single bad timestamp can't blow the whole waterfall to
+// the right. Negative durations (clock skew across hosts/processes)
+// are preserved as-is and flagged `negativeDuration: true` so the
+// renderer can mark them rather than silently clamping to 1ms.
 export function buildSpanWaterfall(spans: TraceSpanRecord[]): TraceWaterfall {
   if (!spans || spans.length === 0) return { spans: [], totalMs: 0, phases: [] };
 
-  const parsed = spans.map((s) => {
-    const start = s.start_time ? Date.parse(s.start_time) : 0;
-    const end = s.end_time ? Date.parse(s.end_time) : start;
-    return { span: s, start: Number.isFinite(start) ? start : 0, end: Number.isFinite(end) ? end : 0 };
+  // Parse timestamps. Track start and end validity separately. Two
+  // failure modes get distinct flags downstream:
+  //   - either timestamp missing/unparseable → `unknownTiming: true`
+  //     (the renderer can't trust the position OR the width)
+  //   - both parsed but end < start → `negativeDuration: true`
+  //     (clock skew; position is OK, duration label is "?")
+  // The t0 computation can include start-valid-end-bad spans
+  // (their start contributes to the trace anchor) but those rows
+  // still get `unknownTiming: true` because we can't draw their bar.
+  type Parsed = {
+    span: TraceSpanRecord;
+    start: number;       // NaN if unparseable
+    end: number;         // NaN if unparseable
+    startValid: boolean;
+    endValid: boolean;
+    durMs: number;       // end - start, or NaN if either is bad
+  };
+  const parsed: Parsed[] = spans.map((s) => {
+    const startRaw = s.start_time ? Date.parse(s.start_time) : NaN;
+    const endRaw = s.end_time ? Date.parse(s.end_time) : NaN;
+    const startValid = Number.isFinite(startRaw);
+    const endValid = Number.isFinite(endRaw);
+    const start = startValid ? startRaw : NaN;
+    const end = endValid ? endRaw : NaN;
+    const durMs = startValid && endValid ? end - start : NaN;
+    return { span: s, start, end, startValid, endValid, durMs };
   });
-  const t0 = Math.min(...parsed.map((p) => p.start));
-  const totalMs = Math.max(...parsed.map((p) => p.end - t0), 1);
 
-  // depth via parent_span_id chain
+  // Cache parsed values by span_id so the sibling sort comparators and
+  // the descent DP don't re-parse ISO timestamps for every comparison.
+  // On a 200-span trace the previous code did O(span × log(siblings))
+  // Date.parse calls; this drops it to O(span).
+  const parsedByID = new Map<string, Parsed>();
+  for (const p of parsed) parsedByID.set(p.span.span_id, p);
+
+  // Compute t0/totalMs from spans with parseable starts. End-bad
+  // spans still contribute their start to t0; they just don't
+  // contribute to totalMs (their end is unknown). If every span is
+  // bad (rare but possible when the trace store mangles ISO
+  // timestamps), fall back to a 1ms total so percentages stay finite.
+  //
+  // Negative-duration spans (clock skew across hosts: end < start)
+  // get their *start* counted into totalMs as well — without that,
+  // a span starting at +200ms in a trace that otherwise ends at
+  // +150ms would render at leftPct=133%, off-scale to the right.
+  // Including the start keeps the renderable area covering every
+  // bar's position.
+  const startValidParsed = parsed.filter((p) => p.startValid);
+  const t0 = startValidParsed.length > 0 ? Math.min(...startValidParsed.map((p) => p.start)) : 0;
+  const endValidParsed = parsed.filter((p) => p.startValid && p.endValid);
+  const totalMs = startValidParsed.length > 0
+    ? Math.max(
+      ...endValidParsed.map((p) => p.end - t0),
+      ...startValidParsed.map((p) => p.start - t0),
+      1,
+    )
+    : 1;
+
   const byID = new Map<string, TraceSpanRecord>();
   for (const s of spans) byID.set(s.span_id, s);
+
+  // Children index keyed on parent span id. Spans whose parent is
+  // missing from the visible set are treated as roots so an orphan
+  // subtree (parent pruned by retention, partial trace) still
+  // renders rather than disappearing.
+  const children = new Map<string, TraceSpanRecord[]>();
+  const roots: TraceSpanRecord[] = [];
+  for (const s of spans) {
+    if (!s.parent_span_id || !byID.has(s.parent_span_id)) {
+      roots.push(s);
+    } else {
+      const arr = children.get(s.parent_span_id) ?? [];
+      arr.push(s);
+      children.set(s.parent_span_id, arr);
+    }
+  }
+  // Sort siblings by start time so DFS order matches wall-clock
+  // order within each subtree. Reads from the parsed cache rather
+  // than re-parsing ISO timestamps. Siblings with unparseable starts
+  // sort last (NaN comparisons fall through to 0, but we guard
+  // explicitly).
+  const sortByStart = (a: TraceSpanRecord, b: TraceSpanRecord): number => {
+    const sa = parsedByID.get(a.span_id)?.start ?? NaN;
+    const sb = parsedByID.get(b.span_id)?.start ?? NaN;
+    if (Number.isFinite(sa) && Number.isFinite(sb)) return sa - sb;
+    if (Number.isFinite(sa)) return -1;
+    if (Number.isFinite(sb)) return 1;
+    return 0;
+  };
+  for (const [, kids] of children) kids.sort(sortByStart);
+  roots.sort(sortByStart);
+
+  // depthOf walks parent_span_id; cycle guard via `seen` set returns
+  // 0 if a cycle is detected (corrupt data — shouldn't happen, but
+  // we'd rather render than throw).
   const depthCache = new Map<string, number>();
   function depthOf(id: string, seen: Set<string> = new Set()): number {
     if (depthCache.has(id)) return depthCache.get(id)!;
@@ -191,51 +299,103 @@ export function buildSpanWaterfall(spans: TraceSpanRecord[]): TraceWaterfall {
     return d;
   }
 
-  // children index for critical-path walk
-  const children = new Map<string, TraceSpanRecord[]>();
-  let root: TraceSpanRecord | null = null;
-  for (const s of spans) {
-    if (!s.parent_span_id || !byID.has(s.parent_span_id)) {
-      // First top-level span is the root for critical-path purposes.
-      if (!root) root = s;
-    } else {
-      const arr = children.get(s.parent_span_id) ?? [];
-      arr.push(s);
-      children.set(s.parent_span_id, arr);
+  // descent: longest chain (in ms, including own duration) from this
+  // span down. Reads its own duration from the parsed cache rather
+  // than re-parsing. Memoized; cycle-guarded via the visiting set.
+  const descentCache = new Map<string, number>();
+  const visiting = new Set<string>();
+  function descent(id: string): number {
+    const cached = descentCache.get(id);
+    if (cached !== undefined) return cached;
+    if (visiting.has(id)) return 0; // cycle: terminate at this node
+    visiting.add(id);
+    const ownDurRaw = parsedByID.get(id)?.durMs ?? 0;
+    // NaN or negative durations don't contribute to a chain length.
+    const ownDur = Number.isFinite(ownDurRaw) && ownDurRaw > 0 ? ownDurRaw : 0;
+    let maxChild = 0;
+    for (const k of children.get(id) ?? []) {
+      const d = descent(k.span_id);
+      if (d > maxChild) maxChild = d;
     }
+    visiting.delete(id);
+    const total = ownDur + maxChild;
+    descentCache.set(id, total);
+    return total;
   }
-  const criticalIDs = new Set<string>();
-  function walkCritical(node: TraceSpanRecord | null) {
-    if (!node) return;
-    criticalIDs.add(node.span_id);
-    const kids = children.get(node.span_id) ?? [];
-    if (kids.length === 0) return;
-    let longest: TraceSpanRecord | null = null;
-    let longestDur = -1;
-    for (const k of kids) {
-      const ks = k.start_time ? Date.parse(k.start_time) : 0;
-      const ke = k.end_time ? Date.parse(k.end_time) : ks;
-      const dur = Number.isFinite(ke) && Number.isFinite(ks) ? ke - ks : 0;
-      if (dur > longestDur) {
-        longestDur = dur;
-        longest = k;
-      }
-    }
-    walkCritical(longest);
-  }
-  walkCritical(root);
 
-  const out: WaterfallSpan[] = parsed
-    .map((p) => ({
+  // Walk longest-descent chain from every root. Multi-root traces
+  // (orphaned subtrees) get every root highlighted so we don't drop
+  // them silently.
+  const criticalIDs = new Set<string>();
+  for (const root of roots) {
+    let node: TraceSpanRecord | null = root;
+    const walkSeen = new Set<string>();
+    while (node && !walkSeen.has(node.span_id)) {
+      walkSeen.add(node.span_id);
+      criticalIDs.add(node.span_id);
+      const kids: TraceSpanRecord[] = children.get(node.span_id) ?? [];
+      if (kids.length === 0) break;
+      let best: TraceSpanRecord | null = null;
+      let bestD = -1;
+      for (const k of kids) {
+        const d: number = descent(k.span_id);
+        if (d > bestD) { bestD = d; best = k; }
+      }
+      node = best;
+    }
+  }
+
+  const waterfallByID = new Map<string, WaterfallSpan>();
+  for (const p of parsed) {
+    // unknownTiming covers any span we can't reliably draw a bar for —
+    // either start or end (or both) was missing/unparseable. The
+    // renderer treats these the same: render the row, mark the bar
+    // slot with "?", don't trust the position.
+    const unknownTiming = !p.startValid || !p.endValid;
+    // negativeDuration is the narrower clock-skew case — both
+    // timestamps parsed but end < start. Bar is positioned but the
+    // duration is "?" rather than a misleading "-50ms" tick.
+    const negativeDuration = !unknownTiming && p.durMs < 0;
+    waterfallByID.set(p.span.span_id, {
       span: p.span,
-      startMs: Math.max(0, p.start - t0),
-      durMs: Math.max(p.end - p.start, 1),
+      // Both startMs and durMs are NaN for unknownTiming rows — the
+      // doc contract is "no usable timing"; even start-OK / end-bad
+      // gets NaN startMs so callers don't accidentally render a bar
+      // at a known position with an unknown width.
+      startMs: unknownTiming ? NaN : Math.max(0, p.start - t0),
+      durMs: unknownTiming ? NaN : p.durMs,
       depth: depthOf(p.span.span_id),
       phase: tracePhaseFromSpan(p.span.name),
-      hasError: p.span.status_code === "error" || (p.span.attributes?.["error"] != null && p.span.attributes?.["error"] !== ""),
+      hasError: p.span.status_code === "error"
+        || (p.span.attributes?.["error"] != null && p.span.attributes?.["error"] !== ""),
       critical: criticalIDs.has(p.span.span_id),
-    }))
-    .sort((a, b) => a.startMs - b.startMs || a.depth - b.depth);
+      unknownTiming,
+      negativeDuration,
+    });
+  }
+
+  // Pre-order DFS emit: parent, then descendants. Cycle guard via
+  // `emitted` set so a corrupt parent_span_id loop doesn't infinite-
+  // recurse, and so a span reachable from multiple roots doesn't
+  // appear twice.
+  const out: WaterfallSpan[] = [];
+  const emitted = new Set<string>();
+  function emit(node: TraceSpanRecord) {
+    if (emitted.has(node.span_id)) return;
+    emitted.add(node.span_id);
+    const w = waterfallByID.get(node.span_id);
+    if (w) out.push(w);
+    for (const k of children.get(node.span_id) ?? []) emit(k);
+  }
+  for (const r of roots) emit(r);
+  // Sweep up any spans not reachable from a root (shouldn't happen
+  // given roots is built as "no valid parent", but defensive).
+  for (const p of parsed) {
+    if (!emitted.has(p.span.span_id)) {
+      const w = waterfallByID.get(p.span.span_id);
+      if (w) out.push(w);
+    }
+  }
 
   const phases: TraceTimelineItem["phase"][] = [];
   for (const s of out) if (!phases.includes(s.phase)) phases.push(s.phase);


### PR DESCRIPTION
## Summary

Six concrete bugs in `ui/src/lib/runtime-trace.ts` and the SpanRow that consumes its output. Tier 1 (bugfix half) of the [Observability redesign RFC](https://github.com/hecatehq/hecate/pull/72) — the structural file split is a separate follow-up PR.

## Bugs fixed

1. **`t0 = Math.min(...starts)` collapsed to 0 when any span had unparseable `start_time`.** Every other span's `startMs` went to ~1.7e12 ms, rendering the whole waterfall as a wall of zero-width bars to the right. **One bad row broke every trace.** Fixed by parsing timestamps to NaN-or-finite, computing t0/totalMs from valid spans only, and tagging bad rows `unknownTiming: true`.
2. **`totalMs` inherited the same blowup.** Same fix.
3. **Critical-path walk only highlighted the first root.** Multi-root traces (parent pruned by retention, partial trace) silently dropped every other root's chain. Fixed by collecting all roots and walking each.
4. **The walk picked "longest single child by duration" — wrong** when a shorter child has a deeper subtree containing a longer chain. Replaced with longest-descent DP: `descent(node) = ownDur + max(descent(child))`. Critical path walks the child with the largest descent at each level.
5. **Spans were sorted by `(startMs, depth)`.** A child with clock skew that put its start before the parent rendered visually *above* the parent. Replaced with pre-order DFS: parent followed by descendants, siblings sorted by start time.
6. **Negative-duration spans (clock skew across hosts/processes) clamped to 1ms** — visually indistinguishable from a real 1ms span. Now flagged `negativeDuration: true`; SpanRow renders a `"?"` duration label in amber instead.

Plus: trace-detail polling in ObservabilityView now caps at 5 attempts (10s) instead of polling forever when a trace will never arrive (sampled out, dropped, retention-pruned mid-poll).

## Defensive guards added

- Cycle guard in `depthOf` (already existed) preserved.
- Cycle guard added to the new `descent` DP via a `visiting` set — corrupt `parent_span_id` loops terminate at the cycle node rather than infinite-recursing.
- Cycle guard in DFS emit so a span reachable from multiple roots (shouldn't happen, but) doesn't appear twice.
- Fallback to `totalMs = 1` when every span has unparseable timestamps so the renderer doesn't divide-by-zero.

## New types on `WaterfallSpan`

```ts
unknownTiming: boolean;     // start_time/end_time unparseable
negativeDuration: boolean;  // end_time < start_time (clock skew)
```

`startMs` and `durMs` are NaN for `unknownTiming` rows so the renderer can detect and special-case rather than rendering a stale 0%-positioned bar.

## Tests

New `ui/src/lib/runtime-trace.test.ts` with 11 cases covering every bug shape above plus the edge cases:

- empty input
- pre-order DFS emission with a multi-level tree
- child rendered after parent under clock skew
- one bad timestamp doesn't blow t0/totalMs
- negative durations are flagged, not clamped
- critical-path DP picks the chain through a shorter child whose subtree is deeper
- multi-root critical-path highlights every root's chain
- orphaned span (parent missing from visible set) renders as a root
- parent_span_id cycle terminates rather than recursing forever
- all-bad-timestamps case returns a degenerate but renderable waterfall
- existing "long span on root's longest descent is critical" contract preserved (sanity for `runtime-utils.test.ts`'s existing test)

## Verification

- `bun run test`: 30 files, 665 tests passing (+11 new).
- `bun run build`: clean. ObservabilityView chunk +450 bytes (the new bug-state branches in SpanRow).
- `bun run test:e2e`: 52 passed.

## Test plan

- [x] Unit tests cover every bug shape.
- [x] Build + typecheck clean (`tsgo --build`).
- [x] Playwright e2e green.
- [ ] Manual: open Observability with a real trace that has clock skew between gateway and a Codex sidecar (the original "buggy" symptom). Confirm the waterfall renders correctly and the skewed span shows a `?` duration in amber.