### PR TITLE
feat(website): release-aware download buttons on the homepage

### DIFF
--- a/website/bun.lock
+++ b/website/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@types/node": "^25.6.2",
         "@typescript/native-preview": "beta",
       },
     },
@@ -245,6 +246,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -715,6 +718,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/node": "^25.6.2",
     "@typescript/native-preview": "beta"
   }
 }

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,5 +1,60 @@
 ---
+import fs from "node:fs";
+import path from "node:path";
 import "../styles/global.css";
+
+// Release-aware download buttons. The release workflow's
+// publish-updater-website job commits the alpha channel's
+// latest.json to public/releases/alpha/ on every successful
+// release and then dispatches website.yml to rebuild. Reading
+// the manifest here lets the homepage track the latest release
+// without any manual edit — when alpha.29 ships, this page
+// rebuilds with alpha.29's URLs.
+//
+// Path resolution: anchored on `process.cwd()` rather than
+// `import.meta.url`. At Astro build time `import.meta.url` is
+// the bundled chunk inside `dist/.prerender/`, not this source
+// file, so relative offsets would couple us to Astro's
+// internal output structure. Astro itself runs from the
+// project root (any wrapper changing cwd would also break
+// Astro's config + public/ resolution), so cwd is a stable
+// anchor here.
+type Manifest = {
+  version: string;
+  platforms?: Record<string, { url?: string }>;
+};
+
+// Fallbacks for a fresh checkout where the alpha manifest hasn't
+// been published yet — every link points at the releases index,
+// where the operator can find whatever's available.
+const fallback = "https://github.com/hecatehq/hecate/releases";
+let version = "0.1.0-alpha";
+let releaseUrl = fallback;
+let macos = fallback;
+let linux = fallback;
+let windows = fallback;
+
+try {
+  const manifestPath = path.resolve(
+    process.cwd(),
+    "public/releases/alpha/latest.json",
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(manifestPath, "utf8"),
+  ) as Manifest;
+  version = manifest.version;
+  // Point at the specific tag, not /releases/latest — the latter
+  // will keep resolving to alpha.28 (the auto-update bridge
+  // release) even after alpha.29+ ship as pre-releases.
+  releaseUrl = `https://github.com/hecatehq/hecate/releases/tag/v${version}`;
+  // Release matrix currently ships macOS Apple Silicon only;
+  // if/when we add x86_64 macOS, derive a second URL here.
+  macos = `https://github.com/hecatehq/hecate/releases/download/v${version}/Hecate_${version}_aarch64.dmg`;
+  linux = manifest.platforms?.["linux-x86_64"]?.url ?? releaseUrl;
+  windows = manifest.platforms?.["windows-x86_64"]?.url ?? releaseUrl;
+} catch {
+  // No manifest yet — keep the generic fallbacks above.
+}
 ---
 
 <!doctype html>
@@ -33,16 +88,17 @@ import "../styles/global.css";
           </p>
 
           <div class="hero__actions" aria-label="Primary actions">
-          <a
-            class="button button--primary"
-            href="https://github.com/hecatehq/hecate/releases"
-          >
-            Download
-          </a>
-            <a class="button button--ghost" href="https://github.com/hecatehq/hecate">
-              GitHub
-            </a>
+            <a class="button button--primary" href={macos}>Download for macOS</a>
+            <a class="button button--ghost" href={linux}>Linux .AppImage</a>
+            <a class="button button--ghost" href={windows}>Windows .msi</a>
           </div>
+
+          <p class="hero__release">
+            <span class="hero__release-tag">v{version}</span>
+            · <a href={releaseUrl}>release notes</a>
+            · <a href="https://github.com/hecatehq/hecate/releases">all releases</a>
+            · <a href="https://github.com/hecatehq/hecate">GitHub</a>
+          </p>
         </div>
 
         <div class="hero__symbol" aria-hidden="true">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,14 +25,19 @@ type Manifest = {
 };
 
 // Fallbacks for a fresh checkout where the alpha manifest hasn't
-// been published yet — every link points at the releases index,
-// where the operator can find whatever's available.
-const fallback = "https://github.com/hecatehq/hecate/releases";
-let version = "0.1.0-alpha";
-let releaseUrl = fallback;
-let macos = fallback;
-let linux = fallback;
-let windows = fallback;
+// been published yet — every download link points at the releases
+// index so the operator can find whatever's available. The
+// version + release-notes footer is hidden in this case (see the
+// `manifestLoaded` gate in the markup below) — a fabricated
+// version string would mislead operators into thinking they're
+// downloading a specific build.
+const releasesIndex = "https://github.com/hecatehq/hecate/releases";
+let manifestLoaded = false;
+let version = "";
+let releaseUrl = releasesIndex;
+let macos = releasesIndex;
+let linux = releasesIndex;
+let windows = releasesIndex;
 
 try {
   const manifestPath = path.resolve(
@@ -52,8 +57,15 @@ try {
   macos = `https://github.com/hecatehq/hecate/releases/download/v${version}/Hecate_${version}_aarch64.dmg`;
   linux = manifest.platforms?.["linux-x86_64"]?.url ?? releaseUrl;
   windows = manifest.platforms?.["windows-x86_64"]?.url ?? releaseUrl;
-} catch {
-  // No manifest yet — keep the generic fallbacks above.
+  manifestLoaded = true;
+} catch (err) {
+  // ENOENT (fresh checkout, no release yet) is the only error we
+  // silence. Corrupt JSON, schema mismatches, permission issues,
+  // anything else — re-throw so the build fails loud rather than
+  // shipping a broken homepage with silently-wrong links.
+  if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+    throw err;
+  }
 }
 ---
 
@@ -93,10 +105,21 @@ try {
             <a class="button button--ghost" href={windows}>Windows .msi</a>
           </div>
 
+          {/* Version + release-notes link only render when the
+              manifest actually loaded — fabricating a version
+              string in the fresh-checkout case (no published
+              release yet) would mislead operators into thinking
+              they're downloading a specific build. The "all
+              releases" + "GitHub" links render either way. */}
           <p class="hero__release">
-            <span class="hero__release-tag">v{version}</span>
-            · <a href={releaseUrl}>release notes</a>
-            · <a href="https://github.com/hecatehq/hecate/releases">all releases</a>
+            {manifestLoaded && (
+              <Fragment>
+                <span class="hero__release-tag">v{version}</span>
+                · <a href={releaseUrl}>release notes</a>
+                ·
+              </Fragment>
+            )}
+            <a href="https://github.com/hecatehq/hecate/releases">all releases</a>
             · <a href="https://github.com/hecatehq/hecate">GitHub</a>
           </p>
         </div>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -184,6 +184,31 @@ h1 {
   background: rgba(250, 248, 255, 0.045);
 }
 
+.hero__release {
+  margin-top: 1.2rem;
+  color: var(--muted);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: clamp(0.78rem, 1.1vw, 0.95rem);
+  letter-spacing: 0.04em;
+}
+
+.hero__release a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-color: rgba(168, 163, 184, 0.4);
+  text-underline-offset: 0.18em;
+  transition: color 180ms ease, text-decoration-color 180ms ease;
+}
+
+.hero__release a:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink);
+}
+
+.hero__release-tag {
+  color: var(--ink);
+}
+
 .hero__symbol {
   position: relative;
   display: grid;


### PR DESCRIPTION
## Summary

The homepage's "Download" button used to point at `https://github.com/hecatehq/hecate/releases` (the full list page) — operators had to scroll, identify their platform, and click through. Now the page reads the alpha channel's `latest.json` at build time and renders three explicit platform buttons plus a version + release-notes footer.

The plumbing is already in place from PR #85: the release workflow's `publish-updater-website` job commits `latest.json` to `website/public/releases/alpha/` on every release and dispatches `website.yml` to rebuild. So when alpha.29 ships, this page auto-updates to point at alpha.29's bundles — zero manual edits.

## Decisions worth flagging

- **Three explicit buttons over JS-based OS detection.** UA sniffing fails for ARM Linux, iPads-as-laptops, headless installs, and can't carry per-distro nuance (`.deb` vs `.AppImage`) if we ever want it.
- **macOS URL is derived, not pulled from the manifest.** The manifest carries the updater payload (`.app.tar.gz`); fresh-install operators want the `.dmg`. They share a predictable filename pattern. Comment in the code notes the Apple-Silicon-only assumption.
- **Release-notes link points at `/releases/tag/v<version>`**, not `/releases/latest`. The latter resolves to alpha.28 (the auto-update bridge release) and will keep doing so after alpha.29+ ship as pre-releases. The tag URL re-derives correctly on every build.
- **Path resolution anchored on `process.cwd()`, not `import.meta.url`.** Reviewer originally suggested `new URL(..., import.meta.url)` for robustness against cwd changes. Verified empirically that at Astro build time `import.meta.url` is the bundled chunk inside `dist/.prerender/` (e.g., `dist/.prerender/chunks/index_Cq2Fom-6.mjs`), not the source file. Relative offsets from there would couple us to Astro's internal output structure and break on Astro major-version bumps. Astro itself runs from the project root (any wrapper changing cwd would also break Astro's config + public/ resolution), so cwd is the stable anchor.
- **Try/catch with fallbacks** to `/releases`, so a fresh checkout without a published manifest still renders working links instead of failing the build.

## Test plan

- [x] `bun --bun run check` — 0 errors, 0 warnings.
- [x] `bun --bun run build` — clean.
- [x] Inspected `dist/index.html` post-build; verified the three platform URLs carry the alpha.28 version:
  ```
  Hecate_0.1.0-alpha.28_aarch64.dmg
  Hecate_0.1.0-alpha.28_amd64.AppImage
  Hecate_0.1.0-alpha.28_x64_en-US.msi
  /releases/tag/v0.1.0-alpha.28
  ```
- [ ] Reviewer to render `bun run dev` locally and sanity-check the styling of the new `.hero__release` metadata line under both desktop and mobile breakpoints. Style additions are minimal (matches existing `.eyebrow` typography family + `--muted` color).
- [ ] End-to-end test on the next release: alpha.29 should auto-update the published homepage to point at alpha.29's bundles. This is the real validation of the manifest-read + workflow-dispatch loop.
