### PR TITLE
feat(gateway): clean startup banner on stderr; trim startup JSON log

### DIFF
--- a/cmd/hecate/banner_test.go
+++ b/cmd/hecate/banner_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hecate/agent-runtime/internal/config"
+)
+
+func TestOperatorURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		publicURL  string
+		listenAddr string
+		want       string
+	}{
+		{"explicit PublicURL wins", "https://hecate.example.com", "127.0.0.1:8765", "https://hecate.example.com"},
+		{"PublicURL is trimmed", "  http://app.local  ", "127.0.0.1:8765", "http://app.local"},
+		{"loopback passthrough", "", "127.0.0.1:8765", "http://127.0.0.1:8765"},
+		{"empty host becomes 127.0.0.1", "", ":8765", "http://127.0.0.1:8765"},
+		{"0.0.0.0 host becomes 127.0.0.1", "", "0.0.0.0:8765", "http://127.0.0.1:8765"},
+		{"IPv6 :: host becomes 127.0.0.1", "", "[::]:8765", "http://127.0.0.1:8765"},
+		// A malformed listen address that SplitHostPort rejects should
+		// still render — operator sees the raw thing rather than the
+		// gateway failing to start up because of a banner bug.
+		{"malformed addr falls back to raw", "", "garbage", "http://garbage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Config{
+				Server: config.ServerConfig{PublicURL: tc.publicURL},
+			}
+			got := operatorURL(cfg, tc.listenAddr)
+			if got != tc.want {
+				t.Fatalf("operatorURL(%q, %q) = %q, want %q", tc.publicURL, tc.listenAddr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOtelSummary(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		o    config.OTelConfig
+		want string
+	}{
+		{"all off", config.OTelConfig{}, ""},
+		{
+			"traces only",
+			config.OTelConfig{Traces: config.OTelSignalConfig{Enabled: true}},
+			"traces",
+		},
+		{
+			"traces + metrics",
+			config.OTelConfig{
+				Traces:  config.OTelSignalConfig{Enabled: true},
+				Metrics: config.OTelSignalConfig{Enabled: true},
+			},
+			"traces, metrics",
+		},
+		{
+			"all three",
+			config.OTelConfig{
+				Traces:  config.OTelSignalConfig{Enabled: true},
+				Metrics: config.OTelSignalConfig{Enabled: true},
+				Logs:    config.OTelSignalConfig{Enabled: true},
+			},
+			"traces, metrics, logs",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := otelSummary(tc.o); got != tc.want {
+				t.Fatalf("otelSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStorageSummary(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{"empty defaults to memory", config.Config{}, "memory"},
+		{
+			"explicit memory",
+			config.Config{Server: config.ServerConfig{ControlPlaneBackend: "memory"}},
+			"memory",
+		},
+		{
+			"uniform sqlite",
+			config.Config{
+				Server: config.ServerConfig{
+					ControlPlaneBackend: "sqlite",
+					TasksBackend:        "sqlite",
+					TaskQueueBackend:    "sqlite",
+				},
+				Provider: config.ProviderConfig{HistoryBackend: "sqlite"},
+			},
+			"sqlite",
+		},
+		{
+			"mixed control-plane=memory but tasks=sqlite",
+			config.Config{
+				Server: config.ServerConfig{
+					ControlPlaneBackend: "memory",
+					TasksBackend:        "sqlite",
+				},
+			},
+			"memory (mixed)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := storageSummary(tc.cfg); got != tc.want {
+				t.Fatalf("storageSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintStartupBanner(t *testing.T) {
+	// Cannot t.Parallel() — we swap os.Stderr.
+	out := captureStderr(t, func() {
+		cfg := config.Config{
+			Server: config.ServerConfig{
+				DataDir:             ".data",
+				ControlPlaneBackend: "sqlite",
+			},
+			Router: config.RouterConfig{DefaultModel: "gpt-5"},
+		}
+		printStartupBanner(cfg, "127.0.0.1:8765")
+	})
+	for _, want := range []string{
+		"hecate ·",
+		"http://127.0.0.1:8765",
+		"data dir       .data",
+		"storage        sqlite",
+		"default model  gpt-5",
+		"providers      0 configured",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("banner missing %q\n---banner---\n%s\n---", want, out)
+		}
+	}
+	// Conditional rows omitted when their feature is off — alpha
+	// operators shouldn't see "otel off" / "retention off" noise.
+	for _, unwanted := range []string{"otel", "retention"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("banner unexpectedly contains %q\n---banner---\n%s\n---", unwanted, out)
+		}
+	}
+}
+
+func TestPrintStartupBannerShowsOptionalRows(t *testing.T) {
+	// Cannot t.Parallel() — we swap os.Stderr.
+	out := captureStderr(t, func() {
+		cfg := config.Config{
+			Server:    config.ServerConfig{DataDir: ".data"},
+			Router:    config.RouterConfig{DefaultModel: "gpt-5"},
+			Retention: config.RetentionConfig{Enabled: true, Interval: 0},
+			OTel: config.OTelConfig{
+				Traces:  config.OTelSignalConfig{Enabled: true},
+				Metrics: config.OTelSignalConfig{Enabled: true},
+			},
+		}
+		printStartupBanner(cfg, "127.0.0.1:8765")
+	})
+	for _, want := range []string{
+		"otel           traces, metrics",
+		"retention      every",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("banner missing optional row %q\n---banner---\n%s\n---", want, out)
+		}
+	}
+}
+
+// captureStderr swaps os.Stderr with an os.Pipe, runs fn, restores
+// os.Stderr, and returns whatever fn wrote. Worth the dance because
+// printStartupBanner writes via fmt.Fprintln(os.Stderr, …) directly
+// rather than through an injected io.Writer — that surface is what
+// operators see, and routing tests around it would be a different
+// design choice.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = original
+	}()
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+	fn()
+	_ = w.Close()
+	return string(<-done)
+}

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -324,32 +324,19 @@ func main() {
 		defer removeGatewayRuntimeState(gatewayStatePath)
 	}
 
+	printStartupBanner(cfg, listener.Addr().String())
+	logFullStartupConfig(logger, cfg)
+
 	go func() {
+		// Operator-essential fields only — full config is at Debug level
+		// via logFullStartupConfig above. Tighter top-of-log line means
+		// the banner above is what an operator scans first.
 		logger.Info("gateway starting",
-			slog.String("addr", cfg.Server.Address),
 			slog.String("listen_addr", listener.Addr().String()),
-			slog.String("hecate.runtime.path", gatewayStatePath),
+			slog.String("data_dir", cfg.Server.DataDir),
 			slog.String("default_model", cfg.Router.DefaultModel),
-			slog.Int("provider_max_attempts", cfg.Provider.MaxAttempts),
-			slog.Bool("provider_failover_enabled", cfg.Provider.FailoverEnabled),
-			slog.Int("provider_health_failure_threshold", cfg.Provider.HealthThreshold),
-			slog.Duration("provider_health_cooldown", cfg.Provider.HealthCooldown),
-			slog.Duration("provider_health_latency_degraded_threshold", cfg.Provider.HealthLatencyDegradedThreshold),
-			slog.String("provider_history_backend", cfg.Provider.HistoryBackend),
-			slog.Int("provider_history_limit", cfg.Provider.HistoryLimit),
-			slog.Bool("retention_enabled", cfg.Retention.Enabled),
-			slog.Duration("retention_interval", cfg.Retention.Interval),
-			slog.Bool("otel_traces_enabled", cfg.OTel.Traces.Enabled),
-			slog.String("otel_traces_endpoint", cfg.OTel.Traces.Endpoint),
-			slog.String("otel_traces_transport", cfg.OTel.Traces.Transport),
-			slog.Bool("otel_metrics_enabled", cfg.OTel.Metrics.Enabled),
-			slog.String("otel_metrics_endpoint", cfg.OTel.Metrics.Endpoint),
-			slog.String("otel_metrics_transport", cfg.OTel.Metrics.Transport),
-			slog.String("otel_metrics_exemplar_filter", cfg.OTel.MetricsExemplarFilter),
-			slog.Bool("otel_logs_enabled", cfg.OTel.Logs.Enabled),
-			slog.String("otel_logs_endpoint", firstNonEmpty(cfg.OTel.Logs.Endpoint, cfg.OTel.Traces.Endpoint)),
-			slog.String("otel_logs_transport", firstNonEmpty(cfg.OTel.Logs.Transport, cfg.OTel.Transport)),
 			slog.Int("provider_count", len(cfg.Providers.OpenAICompatible)),
+			slog.String("version", version.Version),
 		)
 
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
@@ -382,6 +369,133 @@ func main() {
 		logger.Error("shutdown failed", slog.Any("error", err))
 		os.Exit(1)
 	}
+}
+
+// printStartupBanner writes a short human-readable summary of the
+// gateway's startup state to stderr. Goes to stderr (not stdout) so
+// log scrapers reading stdout's structured JSON aren't disrupted; an
+// operator running `just dev` from a terminal sees both streams
+// interleaved and gets the human banner first. Always emitted —
+// runs the same in `just dev`, Docker logs, or systemd journal.
+func printStartupBanner(cfg config.Config, listenAddr string) {
+	url := operatorURL(cfg, listenAddr)
+	dataDir := cfg.Server.DataDir
+	if dataDir == "" {
+		dataDir = "(memory)"
+	}
+	providers := len(cfg.Providers.OpenAICompatible)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  hecate · %s\n", version.Version)
+	fmt.Fprintf(os.Stderr, "  → %s\n", url)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "    data dir       %s\n", dataDir)
+	fmt.Fprintf(os.Stderr, "    storage        %s\n", storageSummary(cfg))
+	fmt.Fprintf(os.Stderr, "    default model  %s\n", cfg.Router.DefaultModel)
+	fmt.Fprintf(os.Stderr, "    providers      %d configured\n", providers)
+	if otel := otelSummary(cfg.OTel); otel != "" {
+		fmt.Fprintf(os.Stderr, "    otel           %s\n", otel)
+	}
+	if cfg.Retention.Enabled {
+		fmt.Fprintf(os.Stderr, "    retention      every %s\n", cfg.Retention.Interval)
+	}
+	fmt.Fprintln(os.Stderr)
+}
+
+// logFullStartupConfig captures the full startup configuration at
+// Debug level for diagnostics. The user-visible startup log line
+// stays small; this is what an operator running with -log-level=debug
+// sees when something's misbehaving and they need the whole config
+// snapshot.
+func logFullStartupConfig(logger *slog.Logger, cfg config.Config) {
+	logger.Debug("gateway config",
+		slog.String("addr", cfg.Server.Address),
+		slog.Int("provider_max_attempts", cfg.Provider.MaxAttempts),
+		slog.Bool("provider_failover_enabled", cfg.Provider.FailoverEnabled),
+		slog.Int("provider_health_failure_threshold", cfg.Provider.HealthThreshold),
+		slog.String("provider_health_cooldown", cfg.Provider.HealthCooldown.String()),
+		slog.String("provider_health_latency_degraded_threshold", cfg.Provider.HealthLatencyDegradedThreshold.String()),
+		slog.String("provider_history_backend", cfg.Provider.HistoryBackend),
+		slog.Int("provider_history_limit", cfg.Provider.HistoryLimit),
+		slog.Bool("retention_enabled", cfg.Retention.Enabled),
+		slog.String("retention_interval", cfg.Retention.Interval.String()),
+		slog.Bool("otel_traces_enabled", cfg.OTel.Traces.Enabled),
+		slog.String("otel_traces_endpoint", cfg.OTel.Traces.Endpoint),
+		slog.String("otel_traces_transport", cfg.OTel.Traces.Transport),
+		slog.Bool("otel_metrics_enabled", cfg.OTel.Metrics.Enabled),
+		slog.String("otel_metrics_endpoint", cfg.OTel.Metrics.Endpoint),
+		slog.String("otel_metrics_transport", cfg.OTel.Metrics.Transport),
+		slog.String("otel_metrics_exemplar_filter", cfg.OTel.MetricsExemplarFilter),
+		slog.Bool("otel_logs_enabled", cfg.OTel.Logs.Enabled),
+		slog.String("otel_logs_endpoint", firstNonEmpty(cfg.OTel.Logs.Endpoint, cfg.OTel.Traces.Endpoint)),
+		slog.String("otel_logs_transport", firstNonEmpty(cfg.OTel.Logs.Transport, cfg.OTel.Transport)),
+	)
+}
+
+// operatorURL derives a clickable URL from the gateway's
+// configuration. Prefers PublicURL when set (operator-supplied) and
+// falls back to a 127.0.0.1-rewritten form of the listen address.
+// `:8765` and `[::]:8765` are both ugly in a terminal; `127.0.0.1:8765`
+// renders as a clickable link in most modern terminals.
+func operatorURL(cfg config.Config, listenAddr string) string {
+	if u := strings.TrimSpace(cfg.Server.PublicURL); u != "" {
+		return u
+	}
+	host, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return "http://" + listenAddr
+	}
+	// net.SplitHostPort strips the IPv6 brackets, so we match the
+	// unbracketed form "::" (the bracketed "[::]" branch never fires).
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}
+
+// otelSummary returns a short human-readable description of which
+// OTel signals are enabled, or "" when none are. Operators on alpha
+// usually have all three off; the banner omits the row entirely in
+// that case rather than printing "otel off".
+func otelSummary(o config.OTelConfig) string {
+	var parts []string
+	if o.Traces.Enabled {
+		parts = append(parts, "traces")
+	}
+	if o.Metrics.Enabled {
+		parts = append(parts, "metrics")
+	}
+	if o.Logs.Enabled {
+		parts = append(parts, "logs")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ", ")
+}
+
+// storageSummary collapses Hecate's per-subsystem backend choices into
+// one short hint. Hecate has ~12 independent storage subsystems (control
+// plane, tasks, sessions, etc.) — most deployments are uniformly memory
+// (local dev) or sqlite (Docker, native binary). The hint reflects the
+// control-plane backend by default — that's the "primary" backend an
+// operator identifies with — and appends "(mixed)" when a peer subsystem
+// disagrees, signaling to look at `docs/deployment.md`.
+func storageSummary(cfg config.Config) string {
+	primary := strings.TrimSpace(cfg.Server.ControlPlaneBackend)
+	if primary == "" {
+		primary = "memory"
+	}
+	peers := []string{
+		cfg.Server.TasksBackend,
+		cfg.Server.TaskQueueBackend,
+		cfg.Provider.HistoryBackend,
+	}
+	for _, peer := range peers {
+		if peer = strings.TrimSpace(peer); peer != "" && peer != primary {
+			return primary + " (mixed)"
+		}
+	}
+	return primary
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
## Summary

Replaces the single 25-field JSON line at gateway startup with a clean human-readable banner on stderr + a tight 5-field "gateway starting" Info log on stdout. Full config dump moves to Debug level for diagnostics.

## Before

```json
{"time":"2026-05-10T21:28:18.175715+02:00","level":"INFO","msg":"gateway starting","service.name":"hecate-gateway","addr":":8765","listen_addr":"[::]:8765","hecate.runtime.path":".data/hecate.runtime.json","default_model":"gpt-5.4-mini","provider_max_attempts":2,"provider_failover_enabled":true,"provider_health_failure_threshold":3,"provider_health_cooldown":30000000000,"provider_health_latency_degraded_threshold":0,"provider_history_backend":"memory","provider_history_limit":100,"retention_enabled":false,"retention_interval":900000000000,"otel_traces_enabled":false,"otel_traces_endpoint":"","otel_traces_transport":"http","otel_metrics_enabled":false,"otel_metrics_endpoint":"","otel_metrics_transport":"http","otel_metrics_exemplar_filter":"","otel_logs_enabled":false,"otel_logs_endpoint":"","otel_logs_transport":"http","provider_count":0}
```

Nanosecond durations (`30000000000`), empty OTel endpoints as clutter, `[::]:8765` instead of a clickable URL.

## After

```
  hecate · dev
  → http://127.0.0.1:8765

    data dir       .data
    default model  gpt-5.4-mini
    providers      0 configured

{"time":"2026-05-10T21:35:42.868721+02:00","level":"INFO","msg":"gateway starting","service.name":"hecate-gateway","listen_addr":"127.0.0.1:8765","data_dir":".data","default_model":"gpt-5.4-mini","provider_count":0,"version":"dev"}
```

## Design choices

- **Banner → stderr, JSON → stdout.** Standard Go-service convention: stdout for structured data, stderr for human messages. Log scrapers reading stdout aren't affected; operators running `just dev` from a terminal see both streams interleaved (banner first).
- **Banner always emits**, no TTY detection. Same shape in `just dev`, Docker logs, systemd journals, Tauri stderr capture (`gateway.log`). Operator + machine reader both happy.
- **Clickable URL.** Rewrites `0.0.0.0` / `::` / `[::]` / empty-host to `127.0.0.1` so the URL renders as a link in modern terminals. Honors `cfg.Server.PublicURL` when operator-supplied.
- **Conditional banner rows.** OTel listed only when any signal is on; retention listed only when enabled. Alpha operators with everything-off see a 5-line summary, not nine lines with mostly "off" / "n/a".
- **Full config dump at Debug.** What used to be the verbose 20-field Info line is now `logger.Debug("gateway config", ...)` — still captured at `-log-level=debug` for diagnostics but doesn't clutter the default Info stream. Durations now render as human strings (`30s`, `15m0s`) instead of nanosecond ints.
- **Tight Info "gateway starting" line.** 5 fields: `listen_addr`, `data_dir`, `default_model`, `provider_count`, `version`. The fields a log scraper actually wants for an alert ("gateway came up; here's the address and version").

## Verification

- `go build ./...` clean.
- `go test ./... -count=1` — 1742 passing across 35 packages.
- Manual: `go run ./cmd/hecate` shows the banner + trimmed JSON exactly as the README shows above.

## Test plan

- [x] Build + full Go test suite green.
- [ ] Manual: `just dev` and visually inspect the banner.
- [ ] Manual: confirm `-log-level=debug` adds back the full config dump as `gateway config` log line.
- [ ] Manual (optional): confirm the Tauri desktop app's `gateway.log` captures both streams cleanly (it pipes stderr to that file).

## What this does NOT change

- The Info-level `gateway starting` log entry still exists — log-parsing tools that key on `msg=gateway starting` keep working, just with fewer fields. The 5 fields that remain are the ones a monitoring tool actually needs.
- No new dependencies (only stdlib `fmt`, `net`).
- `cfg.Server.PublicURL` honored when set — operator-controlled URL display.
