### PR TITLE
fix: bump local-provider HTTP timeout + outline parent spans in waterfall

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1073,7 +1073,7 @@ func providerDefaults(name, globalDefaultModel string) OpenAICompatibleProviderC
 		Name:         strings.ToLower(strings.TrimSpace(name)),
 		Kind:         "cloud",
 		Protocol:     "openai",
-		Timeout:      30 * time.Second,
+		Timeout:      DefaultProviderTimeout("cloud"),
 		StubMode:     false,
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
 	}
@@ -1098,7 +1098,9 @@ func normalizeProviders(items []OpenAICompatibleProviderConfig) {
 			items[i].Protocol = "openai"
 		}
 		if items[i].Timeout == 0 {
-			items[i].Timeout = 30 * time.Second
+			// At this point Kind has been normalized above ("" → "cloud"),
+			// so DefaultProviderTimeout sees a non-empty kind.
+			items[i].Timeout = DefaultProviderTimeout(items[i].Kind)
 		}
 		if items[i].StubResponse == "" {
 			items[i].StubResponse = "Stubbed response from the AI Agent Runtime MVP."

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,33 @@ import (
 	"time"
 )
 
+func TestDefaultProviderTimeoutBranchesOnKind(t *testing.T) {
+	// Local LLM servers (LMStudio, Ollama) can spend 30–120s loading a
+	// model before the first token comes back. The previous 30s default
+	// tripped agent loops on cold local models with
+	// `context deadline exceeded`. Cloud providers stay on a tighter
+	// budget — p99 chat completions don't approach 60s.
+	cases := []struct {
+		kind string
+		want time.Duration
+	}{
+		{"local", 5 * time.Minute},
+		{"LOCAL", 5 * time.Minute},     // case-insensitive
+		{"  local  ", 5 * time.Minute}, // whitespace-tolerant
+		{"cloud", 60 * time.Second},
+		{"", 60 * time.Second},       // unset → cloud default
+		{"hosted", 60 * time.Second}, // unknown kind → cloud default (safer)
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			got := DefaultProviderTimeout(tc.kind)
+			if got != tc.want {
+				t.Fatalf("DefaultProviderTimeout(%q) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadFromEnvUsesCurrentOpenAIDefaultModel(t *testing.T) {
 	t.Setenv("GATEWAY_DEFAULT_MODEL", "")
 

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -252,6 +252,23 @@ func builtInProviderLookupKey(value string) string {
 	return builtInProviderLookupSanitizer.ReplaceAllString(value, "")
 }
 
+// DefaultProviderTimeout returns the HTTP client timeout used per
+// provider LLM call when the operator hasn't configured one
+// explicitly. Local providers (LMStudio, Ollama, etc.) get a much
+// larger budget than cloud providers because a cold local model can
+// take 30–120s just to produce its first token after a fresh load;
+// the previous unconditional 30s default tripped agent loops on
+// LMStudio with `context deadline exceeded`. Cloud providers get
+// 60s, which still fits well within p99 for chat completions but
+// leaves slack for slow upstreams. Operators who want a different
+// budget can set `Timeout` on the provider config directly.
+func DefaultProviderTimeout(kind string) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(kind), "local") {
+		return 5 * time.Minute
+	}
+	return 60 * time.Second
+}
+
 func (p BuiltInProvider) RuntimeConfig(globalDefaultModel string) OpenAICompatibleProviderConfig {
 	defaultModel := p.DefaultModel
 	if p.ID == "openai" && strings.TrimSpace(globalDefaultModel) != "" {
@@ -265,7 +282,7 @@ func (p BuiltInProvider) RuntimeConfig(globalDefaultModel string) OpenAICompatib
 		APIVersion:   p.APIVersion,
 		ChatPath:     p.ChatPath,
 		ModelsPath:   p.ModelsPath,
-		Timeout:      30 * time.Second,
+		Timeout:      DefaultProviderTimeout(p.Kind),
 		StubMode:     false,
 		StubResponse: p.StubResponse,
 		DefaultModel: defaultModel,

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/hecate/agent-runtime/internal/config"
 	"github.com/hecate/agent-runtime/internal/controlplane"
@@ -217,7 +216,7 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 			APIKey:       apiKey,
 			APIVersion:   item.APIVersion,
 			DefaultModel: item.DefaultModel,
-			Timeout:      30 * time.Second,
+			Timeout:      config.DefaultProviderTimeout(item.Kind),
 			Enabled:      true,
 		}
 		// Apply the gateway-wide Anthropic cache toggle to any
@@ -252,7 +251,7 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 		seen[name] = struct{}{}
 		cfg := byName[name]
 		if cfg.Timeout == 0 {
-			cfg.Timeout = 30 * time.Second
+			cfg.Timeout = config.DefaultProviderTimeout(cfg.Kind)
 		}
 		out = append(out, cfg)
 	}

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -183,8 +183,11 @@ function SpanRow({
     : Math.max((ws.durMs / totalMs) * 100, 0.5);
   const color = phaseColor(ws.phase, ws.span);
   const opacity = isDimmed ? 0.3 : 1;
-  // Duration label inside the bar when wide enough, otherwise to its right.
-  const labelInside = widthPct > 12 && !ws.unknownTiming && !ws.negativeDuration;
+  // Duration label inside the bar when wide enough, otherwise to its
+  // right. Parent spans (hasChildren) render as a thin outlined
+  // bracket — no room for an inside label, so the duration falls back
+  // to the right column.
+  const labelInside = widthPct > 12 && !ws.unknownTiming && !ws.negativeDuration && !ws.hasChildren;
   const durLabel = ws.unknownTiming || ws.negativeDuration ? "?" : `${Math.max(ws.durMs, 0).toFixed(0)}ms`;
   const barTone = ws.unknownTiming || ws.negativeDuration ? "var(--t3)" : (ws.hasError ? "var(--red)" : color);
 
@@ -239,7 +242,13 @@ function SpanRow({
           )}
         </div>
 
-        {/* Bar column */}
+        {/* Bar column. Parent spans (hasChildren) render as a thin
+            outlined bracket so the child rows below show their real
+            offsets without competing with an always-fully-covering
+            parent bar — see hasChildren in runtime-trace.ts.
+            Unknown-timing and negative-duration spans always render
+            as filled markers regardless: the parent/child distinction
+            isn't meaningful when the timing is unusable. */}
         <div style={{ position: "relative", height: 14 }}>
           <div
             style={{
@@ -247,8 +256,10 @@ function SpanRow({
               left: `${leftPct}%`,
               width: `${widthPct}%`,
               minWidth: 2,
-              height: "100%",
-              background: barTone,
+              height: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? 6 : "100%",
+              top: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? 4 : 0,
+              background: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? "transparent" : barTone,
+              border: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? `1px solid ${barTone}` : "none",
               borderRadius: 2,
               display: "flex",
               alignItems: "center",

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -53,6 +53,25 @@ describe("buildSpanWaterfall", () => {
     expect(wf.spans.map((s) => s.span.span_id)).toEqual(["root", "A", "A1", "B"]);
   });
 
+  it("flags spans that have at least one child via hasChildren", () => {
+    // Trace from the dev server: gateway.request is the root and the
+    // other three are its direct children. Only the root should have
+    // hasChildren=true; the leaves stay false. This drives the
+    // outline-vs-filled bar style in SpanWaterfall.
+    const spans: TraceSpanRecord[] = [
+      span({ span_id: "root", name: "gateway.request", start_time: at(0), end_time: at(912) }),
+      span({ span_id: "parse", name: "gateway.request.parse", parent_span_id: "root", start_time: at(43), end_time: at(43) }),
+      span({ span_id: "gov", name: "gateway.governor", parent_span_id: "root", start_time: at(126), end_time: at(912) }),
+      span({ span_id: "rtr", name: "gateway.router", parent_span_id: "root", start_time: at(442), end_time: at(481) }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    const byID = Object.fromEntries(wf.spans.map((s) => [s.span.span_id, s]));
+    expect(byID.root.hasChildren).toBe(true);
+    expect(byID.parse.hasChildren).toBe(false);
+    expect(byID.gov.hasChildren).toBe(false);
+    expect(byID.rtr.hasChildren).toBe(false);
+  });
+
   it("emits a child after its parent in DFS order even when clock skew puts the child's start earlier", () => {
     // Even though A's start (-50) is earlier than root's (0), A must
     // still render below root because of the parent→child relationship.

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -55,6 +55,12 @@ export type WaterfallSpan = {
   critical: boolean;
   unknownTiming: boolean;
   negativeDuration: boolean;
+  // True when at least one other span in the same trace lists this
+  // span as its parent. Drives the renderer's "outline vs filled" bar
+  // style — parent rows are subordinated visually so the leaf spans
+  // underneath show their real start offsets without competing with
+  // an always-fully-covering parent bar.
+  hasChildren: boolean;
 };
 
 export type TraceWaterfall = {
@@ -371,6 +377,13 @@ export function buildSpanWaterfall(spans: TraceSpanRecord[]): TraceWaterfall {
       critical: criticalIDs.has(p.span.span_id),
       unknownTiming,
       negativeDuration,
+      // `children` is indexed by parent_span_id, so a non-empty entry
+      // for this span's id means it has at least one rendered child.
+      // Note: this uses the same visibility filter as the tree
+      // ordering above — children whose parent span was pruned from
+      // the trace render as roots, so the count here matches what the
+      // viewer actually sees.
+      hasChildren: (children.get(p.span.span_id) ?? []).length > 0,
     });
   }
 


### PR DESCRIPTION
## Summary

Two follow-ups from the post-#81 observability review.

### Local provider HTTP timeout — 30s → 5min

User hit \`LLM call failed on turn 2: context deadline exceeded\` after exactly 30s in an agent loop against an LMStudio local model. The 30s budget was hardcoded in three provider-config call sites and is fine for cloud providers, but a cold local model routinely needs 30–120s just to produce its first token after a fresh load.

New \`DefaultProviderTimeout(kind)\` helper in \`internal/config\` — \`5 * time.Minute\` for \`kind == \"local\"\`, \`60s\` otherwise. The three call sites that owned the literal 30s now delegate:

- \`internal/config/config.go\` — \`providerDefaults\` and the \`normalizeProviders\` zero-value pass
- \`internal/config/provider_catalog.go\` — \`BuiltInProvider.RuntimeConfig\`
- \`internal/providers/runtime_manager.go\` — control-plane provider builder + post-merge zero-value pass

Operators who want a different budget still override via \`Timeout\` on the provider config directly. Pinned by a kind-matrix test (local case-insensitive, cloud, empty → cloud, unknown kind → cloud).

### Waterfall — outline parent spans, fill leaves

The drawer's span waterfall rendered every span as a fully-filled bar. A parent like \`gateway.request\` and one of its child spans (\`gateway.governor\` covering ~86% of the parent's duration) read as two competing same-color bars in adjacent rows. Reviewer flagged the result as \"looks duplicated\".

\`buildSpanWaterfall\` now stamps \`hasChildren: boolean\` on each \`WaterfallSpan\` (true when at least one rendered span lists this span as its \`parent_span_id\`). \`SpanWaterfall\` switches bar style on this flag:

- **hasChildren**: thin 6px outlined bracket, transparent fill, 1px colored border, duration label in the right column.
- **leaf**: existing 14px filled bar with inside label when wide enough.

Unknown-timing and negative-duration spans always render as filled markers regardless — the parent/child distinction isn't meaningful when the timing is unusable.

Pinned by a new \`buildSpanWaterfall\` test using the actual parent/child shape we observed in the dev server trace (\`gateway.request\` as root + three sibling children).

## Test plan

- [x] \`go test ./... -race -count=1\` — 1778/1778 pass across 37 packages.
- [x] \`bun run typecheck\` — clean.
- [x] \`bun run test\` — 690/690 pass (was 689, +1).
- [ ] Reviewer to sanity-check the 5min default against any test fixture that depended on the previous 30s timeout firing during the test window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)