### PR TITLE
fix(ui): polish observability trace and runtime UX

### DIFF
--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -200,6 +200,37 @@ describe("ObservabilityView", () => {
     // Provider names appear
     expect(container.textContent).toMatch(/openai/);
     expect(container.textContent).toMatch(/anthropic/);
+    expect(container.textContent).toMatch(/Route/);
+    expect(container.textContent).not.toMatch(/Fallback/);
+    expect(container.textContent).toMatch(/Requested model/);
+  });
+
+  it("folds fallback source into the compact route column", async () => {
+    fetchMock.mockImplementation(tracesFetchHandler([
+      {
+        request_id: "req-fallback",
+        started_at: new Date(Date.now() - 5000).toISOString(),
+        span_count: 1,
+        duration_ms: 12,
+        status_code: "ok",
+        route: {
+          final_provider: "ollama",
+          final_model: "ministral-3:latest",
+          final_reason: "provider_default_model_failover",
+          fallback_from: "openai",
+        },
+      },
+    ]));
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/req-fall/);
+    });
+    expect(container.textContent).toMatch(/Fallback from openai/);
   });
 
   it("collapses traces sharing one request_id into one row with a sibling badge", async () => {

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -13,6 +13,16 @@ const localSession = { label: "Local" };
 
 const fetchMock = vi.fn<typeof fetch>();
 
+function expectHTMLElement(selector: string): HTMLElement {
+  const el = document.querySelector(selector);
+  expect(el).toBeTruthy();
+  return el as HTMLElement;
+}
+
+function normalizedInlineStyle(el: HTMLElement, prop: string): string {
+  return el.style.getPropertyValue(prop).replace(/\s+/g, "");
+}
+
 beforeEach(() => {
   // Default to wide-viewport drawer mode. Individual tests override.
   setViewportWidth(1280);
@@ -424,6 +434,7 @@ describe("ObservabilityView", () => {
       expect(container.textContent).toMatch(/detail-r/);
     });
     const row = container.querySelector("tbody tr") as HTMLElement;
+    expect(row).toBeTruthy();
     await act(async () => { fireEvent.click(row); });
     await waitFor(() => {
       expect(container.textContent).toMatch(/ollama/);
@@ -681,19 +692,19 @@ describe("ObservabilityView", () => {
     expect(document.body.textContent).toMatch(/gateway\.usage/);
     expect(Array.from(document.querySelectorAll('[data-testid="span-waterfall-tick"]')).map(el => el.textContent))
       .toEqual(["0ms", "100ms", "200ms", "300ms", "400ms"]);
-    expect((document.querySelector('[data-testid="span-waterfall-bar-root"]') as HTMLElement).style.left).toBe("0%");
-    expect((document.querySelector('[data-testid="span-waterfall-bar-root"]') as HTMLElement).style.width).toBe("100%");
-    expect((document.querySelector('[data-testid="span-waterfall-bar-child-a"]') as HTMLElement).style.left).toBe("12.5%");
-    expect((document.querySelector('[data-testid="span-waterfall-bar-child-a"]') as HTMLElement).style.width).toBe("62.5%");
-    const waterfallScroller = document.querySelector('[data-testid="span-waterfall-scroll"]') as HTMLElement;
-    expect(waterfallScroller).toBeTruthy();
-    const rootRow = document.querySelector('[aria-label="span provider chain"]') as HTMLElement;
+    const rootBar = expectHTMLElement('[data-testid="span-waterfall-bar-root"]');
+    expect(rootBar.style.left).toBe("0%");
+    expect(rootBar.style.width).toBe("100%");
+    const childABar = expectHTMLElement('[data-testid="span-waterfall-bar-child-a"]');
+    expect(childABar.style.left).toBe("12.5%");
+    expect(childABar.style.width).toBe("62.5%");
+    const waterfallScroller = expectHTMLElement('[data-testid="span-waterfall-scroll"]');
+    const rootRow = expectHTMLElement('[aria-label="span provider chain"]');
     expect(rootRow.style.gridTemplateColumns).toBe("153px minmax(360px, 1fr) 72px");
-    expect(waterfallScroller.style.maxHeight).toBe("min(420px, 52vh)");
+    expect(normalizedInlineStyle(waterfallScroller, "max-height")).toBe("min(420px,52vh)");
     expect(waterfallScroller.style.overflowY).toBe("auto");
-    const eventFlow = document.querySelector('[data-testid="trace-event-flow"]') as HTMLElement;
-    expect(eventFlow).toBeTruthy();
-    expect(eventFlow.style.maxHeight).toBe("min(320px, 42vh)");
+    const eventFlow = expectHTMLElement('[data-testid="trace-event-flow"]');
+    expect(normalizedInlineStyle(eventFlow, "max-height")).toBe("min(320px,42vh)");
     expect(eventFlow.style.overflowY).toBe("auto");
     expect(document.body.textContent).not.toMatch(/★/);
 

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -288,12 +288,13 @@ describe("ObservabilityView", () => {
     await waitFor(() => {
       expect(container.textContent).toMatch(/req-rou/);
     });
-    // Single row collapses both siblings; the row shown is the routed
-    // one (8ms / ollama), not the empty-route 17382ms one.
+    // Single row collapses both siblings; the row uses routed
+    // provider/model context while latency reflects the whole
+    // request window across siblings.
     expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
     expect(container.textContent).toMatch(/ollama/);
     expect(container.textContent).toMatch(/ministral-3:latest/);
-    expect(container.textContent).toMatch(/8ms/);
+    expect(container.textContent).toMatch(/17382ms/);
     expect(container.textContent).toMatch(/\+1/);
   });
 
@@ -463,11 +464,12 @@ describe("ObservabilityView", () => {
     await act(async () => {
       fireEvent.click(row);
     });
-    // Modal opens — title is provider/model; request id is available via the copy button.
+    // Modal opens — visible title is provider/model while the accessible
+    // label also includes the full request id.
     await waitFor(() => {
       const dialog = document.querySelector('[role="dialog"]');
       expect(dialog).toBeTruthy();
-      expect(dialog?.getAttribute("aria-label")).toBe("openai/gpt-4o");
+      expect(dialog?.getAttribute("aria-label")).toBe("openai/gpt-4o · Request req-12345678abcd");
     });
   });
 
@@ -549,7 +551,7 @@ describe("ObservabilityView", () => {
     await waitFor(() => {
       expect(container.textContent).toMatch(/ollama/);
       expect(container.textContent).toMatch(/ministral-3:latest/);
-      expect(document.querySelector('[role="dialog"]')?.getAttribute("aria-label")).toBe("ollama/ministral-3:latest");
+      expect(document.querySelector('[role="dialog"]')?.getAttribute("aria-label")).toBe("ollama/ministral-3:latest · Request detail-route-fallback");
     });
   });
 
@@ -705,6 +707,7 @@ describe("ObservabilityView", () => {
     await waitFor(() => {
       const dialog = document.querySelector('[role="dialog"]');
       expect(dialog).toBeTruthy();
+      expect(dialog?.getAttribute("aria-label")).toMatch(/openai\/gpt-4o · Request req-drawer/);
       // Drawer is inline — its parent is NOT a fixed-position scrim.
       const parent = dialog?.parentElement;
       expect(parent?.getAttribute("style") || "").not.toMatch(/position:\s*fixed/);

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -396,6 +396,41 @@ describe("ObservabilityView", () => {
     });
   });
 
+  it("model filter matches provider-qualified model inventory IDs to trace model names", async () => {
+    fetchMock.mockImplementation(tracesFetchHandler([
+      { request_id: "ministral-req", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "ollama", final_model: "ministral-3:latest" } },
+      { request_id: "other-req", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "openai", final_model: "gpt-4o" } },
+    ]));
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerScopedModels: [
+        { id: "ollama/ministral-3:latest", owned_by: "ollama", metadata: { provider: "ollama" } },
+      ],
+    });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/ministral-3:latest/);
+      expect(container.textContent).toMatch(/gpt-4o/);
+    });
+
+    const select = container.querySelector('[aria-label^="Model picker"]') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(select);
+    });
+    const modelOption = Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("ollama/ministral-3:latest"))!;
+    await act(async () => {
+      fireEvent.click(modelOption);
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/ministral-3:latest/);
+      expect(container.textContent).not.toMatch(/gpt-4o/);
+    });
+  });
+
   it("row click opens the trace detail modal with the trace title", async () => {
     fetchMock.mockImplementation(tracesFetchHandler(
       [{

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -385,6 +385,53 @@ describe("ObservabilityView", () => {
     });
   });
 
+  it("uses selected trace detail spans when list route fields are missing", async () => {
+    const started = new Date().toISOString();
+    fetchMock.mockImplementation(tracesFetchHandler(
+      [{ request_id: "detail-route-fallback", started_at: started, span_count: 1, duration_ms: 1, status_code: "ok", route: {} }],
+      {
+        request_id: "detail-route-fallback",
+        started_at: started,
+        spans: [{
+          trace_id: "trace-detail",
+          span_id: "router",
+          name: "gateway.router",
+          start_time: started,
+          end_time: started,
+          attributes: {
+            "gen_ai.provider.name": "ollama",
+            "gen_ai.request.model": "ministral-3:latest",
+          },
+          events: [{
+            name: "router.selected",
+            timestamp: started,
+            attributes: {
+              "gen_ai.provider.name": "ollama",
+              "gen_ai.request.model": "ministral-3:latest",
+            },
+          }],
+        }],
+        route: { candidates: [] },
+      },
+    ));
+    const state = createRuntimeConsoleFixture({ session: localSession, requestLedger: [] });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/detail-r/);
+    });
+    const row = container.querySelector("tbody tr") as HTMLElement;
+    await act(async () => { fireEvent.click(row); });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/ollama/);
+      expect(container.textContent).toMatch(/ministral-3:latest/);
+      expect(document.querySelector('[role="dialog"]')?.getAttribute("aria-label")).toBe("ollama/ministral-3:latest");
+    });
+  });
+
   it("opens a trace detail drawer when focused by request id", async () => {
     fetchMock.mockImplementation(tracesFetchHandler(
       [{

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -75,6 +75,8 @@ describe("ObservabilityView", () => {
     });
     expect(container.textContent).toMatch(/Observability/);
     expect(container.querySelector('[aria-label="Status filter"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Model filter"]')).toBeTruthy();
+    expect(container.textContent).toMatch(/All models/);
     expect(container.querySelector('[aria-label="Live mode"]')).toBeTruthy();
     expect(container.textContent).toMatch(/Live|Paused/);
   });
@@ -324,6 +326,35 @@ describe("ObservabilityView", () => {
     await waitFor(() => {
       expect(container.textContent).not.toMatch(/ok-1/);
       expect(container.textContent).toMatch(/err-1/);
+    });
+  });
+
+  it("model filter starts at all models and narrows by observed traffic", async () => {
+    fetchMock.mockImplementation(tracesFetchHandler([
+      { request_id: "m1-req", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "openai", final_model: "m1" } },
+      { request_id: "m2-req", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: { final_provider: "ollama", final_model: "m2" } },
+    ]));
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/m1-req/);
+      expect(container.textContent).toMatch(/m2-req/);
+    });
+
+    const select = container.querySelector('[aria-label="Model filter"]') as HTMLSelectElement;
+    expect(select.value).toBe("");
+    expect(Array.from(select.options).map((option) => option.textContent)).toContain("All models");
+
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "m2" } });
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toMatch(/m1-req/);
+      expect(container.textContent).toMatch(/m2-req/);
     });
   });
 

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -225,8 +225,10 @@ describe("ObservabilityView", () => {
     });
     // Exactly one body row, not five.
     expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
-    // The chosen entry is the trace with span_count: 6 / 17382ms.
-    expect(container.textContent).toMatch(/17382ms/);
+    // Latency is request-level across siblings, not the representative
+    // trace duration. The representative remains the 6-span trace, but
+    // the row shows the latest sibling end time for the whole request.
+    expect(container.textContent).toMatch(/17502ms/);
     // Sibling count badge surfaces the four collapsed siblings.
     expect(container.textContent).toMatch(/\+4/);
   });

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -544,7 +544,7 @@ describe("ObservabilityView", () => {
     });
   });
 
-  it("renders the span waterfall with rows, expandable attributes, and a critical-path indicator", async () => {
+  it("renders the span waterfall with rows, expandable attributes, and bounded timelines", async () => {
     const traceID = "trace-abc";
     const t0 = new Date(Date.now() - 1000);
     const spans = [
@@ -557,7 +557,14 @@ describe("ObservabilityView", () => {
       { trace_id: traceID, span_id: "child-a", parent_span_id: "root", name: "provider.openai",
         start_time: new Date(t0.getTime() + 50).toISOString(),
         end_time: new Date(t0.getTime() + 300).toISOString(),
-        attributes: { "gen_ai.provider.name": "openai", model: "gpt-4o" } },
+        attributes: { "gen_ai.provider.name": "openai", model: "gpt-4o" },
+        events: [
+          {
+            name: "provider.request.started",
+            timestamp: new Date(t0.getTime() + 55).toISOString(),
+            attributes: { "gen_ai.provider.name": "openai" },
+          },
+        ] },
       // child B: 310–340ms (shorter)
       { trace_id: traceID, span_id: "child-b", parent_span_id: "root", name: "gateway.usage",
         start_time: new Date(t0.getTime() + 310).toISOString(),
@@ -593,10 +600,21 @@ describe("ObservabilityView", () => {
     expect(document.body.textContent).toMatch(/provider chain/);
     expect(document.body.textContent).toMatch(/provider\.openai/);
     expect(document.body.textContent).toMatch(/gateway\.usage/);
-
-    // Critical-path indicator (★) appears at least twice (root + longest child).
-    const stars = document.body.textContent?.match(/★/g) ?? [];
-    expect(stars.length).toBeGreaterThanOrEqual(2);
+    expect(Array.from(document.querySelectorAll('[data-testid="span-waterfall-tick"]')).map(el => el.textContent))
+      .toEqual(["0ms", "100ms", "200ms", "300ms", "400ms"]);
+    expect((document.querySelector('[data-testid="span-waterfall-bar-root"]') as HTMLElement).style.left).toBe("0%");
+    expect((document.querySelector('[data-testid="span-waterfall-bar-root"]') as HTMLElement).style.width).toBe("100%");
+    expect((document.querySelector('[data-testid="span-waterfall-bar-child-a"]') as HTMLElement).style.left).toBe("12.5%");
+    expect((document.querySelector('[data-testid="span-waterfall-bar-child-a"]') as HTMLElement).style.width).toBe("62.5%");
+    const waterfallScroller = document.querySelector('[data-testid="span-waterfall-scroll"]') as HTMLElement;
+    expect(waterfallScroller).toBeTruthy();
+    expect(waterfallScroller.style.maxHeight).toBe("min(420px, 52vh)");
+    expect(waterfallScroller.style.overflowY).toBe("auto");
+    const eventFlow = document.querySelector('[data-testid="trace-event-flow"]') as HTMLElement;
+    expect(eventFlow).toBeTruthy();
+    expect(eventFlow.style.maxHeight).toBe("min(320px, 42vh)");
+    expect(eventFlow.style.overflowY).toBe("auto");
+    expect(document.body.textContent).not.toMatch(/★/);
 
     // Click the longest child to expand its attributes inline.
     const childARow = Array.from(document.querySelectorAll('[role="button"]'))

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -343,12 +343,45 @@ describe("ObservabilityView", () => {
     await act(async () => {
       fireEvent.click(row);
     });
-    // Modal opens — title contains the truncated request id and provider/model
+    // Modal opens — title is provider/model; request id is available via the copy button.
     await waitFor(() => {
       const dialog = document.querySelector('[role="dialog"]');
       expect(dialog).toBeTruthy();
-      expect(dialog?.getAttribute("aria-label")).toMatch(/req-1234/);
-      expect(dialog?.getAttribute("aria-label")).toMatch(/openai\/gpt-4o/);
+      expect(dialog?.getAttribute("aria-label")).toBe("openai/gpt-4o");
+    });
+  });
+
+  it("uses ledger provider and model when trace route fields are missing", async () => {
+    fetchMock.mockImplementation(tracesFetchHandler([
+      { request_id: "ledger-route-fallback", started_at: new Date().toISOString(), span_count: 1, duration_ms: 1, status_code: "ok", route: {} },
+    ]));
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      requestLedger: [{
+        type: "debit",
+        request_id: "ledger-route-fallback",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        amount_micros_usd: 0,
+        amount_usd: "0",
+        balance_micros_usd: 0,
+        balance_usd: "0",
+        credited_micros_usd: 0,
+        credited_usd: "0",
+        debited_micros_usd: 0,
+        debited_usd: "0",
+      }],
+    });
+    let container = null as unknown as HTMLElement;
+    await act(async () => {
+      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      container = result.container;
+    });
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/ollama/);
+      expect(container.textContent).toMatch(/ministral-3:latest/);
+      expect(container.textContent).toMatch(/ledger-r/);
+      expect(container.textContent).not.toMatch(/ledger-route-fallback/);
     });
   });
 
@@ -384,7 +417,6 @@ describe("ObservabilityView", () => {
       const urls = fetchMock.mock.calls.map(([u]) => String(u));
       expect(urls.some(u => u === "/hecate/v1/traces?request_id=req-focus-from-chat")).toBe(true);
       const dialog = document.querySelector('[role="dialog"]');
-      expect(dialog?.getAttribute("aria-label")).toMatch(/req-focu/);
       expect(dialog?.getAttribute("aria-label")).toMatch(/ollama\/ministral-3:latest/);
     });
   });

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -91,7 +91,7 @@ describe("ObservabilityView", () => {
     });
   });
 
-  it("renders MCP cache panel when configured", async () => {
+  it("renders MCP cache status when configured", async () => {
     fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.startsWith("/hecate/v1/system/mcp/cache")) {
@@ -111,11 +111,14 @@ describe("ObservabilityView", () => {
       container = result.container;
     });
     await waitFor(() => {
-      expect(container.querySelector('[aria-label="MCP cache stats"]')).toBeTruthy();
+      expect(container.querySelector('[aria-label="Storage and MCP cache"]')).toBeTruthy();
+      expect(container.textContent).toMatch(/MCP cache/);
+      expect(container.textContent).toMatch(/4 entries/);
+      expect(container.textContent).toMatch(/1 active · 3 idle/);
     });
   });
 
-  it("renders 'No MCP cache wired' fallback when configured=false", async () => {
+  it("renders disabled MCP cache status when configured=false", async () => {
     fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.startsWith("/hecate/v1/system/mcp/cache")) {
@@ -135,9 +138,10 @@ describe("ObservabilityView", () => {
       container = result.container;
     });
     await waitFor(() => {
-      expect(container.textContent).toMatch(/No MCP cache wired/i);
+      expect(container.textContent).toMatch(/MCP cache/);
+      expect(container.textContent).toMatch(/Disabled/);
     });
-    expect(container.querySelector('[aria-label="MCP cache stats"]')).toBeNull();
+    expect(container.textContent).not.toMatch(/No MCP cache wired/i);
   });
 
   it("renders empty state with Open Chats button when traces is empty", async () => {

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -640,6 +640,8 @@ describe("ObservabilityView", () => {
     expect((document.querySelector('[data-testid="span-waterfall-bar-child-a"]') as HTMLElement).style.width).toBe("62.5%");
     const waterfallScroller = document.querySelector('[data-testid="span-waterfall-scroll"]') as HTMLElement;
     expect(waterfallScroller).toBeTruthy();
+    const rootRow = document.querySelector('[aria-label="span provider chain"]') as HTMLElement;
+    expect(rootRow.style.gridTemplateColumns).toBe("153px minmax(360px, 1fr) 72px");
     expect(waterfallScroller.style.maxHeight).toBe("min(420px, 52vh)");
     expect(waterfallScroller.style.overflowY).toBe("auto");
     const eventFlow = document.querySelector('[data-testid="trace-event-flow"]') as HTMLElement;

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -113,7 +113,7 @@ describe("ObservabilityView", () => {
       container = result.container;
     });
     await waitFor(() => {
-      expect(container.querySelector('[aria-label="Storage and MCP cache"]')).toBeTruthy();
+      expect(container.querySelector('[aria-label="Runtime stats"]')).toBeTruthy();
       expect(container.textContent).toMatch(/MCP cache/);
       expect(container.textContent).toMatch(/4 entries/);
       expect(container.textContent).toMatch(/1 active · 3 idle/);

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -74,8 +74,8 @@ describe("ObservabilityView", () => {
       container = result.container;
     });
     expect(container.textContent).toMatch(/Observability/);
-    expect(container.querySelector('[aria-label="Status filter"]')).toBeTruthy();
-    expect(container.querySelector('[aria-label="Model filter"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label^="Status filter"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label^="Model picker"]')).toBeTruthy();
     expect(container.textContent).toMatch(/All models/);
     expect(container.querySelector('[aria-label="Live mode"]')).toBeTruthy();
     expect(container.textContent).toMatch(/Live|Paused/);
@@ -350,9 +350,13 @@ describe("ObservabilityView", () => {
     await waitFor(() => {
       expect(container.textContent).toMatch(/ok-1/);
     });
-    const select = container.querySelector('[aria-label="Status filter"]') as HTMLSelectElement;
+    const select = container.querySelector('[aria-label^="Status filter"]') as HTMLButtonElement;
     await act(async () => {
-      fireEvent.change(select, { target: { value: "error" } });
+      fireEvent.click(select);
+    });
+    const errorOption = Array.from(document.querySelectorAll("button")).find((button) => button.textContent === "Error")!;
+    await act(async () => {
+      fireEvent.click(errorOption);
     });
     await waitFor(() => {
       expect(container.textContent).not.toMatch(/ok-1/);
@@ -376,12 +380,15 @@ describe("ObservabilityView", () => {
       expect(container.textContent).toMatch(/m2-req/);
     });
 
-    const select = container.querySelector('[aria-label="Model filter"]') as HTMLSelectElement;
-    expect(select.value).toBe("");
-    expect(Array.from(select.options).map((option) => option.textContent)).toContain("All models");
+    const select = container.querySelector('[aria-label^="Model picker"]') as HTMLButtonElement;
+    expect(select.textContent).toContain("All models");
 
     await act(async () => {
-      fireEvent.change(select, { target: { value: "m2" } });
+      fireEvent.click(select);
+    });
+    const modelOption = Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("m2"))!;
+    await act(async () => {
+      fireEvent.click(modelOption);
     });
     await waitFor(() => {
       expect(container.textContent).not.toMatch(/m1-req/);

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -123,17 +123,34 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     return () => window.clearInterval(interval);
   }, [loadTraces]);
 
+  const ledgerByRequest = useMemo(() => {
+    const out = new Map<string, NonNullable<typeof state.requestLedger>[number]>();
+    for (const entry of state.requestLedger ?? []) {
+      if (entry.request_id) out.set(entry.request_id, entry);
+    }
+    return out;
+  }, [state.requestLedger]);
+
+  const traceProvider = useCallback(
+    (trace: TraceListItem) => trace.route?.final_provider || ledgerByRequest.get(trace.request_id)?.provider || "",
+    [ledgerByRequest],
+  );
+  const traceModel = useCallback(
+    (trace: TraceListItem) => trace.route?.final_model || ledgerByRequest.get(trace.request_id)?.model || "",
+    [ledgerByRequest],
+  );
+
   // Filter traces before deriving the live-mode auto-selection so the
   // highlight tracks what the operator is actually looking at.
   const filteredTraces = useMemo(() => {
     return traces.filter(t => {
-      if (providerFilter !== "auto" && t.route?.final_provider !== providerFilter) return false;
-      if (modelFilter && t.route?.final_model !== modelFilter) return false;
+      if (providerFilter !== "auto" && traceProvider(t) !== providerFilter) return false;
+      if (modelFilter && traceModel(t) !== modelFilter) return false;
       if (statusFilter === "healthy" && t.status_code === "error") return false;
       if (statusFilter === "error" && t.status_code !== "error") return false;
       return true;
     });
-  }, [traces, providerFilter, modelFilter, statusFilter]);
+  }, [traces, providerFilter, modelFilter, statusFilter, traceProvider, traceModel]);
 
   // One user-facing request can fan out into multiple internal traces
   // (route attempts, provider call, auxiliary calls — all sharing
@@ -155,7 +172,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     // — otherwise the drawer header shows "request" or "—/—" even
     // though we know which provider handled the chat.
     const hasRoute = (t: typeof filteredTraces[number]) =>
-      !!(t.route?.final_provider || t.route?.final_model);
+      !!(traceProvider(t) || traceModel(t));
     const byID = new Map<string, { entry: typeof filteredTraces[number]; siblings: number }>();
     for (const t of filteredTraces) {
       const existing = byID.get(t.request_id);
@@ -185,15 +202,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
       const tb = b.entry.started_at ? Date.parse(b.entry.started_at) : 0;
       return tb - ta;
     });
-  }, [filteredTraces]);
-
-  const ledgerByRequest = useMemo(() => {
-    const out = new Map<string, NonNullable<typeof state.requestLedger>[number]>();
-    for (const entry of state.requestLedger ?? []) {
-      if (entry.request_id) out.set(entry.request_id, entry);
-    }
-    return out;
-  }, [state.requestLedger]);
+  }, [filteredTraces, traceProvider, traceModel]);
 
   // In live mode, auto-highlight the newest visible request. The drawer
   // does NOT auto-open — opens only on explicit click. Track by grouped
@@ -296,11 +305,10 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   }, [state.settingsConfig, state.providers, state.providerPresets]);
 
   const drawerTitle = (() => {
-    if (!selectedTrace) return selectedID ? selectedID.slice(0, 8) + "…" : "";
-    const id = (selectedTrace.request_id || "").slice(0, 8);
-    const prov = selectedTrace.route?.final_provider;
-    const model = selectedTrace.route?.final_model;
-    if (prov || model) return `${id}… · ${prov || "—"}/${model || "—"}`;
+    if (!selectedTrace) return selectedID ?? "";
+    const prov = traceProvider(selectedTrace);
+    const model = traceModel(selectedTrace);
+    if (prov || model) return `${prov || "—"}/${model || "—"}`;
     // No provider was selected — show the rejected candidate (if any)
     // and label the trace as a route-only attempt so the dash-pair
     // header doesn't read as missing data. Detailed candidate
@@ -308,8 +316,8 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     // `provider` is optional on the candidate type, so fall back to a
     // dash rather than letting "undefined" reach the rendered header.
     const rejected = selectedTrace.route?.candidates?.find(c => c.outcome === "skipped");
-    if (rejected) return `${id}… · no provider selected (tried ${rejected.provider || "—"})`;
-    return `${id}… · request`;
+    if (rejected) return `No provider selected (tried ${rejected.provider || "—"})`;
+    return "Request";
   })();
 
   const closeDrawer = () => {
@@ -485,8 +493,8 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                       ? t.status_message
                       : "—";
                   const time = formatRelativeTime(t.started_at || "");
-                  const provider = t.route?.final_provider || "";
-                  const model = t.route?.final_model || "";
+                  const provider = traceProvider(t);
+                  const model = traceModel(t);
                   // When the router skipped every candidate, the
                   // provider/model cells would otherwise just read "—".
                   // Show the rejected candidate (muted) with a tooltip
@@ -552,7 +560,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                       </td>
                       <td style={tdBase} onClick={e => e.stopPropagation()}>
                         <div style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                          <CopyableID text={t.request_id} />
+                          <CopyableID text={t.request_id} compact />
                           {group.siblings > 0 && (
                             <span
                               title={`This request produced ${group.siblings + 1} traces; showing the one with the most spans.`}

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -5,7 +5,7 @@
 // `./observability/`; this file is orchestration only — state, polling
 // effects, filter computation, and layout.
 
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { getMCPCacheStats, getRecentTraces, getRuntimeStats, getTrace } from "../../lib/api";
@@ -462,9 +462,9 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
 
         {/* Runtime health cards */}
         {(stats || mcpCacheStats) && (
-          <div style={{ display: "grid", gap: 10, marginBottom: 20 }} aria-label="Runtime stats">
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 20 }} aria-label="Runtime stats">
             {stats && (
-              <StatGroup title="Task runtime" summary={runtimeSummary(stats)}>
+              <>
                 <StatCard
                   label="Queue depth"
                   value={stats.queue_depth > 0 ? stats.queue_depth : "Idle"}
@@ -505,10 +505,6 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                   help="Runs paused on an operator approval gate."
                   highlight={stats.awaiting_approval_runs > 0}
                 />
-              </StatGroup>
-            )}
-            {(stats?.store_backend || mcpCacheStats) && (
-              <StatGroup title="Storage and MCP cache">
                 {stats?.store_backend && (
                   <StatCard
                     label="Runtime store"
@@ -516,26 +512,24 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                     help="Persistence backend for runtime state."
                   />
                 )}
-                {mcpCacheStats && (
-                  mcpCacheStats.configured ? (
-                    <>
-                      <StatCard
-                        label="MCP cache"
-                        value={`${mcpCacheStats.entries} entries`}
-                        sub={`${mcpCacheStats.in_use} active · ${mcpCacheStats.idle} idle`}
-                        help="Cached MCP clients available for reuse."
-                        highlight={mcpCacheStats.in_use > 0}
-                      />
-                    </>
-                  ) : (
-                    <StatCard
-                      label="MCP cache"
-                      value="Disabled"
-                      help="No MCP cache is configured for this gateway."
-                    />
-                  )
-                )}
-              </StatGroup>
+              </>
+            )}
+            {mcpCacheStats && (
+              mcpCacheStats.configured ? (
+                <StatCard
+                  label="MCP cache"
+                  value={`${mcpCacheStats.entries} entries`}
+                  sub={`${mcpCacheStats.in_use} active · ${mcpCacheStats.idle} idle`}
+                  help="Cached MCP clients available for reuse."
+                  highlight={mcpCacheStats.in_use > 0}
+                />
+              ) : (
+                <StatCard
+                  label="MCP cache"
+                  value="Disabled"
+                  help="No MCP cache is configured for this gateway."
+                />
+              )
             )}
           </div>
         )}
@@ -765,37 +759,6 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   );
 }
 
-function StatGroup({ title, summary, children }: { title: string; summary?: string; children: ReactNode }) {
-  return (
-    <section
-      className="card"
-      aria-label={title}
-      style={{
-        padding: 10,
-        display: "grid",
-        gap: 8,
-      }}>
-      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "baseline" }}>
-        <div className="kicker" style={{ color: "var(--t2)" }}>{title}</div>
-        {summary && (
-          <div
-            style={{
-              fontSize: 11,
-              color: "var(--t3)",
-              fontFamily: "var(--font-mono)",
-              textAlign: "right",
-            }}>
-            {summary}
-          </div>
-        )}
-      </div>
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        {children}
-      </div>
-    </section>
-  );
-}
-
 const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
   { value: "all", label: "All" },
   { value: "healthy", label: "Healthy" },
@@ -939,23 +902,6 @@ function routeSummaryLabel(trace: TraceListItem): { label: string; title: string
   return { label: "No route", title: "No route summary was recorded for this request.", tone: "empty" };
 }
 
-function runtimeSummary(stats: RuntimeStatsResponse["data"]): string {
-  if (stats.awaiting_approval_runs > 0) {
-    return `${stats.awaiting_approval_runs} ${plural(stats.awaiting_approval_runs, "run")} waiting for approval`;
-  }
-  if (stats.running_runs > 0 || stats.in_flight_jobs > 0) {
-    return `${stats.running_runs} ${plural(stats.running_runs, "run")} running, ${stats.in_flight_jobs} active ${plural(stats.in_flight_jobs, "job")}`;
-  }
-  if (stats.queue_depth > 0 || stats.queued_runs > 0) {
-    return `${stats.queue_depth || stats.queued_runs} queued, ${stats.worker_count} ${plural(stats.worker_count, "runner")} available`;
-  }
-  return `${stats.worker_count} ${plural(stats.worker_count, "task runner")} available, no queued work`;
-}
-
 function describeStoreBackend(backend: string): string {
   return backend === "memory" ? "Memory store" : backend;
-}
-
-function plural(count: number, singular: string): string {
-  return count === 1 ? singular : `${singular}s`;
 }

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -212,6 +212,18 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     });
   }, [filteredTraces, traceProvider, traceModel]);
 
+  const traceLabelsByRequestID = useMemo(() => {
+    const out = new Map<string, { provider?: string; model?: string }>();
+    for (const group of groupedTraces) {
+      const provider = traceProvider(group.entry);
+      const model = traceModel(group.entry);
+      if (provider || model) {
+        out.set(group.entry.request_id, { provider, model });
+      }
+    }
+    return out;
+  }, [groupedTraces, traceProvider, traceModel]);
+
   // In live mode, auto-highlight the newest visible request. The drawer
   // does NOT auto-open — opens only on explicit click. Track by grouped
   // request_id so the highlight matches what's actually visible in the
@@ -451,7 +463,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
             visible traces. Sits above the table so the operator
             gets a "is this OK right now?" answer before parsing
             individual rows. */}
-        <RecentActivityStrip traces={groupedTraces.map(g => g.entry)} />
+        <RecentActivityStrip traces={groupedTraces.map(g => g.entry)} labelsByRequestID={traceLabelsByRequestID} />
 
         {/* Table */}
         {filteredTraces.length > 0 ? (

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -27,7 +27,7 @@ import type {
   TraceListItem,
   TraceResponse,
 } from "../../types/runtime";
-import { Badge, Icon, Icons, Modal, ModelPicker, ProviderPicker, Toggle } from "../shared/ui";
+import { Badge, Icon, Icons, Modal, ProviderPicker, Toggle } from "../shared/ui";
 
 import { CopyableID } from "./observability/CopyableID";
 import { RecentActivityStrip } from "./observability/RecentActivityStrip";
@@ -333,6 +333,28 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     }));
   }, [state.settingsConfig, state.providers, state.providerPresets]);
 
+  const modelOptions = useMemo(() => {
+    const byID = new Map<string, { id: string; provider?: string }>();
+    const add = (id?: string, provider?: string) => {
+      const trimmed = id?.trim();
+      if (!trimmed) return;
+      if (providerFilter !== "auto" && provider && provider !== providerFilter) return;
+      byID.set(trimmed, { id: trimmed, provider });
+    };
+
+    for (const trace of traces) {
+      add(traceModel(trace), traceProvider(trace));
+    }
+    for (const entry of state.requestLedger ?? []) {
+      add(entry.model, entry.provider);
+    }
+    for (const model of state.providerScopedModels) {
+      add(model.id, model.metadata?.provider);
+    }
+
+    return Array.from(byID.values()).sort((a, b) => a.id.localeCompare(b.id));
+  }, [providerFilter, state.providerScopedModels, state.requestLedger, traceModel, traceProvider, traces]);
+
   const drawerTitle = (() => {
     if (!selectedTrace) return selectedID ?? "";
     const prov = traceProvider(selectedTrace);
@@ -407,17 +429,26 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
           <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
             <ProviderPicker
               value={providerFilter}
-              onChange={setProviderFilter}
+              onChange={(value) => {
+                setProviderFilter(value);
+                setModelFilter("");
+              }}
               options={providerOptions}
               includeAuto
             />
-            <ModelPicker
+            <select
+              className="input"
+              aria-label="Model filter"
               value={modelFilter}
-              onChange={setModelFilter}
-              models={state.providerScopedModels}
-              presets={state.providerPresets}
-              showProvider={providerFilter === "auto"}
-            />
+              onChange={e => setModelFilter(e.target.value)}
+              style={{ fontSize: 11, padding: "4px 8px", height: 28, minWidth: 180 }}>
+              <option value="">All models</option>
+              {modelOptions.map((model) => (
+                <option key={`${model.provider ?? "any"}:${model.id}`} value={model.id}>
+                  {providerFilter === "auto" && model.provider ? `${model.id} · ${model.provider}` : model.id}
+                </option>
+              ))}
+            </select>
             <select
               className="input"
               aria-label="Status filter"
@@ -429,7 +460,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
               <option value="error">Error</option>
             </select>
             <Toggle on={liveMode} onChange={setLiveMode} ariaLabel="Live mode" />
-            <span style={{ fontSize: 11, color: liveMode ? "var(--teal)" : "var(--t3)" }}>
+            <span style={{ fontSize: 11, color: liveMode ? "var(--teal)" : "var(--t3)", width: 42, display: "inline-block" }}>
               {liveMode ? "Live" : "Paused"}
             </span>
           </div>

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -51,6 +51,14 @@ type Props = {
   focusRequest?: { requestID: string; nonce: number } | null;
 };
 
+type TraceGroup = {
+  entry: TraceListItem;
+  siblings: number;
+  earliestMs?: number;
+  latestMs?: number;
+  latencyMs?: number;
+};
+
 export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   const [runtimeStats, setRuntimeStats] = useState<RuntimeStatsResponse["data"] | null>(null);
   const [mcpCacheStats, setMCPCacheStats] = useState<MCPCacheStatsResponse["data"] | null>(null);
@@ -181,14 +189,15 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     // though we know which provider handled the chat.
     const hasRoute = (t: typeof filteredTraces[number]) =>
       !!(traceProvider(t) || traceModel(t));
-    const byID = new Map<string, { entry: typeof filteredTraces[number]; siblings: number }>();
+    const byID = new Map<string, TraceGroup>();
     for (const t of filteredTraces) {
       const existing = byID.get(t.request_id);
       if (!existing) {
-        byID.set(t.request_id, { entry: t, siblings: 0 });
+        byID.set(t.request_id, applyTraceWindow({ entry: t, siblings: 0 }, t));
         continue;
       }
       existing.siblings += 1;
+      applyTraceWindow(existing, t);
       // Decision order: route info > span count > status (errors win).
       const incomingHasRoute = hasRoute(t);
       const haveHasRoute = hasRoute(existing.entry);
@@ -565,6 +574,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                   const time = formatRelativeTime(t.started_at || "");
                   const provider = traceProvider(t);
                   const model = traceModel(t);
+                  const latency = group.latencyMs ?? t.duration_ms;
                   // When the router skipped every candidate, the
                   // provider/model cells would otherwise just read "—".
                   // Show the rejected candidate (muted) with a tooltip
@@ -621,7 +631,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                             : "—"}
                       </td>
                       <td style={{ ...tdBase, color: "var(--t1)", textAlign: "right" }}>
-                        {t.duration_ms != null ? `${t.duration_ms}ms` : "—"}
+                        {latency != null ? `${latency}ms` : "—"}
                       </td>
                       <td style={{ ...tdBase, color: "var(--t1)", textAlign: "right" }}>{cost}</td>
                       <td style={{ ...tdBase, color: "var(--t2)" }} title={reason}>{reason}</td>
@@ -765,6 +775,26 @@ function normalizeRuntimeStats(stats: RuntimeStatsResponse["data"] | null): Runt
     return null;
   }
   return stats;
+}
+
+function applyTraceWindow(
+  group: TraceGroup,
+  trace: TraceListItem,
+): TraceGroup {
+  if (typeof trace.duration_ms !== "number" || trace.duration_ms < 0) {
+    return group;
+  }
+  const startMs = trace.started_at ? Date.parse(trace.started_at) : NaN;
+  if (!Number.isFinite(startMs)) {
+    group.latencyMs ??= trace.duration_ms;
+    return group;
+  }
+
+  const endMs = startMs + trace.duration_ms;
+  group.earliestMs = group.earliestMs == null ? startMs : Math.min(group.earliestMs, startMs);
+  group.latestMs = group.latestMs == null ? endMs : Math.max(group.latestMs, endMs);
+  group.latencyMs = Math.max(0, Math.round(group.latestMs - group.earliestMs));
+  return group;
 }
 
 function runtimeSummary(stats: RuntimeStatsResponse["data"]): string {

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -235,6 +235,15 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     }
     return out;
   }, [groupedTraces, traceProvider, traceModel]);
+  const traceLatencyByRequestID = useMemo(() => {
+    const out = new Map<string, number>();
+    for (const group of groupedTraces) {
+      if (typeof group.latencyMs === "number") {
+        out.set(group.entry.request_id, group.latencyMs);
+      }
+    }
+    return out;
+  }, [groupedTraces]);
 
   // In live mode, auto-highlight the newest visible request. The drawer
   // does NOT auto-open — opens only on explicit click. Track by grouped
@@ -377,6 +386,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     if (rejected) return `No provider selected (tried ${rejected.provider || "—"})`;
     return "Request";
   })();
+  const drawerDialogLabel = selectedID ? `${drawerTitle} · Request ${selectedID}` : drawerTitle;
 
   const closeDrawer = () => {
     setDrawerOpen(false);
@@ -551,7 +561,11 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
             visible traces. Sits above the table so the operator
             gets a "is this OK right now?" answer before parsing
             individual rows. */}
-        <RecentActivityStrip traces={groupedTraces.map(g => g.entry)} labelsByRequestID={traceLabelsByRequestID} />
+        <RecentActivityStrip
+          traces={groupedTraces.map(g => g.entry)}
+          labelsByRequestID={traceLabelsByRequestID}
+          latencyByRequestID={traceLatencyByRequestID}
+        />
 
         {/* Table */}
         {filteredTraces.length > 0 ? (
@@ -717,7 +731,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
       {drawerActive && (
         <div
           role="dialog"
-          aria-label={drawerTitle}
+          aria-label={drawerDialogLabel}
           style={{
             flex: "1 1 50%",
             minHeight: 0,
@@ -759,6 +773,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
       {!useDrawer && drawerOpen && selectedID && (
         <Modal
           title={drawerTitle}
+          ariaLabel={drawerDialogLabel}
           onClose={closeDrawer}
           footer={null}
           width={760}>

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -12,6 +12,8 @@ import { getMCPCacheStats, getRecentTraces, getRuntimeStats, getTrace } from "..
 import {
   buildSpanWaterfall,
   buildTraceTimeline,
+  findModelInTrace,
+  findProviderInTrace,
   type TraceTimelineItem,
 } from "../../lib/runtime-trace";
 import {
@@ -132,12 +134,18 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   }, [state.requestLedger]);
 
   const traceProvider = useCallback(
-    (trace: TraceListItem) => trace.route?.final_provider || ledgerByRequest.get(trace.request_id)?.provider || "",
-    [ledgerByRequest],
+    (trace: TraceListItem) => trace.route?.final_provider
+      || (traceDetail?.request_id === trace.request_id ? findProviderInTrace(traceDetail.spans ?? []) : "")
+      || ledgerByRequest.get(trace.request_id)?.provider
+      || "",
+    [ledgerByRequest, traceDetail],
   );
   const traceModel = useCallback(
-    (trace: TraceListItem) => trace.route?.final_model || ledgerByRequest.get(trace.request_id)?.model || "",
-    [ledgerByRequest],
+    (trace: TraceListItem) => trace.route?.final_model
+      || (traceDetail?.request_id === trace.request_id ? findModelInTrace(traceDetail.spans ?? [], traceProvider(trace)) : "")
+      || ledgerByRequest.get(trace.request_id)?.model
+      || "",
+    [ledgerByRequest, traceDetail, traceProvider],
   );
 
   // Filter traces before deriving the live-mode auto-selection so the

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -5,7 +5,7 @@
 // `./observability/`; this file is orchestration only — state, polling
 // effects, filter computation, and layout.
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { getMCPCacheStats, getRecentTraces, getRuntimeStats, getTrace } from "../../lib/api";
@@ -23,11 +23,14 @@ import {
 } from "../../lib/runtime-utils";
 import type {
   MCPCacheStatsResponse,
+  ModelRecord,
   RuntimeStatsResponse,
   TraceListItem,
   TraceResponse,
 } from "../../types/runtime";
-import { Badge, Icon, Icons, Modal, ProviderPicker, Toggle } from "../shared/ui";
+import { focusDropdownItem, focusInitialDropdownItem } from "../shared/dropdownKeyboard";
+import { useFloatingDropdownStyle } from "../shared/useFloatingDropdownStyle";
+import { Badge, Icon, Icons, Modal, ModelPicker, ProviderPicker, Toggle } from "../shared/ui";
 
 import { CopyableID } from "./observability/CopyableID";
 import { RecentActivityStrip } from "./observability/RecentActivityStrip";
@@ -333,13 +336,17 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     }));
   }, [state.settingsConfig, state.providers, state.providerPresets]);
 
-  const modelOptions = useMemo(() => {
-    const byID = new Map<string, { id: string; provider?: string }>();
+  const modelOptions = useMemo<ModelRecord[]>(() => {
+    const byID = new Map<string, ModelRecord>();
     const add = (id?: string, provider?: string) => {
       const trimmed = id?.trim();
       if (!trimmed) return;
       if (providerFilter !== "auto" && provider && provider !== providerFilter) return;
-      byID.set(trimmed, { id: trimmed, provider });
+      byID.set(trimmed, {
+        id: trimmed,
+        owned_by: provider || "observed",
+        metadata: provider ? { provider } : undefined,
+      });
     };
 
     for (const trace of traces) {
@@ -436,29 +443,16 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
               options={providerOptions}
               includeAuto
             />
-            <select
-              className="input"
-              aria-label="Model filter"
+            <ModelPicker
               value={modelFilter}
-              onChange={e => setModelFilter(e.target.value)}
-              style={{ fontSize: 11, padding: "4px 8px", height: 28, minWidth: 180 }}>
-              <option value="">All models</option>
-              {modelOptions.map((model) => (
-                <option key={`${model.provider ?? "any"}:${model.id}`} value={model.id}>
-                  {providerFilter === "auto" && model.provider ? `${model.id} · ${model.provider}` : model.id}
-                </option>
-              ))}
-            </select>
-            <select
-              className="input"
-              aria-label="Status filter"
-              value={statusFilter}
-              onChange={e => setStatusFilter(e.target.value as StatusFilter)}
-              style={{ fontSize: 11, padding: "4px 8px", height: 28 }}>
-              <option value="all">All</option>
-              <option value="healthy">Healthy</option>
-              <option value="error">Error</option>
-            </select>
+              onChange={setModelFilter}
+              models={modelOptions}
+              presets={state.providerPresets}
+              showProvider={providerFilter === "auto"}
+              includeAll
+              triggerWidth={220}
+            />
+            <StatusFilterPicker value={statusFilter} onChange={setStatusFilter} />
             <Toggle on={liveMode} onChange={setLiveMode} ariaLabel="Live mode" />
             <span style={{ fontSize: 11, color: liveMode ? "var(--teal)" : "var(--t3)", width: 42, display: "inline-block" }}>
               {liveMode ? "Live" : "Paused"}
@@ -799,6 +793,101 @@ function StatGroup({ title, summary, children }: { title: string; summary?: stri
         {children}
       </div>
     </section>
+  );
+}
+
+const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "healthy", label: "Healthy" },
+  { value: "error", label: "Error" },
+];
+
+function StatusFilterPicker({ value, onChange }: { value: StatusFilter; onChange: (value: StatusFilter) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const floatingStyle = useFloatingDropdownStyle(triggerRef, open, "right");
+  const label = STATUS_FILTER_OPTIONS.find((option) => option.value === value)?.label ?? "All";
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (ref.current && ref.current.contains(target)) return;
+      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => focusInitialDropdownItem(menuRef.current));
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  function closeMenu() {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function onMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      focusDropdownItem(menuRef.current, event.key);
+    }
+  }
+
+  return (
+    <div className="dropdown-wrap" ref={ref}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={`Status filter: ${label}`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="btn btn-ghost btn-sm"
+        onClick={() => setOpen((current) => !current)}
+        style={{ fontFamily: "var(--font-mono)", fontSize: 11, gap: 5, color: "var(--t1)", width: 110 }}>
+        <span style={{ flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", textAlign: "left" }}>
+          {label}
+        </span>
+        <Icon d={Icons.chevD} size={11} />
+      </button>
+      {open && floatingStyle && (
+        <div
+          ref={menuRef}
+          role="listbox"
+          className="dropdown-menu dropdown-menu-floating"
+          onKeyDown={onMenuKeyDown}
+          style={{ ...floatingStyle, minWidth: 110 }}>
+          {STATUS_FILTER_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              data-dropdown-item
+              data-selected={value === option.value ? "true" : undefined}
+              role="option"
+              aria-selected={value === option.value}
+              className={`dropdown-item ${value === option.value ? "selected" : ""}`}
+              onClick={() => {
+                onChange(option.value);
+                closeMenu();
+              }}>
+              <span style={{ flex: 1, fontFamily: "var(--font-mono)", fontSize: 12, textAlign: "left" }}>
+                {option.label}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -164,7 +164,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   const filteredTraces = useMemo(() => {
     return traces.filter(t => {
       if (providerFilter !== "auto" && traceProvider(t) !== providerFilter) return false;
-      if (modelFilter && traceModel(t) !== modelFilter) return false;
+      if (modelFilter && !modelMatchesFilter(traceModel(t), modelFilter)) return false;
       if (statusFilter === "healthy" && t.status_code === "error") return false;
       if (statusFilter === "error" && t.status_code !== "error") return false;
       return true;
@@ -434,25 +434,6 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
           <span style={{ fontSize: 14, fontWeight: 500, color: "var(--t0)" }}>Observability</span>
 
           <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
-            <ProviderPicker
-              value={providerFilter}
-              onChange={(value) => {
-                setProviderFilter(value);
-                setModelFilter("");
-              }}
-              options={providerOptions}
-              includeAuto
-            />
-            <ModelPicker
-              value={modelFilter}
-              onChange={setModelFilter}
-              models={modelOptions}
-              presets={state.providerPresets}
-              showProvider={providerFilter === "auto"}
-              includeAll
-              triggerWidth={220}
-            />
-            <StatusFilterPicker value={statusFilter} onChange={setStatusFilter} />
             <Toggle on={liveMode} onChange={setLiveMode} ariaLabel="Live mode" />
             <span style={{ fontSize: 11, color: liveMode ? "var(--teal)" : "var(--t3)", width: 42, display: "inline-block" }}>
               {liveMode ? "Live" : "Paused"}
@@ -534,8 +515,37 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
           </div>
         )}
 
-        {/* Recent requests label */}
-        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", marginBottom: 10 }}>Recent requests</div>
+        {/* Recent requests filters */}
+        <div style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          justifyContent: "space-between",
+          marginBottom: 10,
+        }}>
+          <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)" }}>Recent requests</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <ProviderPicker
+              value={providerFilter}
+              onChange={(value) => {
+                setProviderFilter(value);
+                setModelFilter("");
+              }}
+              options={providerOptions}
+              includeAuto
+            />
+            <ModelPicker
+              value={modelFilter}
+              onChange={setModelFilter}
+              models={modelOptions}
+              presets={state.providerPresets}
+              showProvider={providerFilter === "auto"}
+              includeAll
+              triggerWidth={220}
+            />
+            <StatusFilterPicker value={statusFilter} onChange={setStatusFilter} />
+          </div>
+        </div>
 
         {/* Activity strip — status dots + p50/p95/errors over the
             visible traces. Sits above the table so the operator
@@ -900,6 +910,29 @@ function routeSummaryLabel(trace: TraceListItem): { label: string; title: string
     return { label: trace.status_message, title: trace.status_message, tone: "default" };
   }
   return { label: "No route", title: "No route summary was recorded for this request.", tone: "empty" };
+}
+
+function modelMatchesFilter(model: string, filter: string): boolean {
+  const normalizedModel = normalizeModelFilterValue(model);
+  const normalizedFilter = normalizeModelFilterValue(filter);
+  if (!normalizedModel || !normalizedFilter) return false;
+  if (normalizedModel === normalizedFilter) return true;
+
+  // Some inventories carry provider-qualified IDs while traces usually
+  // record the served model name. Keep filtering forgiving so choosing
+  // "ollama/ministral-3:latest" still matches a trace whose final_model
+  // is "ministral-3:latest".
+  const suffixes = [
+    `/${normalizedModel}`,
+    `::${normalizedModel}`,
+    `:${normalizedModel}`,
+    ` ${normalizedModel}`,
+  ];
+  return suffixes.some((suffix) => normalizedFilter.endsWith(suffix));
+}
+
+function normalizeModelFilterValue(value: string): string {
+  return value.trim().toLowerCase();
 }
 
 function describeStoreBackend(backend: string): string {

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -5,7 +5,7 @@
 // `./observability/`; this file is orchestration only — state, polling
 // effects, filter computation, and layout.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { getMCPCacheStats, getRecentTraces, getRuntimeStats, getTrace } from "../../lib/api";
@@ -294,7 +294,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedID, drawerOpen]);
 
-  const stats = runtimeStats;
+  const stats = normalizeRuntimeStats(runtimeStats);
   // Resolve via groupedTraces so the drawer header/stats mirror the
   // representative entry the table actually chose for the row. Falling
   // back to the raw traces array would return the first match — usually
@@ -426,32 +426,82 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
           </div>
         </div>
 
-        {/* Stat strip */}
+        {/* Runtime health cards */}
         {(stats || mcpCacheStats) && (
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 20 }} aria-label="Runtime stats">
+          <div style={{ display: "grid", gap: 10, marginBottom: 20 }} aria-label="Runtime stats">
             {stats && (
-              <>
-                <StatCard label="queue depth" value={stats.queue_depth} sub={stats.queue_capacity ? `cap ${stats.queue_capacity}` : undefined} highlight={stats.queue_depth > 0} />
-                <StatCard label="workers" value={stats.worker_count} />
-                <StatCard label="in-flight" value={stats.in_flight_jobs} highlight={stats.in_flight_jobs > 0} />
-                <StatCard label="running" value={stats.running_runs} highlight={stats.running_runs > 0} />
-                {stats.queued_runs > 0 && <StatCard label="queued" value={stats.queued_runs} highlight />}
-                {stats.awaiting_approval_runs > 0 && <StatCard label="awaiting approval" value={stats.awaiting_approval_runs} highlight />}
-                {stats.store_backend && <StatCard label="store" value={stats.store_backend} />}
-              </>
+              <StatGroup title="Task runtime" summary={runtimeSummary(stats)}>
+                <StatCard
+                  label="Queue depth"
+                  value={stats.queue_depth > 0 ? stats.queue_depth : "Idle"}
+                  sub={stats.queue_capacity ? `capacity ${stats.queue_capacity}` : undefined}
+                  help="Tasks waiting to be claimed by a task runner."
+                  highlight={stats.queue_depth > 0}
+                  status={stats.queue_depth > 0 ? "active" : "idle"}
+                />
+                <StatCard
+                  label="Task runners"
+                  value={stats.worker_count}
+                  sub={stats.worker_count === 1 ? "slot available" : "slots available"}
+                  help="Configured runner slots that can claim queued tasks."
+                />
+                <StatCard
+                  label="Active jobs"
+                  value={stats.in_flight_jobs > 0 ? stats.in_flight_jobs : "Idle"}
+                  help="Task jobs currently claimed by runner slots."
+                  highlight={stats.in_flight_jobs > 0}
+                  status={stats.in_flight_jobs > 0 ? "active" : "idle"}
+                />
+                <StatCard
+                  label="Running task runs"
+                  value={stats.running_runs > 0 ? stats.running_runs : "Idle"}
+                  help="Task runs currently executing."
+                  highlight={stats.running_runs > 0}
+                  status={stats.running_runs > 0 ? "active" : "idle"}
+                />
+                <StatCard
+                  label="Queued runs"
+                  value={stats.queued_runs > 0 ? stats.queued_runs : "None"}
+                  help="Runs persisted as queued but not yet executing."
+                  highlight={stats.queued_runs > 0}
+                />
+                <StatCard
+                  label="Awaiting approval"
+                  value={stats.awaiting_approval_runs > 0 ? stats.awaiting_approval_runs : "None"}
+                  help="Runs paused on an operator approval gate."
+                  highlight={stats.awaiting_approval_runs > 0}
+                />
+              </StatGroup>
             )}
-            {mcpCacheStats && (
-              !mcpCacheStats.configured ? (
-                <div className="card" style={{ padding: "12px 14px", display: "flex", alignItems: "center", fontSize: 11, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
-                  No MCP cache wired
-                </div>
-              ) : (
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }} aria-label="MCP cache stats">
-                  <StatCard label="mcp entries" value={mcpCacheStats.entries} />
-                  <StatCard label="mcp in-use" value={mcpCacheStats.in_use} highlight={mcpCacheStats.in_use > 0} />
-                  <StatCard label="mcp idle" value={mcpCacheStats.idle} />
-                </div>
-              )
+            {(stats?.store_backend || mcpCacheStats) && (
+              <StatGroup title="Storage and MCP cache">
+                {stats?.store_backend && (
+                  <StatCard
+                    label="Runtime store"
+                    value={describeStoreBackend(stats.store_backend)}
+                    help="Persistence backend for runtime state."
+                  />
+                )}
+                {mcpCacheStats && (
+                  mcpCacheStats.configured ? (
+                    <>
+                      <StatCard
+                        label="MCP cache"
+                        value={`${mcpCacheStats.entries} entries`}
+                        sub={`${mcpCacheStats.in_use} active · ${mcpCacheStats.idle} idle`}
+                        help="Cached MCP clients available for reuse."
+                        highlight={mcpCacheStats.in_use > 0}
+                      />
+                    </>
+                  ) : (
+                    <StatCard
+                      label="MCP cache"
+                      value="Disabled"
+                      help="No MCP cache is configured for this gateway."
+                    />
+                  )
+                )}
+              </StatGroup>
             )}
           </div>
         )}
@@ -677,4 +727,63 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
       )}
     </div>
   );
+}
+
+function StatGroup({ title, summary, children }: { title: string; summary?: string; children: ReactNode }) {
+  return (
+    <section
+      className="card"
+      aria-label={title}
+      style={{
+        padding: 10,
+        display: "grid",
+        gap: 8,
+      }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "baseline" }}>
+        <div className="kicker" style={{ color: "var(--t2)" }}>{title}</div>
+        {summary && (
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--t3)",
+              fontFamily: "var(--font-mono)",
+              textAlign: "right",
+            }}>
+            {summary}
+          </div>
+        )}
+      </div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function normalizeRuntimeStats(stats: RuntimeStatsResponse["data"] | null): RuntimeStatsResponse["data"] | null {
+  if (!stats || typeof stats.queue_depth !== "number" || typeof stats.worker_count !== "number") {
+    return null;
+  }
+  return stats;
+}
+
+function runtimeSummary(stats: RuntimeStatsResponse["data"]): string {
+  if (stats.awaiting_approval_runs > 0) {
+    return `${stats.awaiting_approval_runs} ${plural(stats.awaiting_approval_runs, "run")} waiting for approval`;
+  }
+  if (stats.running_runs > 0 || stats.in_flight_jobs > 0) {
+    return `${stats.running_runs} ${plural(stats.running_runs, "run")} running, ${stats.in_flight_jobs} active ${plural(stats.in_flight_jobs, "job")}`;
+  }
+  if (stats.queue_depth > 0 || stats.queued_runs > 0) {
+    return `${stats.queue_depth || stats.queued_runs} queued, ${stats.worker_count} ${plural(stats.worker_count, "runner")} available`;
+  }
+  return `${stats.worker_count} ${plural(stats.worker_count, "task runner")} available, no queued work`;
+}
+
+function describeStoreBackend(backend: string): string {
+  return backend === "memory" ? "Memory store" : backend;
+}
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
 }

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -566,8 +566,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                 <col style={{ width: "16%" }} />
                 <col style={{ width: "7%" }} />
                 <col style={{ width: "8%" }} />
-                <col style={{ width: "17%" }} />
-                <col style={{ width: "9%" }} />
+                <col style={{ width: "20%" }} />
                 <col style={{ width: "9%" }} />
                 <col style={{ width: "4%" }} />
               </colgroup>
@@ -579,8 +578,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                   <th style={thStyle}>Model</th>
                   <th style={{ ...thStyle, textAlign: "right" }}>Latency</th>
                   <th style={{ ...thStyle, textAlign: "right" }}>Cost</th>
-                  <th style={thStyle}>Reason</th>
-                  <th style={thStyle}>Fallback</th>
+                  <th style={thStyle}>Route</th>
                   <th style={thStyle}>Request ID</th>
                   <th style={thStyle}></th>
                 </tr>
@@ -597,11 +595,7 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                     : ledger
                       ? "$0.00000"
                       : "—";
-                  const reason = t.route?.final_reason
-                    ? describeRouteReason(t.route.final_reason)
-                    : t.status_code === "error" && t.status_message
-                      ? t.status_message
-                      : "—";
+                  const routeLabel = routeSummaryLabel(t);
                   const time = formatRelativeTime(t.started_at || "");
                   const provider = traceProvider(t);
                   const model = traceModel(t);
@@ -665,9 +659,16 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
                         {latency != null ? `${latency}ms` : "—"}
                       </td>
                       <td style={{ ...tdBase, color: "var(--t1)", textAlign: "right" }}>{cost}</td>
-                      <td style={{ ...tdBase, color: "var(--t2)" }} title={reason}>{reason}</td>
-                      <td style={{ ...tdBase, color: t.route?.fallback_from ? "var(--amber)" : "var(--t3)" }}>
-                        {t.route?.fallback_from ? `↳ ${t.route.fallback_from}` : "—"}
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: routeLabel.tone === "fallback" ? "var(--amber)" : routeLabel.tone === "empty" ? "var(--t3)" : "var(--t2)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                        title={routeLabel.title}>
+                        {routeLabel.label}
                       </td>
                       <td style={tdBase} onClick={e => e.stopPropagation()}>
                         <div style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
@@ -826,6 +827,27 @@ function applyTraceWindow(
   group.latestMs = group.latestMs == null ? endMs : Math.max(group.latestMs, endMs);
   group.latencyMs = Math.max(0, Math.round(group.latestMs - group.earliestMs));
   return group;
+}
+
+function routeSummaryLabel(trace: TraceListItem): { label: string; title: string; tone: "default" | "fallback" | "empty" } {
+  if (trace.route?.fallback_from) {
+    const label = `Fallback from ${trace.route.fallback_from}`;
+    return {
+      label,
+      title: trace.route.final_reason
+        ? `${label}; ${describeRouteReason(trace.route.final_reason)}`
+        : label,
+      tone: "fallback",
+    };
+  }
+  if (trace.route?.final_reason) {
+    const label = describeRouteReason(trace.route.final_reason);
+    return { label, title: label, tone: "default" };
+  }
+  if (trace.status_code === "error" && trace.status_message) {
+    return { label: trace.status_message, title: trace.status_message, tone: "default" };
+  }
+  return { label: "No route", title: "No route summary was recorded for this request.", tone: "empty" };
 }
 
 function runtimeSummary(stats: RuntimeStatsResponse["data"]): string {

--- a/ui/src/features/overview/observability/CopyableID.tsx
+++ b/ui/src/features/overview/observability/CopyableID.tsx
@@ -1,5 +1,5 @@
-// CopyableID renders the truncated request-ID + a copy-to-clipboard
-// button. Used in the recent-traces table cell and in the trace
+// CopyableID renders a request-ID + a copy-to-clipboard button.
+// Used in the recent-traces table cell and in the trace
 // drawer header. Self-contained: owns its own "copied" timeout state
 // so a click in one place doesn't flash the icon elsewhere.
 
@@ -7,8 +7,9 @@ import { useState } from "react";
 
 import { Icon, Icons } from "../../shared/ui";
 
-export function CopyableID({ text }: { text: string }) {
+export function CopyableID({ text, compact = false }: { text: string; compact?: boolean }) {
   const [copied, setCopied] = useState(false);
+  const label = compact && text.length > 12 ? `${text.slice(0, 8)}…` : text;
   return (
     <button
       onClick={e => {
@@ -25,7 +26,7 @@ export function CopyableID({ text }: { text: string }) {
         display: "inline-flex", alignItems: "center", gap: 4,
         overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%",
       }}>
-      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{text.slice(0, 8)}…</span>
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{label}</span>
       <Icon d={copied ? Icons.check : Icons.copy} size={11} />
     </button>
   );

--- a/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
@@ -52,6 +52,22 @@ describe("RecentActivityStrip", () => {
     expect(text).toMatch(/errors.*1.*\/.*5/);
   });
 
+  it("uses request-level latency overrides for summary and dot tooltips", () => {
+    const traces = [
+      trace({ request_id: "a", duration_ms: 1, status_code: "ok" }),
+      trace({ request_id: "b", duration_ms: 2, status_code: "ok" }),
+    ];
+    const latencyByRequestID = new Map([
+      ["a", 100],
+      ["b", 300],
+    ]);
+    const { container } = render(<RecentActivityStrip traces={traces} latencyByRequestID={latencyByRequestID} />);
+    const text = container.textContent || "";
+    expect(text).toMatch(/p50.*100ms/);
+    expect(text).toMatch(/p95.*300ms/);
+    expect(container.querySelector('span[title*="a · —/— · 100ms"]')).toBeTruthy();
+  });
+
   it("shows recovered count when a trace has fallback_from", () => {
     const traces = [
       trace({ request_id: "a", duration_ms: 100, status_code: "ok", route: { fallback_from: "openai" } }),

--- a/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.test.tsx
@@ -30,9 +30,8 @@ describe("RecentActivityStrip", () => {
       trace({ request_id: "c", duration_ms: 300, status_code: "ok" }),
     ];
     const { container } = render(<RecentActivityStrip traces={traces} />);
-    // The dots are the only `display: inline-block` spans inside the
-    // strip; everything else is text or flex/grid layout.
-    const dots = container.querySelectorAll('span[title*="…"]');
+    // The dots are the only spans whose title carries request metadata.
+    const dots = container.querySelectorAll('span[title*="/"]');
     expect(dots.length).toBe(3);
   });
 
@@ -60,6 +59,21 @@ describe("RecentActivityStrip", () => {
     ];
     const { container } = render(<RecentActivityStrip traces={traces} />);
     expect(container.textContent).toMatch(/recovered.*1/);
+  });
+
+  it("uses derived provider/model labels in dot tooltips when route fields are missing", () => {
+    const traces = [
+      trace({ request_id: "req-1", duration_ms: 25, status_code: "ok" }),
+    ];
+    const labelsByRequestID = new Map([
+      ["req-1", { provider: "ollama", model: "ministral-3:latest" }],
+    ]);
+
+    const { container } = render(
+      <RecentActivityStrip traces={traces} labelsByRequestID={labelsByRequestID} />,
+    );
+
+    expect(container.querySelector('span[title*="ollama/ministral-3:latest"]')).toBeTruthy();
   });
 
   it("does not count error+fallback_from as recovered (the fallback also failed)", () => {

--- a/ui/src/features/overview/observability/RecentActivityStrip.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.tsx
@@ -61,7 +61,7 @@ export function RecentActivityStrip({ traces }: Props) {
           return (
             <span
               key={t.request_id}
-              title={`${t.request_id.slice(0, 8)}… · ${t.route?.final_provider || "—"}/${t.route?.final_model || "—"}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
+              title={`${t.request_id} · ${t.route?.final_provider || "—"}/${t.route?.final_model || "—"}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
               style={{
                 display: "inline-block",
                 width: 6, height: 6, borderRadius: "50%",

--- a/ui/src/features/overview/observability/RecentActivityStrip.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.tsx
@@ -13,9 +13,10 @@ import type { TraceListItem } from "../../../types/runtime";
 
 type Props = {
   traces: TraceListItem[];
+  labelsByRequestID?: Map<string, { provider?: string; model?: string }>;
 };
 
-export function RecentActivityStrip({ traces }: Props) {
+export function RecentActivityStrip({ traces, labelsByRequestID }: Props) {
   if (traces.length === 0) return null;
 
   // Oldest → newest left to right matches "what just happened ←
@@ -58,10 +59,13 @@ export function RecentActivityStrip({ traces }: Props) {
           // visually conflate them with recovered traces in this
           // strip. Here, in-flight stays gray.
           const color = dotColor(t);
+          const label = labelsByRequestID?.get(t.request_id);
+          const provider = label?.provider || t.route?.final_provider || "—";
+          const model = label?.model || t.route?.final_model || "—";
           return (
             <span
               key={t.request_id}
-              title={`${t.request_id} · ${t.route?.final_provider || "—"}/${t.route?.final_model || "—"}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
+              title={`${t.request_id} · ${provider}/${model}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
               style={{
                 display: "inline-block",
                 width: 6, height: 6, borderRadius: "50%",

--- a/ui/src/features/overview/observability/RecentActivityStrip.tsx
+++ b/ui/src/features/overview/observability/RecentActivityStrip.tsx
@@ -14,9 +14,10 @@ import type { TraceListItem } from "../../../types/runtime";
 type Props = {
   traces: TraceListItem[];
   labelsByRequestID?: Map<string, { provider?: string; model?: string }>;
+  latencyByRequestID?: Map<string, number>;
 };
 
-export function RecentActivityStrip({ traces, labelsByRequestID }: Props) {
+export function RecentActivityStrip({ traces, labelsByRequestID, latencyByRequestID }: Props) {
   if (traces.length === 0) return null;
 
   // Oldest → newest left to right matches "what just happened ←
@@ -24,7 +25,7 @@ export function RecentActivityStrip({ traces, labelsByRequestID }: Props) {
   // so we reverse for the strip; the table below keeps newest first.
   const ordered = traces.slice().reverse();
   const durations = traces
-    .map((t) => t.duration_ms)
+    .map((t) => traceLatency(t, latencyByRequestID))
     .filter((d): d is number => typeof d === "number" && d >= 0)
     .sort((a, b) => a - b);
   const p50 = percentile(durations, 0.5);
@@ -62,10 +63,11 @@ export function RecentActivityStrip({ traces, labelsByRequestID }: Props) {
           const label = labelsByRequestID?.get(t.request_id);
           const provider = label?.provider || t.route?.final_provider || "—";
           const model = label?.model || t.route?.final_model || "—";
+          const latency = traceLatency(t, latencyByRequestID);
           return (
             <span
               key={t.request_id}
-              title={`${t.request_id} · ${provider}/${model}${t.duration_ms != null ? ` · ${t.duration_ms}ms` : ""}`}
+              title={`${t.request_id} · ${provider}/${model}${latency != null ? ` · ${latency}ms` : ""}`}
               style={{
                 display: "inline-block",
                 width: 6, height: 6, borderRadius: "50%",
@@ -88,6 +90,10 @@ export function RecentActivityStrip({ traces, labelsByRequestID }: Props) {
       </div>
     </div>
   );
+}
+
+function traceLatency(t: TraceListItem, latencyByRequestID?: Map<string, number>): number | undefined {
+  return latencyByRequestID?.get(t.request_id) ?? t.duration_ms;
 }
 
 function dotColor(t: TraceListItem): string {

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -1,12 +1,15 @@
 // SpanWaterfall renders the trace drawer's centerpiece: the per-span
-// waterfall with sticky ruler, phase-legend filter chips, depth indent,
-// critical-path star, and an expandable attribute panel per row. The
+// waterfall with a DevTools-style ruler, phase-legend filter chips,
+// depth indent, and an expandable attribute panel per row. The
 // data model lives in `lib/runtime-trace.ts` (`buildSpanWaterfall`);
 // this file is the React surface only.
 
 import type { TraceTimelineItem, TraceWaterfall, WaterfallSpan } from "../../../lib/runtime-trace";
 
 import { ATTR_PRIORITY_KEYS, PHASE_LABEL, phaseColor } from "./styles";
+
+const WATERFALL_COLUMNS = "minmax(240px, 30%) minmax(360px, 1fr) 72px";
+const WATERFALL_COLUMN_GAP = 12;
 
 type SpanWaterfallProps = {
   waterfall: TraceWaterfall;
@@ -35,10 +38,7 @@ export function SpanWaterfall({
     );
   }
 
-  const ticks = [0, Math.round(totalMs / 3), Math.round((2 * totalMs) / 3), totalMs];
-  // Whether any span is on the critical path. Drives the legend chip
-  // — no point showing "★ critical path" when no row has the star.
-  const hasCriticalPath = spans.some(s => s.critical);
+  const ticks = waterfallTicks(totalMs);
 
   return (
     <div style={{ padding: "10px 12px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
@@ -47,7 +47,7 @@ export function SpanWaterfall({
         <span className="kicker-lg" style={{ fontSize: 12, fontWeight: 500, color: "var(--t0)", letterSpacing: "0.04em", textTransform: "uppercase" }}>
           Spans ({spans.length}) · total {totalMs} ms
         </span>
-        {(phases.length > 1 || hasCriticalPath) && (
+        {phases.length > 1 && (
           <div role="group" aria-label="Phase legend" style={{ display: "flex", gap: 4, flexWrap: "wrap", marginLeft: "auto" }}>
             {phases.map(p => {
               const active = phaseFilter === p;
@@ -74,96 +74,97 @@ export function SpanWaterfall({
                 </button>
               );
             })}
-            {hasCriticalPath && (
-              <span
-                title="Spans on the critical path — the longest dependency chain through this trace."
-                style={{
-                  border: "1px solid var(--border)",
-                  borderRadius: "var(--radius-sm)",
-                  padding: "2px 6px",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 4,
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 10,
-                  color: "var(--t2)",
-                }}>
-                <span style={{ color: "var(--amber)" }}>★</span>
-                critical path
-              </span>
-            )}
           </div>
         )}
       </div>
 
-      {/* Sticky ruler. Three things needed for it to render reliably
-        on top of subsequent span rows:
-         - `bg2` (not `bg1`) so the ruler has visible contrast against
-           the surrounding card and so its background actually
-           occludes the row that scrolls under it. `bg1` is the same
-           color as the card it's sitting in.
-         - `isolation: isolate` creates a stacking context so the
-           absolute-positioned bar children inside SpanRow can't
-           paint above the sticky ruler. Without it, a high-z-index
-           descendant of a sibling could land on top.
-         - `marginBottom: 6` separates the ruler from the first span
-           row — without it, the row's amber critical-path border
-           visually merges with the ruler's own bottom border. */}
-      <div style={{
-        position: "sticky", top: 0, zIndex: 5,
-        background: "var(--bg2)",
-        isolation: "isolate",
-        display: "grid",
-        gridTemplateColumns: "240px 1fr 60px",
-        gap: 8,
-        // paddingRight matches the SpanRow grid below so the time-axis
-        // ticks line up with bar-column edges. Without this the
-        // ruler's "1fr" is 4px wider than each row's "1fr" and the
-        // rightmost tick label drifts past the bar ends.
-        padding: "6px 4px 6px 0",
-        marginBottom: 6,
-        borderBottom: "1px solid var(--border)",
-      }}>
-        <div />
-        <div style={{ position: "relative", height: 12 }}>
-          {ticks.map((t, i) => (
-            <span
-              key={i}
-              style={{
-                position: "absolute",
-                left: `${(t / totalMs) * 100}%`,
-                transform: i === 0 ? "translateX(0)" : i === ticks.length - 1 ? "translateX(-100%)" : "translateX(-50%)",
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                color: "var(--t2)",
-              }}>{t}ms</span>
+      <div
+        data-testid="span-waterfall-scroll"
+        style={{
+          maxHeight: "min(420px, 52vh)",
+          overflowY: "auto",
+          overflowX: "hidden",
+          borderTop: "1px solid var(--border)",
+        }}>
+        {/* Ruler sticks only inside the waterfall scroller. If it
+            sticks to the whole trace drawer, it floats at the top
+            after the waterfall itself has scrolled away. */}
+        <div style={{
+          position: "sticky", top: 0, zIndex: 5,
+          background: "var(--bg2)",
+          isolation: "isolate",
+          display: "grid",
+          gridTemplateColumns: WATERFALL_COLUMNS,
+          columnGap: WATERFALL_COLUMN_GAP,
+          padding: "6px 0",
+          marginBottom: 6,
+          borderBottom: "1px solid var(--border)",
+        }}>
+          <div />
+          <div style={{
+            position: "relative",
+            height: 18,
+            borderTop: "1px solid var(--border)",
+            borderBottom: "1px solid var(--border)",
+            background: "linear-gradient(180deg, color-mix(in srgb, var(--bg3) 65%, transparent), transparent)",
+          }}>
+            {ticks.map((t, i) => (
+              <div key={i}>
+                <span
+                  aria-hidden="true"
+                  style={{
+                    position: "absolute",
+                    left: `${t.pct}%`,
+                    top: 0,
+                    bottom: 0,
+                    width: 1,
+                    background: t.edge ? "var(--border)" : "color-mix(in srgb, var(--border) 55%, transparent)",
+                  }}
+                />
+                <span
+                  data-testid="span-waterfall-tick"
+                  style={{
+                    position: "absolute",
+                    left: `${t.pct}%`,
+                    top: -1,
+                    transform: t.pct === 0 ? "translateX(0)" : t.pct === 100 ? "translateX(-100%)" : "translateX(-50%)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--t2)",
+                    lineHeight: "18px",
+                    whiteSpace: "nowrap",
+                  }}>{t.label}</span>
+              </div>
+            ))}
+          </div>
+          <div />
+        </div>
+
+        {/* Span rows */}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {spans.map((ws) => (
+            <SpanRow
+              key={ws.span.span_id}
+              ws={ws}
+              totalMs={totalMs}
+              ticks={ticks}
+              isExpanded={expandedSpanID === ws.span.span_id}
+              isDimmed={phaseFilter !== null && ws.phase !== phaseFilter}
+              onToggle={() => setExpandedSpanID(expandedSpanID === ws.span.span_id ? null : ws.span.span_id)}
+            />
           ))}
         </div>
-        <div />
-      </div>
-
-      {/* Span rows */}
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {spans.map((ws) => (
-          <SpanRow
-            key={ws.span.span_id}
-            ws={ws}
-            totalMs={totalMs}
-            isExpanded={expandedSpanID === ws.span.span_id}
-            isDimmed={phaseFilter !== null && ws.phase !== phaseFilter}
-            onToggle={() => setExpandedSpanID(expandedSpanID === ws.span.span_id ? null : ws.span.span_id)}
-          />
-        ))}
       </div>
     </div>
   );
 }
 
 function SpanRow({
-  ws, totalMs, isExpanded, isDimmed, onToggle,
+  ws, totalMs, ticks, isExpanded, isDimmed, onToggle,
 }: {
   ws: WaterfallSpan;
   totalMs: number;
+  ticks: WaterfallTick[];
   isExpanded: boolean;
   isDimmed: boolean;
   onToggle: () => void;
@@ -184,11 +185,9 @@ function SpanRow({
   const color = phaseColor(ws.phase, ws.span);
   const opacity = isDimmed ? 0.3 : 1;
   // Duration label inside the bar when wide enough, otherwise to its
-  // right. Parent spans (hasChildren) render as a thin outlined
-  // bracket — no room for an inside label, so the duration falls back
-  // to the right column.
-  const labelInside = widthPct > 12 && !ws.unknownTiming && !ws.negativeDuration && !ws.hasChildren;
-  const durLabel = ws.unknownTiming || ws.negativeDuration ? "?" : `${Math.max(ws.durMs, 0).toFixed(0)}ms`;
+  // right.
+  const labelInside = widthPct > 12 && !ws.unknownTiming && !ws.negativeDuration;
+  const durLabel = ws.unknownTiming || ws.negativeDuration ? "?" : formatWaterfallMs(Math.max(ws.durMs, 0));
   const barTone = ws.unknownTiming || ws.negativeDuration ? "var(--t3)" : (ws.hasError ? "var(--red)" : color);
 
   return (
@@ -203,16 +202,14 @@ function SpanRow({
           if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(); }
         }}
         style={{
-          height: 22,
+          minHeight: 24,
           display: "grid",
-          gridTemplateColumns: "240px 1fr 60px",
-          gap: 8,
+          gridTemplateColumns: WATERFALL_COLUMNS,
+          columnGap: WATERFALL_COLUMN_GAP,
           alignItems: "center",
           cursor: "pointer",
           background: isExpanded ? "var(--bg2)" : "transparent",
-          borderLeft: ws.critical ? "2px solid var(--amber)" : "2px solid transparent",
           opacity,
-          paddingRight: 4,
         }}>
         {/* Span name column with depth indent + status dot */}
         <div style={{ display: "flex", alignItems: "center", gap: 6, paddingLeft: 6 + ws.depth * 12, overflow: "hidden" }}>
@@ -237,29 +234,37 @@ function SpanRow({
             }}>
             {ws.span.name}
           </span>
-          {ws.critical && (
-            <span title="critical path" style={{ color: "var(--amber)", fontSize: 10, flexShrink: 0 }}>★</span>
-          )}
         </div>
 
-        {/* Bar column. Parent spans (hasChildren) render as a thin
-            outlined bracket so the child rows below show their real
-            offsets without competing with an always-fully-covering
-            parent bar — see hasChildren in runtime-trace.ts.
-            Unknown-timing and negative-duration spans always render
-            as filled markers regardless: the parent/child distinction
-            isn't meaningful when the timing is unusable. */}
-        <div style={{ position: "relative", height: 14 }}>
+        {/* Bar column. Every row uses the same filled-bar treatment,
+            which is closer to browser DevTools and avoids making
+            parent spans look like selected/outlined objects. */}
+        <div style={{ position: "relative", height: 18, overflow: "hidden" }}>
+          {ticks.map((t, i) => (
+            <span
+              key={i}
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                left: `${t.pct}%`,
+                top: 0,
+                bottom: 0,
+                width: 1,
+                background: t.edge ? "color-mix(in srgb, var(--border) 75%, transparent)" : "color-mix(in srgb, var(--border) 28%, transparent)",
+              }}
+            />
+          ))}
           <div
+            data-testid={`span-waterfall-bar-${ws.span.span_id}`}
             style={{
               position: "absolute",
               left: `${leftPct}%`,
               width: `${widthPct}%`,
               minWidth: 2,
-              height: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? 6 : "100%",
-              top: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? 4 : 0,
-              background: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? "transparent" : barTone,
-              border: ws.hasChildren && !ws.unknownTiming && !ws.negativeDuration ? `1px solid ${barTone}` : "none",
+              height: "100%",
+              top: 0,
+              background: barTone,
+              border: "none",
               borderRadius: 2,
               display: "flex",
               alignItems: "center",
@@ -297,6 +302,37 @@ function SpanRow({
       {isExpanded && <SpanAttributePanel ws={ws} />}
     </div>
   );
+}
+
+type WaterfallTick = {
+  pct: number;
+  label: string;
+  edge: boolean;
+};
+
+function waterfallTicks(totalMs: number): WaterfallTick[] {
+  const safeTotal = Number.isFinite(totalMs) && totalMs > 0 ? totalMs : 1;
+  return [0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+    const value = safeTotal * ratio;
+    return {
+      pct: ratio * 100,
+      label: formatWaterfallMs(value),
+      edge: ratio === 0 || ratio === 1,
+    };
+  });
+}
+
+function formatWaterfallMs(value: number): string {
+  if (!Number.isFinite(value)) return "?";
+  const abs = Math.abs(value);
+  if (abs === 0) return "0ms";
+  if (abs < 1) return `${trimFixed(value, 2)}ms`;
+  if (abs < 10) return `${trimFixed(value, 1)}ms`;
+  return `${Math.round(value)}ms`;
+}
+
+function trimFixed(value: number, digits: number): string {
+  return value.toFixed(digits).replace(/\.?0+$/, "");
 }
 
 function SpanAttributePanel({ ws }: { ws: WaterfallSpan }) {

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -10,7 +10,8 @@ import type { TraceTimelineItem, TraceWaterfall, WaterfallSpan } from "../../../
 
 import { ATTR_PRIORITY_KEYS, PHASE_LABEL, phaseColor } from "./styles";
 
-const WATERFALL_COLUMNS = "minmax(240px, 30%) minmax(360px, 1fr) 72px";
+const WATERFALL_MIN_LABEL_PX = 120;
+const WATERFALL_MAX_LABEL_PX = 280;
 const WATERFALL_COLUMN_GAP = 12;
 
 type SpanWaterfallProps = {
@@ -41,6 +42,7 @@ export function SpanWaterfall({
   }
 
   const ticks = waterfallTicks(totalMs);
+  const columns = waterfallColumns(spans);
 
   return (
     <div style={{ padding: "10px 12px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
@@ -87,7 +89,7 @@ export function SpanWaterfall({
           overflowY: "auto",
           overflowX: "hidden",
         }}>
-        <WaterfallRuler ticks={ticks} />
+        <WaterfallRuler ticks={ticks} columns={columns} />
 
         {/* Span rows */}
         <div style={{ display: "flex", flexDirection: "column" }}>
@@ -97,6 +99,7 @@ export function SpanWaterfall({
               ws={ws}
               totalMs={totalMs}
               ticks={ticks}
+              columns={columns}
               isExpanded={expandedSpanID === ws.span.span_id}
               isDimmed={phaseFilter !== null && ws.phase !== phaseFilter}
               onToggle={() => setExpandedSpanID(expandedSpanID === ws.span.span_id ? null : ws.span.span_id)}
@@ -108,7 +111,7 @@ export function SpanWaterfall({
   );
 }
 
-function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
+function WaterfallRuler({ ticks, columns }: { ticks: WaterfallTick[]; columns: string }) {
   return (
     // Ruler sticks only inside the waterfall scroller. If it sticks
     // to the whole trace drawer, it floats at the top after the
@@ -118,7 +121,7 @@ function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
       background: "var(--bg2)",
       isolation: "isolate",
       display: "grid",
-      gridTemplateColumns: WATERFALL_COLUMNS,
+      gridTemplateColumns: columns,
       columnGap: WATERFALL_COLUMN_GAP,
       padding: "0 0 6px",
       marginBottom: 6,
@@ -165,11 +168,12 @@ function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
 }
 
 function SpanRow({
-  ws, totalMs, ticks, isExpanded, isDimmed, onToggle,
+  ws, totalMs, ticks, columns, isExpanded, isDimmed, onToggle,
 }: {
   ws: WaterfallSpan;
   totalMs: number;
   ticks: WaterfallTick[];
+  columns: string;
   isExpanded: boolean;
   isDimmed: boolean;
   onToggle: () => void;
@@ -209,7 +213,7 @@ function SpanRow({
         style={{
           minHeight: 24,
           display: "grid",
-          gridTemplateColumns: WATERFALL_COLUMNS,
+          gridTemplateColumns: columns,
           columnGap: WATERFALL_COLUMN_GAP,
           alignItems: "center",
           cursor: "pointer",
@@ -314,6 +318,18 @@ type WaterfallTick = {
   label: string;
   edge: boolean;
 };
+
+function waterfallColumns(spans: WaterfallSpan[]): string {
+  const labelPx = spans.reduce((max, ws) => {
+    // Monospace span labels render near 7.5px per character at 12px.
+    // Add indentation and dot/gap chrome, then clamp so short names
+    // give the waterfall more room while long names cannot squeeze it.
+    const estimate = 28 + ws.depth * 12 + ws.span.name.length * 7.5;
+    return Math.max(max, estimate);
+  }, WATERFALL_MIN_LABEL_PX);
+  const clamped = Math.min(WATERFALL_MAX_LABEL_PX, Math.max(WATERFALL_MIN_LABEL_PX, Math.ceil(labelPx)));
+  return `${clamped}px minmax(360px, 1fr) 72px`;
+}
 
 function waterfallTicks(totalMs: number): WaterfallTick[] {
   const safeTotal = Number.isFinite(totalMs) && totalMs > 0 ? totalMs : 1;

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react";
+
 // SpanWaterfall renders the trace drawer's centerpiece: the per-span
 // waterfall with a DevTools-style ruler, phase-legend filter chips,
 // depth indent, and an expandable attribute panel per row. The
@@ -86,59 +88,7 @@ export function SpanWaterfall({
           overflowX: "hidden",
           borderTop: "1px solid var(--border)",
         }}>
-        {/* Ruler sticks only inside the waterfall scroller. If it
-            sticks to the whole trace drawer, it floats at the top
-            after the waterfall itself has scrolled away. */}
-        <div style={{
-          position: "sticky", top: 0, zIndex: 5,
-          background: "var(--bg2)",
-          isolation: "isolate",
-          display: "grid",
-          gridTemplateColumns: WATERFALL_COLUMNS,
-          columnGap: WATERFALL_COLUMN_GAP,
-          padding: "6px 0",
-          marginBottom: 6,
-          borderBottom: "1px solid var(--border)",
-        }}>
-          <div />
-          <div style={{
-            position: "relative",
-            height: 18,
-            borderTop: "1px solid var(--border)",
-            borderBottom: "1px solid var(--border)",
-            background: "linear-gradient(180deg, color-mix(in srgb, var(--bg3) 65%, transparent), transparent)",
-          }}>
-            {ticks.map((t, i) => (
-              <div key={i}>
-                <span
-                  aria-hidden="true"
-                  style={{
-                    position: "absolute",
-                    left: `${t.pct}%`,
-                    top: 0,
-                    bottom: 0,
-                    width: 1,
-                    background: t.edge ? "var(--border)" : "color-mix(in srgb, var(--border) 55%, transparent)",
-                  }}
-                />
-                <span
-                  data-testid="span-waterfall-tick"
-                  style={{
-                    position: "absolute",
-                    left: `${t.pct}%`,
-                    top: -1,
-                    transform: t.pct === 0 ? "translateX(0)" : t.pct === 100 ? "translateX(-100%)" : "translateX(-50%)",
-                    fontFamily: "var(--font-mono)",
-                    fontSize: 10,
-                    color: "var(--t2)",
-                    lineHeight: "18px",
-                    whiteSpace: "nowrap",
-                  }}>{t.label}</span>
-              </div>
-            ))}
-          </div>
-          <div />
-        </div>
+        <WaterfallRuler ticks={ticks} />
 
         {/* Span rows */}
         <div style={{ display: "flex", flexDirection: "column" }}>
@@ -155,6 +105,64 @@ export function SpanWaterfall({
           ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
+  return (
+    // Ruler sticks only inside the waterfall scroller. If it sticks
+    // to the whole trace drawer, it floats at the top after the
+    // waterfall itself has scrolled away.
+    <div style={{
+      position: "sticky", top: 0, zIndex: 5,
+      background: "var(--bg2)",
+      isolation: "isolate",
+      display: "grid",
+      gridTemplateColumns: WATERFALL_COLUMNS,
+      columnGap: WATERFALL_COLUMN_GAP,
+      padding: "6px 0",
+      marginBottom: 6,
+      borderBottom: "1px solid var(--border)",
+    }}>
+      <div />
+      <div style={{
+        position: "relative",
+        height: 18,
+        borderTop: "1px solid var(--border)",
+        borderBottom: "1px solid var(--border)",
+        background: "linear-gradient(180deg, color-mix(in srgb, var(--bg3) 65%, transparent), transparent)",
+      }}>
+        {ticks.map((t) => (
+          <Fragment key={t.pct}>
+            <span
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                left: `${t.pct}%`,
+                top: 0,
+                bottom: 0,
+                width: 1,
+                background: t.edge ? "var(--border)" : "color-mix(in srgb, var(--border) 55%, transparent)",
+              }}
+            />
+            <span
+              data-testid="span-waterfall-tick"
+              style={{
+                position: "absolute",
+                left: `${t.pct}%`,
+                top: -1,
+                transform: t.pct === 0 ? "translateX(0)" : t.pct === 100 ? "translateX(-100%)" : "translateX(-50%)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: "var(--t2)",
+                lineHeight: "18px",
+                whiteSpace: "nowrap",
+              }}>{t.label}</span>
+          </Fragment>
+        ))}
+      </div>
+      <div />
     </div>
   );
 }

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -86,7 +86,6 @@ export function SpanWaterfall({
           maxHeight: "min(420px, 52vh)",
           overflowY: "auto",
           overflowX: "hidden",
-          borderTop: "1px solid var(--border)",
         }}>
         <WaterfallRuler ticks={ticks} />
 
@@ -121,12 +120,11 @@ function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
       display: "grid",
       gridTemplateColumns: WATERFALL_COLUMNS,
       columnGap: WATERFALL_COLUMN_GAP,
-      padding: "6px 0",
+      padding: "0 0 6px",
       marginBottom: 6,
-      borderBottom: "1px solid var(--border)",
     }}>
-      <div />
       <div style={{
+        gridColumn: 2,
         position: "relative",
         height: 18,
         borderTop: "1px solid var(--border)",
@@ -162,7 +160,6 @@ function WaterfallRuler({ ticks }: { ticks: WaterfallTick[] }) {
           </Fragment>
         ))}
       </div>
-      <div />
     </div>
   );
 }

--- a/ui/src/features/overview/observability/SpanWaterfall.tsx
+++ b/ui/src/features/overview/observability/SpanWaterfall.tsx
@@ -49,7 +49,7 @@ export function SpanWaterfall({
       {/* Header — count + total */}
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8, flexWrap: "wrap" }}>
         <span className="kicker-lg" style={{ fontSize: 12, fontWeight: 500, color: "var(--t0)", letterSpacing: "0.04em", textTransform: "uppercase" }}>
-          Spans ({spans.length}) · total {totalMs} ms
+          Spans ({spans.length}) · total {formatWaterfallMs(totalMs)}
         </span>
         {phases.length > 1 && (
           <div role="group" aria-label="Phase legend" style={{ display: "flex", gap: 4, flexWrap: "wrap", marginLeft: "auto" }}>

--- a/ui/src/features/overview/observability/StatCard.tsx
+++ b/ui/src/features/overview/observability/StatCard.tsx
@@ -1,20 +1,23 @@
 // StatCard is the single-cell stat display used in the Observability
-// runtime strip (queue depth, worker count, in-flight, etc.). Tiny on
-// purpose — just label + value + optional sub-text + optional amber
-// highlight when the value is non-zero / out of normal range.
+// runtime strip. It favors operator language over raw internal names:
+// label/value for scanning, helper copy in the tooltip/title, and
+// optional status text for "Idle" / "Memory store" style states.
 
 type StatCardProps = {
   label: string;
   value: string | number;
   sub?: string;
+  help?: string;
   highlight?: boolean;
+  status?: "idle" | "active" | "warning";
 };
 
-export function StatCard({ label, value, sub, highlight }: StatCardProps) {
+export function StatCard({ label, value, sub, help, highlight, status }: StatCardProps) {
+  const tone = highlight || status === "active" || status === "warning" ? "var(--amber)" : "var(--t0)";
   return (
-    <div className="card" style={{ padding: "12px 14px", minWidth: 110 }}>
+    <div className="card" title={help} style={{ padding: "12px 14px", minWidth: 128 }}>
       <div className="kicker" style={{ color: "var(--t2)", marginBottom: 6 }}>{label}</div>
-      <div style={{ fontSize: 22, fontWeight: 600, fontFamily: "var(--font-mono)", color: highlight ? "var(--amber)" : "var(--t0)", lineHeight: 1 }}>{value}</div>
+      <div style={{ fontSize: 22, fontWeight: 600, fontFamily: "var(--font-mono)", color: tone, lineHeight: 1 }}>{value}</div>
       {sub && <div style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)", marginTop: 4 }}>{sub}</div>}
     </div>
   );

--- a/ui/src/features/overview/observability/TraceDetail.tsx
+++ b/ui/src/features/overview/observability/TraceDetail.tsx
@@ -118,9 +118,19 @@ export function TraceDetail({
 
       {/* Event flow */}
       {traceTimeline.length > 0 && (
-        <div style={{ padding: "10px 12px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
+        <div style={{ padding: "10px 12px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", overflow: "hidden" }}>
           <div className="kicker" style={{ marginBottom: 8 }}>Event flow</div>
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div
+            data-testid="trace-event-flow"
+            aria-label="Trace event flow"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+              maxHeight: "min(320px, 42vh)",
+              overflowY: "auto",
+              paddingRight: 4,
+            }}>
             {traceTimeline.map((event, index) => (
               <div key={`${event.timestamp}-${event.name}-${index}`} style={{ display: "grid", gridTemplateColumns: "56px 92px 1fr", gap: 10, alignItems: "start" }}>
                 <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>{event.offsetLabel}</div>

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -27,6 +27,9 @@ export function ModelPicker({
   modelWarnings,
   showProvider = true,
   triggerWidth,
+  includeAll = false,
+  allValue = "",
+  allLabel = "All models",
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -58,6 +61,12 @@ export function ModelPicker({
   // Defaults to the historical chat width of 220px; pass `undefined`
   // to let the button size to its content.
   triggerWidth?: number | undefined;
+  // Optional sentinel used by filter surfaces such as Observability.
+  // Chat/task creation leave this off because they require a concrete
+  // model selection; trace filters can start from "All models".
+  includeAll?: boolean;
+  allValue?: string;
+  allLabel?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
@@ -117,8 +126,8 @@ export function ModelPicker({
   // outer caller already passes a provider-scoped `models` array, so this
   // check covers both "no providers configured" and "scoped provider has
   // no models" without extra plumbing.
-  const isEmpty = models.length === 0;
-  const label = isEmpty ? "no models available" : (value || models[0]?.id || "model");
+  const isEmpty = models.length === 0 && !includeAll;
+  const label = includeAll && value === allValue ? allLabel : isEmpty ? "no models available" : (value || models[0]?.id || "model");
   const buttonWidth = triggerWidth === undefined ? undefined : triggerWidth;
   const disabledTitle = isEmpty
     ? "No discovered models for this provider. Configure credentials or start the local runtime."
@@ -151,6 +160,13 @@ export function ModelPicker({
       return;
     }
     if (event.key === "Enter") {
+      if (includeAll && filter.trim() === "") {
+        event.preventDefault();
+        event.stopPropagation();
+        onChange(allValue);
+        closeMenu();
+        return;
+      }
       const firstEnabled = filtered.find((model) => {
         const provider = model.metadata?.provider;
         return !provider || !disabledProviders?.has(provider);
@@ -221,7 +237,27 @@ export function ModelPicker({
             />
           </div>
           <div role="listbox" style={{ maxHeight: 300, overflowY: "auto", overflowX: "hidden" }}>
-            {filtered.length === 0 && (
+            {includeAll && (
+              <>
+                <button
+                  type="button"
+                  data-dropdown-item
+                  data-selected={value === allValue ? "true" : undefined}
+                  className={`dropdown-item ${value === allValue ? "selected" : ""}`}
+                  aria-selected={value === allValue}
+                  role="option"
+                  onClick={() => {
+                    onChange(allValue);
+                    closeMenu();
+                  }}>
+                  <span style={{ flex: 1, fontFamily: "var(--font-mono)", fontSize: 12, textAlign: "left" }}>
+                    {allLabel}
+                  </span>
+                </button>
+                {filtered.length > 0 && <div className="dropdown-divider" />}
+              </>
+            )}
+            {filtered.length === 0 && !includeAll && (
               <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--t3)" }}>No models match</div>
             )}
             {filtered.map(m => {

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -257,7 +257,7 @@ export function ModelPicker({
                 {filtered.length > 0 && <div className="dropdown-divider" />}
               </>
             )}
-            {filtered.length === 0 && !includeAll && (
+            {filtered.length === 0 && (!includeAll || filter.trim()) && (
               <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--t3)" }}>No models match</div>
             )}
             {filtered.map(m => {

--- a/ui/src/features/shared/Overlays.tsx
+++ b/ui/src/features/shared/Overlays.tsx
@@ -15,12 +15,14 @@ import { Icon, Icons } from "./Icons";
 // system widget. Keyboard: Escape closes.
 function DialogChrome({
   title,
+  ariaLabel,
   children,
   footer,
   onClose,
   surface,
 }: {
   title: string;
+  ariaLabel?: string;
   children: React.ReactNode;
   footer: React.ReactNode;
   onClose: () => void;
@@ -61,7 +63,7 @@ function DialogChrome({
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-label={ariaLabel ?? title}
         tabIndex={-1}
         style={surface}
         onClick={e => e.stopPropagation()}>
@@ -158,8 +160,9 @@ export function SlideOver({ title, children, footer, onClose, width = 420 }: {
 // floats in the middle of the viewport — use for confirmations and
 // content that interrupts to ask a question (vs SlideOver which feels
 // like an inspector slot attached to the page).
-export function Modal({ title, children, footer, onClose, width = 560 }: {
+export function Modal({ title, ariaLabel, children, footer, onClose, width = 560 }: {
   title: string;
+  ariaLabel?: string;
   children: React.ReactNode;
   footer: React.ReactNode;
   onClose: () => void;
@@ -168,6 +171,7 @@ export function Modal({ title, children, footer, onClose, width = 560 }: {
   return (
     <DialogChrome
       title={title}
+      ariaLabel={ariaLabel}
       footer={footer}
       onClose={onClose}
       surface={{

--- a/ui/src/features/shared/ui.test.tsx
+++ b/ui/src/features/shared/ui.test.tsx
@@ -376,6 +376,17 @@ describe("ModelPicker", () => {
     expect(within(menu as HTMLElement).queryByText("gpt-4o")).toBeNull();
   });
 
+  it("shows an empty-state message for no-match filters when the all-models sentinel is enabled", async () => {
+    const user = userEvent.setup();
+    render(<ModelPicker value="" onChange={() => {}} models={models} includeAll />);
+    await user.click(screen.getByRole("button"));
+    const input = screen.getByPlaceholderText(/Filter models/i);
+    await user.type(input, "not-a-model");
+    const menu = document.querySelector(".dropdown-menu")!;
+    expect(within(menu as HTMLElement).getByText("All models")).toBeTruthy();
+    expect(within(menu as HTMLElement).getByText("No models match")).toBeTruthy();
+  });
+
   it("greys out and blocks selection of disabled-provider rows", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -96,6 +96,28 @@ describe("buildSpanWaterfall", () => {
       .toBe(Date.parse("2026-05-11T06:14:05.428Z"));
   });
 
+  it("scales valid sub-ms traces to their real latest end, not a 1ms floor", () => {
+    const spans: TraceSpanRecord[] = [
+      span({
+        span_id: "root",
+        name: "gateway.request",
+        start_time: "2026-05-11T06:14:05.428000Z",
+        end_time: "2026-05-11T06:14:05.428090Z",
+      }),
+      span({
+        span_id: "router",
+        name: "gateway.router",
+        parent_span_id: "root",
+        start_time: "2026-05-11T06:14:05.428050Z",
+        end_time: "2026-05-11T06:14:05.428090Z",
+      }),
+    ];
+    const wf = buildSpanWaterfall(spans);
+    expect(wf.totalMs).toBeCloseTo(0.09, 3);
+    const root = wf.spans.find((s) => s.span.span_id === "root")!;
+    expect(root.startMs + root.durMs).toBeCloseTo(wf.totalMs, 3);
+  });
+
   it("flags spans that have at least one child via hasChildren", () => {
     // Trace from the dev server: gateway.request is the root and the
     // other three are its direct children. Only the root should have

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSpanWaterfall, findModelInTrace, findProviderInTrace, parseISOWithSubMs } from "./runtime-trace";
+import { buildSpanWaterfall, buildTraceTimeline, findModelInTrace, findProviderInTrace, parseISOWithSubMs } from "./runtime-trace";
 import type { TraceSpanRecord } from "../types/runtime";
 
 // Helpers for the synthetic-trace fixtures. `at(ms)` returns an ISO
@@ -348,5 +348,32 @@ describe("buildSpanWaterfall", () => {
     const short = wf.spans.find((s) => s.span.span_id === "short")!;
     expect(long.critical).toBe(true);
     expect(short.critical).toBe(false);
+  });
+});
+
+describe("buildTraceTimeline", () => {
+  it("uses sub-ms event offsets instead of collapsing them to 0 ms", () => {
+    const timeline = buildTraceTimeline([
+      span({
+        span_id: "root",
+        name: "gateway.request",
+        events: [
+          {
+            name: "request.received",
+            timestamp: "2026-05-11T06:14:05.428427Z",
+          },
+          {
+            name: "governor.allowed",
+            timestamp: "2026-05-11T06:14:05.428912Z",
+          },
+          {
+            name: "router.selected",
+            timestamp: "2026-05-11T06:14:05.430869Z",
+          },
+        ],
+      }),
+    ], "2026-05-11T06:14:05.428427Z");
+
+    expect(timeline.map((event) => event.offsetLabel)).toEqual(["0 ms", "0.485 ms", "2.44 ms"]);
   });
 });

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSpanWaterfall, parseISOWithSubMs } from "./runtime-trace";
+import { buildSpanWaterfall, findModelInTrace, findProviderInTrace, parseISOWithSubMs } from "./runtime-trace";
 import type { TraceSpanRecord } from "../types/runtime";
 
 // Helpers for the synthetic-trace fixtures. `at(ms)` returns an ISO
@@ -94,6 +94,36 @@ describe("buildSpanWaterfall", () => {
     // Plain ms-precision input still works, same as Date.parse.
     expect(parseISOWithSubMs("2026-05-11T06:14:05.428Z"))
       .toBe(Date.parse("2026-05-11T06:14:05.428Z"));
+  });
+
+  it("uses sub-ms event timestamps when choosing the latest inferred provider and model", () => {
+    const spans: TraceSpanRecord[] = [
+      span({
+        span_id: "root",
+        name: "gateway.provider",
+        events: [
+          {
+            name: "provider.call.finished",
+            timestamp: "2026-05-11T06:14:05.428427Z",
+            attributes: {
+              "gen_ai.provider.name": "ollama",
+              "gen_ai.response.model": "llama3.1:8b",
+            },
+          },
+          {
+            name: "provider.call.finished",
+            timestamp: "2026-05-11T06:14:05.428912Z",
+            attributes: {
+              "gen_ai.provider.name": "lmstudio",
+              "gen_ai.response.model": "ministral-3:latest",
+            },
+          },
+        ],
+      }),
+    ];
+
+    expect(findProviderInTrace(spans)).toBe("lmstudio");
+    expect(findModelInTrace(spans, "lmstudio")).toBe("ministral-3:latest");
   });
 
   it("scales valid sub-ms traces to their real latest end, not a 1ms floor", () => {

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -103,7 +103,7 @@ export function findModelInTrace(spans: TraceSpanRecord[], provider?: string): s
       const spanModel = traceStringAttr(span.attributes ?? {}, "gen_ai.response.model")
         || traceStringAttr(span.attributes ?? {}, "gen_ai.request.model");
       if (spanModel) {
-        candidates.push({ priority: span.name === "gateway.router" ? 2 : 1, timestamp: Date.parse(span.start_time ?? ""), model: spanModel });
+        candidates.push({ priority: span.name === "gateway.router" ? 2 : 1, timestamp: parseISOWithSubMs(span.start_time ?? ""), model: spanModel });
       }
     }
 
@@ -118,13 +118,13 @@ export function findModelInTrace(spans: TraceSpanRecord[], provider?: string): s
 
       const responseModel = traceStringAttr(attrs, "gen_ai.response.model");
       if (responseModel) {
-        candidates.push({ priority: 3, timestamp: Date.parse(event.timestamp), model: responseModel });
+        candidates.push({ priority: 3, timestamp: parseISOWithSubMs(event.timestamp), model: responseModel });
       }
 
       const requestModel = traceStringAttr(attrs, "gen_ai.request.model");
       if (requestModel) {
         const priority = event.name === "provider.call.finished" || event.name === "router.candidate.selected" ? 2 : 1;
-        candidates.push({ priority, timestamp: Date.parse(event.timestamp), model: requestModel });
+        candidates.push({ priority, timestamp: parseISOWithSubMs(event.timestamp), model: requestModel });
       }
     }
   }
@@ -147,14 +147,14 @@ export function findProviderInTrace(spans: TraceSpanRecord[]): string {
   for (const span of spans) {
     const spanProvider = traceStringAttr(span.attributes ?? {}, "gen_ai.provider.name");
     if (spanProvider) {
-      candidates.push({ priority: span.name === "gateway.router" || span.name.startsWith("provider.") ? 2 : 1, timestamp: Date.parse(span.start_time ?? ""), provider: spanProvider });
+      candidates.push({ priority: span.name === "gateway.router" || span.name.startsWith("provider.") ? 2 : 1, timestamp: parseISOWithSubMs(span.start_time ?? ""), provider: spanProvider });
     }
 
     for (const event of span.events ?? []) {
       const provider = traceStringAttr(event.attributes ?? {}, "gen_ai.provider.name");
       if (!provider) continue;
       const selected = event.name === "router.selected" || event.name === "router.candidate.selected" || event.name.startsWith("provider.call.");
-      candidates.push({ priority: selected ? 3 : 1, timestamp: Date.parse(event.timestamp), provider });
+      candidates.push({ priority: selected ? 3 : 1, timestamp: parseISOWithSubMs(event.timestamp), provider });
     }
   }
 

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -70,17 +70,17 @@ export type TraceWaterfall = {
 export function buildTraceTimeline(spans: TraceSpanRecord[], traceStartedAt?: string): TraceTimelineItem[] {
   const flattened: TraceTimelineItem[] = [];
   const startSource = traceStartedAt || spans[0]?.start_time || "";
-  const startMs = Date.parse(startSource);
+  const startMs = parseISOWithSubMs(startSource);
 
   for (const span of spans) {
     for (const event of span.events ?? []) {
-      const currentMs = Date.parse(event.timestamp);
+      const currentMs = parseISOWithSubMs(event.timestamp);
       const offsetMs = Number.isFinite(startMs) && Number.isFinite(currentMs) ? Math.max(0, currentMs - startMs) : 0;
       flattened.push({
         name: event.name,
         timestamp: event.timestamp,
         offsetMs,
-        offsetLabel: `${offsetMs} ms`,
+        offsetLabel: formatTraceOffsetMs(offsetMs),
         spanName: span.name,
         spanKind: span.kind || "internal",
         phase: tracePhaseFromEvent(event.name),
@@ -91,6 +91,18 @@ export function buildTraceTimeline(spans: TraceSpanRecord[], traceStartedAt?: st
 
   flattened.sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp));
   return flattened;
+}
+
+function formatTraceOffsetMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "0 ms";
+  if (ms < 1) return `${trimFixed(ms, 3)} ms`;
+  if (ms < 10) return `${trimFixed(ms, 2)} ms`;
+  if (ms < 100) return `${trimFixed(ms, 1)} ms`;
+  return `${Math.round(ms)} ms`;
+}
+
+function trimFixed(value: number, digits: number): string {
+  return value.toFixed(digits).replace(/\.?0+$/, "");
 }
 
 export function findModelInTrace(spans: TraceSpanRecord[], provider?: string): string {

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -56,10 +56,8 @@ export type WaterfallSpan = {
   unknownTiming: boolean;
   negativeDuration: boolean;
   // True when at least one other span in the same trace lists this
-  // span as its parent. Drives the renderer's "outline vs filled" bar
-  // style — parent rows are subordinated visually so the leaf spans
-  // underneath show their real start offsets without competing with
-  // an always-fully-covering parent bar.
+  // span as its parent. The renderer uses this as hierarchy metadata;
+  // parent rows still render as normal bars.
   hasChildren: boolean;
 };
 
@@ -100,6 +98,15 @@ export function findModelInTrace(spans: TraceSpanRecord[], provider?: string): s
   const candidates: Array<{ priority: number; timestamp: number; model: string }> = [];
 
   for (const span of spans) {
+    const spanProvider = traceStringAttr(span.attributes ?? {}, "gen_ai.provider.name");
+    if (!normalizedProvider || !spanProvider || spanProvider === normalizedProvider) {
+      const spanModel = traceStringAttr(span.attributes ?? {}, "gen_ai.response.model")
+        || traceStringAttr(span.attributes ?? {}, "gen_ai.request.model");
+      if (spanModel) {
+        candidates.push({ priority: span.name === "gateway.router" ? 2 : 1, timestamp: Date.parse(span.start_time ?? ""), model: spanModel });
+      }
+    }
+
     for (const event of span.events ?? []) {
       const attrs = event.attributes ?? {};
       if (normalizedProvider) {
@@ -132,6 +139,35 @@ export function findModelInTrace(spans: TraceSpanRecord[], provider?: string): s
   });
 
   return candidates[0]?.model ?? "";
+}
+
+export function findProviderInTrace(spans: TraceSpanRecord[]): string {
+  const candidates: Array<{ priority: number; timestamp: number; provider: string }> = [];
+
+  for (const span of spans) {
+    const spanProvider = traceStringAttr(span.attributes ?? {}, "gen_ai.provider.name");
+    if (spanProvider) {
+      candidates.push({ priority: span.name === "gateway.router" || span.name.startsWith("provider.") ? 2 : 1, timestamp: Date.parse(span.start_time ?? ""), provider: spanProvider });
+    }
+
+    for (const event of span.events ?? []) {
+      const provider = traceStringAttr(event.attributes ?? {}, "gen_ai.provider.name");
+      if (!provider) continue;
+      const selected = event.name === "router.selected" || event.name === "router.candidate.selected" || event.name.startsWith("provider.call.");
+      candidates.push({ priority: selected ? 3 : 1, timestamp: Date.parse(event.timestamp), provider });
+    }
+  }
+
+  candidates.sort((left, right) => {
+    if (left.priority !== right.priority) {
+      return right.priority - left.priority;
+    }
+    const leftTime = Number.isFinite(left.timestamp) ? left.timestamp : 0;
+    const rightTime = Number.isFinite(right.timestamp) ? right.timestamp : 0;
+    return rightTime - leftTime;
+  });
+
+  return candidates[0]?.provider ?? "";
 }
 
 function traceStringAttr(attrs: Record<string, unknown>, key: string): string {

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -313,13 +313,13 @@ export function buildSpanWaterfall(spans: TraceSpanRecord[]): TraceWaterfall {
   const startValidParsed = parsed.filter((p) => p.startValid);
   const t0 = startValidParsed.length > 0 ? Math.min(...startValidParsed.map((p) => p.start)) : 0;
   const endValidParsed = parsed.filter((p) => p.startValid && p.endValid);
-  const totalMs = startValidParsed.length > 0
+  const rawTotalMs = startValidParsed.length > 0
     ? Math.max(
       ...endValidParsed.map((p) => p.end - t0),
       ...startValidParsed.map((p) => p.start - t0),
-      1,
     )
-    : 1;
+    : 0;
+  const totalMs = rawTotalMs > 0 ? rawTotalMs : 1;
 
   const byID = new Map<string, TraceSpanRecord>();
   for (const s of spans) byID.set(s.span_id, s);

--- a/ui/src/lib/runtime-utils.test.ts
+++ b/ui/src/lib/runtime-utils.test.ts
@@ -15,6 +15,7 @@ import {
   filterModelsByKind,
   filterModelsByProvider,
   findModelInTrace,
+  findProviderInTrace,
   formatRelativeTime,
   formatTraceAttributeKey,
   formatTraceAttributeValue,
@@ -145,6 +146,7 @@ describe("runtime-utils", () => {
 
     expect(findModelInTrace(spans, "ollama")).toBe("llama3.1:8b");
     expect(findModelInTrace(spans, "openai")).toBe("");
+    expect(findProviderInTrace(spans)).toBe("ollama");
   });
 
   it("formats route and provider diagnostics", () => {

--- a/ui/src/lib/runtime-utils.ts
+++ b/ui/src/lib/runtime-utils.ts
@@ -68,6 +68,7 @@ export type { TraceTimelineItem, WaterfallSpan, TraceWaterfall } from "./runtime
 export {
   buildTraceTimeline,
   findModelInTrace,
+  findProviderInTrace,
   formatTraceAttributeKey,
   formatTraceAttributeValue,
   tracePhaseFromSpan,


### PR DESCRIPTION
## Summary

- Rework the trace drawer waterfall into a DevTools-style timeline with aligned ticks, grid lines, sticky local axis, real sub-ms scaling, and request bars that use the full available width.
- Make Recent requests easier to read: provider/model are recovered from route spans or request ledger when route fields are missing, request IDs are compact in the table but copy the full value, latency is request-level across grouped sibling traces, and Reason/Fallback are collapsed into one compact Route column.
- Simplify Observability filters: provider stays explicit, model now starts at All models and filters observed traffic instead of implying the current chat model is the scope; Live/Paused no longer shifts the header.
- Clarify runtime cards with operator language, grouped sections, helper tooltips, status labels like Idle/Disabled/Memory store, and a short task-runtime summary.
- Remove confusing waterfall affordances: critical-path star, parent-span outline style, and mispositioned global timeline scrolling.

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run test`
