### PR TITLE
feat(agent-adapters): guide Claude Code ACP credential setup

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -36,7 +36,7 @@ own the `hecate-acp` bridge process.
 | Adapter | How Hecate starts it | Auth expected by the underlying agent |
 |---|---|---|
 | Codex | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works | Codex CLI / adapter login or config |
-| Claude Code | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works | Claude agent / adapter login or config |
+| Claude Code | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works | Adapter-visible Claude auth: `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`, `ANTHROPIC_API_KEY`, or `ANTHROPIC_AUTH_TOKEN` |
 | Cursor Agent | `cursor-agent acp` | `cursor-agent login` or `CURSOR_API_KEY` |
 
 ## Quick start from the operator UI
@@ -68,6 +68,17 @@ curl -s http://127.0.0.1:8765/hecate/v1/agent-adapters | jq
 
 Discovery reports command availability, tested version range, and lightweight
 auth hints (`auth_status`: `ok`, `unauthenticated`, `billing`, or `unknown`).
+
+Claude Code has one important wrinkle: a normal interactive `claude /login`
+or `~/.claude.json` config can make the standalone Claude Code CLI work while
+the ACP adapter still reports `Authentication required`. If **Test** fails and
+you want to use your Claude subscription instead of an API key, open
+Settings → External agents, run `claude setup-token`, paste the printed token
+into the Claude Code guided setup card, and click **Save + test**. Hecate
+stores the token in the local control-plane secret store and injects it only
+into `claude-agent-acp` as `CLAUDE_CODE_OAUTH_TOKEN`. `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN` also work when you want to supply Anthropic credentials
+directly.
 Use Settings → External agents → **Test**, or call the probe endpoint, for a
 full spawn + ACP handshake + no-op session check:
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -677,7 +677,9 @@ GET /hecate/v1/agent-adapters
       "version": "1.2.3",
       "supported_range": ">=0.1.0",
       "version_outside_range": false,
-      "auth_status": "ok"
+      "auth_status": "ok",
+      "credential_configured": true,
+      "credential_preview": "clau...oken"
     },
     {
       "id": "cursor_agent",
@@ -725,6 +727,9 @@ shows an amber "outside tested range" chip in that case.
 `ok`, `unauthenticated`, `billing`, or `unknown`. It is derived from known env
 vars and login files without spawning the adapter. Use `POST
 /hecate/v1/agent-adapters/{id}/probe` for the full ACP handshake.
+`credential_configured` means Hecate has a stored local adapter credential
+that will be injected into that adapter process during probes and chat turns;
+the secret value is never returned, only the optional `credential_preview`.
 
 These are **agent adapters**, not model providers. They run ACP-compatible
 external coding agents under Hecate supervision; cost is reported as `external`
@@ -766,6 +771,65 @@ Status codes:
 - `200 OK` when the adapter id is registered; `health.status` carries
   `ready`, `not_installed`, `auth_required`, or `error`.
 - `404 not_found` when the adapter id is not registered.
+
+### `PUT /hecate/v1/agent-adapters/{id}/credentials`
+
+Stores a local adapter credential. Hecate encrypts the value with the
+configured control-plane secret key and injects it only into the matching
+adapter subprocess. The first guided setup uses this for Claude Code
+subscription auth: save the token from `claude setup-token` as
+`CLAUDE_CODE_OAUTH_TOKEN`, then run the adapter probe again.
+
+```json
+PUT /hecate/v1/agent-adapters/claude_code/credentials
+{
+  "name": "CLAUDE_CODE_OAUTH_TOKEN",
+  "value": "claude-oauth-token"
+}
+→ 200
+{
+  "object": "agent_adapter_credential",
+  "data": {
+    "adapter_id": "claude_code",
+    "name": "CLAUDE_CODE_OAUTH_TOKEN",
+    "configured": true,
+    "preview": "clau...oken"
+  }
+}
+```
+
+`name` may be omitted for `claude_code`; it defaults to
+`CLAUDE_CODE_OAUTH_TOKEN`. Supported credential names are intentionally
+allowlisted per adapter:
+
+- Claude Code: `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`
+- Codex: `OPENAI_API_KEY`, `CODEX_AUTH_TOKEN`, `CODEX_API_KEY`
+- Cursor Agent: `CURSOR_API_KEY`
+
+Status codes:
+- `200 OK` when the credential is stored.
+- `400 invalid_request` when secret storage is not configured, the credential
+  name is unsupported, or the value is empty.
+- `404 not_found` when the adapter id is not registered.
+
+### `DELETE /hecate/v1/agent-adapters/{id}/credentials/{name}`
+
+Removes a stored adapter credential. Future probes and chat turns stop
+injecting that value.
+
+```json
+DELETE /hecate/v1/agent-adapters/claude_code/credentials/CLAUDE_CODE_OAUTH_TOKEN
+→ 200
+{
+  "object": "agent_adapter_credential",
+  "data": {
+    "adapter_id": "claude_code",
+    "name": "CLAUDE_CODE_OAUTH_TOKEN",
+    "configured": false
+  }
+}
+```
 
 ### `GET /hecate/v1/agent-adapters/{id}/health`
 

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -78,11 +78,12 @@ type Runner interface {
 }
 
 type SessionManager struct {
-	mu          sync.Mutex
-	sessions    map[string]*acpSession
-	starts      map[string]*sessionStart
-	logger      *slog.Logger
-	coordinator *ApprovalCoordinator
+	mu            sync.Mutex
+	sessions      map[string]*acpSession
+	starts        map[string]*sessionStart
+	logger        *slog.Logger
+	coordinator   *ApprovalCoordinator
+	credentialEnv CredentialEnvProvider
 	// metrics carries the AgentAdapterMetrics used by every
 	// acpChatClient created from this manager. Optional — nil is
 	// safe (every Record* method is nil-tolerant) and matches the
@@ -90,6 +91,8 @@ type SessionManager struct {
 	metrics *telemetry.AgentAdapterMetrics
 	closed  bool
 }
+
+type CredentialEnvProvider func(ctx context.Context, adapterID string) []string
 
 func NewSessionManager() *SessionManager {
 	return &SessionManager{
@@ -126,6 +129,12 @@ func (m *SessionManager) SetAdapterMetrics(metrics *telemetry.AgentAdapterMetric
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.metrics = metrics
+}
+
+func (m *SessionManager) SetCredentialEnvProvider(provider CredentialEnvProvider) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.credentialEnv = provider
 }
 
 // shutdownCancelHook is invoked once per adapter id torn down via
@@ -229,9 +238,14 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		logger := m.logger
 		coordinator := m.coordinator
 		metrics := m.metrics
+		credentialEnv := m.credentialEnv
 		m.mu.Unlock()
 
-		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, logger, coordinator, metrics)
+		var extraEnv []string
+		if credentialEnv != nil {
+			extraEnv = credentialEnv(startCtx, adapter.ID)
+		}
+		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, logger, coordinator, metrics, extraEnv)
 		startCancel()
 
 		var previous *acpSession
@@ -340,7 +354,7 @@ type acpSession struct {
 	activeDone   chan struct{}
 }
 
-func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics) (*acpSession, bool, string, error) {
+func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics, extraEnv []string) (*acpSession, bool, string, error) {
 	command, err := resolveExecutable(adapter, exec.LookPath)
 	if err != nil {
 		return nil, false, "", err
@@ -349,7 +363,7 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	cmd := exec.CommandContext(context.Background(), command, args...)
 	configureCommandProcessGroup(cmd)
 	cmd.Dir = workspace
-	cmd.Env = sanitizedEnv(os.Environ())
+	cmd.Env = mergeEnv(sanitizedEnv(os.Environ()), extraEnv)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -16,10 +16,13 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 		}
 		return AuthStatusUnauthenticated, "Run codex login, or set OPENAI_API_KEY for the adapter environment."
 	case "claude_code":
-		if envAny("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN") || fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json") {
+		if envAny("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN") {
 			return AuthStatusOK, ""
 		}
-		return AuthStatusUnknown, "Run claude /status or claude login if the ACP probe reports auth or billing errors."
+		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
+			return AuthStatusUnknown, "Claude Code config is present, but the ACP adapter may still need adapter-visible auth. Use Test adapter; if it fails, " + claudeCodeACPAuthHint()
+		}
+		return AuthStatusUnknown, "Use Test adapter; if Claude Code reports auth errors, " + claudeCodeACPAuthHint()
 	case "cursor_agent":
 		if envAny("CURSOR_API_KEY") || fileAny("${HOME}/.cursor", "${HOME}/Library/Application Support/Cursor") {
 			return AuthStatusOK, ""
@@ -28,6 +31,10 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 	default:
 		return AuthStatusUnknown, "No auth heuristic is available for this adapter."
 	}
+}
+
+func claudeCodeACPAuthHint() string {
+	return "set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`, ANTHROPIC_API_KEY, or ANTHROPIC_AUTH_TOKEN for the adapter environment."
 }
 
 func envAny(names ...string) bool {

--- a/internal/agentadapters/auth_status_test.go
+++ b/internal/agentadapters/auth_status_test.go
@@ -50,8 +50,34 @@ func TestDetectAuthStatusClaudeUnknownWithoutMarker(t *testing.T) {
 	if status != AuthStatusUnknown {
 		t.Fatalf("status = %q, want %q", status, AuthStatusUnknown)
 	}
-	if !strings.Contains(hint, "claude") {
-		t.Fatalf("hint = %q, want Claude login/status guidance", hint)
+	if !strings.Contains(hint, "CLAUDE_CODE_OAUTH_TOKEN") || !strings.Contains(hint, "ANTHROPIC_API_KEY") {
+		t.Fatalf("hint = %q, want adapter-visible subscription/API-key guidance", hint)
+	}
+}
+
+func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
+	home := isolatedAuthHome(t)
+	configPath := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(configPath, []byte(`{"hasCompletedOnboarding":true}`), 0o600); err != nil {
+		t.Fatalf("write claude config: %v", err)
+	}
+
+	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
+	if status != AuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, AuthStatusUnknown)
+	}
+	if !strings.Contains(hint, "ACP adapter") || !strings.Contains(hint, "ANTHROPIC_API_KEY") {
+		t.Fatalf("hint = %q, want ACP-specific auth guidance", hint)
+	}
+}
+
+func TestDetectAuthStatusClaudeUsesAdapterVisibleAuth(t *testing.T) {
+	isolatedAuthHome(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
+	if status != AuthStatusOK || hint != "" {
+		t.Fatalf("status/hint = %q/%q, want ok/empty", status, hint)
 	}
 }
 
@@ -63,6 +89,7 @@ func isolatedAuthHome(t *testing.T) string {
 	t.Setenv("CODEX_AUTH_TOKEN", "")
 	t.Setenv("CODEX_API_KEY", "")
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("CURSOR_API_KEY", "")
 	return home

--- a/internal/agentadapters/normalize.go
+++ b/internal/agentadapters/normalize.go
@@ -31,6 +31,9 @@ func NormalizeError(adapterName string, err error) string {
 	if raw == "" {
 		return ""
 	}
+	if adapterName == "Claude Code" && isAuthErrorText(raw) {
+		return "Claude Code needs adapter-visible authentication: " + claudeCodeACPAuthHint() + " Restart Hecate after changing environment credentials."
+	}
 	parsed, ok := parseJSONRPCError(raw)
 	if !ok {
 		return raw
@@ -45,10 +48,22 @@ func NormalizeError(adapterName string, err error) string {
 	if adapterName == "" {
 		adapterName = "Agent adapter"
 	}
+	if adapterName == "Claude Code" && isAuthErrorText(message) {
+		return "Claude Code needs adapter-visible authentication: " + claudeCodeACPAuthHint() + " Restart Hecate after changing environment credentials."
+	}
 	if kind := parsed.Data.ErrorKind; kind != "" {
 		return adapterName + " error (" + kind + "): " + message
 	}
 	return adapterName + " error: " + message
+}
+
+func isAuthErrorText(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "authentication required") ||
+		strings.Contains(lower, "not logged in") ||
+		strings.Contains(lower, "please log in") ||
+		strings.Contains(lower, "please login") ||
+		strings.Contains(lower, "unauthenticated")
 }
 
 type jsonRPCErrorPayload struct {

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -91,6 +91,10 @@ func SetProbeMetrics(metrics *telemetry.AgentAdapterMetrics) {
 // will see no charge. The `cwd` passed to NewSession is a temporary
 // directory that's removed before Probe returns.
 func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
+	return ProbeWithEnv(ctx, adapterID, nil)
+}
+
+func ProbeWithEnv(ctx context.Context, adapterID string, extraEnv []string) (res ProbeResult) {
 	defer func() {
 		// Fire the probe counter at the very end, after every return
 		// path has converged on res.Status. Inline-defer rather than
@@ -144,7 +148,7 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 	cmd := exec.CommandContext(context.Background(), path, args...)
 	configureCommandProcessGroup(cmd)
 	cmd.Dir = workspace
-	cmd.Env = sanitizedEnv(os.Environ())
+	cmd.Env = mergeEnv(sanitizedEnv(os.Environ()), extraEnv)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -199,6 +203,9 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 	if err != nil {
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
+		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
+			res.Hint = "Claude Code ACP needs adapter-visible auth. " + claudeCodeACPAuthHint()
+		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)
 		return res
@@ -214,6 +221,9 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 	if err != nil {
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
+		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
+			res.Hint = "Claude Code ACP needs adapter-visible auth. " + claudeCodeACPAuthHint()
+		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)
 		return res
@@ -224,6 +234,33 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 	res.Stderr = strings.TrimSpace(stderr.String())
 	res.DurationMS = elapsedMS(start)
 	return res
+}
+
+func claudeCodeErrorNeedsAdapterVisibleAuth(errText, stderr string) bool {
+	combined := strings.ToLower(errText + "\n" + stderr)
+	if matchesAny(combined, "credit balance", "payment required", "subscription required", "billing") {
+		return false
+	}
+	return matchesAny(combined,
+		"authentication required",
+		"unauthenticated",
+		"unauthorized",
+		"please log in",
+		"please login",
+		"please sign in",
+		"login required",
+		"sign in required",
+		"not logged in",
+		"api key",
+		"apikey",
+		"missing credentials",
+		"invalid credentials",
+		"credential",
+		"401 unauthorized",
+		" 401 ",
+		"403 forbidden",
+		" 403 ",
+	)
 }
 
 // classifyAdapterError sorts a (raw error, stderr) pair into either

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -83,6 +83,32 @@ func TestClassifyAdapterError(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeErrorNeedsAdapterVisibleAuth(t *testing.T) {
+	t.Parallel()
+
+	authCases := []string{
+		"Authentication required",
+		"missing credentials",
+		"request returned 401 unauthorized",
+	}
+	for _, tc := range authCases {
+		if !claudeCodeErrorNeedsAdapterVisibleAuth(tc, "") {
+			t.Fatalf("claudeCodeErrorNeedsAdapterVisibleAuth(%q) = false, want true", tc)
+		}
+	}
+
+	billingCases := []string{
+		"Credit balance is too low",
+		"payment required",
+		"subscription required",
+	}
+	for _, tc := range billingCases {
+		if claudeCodeErrorNeedsAdapterVisibleAuth(tc, "") {
+			t.Fatalf("claudeCodeErrorNeedsAdapterVisibleAuth(%q) = true, want false", tc)
+		}
+	}
+}
+
 // TestProbeUnknownAdapter ensures we surface a clean error rather than
 // crashing or attempting to spawn a phantom binary.
 func TestProbeUnknownAdapter(t *testing.T) {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -598,6 +598,35 @@ func sanitizedEnv(env []string) []string {
 	return out
 }
 
+func mergeEnv(base []string, overrides []string) []string {
+	if len(overrides) == 0 {
+		return append([]string(nil), base...)
+	}
+	names := make(map[string]struct{}, len(overrides))
+	filteredOverrides := make([]string, 0, len(overrides))
+	for _, entry := range overrides {
+		name, value, ok := strings.Cut(entry, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		names[name] = struct{}{}
+		filteredOverrides = append(filteredOverrides, name+"="+value)
+	}
+	out := make([]string, 0, len(base)+len(filteredOverrides))
+	for _, entry := range base {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, replace := names[name]; replace {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	out = append(out, filteredOverrides...)
+	return out
+}
+
 func captureGitDiff(ctx context.Context, workspace string, maxBytes int64) (string, string) {
 	diffCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -395,6 +395,29 @@ func TestSanitizedEnvPreservesAgentAndRuntimeEssentials(t *testing.T) {
 	}
 }
 
+func TestMergeEnvOverridesSanitizedBase(t *testing.T) {
+	t.Parallel()
+
+	got := mergeEnv([]string{
+		"PATH=/bin",
+		"CLAUDE_CODE_OAUTH_TOKEN=old",
+		"HOME=/tmp/home",
+	}, []string{
+		"CLAUDE_CODE_OAUTH_TOKEN=new",
+		"BAD_ENTRY",
+		"CURSOR_API_KEY=cursor-token",
+	})
+	want := []string{
+		"PATH=/bin",
+		"HOME=/tmp/home",
+		"CLAUDE_CODE_OAUTH_TOKEN=new",
+		"CURSOR_API_KEY=cursor-token",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("mergeEnv() = %#v, want %#v", got, want)
+	}
+}
+
 func TestNormalizeOutputPreservesPlainText(t *testing.T) {
 	t.Parallel()
 
@@ -438,5 +461,14 @@ func TestNormalizeErrorTagsClaudeBillingJSONRPC(t *testing.T) {
 	want := "Claude Code error (billing_error): Credit balance is too low"
 	if got != want {
 		t.Fatalf("NormalizeError = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeErrorExplainsClaudeAuthRequirement(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeError("Claude Code", errors.New(`{"code":-32603,"message":"Authentication required"}`))
+	if !strings.Contains(got, "adapter-visible authentication") || !strings.Contains(got, "ANTHROPIC_API_KEY") {
+		t.Fatalf("NormalizeError = %q, want Claude ACP auth guidance", got)
 	}
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -295,6 +295,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		agentChatMetrics:    agentChatMetrics,
 		approvalConfig:      approvalCfg,
 	}
+	agentChatRunner.SetCredentialEnvProvider(h.agentAdapterCredentialEnv)
 	h.startAgentChatIdleSweeper()
 	return h
 }
@@ -387,6 +388,9 @@ func (h *Handler) SetSecretCipher(cipher secrets.Cipher) {
 	}
 	h.secretCipher = cipher
 	h.rebuildMCPHostFactory()
+	if mgr, ok := h.agentChatRunner.(*agentadapters.SessionManager); ok {
+		mgr.SetCredentialEnvProvider(h.agentAdapterCredentialEnv)
+	}
 }
 
 // SetMCPClientCache wires a SharedClientCache into the runner so MCP

--- a/internal/api/handler_agent_adapter_credentials.go
+++ b/internal/api/handler_agent_adapter_credentials.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hecate/agent-runtime/internal/agentadapters"
+	"github.com/hecate/agent-runtime/internal/controlplane"
+)
+
+const claudeCodeOAuthTokenName = "CLAUDE_CODE_OAUTH_TOKEN"
+
+func (h *Handler) HandleSetAgentAdapterCredential(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSettings(w, r) {
+		return
+	}
+	if h.secretCipher == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "control plane secret storage is not configured")
+		return
+	}
+	adapterID := strings.TrimSpace(r.PathValue("id"))
+	if _, ok := agentadapters.FindAdapter(adapterID); !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "adapter not found")
+		return
+	}
+	var req AgentAdapterCredentialSetRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	name := normalizeAgentAdapterCredentialName(adapterID, req.Name)
+	if err := validateAgentAdapterCredentialName(adapterID, name); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	value := strings.TrimSpace(req.Value)
+	if value == "" {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "credential value is required")
+		return
+	}
+	encrypted, err := h.secretCipher.Encrypt(value)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("encrypt adapter credential: %v", err))
+		return
+	}
+	credential, err := h.controlPlane.UpsertAgentAdapterCredential(controlplane.WithActor(r.Context(), settingsActor(r)), controlplane.AgentAdapterCredential{
+		AdapterID:      adapterID,
+		Name:           name,
+		ValueEncrypted: encrypted,
+		ValuePreview:   previewAdapterCredential(value),
+	})
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, AgentAdapterCredentialResponse{
+		Object: "agent_adapter_credential",
+		Data: AgentAdapterCredentialResponseItem{
+			AdapterID:  credential.AdapterID,
+			Name:       credential.Name,
+			Configured: true,
+			Preview:    credential.ValuePreview,
+		},
+	})
+}
+
+func (h *Handler) HandleDeleteAgentAdapterCredential(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSettings(w, r) {
+		return
+	}
+	adapterID := strings.TrimSpace(r.PathValue("id"))
+	if _, ok := agentadapters.FindAdapter(adapterID); !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "adapter not found")
+		return
+	}
+	name := normalizeAgentAdapterCredentialName(adapterID, r.PathValue("name"))
+	if err := validateAgentAdapterCredentialName(adapterID, name); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if err := h.controlPlane.DeleteAgentAdapterCredential(controlplane.WithActor(r.Context(), settingsActor(r)), adapterID, name); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, AgentAdapterCredentialResponse{
+		Object: "agent_adapter_credential",
+		Data: AgentAdapterCredentialResponseItem{
+			AdapterID:  adapterID,
+			Name:       name,
+			Configured: false,
+		},
+	})
+}
+
+func (h *Handler) agentAdapterCredentialEnv(ctx context.Context, adapterID string) []string {
+	if h == nil || h.controlPlane == nil || h.secretCipher == nil {
+		return nil
+	}
+	state, err := h.controlPlane.Snapshot(ctx)
+	if err != nil {
+		return nil
+	}
+	env := make([]string, 0, len(state.AgentAdapterCredentials))
+	for _, credential := range state.AgentAdapterCredentials {
+		if credential.AdapterID != adapterID {
+			continue
+		}
+		if err := validateAgentAdapterCredentialName(adapterID, credential.Name); err != nil {
+			continue
+		}
+		value, err := h.secretCipher.Decrypt(credential.ValueEncrypted)
+		if err != nil || strings.TrimSpace(value) == "" {
+			continue
+		}
+		env = append(env, credential.Name+"="+value)
+	}
+	return env
+}
+
+func normalizeAgentAdapterCredentialName(adapterID, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" && adapterID == "claude_code" {
+		return claudeCodeOAuthTokenName
+	}
+	return name
+}
+
+func validateAgentAdapterCredentialName(adapterID, name string) error {
+	switch adapterID {
+	case "claude_code":
+		if name == claudeCodeOAuthTokenName || name == "ANTHROPIC_API_KEY" || name == "ANTHROPIC_AUTH_TOKEN" {
+			return nil
+		}
+	case "codex":
+		if name == "OPENAI_API_KEY" || name == "CODEX_AUTH_TOKEN" || name == "CODEX_API_KEY" {
+			return nil
+		}
+	case "cursor_agent":
+		if name == "CURSOR_API_KEY" {
+			return nil
+		}
+	}
+	return fmt.Errorf("credential %q is not supported for adapter %q", name, adapterID)
+}
+
+func previewAdapterCredential(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if len(value) <= 8 {
+		return "****"
+	}
+	return value[:4] + "..." + value[len(value)-4:]
+}

--- a/internal/api/handler_agent_adapter_health.go
+++ b/internal/api/handler_agent_adapter_health.go
@@ -48,10 +48,12 @@ func (h *Handler) HandleAgentAdapterHealth(w http.ResponseWriter, r *http.Reques
 	}
 
 	probe := h.agentAdapterProbe
+	var result agentadapters.ProbeResult
 	if probe == nil {
-		probe = agentadapters.Probe
+		result = agentadapters.ProbeWithEnv(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
+	} else {
+		result = probe(ctx, id)
 	}
-	result := probe(ctx, id)
 	WriteJSON(w, http.StatusOK, AgentAdapterHealthResponse{
 		Object: "agent_adapter_health",
 		Data:   result,

--- a/internal/api/handler_agent_adapter_health_test.go
+++ b/internal/api/handler_agent_adapter_health_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hecate/agent-runtime/internal/agentadapters"
 	"github.com/hecate/agent-runtime/internal/config"
+	"github.com/hecate/agent-runtime/internal/controlplane"
 )
 
 // TestAgentAdapterHealthSurfacesProbeResult covers the happy-path
@@ -169,5 +170,65 @@ func TestAgentAdapterProbeEndpointReturnsFreshAdapterAndHealth(t *testing.T) {
 	}
 	if resp.Data.Health.Status != agentadapters.ProbeStatusReady || resp.Data.Health.DurationMS != 42 {
 		t.Fatalf("health = %#v, want ready duration 42", resp.Data.Health)
+	}
+}
+
+func TestAgentAdapterCredentialEndpointsStoreAndDeleteCredential(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	store := controlplane.NewMemoryStore()
+	apiHandler := NewHandler(config.Config{}, logger, nil, store, nil, nil)
+	apiHandler.SetSecretCipher(newTestCipherForAPI(t))
+	server := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, server)
+
+	set := mustRequestJSON[AgentAdapterCredentialResponse](client, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"token-secret"}`)
+	if set.Object != "agent_adapter_credential" {
+		t.Fatalf("object = %q, want agent_adapter_credential", set.Object)
+	}
+	if set.Data.AdapterID != "claude_code" || set.Data.Name != claudeCodeOAuthTokenName || !set.Data.Configured {
+		t.Fatalf("set response = %#v, want configured claude token", set.Data)
+	}
+	if strings.Contains(set.Data.Preview, "token-secret") {
+		t.Fatalf("preview leaked full token: %q", set.Data.Preview)
+	}
+
+	state, err := store.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := len(state.AgentAdapterCredentials); got != 1 {
+		t.Fatalf("credentials len = %d, want 1", got)
+	}
+	if state.AgentAdapterCredentials[0].ValueEncrypted == "token-secret" {
+		t.Fatal("credential was stored in plaintext")
+	}
+
+	env := apiHandler.agentAdapterCredentialEnv(context.Background(), "claude_code")
+	if got, want := strings.Join(env, "\n"), claudeCodeOAuthTokenName+"=token-secret"; got != want {
+		t.Fatalf("credential env = %q, want %q", got, want)
+	}
+
+	deleted := mustRequestJSON[AgentAdapterCredentialResponse](client, http.MethodDelete, "/hecate/v1/agent-adapters/claude_code/credentials/CLAUDE_CODE_OAUTH_TOKEN", "")
+	if deleted.Data.Configured {
+		t.Fatalf("delete response configured = true, want false")
+	}
+	if env := apiHandler.agentAdapterCredentialEnv(context.Background(), "claude_code"); len(env) != 0 {
+		t.Fatalf("credential env after delete = %#v, want empty", env)
+	}
+}
+
+func TestAgentAdapterCredentialEndpointRequiresSecretStorage(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := NewHandler(config.Config{}, logger, nil, controlplane.NewMemoryStore(), nil, nil)
+	server := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, server)
+
+	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"token"}`)
+	if !strings.Contains(rec.Body.String(), "secret storage") {
+		t.Fatalf("response = %s, want secret storage error", rec.Body.String())
 	}
 }

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -11,7 +12,7 @@ func (h *Handler) HandleAgentAdapters(w http.ResponseWriter, r *http.Request) {
 	items := agentadapters.List(r.Context())
 	data := make([]AgentAdapterResponseItem, 0, len(items))
 	for _, item := range items {
-		data = append(data, renderAgentAdapterItem(item))
+		data = append(data, h.renderAgentAdapterItem(r.Context(), item))
 	}
 
 	WriteJSON(w, http.StatusOK, AgentAdapterResponse{
@@ -33,11 +34,13 @@ func (h *Handler) HandleAgentAdapterProbe(w http.ResponseWriter, r *http.Request
 		return
 	}
 	probe := h.agentAdapterProbe
+	var result agentadapters.ProbeResult
 	if probe == nil {
-		probe = agentadapters.Probe
+		result = agentadapters.ProbeWithEnv(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
+	} else {
+		result = probe(ctx, id)
 	}
-	result := probe(ctx, id)
-	item := renderAgentAdapterItem(status)
+	item := h.renderAgentAdapterItem(ctx, status)
 	item.AuthStatus, item.AuthError = authStatusFromProbe(result, item.AuthStatus, item.AuthError)
 	WriteJSON(w, http.StatusOK, AgentAdapterProbeResponse{
 		Object: "agent_adapter_probe",
@@ -65,7 +68,7 @@ func (h *Handler) HandleAgentAdapterRefreshLauncher(w http.ResponseWriter, r *ht
 	}
 	WriteJSON(w, http.StatusOK, AgentAdapterResponse{
 		Object: "agent_adapters",
-		Data:   []AgentAdapterResponseItem{renderAgentAdapterItem(status)},
+		Data:   []AgentAdapterResponseItem{h.renderAgentAdapterItem(r.Context(), status)},
 	})
 }
 
@@ -101,6 +104,25 @@ func renderAgentAdapterItem(item agentadapters.Status) AgentAdapterResponseItem 
 		AuthStatus:          item.AuthStatus,
 		AuthError:           item.AuthError,
 	}
+}
+
+func (h *Handler) renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) AgentAdapterResponseItem {
+	rendered := renderAgentAdapterItem(item)
+	if h == nil || h.controlPlane == nil {
+		return rendered
+	}
+	state, err := h.controlPlane.Snapshot(ctx)
+	if err != nil {
+		return rendered
+	}
+	for _, credential := range state.AgentAdapterCredentials {
+		if credential.AdapterID == item.ID {
+			rendered.CredentialConfigured = true
+			rendered.CredentialPreview = credential.ValuePreview
+			break
+		}
+	}
+	return rendered
 }
 
 func authStatusFromProbe(result agentadapters.ProbeResult, fallbackStatus, fallbackError string) (string, string) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -595,25 +595,44 @@ type LocalProviderDiscoveryResponseItem struct {
 }
 
 type AgentAdapterResponseItem struct {
-	ID                  string   `json:"id"`
-	Name                string   `json:"name"`
-	Kind                string   `json:"kind"`
-	Command             string   `json:"command"`
-	Args                []string `json:"args,omitempty"`
-	Managed             bool     `json:"managed,omitempty"`
-	ManagedPackage      string   `json:"managed_package,omitempty"`
-	Available           bool     `json:"available"`
-	Status              string   `json:"status"`
-	Path                string   `json:"path,omitempty"`
-	Error               string   `json:"error,omitempty"`
-	Description         string   `json:"description,omitempty"`
-	CostMode            string   `json:"cost_mode,omitempty"`
-	DocsURL             string   `json:"docs_url,omitempty"`
-	Version             string   `json:"version,omitempty"`
-	SupportedRange      string   `json:"supported_range,omitempty"`
-	VersionOutsideRange bool     `json:"version_outside_range,omitempty"`
-	AuthStatus          string   `json:"auth_status,omitempty"`
-	AuthError           string   `json:"auth_error,omitempty"`
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name"`
+	Kind                 string   `json:"kind"`
+	Command              string   `json:"command"`
+	Args                 []string `json:"args,omitempty"`
+	Managed              bool     `json:"managed,omitempty"`
+	ManagedPackage       string   `json:"managed_package,omitempty"`
+	Available            bool     `json:"available"`
+	Status               string   `json:"status"`
+	Path                 string   `json:"path,omitempty"`
+	Error                string   `json:"error,omitempty"`
+	Description          string   `json:"description,omitempty"`
+	CostMode             string   `json:"cost_mode,omitempty"`
+	DocsURL              string   `json:"docs_url,omitempty"`
+	Version              string   `json:"version,omitempty"`
+	SupportedRange       string   `json:"supported_range,omitempty"`
+	VersionOutsideRange  bool     `json:"version_outside_range,omitempty"`
+	AuthStatus           string   `json:"auth_status,omitempty"`
+	AuthError            string   `json:"auth_error,omitempty"`
+	CredentialConfigured bool     `json:"credential_configured,omitempty"`
+	CredentialPreview    string   `json:"credential_preview,omitempty"`
+}
+
+type AgentAdapterCredentialSetRequest struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value"`
+}
+
+type AgentAdapterCredentialResponse struct {
+	Object string                             `json:"object"`
+	Data   AgentAdapterCredentialResponseItem `json:"data"`
+}
+
+type AgentAdapterCredentialResponseItem struct {
+	AdapterID  string `json:"adapter_id"`
+	Name       string `json:"name"`
+	Configured bool   `json:"configured"`
+	Preview    string `json:"preview,omitempty"`
 }
 
 type CreateAgentChatSessionRequest struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -71,6 +71,8 @@ func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/agent-adapters", handler.HandleAgentAdapters)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/probe", handler.HandleAgentAdapterProbe)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/refresh-launcher", handler.HandleAgentAdapterRefreshLauncher)
+	mux.HandleFunc("PUT /hecate/v1/agent-adapters/{id}/credentials", handler.HandleSetAgentAdapterCredential)
+	mux.HandleFunc("DELETE /hecate/v1/agent-adapters/{id}/credentials/{name}", handler.HandleDeleteAgentAdapterCredential)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters/{id}/health", handler.HandleAgentAdapterHealth)
 	mux.HandleFunc("GET /hecate/v1/agent-chat/sessions", handler.HandleAgentChatSessions)
 	mux.HandleFunc("POST /hecate/v1/agent-chat/sessions", handler.HandleCreateAgentChatSession)

--- a/internal/controlplane/agent_adapter_credentials.go
+++ b/internal/controlplane/agent_adapter_credentials.go
@@ -1,0 +1,72 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func applyUpsertAgentAdapterCredential(ctx context.Context, state *State, credential AgentAdapterCredential) (AgentAdapterCredential, error) {
+	if state == nil {
+		return AgentAdapterCredential{}, fmt.Errorf("control plane state is required")
+	}
+	credential.AdapterID = strings.TrimSpace(credential.AdapterID)
+	credential.Name = strings.TrimSpace(credential.Name)
+	if credential.AdapterID == "" {
+		return AgentAdapterCredential{}, fmt.Errorf("agent adapter id is required")
+	}
+	if credential.Name == "" {
+		return AgentAdapterCredential{}, fmt.Errorf("agent adapter credential name is required")
+	}
+	if strings.TrimSpace(credential.ValueEncrypted) == "" {
+		return AgentAdapterCredential{}, fmt.Errorf("agent adapter credential ciphertext is required")
+	}
+
+	now := time.Now().UTC()
+	index := agentAdapterCredentialIndex(state.AgentAdapterCredentials, credential.AdapterID, credential.Name)
+	if index >= 0 {
+		existing := state.AgentAdapterCredentials[index]
+		if credential.CreatedAt.IsZero() {
+			credential.CreatedAt = existing.CreatedAt
+		}
+	} else if credential.CreatedAt.IsZero() {
+		credential.CreatedAt = now
+	}
+	credential.RotatedAt = now
+
+	if index >= 0 {
+		state.AgentAdapterCredentials[index] = credential
+	} else {
+		state.AgentAdapterCredentials = append(state.AgentAdapterCredentials, credential)
+	}
+	appendAuditEvent(state, newAuditEvent(ctx, "agent_adapter.credential_saved", "agent_adapter", credential.AdapterID, credential.Name))
+	return credential, nil
+}
+
+func applyDeleteAgentAdapterCredential(ctx context.Context, state *State, adapterID, name string) error {
+	adapterID = strings.TrimSpace(adapterID)
+	name = strings.TrimSpace(name)
+	if adapterID == "" {
+		return fmt.Errorf("agent adapter id is required")
+	}
+	if name == "" {
+		return fmt.Errorf("agent adapter credential name is required")
+	}
+	index := agentAdapterCredentialIndex(state.AgentAdapterCredentials, adapterID, name)
+	if index < 0 {
+		return fmt.Errorf("agent adapter credential %q for %q not found", name, adapterID)
+	}
+	state.AgentAdapterCredentials = append(state.AgentAdapterCredentials[:index], state.AgentAdapterCredentials[index+1:]...)
+	appendAuditEvent(state, newAuditEvent(ctx, "agent_adapter.credential_deleted", "agent_adapter", adapterID, name))
+	return nil
+}
+
+func agentAdapterCredentialIndex(items []AgentAdapterCredential, adapterID, name string) int {
+	for i := range items {
+		if items[i].AdapterID == adapterID && items[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -40,6 +40,15 @@ type ProviderSecret struct {
 	RotatedAt       time.Time `json:"rotated_at,omitempty"`
 }
 
+type AgentAdapterCredential struct {
+	AdapterID      string    `json:"adapter_id"`
+	Name           string    `json:"name"`
+	ValueEncrypted string    `json:"value_encrypted"`
+	ValuePreview   string    `json:"value_preview,omitempty"`
+	CreatedAt      time.Time `json:"created_at,omitempty"`
+	RotatedAt      time.Time `json:"rotated_at,omitempty"`
+}
+
 type AuditEvent struct {
 	Timestamp  time.Time `json:"timestamp"`
 	Actor      string    `json:"actor"`
@@ -68,6 +77,7 @@ type ModelCapabilityRecord struct {
 type State struct {
 	Providers                 []Provider                `json:"providers,omitempty"`
 	ProviderSecrets           []ProviderSecret          `json:"provider_secrets,omitempty"`
+	AgentAdapterCredentials   []AgentAdapterCredential  `json:"agent_adapter_credentials,omitempty"`
 	PolicyRules               []config.PolicyRuleConfig `json:"policy_rules,omitempty"`
 	Pricebook                 []config.ModelPriceConfig `json:"pricebook,omitempty"`
 	ModelCapabilityOverrides  []ModelCapabilityRecord   `json:"model_capability_overrides,omitempty"`
@@ -82,6 +92,8 @@ type Store interface {
 	RotateProviderSecret(ctx context.Context, id string, secret ProviderSecret) (Provider, error)
 	DeleteProviderCredential(ctx context.Context, id string) (Provider, error)
 	DeleteProvider(ctx context.Context, id string) error
+	UpsertAgentAdapterCredential(ctx context.Context, credential AgentAdapterCredential) (AgentAdapterCredential, error)
+	DeleteAgentAdapterCredential(ctx context.Context, adapterID, name string) error
 	UpsertPolicyRule(ctx context.Context, rule config.PolicyRuleConfig) (config.PolicyRuleConfig, error)
 	DeletePolicyRule(ctx context.Context, id string) error
 	UpsertPricebookEntry(ctx context.Context, entry config.ModelPriceConfig) (config.ModelPriceConfig, error)
@@ -108,6 +120,7 @@ func cloneState(state State) State {
 	out := State{
 		Providers:                 make([]Provider, 0, len(state.Providers)),
 		ProviderSecrets:           make([]ProviderSecret, 0, len(state.ProviderSecrets)),
+		AgentAdapterCredentials:   make([]AgentAdapterCredential, 0, len(state.AgentAdapterCredentials)),
 		PolicyRules:               make([]config.PolicyRuleConfig, 0, len(state.PolicyRules)),
 		Pricebook:                 make([]config.ModelPriceConfig, 0, len(state.Pricebook)),
 		ModelCapabilityOverrides:  make([]ModelCapabilityRecord, 0, len(state.ModelCapabilityOverrides)),
@@ -140,6 +153,16 @@ func cloneState(state State) State {
 			APIKeyPreview:   secret.APIKeyPreview,
 			CreatedAt:       secret.CreatedAt,
 			RotatedAt:       secret.RotatedAt,
+		})
+	}
+	for _, credential := range state.AgentAdapterCredentials {
+		out.AgentAdapterCredentials = append(out.AgentAdapterCredentials, AgentAdapterCredential{
+			AdapterID:      credential.AdapterID,
+			Name:           credential.Name,
+			ValueEncrypted: credential.ValueEncrypted,
+			ValuePreview:   credential.ValuePreview,
+			CreatedAt:      credential.CreatedAt,
+			RotatedAt:      credential.RotatedAt,
 		})
 	}
 	for _, rule := range state.PolicyRules {

--- a/internal/controlplane/store_memory.go
+++ b/internal/controlplane/store_memory.go
@@ -56,6 +56,18 @@ func (s *MemoryStore) DeleteProvider(ctx context.Context, id string) error {
 	return applyDeleteProvider(ctx, &s.data, id)
 }
 
+func (s *MemoryStore) UpsertAgentAdapterCredential(ctx context.Context, credential AgentAdapterCredential) (AgentAdapterCredential, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return applyUpsertAgentAdapterCredential(ctx, &s.data, credential)
+}
+
+func (s *MemoryStore) DeleteAgentAdapterCredential(ctx context.Context, adapterID, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return applyDeleteAgentAdapterCredential(ctx, &s.data, adapterID, name)
+}
+
 func (s *MemoryStore) UpsertPolicyRule(ctx context.Context, rule config.PolicyRuleConfig) (config.PolicyRuleConfig, error) {
 	rule, err := normalizePolicyRule(rule)
 	if err != nil {

--- a/internal/controlplane/store_sqlite.go
+++ b/internal/controlplane/store_sqlite.go
@@ -132,6 +132,38 @@ func (s *SQLiteStore) DeleteProvider(ctx context.Context, id string) error {
 	return s.writeState(ctx, state)
 }
 
+func (s *SQLiteStore) UpsertAgentAdapterCredential(ctx context.Context, credential AgentAdapterCredential) (AgentAdapterCredential, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.readState(ctx)
+	if err != nil {
+		return AgentAdapterCredential{}, err
+	}
+	credential, err = applyUpsertAgentAdapterCredential(ctx, &state, credential)
+	if err != nil {
+		return AgentAdapterCredential{}, err
+	}
+	if err := s.writeState(ctx, state); err != nil {
+		return AgentAdapterCredential{}, err
+	}
+	return credential, nil
+}
+
+func (s *SQLiteStore) DeleteAgentAdapterCredential(ctx context.Context, adapterID, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.readState(ctx)
+	if err != nil {
+		return err
+	}
+	if err := applyDeleteAgentAdapterCredential(ctx, &state, adapterID, name); err != nil {
+		return err
+	}
+	return s.writeState(ctx, state)
+}
+
 func (s *SQLiteStore) UpsertPolicyRule(ctx context.Context, rule config.PolicyRuleConfig) (config.PolicyRuleConfig, error) {
 	rule, err := normalizePolicyRule(rule)
 	if err != nil {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -30,6 +30,8 @@ import {
   listAgentChatApprovals as listAgentChatApprovalsRequest,
   listAgentChatGrants as listAgentChatGrantsRequest,
   probeAgentAdapter as probeAgentAdapterRequest,
+  setAgentAdapterCredential as setAgentAdapterCredentialRequest,
+  deleteAgentAdapterCredential as deleteAgentAdapterCredentialRequest,
   revertAgentChatMessageFiles as revertAgentChatMessageFilesRequest,
   resolveTaskApproval as resolveTaskApprovalRequest,
   resolveAgentChatApproval as resolveAgentChatApprovalRequest,
@@ -1825,6 +1827,40 @@ export function useRuntimeConsole() {
     }
   }
 
+  async function setAgentAdapterCredential(adapterID: string, value: string, name?: string): Promise<boolean> {
+    try {
+      const payload = await setAgentAdapterCredentialRequest(adapterID, value, name);
+      setAgentAdapters((current) => current.map((item) => item.id === adapterID
+        ? { ...item, credential_configured: payload.data.configured, credential_preview: payload.data.preview }
+        : item));
+      setNoticeMessage("success", "Adapter credential saved.");
+      return true;
+    } catch (error) {
+      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to save adapter credential.");
+      return false;
+    }
+  }
+
+  async function deleteAgentAdapterCredential(adapterID: string, name: string): Promise<boolean> {
+    try {
+      await deleteAgentAdapterCredentialRequest(adapterID, name);
+      setAgentAdapters((current) => current.map((item) => item.id === adapterID
+        ? { ...item, credential_configured: false, credential_preview: undefined }
+        : item));
+      setAgentAdapterHealthByID((current) => {
+        if (!current.has(adapterID)) return current;
+        const next = new Map(current);
+        next.delete(adapterID);
+        return next;
+      });
+      setNoticeMessage("success", "Adapter credential removed.");
+      return true;
+    } catch (error) {
+      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to remove adapter credential.");
+      return false;
+    }
+  }
+
   async function renameChatSession(id: string, title: string) {
     try {
       const payload = await updateChatSessionRequest(id, title);
@@ -1998,6 +2034,8 @@ export function useRuntimeConsole() {
       listAgentChatGrants,
       deleteAgentChatGrant,
       probeAgentAdapter,
+      setAgentAdapterCredential,
+      deleteAgentAdapterCredential,
       dismissNotice: () => setNotice(null),
     },
   };

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -382,5 +382,58 @@ describe("SettingsView external agents tab", () => {
       expect(button.disabled).toBe(true);
       expect(button.textContent).toMatch(/Testing/);
     });
+
+    it("shows Claude Code guided setup and saves the pasted token", async () => {
+      const setAgentAdapterCredential = vi.fn(async () => true);
+      const probeAgentAdapter = vi.fn(async () => null);
+      const { state, actions, user } = setup(withAdapter({
+        agentAdapters: [
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            auth_status: "unknown",
+            auth_error: "Use Test adapter; if Claude Code reports auth errors, set CLAUDE_CODE_OAUTH_TOKEN.",
+          },
+        ],
+      }), { setAgentAdapterCredential, probeAgentAdapter });
+      render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+
+      expect(await screen.findByTestId("claude-code-guided-setup")).toBeTruthy();
+      await user.type(screen.getByLabelText("Claude Code OAuth token"), "claude-token");
+      await user.click(screen.getByRole("button", { name: "Save + test" }));
+
+      expect(setAgentAdapterCredential).toHaveBeenCalledWith("claude_code", "claude-token", "CLAUDE_CODE_OAUTH_TOKEN");
+      expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
+    });
+
+    it("can remove a stored Claude Code token", async () => {
+      const deleteAgentAdapterCredential = vi.fn(async () => true);
+      const { state, actions, user } = setup(withAdapter({
+        agentAdapters: [
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            credential_configured: true,
+            credential_preview: "clau...oken",
+          },
+        ],
+      }), { deleteAgentAdapterCredential });
+      render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+      await user.click(await screen.findByRole("button", { name: "Remove" }));
+
+      expect(deleteAgentAdapterCredential).toHaveBeenCalledWith("claude_code", "CLAUDE_CODE_OAUTH_TOKEN");
+    });
   });
 });

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -576,6 +576,9 @@ function AdapterStatusSection({ state, actions }: Props) {
             health={state.agentAdapterHealthByID.get(adapter.id) ?? null}
             loading={Boolean(state.agentAdapterHealthLoadingByID.get(adapter.id))}
             onTest={() => void actions.probeAgentAdapter(adapter.id)}
+            onSaveCredential={(value) => actions.setAgentAdapterCredential(adapter.id, value, "CLAUDE_CODE_OAUTH_TOKEN")}
+            onDeleteCredential={() => actions.deleteAgentAdapterCredential(adapter.id, "CLAUDE_CODE_OAUTH_TOKEN")}
+            onCopyCommand={() => void actions.copyCommand("claude setup-token")}
           />
         ))}
       </div>
@@ -589,12 +592,18 @@ function AdapterStatusRow({
   health,
   loading,
   onTest,
+  onSaveCredential,
+  onDeleteCredential,
+  onCopyCommand,
 }: {
   adapter: AgentAdapterRecord;
   divider: boolean;
   health: AgentAdapterHealthRecord | null;
   loading: boolean;
   onTest: () => void;
+  onSaveCredential: (value: string) => Promise<boolean>;
+  onDeleteCredential: () => Promise<boolean>;
+  onCopyCommand: () => void;
 }) {
   // Two status sources: the dashboard's /hecate/v1/agent-adapters availability
   // (binary discovery only) and the on-demand probe (full handshake).
@@ -696,6 +705,21 @@ function AdapterStatusRow({
             {adapter.auth_error}
           </div>
         )}
+        {adapter.id === "claude_code" && (
+          <ClaudeCredentialSetup
+            configured={Boolean(adapter.credential_configured)}
+            preview={adapter.credential_preview}
+            authNeedsAttention={Boolean(
+              health?.status === "auth_required" ||
+              adapter.auth_status === "unauthenticated" ||
+              adapter.auth_status === "unknown"
+            )}
+            onCopyCommand={onCopyCommand}
+            onSave={onSaveCredential}
+            onDelete={onDeleteCredential}
+            onTest={onTest}
+          />
+        )}
       </div>
       <button
         type="button"
@@ -707,6 +731,101 @@ function AdapterStatusRow({
       >
         <Icon d={Icons.refresh} size={13} /> {loading ? "Testing…" : "Test"}
       </button>
+    </div>
+  );
+}
+
+function ClaudeCredentialSetup({
+  configured,
+  preview,
+  authNeedsAttention,
+  onCopyCommand,
+  onSave,
+  onDelete,
+  onTest,
+}: {
+  configured: boolean;
+  preview?: string;
+  authNeedsAttention: boolean;
+  onCopyCommand: () => void;
+  onSave: (value: string) => Promise<boolean>;
+  onDelete: () => Promise<boolean>;
+  onTest: () => void;
+}) {
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  if (!configured && !authNeedsAttention) {
+    return null;
+  }
+
+  async function save() {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    try {
+      if (await onSave(trimmed)) {
+        setToken("");
+        onTest();
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove() {
+    setRemoving(true);
+    try {
+      await onDelete();
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid="claude-code-guided-setup"
+      style={{
+        marginTop: 10,
+        padding: 10,
+        border: "1px solid rgba(245, 158, 11, 0.28)",
+        borderRadius: 10,
+        background: "rgba(245, 158, 11, 0.06)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, marginBottom: 8 }}>
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 600, color: "var(--amber)" }}>Claude Code guided setup</div>
+          <div style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.4 }}>
+            Run <code>claude setup-token</code>, paste the token here, then Hecate injects it only into Claude ACP.
+          </div>
+        </div>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onCopyCommand}>
+          Copy command
+        </button>
+      </div>
+      {configured && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8, fontSize: 11, color: "var(--t2)" }}>
+          <span>Stored token {preview ? <span style={{ fontFamily: "var(--font-mono)", color: "var(--t1)" }}>{preview}</span> : "configured"}</span>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={() => void remove()} disabled={removing}>
+            {removing ? "Removing..." : "Remove"}
+          </button>
+        </div>
+      )}
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          placeholder="Paste CLAUDE_CODE_OAUTH_TOKEN"
+          type="password"
+          className="input"
+          style={{ flex: 1, minWidth: 180 }}
+          aria-label="Claude Code OAuth token"
+        />
+        <button type="button" className="btn btn-primary btn-sm" onClick={() => void save()} disabled={saving || token.trim() === ""}>
+          {saving ? "Saving..." : "Save + test"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -22,6 +22,8 @@ import {
   revertAgentChatMessageFiles,
   resolveAgentChatApproval,
   recordModelCapabilityProbe,
+  setAgentAdapterCredential,
+  deleteAgentAdapterCredential,
   setProviderAPIKey,
   setProviderBaseURL,
   streamAgentChatSession,
@@ -655,6 +657,50 @@ describe("api client", () => {
 
       const [url] = fetchMock.mock.lastCall ?? [];
       expect(url).toBe("/hecate/v1/agent-adapters/weird%20id/refresh-launcher");
+    });
+  });
+
+  describe("agent adapter credentials", () => {
+    it("stores a named adapter credential without returning the value", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          object: "agent_adapter_credential",
+          data: {
+            adapter_id: "claude_code",
+            name: "CLAUDE_CODE_OAUTH_TOKEN",
+            configured: true,
+            preview: "clau...oken",
+          },
+        }),
+      );
+
+      const result = await setAgentAdapterCredential("claude_code", "claude-token", "CLAUDE_CODE_OAUTH_TOKEN");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/hecate/v1/agent-adapters/claude_code/credentials",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ name: "CLAUDE_CODE_OAUTH_TOKEN", value: "claude-token" }),
+        }),
+      );
+      expect(result.data.configured).toBe(true);
+      expect(JSON.stringify(result)).not.toContain("claude-token");
+    });
+
+    it("deletes an adapter credential by encoded name", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          object: "agent_adapter_credential",
+          data: { adapter_id: "claude_code", name: "CLAUDE_CODE_OAUTH_TOKEN", configured: false },
+        }),
+      );
+
+      await deleteAgentAdapterCredential("claude_code", "CLAUDE_CODE_OAUTH_TOKEN");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/hecate/v1/agent-adapters/claude_code/credentials/CLAUDE_CODE_OAUTH_TOKEN",
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   PricebookImportDiffResponse,
   ProviderPresetResponse,
   AgentAdapterProbeResponse,
+  AgentAdapterCredentialResponse,
   AgentAdapterResponse,
   AgentChatApprovalRequestedEvent,
   AgentChatApprovalResolvedEvent,
@@ -275,6 +276,20 @@ export async function refreshAgentAdapterLauncher(adapterID: string): Promise<Ag
   return fetchJSON<AgentAdapterResponse>(
     `${HECATE_API}/agent-adapters/${encodeURIComponent(adapterID)}/refresh-launcher`,
     { method: "POST" },
+  );
+}
+
+export async function setAgentAdapterCredential(adapterID: string, value: string, name?: string): Promise<AgentAdapterCredentialResponse> {
+  return fetchJSON<AgentAdapterCredentialResponse>(
+    `${HECATE_API}/agent-adapters/${encodeURIComponent(adapterID)}/credentials`,
+    { method: "PUT", body: { name, value } },
+  );
+}
+
+export async function deleteAgentAdapterCredential(adapterID: string, name: string): Promise<AgentAdapterCredentialResponse> {
+  return fetchJSON<AgentAdapterCredentialResponse>(
+    `${HECATE_API}/agent-adapters/${encodeURIComponent(adapterID)}/credentials/${encodeURIComponent(name)}`,
+    { method: "DELETE" },
   );
 }
 

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -136,6 +136,8 @@ export function createRuntimeConsoleActions(): RuntimeConsoleViewModel["actions"
     listAgentChatGrants: async () => undefined,
     deleteAgentChatGrant: async () => true,
     probeAgentAdapter: async () => null,
+    setAgentAdapterCredential: async () => true,
+    deleteAgentAdapterCredential: async () => true,
     dismissNotice: () => undefined,
   };
 }

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -247,6 +247,8 @@ export type AgentAdapterRecord = {
   version_outside_range?: boolean;
   auth_status?: "ok" | "unauthenticated" | "billing" | "unknown" | string;
   auth_error?: string;
+  credential_configured?: boolean;
+  credential_preview?: string;
 };
 
 export type AgentAdapterResponse = {
@@ -564,6 +566,16 @@ export type AgentAdapterProbeResponse = {
   data: {
     adapter: AgentAdapterRecord;
     health: AgentAdapterHealthRecord;
+  };
+};
+
+export type AgentAdapterCredentialResponse = {
+  object: string;
+  data: {
+    adapter_id: string;
+    name: string;
+    configured: boolean;
+    preview?: string;
   };
 };
 


### PR DESCRIPTION
## Summary

Adds a guided Claude Code ACP credential setup path and folds the earlier auth-readiness clarification into one commit.

- Treat Claude Code config-file presence as `auth_status=unknown` because it can make the standalone `claude` CLI work while `claude-agent-acp` still fails with `Authentication required`.
- Add encrypted local adapter credentials to the control-plane store, persisted by both memory and SQLite backends.
- Add allowlisted adapter credential endpoints and expose only `credential_configured` plus a redacted preview in adapter status rows.
- Inject stored adapter credentials into both Settings probes and real ACP sessions after env sanitization.
- Add a Settings -> External agents guided setup card for Claude Code: copy `claude setup-token`, paste token, save, then re-test.
- Keep Claude billing/subscription probe failures from being rewritten as auth-token setup guidance.
- Update runtime API and external-agent docs for the guided setup and credential endpoints.

## Verification

- `go vet ./...`
- `go test ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
