### PR TITLE
revert(agent): pass ANTHROPIC_* through to Claude Code adapter

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -143,17 +143,9 @@ cache the official `@agentclientprotocol/claude-agent-acp` package through
 `npx`.
 
 If Hecate reports that the managed launcher is unavailable, install Node/npm or
-start Hecate from an environment where `npx` is available.
-
-Hecate strips `ANTHROPIC_*` provider variables from the Claude Code adapter
-environment. Claude Code subscription login is file-backed, and forwarding
-provider API variables can make the ACP runner use Console credits instead of
-the `/login` managed key shown by `claude /status`.
-
-If Claude reports `Credit balance is too low`, run `claude /status` from the
-same workspace and confirm it is using the account you expect. Hecate preserves
-the raw adapter error in diagnostics, but shows a friendlier usage-limit message
-in Chats.
+start Hecate from an environment where `npx` is available. Hecate also checks
+common operator locations such as Volta, mise/asdf shims, Homebrew, and
+`/usr/bin`.
 
 ### Cursor Agent
 
@@ -327,21 +319,6 @@ clears the native ACP handle, and appends an `interrupted` activity to the last
 assistant message when one exists. If the operator sends a new prompt before
 the sweeper has closed the stale session, the request returns HTTP 422 with
 `agent_chat.session_idle_timeout`; start a new chat to continue.
-
-## Troubleshooting
-
-| Symptom | What to check |
-|---|---|
-| Codex or Claude adapter is missing | Hecate could not find the direct ACP command or a local `npx` runner. Install Node/npm, or make sure Volta/mise/asdf/Homebrew is visible to the process that starts Hecate. |
-| Codex or Claude managed launcher is stale | Click **Reinstall** in Settings → External agents, or call `POST /hecate/v1/agent-adapters/{id}/refresh-launcher`. |
-| Cursor adapter is missing | `cursor-agent` is not visible to Hecate. Install Cursor Agent and restart Hecate after changing shell/runtime managers such as Volta. |
-| Cursor says authentication is required | Run `cursor-agent login` or set `CURSOR_API_KEY` in the environment that starts Hecate. |
-| Claude reports low credit balance while `/status` shows a subscription | Confirm the same environment/account starts Hecate and Claude. Hecate strips provider `ANTHROPIC_*` env vars so Claude Code should use its own login; raw diagnostics show which error the adapter returned. |
-| The chat says the adapter version is outside the tested range | The adapter may still work, but Hecate has not verified that ACP wire shape. Update/downgrade the adapter package or use the managed launcher path. |
-| Approval is waiting | Review it in the Chats banner/modal or Settings approval surfaces. In `prompt` mode, unreviewed requests time out with ACP `Cancelled`. |
-| Output looks strange | Open the message's raw output disclosure. The visible transcript is normalized from ACP updates, but raw update JSON is retained for adapter debugging. |
-| Run hangs | Use the Stop button. Hecate sends ACP cancellation and marks the run `cancelled`. |
-| Diff is empty | The workspace may not be a Git repo, or the adapter did not change files. |
 
 ## Stable alpha scope
 

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -349,7 +349,7 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	cmd := exec.CommandContext(context.Background(), command, args...)
 	configureCommandProcessGroup(cmd)
 	cmd.Dir = workspace
-	cmd.Env = sanitizedEnvForAdapter(adapter.ID, os.Environ())
+	cmd.Env = sanitizedEnv(os.Environ())
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/agentadapters/normalize.go
+++ b/internal/agentadapters/normalize.go
@@ -45,14 +45,10 @@ func NormalizeError(adapterName string, err error) string {
 	if adapterName == "" {
 		adapterName = "Agent adapter"
 	}
-	switch parsed.Data.ErrorKind {
-	case "billing_error":
-		return adapterName + " usage limit: " + lowerFirst(message) + ". Check the active Claude credential and switch to subscription login or add API credits."
-	case "":
-		return adapterName + " error: " + message
-	default:
-		return adapterName + " error (" + parsed.Data.ErrorKind + "): " + message
+	if kind := parsed.Data.ErrorKind; kind != "" {
+		return adapterName + " error (" + kind + "): " + message
 	}
+	return adapterName + " error: " + message
 }
 
 type jsonRPCErrorPayload struct {
@@ -76,14 +72,6 @@ func parseJSONRPCError(raw string) (jsonRPCErrorPayload, bool) {
 		return payload, false
 	}
 	return payload, true
-}
-
-func lowerFirst(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	return strings.ToLower(value[:1]) + value[1:]
 }
 
 func normalizeJSONLines(raw string) string {

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -144,7 +144,7 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 	cmd := exec.CommandContext(context.Background(), path, args...)
 	configureCommandProcessGroup(cmd)
 	cmd.Dir = workspace
-	cmd.Env = sanitizedEnvForAdapter(adapter.ID, os.Environ())
+	cmd.Env = sanitizedEnv(os.Environ())
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -598,23 +598,6 @@ func sanitizedEnv(env []string) []string {
 	return out
 }
 
-func sanitizedEnvForAdapter(adapterID string, env []string) []string {
-	out := sanitizedEnv(env)
-	if adapterID != "claude_code" {
-		return out
-	}
-	filtered := out[:0]
-	for _, entry := range out {
-		// Claude Code subscription auth is file-backed. Forwarding Anthropic API
-		// variables makes the ACP runner prefer Console credits over /login.
-		if strings.HasPrefix(entry, "ANTHROPIC_") {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
 func captureGitDiff(ctx context.Context, workspace string, maxBytes int64) (string, string) {
 	diffCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -430,34 +430,13 @@ func TestNormalizeOutputFallsBackToRawCodexWhenNoText(t *testing.T) {
 	}
 }
 
-func TestNormalizeErrorHumanizesClaudeBillingJSONRPC(t *testing.T) {
+func TestNormalizeErrorTagsClaudeBillingJSONRPC(t *testing.T) {
 	t.Parallel()
 
 	err := errors.New(`{"code":-32603,"message":"Internal error: Credit balance is too low","data":{"errorKind":"billing_error"}}`)
 	got := NormalizeError("Claude Code", err)
-	want := "Claude Code usage limit: credit balance is too low. Check the active Claude credential and switch to subscription login or add API credits."
+	want := "Claude Code error (billing_error): Credit balance is too low"
 	if got != want {
 		t.Fatalf("NormalizeError = %q, want %q", got, want)
-	}
-}
-
-func TestSanitizedEnvForClaudeCodeDropsAnthropicProviderCredentials(t *testing.T) {
-	t.Parallel()
-
-	env := sanitizedEnvForAdapter("claude_code", []string{
-		"ANTHROPIC_API_KEY=sk-ant-test",
-		"ANTHROPIC_BASE_URL=https://api.anthropic.com",
-		"CLAUDE_CONFIG_DIR=/tmp/claude",
-		"PATH=/usr/bin",
-	})
-	got := map[string]bool{}
-	for _, entry := range env {
-		got[entry] = true
-	}
-	if got["ANTHROPIC_API_KEY=sk-ant-test"] || got["ANTHROPIC_BASE_URL=https://api.anthropic.com"] {
-		t.Fatalf("Anthropic provider credentials leaked into Claude adapter env: %#v", env)
-	}
-	if !got["CLAUDE_CONFIG_DIR=/tmp/claude"] || !got["PATH=/usr/bin"] {
-		t.Fatalf("Claude runtime env missing expected entries: %#v", env)
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1383,7 +1383,7 @@ func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
 	}
 }
 
-func TestAgentChatHumanizesAdapterJSONRPCBillingError(t *testing.T) {
+func TestAgentChatTagsAdapterJSONRPCBillingError(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
@@ -1399,8 +1399,8 @@ func TestAgentChatHumanizesAdapterJSONRPCBillingError(t *testing.T) {
 	if assistant.Status != "failed" {
 		t.Fatalf("assistant status = %q, want failed", assistant.Status)
 	}
-	if !strings.Contains(assistant.Content, "Claude Code usage limit: credit balance is too low") {
-		t.Fatalf("assistant content = %q, want humanized Claude usage-limit error", assistant.Content)
+	if !strings.Contains(assistant.Content, "Claude Code error (billing_error): Credit balance is too low") {
+		t.Fatalf("assistant content = %q, want errorKind-tagged adapter error", assistant.Content)
 	}
 	if strings.Contains(assistant.Content, `"code":-32603`) {
 		t.Fatalf("assistant content leaked raw JSON-RPC error: %q", assistant.Content)


### PR DESCRIPTION
## Summary

Reverts the env strip introduced by [85f495fd](https://github.com/hecatehq/hecate/commit/85f495fd) (May 4 — _"prevent Claude adapter from using provider API credits"_). That commit was based on a wrong assumption — _"Claude Code subscription auth is file-backed"_ — which doesn't hold on macOS, where the OAuth token lives in Keychain rather than `~/.claude.json` (which only carries config).

Stripping `ANTHROPIC_*` didn't help operators on subscription (they still rely on the SDK to find a credential the spawned process can reach) and silently broke operators who relied on `ANTHROPIC_API_KEY` as a fallback. Net effect: the adapter "worked before, broken now" with no error path that explained why.

Hecate's job here is to spawn the shim with a clean, predictable env — not to second-guess which Claude credential the operator wants. Both adapter spawn sites go back to plain `sanitizedEnv`, matching how `codex_acp` and `cursor_agent` are wired.

## Diff

- `internal/agentadapters/registry.go` — drop `sanitizedEnvForAdapter`.
- `internal/agentadapters/acp_session.go`, `probe.go` — both spawn sites back to plain `sanitizedEnv`.
- `internal/agentadapters/registry_test.go` — drop the test that pinned the strip; rename the billing-error test to reflect its new role (exercises the default error-tagging branch).
- `internal/agentadapters/normalize.go` — drop the `billing_error` special case in the error humanizer. The default branch already produces a sensible `<adapter> error (<kind>): <message>` form; the custom "switch to subscription login or add API credits" message was paternalistic and pushed an API-key path that Hecate doesn't actually document. The collapsed switch is now a single `if kind != "" { … } else { … }`.
- `docs/external-agent-adapters.md`:
  - Align the Claude ACP subsection structure with the Codex one (both now have identical shape modulo package id).
  - Drop the keychain / file-path mechanics from the troubleshooting copy — operators don't act on platform-specific paths and the SDK's resolution order isn't a stable contract for the doc to lean on.
  - Drop the `ANTHROPIC_API_KEY` fallback suggestion. Codex and Claude both auth via shell login (`codex login` / `claude /login`) per the rest of the doc; suggesting API keys as a fix misframes the supported model.
  - Delete the Troubleshooting section entirely. Most rows restated UI affordances (Reinstall button, Stop button, approval banner) or duplicated guidance already in the per-adapter prose. The genuinely-useful pointers are discoverable from the UI's own probe hint and error banners.

## Verification

- `go build ./...` clean.
- `go test ./internal/agentadapters/...` passes (208 tests).
- This restores pre-May-4 behavior for the operator who reported the regression.

## Test plan

- [x] Go build + adapter tests pass.
- [ ] Manual: from a shell where `claude /status` shows an active subscription, start Hecate, hit Settings → External agents → **Test** for Claude Code. Expect green, not "Authentication required".
- [ ] Manual: Codex and Claude adapters both work without any `*_API_KEY` env vars when their CLIs are logged in.

## Related

- `85f495fd` — the commit being reverted.
- Earlier in this thread, I suggested switching shims to fix this. That was wrong — Hecate's already on the canonical `@agentclientprotocol/claude-agent-acp` (latest 0.33.1, parallel to what Zed ships). The shim is fine; the strip and the surrounding humanization were the bugs.