### PR TITLE
fix(adapters): rewrite Claude Code auth error + one-click setup deep-link

### DIFF
--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -37,11 +37,15 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 // the chat when a Claude Code agent run fails because the adapter
 // couldn't sign in. Two priorities behind the wording:
 //
-//  1. The chat UI pattern-matches `claude_code_auth_required` (the
-//     trailing token in the parenthetical below) to render an inline
+//  1. ui/src/features/chats/ChatView.tsx pattern-matches the
+//     `claude_code_auth_required` token in this string (via
+//     .includes()) to decide whether to render an inline
 //     "Open Claude Code setup" button that deep-links to the guided
-//     setup card in Settings → External agents. Keep that token in
+//     setup card in Settings → External agents. Keep the token in
 //     the string verbatim — the UI handler depends on it.
+//     (TranscriptMessageRow only strips the trailing parenthetical
+//     marker from the visible copy; the match-and-render-button
+//     decision lives in ChatView.)
 //  2. Distinguish this credential from the Anthropic key in the
 //     Providers tab. Operators who paste a key into Providers tab
 //     reasonably expect Claude Code to "just work" — it doesn't,

--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -20,9 +20,9 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 			return AuthStatusOK, ""
 		}
 		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
-			return AuthStatusUnknown, "Claude Code config is present, but the ACP adapter may still need adapter-visible auth. Use Test adapter; if it fails, " + claudeCodeACPAuthHint()
+			return AuthStatusUnknown, "Claude Code config is present on disk, but the ACP adapter may need its own token. Use Test adapter to check; if it fails, open the guided setup card below."
 		}
-		return AuthStatusUnknown, "Use Test adapter; if Claude Code reports auth errors, " + claudeCodeACPAuthHint()
+		return AuthStatusUnknown, "Use Test adapter to check. If Claude Code reports a sign-in error, open the guided setup card below to paste a token from `claude setup-token`."
 	case "cursor_agent":
 		if envAny("CURSOR_API_KEY") || fileAny("${HOME}/.cursor", "${HOME}/Library/Application Support/Cursor") {
 			return AuthStatusOK, ""
@@ -33,8 +33,26 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 	}
 }
 
-func claudeCodeACPAuthHint() string {
-	return "set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`, ANTHROPIC_API_KEY, or ANTHROPIC_AUTH_TOKEN for the adapter environment."
+// claudeCodeAuthErrorMessage is the user-facing message rendered in
+// the chat when a Claude Code agent run fails because the adapter
+// couldn't sign in. Two priorities behind the wording:
+//
+//  1. The chat UI pattern-matches `claude_code_auth_required` (the
+//     trailing token in the parenthetical below) to render an inline
+//     "Open Claude Code setup" button that deep-links to the guided
+//     setup card in Settings → External agents. Keep that token in
+//     the string verbatim — the UI handler depends on it.
+//  2. Distinguish this credential from the Anthropic key in the
+//     Providers tab. Operators who paste a key into Providers tab
+//     reasonably expect Claude Code to "just work" — it doesn't,
+//     because Claude Code runs as its own subprocess with its own
+//     credentials.
+//
+// The message stays deliberately short: the UI button does the
+// heavy lifting (one click → Settings → External agents → Claude
+// Code, with the setup card scrolled into view).
+func claudeCodeAuthErrorMessage() string {
+	return "Claude Code isn't signed in. This is a separate credential from the Anthropic key in the Providers tab — Claude Code runs as its own program. Click the button below to paste a token from `claude setup-token` into the guided setup card. No restart needed. (claude_code_auth_required)"
 }
 
 func envAny(names ...string) bool {

--- a/internal/agentadapters/auth_status_test.go
+++ b/internal/agentadapters/auth_status_test.go
@@ -50,8 +50,14 @@ func TestDetectAuthStatusClaudeUnknownWithoutMarker(t *testing.T) {
 	if status != AuthStatusUnknown {
 		t.Fatalf("status = %q, want %q", status, AuthStatusUnknown)
 	}
-	if !strings.Contains(hint, "CLAUDE_CODE_OAUTH_TOKEN") || !strings.Contains(hint, "ANTHROPIC_API_KEY") {
-		t.Fatalf("hint = %q, want adapter-visible subscription/API-key guidance", hint)
+	// The hint points at the in-app guided setup card rather than
+	// enumerating env vars. The card itself documents the env-var
+	// alternative for power users.
+	if !strings.Contains(hint, "guided setup card") {
+		t.Fatalf("hint = %q, want guided-setup card guidance", hint)
+	}
+	if !strings.Contains(hint, "claude setup-token") {
+		t.Fatalf("hint = %q, want the `claude setup-token` command callout", hint)
 	}
 }
 
@@ -66,8 +72,11 @@ func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
 	if status != AuthStatusUnknown {
 		t.Fatalf("status = %q, want %q", status, AuthStatusUnknown)
 	}
-	if !strings.Contains(hint, "ACP adapter") || !strings.Contains(hint, "ANTHROPIC_API_KEY") {
-		t.Fatalf("hint = %q, want ACP-specific auth guidance", hint)
+	// Same in-app guidance — but mention the on-disk config so the
+	// operator understands why we still flag this as needing
+	// verification despite the file being present.
+	if !strings.Contains(hint, "ACP adapter") || !strings.Contains(hint, "guided setup card") {
+		t.Fatalf("hint = %q, want ACP-specific guided-setup guidance", hint)
 	}
 }
 

--- a/internal/agentadapters/normalize.go
+++ b/internal/agentadapters/normalize.go
@@ -32,7 +32,7 @@ func NormalizeError(adapterName string, err error) string {
 		return ""
 	}
 	if adapterName == "Claude Code" && isAuthErrorText(raw) {
-		return "Claude Code needs adapter-visible authentication: " + claudeCodeACPAuthHint() + " Restart Hecate after changing environment credentials."
+		return claudeCodeAuthErrorMessage()
 	}
 	parsed, ok := parseJSONRPCError(raw)
 	if !ok {
@@ -49,7 +49,7 @@ func NormalizeError(adapterName string, err error) string {
 		adapterName = "Agent adapter"
 	}
 	if adapterName == "Claude Code" && isAuthErrorText(message) {
-		return "Claude Code needs adapter-visible authentication: " + claudeCodeACPAuthHint() + " Restart Hecate after changing environment credentials."
+		return claudeCodeAuthErrorMessage()
 	}
 	if kind := parsed.Data.ErrorKind; kind != "" {
 		return adapterName + " error (" + kind + "): " + message

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -204,7 +204,7 @@ func ProbeWithEnv(ctx context.Context, adapterID string, extraEnv []string) (res
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
 		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
-			res.Hint = "Claude Code ACP needs adapter-visible auth. " + claudeCodeACPAuthHint()
+			res.Hint = "Claude Code isn't signed in. Open the guided setup card in Settings → External agents and paste a token from `claude setup-token`. No restart needed."
 		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)
@@ -222,7 +222,7 @@ func ProbeWithEnv(ctx context.Context, adapterID string, extraEnv []string) (res
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
 		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
-			res.Hint = "Claude Code ACP needs adapter-visible auth. " + claudeCodeACPAuthHint()
+			res.Hint = "Claude Code isn't signed in. Open the guided setup card in Settings → External agents and paste a token from `claude setup-token`. No restart needed."
 		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -468,7 +468,22 @@ func TestNormalizeErrorExplainsClaudeAuthRequirement(t *testing.T) {
 	t.Parallel()
 
 	got := NormalizeError("Claude Code", errors.New(`{"code":-32603,"message":"Authentication required"}`))
-	if !strings.Contains(got, "adapter-visible authentication") || !strings.Contains(got, "ANTHROPIC_API_KEY") {
-		t.Fatalf("NormalizeError = %q, want Claude ACP auth guidance", got)
+	// Three load-bearing markers in the rewritten copy:
+	//   - "Claude Code isn't signed in" — the friendly headline.
+	//   - "Providers tab" — explicit separation from the Anthropic
+	//     provider key (the original message conflated them, which
+	//     misled operators who had configured Anthropic in the UI).
+	//   - "claude_code_auth_required" — the stable token the chat
+	//     UI pattern-matches on to render the "Open Claude Code
+	//     setup" inline action. Don't change it without updating
+	//     the matching UI handler in TranscriptMessageRow.
+	if !strings.Contains(got, "isn't signed in") {
+		t.Fatalf("NormalizeError = %q, want friendly 'isn't signed in' headline", got)
+	}
+	if !strings.Contains(got, "Providers tab") {
+		t.Fatalf("NormalizeError = %q, want explicit separation from the Anthropic Providers-tab key", got)
+	}
+	if !strings.Contains(got, "claude_code_auth_required") {
+		t.Fatalf("NormalizeError = %q, want claude_code_auth_required token for UI pattern-match", got)
 	}
 }

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -473,10 +473,13 @@ func TestNormalizeErrorExplainsClaudeAuthRequirement(t *testing.T) {
 	//   - "Providers tab" — explicit separation from the Anthropic
 	//     provider key (the original message conflated them, which
 	//     misled operators who had configured Anthropic in the UI).
-	//   - "claude_code_auth_required" — the stable token the chat
-	//     UI pattern-matches on to render the "Open Claude Code
-	//     setup" inline action. Don't change it without updating
-	//     the matching UI handler in TranscriptMessageRow.
+	//   - "claude_code_auth_required" — the stable token that
+	//     ui/src/features/chats/ChatView.tsx pattern-matches on
+	//     (via .includes()) when building the setupAction prop for
+	//     TranscriptMessageRow. TranscriptMessageRow itself only
+	//     strips the marker from the visible message text; the
+	//     match-and-render-button decision lives in ChatView. Don't
+	//     change this token without updating the ChatView handler.
 	if !strings.Contains(got, "isn't signed in") {
 		t.Fatalf("NormalizeError = %q, want friendly 'isn't signed in' headline", got)
 	}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -17,7 +17,7 @@ import { AddProviderModal } from "../providers/AddProviderModal";
 type Props = {
   state: RuntimeConsoleViewModel["state"];
   actions: RuntimeConsoleViewModel["actions"];
-  onNavigate?: (workspace: "providers" | "runs" | "overview") => void;
+  onNavigate?: (workspace: "providers" | "runs" | "overview" | "settings") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
 };
@@ -961,6 +961,39 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                 agentUsage={isAgentChat && role === "assistant" ? m.usage : undefined}
                 agentTiming={isAgentChat && role === "assistant" ? m.timing : undefined}
                 error={isAgentChat && role === "assistant" ? m.error : undefined}
+                setupAction={
+                  // Render the "Open Claude Code setup" button only
+                  // when the server-side message carries the
+                  // claude_code_auth_required marker. Pattern-match
+                  // (not strict equality) is deliberate — the marker
+                  // is part of a paragraph that may be reworded over
+                  // time; the token itself is stable contract between
+                  // internal/agentadapters/auth_status.go and this UI
+                  // handler.
+                  isAgentChat && role === "assistant" && m.agent_adapter_id === "claude_code"
+                    && typeof m.error === "string" && m.error.includes("claude_code_auth_required")
+                    ? {
+                        label: "Open Claude Code setup",
+                        title: "Open Settings → External agents and scroll to the guided setup card",
+                        onClick: () => {
+                          // Pre-set the persisted Settings sub-tab so
+                          // SettingsView mounts directly on External
+                          // agents (rather than wherever the operator
+                          // last left it). The session flag drives a
+                          // one-shot scroll-into-view + highlight on
+                          // the guided setup card.
+                          try {
+                            localStorage.setItem("hecate.settingsTab", "external_agents");
+                            sessionStorage.setItem("hecate.settingsFocus", "claude-code-guided-setup");
+                          } catch {
+                            // localStorage / sessionStorage unavailable —
+                            // navigation still works, just no auto-scroll.
+                          }
+                          onNavigate?.("settings");
+                        },
+                      }
+                    : undefined
+                }
                 onCopy={copyMsg}
                 copied={copiedMsgId === m.id}
               />

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -489,6 +489,33 @@ function ExternalAgentsTab({ state, actions }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // One-shot scroll + highlight when the operator arrived here via
+  // the "Open Claude Code setup" button on a failed Claude run.
+  // The chat sets `hecate.settingsFocus` in sessionStorage before
+  // navigating; we read-and-clear it so subsequent visits to this
+  // tab don't re-trigger the scroll.
+  useEffect(() => {
+    let focusTarget: string | null = null;
+    try {
+      focusTarget = sessionStorage.getItem("hecate.settingsFocus");
+      if (focusTarget) sessionStorage.removeItem("hecate.settingsFocus");
+    } catch {
+      // sessionStorage unavailable — nothing to focus.
+    }
+    if (!focusTarget) return;
+    // Defer one frame so the card has rendered before we measure it.
+    const handle = window.setTimeout(() => {
+      const card = document.querySelector(`[data-testid="${focusTarget}"]`);
+      if (!card) return;
+      card.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Brief highlight so the operator's eye lands on it. Class is
+      // toggled rather than inlined so the styling lives in CSS.
+      card.classList.add("settings-focus-flash");
+      window.setTimeout(() => card.classList.remove("settings-focus-flash"), 2200);
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, []);
+
   const grants = state.agentChatGrants;
   const loading = state.agentChatGrantsLoading;
   const error = state.agentChatGrantsError;

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -494,26 +494,45 @@ function ExternalAgentsTab({ state, actions }: Props) {
   // The chat sets `hecate.settingsFocus` in sessionStorage before
   // navigating; we read-and-clear it so subsequent visits to this
   // tab don't re-trigger the scroll.
+  //
+  // The focus target is validated against a small allowlist before
+  // it's interpolated into a DOM lookup — that avoids any selector-
+  // injection class from an unexpected sessionStorage value (which
+  // could happen via a stale entry, a third-party extension writing
+  // into the same key, or a forward-compat token a newer build set
+  // that this build doesn't know about). Add new targets to the
+  // KNOWN_FOCUS_TARGETS set when more callers wire one in.
   useEffect(() => {
+    const KNOWN_FOCUS_TARGETS = new Set(["claude-code-guided-setup"]);
     let focusTarget: string | null = null;
     try {
-      focusTarget = sessionStorage.getItem("hecate.settingsFocus");
-      if (focusTarget) sessionStorage.removeItem("hecate.settingsFocus");
+      const raw = sessionStorage.getItem("hecate.settingsFocus");
+      if (raw) sessionStorage.removeItem("hecate.settingsFocus");
+      if (raw && KNOWN_FOCUS_TARGETS.has(raw)) focusTarget = raw;
     } catch {
       // sessionStorage unavailable — nothing to focus.
     }
     if (!focusTarget) return;
-    // Defer one frame so the card has rendered before we measure it.
-    const handle = window.setTimeout(() => {
-      const card = document.querySelector(`[data-testid="${focusTarget}"]`);
+    const target = focusTarget; // narrow for the inner closure
+    // Defer one frame so the card has rendered before we measure
+    // it. Track both timers so an unmount mid-flash doesn't leak
+    // or run the class-removal against a detached node.
+    let removeHandle: number | null = null;
+    const startHandle = window.setTimeout(() => {
+      const card = document.querySelector(`[data-testid="${target}"]`);
       if (!card) return;
       card.scrollIntoView({ behavior: "smooth", block: "center" });
       // Brief highlight so the operator's eye lands on it. Class is
       // toggled rather than inlined so the styling lives in CSS.
       card.classList.add("settings-focus-flash");
-      window.setTimeout(() => card.classList.remove("settings-focus-flash"), 2200);
+      removeHandle = window.setTimeout(() => {
+        card.classList.remove("settings-focus-flash");
+      }, 2200);
     }, 0);
-    return () => window.clearTimeout(handle);
+    return () => {
+      window.clearTimeout(startHandle);
+      if (removeHandle !== null) window.clearTimeout(removeHandle);
+    };
   }, []);
 
   const grants = state.agentChatGrants;

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -37,6 +37,39 @@ describe("TranscriptMessageRow", () => {
     render(<TranscriptMessageRow {...baseProps} badge="failed" error="adapter exited 1" />);
     expect(screen.getByText("agent run failed")).toBeInTheDocument();
     expect(screen.getByText("adapter exited 1")).toBeInTheDocument();
+  });
+
+  it("strips the recovery marker from the visible failure message", () => {
+    render(<TranscriptMessageRow
+      {...baseProps}
+      badge="failed"
+      error="Claude Code isn't signed in. Click the button below. (claude_code_auth_required)"
+    />);
+    expect(screen.getByText(/Claude Code isn't signed in/)).toBeInTheDocument();
+    expect(screen.queryByText(/claude_code_auth_required/)).toBeNull();
+  });
+
+  it("renders the setup-action button on a failed agent run", () => {
+    const onClick = vi.fn();
+    render(<TranscriptMessageRow
+      {...baseProps}
+      badge="failed"
+      error="Claude Code isn't signed in. (claude_code_auth_required)"
+      setupAction={{ label: "Open Claude Code setup", onClick }}
+    />);
+    const button = screen.getByRole("button", { name: "Open Claude Code setup" });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the setup-action button when the run is cancelled (only on failure)", () => {
+    render(<TranscriptMessageRow
+      {...baseProps}
+      badge="cancelled"
+      error="user pressed stop"
+      setupAction={{ label: "Open Claude Code setup", onClick: vi.fn() }}
+    />);
+    expect(screen.queryByRole("button", { name: "Open Claude Code setup" })).toBeNull();
   });
 
   it("renders an agent run cancelled notice when badge=cancelled", () => {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -7,7 +7,7 @@ import { TranscriptActivityTimeline } from "./TranscriptActivityTimeline";
 import { TranscriptDiffReview } from "./TranscriptDiffReview";
 import { TranscriptMarkdown } from "./TranscriptMarkdown";
 
-export function TranscriptMessageRow({ id, role, model, content, time, promptTokens, completionTokens, costUsd, badge, runtimeMeta, taskLink, traceLink, activities, diffStat, diff, agentSessionID, onListAgentFiles, onGetAgentFileDiff, onRevertAgentFiles, rawOutput, agentUsage, agentTiming, error, onCopy, copied }: {
+export function TranscriptMessageRow({ id, role, model, content, time, promptTokens, completionTokens, costUsd, badge, runtimeMeta, taskLink, traceLink, activities, diffStat, diff, agentSessionID, onListAgentFiles, onGetAgentFileDiff, onRevertAgentFiles, rawOutput, agentUsage, agentTiming, error, setupAction, onCopy, copied }: {
   id: string; role: "user" | "assistant"; model?: string; content: string;
   time: string; promptTokens?: number; completionTokens?: number; costUsd?: string;
   badge?: string; runtimeMeta?: string; agentSessionID?: string;
@@ -18,6 +18,13 @@ export function TranscriptMessageRow({ id, role, model, content, time, promptTok
   onGetAgentFileDiff?: (sessionID: string, messageID: string, path: string) => Promise<AgentChatChangedFileDiffRecord | null>;
   onRevertAgentFiles?: (sessionID: string, messageID: string, paths: string[]) => Promise<boolean>;
   rawOutput?: string; agentUsage?: AgentChatUsageRecord; agentTiming?: AgentChatTimingRecord; error?: string;
+  // setupAction is an inline button rendered inside the agent-run
+  // failure notice. The chat passes it when the failure has a
+  // known one-click recovery path — currently just the Claude Code
+  // auth error (where the button deep-links to the guided setup
+  // card in Settings → External agents). Optional in all other
+  // cases.
+  setupAction?: { label: string; title?: string; onClick: () => void };
   onCopy: (id: string, text: string) => void; copied: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
@@ -83,7 +90,11 @@ export function TranscriptMessageRow({ id, role, model, content, time, promptTok
             </div>
           </div>
           {failed || cancelled ? (
-            <AgentRunNotice status={failed ? "failed" : "cancelled"} message={error || content} />
+            <AgentRunNotice
+              status={failed ? "failed" : "cancelled"}
+              message={error || content}
+              action={failed ? setupAction : undefined}
+            />
           ) : thinkingForAgent ? (
             <AgentLiveText content={content} />
           ) : waitingForAgentOutput ? (
@@ -300,8 +311,22 @@ function isActiveAgentActivity(activity: AgentChatActivityRecord): boolean {
   return activity.status === "running" || activity.status === "in_progress";
 }
 
-function AgentRunNotice({ status, message }: { status: "failed" | "cancelled"; message: string }) {
+function AgentRunNotice({
+  status,
+  message,
+  action,
+}: {
+  status: "failed" | "cancelled";
+  message: string;
+  action?: { label: string; title?: string; onClick: () => void };
+}) {
   const color = status === "failed" ? "var(--red)" : "var(--amber)";
+  // The trailing parenthetical marker (e.g. "(claude_code_auth_required)")
+  // is intentional in the server-side string — the chat uses it to
+  // decide whether to render the recovery action. Strip it from
+  // the visible copy so operators don't see the implementation
+  // detail.
+  const visible = message ? message.replace(/\s*\([a-z][a-z0-9_]+_required\)\s*$/i, "").trim() : "";
   return (
     <div style={{
       border: "1px solid var(--border)",
@@ -313,9 +338,22 @@ function AgentRunNotice({ status, message }: { status: "failed" | "cancelled"; m
       <div style={{ color, fontFamily: "var(--font-mono)", fontSize: 11, marginBottom: 4 }}>
         agent run {status}
       </div>
-      {message && (
+      {visible && (
         <div style={{ color: "var(--t0)", fontSize: 13, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
-          {message}
+          {visible}
+        </div>
+      )}
+      {action && (
+        <div style={{ marginTop: 8 }}>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            onClick={action.onClick}
+            title={action.title}
+            style={{ fontSize: 12, padding: "5px 10px" }}
+          >
+            {action.label}
+          </button>
         </div>
       )}
     </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -231,5 +231,18 @@ button, input, select, textarea { font: inherit; }
 .dropdown-section-label { padding: 6px 12px 3px; font-size: 10px; font-weight: 500; color: var(--t3); letter-spacing: 0.08em; text-transform: uppercase; }
 .dropdown-divider { height: 1px; background: var(--border); margin: 4px 0; }
 
+/* ─── Settings-card focus highlight ───
+   Applied for ~2s by SettingsView.ExternalAgentsTab when an operator
+   arrives via a deep link (e.g. the "Open Claude Code setup" button
+   on a failed Claude run). Pulls the operator's eye to the right
+   card after the scrollIntoView. Class is toggled, not inlined, so
+   the animation lives next to the design tokens. */
+@keyframes settings-focus-flash {
+  0%   { box-shadow: 0 0 0 0 oklch(0.68 0.13 185 / 0); }
+  20%  { box-shadow: 0 0 0 3px oklch(0.68 0.13 185 / 0.55); }
+  100% { box-shadow: 0 0 0 0 oklch(0.68 0.13 185 / 0); }
+}
+.settings-focus-flash { animation: settings-focus-flash 2.2s ease-out; }
+
 /* ─── Scrollbar ─── */
 * { scrollbar-width: thin; scrollbar-color: var(--bg4) transparent; }


### PR DESCRIPTION
## What an operator sees today

When Claude Code can't sign in, the chat shows:

> Claude Code needs adapter-visible authentication: set `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`, `ANTHROPIC_API_KEY`, or `ANTHROPIC_AUTH_TOKEN` for the adapter environment. Restart Hecate after changing environment credentials.

Five things wrong with that for a non-developer:

1. **Jargon** — "adapter-visible authentication", "adapter environment" mean nothing without context.
2. **Three options at the same priority** — paralyzing, no recommendation.
3. **"Restart Hecate"** as the headline, but the easiest fix doesn't require a restart.
4. **No mention** that Hecate already has a guided setup card in `Settings → External agents` that takes the token via paste (Hecate stores it, injects it into the adapter, no restart).
5. **Conflates two different keys** — operators who configured Anthropic in the Providers tab reasonably think Claude Code "just works." It doesn't, because Claude Code is a separate subprocess with its own credentials. The error message gives them no hint that this is a different surface.

## What this PR changes

**Server-side (Tier 1) — friendly message + stable marker:**

```
Claude Code isn't signed in. This is a separate credential from
the Anthropic key in the Providers tab — Claude Code runs as its
own program. Click the button below to paste a token from
`claude setup-token` into the guided setup card. No restart
needed. (claude_code_auth_required)
```

The trailing `(claude_code_auth_required)` is a load-bearing token the chat UI pattern-matches on. It's stripped from the visible copy before rendering, so the operator sees clean prose. Documented at the call site in `internal/agentadapters/auth_status.go`.

Dashboard hints (`auth_status.go`) and probe-side hints (`probe.go`) get the same treatment: lead with the guided setup card, drop the three-env-var enumeration. The card itself documents the env-var alternative for power users.

**Client-side (Tier 2) — inline recovery button:**

The chat's failed-run notice now renders an **"Open Claude Code setup"** button when the failure carries the `claude_code_auth_required` marker and the message's adapter is `claude_code`. Click:

- Sets `localStorage.hecate.settingsTab = "external_agents"` so SettingsView mounts on the right sub-tab.
- Sets `sessionStorage.hecate.settingsFocus = "claude-code-guided-setup"` so the External Agents tab scrolls-and-flashes the guided setup card on mount.
- Calls `onNavigate("settings")` to switch workspaces.

One click from "chat failed" to "setup card focused, ready to paste."

The flash animation lives in `styles.css` (2.2s teal ring pulse) next to the design tokens.

## Verification

- `bun run typecheck` — clean.
- `bun run test` — 707/707 (was 704; +3 new tests on `TranscriptMessageRow`: marker stripping, button rendering + onClick, negation for cancelled runs).
- `go test ./internal/agentadapters/... -count=1` — 213/213.

## Risk

- **Marker drift.** If the server-side string is reworded and the `(claude_code_auth_required)` token is accidentally dropped, the UI button silently disappears. Mitigated by an explicit test in `registry_test.go` that asserts the token is present, plus comments at both ends of the contract.
- **Storage unavailable.** `localStorage` / `sessionStorage` access wrapped in try/catch — navigation still works without auto-scroll if storage is denied (private-browsing context, Tauri webview restrictions).
- **Other adapters with similar issues.** The marker convention `(<adapter>_auth_required)` is forward-compatible — Codex / Cursor could use the same pattern. Not implemented in this PR; Claude Code was the reported one.
