### PR TITLE
fix(ui): collapse same-request_id traces in Observability table + drawer polish

### DIFF
--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -217,6 +217,45 @@ describe("ObservabilityView", () => {
     expect(container.textContent).toMatch(/\+4/);
   });
 
+  it("never renders 'undefined' when route candidates are partially populated", async () => {
+    // Defensive against route.candidates entries with missing provider
+    // or model fields — both are optional on the runtime type. A
+    // half-populated candidate must NOT reach the rendered output as
+    // literal "undefined" in the table cells or drawer header.
+    fetchMock.mockImplementation(tracesFetchHandler(
+      [{
+        request_id: "req-partial-cand",
+        started_at: new Date().toISOString(),
+        span_count: 1,
+        status_code: "ok",
+        route: { candidates: [{ outcome: "skipped", skip_reason: "unsupported_model" }] },
+      }],
+      {
+        request_id: "req-partial-cand",
+        started_at: new Date().toISOString(),
+        spans: [],
+        route: { candidates: [{ outcome: "skipped", skip_reason: "unsupported_model" }] },
+      },
+    ));
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/req-part/);
+    });
+    expect(container.textContent).not.toMatch(/undefined/);
+    // Open the drawer and re-check the header path that interpolates
+    // candidate.provider.
+    const row = container.querySelector("tbody tr") as HTMLElement;
+    await act(async () => {
+      fireEvent.click(row);
+    });
+    expect(container.textContent).not.toMatch(/undefined/);
+  });
+
   it("status filter narrows the table to error rows only", async () => {
     fetchMock.mockImplementation(tracesFetchHandler([
       { request_id: "ok-1", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "openai", final_model: "m1" } },

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -186,6 +186,37 @@ describe("ObservabilityView", () => {
     expect(container.textContent).toMatch(/anthropic/);
   });
 
+  it("collapses traces sharing one request_id into one row with a sibling badge", async () => {
+    // Five traces sharing one request_id, only the third has a meaningful
+    // span_count and duration — that's the one the table should pick to
+    // represent the row. The other four become siblings, surfaced as
+    // "+4" next to the request ID.
+    const reqID = "req-shared-id";
+    const startedAt = new Date().toISOString();
+    fetchMock.mockImplementation(tracesFetchHandler([
+      { request_id: reqID, trace_id: "t1", started_at: startedAt, span_count: 4, duration_ms: 1, status_code: "ok", route: { candidates: [{ provider: "lmstudio", model: "x", outcome: "skipped", skip_reason: "unsupported_model" }] } },
+      { request_id: reqID, trace_id: "t2", started_at: startedAt, span_count: 4, status_code: "ok", route: {} },
+      { request_id: reqID, trace_id: "t3", started_at: startedAt, span_count: 6, duration_ms: 17382, status_code: "ok", route: {} },
+      { request_id: reqID, trace_id: "t4", started_at: startedAt, span_count: 4, status_code: "unset", route: {} },
+      { request_id: reqID, trace_id: "t5", started_at: startedAt, span_count: 2, duration_ms: 17502, status_code: "ok", route: {} },
+    ]));
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/req-shar/);
+    });
+    // Exactly one body row, not five.
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+    // The chosen entry is the trace with span_count: 6 / 17382ms.
+    expect(container.textContent).toMatch(/17382ms/);
+    // Sibling count badge surfaces the four collapsed siblings.
+    expect(container.textContent).toMatch(/\+4/);
+  });
+
   it("status filter narrows the table to error rows only", async () => {
     fetchMock.mockImplementation(tracesFetchHandler([
       { request_id: "ok-1", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "openai", final_model: "m1" } },

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -135,6 +135,42 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     });
   }, [traces, providerFilter, modelFilter, statusFilter]);
 
+  // One user-facing request can fan out into multiple internal traces
+  // (route attempts, provider call, auxiliary calls — all sharing
+  // request_id but with distinct trace_id). Showing each trace as its
+  // own row gives the operator five visually-identical rows for one
+  // chat send. Collapse to one row per request_id, keeping the most
+  // span-rich entry as the representative (usually the provider
+  // call), and surface the sibling count as a "+N" badge so the
+  // operator can tell when a request had multiple traces. The detail
+  // panel still operates on the representative trace — drill-down to
+  // sibling traces is a separate feature.
+  const groupedTraces = useMemo(() => {
+    const statusRank = (code?: string) => code === "error" ? 2 : code === "ok" ? 1 : 0;
+    const byID = new Map<string, { entry: typeof filteredTraces[number]; siblings: number }>();
+    for (const t of filteredTraces) {
+      const existing = byID.get(t.request_id);
+      if (!existing) {
+        byID.set(t.request_id, { entry: t, siblings: 0 });
+        continue;
+      }
+      existing.siblings += 1;
+      const incoming = t.span_count ?? 0;
+      const have = existing.entry.span_count ?? 0;
+      // Prefer the trace with more spans (typically the provider call
+      // vs. the route-only attempts). Tie-break by status_code to
+      // surface errors over ok over unset.
+      if (incoming > have || (incoming === have && statusRank(t.status_code) > statusRank(existing.entry.status_code))) {
+        existing.entry = t;
+      }
+    }
+    return Array.from(byID.values()).sort((a, b) => {
+      const ta = a.entry.started_at ? Date.parse(a.entry.started_at) : 0;
+      const tb = b.entry.started_at ? Date.parse(b.entry.started_at) : 0;
+      return tb - ta;
+    });
+  }, [filteredTraces]);
+
   const ledgerByRequest = useMemo(() => {
     const out = new Map<string, NonNullable<typeof state.requestLedger>[number]>();
     for (const entry of state.requestLedger ?? []) {
@@ -144,14 +180,16 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   }, [state.requestLedger]);
 
   // In live mode, auto-highlight the newest visible request. The drawer
-  // does NOT auto-open — opens only on explicit click.
+  // does NOT auto-open — opens only on explicit click. Track by grouped
+  // request_id so the highlight matches what's actually visible in the
+  // table after dedup.
   useEffect(() => {
-    if (!liveMode || filteredTraces.length === 0) return;
-    const newest = filteredTraces[0];
+    if (!liveMode || groupedTraces.length === 0) return;
+    const newest = groupedTraces[0]?.entry;
     if (newest?.request_id) {
       setSelectedID(id => id === newest.request_id ? id : newest.request_id);
     }
-  }, [liveMode, filteredTraces]);
+  }, [liveMode, groupedTraces]);
 
   const fetchTraceDetail = useCallback((reqId: string) => {
     setTraceFetching(true);
@@ -212,7 +250,13 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   }, [selectedID, drawerOpen]);
 
   const stats = runtimeStats;
-  const selectedTrace = traces.find(t => t.request_id === selectedID);
+  // Resolve via groupedTraces so the drawer header/stats mirror the
+  // representative entry the table actually chose for the row. Falling
+  // back to the raw traces array would return the first match — usually
+  // a different sibling than the one shown in the row, so the table
+  // row and the drawer header would disagree on latency/status.
+  const selectedTrace = groupedTraces.find(g => g.entry.request_id === selectedID)?.entry
+    ?? traces.find(t => t.request_id === selectedID);
   const waterfall = useMemo(
     () => buildSpanWaterfall(traceDetail?.spans ?? []),
     [traceDetail?.spans],
@@ -235,9 +279,20 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     }));
   }, [state.settingsConfig, state.providers, state.providerPresets]);
 
-  const drawerTitle = selectedTrace
-    ? `${(selectedTrace.request_id || "").slice(0, 8)}… · ${selectedTrace.route?.final_provider || "—"}/${selectedTrace.route?.final_model || "—"}`
-    : selectedID ? selectedID.slice(0, 8) + "…" : "";
+  const drawerTitle = (() => {
+    if (!selectedTrace) return selectedID ? selectedID.slice(0, 8) + "…" : "";
+    const id = (selectedTrace.request_id || "").slice(0, 8);
+    const prov = selectedTrace.route?.final_provider;
+    const model = selectedTrace.route?.final_model;
+    if (prov || model) return `${id}… · ${prov || "—"}/${model || "—"}`;
+    // No provider was selected — show the rejected candidate (if any)
+    // and label the trace as a route-only attempt so the dash-pair
+    // header doesn't read as missing data. Detailed candidate
+    // breakdown still lives in the Route Summary section below.
+    const rejected = selectedTrace.route?.candidates?.find(c => c.outcome === "skipped");
+    if (rejected) return `${id}… · no provider selected (tried ${rejected.provider})`;
+    return `${id}… · request`;
+  })();
 
   const closeDrawer = () => {
     setDrawerOpen(false);
@@ -395,9 +450,10 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {filteredTraces.map((t, i) => {
+                {groupedTraces.map((group, i) => {
+                  const t = group.entry;
                   const isSel = selectedID === t.request_id;
-                  const isLast = i === filteredTraces.length - 1;
+                  const isLast = i === groupedTraces.length - 1;
                   const status = traceStatusBadge(t);
                   const ledger = ledgerByRequest.get(t.request_id);
                   const cost = ledger?.amount_usd
@@ -412,6 +468,16 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                       : "—";
                   const time = formatRelativeTime(t.started_at || "");
                   const provider = t.route?.final_provider || "";
+                  const model = t.route?.final_model || "";
+                  // When the router skipped every candidate, the
+                  // provider/model cells would otherwise just read "—".
+                  // Show the rejected candidate (muted) with a tooltip
+                  // so the operator can tell at-a-glance that the
+                  // request DID attempt routing — the request didn't
+                  // simply have no provider/model context.
+                  const rejected = !provider && !model
+                    ? t.route?.candidates?.find(c => c.outcome === "skipped")
+                    : undefined;
                   return (
                     <tr
                       key={t.request_id}
@@ -438,10 +504,22 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                               </span>
                               <span style={{ fontSize: 12, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{provider}</span>
                             </>
+                          ) : rejected ? (
+                            <span
+                              style={{ fontSize: 12, color: "var(--t3)", fontStyle: "italic", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                              title={`No candidate accepted. Tried: ${rejected.provider}${rejected.skip_reason ? ` — ${rejected.skip_reason.replace(/_/g, " ")}` : ""}`}>
+                              {rejected.provider}
+                            </span>
                           ) : <span style={{ color: "var(--t3)" }}>—</span>}
                         </div>
                       </td>
-                      <td style={{ ...tdBase, color: "var(--t0)" }}>{t.route?.final_model || "—"}</td>
+                      <td style={{ ...tdBase, color: "var(--t0)" }}>
+                        {model
+                          ? model
+                          : rejected
+                            ? <span style={{ color: "var(--t3)", fontStyle: "italic" }} title="route skipped — see Provider tooltip">{rejected.model}</span>
+                            : "—"}
+                      </td>
                       <td style={{ ...tdBase, color: "var(--t1)", textAlign: "right" }}>
                         {t.duration_ms != null ? `${t.duration_ms}ms` : "—"}
                       </td>
@@ -451,7 +529,22 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                         {t.route?.fallback_from ? `↳ ${t.route.fallback_from}` : "—"}
                       </td>
                       <td style={tdBase} onClick={e => e.stopPropagation()}>
-                        <CopyableID text={t.request_id} />
+                        <div style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                          <CopyableID text={t.request_id} />
+                          {group.siblings > 0 && (
+                            <span
+                              title={`This request produced ${group.siblings + 1} traces; showing the one with the most spans.`}
+                              style={{
+                                fontFamily: "var(--font-mono)", fontSize: 10,
+                                color: "var(--t3)",
+                                background: "var(--bg3)",
+                                border: "1px solid var(--border)",
+                                borderRadius: "var(--radius-sm)",
+                                padding: "0 4px",
+                                lineHeight: 1.4,
+                              }}>+{group.siblings}</span>
+                          )}
+                        </div>
                       </td>
                       <td style={tdBase}></td>
                     </tr>

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -289,8 +289,10 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     // and label the trace as a route-only attempt so the dash-pair
     // header doesn't read as missing data. Detailed candidate
     // breakdown still lives in the Route Summary section below.
+    // `provider` is optional on the candidate type, so fall back to a
+    // dash rather than letting "undefined" reach the rendered header.
     const rejected = selectedTrace.route?.candidates?.find(c => c.outcome === "skipped");
-    if (rejected) return `${id}… · no provider selected (tried ${rejected.provider})`;
+    if (rejected) return `${id}… · no provider selected (tried ${rejected.provider || "—"})`;
     return `${id}… · request`;
   })();
 
@@ -417,7 +419,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
             visible traces. Sits above the table so the operator
             gets a "is this OK right now?" answer before parsing
             individual rows. */}
-        <RecentActivityStrip traces={filteredTraces} />
+        <RecentActivityStrip traces={groupedTraces.map(g => g.entry)} />
 
         {/* Table */}
         {filteredTraces.length > 0 ? (
@@ -474,9 +476,13 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                   // Show the rejected candidate (muted) with a tooltip
                   // so the operator can tell at-a-glance that the
                   // request DID attempt routing — the request didn't
-                  // simply have no provider/model context.
+                  // simply have no provider/model context. Require at
+                  // least a provider name on the candidate: the runtime
+                  // type marks both provider and model as optional, so
+                  // a half-populated entry shouldn't render as "tried
+                  // (empty)".
                   const rejected = !provider && !model
-                    ? t.route?.candidates?.find(c => c.outcome === "skipped")
+                    ? t.route?.candidates?.find(c => c.outcome === "skipped" && !!c.provider)
                     : undefined;
                   return (
                     <tr
@@ -516,7 +522,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                       <td style={{ ...tdBase, color: "var(--t0)" }}>
                         {model
                           ? model
-                          : rejected
+                          : rejected?.model
                             ? <span style={{ color: "var(--t3)", fontStyle: "italic" }} title="route skipped — see Provider tooltip">{rejected.model}</span>
                             : "—"}
                       </td>

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -36,6 +36,9 @@ export function SpanWaterfall({
   }
 
   const ticks = [0, Math.round(totalMs / 3), Math.round((2 * totalMs) / 3), totalMs];
+  // Whether any span is on the critical path. Drives the legend chip
+  // — no point showing "★ critical path" when no row has the star.
+  const hasCriticalPath = spans.some(s => s.critical);
 
   return (
     <div style={{ padding: "10px 12px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
@@ -44,7 +47,7 @@ export function SpanWaterfall({
         <span className="kicker-lg" style={{ fontSize: 12, fontWeight: 500, color: "var(--t0)", letterSpacing: "0.04em", textTransform: "uppercase" }}>
           Spans ({spans.length}) · total {totalMs} ms
         </span>
-        {phases.length > 1 && (
+        {(phases.length > 1 || hasCriticalPath) && (
           <div role="group" aria-label="Phase legend" style={{ display: "flex", gap: 4, flexWrap: "wrap", marginLeft: "auto" }}>
             {phases.map(p => {
               const active = phaseFilter === p;
@@ -71,6 +74,24 @@ export function SpanWaterfall({
                 </button>
               );
             })}
+            {hasCriticalPath && (
+              <span
+                title="Spans on the critical path — the longest dependency chain through this trace."
+                style={{
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-sm)",
+                  padding: "2px 6px",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  color: "var(--t2)",
+                }}>
+                <span style={{ color: "var(--amber)" }}>★</span>
+                critical path
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -95,7 +116,11 @@ export function SpanWaterfall({
         display: "grid",
         gridTemplateColumns: "240px 1fr 60px",
         gap: 8,
-        padding: "6px 0",
+        // paddingRight matches the SpanRow grid below so the time-axis
+        // ticks line up with bar-column edges. Without this the
+        // ruler's "1fr" is 4px wider than each row's "1fr" and the
+        // rightmost tick label drifts past the bar ends.
+        padding: "6px 4px 6px 0",
         marginBottom: 6,
         borderBottom: "1px solid var(--border)",
       }}>


### PR DESCRIPTION
## Summary

In Observability, the Recent Requests table was rendering one row per *trace*, but a single user-facing request can produce multiple internal traces all sharing the same \`request_id\`. In practice a chat send produced four or five visually-identical rows (provider/model both \"—\", same truncated ID). Clicking any of them opened the same detail panel because \`traces.find()\` returned the first array match regardless of which row was clicked.

This PR collapses rows by \`request_id\` and folds in a handful of related polish items from the same audit pass:

- **Group by request_id.** One row per request. The chosen representative is the trace with the most spans (tie-break: errors > ok > unset). Collapsed siblings surface as a \`+N\` badge next to the request ID.
- **Drawer mirrors the row.** \`selectedTrace\` resolves through \`groupedTraces\` first, so the panel's latency and status match the row instead of whichever sibling happened to be first in the array.
- **Friendlier drawer header.** Was \`DEE151F1… · —/—\` when no provider was selected. Now reads \`no provider selected (tried <X>)\` if there's a rejected candidate, or \`request\` if there's no route context at all.
- **Rejected-candidate hints in the table.** When the route skipped every candidate, Provider/Model show the rejected candidate name muted with a tooltip explaining the skip reason instead of a bare \`—\`.
- **★ critical-path legend.** The star marker had only a hover tooltip; added an explicit \`★ critical path\` chip to the phase legend whenever any span is on the critical path.
- **Waterfall padding alignment.** The sticky ruler's \`1fr\` column was 4px wider than each SpanRow's \`1fr\` column (rows had \`paddingRight: 4\`, ruler had none). Time-axis ticks now line up with the bar edges.

Pinned by a new \`ObservabilityView\` test that asserts five traces sharing one \`request_id\` collapse to a single row with the highest-span-count representative and a \`+4\` badge.

## Test plan

- [x] \`bun run test\` — all 687 UI tests pass; one new test added.
- [x] Manual verification against a live dev server with a chat session that produced five traces under one request_id. Confirmed:
  - Table shows one row (was 5).
  - \`+4\` badge appears next to the request ID.
  - Drawer header shows the request label (not \`—/—\`).
  - Drawer latency matches the row's latency.
  - \`★ critical path\` chip visible in the Spans legend.
  - Rightmost time tick aligns with bar edges in the waterfall.
- [ ] Reviewer to sanity-check the dedup heuristic (most spans + status_code tie-break) against any real trace traffic where the \"main\" call might *not* be the one with the most spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)