### PR TITLE
feat(desktop): wire Tauri auto-update — auto-check + dismissible banner

### DIFF
--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -194,6 +194,17 @@ jobs:
           APPLE_PASSWORD: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_TEAM_ID || '' }}
           KEYCHAIN_PASSWORD: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.KEYCHAIN_PASSWORD || '' }}
+          # Updater signing key. Same caller-side / called-side
+          # protection model as the Apple secrets above: scope to a
+          # release-workflow run with a non-empty tagName. When set,
+          # tauri-action signs the platform bundles and emits a
+          # latest.json manifest as a release asset that the in-app
+          # updater consumes. When empty (PR validation, missing
+          # secrets), unsigned bundles ship and the updater stays
+          # inert. See docs/desktop-updater-signing.md for the
+          # keypair custody checklist.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tagName != '' && secrets.TAURI_UPDATER_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.tagName != '' && secrets.TAURI_UPDATER_PRIVATE_KEY_PASSWORD || '' }}
         with:
           projectPath: tauri
           tagName: ${{ inputs.tagName }}

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -69,8 +69,14 @@ What doesn't yet:
 - No Homebrew formula or cask yet. A formula would help CLI installation, and
   a cask would help app distribution. macOS now signs+notarizes via
   `APPLE_*` repo secrets; a cask would still be additional polish.
-- No auto-update — plugin is wired but `active: false` until an update
-  endpoint is decided.
+- Auto-update is wired end-to-end (endpoint, capability, frontend
+  banner, signing in CI) but `active: false` until the operator
+  generates the updater keypair and pastes the pubkey into
+  `tauri.conf.json`. See [`desktop-updater-signing.md`](desktop-updater-signing.md)
+  for the keypair custody checklist. Once the pubkey lands and
+  `active: true`, every release cuts a `latest.json` manifest as
+  a release asset and existing installs surface a "Hecate X is
+  available — Install and Restart" banner on next launch.
 - No tray and no deep links.
 - Linux and Windows: build-only. Need an actual launch on each platform
   before claiming they work.
@@ -93,7 +99,6 @@ the bundle is polished enough to recommend.
 
 | Item | Cost / decision | Notes |
 |---|---|---|
-| **Auto-updater wiring** | Decide endpoint + generate keypair | `tauri-plugin-updater` is installed but `active: false`. Needs `bunx tauri signer generate -w ~/.tauri/hecate.key`, a static `latest.json` host (GitHub Release asset is fine), and the pubkey committed to `tauri.conf.json`. Probably wait until release cadence is established — auto-update on a weekly-bumping alpha is annoying. |
 | **Windows code signing** | EV cert (~$300+/yr) | Lower priority. Reputation builds over hundreds of installs anyway, so signing a low-volume alpha is mostly about removing the SmartScreen warning, not unlocking distribution. |
 
 ### Tier 3 — features

--- a/docs/desktop-updater-signing.md
+++ b/docs/desktop-updater-signing.md
@@ -1,0 +1,166 @@
+# Desktop updater signing
+
+> **Audience: maintainers.** This is the setup + rotation
+> checklist for the Tauri updater keypair that signs auto-update
+> manifests. End users downloading a built `.dmg` / `.deb` /
+> `.AppImage` / `.msi` don't need to read this — the in-app
+> updater verifies signatures transparently when it pulls
+> `latest.json` from the GitHub Release.
+
+The Tauri updater plugin verifies that every update payload is
+signed by a private key that matches the public key embedded in
+the shipping bundle. The signing happens during the release-
+workflow build; the public key is committed to
+`tauri/src-tauri/tauri.conf.json`. Without a keypair, the updater
+stays inert and existing installs never see an update banner.
+
+This doc walks through generating the keypair once, storing the
+secrets, and flipping `active: true`. Subsequent releases then
+auto-emit a signed `latest.json` manifest.
+
+## Prerequisites
+
+- A maintainer Mac (or any machine with `bun` available).
+- Write access to `hecatehq/hecate` GitHub Secrets.
+
+## One-time setup
+
+### 1. Generate the keypair
+
+Run on your local machine:
+
+```sh
+bunx @tauri-apps/cli signer generate -w ~/.tauri/hecate-updater.key
+```
+
+The CLI prompts for a password — pick a strong one and save it
+somewhere you can retrieve later (1Password, etc.). The output:
+
+- `~/.tauri/hecate-updater.key` — the private key, encrypted with
+  the password you just chose.
+- `~/.tauri/hecate-updater.key.pub` — the public key.
+
+The private key never leaves your machine in plaintext; it'll
+travel through GitHub Secrets in its encrypted form.
+
+### 2. Add the GitHub Secrets
+
+In the repo: **Settings → Secrets and variables → Actions → New
+repository secret**. Add two:
+
+| Secret | Value | Source |
+|---|---|---|
+| `TAURI_UPDATER_PRIVATE_KEY` | full contents of `~/.tauri/hecate-updater.key` | step 1 |
+| `TAURI_UPDATER_PRIVATE_KEY_PASSWORD` | the password from step 1 | step 1 |
+
+The release workflow's tauri-action step picks these up and uses
+them to sign the platform bundles + emit `latest.json`. Both
+secrets are scoped to `inputs.tagName != ''` in
+`.github/workflows/_tauri-shared.yml`, so PR-validation runs of
+`tauri-build.yml` never see them.
+
+### 3. Commit the public key + flip `active`
+
+Edit `tauri/src-tauri/tauri.conf.json`:
+
+```json
+"updater": {
+  "active": true,
+  "pubkey": "<paste contents of ~/.tauri/hecate-updater.key.pub>",
+  "endpoints": [
+    "https://github.com/hecatehq/hecate/releases/latest/download/latest.json"
+  ]
+}
+```
+
+Open a one-line PR with that change. After it merges and the
+next release tag is cut, the release workflow produces a signed
+`latest.json` and existing installs (built with the same pubkey
+in their bundle) detect and apply the update.
+
+## Securely store the local key
+
+The private key file is encrypted but the password is in your
+chain too — together they unlock signing. Treat the pair like
+the Apple `.p12` cert: keep both safe, ideally in a password
+manager that supports file attachments. If you lose either, the
+recovery is "generate a new pair, ship a new pubkey, accept that
+operators on the old pubkey lose auto-update until they manually
+reinstall."
+
+## Verify the pipeline
+
+After the next tagged release with both secrets configured and
+`active: true`:
+
+1. Watch the `tauri / build (...)` jobs. The bundle step output
+   should mention signing and emit a `*.sig` file alongside each
+   bundle.
+2. After `goreleaser` and `tauri` jobs finish, the GitHub Release
+   page should have `latest.json` listed as an asset alongside
+   the platform bundles.
+3. Inspect the manifest — should look roughly like:
+   ```json
+   {
+     "version": "0.1.0-alpha.24",
+     "notes": "...",
+     "pub_date": "...",
+     "platforms": {
+       "darwin-aarch64": { "signature": "...", "url": "..." },
+       "linux-x86_64":   { "signature": "...", "url": "..." },
+       "windows-x86_64": { "signature": "...", "url": "..." }
+     }
+   }
+   ```
+4. On a Mac with the previous version installed: launch the app,
+   wait a few seconds, and the "Hecate X.Y.Z is available" banner
+   should appear at the top of the workspace. Click **Install and
+   Restart** — the new bundle downloads, replaces the running
+   app, and relaunches. The banner does not reappear post-update.
+
+## Rotating the keypair
+
+If you suspect the private key is compromised, or it's been more
+than a couple of years, rotate:
+
+1. Generate a new pair (step 1).
+2. Update both GitHub Secrets (step 2).
+3. Commit the new pubkey to `tauri.conf.json` (step 3).
+4. Cut a release.
+
+Operators on the old pubkey **will not be able to auto-update to
+the new pubkey's bundles** — Tauri's updater rejects payloads
+signed by anything other than the embedded pubkey. Those
+operators have to reinstall manually from the GitHub Release
+page. There's no way around this; pubkey rotation is intentionally
+disruptive so a leaked key can't be used to push malicious updates
+to existing installs forever.
+
+For low-stakes rotation (key not actually leaked, just hygiene),
+don't bother — the updater plugin's signature scheme is built to
+make long-lived keypairs safe.
+
+## Troubleshooting
+
+**"signature verification failed" in the updater log on a client
+machine.** The manifest's pubkey doesn't match the bundled
+pubkey. Either the operator's bundle was built before the pubkey
+landed, or the keypair was rotated and the old client is on the
+wrong side of the rotation. Reinstalling from the GitHub Release
+page resolves it.
+
+**`latest.json` is missing from the release.** tauri-action
+didn't get the signing secrets. Confirm both
+`TAURI_UPDATER_PRIVATE_KEY` and `TAURI_UPDATER_PRIVATE_KEY_PASSWORD`
+are set, and that you're cutting a tag (not running PR
+validation, which intentionally skips signing — see
+`tauri-build.yml`).
+
+**Banner never appears even on a known-old install.** Possible
+causes, in rough order:
+
+- `active: false` in the bundle's `tauri.conf.json` — needs the
+  one-line flip.
+- The bundle was shipped without the pubkey embedded.
+- Network / GitHub release fetch failed (the hook silently
+  swallows errors; check the webview console in dev builds).

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Capability granted to the main application window",
   "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "updater:default"
   ]
 }

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -53,7 +53,9 @@
     "updater": {
       "active": false,
       "pubkey": "",
-      "endpoints": []
+      "endpoints": [
+        "https://github.com/hecatehq/hecate/releases/latest/download/latest.json"
+      ]
     }
   }
 }

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "hecate-ui",
       "dependencies": {
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
       },
@@ -116,6 +118,10 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/runtime": "7.29.2", "@types/aria-query": "5.0.4", "aria-query": "5.3.0", "dom-accessibility-api": "0.5.16", "lz-string": "1.5.0", "picocolors": "1.1.1", "pretty-format": "27.5.1" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,8 @@
     "capture-screenshots": "NODE_PATH=$PWD/node_modules bun run ../scripts/capture-screenshots.ts"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -141,6 +141,19 @@
   color: var(--red);
 }
 
+.page-banner--update {
+  border-color: var(--border);
+  background: var(--bg2);
+  color: var(--t1);
+  align-items: center;
+}
+
+.page-banner--update .page-banner__actions {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
 /* Toast notifications */
 .toast {
   position: fixed;

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -154,6 +154,34 @@
   align-items: center;
 }
 
+.page-banner__progress-text {
+  color: var(--t2);
+  margin-left: 4px;
+}
+
+.page-banner__progress {
+  width: 120px;
+  height: 4px;
+  appearance: none;
+  border: none;
+  border-radius: 2px;
+  overflow: hidden;
+  background: var(--bg3);
+}
+
+.page-banner__progress::-webkit-progress-bar {
+  background: var(--bg3);
+}
+
+.page-banner__progress::-webkit-progress-value {
+  background: var(--teal);
+  transition: width 100ms linear;
+}
+
+.page-banner__progress::-moz-progress-bar {
+  background: var(--teal);
+}
+
 /* Toast notifications */
 .toast {
   position: fixed;

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, type WorkspaceID } from "./AppShell";
 import { useRuntimeConsole } from "./useRuntimeConsole";
+import { isTauriRuntime } from "../lib/tauri";
 
 const WORKSPACE_STORAGE_KEY = "hecate.workspace";
 
@@ -55,12 +56,6 @@ export function installTauriEditShortcutFallback(): () => void {
   };
   window.addEventListener("keydown", handler);
   return () => window.removeEventListener("keydown", handler);
-}
-
-function isTauriRuntime(): boolean {
-  return typeof window !== "undefined"
-    && (Object.prototype.hasOwnProperty.call(window, "__TAURI_INTERNALS__")
-      || Object.prototype.hasOwnProperty.call(window, "__TAURI__"));
 }
 
 function editableTarget(target: EventTarget | null): HTMLInputElement | HTMLTextAreaElement | null {

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 
 import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
 import type { AgentChatUsageRecord } from "../types/runtime";
+import { UpdateBanner } from "../features/shared/UpdateBanner";
 
 // Each workspace view is its own dynamic chunk so the initial
 // page load only ships the shell + active workspace, not all six.
@@ -237,6 +238,7 @@ function AuthenticatedShell({
 
         {/* Main content */}
         <main className="hecate-content">
+          <UpdateBanner />
           {state.error && <div className="page-banner page-banner--error">{state.error}</div>}
           <div className={`console-content${isBare ? " console-content--bare" : ""}`}>
             <Suspense fallback={<WorkspaceFallback />}>

--- a/ui/src/features/shared/UpdateBanner.tsx
+++ b/ui/src/features/shared/UpdateBanner.tsx
@@ -1,0 +1,27 @@
+// UpdateBanner surfaces a desktop-app update when the Tauri updater
+// detects a newer version on app start. Inert outside Tauri.
+// "Install and Restart" downloads + installs the new bundle and
+// relaunches; the plugin handles the relaunch.
+
+import { useDesktopUpdate } from "../../lib/desktop-update";
+
+export function UpdateBanner() {
+  const { update, installing, dismiss, installAndRestart } = useDesktopUpdate();
+  if (!update) return null;
+  return (
+    <div className="page-banner page-banner--update" role="status" aria-live="polite">
+      <span>Hecate {update.version} is available.</span>
+      <span className="page-banner__actions">
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={installing}
+          onClick={() => void installAndRestart()}>
+          {installing ? "Installing…" : "Install and Restart"}
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={dismiss} disabled={installing}>
+          Dismiss
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/ui/src/features/shared/UpdateBanner.tsx
+++ b/ui/src/features/shared/UpdateBanner.tsx
@@ -6,12 +6,34 @@
 import { useDesktopUpdate } from "../../lib/desktop-update";
 
 export function UpdateBanner() {
-  const { update, installing, dismiss, installAndRestart } = useDesktopUpdate();
+  const { update, installing, progress, dismiss, installAndRestart } = useDesktopUpdate();
   if (!update) return null;
   return (
     <div className="page-banner page-banner--update" role="status" aria-live="polite">
-      <span>Hecate {update.version} is available.</span>
+      <span>
+        Hecate {update.version} is available.
+        {installing && (
+          <>
+            {" "}
+            <span className="page-banner__progress-text">
+              {progress !== null
+                ? `Downloading… ${Math.round(progress * 100)}%`
+                : "Downloading…"}
+            </span>
+          </>
+        )}
+      </span>
       <span className="page-banner__actions">
+        {installing && (
+          // Indeterminate <progress> when total is unknown
+          // (Started event missing); otherwise determinate.
+          <progress
+            className="page-banner__progress"
+            value={progress !== null ? progress : undefined}
+            max={1}
+            aria-label="Update download progress"
+          />
+        )}
         <button
           className="btn btn-primary btn-sm"
           disabled={installing}

--- a/ui/src/lib/desktop-update.test.ts
+++ b/ui/src/lib/desktop-update.test.ts
@@ -1,0 +1,151 @@
+import { StrictMode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDesktopUpdate } from "./desktop-update";
+
+// The hook dynamically imports @tauri-apps/plugin-updater inside
+// the Tauri runtime check. We mock the module so the tests don't
+// pull the real plugin (which expects __TAURI_INTERNALS__ wired
+// into the host) and so each test can drive check() to return
+// whatever shape it needs.
+const checkMock = vi.fn();
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: () => checkMock(),
+}));
+
+function enterTauriRuntime() {
+  // Stamp the marker isTauriRuntime() looks for. cleanup in afterEach.
+  (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+}
+
+function exitTauriRuntime() {
+  delete (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+}
+
+beforeEach(() => {
+  checkMock.mockReset();
+  sessionStorage.clear();
+  exitTauriRuntime();
+});
+
+afterEach(() => {
+  exitTauriRuntime();
+});
+
+describe("useDesktopUpdate", () => {
+  it("does not call check() outside the Tauri runtime", async () => {
+    const { result } = renderHook(() => useDesktopUpdate());
+    // Yield once so any pending effect work would have fired.
+    await waitFor(() => expect(result.current.update).toBeNull());
+    expect(checkMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the available version when check() returns an update", async () => {
+    enterTauriRuntime();
+    checkMock.mockResolvedValue({
+      version: "0.1.0-alpha.24",
+      downloadAndInstall: vi.fn(),
+    });
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(result.current.update).not.toBeNull());
+    expect(result.current.update).toEqual({ version: "0.1.0-alpha.24" });
+    expect(result.current.installing).toBe(false);
+  });
+
+  it("returns null when check() resolves with no update", async () => {
+    enterTauriRuntime();
+    checkMock.mockResolvedValue(null);
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(checkMock).toHaveBeenCalled());
+    expect(result.current.update).toBeNull();
+  });
+
+  it("swallows check() failures and stays inert", async () => {
+    enterTauriRuntime();
+    checkMock.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(checkMock).toHaveBeenCalled());
+    expect(result.current.update).toBeNull();
+    expect(result.current.installing).toBe(false);
+  });
+
+  it("dismiss() hides the update for the session and writes sessionStorage", async () => {
+    enterTauriRuntime();
+    checkMock.mockResolvedValue({
+      version: "0.1.0-alpha.24",
+      downloadAndInstall: vi.fn(),
+    });
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(result.current.update).not.toBeNull());
+    act(() => result.current.dismiss());
+    expect(result.current.update).toBeNull();
+    expect(sessionStorage.getItem("hecate.update.dismissed")).toBe("1");
+  });
+
+  it("skips the check entirely when sessionStorage marks the update dismissed", async () => {
+    enterTauriRuntime();
+    sessionStorage.setItem("hecate.update.dismissed", "1");
+    const { result } = renderHook(() => useDesktopUpdate());
+    // Give the effect a tick — if the dismiss check is honored,
+    // checkMock should never be invoked at all.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(checkMock).not.toHaveBeenCalled();
+    expect(result.current.update).toBeNull();
+  });
+
+  it("installAndRestart() toggles installing and calls downloadAndInstall", async () => {
+    enterTauriRuntime();
+    let resolveDownload: (() => void) | null = null;
+    const downloadAndInstall = vi.fn(
+      () => new Promise<void>((resolve) => { resolveDownload = resolve; }),
+    );
+    checkMock.mockResolvedValue({
+      version: "0.1.0-alpha.24",
+      downloadAndInstall,
+    });
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(result.current.update).not.toBeNull());
+    act(() => { void result.current.installAndRestart(); });
+    await waitFor(() => expect(result.current.installing).toBe(true));
+    expect(downloadAndInstall).toHaveBeenCalledTimes(1);
+    // Resolve the download — installing flips back only on error;
+    // on success the plugin relaunches and the renderer terminates.
+    // We simulate the success path by resolving without exception.
+    act(() => { resolveDownload?.(); });
+  });
+
+  it("only calls check() once under React StrictMode (no double-fire on dev remount)", async () => {
+    enterTauriRuntime();
+    checkMock.mockResolvedValue(null);
+    renderHook(() => useDesktopUpdate(), { wrapper: StrictMode });
+    await waitFor(() => expect(checkMock).toHaveBeenCalled());
+    // StrictMode would invoke the effect twice without the
+    // checkedRef guard. The guard is what keeps this at 1.
+    expect(checkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives progress from plugin events", async () => {
+    enterTauriRuntime();
+    let onEventCb: ((e: unknown) => void) | null = null;
+    const downloadAndInstall = vi.fn((cb?: (e: unknown) => void) => {
+      onEventCb = cb ?? null;
+      return new Promise<void>(() => { /* never resolves */ });
+    });
+    checkMock.mockResolvedValue({
+      version: "0.1.0-alpha.24",
+      downloadAndInstall,
+    });
+    const { result } = renderHook(() => useDesktopUpdate());
+    await waitFor(() => expect(result.current.update).not.toBeNull());
+    act(() => { void result.current.installAndRestart(); });
+    await waitFor(() => expect(onEventCb).not.toBeNull());
+
+    // Started fires the total length; Progress events accumulate.
+    act(() => { onEventCb?.({ event: "Started", data: { contentLength: 1000 } }); });
+    act(() => { onEventCb?.({ event: "Progress", data: { chunkLength: 250 } }); });
+    await waitFor(() => expect(result.current.progress).toBe(0.25));
+    act(() => { onEventCb?.({ event: "Progress", data: { chunkLength: 500 } }); });
+    await waitFor(() => expect(result.current.progress).toBe(0.75));
+  });
+});

--- a/ui/src/lib/desktop-update.ts
+++ b/ui/src/lib/desktop-update.ts
@@ -7,7 +7,9 @@
 // mismatch) are swallowed — we treat "no update detected" the same
 // regardless of why. The banner only appears on a positive answer.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { isTauriRuntime } from "./tauri";
 
 const DISMISS_STORAGE_KEY = "hecate.update.dismissed";
 
@@ -50,7 +52,14 @@ export function useDesktopUpdate(): {
     downloadAndInstall: (onEvent?: (e: DownloadEvent) => void) => Promise<void>;
   } | null>(null);
 
+  // Guard against React StrictMode double-invoking the effect in
+  // dev. We don't want two parallel check() calls hitting the
+  // GitHub release endpoint per app start. The ref persists across
+  // the strict-mode remount so the second run becomes a no-op.
+  const checkedRef = useRef(false);
   useEffect(() => {
+    if (checkedRef.current) return;
+    checkedRef.current = true;
     if (!isTauriRuntime()) return;
     if (sessionStorage.getItem(DISMISS_STORAGE_KEY)) return;
     let cancelled = false;
@@ -101,10 +110,4 @@ export function useDesktopUpdate(): {
     : null;
 
   return { update: state.update, installing: state.installing, progress, dismiss, installAndRestart };
-}
-
-function isTauriRuntime(): boolean {
-  return typeof window !== "undefined"
-    && (Object.prototype.hasOwnProperty.call(window, "__TAURI_INTERNALS__")
-      || Object.prototype.hasOwnProperty.call(window, "__TAURI__"));
 }

--- a/ui/src/lib/desktop-update.ts
+++ b/ui/src/lib/desktop-update.ts
@@ -18,20 +18,36 @@ export type DesktopUpdate = {
 type State = {
   update: DesktopUpdate | null;
   installing: boolean;
+  // downloaded/total drive a 0..1 progress fraction surfaced as
+  // `progress` below. total may be 0 if the Started event never
+  // fires (some Tauri builds skip it on small payloads); the
+  // banner falls back to indeterminate "Downloading…" in that case.
+  downloaded: number;
+  total: number;
 };
+
+// Plugin event shape — narrowed locally so the dynamic-import path
+// doesn't drag the whole @tauri-apps/plugin-updater type surface
+// into the web build.
+type DownloadEvent =
+  | { event: "Started"; data: { contentLength?: number } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished" };
 
 export function useDesktopUpdate(): {
   update: DesktopUpdate | null;
   installing: boolean;
+  /** 0..1 while downloading, null when not downloading or when total is unknown. */
+  progress: number | null;
   dismiss: () => void;
   installAndRestart: () => Promise<void>;
 } {
-  const [state, setState] = useState<State>({ update: null, installing: false });
+  const [state, setState] = useState<State>({ update: null, installing: false, downloaded: 0, total: 0 });
   // The plugin's Update object holds the download/install methods. We
   // keep it in a ref-shaped state slot so the banner's button can
   // call back into the same instance the check() returned.
   const [pluginUpdate, setPluginUpdate] = useState<{
-    downloadAndInstall: () => Promise<void>;
+    downloadAndInstall: (onEvent?: (e: DownloadEvent) => void) => Promise<void>;
   } | null>(null);
 
   useEffect(() => {
@@ -44,7 +60,7 @@ export function useDesktopUpdate(): {
         const result = await mod.check();
         if (cancelled || !result) return;
         setPluginUpdate(result);
-        setState({ update: { version: result.version }, installing: false });
+        setState((prev) => ({ ...prev, update: { version: result.version } }));
       } catch {
         // Updater not configured (no pubkey, empty endpoints), or
         // a network/signature error. Treat all as "no update" —
@@ -63,17 +79,28 @@ export function useDesktopUpdate(): {
 
   const installAndRestart = useCallback(async () => {
     if (!pluginUpdate) return;
-    setState((prev) => ({ ...prev, installing: true }));
+    setState((prev) => ({ ...prev, installing: true, downloaded: 0, total: 0 }));
     try {
-      await pluginUpdate.downloadAndInstall();
-      // The plugin relaunches automatically on success; we never
-      // reach the line below in practice.
+      await pluginUpdate.downloadAndInstall((event) => {
+        if (event.event === "Started") {
+          const total = event.data.contentLength ?? 0;
+          setState((prev) => ({ ...prev, total, downloaded: 0 }));
+        } else if (event.event === "Progress") {
+          setState((prev) => ({ ...prev, downloaded: prev.downloaded + event.data.chunkLength }));
+        }
+        // "Finished" needs no UI change — the plugin proceeds to
+        // install + relaunch immediately, terminating the renderer.
+      });
     } catch {
-      setState((prev) => ({ ...prev, installing: false }));
+      setState((prev) => ({ ...prev, installing: false, downloaded: 0, total: 0 }));
     }
   }, [pluginUpdate]);
 
-  return { update: state.update, installing: state.installing, dismiss, installAndRestart };
+  const progress = state.installing && state.total > 0
+    ? Math.min(1, state.downloaded / state.total)
+    : null;
+
+  return { update: state.update, installing: state.installing, progress, dismiss, installAndRestart };
 }
 
 function isTauriRuntime(): boolean {

--- a/ui/src/lib/desktop-update.ts
+++ b/ui/src/lib/desktop-update.ts
@@ -1,0 +1,83 @@
+// Desktop update hook. Fires once on mount in the Tauri runtime and
+// asks the updater plugin whether a newer version is published. If
+// the gateway UI is loaded outside Tauri (browser, Docker, bare
+// binary), the hook is inert — there is no app to update from there.
+//
+// Failures (no updater configured, network down, signature
+// mismatch) are swallowed — we treat "no update detected" the same
+// regardless of why. The banner only appears on a positive answer.
+
+import { useCallback, useEffect, useState } from "react";
+
+const DISMISS_STORAGE_KEY = "hecate.update.dismissed";
+
+export type DesktopUpdate = {
+  version: string;
+};
+
+type State = {
+  update: DesktopUpdate | null;
+  installing: boolean;
+};
+
+export function useDesktopUpdate(): {
+  update: DesktopUpdate | null;
+  installing: boolean;
+  dismiss: () => void;
+  installAndRestart: () => Promise<void>;
+} {
+  const [state, setState] = useState<State>({ update: null, installing: false });
+  // The plugin's Update object holds the download/install methods. We
+  // keep it in a ref-shaped state slot so the banner's button can
+  // call back into the same instance the check() returned.
+  const [pluginUpdate, setPluginUpdate] = useState<{
+    downloadAndInstall: () => Promise<void>;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (sessionStorage.getItem(DISMISS_STORAGE_KEY)) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const mod = await import("@tauri-apps/plugin-updater");
+        const result = await mod.check();
+        if (cancelled || !result) return;
+        setPluginUpdate(result);
+        setState({ update: { version: result.version }, installing: false });
+      } catch {
+        // Updater not configured (no pubkey, empty endpoints), or
+        // a network/signature error. Treat all as "no update" —
+        // the banner stays hidden.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    sessionStorage.setItem(DISMISS_STORAGE_KEY, "1");
+    setState((prev) => ({ ...prev, update: null }));
+  }, []);
+
+  const installAndRestart = useCallback(async () => {
+    if (!pluginUpdate) return;
+    setState((prev) => ({ ...prev, installing: true }));
+    try {
+      await pluginUpdate.downloadAndInstall();
+      // The plugin relaunches automatically on success; we never
+      // reach the line below in practice.
+    } catch {
+      setState((prev) => ({ ...prev, installing: false }));
+    }
+  }, [pluginUpdate]);
+
+  return { update: state.update, installing: state.installing, dismiss, installAndRestart };
+}
+
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined"
+    && (Object.prototype.hasOwnProperty.call(window, "__TAURI_INTERNALS__")
+      || Object.prototype.hasOwnProperty.call(window, "__TAURI__"));
+}

--- a/ui/src/lib/tauri.ts
+++ b/ui/src/lib/tauri.ts
@@ -1,0 +1,11 @@
+// Tauri runtime detection. Returns true when the gateway UI is
+// loaded inside the Tauri webview (the desktop app), false in any
+// other host — browser tab, Docker, bare binary serving the
+// embedded UI. Anything that calls Tauri-only APIs should gate on
+// this check.
+
+export function isTauriRuntime(): boolean {
+  return typeof window !== "undefined"
+    && (Object.prototype.hasOwnProperty.call(window, "__TAURI_INTERNALS__")
+      || Object.prototype.hasOwnProperty.call(window, "__TAURI__"));
+}


### PR DESCRIPTION
## Summary

End-to-end auto-update for the desktop app: silent check on launch, dismissible banner if a newer release is found, click installs and restarts. Gated on a maintainer keypair you generate once and a one-line follow-up commit to flip `active: true` after the pubkey lands.

Today the updater plugin is loaded in Rust but `active: false` with empty endpoint and pubkey. This PR wires every layer so once the keypair is in place, the next tagged release automatically signs the bundles and emits `latest.json`.

## What's in this PR

**Frontend (gateway UI, runs inside the webview):**
- `useDesktopUpdate()` hook in `ui/src/lib/desktop-update.ts` — fires once on mount in the Tauri runtime via dynamic `import()`, otherwise no-op. Errors swallowed (no pubkey, network down, signature mismatch all collapse to "no update").
- `<UpdateBanner />` in `ui/src/features/shared/UpdateBanner.tsx` — top-of-app banner with **Install and Restart** / **Dismiss**. Dismiss persists for the session via `sessionStorage`. Shows live download progress (text + thin bar) while installing.
- Wired into `AppShell.tsx` above the existing error banner. Reuses the existing `.page-banner` CSS pattern with a new `--update` modifier.
- `isTauriRuntime()` lives in `ui/src/lib/tauri.ts` (shared with `App.tsx`).

**Tauri config:**
- `tauri.conf.json`: endpoints set to `https://github.com/hecatehq/hecate/releases/latest/download/latest.json`. `pubkey` stays empty and `active` stays `false` — the one-line follow-up commit (after you generate the key) flips both.
- `capabilities/default.json`: adds `updater:default` so the frontend can call updater APIs.

**CI:**
- `.github/workflows/_tauri-shared.yml`: passes `TAURI_UPDATER_PRIVATE_KEY` + `TAURI_UPDATER_PRIVATE_KEY_PASSWORD` to tauri-action for release-workflow runs only. Same caller-side / called-side protection model as the Apple secrets — PR validation builds never see them. With the secrets present, tauri-action signs each platform bundle and produces `latest.json` as a release asset alongside the `.dmg` / `.deb` / `.AppImage` / `.msi`.

**Docs:**
- `docs/desktop-updater-signing.md` — new maintainer-side checklist (parallel to `docs/macos-signing.md`): generate keypair, add secrets, paste pubkey, flip `active`. Includes verification recipe and rotation playbook.
- `docs/desktop-app.md` — updated the "what doesn't yet" bullet to describe the wired-but-inactive state; dropped the matching Tier-2 roadmap row.

## What you need to do once

1. `bunx @tauri-apps/cli signer generate -w ~/.tauri/hecate-updater.key` — pick a strong password, save it.
2. Add to repo secrets:
   - `TAURI_UPDATER_PRIVATE_KEY` = full contents of the `.key` file
   - `TAURI_UPDATER_PRIVATE_KEY_PASSWORD` = the password from step 1
3. One-line PR: paste the contents of `~/.tauri/hecate-updater.key.pub` into `tauri.conf.json`'s `updater.pubkey`, flip `active` to `true`.

Once that lands and the next release tag is cut, every existing install (built with the same pubkey embedded) sees a banner on next launch.

## Verification

- `bun run test`: 683 passing (+9 new in `ui/src/lib/desktop-update.test.ts` covering no-check-outside-Tauri, dismiss flow, sessionStorage skip, error swallowing, install-and-restart toggling, progress events, and an explicit StrictMode guard test).
- `bun run build`: clean. Index chunk +1.4 KB (the dynamic-import wrapper) + the progress UI.
- The dynamic import keeps the plugin out of the web bundle path; non-Tauri runtimes get a no-op hook.

## Test plan

- [x] Unit + build clean.
- [ ] After you do the one-time setup and cut a release: install the previous version on a clean machine, launch it, confirm the banner appears within ~5 seconds and clicking **Install and Restart** completes the upgrade with visible progress.
- [ ] Confirm dismissed banner stays dismissed within a session and reappears after a fresh launch (sessionStorage scope).
- [ ] Confirm web build (browser tab pointing at gateway) and Docker run never show the banner — gated on `isTauriRuntime()`.

## Notes / decisions

- **Endpoint**: GitHub Releases asset, not a custom redirect — zero new infrastructure, secret-free fetch from the client.
- **Cadence**: silent check on launch, banner if found. No menu item, no auto-install, no forced restart. Dismissible per-session.
- **Channel**: single channel for now (`latest`). If alpha cadence becomes too noisy, the next iteration can introduce a stable / preview switch — out of scope here.
- **Install-on-quit**: deliberately not implemented. The Tauri 2 updater plugin only exposes immediate install + relaunch on every platform; deferred install would need custom per-platform staging code (~2-3 days). Out of scope here. The button label is "Install and Restart" — explicit about the trade.
- **`active: false` ships in this PR by design**: lets the wiring land and be reviewed without forcing keypair generation in the same PR. Flipping it is a one-line follow-up after secrets are in place.
