### PR TITLE
feat(observability): task→trace drill-down + recent-activity strip

### DIFF
--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -242,7 +242,7 @@ function AuthenticatedShell({
             <Suspense fallback={<WorkspaceFallback />}>
               {activeWorkspace === "overview"   && <ObservabilityView actions={actions} state={state} onNavigate={onSelectWorkspace} focusRequest={traceFocusRequest} />}
               {activeWorkspace === "chats" && <ChatView actions={actions} state={state} onNavigate={onSelectWorkspace} onOpenTask={openTaskFromChat} onOpenTrace={openTraceFromChat} />}
-              {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} />}
+              {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} onOpenTrace={openTraceFromChat} />}
               {activeWorkspace === "providers"     && <ProvidersView actions={actions} state={state} />}
               {activeWorkspace === "costs"         && <CostsView actions={actions} state={state} />}
               {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} />}

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -28,6 +28,7 @@ import type {
 import { Badge, Icon, Icons, Modal, ModelPicker, ProviderPicker, Toggle } from "../shared/ui";
 
 import { CopyableID } from "./observability/CopyableID";
+import { RecentActivityStrip } from "./observability/RecentActivityStrip";
 import { StatCard } from "./observability/StatCard";
 import { TraceDetail } from "./observability/TraceDetail";
 import {
@@ -356,6 +357,12 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
 
         {/* Recent requests label */}
         <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", marginBottom: 10 }}>Recent requests</div>
+
+        {/* Activity strip — status dots + p50/p95/errors over the
+            visible traces. Sits above the table so the operator
+            gets a "is this OK right now?" answer before parsing
+            individual rows. */}
+        <RecentActivityStrip traces={filteredTraces} />
 
         {/* Table */}
         {filteredTraces.length > 0 ? (

--- a/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
@@ -61,4 +61,21 @@ describe("RecentActivityStrip", () => {
     const { container } = render(<RecentActivityStrip traces={traces} />);
     expect(container.textContent).toMatch(/recovered.*1/);
   });
+
+  it("does not count error+fallback_from as recovered (the fallback also failed)", () => {
+    // A trace with both status_code="error" and fallback_from means
+    // the primary failed AND the fallback failed. That's a double-
+    // fault, not a recovery — the dot is red, the error count
+    // increments, the recovered count does not.
+    const traces = [
+      trace({ request_id: "a", duration_ms: 100, status_code: "error", route: { fallback_from: "openai" } }),
+      trace({ request_id: "b", duration_ms: 200, status_code: "ok", route: { fallback_from: "openai" } }),
+    ];
+    const { container } = render(<RecentActivityStrip traces={traces} />);
+    const text = container.textContent || "";
+    expect(text).toMatch(/errors.*1.*\/.*2/);
+    // Only the second trace recovered; the first double-faulted.
+    expect(text).toMatch(/recovered.*1/);
+    expect(text).not.toMatch(/recovered.*2/);
+  });
 });

--- a/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import type { TraceListItem } from "../../../types/runtime";
+
+import { RecentActivityStrip } from "./RecentActivityStrip";
+
+function trace(p: Partial<TraceListItem> & Pick<TraceListItem, "request_id">): TraceListItem {
+  return {
+    request_id: p.request_id,
+    started_at: p.started_at ?? new Date().toISOString(),
+    span_count: p.span_count ?? 1,
+    duration_ms: p.duration_ms,
+    status_code: p.status_code,
+    status_message: p.status_message,
+    route: p.route,
+  } as TraceListItem;
+}
+
+describe("RecentActivityStrip", () => {
+  it("renders nothing when there are no traces", () => {
+    const { container } = render(<RecentActivityStrip traces={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one dot per trace", () => {
+    const traces = [
+      trace({ request_id: "a", duration_ms: 100, status_code: "ok" }),
+      trace({ request_id: "b", duration_ms: 200, status_code: "error" }),
+      trace({ request_id: "c", duration_ms: 300, status_code: "ok" }),
+    ];
+    const { container } = render(<RecentActivityStrip traces={traces} />);
+    // The dots are the only `display: inline-block` spans inside the
+    // strip; everything else is text or flex/grid layout.
+    const dots = container.querySelectorAll('span[title*="…"]');
+    expect(dots.length).toBe(3);
+  });
+
+  it("computes p50/p95 from durations and counts errors", () => {
+    // Latencies: 10, 20, 30, 40, 50 → p50 picks index ceil(5*0.5)-1=2 (30ms);
+    // p95 picks index ceil(5*0.95)-1=4 (50ms).
+    const traces = [
+      trace({ request_id: "a", duration_ms: 30, status_code: "ok" }),
+      trace({ request_id: "b", duration_ms: 50, status_code: "error" }),
+      trace({ request_id: "c", duration_ms: 10, status_code: "ok" }),
+      trace({ request_id: "d", duration_ms: 40, status_code: "ok" }),
+      trace({ request_id: "e", duration_ms: 20, status_code: "ok" }),
+    ];
+    const { container } = render(<RecentActivityStrip traces={traces} />);
+    const text = container.textContent || "";
+    expect(text).toMatch(/p50.*30ms/);
+    expect(text).toMatch(/p95.*50ms/);
+    expect(text).toMatch(/errors.*1.*\/.*5/);
+  });
+
+  it("shows recovered count when a trace has fallback_from", () => {
+    const traces = [
+      trace({ request_id: "a", duration_ms: 100, status_code: "ok", route: { fallback_from: "openai" } }),
+      trace({ request_id: "b", duration_ms: 200, status_code: "ok" }),
+    ];
+    const { container } = render(<RecentActivityStrip traces={traces} />);
+    expect(container.textContent).toMatch(/recovered.*1/);
+  });
+});

--- a/ui/src/features/overview/observability/RecentActivityStrip.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.tsx
@@ -11,8 +11,6 @@
 
 import type { TraceListItem } from "../../../types/runtime";
 
-import { traceStatusBadge } from "../../../lib/runtime-utils";
-
 type Props = {
   traces: TraceListItem[];
 };
@@ -31,10 +29,17 @@ export function RecentActivityStrip({ traces }: Props) {
   const p50 = percentile(durations, 0.5);
   const p95 = percentile(durations, 0.95);
   const errorCount = traces.filter((t) => t.status_code === "error").length;
-  const recoveredCount = traces.filter((t) => t.route?.fallback_from).length;
+  // Recovered = a fallback was used AND the final result wasn't an
+  // error. A trace with both status_code="error" and fallback_from
+  // means the fallback ALSO failed; that's not a recovery, it's a
+  // double-fault, and gets counted only as an error.
+  const recoveredCount = traces.filter(
+    (t) => t.route?.fallback_from && t.status_code !== "error",
+  ).length;
 
   return (
     <div
+      role="group"
       aria-label="Recent activity"
       style={{
         padding: "10px 12px",
@@ -47,12 +52,12 @@ export function RecentActivityStrip({ traces }: Props) {
       }}>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 2, alignItems: "center" }}>
         {ordered.map((t) => {
-          const tone = traceStatusBadge(t).status;
-          const color =
-            tone === "down" ? "var(--red)" :
-            tone === "degraded" ? "var(--amber)" :
-            tone === "healthy" ? "var(--green)" :
-            "var(--t3)";
+          // Map dot color from raw fields rather than reusing
+          // traceStatusBadge — that helper paints missing status_code
+          // (in-flight traces) as "degraded"/amber, which would
+          // visually conflate them with recovered traces in this
+          // strip. Here, in-flight stays gray.
+          const color = dotColor(t);
           return (
             <span
               key={t.request_id}
@@ -79,6 +84,13 @@ export function RecentActivityStrip({ traces }: Props) {
       </div>
     </div>
   );
+}
+
+function dotColor(t: TraceListItem): string {
+  if (t.status_code === "error") return "var(--red)";
+  if (t.route?.fallback_from) return "var(--amber)";
+  if (t.status_code === "ok") return "var(--green)";
+  return "var(--t3)"; // in-flight or unknown
 }
 
 // percentile picks the ceil-indexed value at q on a sorted ascending

--- a/ui/src/features/overview/observability/RecentActivityStrip.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.tsx
@@ -1,0 +1,98 @@
+// RecentActivityStrip is a tiny "is the system OK right now?"
+// summary that sits above the recent-traces table. One row of
+// status dots — one per visible trace, color-coded — gives the
+// operator the visual rhythm of recent requests; a stat line
+// underneath gives p50/p95 latency and the error count.
+//
+// No bucketing, no time axis. The table below is the detail view;
+// this strip is just the rhythm. Derived entirely from the
+// already-loaded recent-traces feed — no new endpoint, no new
+// polling.
+
+import type { TraceListItem } from "../../../types/runtime";
+
+import { traceStatusBadge } from "../../../lib/runtime-utils";
+
+type Props = {
+  traces: TraceListItem[];
+};
+
+export function RecentActivityStrip({ traces }: Props) {
+  if (traces.length === 0) return null;
+
+  // Oldest → newest left to right matches "what just happened ←
+  // earlier" reading order. The trace feed comes back newest first
+  // so we reverse for the strip; the table below keeps newest first.
+  const ordered = traces.slice().reverse();
+  const durations = traces
+    .map((t) => t.duration_ms)
+    .filter((d): d is number => typeof d === "number" && d >= 0)
+    .sort((a, b) => a - b);
+  const p50 = percentile(durations, 0.5);
+  const p95 = percentile(durations, 0.95);
+  const errorCount = traces.filter((t) => t.status_code === "error").length;
+  const recoveredCount = traces.filter((t) => t.route?.fallback_from).length;
+
+  return (
+    <div
+      aria-label="Recent activity"
+      style={{
+        padding: "10px 12px",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        marginBottom: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 2, alignItems: "center" }}>
+        {ordered.map((t) => {
+          const tone = traceStatusBadge(t).status;
+          const color =
+            tone === "down" ? "var(--red)" :
+            tone === "degraded" ? "var(--amber)" :
+            tone === "healthy" ? "var(--green)" :
+            "var(--t3)";
+          return (
+            <span
+              key={t.request_id}
+              title={`${t.request_id.slice(0, 8)}… · ${t.route?.final_provider || "—"}/${t.route?.final_model || "—"}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
+              style={{
+                display: "inline-block",
+                width: 6, height: 6, borderRadius: "50%",
+                background: color,
+              }}
+            />
+          );
+        })}
+      </div>
+      <div style={{
+        display: "flex", flexWrap: "wrap", gap: 12,
+        fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t2)",
+      }}>
+        <span><span style={{ color: "var(--t3)" }}>p50</span> {formatMs(p50)}</span>
+        <span><span style={{ color: "var(--t3)" }}>p95</span> {formatMs(p95)}</span>
+        <span><span style={{ color: "var(--t3)" }}>errors</span> <span style={{ color: errorCount > 0 ? "var(--red)" : "var(--t2)" }}>{errorCount}</span> / {traces.length}</span>
+        {recoveredCount > 0 && (
+          <span><span style={{ color: "var(--t3)" }}>recovered</span> <span style={{ color: "var(--amber)" }}>{recoveredCount}</span></span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// percentile picks the ceil-indexed value at q on a sorted ascending
+// array. Returns NaN for empty input so the formatter can render
+// "—" instead of "0ms" (zero is meaningfully different from "no
+// duration data" — operators read it as the system being instant).
+function percentile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return NaN;
+  const idx = Math.min(sorted.length - 1, Math.ceil(q * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+function formatMs(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}s`;
+  return `${Math.round(v)}ms`;
+}

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -1212,6 +1212,25 @@ describe("TaskDetail steps timeline — MCP tool distinction", () => {
     expect(screen.getByText(/full upstream result rendered in the agent conversation/i)).toBeTruthy();
   });
 
+  it("renders a clickable Request ID that calls onOpenTrace when wired", async () => {
+    const onOpenTrace = vi.fn();
+    const run = makeRun({ request_id: "req_abc_123" });
+    const { render, user } = setup({ run, runs: [run], selectedRunID: run.id, onOpenTrace });
+    render();
+    const button = screen.getByRole("button", { name: "req_abc_123" });
+    await user.click(button);
+    expect(onOpenTrace).toHaveBeenCalledWith("req_abc_123");
+  });
+
+  it("renders Request ID as plain text when onOpenTrace is not wired", () => {
+    const run = makeRun({ request_id: "req_xyz_789" });
+    const { render } = setup({ run, runs: [run], selectedRunID: run.id, onOpenTrace: undefined });
+    render();
+    // The id appears in text but should not be a clickable button.
+    expect(screen.getByText("req_xyz_789")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "req_xyz_789" })).toBeNull();
+  });
+
   it("handles a tool name with embedded double-underscores in the tool segment", () => {
     // Some upstream MCP servers use `__` inside their tool names
     // (e.g. `mcp__weird__double__under` parses as server=weird,

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AgentChatActivityRecord, TaskActivityRecord, TaskApprovalRecord, TaskArtifactRecord, TaskRecord, TaskRunEventRecord, TaskRunRecord, TaskStepRecord } from "../../types/runtime";
 import { Badge, Dot, Icon, Icons, Modal } from "../shared/ui";
 import { TranscriptActivityTimeline } from "../transcript/TranscriptActivityTimeline";
@@ -383,13 +383,19 @@ type Props = {
   onResumeRaisingCeiling: (budgetMicrosUSD: number) => void;
   onApplyPatch: (artifactID: string) => void;
   onRevertPatch: (artifactID: string) => void;
+  // onOpenTrace opens the Observability drawer pre-targeted on the
+  // run's request_id. Surfaced as a clickable Request ID in the run
+  // metadata grid when both the callback and the run.request_id are
+  // present. Optional so unit tests can render TaskDetail in
+  // isolation without wiring AppShell.
+  onOpenTrace?: (requestID: string) => void;
 };
 
 export function TaskDetail({
   task, run, runs, selectedRunID, events, steps, artifacts, activity, approvals,
   streamTurnCosts, streamState, busyAction, notice,
   onSelectRun, onResolveApproval, onCancelRun, onRetryRun, onResumeRun, onRetryFromTurn,
-  onOpenAgentChat, onResumeRaisingCeiling, onApplyPatch, onRevertPatch,
+  onOpenAgentChat, onResumeRaisingCeiling, onApplyPatch, onRevertPatch, onOpenTrace,
 }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [runPickerOpen, setRunPickerOpen] = useState(false);
@@ -527,13 +533,29 @@ export function TaskDetail({
               {run.otel_status_message && run.status === "failed" && <Badge status="error" label={run.otel_status_message} />}
             </div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "8px 14px" }}>
-              {[
+              {([
                 ["Model", run.model || "—"],
                 ["Duration", formatDuration(run.started_at, run.finished_at) || "—"],
-                ["Request ID", run.request_id || "—"],
+                // Request ID becomes a clickable trace link when both
+                // the run carries a request_id and the parent wired an
+                // onOpenTrace callback. Otherwise it's plain text — same
+                // shape as the other cells.
+                ["Request ID", run.request_id && onOpenTrace
+                  ? <button
+                      type="button"
+                      onClick={() => onOpenTrace(run.request_id!)}
+                      title={`Open trace for ${run.request_id}`}
+                      style={{
+                        background: "none", border: "none", padding: 0, cursor: "pointer",
+                        fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--teal)",
+                        textAlign: "left", wordBreak: "break-word",
+                      }}>
+                      {run.request_id}
+                    </button>
+                  : (run.request_id || "—")],
                 ["Trace ID", run.trace_id || "—"],
                 ["Last error", run.last_error || "—"],
-              ].map(([label, value]) => (
+              ] as Array<[string, ReactNode]>).map(([label, value]) => (
                 <div key={label}>
                   <div className="kicker" style={{ marginBottom: 3 }}>{label}</div>
                   <div style={{ fontSize: 12, color: value === "—" ? "var(--t3)" : label === "Last error" && value !== "—" ? "var(--red)" : "var(--t1)", fontFamily: "var(--font-mono)", wordBreak: "break-word" }}>

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -40,9 +40,11 @@ export function streamTurnCostKey(turnIndex: number | undefined): number | null 
 export function TasksView({
   focusRequest,
   onOpenAgentChat,
+  onOpenTrace,
 }: {
   focusRequest?: TaskFocusRequest | null;
   onOpenAgentChat?: (sessionID: string) => void;
+  onOpenTrace?: (requestID: string) => void;
 } = {}) {
   const [loading, setLoading] = useState(true);
   const [tasks, setTasks] = useState<TaskRecord[]>([]);
@@ -439,6 +441,7 @@ export function TasksView({
           onResumeRaisingCeiling={(budgetMicrosUSD) => void handleResumeRaisingCeiling(budgetMicrosUSD)}
           onApplyPatch={(artifactID) => void handleApplyPatch(artifactID)}
           onRevertPatch={(artifactID) => void handleRevertPatch(artifactID)}
+          onOpenTrace={onOpenTrace}
         />
       ) : (
         <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>


### PR DESCRIPTION
## Summary

Two small, independent improvements bundled into one PR — both frontend-only, no backend changes, no new endpoints.

### 1. Task → trace drill-down

The Run overview panel in TasksView now renders Request ID as a clickable trace link when both the run carries a `request_id` and AppShell wires `onOpenTrace`. Reuses the existing `openTraceFromChat` plumbing in AppShell — same workspace-switch + `focusRequest` pattern that already powers the chat→trace link.

- Plain text for runs without a `request_id`, or for callers that don't pass the callback (unit tests).
- One-line wiring change in `AppShell.tsx`; no new orchestration code.

### 2. Recent-activity strip above the trace table

A small card showing the rhythm of the last 50 traces:
- 50 status dots, color-coded: green (healthy), red (error), amber (recovered via fallback), gray (unknown / in-flight).
- Stat line below: `p50 · p95 · errors / N · recovered`.

Derived entirely from the already-loaded recent-traces feed — no new polling, no new endpoint. Operators get an "is the system OK right now?" answer at a glance before parsing individual rows.

## What this is NOT

The (now-closed) [#72 RFC](https://github.com/hecatehq/hecate/pull/72) proposed a two-tab IA, a phase-rollup viz, an attribute-autocomplete filter, and a new `/system/stats/timeline` endpoint. Design review reduced the scope: the existing Status dropdown already covers errors-only filtering, the chat→trace drill-down was already shipped, and the rest was over-scoped for the actual operator complaint. This PR closes the genuinely-missing gaps.

## Tests

- `RecentActivityStrip.test.tsx` — 4 cases: empty input renders nothing, N traces render N dots, p50/p95/error count math, recovered count surfaces when fallback_from is set.
- `TaskDetail.test.tsx` — 2 new cases: clickable Request ID calls `onOpenTrace` with the right id, plain-text fallback when the callback isn't wired.

## Verification

- `bun run test`: 31 files, 673 tests passing (+6 new).
- `bun run test:e2e`: 52 passing.
- `bun run build`: clean. ObservabilityView chunk +2 KB (the new strip component).

## Test plan

- [x] Unit tests cover both new behaviors.
- [x] Build + typecheck + e2e green.
- [ ] Manual: open a task with a `request_id`, click it, verify Observability opens with the drawer pre-targeted.
- [ ] Manual: load Observability, watch the activity strip refresh as new traces arrive (4s poll cadence preserved).