### PR TITLE
feat(agent-adapters): improve Claude Code onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,6 +220,12 @@ GATEWAY_AGENT_CHAT_IDLE_TIMEOUT=0s
 # Claude Code when direct adapter binaries are not on PATH. Empty uses the
 # platform user-cache location.
 HECATE_AGENT_ADAPTERS_DIR=
+# Development / e2e-only discovery override for external-agent adapter
+# readiness. Comma-separated adapter states: "all=missing",
+# "claude_code=missing,codex=available", etc. Supported states are
+# "missing" and "available". This only affects discovery surfaces in
+# Settings/Chats; it does not create fake runnable adapter processes.
+GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES=
 
 # Rate limiting — process-local token bucket on /v1/chat/completions
 # and /v1/messages. Off by default. When enabled, every response

--- a/Justfile
+++ b/Justfile
@@ -112,6 +112,32 @@ dev *args: _go-cache
 	set +a; \
 	GOCACHE="$PWD/{{gocache}}" go run ./cmd/hecate
 
+# Run the gateway from source with external-agent discovery forced to a known
+# state. This is discovery-only: it changes Settings/Chats readiness surfaces
+# but does not create fake adapter processes. Example:
+#   just dev-agent-adapters 'all=missing'
+#   just dev-agent-adapters 'claude_code=missing,codex=available'
+# Optional arg after the override: --reset.
+dev-agent-adapters overrides *args: _go-cache
+	needs_reset=0; \
+	for arg in {{args}}; do \
+	  case "$arg" in \
+	    --reset) needs_reset=1 ;; \
+	    *) echo "unknown argument: $arg"; echo "usage: just dev-agent-adapters '<adapter=missing|available,...>' [--reset]"; exit 2 ;; \
+	  esac; \
+	done; \
+	if [ "$needs_reset" = "1" ]; then just reset-dev > /dev/null; else just stop; fi
+	set -a; \
+	[ -f ./.env ] && . ./.env; \
+	set +a; \
+	GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES="{{overrides}}" GOCACHE="$PWD/{{gocache}}" go run ./cmd/hecate
+
+# Run the gateway with all external-agent adapters shown as not installed.
+# Useful for manually testing first-run External Agent onboarding.
+# Optional arg: --reset.
+dev-no-agent-adapters *args:
+	just dev-agent-adapters all=missing {{args}}
+
 # Install UI dependencies.
 ui-install:
 	cd ui && bun install

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -130,6 +130,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
 - Agent Chat readiness belongs in Settings → External agents and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.
+  To smoke-test missing/available adapter states without uninstalling local
+  tools, use `just dev-no-agent-adapters` or `just dev-agent-adapters
+  'claude_code=missing,codex=available'`. The override is discovery-only; do
+  not write tests that expect a forced-available adapter to run a real session.
 - Agent Chat usage is adapter-reported. Show it as helpful telemetry with the
   "reported by adapter · not enforced by Hecate" caveat, never as Hecate-enforced
   billing.

--- a/docs/development.md
+++ b/docs/development.md
@@ -214,6 +214,31 @@ telemetry               # OTel attribute keys, metrics, structured logging
 version                 # build-time version metadata
 ```
 
+## External-agent adapter smoke states
+
+External-agent onboarding depends on local tools (`codex-acp`,
+`claude-agent-acp`, `cursor-agent`) that may already be installed on your
+machine. For manual UI smoke tests and Playwright fixtures, you can force the
+discovery result without uninstalling anything:
+
+```bash
+just dev-no-agent-adapters
+```
+
+That starts the gateway with every external adapter reported as missing, which
+is useful for checking first-run onboarding copy.
+
+For finer control, pass a comma-separated override list:
+
+```bash
+just dev-agent-adapters 'claude_code=missing,codex=available,cursor_agent=missing'
+```
+
+The backing env var is `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`. It accepts
+`all=missing` or per-adapter entries using `missing` / `available`. This is
+discovery-only: it changes Settings and Chats readiness UI, but it does not
+create fake adapter processes or make a chat send succeed.
+
 ## Capturing documentation screenshots
 
 ```bash

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -71,16 +71,16 @@ auth hints (`auth_status`: `ok`, `unauthenticated`, `billing`, or `unknown`).
 
 Claude Code has one important wrinkle: a normal interactive `claude /login`
 or `~/.claude.json` config can make the standalone Claude Code CLI work while
-the ACP adapter still reports `Authentication required`. If **Test** fails and
-you want to use your Claude subscription instead of an API key, open
+the ACP adapter still reports `Authentication required`. If adapter readiness
+reports an auth failure and you want to use your Claude subscription instead of an API key, open
 Settings → External agents, run `claude setup-token`, paste the printed token
-into the Claude Code guided setup card, and click **Save + test**. Hecate
+into the Claude Code guided setup card, and click **Save**. Hecate
 stores the token in the local control-plane secret store and injects it only
 into `claude-agent-acp` as `CLAUDE_CODE_OAUTH_TOKEN`. `ANTHROPIC_API_KEY` and
 `ANTHROPIC_AUTH_TOKEN` also work when you want to supply Anthropic credentials
 directly.
-Use Settings → External agents → **Test**, or call the probe endpoint, for a
-full spawn + ACP handshake + no-op session check:
+Settings → External agents refreshes adapter readiness when opened. You can also
+call the probe endpoint for a full spawn + ACP handshake + no-op session check:
 
 ![Settings → External agents — adapter readiness checks and durable approval grants](screenshots/settings-external-agents.png)
 
@@ -126,6 +126,19 @@ Use this order when troubleshooting:
 3. **Chat run** — send a real prompt only after discovery/probe are green. If
    the adapter still fails, open the message's raw diagnostics disclosure; the
    normalized transcript is for reading, raw ACP output is for debugging.
+
+For development and e2e smoke tests, force discovery states without changing
+your machine:
+
+```sh
+just dev-no-agent-adapters
+just dev-agent-adapters 'claude_code=missing,codex=available,cursor_agent=missing'
+```
+
+Those recipes set `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`. The override is
+intentionally discovery-only: it lets Settings and Chats render missing /
+available states, but it does not create fake adapter processes or make a chat
+send succeed.
 
 ### Codex ACP
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -731,6 +731,12 @@ vars and login files without spawning the adapter. Use `POST
 that will be injected into that adapter process during probes and chat turns;
 the secret value is never returned, only the optional `credential_preview`.
 
+For development and e2e fixtures, `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`
+can force discovery states such as `all=missing` or
+`claude_code=missing,codex=available`. This is discovery-only; it affects the
+catalog response and UI readiness surfaces but does not create runnable fake
+adapter processes.
+
 These are **agent adapters**, not model providers. They run ACP-compatible
 external coding agents under Hecate supervision; cost is reported as `external`
 until an adapter can supply structured usage.

--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -1,13 +1,18 @@
 package agentadapters
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // DetectAuthStatus is a lightweight dashboard hint. It deliberately avoids
-// spawning the adapter; the Settings "Test" action runs the full ACP probe.
+// spawning the adapter; Settings refreshes the full ACP probe when opened.
 func DetectAuthStatus(adapter Adapter) (string, string) {
 	switch adapter.ID {
 	case "codex":
@@ -19,10 +24,15 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 		if envAny("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN") {
 			return AuthStatusOK, ""
 		}
-		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
-			return AuthStatusUnknown, "Claude Code config is present on disk, but the ACP adapter may need its own token. Use Test adapter to check; if it fails, open the guided setup card below."
+		if ok, checked := detectClaudeCLIAuthStatus(); ok {
+			return AuthStatusOK, ""
+		} else if checked {
+			return AuthStatusUnauthenticated, "Run `claude auth login` or use the guided setup card below to paste a token from `claude setup-token`."
 		}
-		return AuthStatusUnknown, "Use Test adapter to check. If Claude Code reports a sign-in error, open the guided setup card below to paste a token from `claude setup-token`."
+		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
+			return AuthStatusUnknown, "Claude Code config is present on disk, but Hecate could not verify the CLI auth status. Open Settings to refresh adapter readiness; if it fails, use the guided setup card below."
+		}
+		return AuthStatusUnknown, "Open Settings to verify Claude Code. If it reports a sign-in error, use the guided setup card below to paste a token from `claude setup-token`."
 	case "cursor_agent":
 		if envAny("CURSOR_API_KEY") || fileAny("${HOME}/.cursor", "${HOME}/Library/Application Support/Cursor") {
 			return AuthStatusOK, ""
@@ -57,6 +67,37 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 // Code, with the setup card scrolled into view).
 func claudeCodeAuthErrorMessage() string {
 	return "Claude Code isn't signed in. This is a separate credential from the Anthropic key in the Providers tab — Claude Code runs as its own program. Click the button below to paste a token from `claude setup-token` into the guided setup card. No restart needed. (claude_code_auth_required)"
+}
+
+var runClaudeAuthStatus = defaultRunClaudeAuthStatus
+
+type claudeAuthStatusPayload struct {
+	LoggedIn bool `json:"loggedIn"`
+}
+
+func detectClaudeCLIAuthStatus() (ok bool, checked bool) {
+	out, err := runClaudeAuthStatus()
+	if err != nil || strings.TrimSpace(out) == "" {
+		return false, false
+	}
+	var payload claudeAuthStatusPayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		return false, false
+	}
+	return payload.LoggedIn, true
+}
+
+func defaultRunClaudeAuthStatus() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "claude", "auth", "status")
+	cmd.Env = sanitizedEnv(os.Environ())
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return stdout.String(), nil
 }
 
 func envAny(names ...string) bool {

--- a/internal/agentadapters/auth_status_test.go
+++ b/internal/agentadapters/auth_status_test.go
@@ -45,6 +45,7 @@ func TestDetectAuthStatusCursorUsesEnv(t *testing.T) {
 
 func TestDetectAuthStatusClaudeUnknownWithoutMarker(t *testing.T) {
 	isolatedAuthHome(t)
+	withClaudeAuthStatus(t, "", os.ErrNotExist)
 
 	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
 	if status != AuthStatusUnknown {
@@ -63,6 +64,7 @@ func TestDetectAuthStatusClaudeUnknownWithoutMarker(t *testing.T) {
 
 func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
 	home := isolatedAuthHome(t)
+	withClaudeAuthStatus(t, "", os.ErrNotExist)
 	configPath := filepath.Join(home, ".claude.json")
 	if err := os.WriteFile(configPath, []byte(`{"hasCompletedOnboarding":true}`), 0o600); err != nil {
 		t.Fatalf("write claude config: %v", err)
@@ -75,13 +77,37 @@ func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
 	// Same in-app guidance — but mention the on-disk config so the
 	// operator understands why we still flag this as needing
 	// verification despite the file being present.
-	if !strings.Contains(hint, "ACP adapter") || !strings.Contains(hint, "guided setup card") {
-		t.Fatalf("hint = %q, want ACP-specific guided-setup guidance", hint)
+	if !strings.Contains(hint, "could not verify the CLI auth status") || !strings.Contains(hint, "guided setup card") {
+		t.Fatalf("hint = %q, want CLI-verification guided-setup guidance", hint)
+	}
+}
+
+func TestDetectAuthStatusClaudeUsesCLIAuthStatus(t *testing.T) {
+	isolatedAuthHome(t)
+	withClaudeAuthStatus(t, `{"loggedIn":true,"authMethod":"claude.ai"}`, nil)
+
+	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
+	if status != AuthStatusOK || hint != "" {
+		t.Fatalf("status/hint = %q/%q, want ok/empty", status, hint)
+	}
+}
+
+func TestDetectAuthStatusClaudeReportsUnauthenticatedFromCLI(t *testing.T) {
+	isolatedAuthHome(t)
+	withClaudeAuthStatus(t, `{"loggedIn":false}`, nil)
+
+	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
+	if status != AuthStatusUnauthenticated {
+		t.Fatalf("status = %q, want %q", status, AuthStatusUnauthenticated)
+	}
+	if !strings.Contains(hint, "claude auth login") {
+		t.Fatalf("hint = %q, want claude auth login guidance", hint)
 	}
 }
 
 func TestDetectAuthStatusClaudeUsesAdapterVisibleAuth(t *testing.T) {
 	isolatedAuthHome(t)
+	withClaudeAuthStatus(t, `{"loggedIn":false}`, nil)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	status, hint := DetectAuthStatus(Adapter{ID: "claude_code"})
@@ -102,4 +128,11 @@ func isolatedAuthHome(t *testing.T) string {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("CURSOR_API_KEY", "")
 	return home
+}
+
+func withClaudeAuthStatus(t *testing.T, output string, err error) {
+	t.Helper()
+	old := runClaudeAuthStatus
+	runClaudeAuthStatus = func() (string, error) { return output, err }
+	t.Cleanup(func() { runClaudeAuthStatus = old })
 }

--- a/internal/agentadapters/claude_setup.go
+++ b/internal/agentadapters/claude_setup.go
@@ -5,8 +5,9 @@ import (
 )
 
 type SetupCommandStatus struct {
-	Available bool   `json:"available"`
-	Path      string `json:"path,omitempty"`
+	Available      bool   `json:"available"`
+	Command        string `json:"command,omitempty"`
+	ExecutablePath string `json:"executable_path,omitempty"`
 }
 
 func DetectClaudeCodeCLI(lookup LookupFunc) SetupCommandStatus {
@@ -15,11 +16,11 @@ func DetectClaudeCodeCLI(lookup LookupFunc) SetupCommandStatus {
 	}
 	path, err := lookup("claude")
 	if err == nil {
-		return SetupCommandStatus{Available: true, Path: path}
+		return SetupCommandStatus{Available: true, Command: path, ExecutablePath: path}
 	}
 	npxPath, err := lookup("npx")
 	if err != nil {
 		return SetupCommandStatus{}
 	}
-	return SetupCommandStatus{Available: true, Path: npxPath + " -y @anthropic-ai/claude-code"}
+	return SetupCommandStatus{Available: true, Command: npxPath + " -y @anthropic-ai/claude-code", ExecutablePath: npxPath}
 }

--- a/internal/agentadapters/claude_setup.go
+++ b/internal/agentadapters/claude_setup.go
@@ -1,0 +1,25 @@
+package agentadapters
+
+import (
+	"os/exec"
+)
+
+type SetupCommandStatus struct {
+	Available bool   `json:"available"`
+	Path      string `json:"path,omitempty"`
+}
+
+func DetectClaudeCodeCLI(lookup LookupFunc) SetupCommandStatus {
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	path, err := lookup("claude")
+	if err == nil {
+		return SetupCommandStatus{Available: true, Path: path}
+	}
+	npxPath, err := lookup("npx")
+	if err != nil {
+		return SetupCommandStatus{}
+	}
+	return SetupCommandStatus{Available: true, Path: npxPath + " -y @anthropic-ai/claude-code"}
+}

--- a/internal/agentadapters/claude_setup_test.go
+++ b/internal/agentadapters/claude_setup_test.go
@@ -1,0 +1,40 @@
+package agentadapters
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDetectClaudeCodeCLI(t *testing.T) {
+	status := DetectClaudeCodeCLI(func(file string) (string, error) {
+		if file != "claude" {
+			t.Fatalf("lookup called with %q", file)
+		}
+		return "/tmp/bin/claude", nil
+	})
+	if !status.Available || status.Path != "/tmp/bin/claude" {
+		t.Fatalf("DetectClaudeCodeCLI() = %+v, want available path", status)
+	}
+
+	status = DetectClaudeCodeCLI(func(file string) (string, error) {
+		switch file {
+		case "claude":
+			return "", errors.New("not found")
+		case "npx":
+			return "/tmp/bin/npx", nil
+		default:
+			t.Fatalf("lookup called with %q", file)
+			return "", errors.New("unexpected")
+		}
+	})
+	if !status.Available || status.Path != "/tmp/bin/npx -y @anthropic-ai/claude-code" {
+		t.Fatalf("DetectClaudeCodeCLI() = %+v, want npx-managed path", status)
+	}
+
+	status = DetectClaudeCodeCLI(func(string) (string, error) {
+		return "", errors.New("not found")
+	})
+	if status.Available || status.Path != "" {
+		t.Fatalf("DetectClaudeCodeCLI() = %+v, want unavailable", status)
+	}
+}

--- a/internal/agentadapters/claude_setup_test.go
+++ b/internal/agentadapters/claude_setup_test.go
@@ -12,7 +12,7 @@ func TestDetectClaudeCodeCLI(t *testing.T) {
 		}
 		return "/tmp/bin/claude", nil
 	})
-	if !status.Available || status.Path != "/tmp/bin/claude" {
+	if !status.Available || status.Command != "/tmp/bin/claude" || status.ExecutablePath != "/tmp/bin/claude" {
 		t.Fatalf("DetectClaudeCodeCLI() = %+v, want available path", status)
 	}
 
@@ -27,14 +27,14 @@ func TestDetectClaudeCodeCLI(t *testing.T) {
 			return "", errors.New("unexpected")
 		}
 	})
-	if !status.Available || status.Path != "/tmp/bin/npx -y @anthropic-ai/claude-code" {
+	if !status.Available || status.Command != "/tmp/bin/npx -y @anthropic-ai/claude-code" || status.ExecutablePath != "/tmp/bin/npx" {
 		t.Fatalf("DetectClaudeCodeCLI() = %+v, want npx-managed path", status)
 	}
 
 	status = DetectClaudeCodeCLI(func(string) (string, error) {
 		return "", errors.New("not found")
 	})
-	if status.Available || status.Path != "" {
+	if status.Available || status.Command != "" || status.ExecutablePath != "" {
 		t.Fatalf("DetectClaudeCodeCLI() = %+v, want unavailable", status)
 	}
 }

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -261,6 +261,7 @@ func adapterDiscoveryOverride(adapterID string) (string, bool) {
 	if raw == "" {
 		return "", false
 	}
+	var allOverride string
 	for _, part := range strings.Split(raw, ",") {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
@@ -271,12 +272,18 @@ func adapterDiscoveryOverride(adapterID string) (string, bool) {
 		if key == "" || value == "" {
 			continue
 		}
-		if key == adapterID || key == "all" {
-			switch value {
-			case StatusAvailable, StatusMissing:
+		switch value {
+		case StatusAvailable, StatusMissing:
+			if key == adapterID {
 				return value, true
 			}
+			if key == "all" {
+				allOverride = value
+			}
 		}
+	}
+	if allOverride != "" {
+		return allOverride, true
 	}
 	return "", false
 }

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -20,6 +20,8 @@ const (
 	StatusMissing   = "missing"
 )
 
+const adapterDiscoveryOverrideEnv = "GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES"
+
 const (
 	AuthStatusOK              = "ok"
 	AuthStatusUnauthenticated = "unauthenticated"
@@ -62,6 +64,7 @@ type Status struct {
 	VersionOutsideRange bool
 	AuthStatus          string
 	AuthError           string
+	ClaudeCodeCLI       SetupCommandStatus
 }
 
 type LookupFunc func(file string) (string, error)
@@ -203,33 +206,7 @@ func ListWithLookup(ctx context.Context, lookup LookupFunc) []Status {
 	items := BuiltIns()
 	out := make([]Status, 0, len(items))
 	for _, item := range items {
-		status := Status{
-			Adapter:    item,
-			Status:     StatusMissing,
-			AuthStatus: AuthStatusUnknown,
-		}
-		if err := ctx.Err(); err != nil {
-			status.Error = err.Error()
-			out = append(out, status)
-			continue
-		}
-		path, err := resolveExecutableForStatus(item, lookup)
-		if err != nil {
-			status.Error = err.Error()
-			out = append(out, status)
-			continue
-		}
-		status.Available = true
-		status.Status = StatusAvailable
-		status.Path = path
-		if v := DetectVersion(ctx, path); v != "" {
-			status.Version = v
-			status.VersionOutsideRange = !satisfiesRange(v, item.SupportedRange)
-		}
-		authStatus, authError := DetectAuthStatus(item)
-		status.AuthStatus = authStatus
-		status.AuthError = authError
-		out = append(out, status)
+		out = append(out, statusForAdapter(ctx, item, lookup))
 	}
 	return out
 }
@@ -253,9 +230,15 @@ func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Stat
 		Status:     StatusMissing,
 		AuthStatus: AuthStatusUnknown,
 	}
+	if item.ID == "claude_code" {
+		status.ClaudeCodeCLI = DetectClaudeCodeCLI(lookup)
+	}
 	if err := ctx.Err(); err != nil {
 		status.Error = err.Error()
 		return status
+	}
+	if override, ok := adapterDiscoveryOverride(item.ID); ok {
+		return applyAdapterDiscoveryOverride(status, override)
 	}
 	path, err := resolveExecutableForStatus(item, lookup)
 	if err != nil {
@@ -270,6 +253,52 @@ func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Stat
 		status.VersionOutsideRange = !satisfiesRange(v, item.SupportedRange)
 	}
 	status.AuthStatus, status.AuthError = DetectAuthStatus(item)
+	return status
+}
+
+func adapterDiscoveryOverride(adapterID string) (string, bool) {
+	raw := strings.TrimSpace(os.Getenv(adapterDiscoveryOverrideEnv))
+	if raw == "" {
+		return "", false
+	}
+	for _, part := range strings.Split(raw, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.ToLower(strings.TrimSpace(value))
+		if key == "" || value == "" {
+			continue
+		}
+		if key == adapterID || key == "all" {
+			switch value {
+			case StatusAvailable, StatusMissing:
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func applyAdapterDiscoveryOverride(status Status, override string) Status {
+	status.Version = ""
+	status.VersionOutsideRange = false
+	status.AuthStatus = AuthStatusUnknown
+	status.AuthError = ""
+	status.ClaudeCodeCLI = SetupCommandStatus{}
+	switch override {
+	case StatusAvailable:
+		status.Available = true
+		status.Status = StatusAvailable
+		status.Path = "dev-override://" + status.ID
+		status.Error = "forced available by " + adapterDiscoveryOverrideEnv
+	case StatusMissing:
+		status.Available = false
+		status.Status = StatusMissing
+		status.Path = ""
+		status.Error = "forced missing by " + adapterDiscoveryOverrideEnv
+	}
 	return status
 }
 

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -102,6 +102,30 @@ func TestStatusForAdapterHonorsDiscoveryOverrideAvailable(t *testing.T) {
 	}
 }
 
+func TestStatusForAdapterDiscoveryOverridePrefersExactMatch(t *testing.T) {
+	t.Setenv(adapterDiscoveryOverrideEnv, "all=missing,codex=available")
+
+	status, ok := StatusForAdapter(context.Background(), "codex", func(file string) (string, error) {
+		return "", errors.New("not found on PATH")
+	})
+	if !ok {
+		t.Fatalf("StatusForAdapter(codex) ok = false")
+	}
+	if !status.Available || status.Status != StatusAvailable {
+		t.Fatalf("codex status = %#v, want exact adapter override to win over all", status)
+	}
+
+	status, ok = StatusForAdapter(context.Background(), "claude_code", func(file string) (string, error) {
+		return "/usr/local/bin/" + file, nil
+	})
+	if !ok {
+		t.Fatalf("StatusForAdapter(claude_code) ok = false")
+	}
+	if status.Available || status.Status != StatusMissing {
+		t.Fatalf("claude_code status = %#v, want all override fallback", status)
+	}
+}
+
 func TestStatusForAdapterIgnoresInvalidDiscoveryOverride(t *testing.T) {
 	t.Setenv(adapterDiscoveryOverrideEnv, "fake=broken")
 

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -65,6 +65,58 @@ func TestListWithLookupReportsAvailability(t *testing.T) {
 	}
 }
 
+func TestListWithLookupHonorsDiscoveryOverrideAllMissing(t *testing.T) {
+	t.Setenv(adapterDiscoveryOverrideEnv, "all=missing")
+
+	response := ListWithLookup(context.Background(), func(file string) (string, error) {
+		return "/usr/local/bin/" + file, nil
+	})
+
+	if len(response) == 0 {
+		t.Fatalf("ListWithLookup returned no adapters")
+	}
+	for _, item := range response {
+		if item.Available || item.Status != StatusMissing || item.Path != "" {
+			t.Fatalf("%s status = %#v, want forced missing", item.ID, item)
+		}
+		if !strings.Contains(item.Error, adapterDiscoveryOverrideEnv) {
+			t.Fatalf("%s error = %q, want override marker", item.ID, item.Error)
+		}
+	}
+}
+
+func TestStatusForAdapterHonorsDiscoveryOverrideAvailable(t *testing.T) {
+	t.Setenv(adapterDiscoveryOverrideEnv, "codex=available")
+
+	status, ok := StatusForAdapter(context.Background(), "codex", func(file string) (string, error) {
+		return "", errors.New("not found on PATH")
+	})
+	if !ok {
+		t.Fatalf("StatusForAdapter(codex) ok = false")
+	}
+	if !status.Available || status.Status != StatusAvailable || status.Path != "dev-override://codex" {
+		t.Fatalf("status = %#v, want forced available", status)
+	}
+	if status.AuthStatus != AuthStatusUnknown {
+		t.Fatalf("auth status = %q, want unknown for discovery-only override", status.AuthStatus)
+	}
+}
+
+func TestStatusForAdapterIgnoresInvalidDiscoveryOverride(t *testing.T) {
+	t.Setenv(adapterDiscoveryOverrideEnv, "fake=broken")
+
+	status := statusForAdapter(context.Background(), Adapter{
+		ID:      "fake",
+		Name:    "Fake",
+		Command: "fake-adapter",
+	}, func(file string) (string, error) {
+		return "", errors.New("not found on PATH")
+	})
+	if status.Available || status.Status != StatusMissing || !strings.Contains(status.Error, "not found") {
+		t.Fatalf("status = %#v, want normal missing lookup", status)
+	}
+}
+
 func TestListWithLookupUsesCandidatePathFallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -19,7 +19,7 @@ var semverRe = regexp.MustCompile(`\d+\.\d+\.\d+(?:[-+][0-9A-Za-z._-]+)*`)
 // stay independent of CI subprocess-startup jitter.
 //
 // 5 s is generous on purpose. Probe runs are pre-flight — an
-// operator clicked "Test adapter" or opened the Settings tab;
+// operator clicked "Check auth" or opened the Settings tab;
 // latency is surfaced in the UI as "checking…" while the request
 // is in flight, so a few seconds of overhead is acceptable.
 // Earlier values (2 s, then 5 s) flaked on CI under -race +

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -70,7 +70,8 @@ type Handler struct {
 	// through to agentadapters.Probe; tests install a fake via
 	// SetAgentAdapterProbe so they can exercise the handler without
 	// spawning real ACP binaries.
-	agentAdapterProbe AgentAdapterProbe
+	agentAdapterProbe    AgentAdapterProbe
+	agentAdapterEnvProbe AgentAdapterEnvProbe
 }
 
 // approvalConfig bundles everything the coordinator needs apart from

--- a/internal/api/handler_agent_adapter_credentials.go
+++ b/internal/api/handler_agent_adapter_credentials.go
@@ -39,6 +39,35 @@ func (h *Handler) HandleSetAgentAdapterCredential(w http.ResponseWriter, r *http
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "credential value is required")
 		return
 	}
+	if adapterID == "claude_code" && name == claudeCodeOAuthTokenName {
+		if err := validateClaudeCodeOAuthToken(value); err != nil {
+			WriteErrorDetails(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error(), ErrorDetails{
+				UserMessage:    "That does not look like a Claude Code setup token, so Hecate did not save it.",
+				OperatorAction: "Run claude setup-token again, copy the token printed in Terminal, paste it here, and retry.",
+				Fields: map[string]any{
+					"adapter_id": adapterID,
+					"name":       name,
+				},
+			})
+			return
+		}
+		result := h.probeAgentAdapter(r.Context(), adapterID, []string{name + "=" + value})
+		if result.Status != agentadapters.ProbeStatusReady {
+			message := firstNonEmptyString(result.Hint, result.Error, result.Stderr, "Claude Code rejected this token")
+			WriteErrorDetails(w, http.StatusConflict, errCodeConflict, message, ErrorDetails{
+				UserMessage:    "Claude Code could not connect with that token, so Hecate did not save it.",
+				OperatorAction: "Run claude setup-token again, copy the token printed in Terminal, paste it here, and retry.",
+				Fields: map[string]any{
+					"adapter_id": adapterID,
+					"status":     result.Status,
+					"stage":      result.Stage,
+					"hint":       result.Hint,
+					"error":      result.Error,
+				},
+			})
+			return
+		}
+	}
 	encrypted, err := h.secretCipher.Encrypt(value)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("encrypt adapter credential: %v", err))
@@ -63,6 +92,14 @@ func (h *Handler) HandleSetAgentAdapterCredential(w http.ResponseWriter, r *http
 			Preview:    credential.ValuePreview,
 		},
 	})
+}
+
+func validateClaudeCodeOAuthToken(value string) error {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "sk-") || len(value) < 20 || strings.ContainsAny(value, " \t\r\n") {
+		return fmt.Errorf("Claude Code setup tokens start with sk- and are printed by `claude setup-token`")
+	}
+	return nil
 }
 
 func (h *Handler) HandleDeleteAgentAdapterCredential(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_agent_adapter_health.go
+++ b/internal/api/handler_agent_adapter_health.go
@@ -14,10 +14,19 @@ import (
 // real adapter binaries.
 type AgentAdapterProbe func(ctx context.Context, adapterID string) agentadapters.ProbeResult
 
+type AgentAdapterEnvProbe func(ctx context.Context, adapterID string, env []string) agentadapters.ProbeResult
+
 // SetAgentAdapterProbe overrides the probe used by HandleAgentAdapterHealth.
 // Pass nil to restore the default (agentadapters.Probe). Test-only.
 func (h *Handler) SetAgentAdapterProbe(p AgentAdapterProbe) {
 	h.agentAdapterProbe = p
+	if p == nil {
+		h.agentAdapterEnvProbe = nil
+		return
+	}
+	h.agentAdapterEnvProbe = func(ctx context.Context, adapterID string, _ []string) agentadapters.ProbeResult {
+		return p(ctx, adapterID)
+	}
 }
 
 // HandleAgentAdapterHealth probes a single adapter to confirm it can
@@ -47,17 +56,18 @@ func (h *Handler) HandleAgentAdapterHealth(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	probe := h.agentAdapterProbe
-	var result agentadapters.ProbeResult
-	if probe == nil {
-		result = agentadapters.ProbeWithEnv(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
-	} else {
-		result = probe(ctx, id)
-	}
+	result := h.probeAgentAdapter(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
 	WriteJSON(w, http.StatusOK, AgentAdapterHealthResponse{
 		Object: "agent_adapter_health",
 		Data:   result,
 	})
+}
+
+func (h *Handler) probeAgentAdapter(ctx context.Context, id string, env []string) agentadapters.ProbeResult {
+	if h != nil && h.agentAdapterEnvProbe != nil {
+		return h.agentAdapterEnvProbe(ctx, id, env)
+	}
+	return agentadapters.ProbeWithEnv(ctx, id, env)
 }
 
 // AgentAdapterHealthResponse wraps the probe result. Object is the

--- a/internal/api/handler_agent_adapter_health_test.go
+++ b/internal/api/handler_agent_adapter_health_test.go
@@ -173,6 +173,43 @@ func TestAgentAdapterProbeEndpointReturnsFreshAdapterAndHealth(t *testing.T) {
 	}
 }
 
+func TestAgentAdapterProbeDoesNotPromoteClaudeHandshakeToAuthOK(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := NewHandler(config.Config{}, logger, nil, controlplane.NewMemoryStore(), nil, nil)
+	apiHandler.SetSecretCipher(newTestCipherForAPI(t))
+	apiHandler.SetAgentAdapterProbe(func(_ context.Context, id string) agentadapters.ProbeResult {
+		if id != "claude_code" {
+			t.Fatalf("probe called for %q, want claude_code", id)
+		}
+		return agentadapters.ProbeResult{
+			AdapterID:  "claude_code",
+			Status:     agentadapters.ProbeStatusReady,
+			Stage:      agentadapters.ProbeStageReady,
+			Path:       "/usr/local/bin/claude-agent-acp",
+			DurationMS: 42,
+		}
+	})
+	server := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, server)
+
+	resp := mustRequestJSON[AgentAdapterProbeResponse](client, http.MethodPost, "/hecate/v1/agent-adapters/claude_code/probe", "")
+	if resp.Data.Health.Status != agentadapters.ProbeStatusReady {
+		t.Fatalf("health status = %q, want ready", resp.Data.Health.Status)
+	}
+	if resp.Data.Adapter.AuthStatus == agentadapters.AuthStatusOK {
+		t.Fatalf("adapter auth_status = ok after bare ready probe; want onboarding to remain visible")
+	}
+	if resp.Data.Adapter.CredentialConfigured {
+		t.Fatalf("credential_configured = true, want false")
+	}
+}
+
 func TestAgentAdapterCredentialEndpointsStoreAndDeleteCredential(t *testing.T) {
 	t.Parallel()
 
@@ -180,17 +217,35 @@ func TestAgentAdapterCredentialEndpointsStoreAndDeleteCredential(t *testing.T) {
 	store := controlplane.NewMemoryStore()
 	apiHandler := NewHandler(config.Config{}, logger, nil, store, nil, nil)
 	apiHandler.SetSecretCipher(newTestCipherForAPI(t))
+	probeCalls := 0
+	apiHandler.agentAdapterEnvProbe = func(_ context.Context, id string, env []string) agentadapters.ProbeResult {
+		probeCalls++
+		if id != "claude_code" {
+			t.Fatalf("probe id = %q, want claude_code", id)
+		}
+		if got, want := strings.Join(env, "\n"), claudeCodeOAuthTokenName+"=sk-valid-token-secret-1234567890"; got != want {
+			t.Fatalf("probe env = %q, want %q", got, want)
+		}
+		return agentadapters.ProbeResult{
+			AdapterID: "claude_code",
+			Status:    agentadapters.ProbeStatusReady,
+			Stage:     agentadapters.ProbeStageReady,
+		}
+	}
 	server := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, server)
 
-	set := mustRequestJSON[AgentAdapterCredentialResponse](client, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"token-secret"}`)
+	set := mustRequestJSON[AgentAdapterCredentialResponse](client, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"sk-valid-token-secret-1234567890"}`)
+	if probeCalls != 1 {
+		t.Fatalf("probe calls = %d, want 1", probeCalls)
+	}
 	if set.Object != "agent_adapter_credential" {
 		t.Fatalf("object = %q, want agent_adapter_credential", set.Object)
 	}
 	if set.Data.AdapterID != "claude_code" || set.Data.Name != claudeCodeOAuthTokenName || !set.Data.Configured {
 		t.Fatalf("set response = %#v, want configured claude token", set.Data)
 	}
-	if strings.Contains(set.Data.Preview, "token-secret") {
+	if strings.Contains(set.Data.Preview, "sk-valid-token-secret-1234567890") {
 		t.Fatalf("preview leaked full token: %q", set.Data.Preview)
 	}
 
@@ -201,12 +256,12 @@ func TestAgentAdapterCredentialEndpointsStoreAndDeleteCredential(t *testing.T) {
 	if got := len(state.AgentAdapterCredentials); got != 1 {
 		t.Fatalf("credentials len = %d, want 1", got)
 	}
-	if state.AgentAdapterCredentials[0].ValueEncrypted == "token-secret" {
+	if state.AgentAdapterCredentials[0].ValueEncrypted == "sk-valid-token-secret-1234567890" {
 		t.Fatal("credential was stored in plaintext")
 	}
 
 	env := apiHandler.agentAdapterCredentialEnv(context.Background(), "claude_code")
-	if got, want := strings.Join(env, "\n"), claudeCodeOAuthTokenName+"=token-secret"; got != want {
+	if got, want := strings.Join(env, "\n"), claudeCodeOAuthTokenName+"=sk-valid-token-secret-1234567890"; got != want {
 		t.Fatalf("credential env = %q, want %q", got, want)
 	}
 
@@ -216,6 +271,74 @@ func TestAgentAdapterCredentialEndpointsStoreAndDeleteCredential(t *testing.T) {
 	}
 	if env := apiHandler.agentAdapterCredentialEnv(context.Background(), "claude_code"); len(env) != 0 {
 		t.Fatalf("credential env after delete = %#v, want empty", env)
+	}
+}
+
+func TestAgentAdapterCredentialEndpointRejectsMalformedClaudeTokenBeforeProbe(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	store := controlplane.NewMemoryStore()
+	apiHandler := NewHandler(config.Config{}, logger, nil, store, nil, nil)
+	apiHandler.SetSecretCipher(newTestCipherForAPI(t))
+	probeCalls := 0
+	apiHandler.agentAdapterEnvProbe = func(context.Context, string, []string) agentadapters.ProbeResult {
+		probeCalls++
+		return agentadapters.ProbeResult{Status: agentadapters.ProbeStatusReady}
+	}
+	server := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, server)
+
+	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"random text"}`)
+	if !strings.Contains(rec.Body.String(), "does not look like a Claude Code setup token") {
+		t.Fatalf("response = %s, want malformed-token guidance", rec.Body.String())
+	}
+	if probeCalls != 0 {
+		t.Fatalf("probe calls = %d, want 0 for malformed token", probeCalls)
+	}
+	state, err := store.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := len(state.AgentAdapterCredentials); got != 0 {
+		t.Fatalf("credentials len = %d, want 0", got)
+	}
+}
+
+func TestAgentAdapterCredentialEndpointDoesNotStoreInvalidClaudeToken(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	store := controlplane.NewMemoryStore()
+	apiHandler := NewHandler(config.Config{}, logger, nil, store, nil, nil)
+	apiHandler.SetSecretCipher(newTestCipherForAPI(t))
+	apiHandler.agentAdapterEnvProbe = func(_ context.Context, id string, env []string) agentadapters.ProbeResult {
+		if id != "claude_code" {
+			t.Fatalf("probe id = %q, want claude_code", id)
+		}
+		if got, want := strings.Join(env, "\n"), claudeCodeOAuthTokenName+"=sk-invalid-token-1234567890"; got != want {
+			t.Fatalf("probe env = %q, want %q", got, want)
+		}
+		return agentadapters.ProbeResult{
+			AdapterID: "claude_code",
+			Status:    agentadapters.ProbeStatusAuthRequired,
+			Stage:     agentadapters.ProbeStageNewSession,
+			Hint:      "Claude Code rejected the token",
+		}
+	}
+	server := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, server)
+
+	rec := client.mustRequestStatus(http.StatusConflict, http.MethodPut, "/hecate/v1/agent-adapters/claude_code/credentials", `{"value":"sk-invalid-token-1234567890"}`)
+	if !strings.Contains(rec.Body.String(), "did not save") {
+		t.Fatalf("response = %s, want did not save message", rec.Body.String())
+	}
+	state, err := store.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := len(state.AgentAdapterCredentials); got != 0 {
+		t.Fatalf("credentials len = %d, want 0", got)
 	}
 }
 

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -33,15 +33,17 @@ func (h *Handler) HandleAgentAdapterProbe(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "adapter not found")
 		return
 	}
-	probe := h.agentAdapterProbe
-	var result agentadapters.ProbeResult
-	if probe == nil {
-		result = agentadapters.ProbeWithEnv(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
-	} else {
-		result = probe(ctx, id)
-	}
+	result := h.probeAgentAdapter(ctx, id, h.agentAdapterCredentialEnv(ctx, id))
 	item := h.renderAgentAdapterItem(ctx, status)
-	item.AuthStatus, item.AuthError = authStatusFromProbe(result, item.AuthStatus, item.AuthError)
+	if id == "claude_code" && result.Status == agentadapters.ProbeStatusReady && !item.CredentialConfigured && status.AuthStatus != agentadapters.AuthStatusOK {
+		// Claude Code can complete the ACP handshake with a normal CLI login,
+		// but chat turns still require an adapter-visible credential in
+		// Hecate's environment. Do not let a bare ready probe erase the
+		// onboarding state.
+		item.AuthStatus, item.AuthError = status.AuthStatus, status.AuthError
+	} else {
+		item.AuthStatus, item.AuthError = authStatusFromProbe(result, item.AuthStatus, item.AuthError)
+	}
 	WriteJSON(w, http.StatusOK, AgentAdapterProbeResponse{
 		Object: "agent_adapter_probe",
 		Data: AgentAdapterProbeData{
@@ -83,7 +85,7 @@ type AgentAdapterProbeData struct {
 }
 
 func renderAgentAdapterItem(item agentadapters.Status) AgentAdapterResponseItem {
-	return AgentAdapterResponseItem{
+	rendered := AgentAdapterResponseItem{
 		ID:                  item.ID,
 		Name:                item.Name,
 		Kind:                item.Kind,
@@ -104,6 +106,13 @@ func renderAgentAdapterItem(item agentadapters.Status) AgentAdapterResponseItem 
 		AuthStatus:          item.AuthStatus,
 		AuthError:           item.AuthError,
 	}
+	if item.ID == "claude_code" {
+		rendered.ClaudeCodeCLI = &AgentAdapterSetupCommandStatusItem{
+			Available: item.ClaudeCodeCLI.Available,
+			Path:      item.ClaudeCodeCLI.Path,
+		}
+	}
+	return rendered
 }
 
 func (h *Handler) renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) AgentAdapterResponseItem {
@@ -130,20 +139,11 @@ func authStatusFromProbe(result agentadapters.ProbeResult, fallbackStatus, fallb
 	case agentadapters.ProbeStatusReady:
 		return agentadapters.AuthStatusOK, ""
 	case agentadapters.ProbeStatusAuthRequired:
-		return agentadapters.AuthStatusUnauthenticated, firstNonEmptyAdapterProbe(result.Hint, result.Error, fallbackError)
+		return agentadapters.AuthStatusUnauthenticated, firstNonEmptyString(result.Hint, result.Error, fallbackError)
 	case agentadapters.ProbeStatusError:
 		if strings.Contains(strings.ToLower(result.Error+"\n"+result.Stderr), "credit balance") {
-			return agentadapters.AuthStatusBilling, firstNonEmptyAdapterProbe(result.Hint, result.Error, fallbackError)
+			return agentadapters.AuthStatusBilling, firstNonEmptyString(result.Hint, result.Error, fallbackError)
 		}
 	}
-	return firstNonEmptyAdapterProbe(fallbackStatus, agentadapters.AuthStatusUnknown), fallbackError
-}
-
-func firstNonEmptyAdapterProbe(items ...string) string {
-	for _, item := range items {
-		if strings.TrimSpace(item) != "" {
-			return item
-		}
-	}
-	return ""
+	return firstNonEmptyString(fallbackStatus, agentadapters.AuthStatusUnknown), fallbackError
 }

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -108,8 +108,9 @@ func renderAgentAdapterItem(item agentadapters.Status) AgentAdapterResponseItem 
 	}
 	if item.ID == "claude_code" {
 		rendered.ClaudeCodeCLI = &AgentAdapterSetupCommandStatusItem{
-			Available: item.ClaudeCodeCLI.Available,
-			Path:      item.ClaudeCodeCLI.Path,
+			Available:      item.ClaudeCodeCLI.Available,
+			Command:        item.ClaudeCodeCLI.Command,
+			ExecutablePath: item.ClaudeCodeCLI.ExecutablePath,
 		}
 	}
 	return rendered

--- a/internal/api/handler_shutdown_test.go
+++ b/internal/api/handler_shutdown_test.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"log/slog"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hecate/agent-runtime/internal/agentadapters"
 	"github.com/hecate/agent-runtime/internal/config"
 	"github.com/hecate/agent-runtime/internal/mcp"
 	mcpclient "github.com/hecate/agent-runtime/internal/mcp/client"
@@ -52,6 +52,22 @@ func (e *blockingShutdownExecutor) Execute(context.Context, orchestrator.Executi
 	close(e.started)
 	<-e.release
 	return &orchestrator.ExecutionResult{Status: "cancelled"}, nil
+}
+
+type failingShutdownAgentChatRunner struct {
+	err error
+}
+
+func (r failingShutdownAgentChatRunner) Run(context.Context, agentadapters.RunRequest) (agentadapters.RunResult, error) {
+	return agentadapters.RunResult{}, errors.New("unexpected Run call")
+}
+
+func (r failingShutdownAgentChatRunner) CloseSession(context.Context, string) error {
+	return nil
+}
+
+func (r failingShutdownAgentChatRunner) Shutdown(context.Context) error {
+	return r.err
 }
 
 // TestHandler_Shutdown_ClosesBothRunnerAndCache pins the headline
@@ -263,42 +279,33 @@ func TestHandler_Shutdown_RunnerErrorPropagated(t *testing.T) {
 	}
 }
 
-// TestHandler_Shutdown_BothErrorsCombined pins the both-errors
-// branch of Handler.Shutdown. We force the runner to fail (cancelled
-// ctx) and assert the resulting error mentions BOTH sources so
-// operators can diagnose either failure from the log line.
-func TestHandler_Shutdown_BothErrorsCombined(t *testing.T) {
+// TestHandler_Shutdown_AgentChatErrorPropagated pins that
+// Handler.Shutdown returns agent-chat shutdown failures with a useful
+// subsystem label while still closing the MCP cache.
+func TestHandler_Shutdown_AgentChatErrorPropagated(t *testing.T) {
 	t.Parallel()
 
-	runner := newShutdownTestRunner(t)
-	// Pre-close the cache so Handler.Shutdown's cache.Close becomes
-	// the second-error path. SharedClientCache.Close on an
-	// already-closed cache returns nil (idempotent), so we can't
-	// drive a non-nil error from Close alone. Instead we pre-close
-	// AND let the runner-error branch drive a single-error result —
-	// that's the realistic combined path on a bad shutdown.
+	sentinel := errors.New("agent chat manager failed")
 	cache := newShutdownTestCache()
-	_ = cache.Close() // proves Close is idempotent — Handler.Shutdown's second call returns nil
 
 	h := &Handler{
-		taskRunner:     runner,
-		mcpClientCache: cache,
+		mcpClientCache:  cache,
+		agentChatRunner: failingShutdownAgentChatRunner{err: sentinel},
 	}
 
-	// Already-cancelled ctx forces a runner error.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := h.Shutdown(ctx)
+	err := h.Shutdown(context.Background())
 	if err == nil {
-		t.Fatal("expected error from cancelled ctx")
+		t.Fatal("expected agent chat shutdown error")
 	}
-	// Cache.Close idempotent → returns nil → only runner error
-	// surfaces. The test's role here is to pin that the both-errors
-	// branch is reachable in code (we ran past it) without panicking;
-	// crafting a deterministic non-nil cache error would require a
-	// fake we don't have a hook for.
-	_ = atomic.LoadInt32(new(int32)) // keep the import set stable
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Shutdown err = %v, want wrapped sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "agent chat shutdown") {
+		t.Fatalf("Shutdown err = %v, want subsystem label", err)
+	}
+	if got := cache.Stats().Entries; got != 0 {
+		t.Errorf("cache.Stats.Entries = %d after agent-chat shutdown error, want 0", got)
+	}
 }
 
 // TestHandler_Shutdown_CalledTwice pins idempotence at the Handler

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -620,8 +620,9 @@ type AgentAdapterResponseItem struct {
 }
 
 type AgentAdapterSetupCommandStatusItem struct {
-	Available bool   `json:"available"`
-	Path      string `json:"path,omitempty"`
+	Available      bool   `json:"available"`
+	Command        string `json:"command,omitempty"`
+	ExecutablePath string `json:"executable_path,omitempty"`
 }
 
 type AgentAdapterCredentialSetRequest struct {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -595,27 +595,33 @@ type LocalProviderDiscoveryResponseItem struct {
 }
 
 type AgentAdapterResponseItem struct {
-	ID                   string   `json:"id"`
-	Name                 string   `json:"name"`
-	Kind                 string   `json:"kind"`
-	Command              string   `json:"command"`
-	Args                 []string `json:"args,omitempty"`
-	Managed              bool     `json:"managed,omitempty"`
-	ManagedPackage       string   `json:"managed_package,omitempty"`
-	Available            bool     `json:"available"`
-	Status               string   `json:"status"`
-	Path                 string   `json:"path,omitempty"`
-	Error                string   `json:"error,omitempty"`
-	Description          string   `json:"description,omitempty"`
-	CostMode             string   `json:"cost_mode,omitempty"`
-	DocsURL              string   `json:"docs_url,omitempty"`
-	Version              string   `json:"version,omitempty"`
-	SupportedRange       string   `json:"supported_range,omitempty"`
-	VersionOutsideRange  bool     `json:"version_outside_range,omitempty"`
-	AuthStatus           string   `json:"auth_status,omitempty"`
-	AuthError            string   `json:"auth_error,omitempty"`
-	CredentialConfigured bool     `json:"credential_configured,omitempty"`
-	CredentialPreview    string   `json:"credential_preview,omitempty"`
+	ID                   string                              `json:"id"`
+	Name                 string                              `json:"name"`
+	Kind                 string                              `json:"kind"`
+	Command              string                              `json:"command"`
+	Args                 []string                            `json:"args,omitempty"`
+	Managed              bool                                `json:"managed,omitempty"`
+	ManagedPackage       string                              `json:"managed_package,omitempty"`
+	Available            bool                                `json:"available"`
+	Status               string                              `json:"status"`
+	Path                 string                              `json:"path,omitempty"`
+	Error                string                              `json:"error,omitempty"`
+	Description          string                              `json:"description,omitempty"`
+	CostMode             string                              `json:"cost_mode,omitempty"`
+	DocsURL              string                              `json:"docs_url,omitempty"`
+	Version              string                              `json:"version,omitempty"`
+	SupportedRange       string                              `json:"supported_range,omitempty"`
+	VersionOutsideRange  bool                                `json:"version_outside_range,omitempty"`
+	AuthStatus           string                              `json:"auth_status,omitempty"`
+	AuthError            string                              `json:"auth_error,omitempty"`
+	CredentialConfigured bool                                `json:"credential_configured,omitempty"`
+	CredentialPreview    string                              `json:"credential_preview,omitempty"`
+	ClaudeCodeCLI        *AgentAdapterSetupCommandStatusItem `json:"claude_code_cli,omitempty"`
+}
+
+type AgentAdapterSetupCommandStatusItem struct {
+	Available bool   `json:"available"`
+	Path      string `json:"path,omitempty"`
 }
 
 type AgentAdapterCredentialSetRequest struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1085,6 +1085,26 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 	}
 }
 
+func TestAgentAdaptersHonorsDiscoveryOverride(t *testing.T) {
+	t.Setenv("GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES", "all=missing")
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
+	client := newAPITestClient(t, handler)
+	response := mustRequestJSON[AgentAdapterResponse](client, http.MethodGet, "/hecate/v1/agent-adapters", "")
+	if len(response.Data) != 3 {
+		t.Fatalf("adapter count = %d, want 3", len(response.Data))
+	}
+	for _, item := range response.Data {
+		if item.Available || item.Status != agentadapters.StatusMissing || item.Path != "" {
+			t.Fatalf("adapter %q = %#v, want forced missing", item.ID, item)
+		}
+		if !strings.Contains(item.Error, "GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES") {
+			t.Fatalf("adapter %q error = %q, want discovery override marker", item.ID, item.Error)
+		}
+	}
+}
+
 func TestAgentChatRunsExternalAdapter(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := exec.LookPath("git"); err == nil {

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1381,3 +1381,220 @@ test("agent changed-files review inspects and reverts a captured file", async ({
   await page.getByRole("button", { name: "Confirm revert README.md" }).click();
   await expect.poll(() => revertedPaths).toEqual(["README.md"]);
 });
+
+type ClaudeAdapterFixture = {
+  available?: boolean;
+  authStatus?: string;
+  credentialConfigured?: boolean;
+  healthStatus?: "ready" | "auth_required" | "not_installed" | "error";
+  credentialPreview?: string;
+};
+
+async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture = {}) {
+  const adapter = {
+    id: "claude_code",
+    name: "Claude Code",
+    kind: "acp",
+    command: "claude-agent-acp",
+    managed: true,
+    managed_package: "@agentclientprotocol/claude-agent-acp",
+    available: fixture.available ?? true,
+    status: fixture.available === false ? "missing" : "available",
+    error: fixture.available === false ? "claude command not found" : undefined,
+    description: "Run Claude Agent through ACP as a long-lived external coding-agent session supervised by Hecate.",
+    cost_mode: "external",
+    auth_status: fixture.authStatus ?? "unknown",
+    auth_error: fixture.authStatus === "unauthenticated" ? "Run claude auth login" : undefined,
+    credential_configured: fixture.credentialConfigured ?? false,
+    credential_preview: fixture.credentialPreview,
+    claude_code_cli: fixture.available === false ? { available: false } : { available: true, path: "/usr/local/bin/claude" },
+  };
+
+  await page.route("/hecate/v1/agent-adapters*", async route => {
+    const method = route.request().method();
+    const url = route.request().url();
+    if (method === "POST" && url.includes("/claude_code/probe")) {
+      const status = fixture.available === false ? "not_installed" : (fixture.healthStatus ?? "ready");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "agent_adapter_probe",
+          data: {
+            adapter: status === "ready" && fixture.credentialConfigured
+              ? { ...adapter, auth_status: "ok", auth_error: undefined }
+              : adapter,
+            health: {
+              adapter_id: "claude_code",
+              status,
+              stage: status === "ready" ? "ready" : status === "not_installed" ? "lookup" : "new_session",
+              path: fixture.available === false ? undefined : "/usr/local/bin/claude-agent-acp",
+              hint: status === "auth_required" ? "Claude Code isn't signed in." : undefined,
+              error: status === "not_installed" ? "claude command not found" : undefined,
+              duration_ms: 20,
+            },
+          },
+        }),
+      });
+      return;
+    }
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "agent_adapters", data: [adapter] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+}
+
+test("Claude Code onboarding appears when the adapter is not installed", async ({ page }) => {
+  await openClaudeExternalAgent(page, { available: false, healthStatus: "not_installed" });
+
+  await expect(page.getByText("Set up Claude Code")).toBeVisible();
+  await expect(page.getByText(/Prepare Claude Code/).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "npx -y @anthropic-ai/claude-code --version" })).toBeVisible();
+  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+});
+
+test("Claude Code onboarding stays visible after a ready handshake without auth", async ({ page }) => {
+  await openClaudeExternalAgent(page, { available: true, authStatus: "unknown", credentialConfigured: false, healthStatus: "ready" });
+
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await page.getByRole("button", { name: "Check auth" }).click();
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await expect(page.getByText(/Claude Code needs its own adapter-visible credential/)).toBeVisible();
+  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+});
+
+test("Claude Code onboarding stays visible when a saved token fails auth", async ({ page }) => {
+  await openClaudeExternalAgent(page, {
+    available: true,
+    authStatus: "unknown",
+    credentialConfigured: true,
+    credentialPreview: "sk-a...bad1",
+    healthStatus: "auth_required",
+  });
+
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await expect(page.getByText("Set up Claude Code")).toBeVisible();
+  await expect(page.getByText(/Claude Code needs sign-in|Claude Code needs its own adapter-visible credential/)).toBeVisible();
+  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+});
+
+test("Claude Code onboarding stays visible when only CLI auth is verified", async ({ page }) => {
+  await openClaudeExternalAgent(page, {
+    available: true,
+    authStatus: "ok",
+    credentialConfigured: false,
+    healthStatus: "ready",
+  });
+
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await expect(page.getByText("adapter installed")).toBeVisible();
+  await expect(page.getByText("token not saved")).toBeVisible();
+  await expect(page.getByText("CLI signed in")).toBeVisible();
+  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+});
+
+test("Claude Code rejects malformed token saves before hiding onboarding", async ({ page }) => {
+  await page.route("/hecate/v1/agent-adapters/claude_code/credentials", async route => {
+    if (route.request().method() !== "PUT") return route.continue();
+    await route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: {
+          type: "invalid_request",
+          message: "Claude Code setup tokens start with sk- and are printed by `claude setup-token`",
+          user_message: "That does not look like a Claude Code setup token, so Hecate did not save it.",
+        },
+      }),
+    });
+  });
+  await openClaudeExternalAgent(page, { available: true, authStatus: "unknown", credentialConfigured: false, healthStatus: "ready" });
+
+  await page.getByLabel("Claude Code OAuth token").fill("random text");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByText(/does not look like a Claude Code setup token|setup tokens start with sk-/)).toBeVisible();
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+});
+
+test("Claude Code valid token save clears onboarding and enables chat", async ({ page }) => {
+  let saved = false;
+  await page.route("/hecate/v1/agent-adapters/claude_code/credentials", async route => {
+    if (route.request().method() !== "PUT") return route.continue();
+    const body = JSON.parse(route.request().postData() ?? "{}") as { value?: string };
+    if (!body.value?.startsWith("sk-")) {
+      await route.fulfill({ status: 400, contentType: "application/json", body: JSON.stringify({ error: { type: "invalid_request", message: "bad token" } }) });
+      return;
+    }
+    saved = true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ object: "agent_adapter_credential", data: { adapter_id: "claude_code", name: "CLAUDE_CODE_OAUTH_TOKEN", configured: true, preview: "sk-v...7890" } }),
+    });
+  });
+  await page.route("/hecate/v1/agent-adapters*", async route => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const configured = saved;
+    const adapter = {
+      id: "claude_code",
+      name: "Claude Code",
+      kind: "acp",
+      command: "claude-agent-acp",
+      managed: true,
+      managed_package: "@agentclientprotocol/claude-agent-acp",
+      available: true,
+      status: "available",
+      cost_mode: "external",
+      auth_status: configured ? "ok" : "unknown",
+      credential_configured: configured,
+      credential_preview: configured ? "sk-v...7890" : undefined,
+      claude_code_cli: { available: true, path: "/usr/local/bin/claude" },
+    };
+    if (method === "POST" && url.includes("/claude_code/probe")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "agent_adapter_probe", data: { adapter, health: { adapter_id: "claude_code", status: "ready", stage: "ready", path: "/usr/local/bin/claude-agent-acp", duration_ms: 20 } } }),
+      });
+      return;
+    }
+    if (method === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ object: "agent_adapters", data: [adapter] }) });
+      return;
+    }
+    await route.continue();
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await expect(page.getByTestId("claude-code-preflight")).toBeVisible();
+  await page.getByLabel("Claude Code OAuth token").fill("sk-valid-token-1234567890");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByTestId("claude-code-preflight")).toHaveCount(0);
+  await expect(page.locator("textarea")).toBeVisible();
+  await page.locator("textarea").fill("hello from Claude Code");
+  await expect(page.locator("button[type='submit']")).toBeEnabled();
+});

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1833,10 +1833,17 @@ export function useRuntimeConsole() {
       setAgentAdapters((current) => current.map((item) => item.id === adapterID
         ? { ...item, credential_configured: payload.data.configured, credential_preview: payload.data.preview }
         : item));
-      setNoticeMessage("success", "Adapter credential saved.");
+      if (adapterID === "claude_code" && payload.data.configured) {
+        setAgentAdapterHealthByID((current) => {
+          const next = new Map(current);
+          next.set(adapterID, { adapter_id: adapterID, status: "ready", stage: "ready", duration_ms: 0 });
+          return next;
+        });
+      }
+      setNoticeMessage("success", adapterID === "claude_code" ? "Claude Code verified." : "Adapter credential saved.");
       return true;
     } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to save adapter credential.");
+      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to validate adapter credential.");
       return false;
     }
   }

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1843,7 +1843,8 @@ export function useRuntimeConsole() {
       setNoticeMessage("success", adapterID === "claude_code" ? "Claude Code verified." : "Adapter credential saved.");
       return true;
     } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to validate adapter credential.");
+      const fallback = adapterID === "claude_code" ? "Failed to validate adapter credential." : "Failed to save adapter credential.";
+      setNoticeMessage("error", error instanceof Error ? error.message : fallback);
       return false;
     }
   }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1565,7 +1565,7 @@ describe("ChatView external-agent target", () => {
           auth_status: "unknown",
           credential_configured: false,
           cost_mode: "external",
-          claude_code_cli: { available: true, path: "/opt/homebrew/bin/claude" },
+          claude_code_cli: { available: true, command: "/opt/homebrew/bin/claude", executable_path: "/opt/homebrew/bin/claude" },
         },
       ],
     });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1345,7 +1345,9 @@ describe("ChatView external-agent target", () => {
     expect(screen.getByText("Codex is unavailable")).toBeTruthy();
     expect(screen.getByText(/could not start Codex/)).toBeTruthy();
     expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Install Node\/npm/)).toBeTruthy();
+    expect(screen.getByText(/Install and sign in to Codex/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /npm install -g @openai\/codex/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /codex login/ })).toBeTruthy();
     expect(screen.getByText(/no local package runner/)).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Add provider/i })).toBeNull();
   });
@@ -1462,6 +1464,195 @@ describe("ChatView external-agent target", () => {
     await user.click(screen.getByRole("button", { name: "External agent adapter" }));
     await user.click(screen.getByText("Claude Code"));
     expect(setAgentAdapterID).toHaveBeenCalledWith("claude_code");
+  });
+
+  it("shows Claude Code setup before the first send when auth is not configured", async () => {
+    const setAgentAdapterCredential = vi.fn(async () => true);
+    const probeAgentAdapter = vi.fn(async () => null);
+    const onNavigate = vi.fn();
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      message: "inspect repo",
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          auth_status: "unknown",
+          credential_configured: false,
+          cost_mode: "external",
+        },
+      ],
+    }, { setAgentAdapterCredential, probeAgentAdapter });
+    render(<ChatView state={state} actions={actions} onNavigate={onNavigate} />);
+
+    expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
+    expect(screen.getByText("Set up Claude Code")).toBeTruthy();
+    expect(screen.getByText(/adapter-visible credential before Hecate can start/)).toBeTruthy();
+    expect(document.querySelector("button[type='submit']")).toBeNull();
+
+    const user = userEvent.setup();
+    const installCommand = screen.getByRole("button", { name: /npx -y @anthropic-ai\/claude-code --version/i });
+    expect(installCommand).toBeTruthy();
+    await user.type(screen.getByLabelText("Claude Code OAuth token"), "claude-token");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(setAgentAdapterCredential).toHaveBeenCalledWith("claude_code", "claude-token", "CLAUDE_CODE_OAUTH_TOKEN");
+    expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
+    await user.click(screen.getByRole("button", { name: "Check auth" }));
+    expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
+    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+
+
+  it("shows compact Claude Code setup for existing empty sessions", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      activeAgentChatSessionID: "chat_1",
+      activeAgentChatSession: {
+        id: "chat_1",
+        title: "Claude work",
+        adapter_id: "claude_code",
+        adapter_name: "Claude Code",
+        workspace: "/tmp/hecate",
+        messages: [],
+        status: "idle",
+        turns_used: 0,
+        max_turns_per_session: 0,
+      },
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          auth_status: "unknown",
+          credential_configured: false,
+          cost_mode: "external",
+        },
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByText("Start a chat")).toBeTruthy();
+    expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
+    expect(document.querySelector("button[type='submit']")).toBeTruthy();
+  });
+
+  it("shows Claude Code install as complete when the CLI is already present", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          auth_status: "unknown",
+          credential_configured: false,
+          cost_mode: "external",
+          claude_code_cli: { available: true, path: "/opt/homebrew/bin/claude" },
+        },
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByText("Available via /opt/homebrew/bin/claude")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "npx -y @anthropic-ai/claude-code --version" })).toBeNull();
+  });
+
+  it("keeps Claude Code setup visible until the adapter probe verifies auth", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          credential_configured: true,
+          cost_mode: "external",
+        },
+      ],
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
+    expect(screen.getByText(/adapter-visible credential/i)).toBeTruthy();
+  });
+
+  it("keeps Claude Code setup visible when only the standalone CLI is signed in", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          auth_status: "ok",
+          cost_mode: "external",
+        },
+      ],
+      agentAdapterHealthByID: new Map([
+        ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 120 }],
+      ]),
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
+    expect(screen.getByText("adapter installed")).toBeTruthy();
+    expect(screen.getByText("token not saved")).toBeTruthy();
+    expect(screen.getByText("CLI signed in")).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: /message/i })).toBeNull();
+  });
+
+  it("hides Claude Code setup after the adapter probe verifies auth", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      agentWorkspace: "/tmp/hecate",
+      agentAdapters: [
+        {
+          id: "claude_code",
+          name: "Claude Code",
+          kind: "acp",
+          command: "claude-agent-acp",
+          available: true,
+          status: "available",
+          credential_configured: true,
+          cost_mode: "external",
+        },
+      ],
+      agentAdapterHealthByID: new Map([
+        ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 120 }],
+      ]),
+    });
+    render(<ChatView state={state} actions={actions} />);
+
+    expect(screen.queryByTestId("claude-code-preflight")).toBeNull();
   });
 
   it("shows a waiting state for a running agent before transcript output arrives", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2809,8 +2809,8 @@ function ClaudeCodeSetupFacts({ state }: { state: ClaudeCodePreflightState }) {
 }
 
 function claudeCodeSetupTokenCommand(status?: AgentAdapterSetupCommandStatus): string {
-  if (status?.path && status.path.includes("@anthropic-ai/claude-code")) {
-    return `${status.path} setup-token`;
+  if (status?.command) {
+    return `${status.command} setup-token`;
   }
   if (!status?.available) {
     return "npx -y @anthropic-ai/claude-code setup-token";
@@ -2918,7 +2918,7 @@ function ClaudeCodeSetupEmptyPanel(props: {
         detail="Hecate can run Claude Code through npx; a global `claude` install also works."
         command="npx -y @anthropic-ai/claude-code --version"
         done={claudeInstalled}
-        statusText={claudeInstalled ? `Available${commandStatus?.path ? ` via ${commandStatus.path}` : ""}` : undefined}
+        statusText={claudeInstalled ? `Available${commandStatus?.command ? ` via ${commandStatus.command}` : ""}` : undefined}
       />
       <ClaudeCodeSetupRow
         label="Auth"

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -6,7 +6,7 @@ import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnosti
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import { describeCredentialState, describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
-import type { AgentAdapterRecord, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
+import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
 import { CompactProviderReadinessChecks } from "../shared/ProviderReadiness";
 import { AgentAdapterPicker, CodeBlock, Icon, Icons, InlineError, ModelPicker, ProviderPicker } from "../shared/ui";
 import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
@@ -96,6 +96,8 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const [quickAddingProviders, setQuickAddingProviders] = useState(false);
   const [taskApprovalBusyID, setTaskApprovalBusyID] = useState("");
   const [capabilitySaving, setCapabilitySaving] = useState(false);
+  const [claudeTokenDraft, setClaudeTokenDraft] = useState("");
+  const [claudeTokenSaving, setClaudeTokenSaving] = useState(false);
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";
   const [modEnterMode, setModEnterMode] = useState(
@@ -194,6 +196,13 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const chatDiagnostic = describeGatewayError(state.chatErrorCode, state.chatErrorStatus ?? undefined);
   const activeAgentAdapterID = state.activeAgentChatSession?.adapter_id || state.agentAdapterID;
   const selectedAgent = state.agentAdapters.find((adapter) => adapter.id === activeAgentAdapterID);
+  const selectedAgentHealth = activeAgentAdapterID
+    ? state.agentAdapterHealthByID.get(activeAgentAdapterID) ?? null
+    : null;
+  const selectedAgentHealthLoading = activeAgentAdapterID
+    ? Boolean(state.agentAdapterHealthLoadingByID.get(activeAgentAdapterID))
+    : false;
+  const claudeCodePreflight = claudeCodePreflightState(selectedAgent, selectedAgentHealth);
   const availableAgents = state.agentAdapters.filter((adapter) => adapter.available);
   const configuredProviders = state.settingsConfig?.providers ?? [];
   const providerConfigLoaded = state.settingsConfig !== null;
@@ -256,13 +265,18 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const hecateChatModelReady = isHecateAgentChat && hecateAgentModelLocked
     ? Boolean(hecateChatModelValue)
     : Boolean(state.model) && !modelRouteUnavailable && !selectedModelIssue;
-  const composerVisible = isExternalAgentChat || (isHecateChat && hecateChatModelReady);
+  const showClaudeCodeEmptyPreflight = isExternalAgentChat
+    && !state.activeAgentChatSessionID
+    && visibleMessages.length === 0
+    && Boolean(claudeCodePreflight?.blockSend);
+  const composerVisible = (isExternalAgentChat || (isHecateChat && hecateChatModelReady)) && !showClaudeCodeEmptyPreflight;
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const sendDisabled = !state.message.trim()
     || (!agentBusy && streaming)
     || (!isAgentChat && modelRouteUnavailable)
     || (!agentBusy && isExternalAgentChat && (!state.agentWorkspace.trim() || !selectedAgent?.available))
+    || (!agentBusy && isExternalAgentChat && Boolean(claudeCodePreflight?.blockSend))
     || (!agentBusy && isHecateAgentChat && (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel));
 
   async function enableToolsForSelectedModel() {
@@ -281,6 +295,32 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
       });
     } finally {
       setCapabilitySaving(false);
+    }
+  }
+
+  function openClaudeCodeSetup() {
+    try {
+      localStorage.setItem("hecate.settingsTab", "external_agents");
+      sessionStorage.setItem("hecate.settingsFocus", "claude-code-guided-setup");
+    } catch {
+      // localStorage / sessionStorage unavailable — navigation still
+      // works, just no auto-scroll to the guided setup card.
+    }
+    onNavigate?.("settings");
+  }
+
+  async function saveClaudeCodeToken() {
+    const token = claudeTokenDraft.trim();
+    if (!token || claudeTokenSaving) return;
+    setClaudeTokenSaving(true);
+    try {
+      const saved = await actions.setAgentAdapterCredential("claude_code", token, "CLAUDE_CODE_OAUTH_TOKEN");
+      if (saved) {
+        setClaudeTokenDraft("");
+        await actions.probeAgentAdapter("claude_code");
+      }
+    } finally {
+      setClaudeTokenSaving(false);
     }
   }
 
@@ -975,22 +1015,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                     ? {
                         label: "Open Claude Code setup",
                         title: "Open Settings → External agents and scroll to the guided setup card",
-                        onClick: () => {
-                          // Pre-set the persisted Settings sub-tab so
-                          // SettingsView mounts directly on External
-                          // agents (rather than wherever the operator
-                          // last left it). The session flag drives a
-                          // one-shot scroll-into-view + highlight on
-                          // the guided setup card.
-                          try {
-                            localStorage.setItem("hecate.settingsTab", "external_agents");
-                            sessionStorage.setItem("hecate.settingsFocus", "claude-code-guided-setup");
-                          } catch {
-                            // localStorage / sessionStorage unavailable —
-                            // navigation still works, just no auto-scroll.
-                          }
-                          onNavigate?.("settings");
-                        },
+                        onClick: openClaudeCodeSetup,
                       }
                     : undefined
                 }
@@ -1064,6 +1089,8 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               isAgentChat={isAgentChat}
               isHecateChat={isHecateChat}
               isExternalAgentChat={isExternalAgentChat}
+              claudeCodePreflight={showClaudeCodeEmptyPreflight ? claudeCodePreflight : null}
+              claudeCodePreflightLoading={selectedAgentHealthLoading}
               modelRouteUnavailable={modelRouteUnavailable}
               selectedModelIssue={selectedModelIssue}
               agentRouteUnavailable={isExternalAgentChat && agentRouteUnavailable}
@@ -1084,6 +1111,12 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               onQuickAddLocalProviders={quickAddLocalProviders}
               onRefreshQuickLocalProviders={refreshQuickLocalProviders}
               onSwitchTarget={actions.setChatTarget}
+              claudeCodeCLI={selectedAgent?.claude_code_cli}
+              claudeTokenDraft={claudeTokenDraft}
+              claudeTokenSaving={claudeTokenSaving}
+              onClaudeTokenDraftChange={setClaudeTokenDraft}
+              onSaveClaudeCodeToken={() => void saveClaudeCodeToken()}
+              onTestClaudeCode={() => void actions.probeAgentAdapter("claude_code")}
             />
           )}
           <div ref={bottomRef} />
@@ -1127,6 +1160,16 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
           )}
           {composerVisible && (
           <>
+          {isExternalAgentChat && claudeCodePreflight && !showClaudeCodeEmptyPreflight && (
+            <ClaudeCodePreflightCard
+              state={claudeCodePreflight}
+              loading={selectedAgentHealthLoading}
+              onCopyInstall={() => void actions.copyCommand("npx -y @anthropic-ai/claude-code --version")}
+              onCopySetup={() => void actions.copyCommand(claudeCodeSetupTokenCommand(selectedAgent?.claude_code_cli))}
+              onOpenSetup={openClaudeCodeSetup}
+              onTest={() => void actions.probeAgentAdapter("claude_code")}
+            />
+          )}
           {isHecateAgentChat && hecateChatModelValue && hecateAgentToolsDisabledForModel && (
             <div style={{
               maxWidth: 820,
@@ -2033,6 +2076,8 @@ function ChatEmptyState({
   isAgentChat,
   isHecateChat,
   isExternalAgentChat,
+  claudeCodePreflight,
+  claudeCodePreflightLoading,
   modelRouteUnavailable,
   selectedModelIssue,
   agentRouteUnavailable,
@@ -2053,10 +2098,18 @@ function ChatEmptyState({
   onQuickAddLocalProviders,
   onRefreshQuickLocalProviders,
   onSwitchTarget,
+  claudeCodeCLI,
+  claudeTokenDraft,
+  claudeTokenSaving,
+  onClaudeTokenDraftChange,
+  onSaveClaudeCodeToken,
+  onTestClaudeCode,
 }: {
   isAgentChat: boolean;
   isHecateChat: boolean;
   isExternalAgentChat: boolean;
+  claudeCodePreflight: ClaudeCodePreflightState | null;
+  claudeCodePreflightLoading: boolean;
   modelRouteUnavailable: boolean;
   selectedModelIssue: SelectedModelIssue | null;
   agentRouteUnavailable: boolean;
@@ -2077,9 +2130,17 @@ function ChatEmptyState({
   onQuickAddLocalProviders: (providers: LocalProviderDiscoveryRecord[]) => void;
   onRefreshQuickLocalProviders: () => void;
   onSwitchTarget: (target: "model" | "agent" | "external_agent") => void;
+  claudeCodeCLI?: AgentAdapterSetupCommandStatus;
+  claudeTokenDraft: string;
+  claudeTokenSaving: boolean;
+  onClaudeTokenDraftChange: (value: string) => void;
+  onSaveClaudeCodeToken: () => void;
+  onTestClaudeCode: () => void;
 }) {
   const hecateModelUnavailable = isHecateChat && (modelRouteUnavailable || Boolean(selectedModelIssue));
-  const title = isAgentChat && selectedAgentUnavailable
+  const title = claudeCodePreflight
+      ? "Set up Claude Code"
+      : isAgentChat && selectedAgentUnavailable
       ? `${selectedAgent?.name || "Selected agent"} is unavailable`
       : isExternalAgentChat && agentRouteUnavailable
       ? "No available coding agent"
@@ -2090,7 +2151,9 @@ function ChatEmptyState({
         : hecateModelUnavailable
           ? "No routable model"
         : "Start a chat";
-  const detail = isAgentChat && selectedAgentUnavailable
+  const detail = claudeCodePreflight
+      ? "Claude Code needs its own adapter-visible credential before Hecate can start a session."
+      : isAgentChat && selectedAgentUnavailable
       ? `Hecate could not start ${selectedAgent?.name || "the selected agent"} because its CLI is not ready in this environment.`
       : isExternalAgentChat && agentRouteUnavailable
       ? "Hecate did not find any supported coding-agent CLI or local adapter runner in the known operator locations."
@@ -2106,6 +2169,18 @@ function ChatEmptyState({
     <div style={{ padding: "48px 16px", maxWidth: 820, margin: "0 auto", textAlign: "center" }}>
       <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 5 }}>{title}</div>
       <div style={{ fontSize: 12, color: "var(--t3)", lineHeight: 1.5, maxWidth: 430, margin: "0 auto" }}>{detail}</div>
+      {claudeCodePreflight && (
+        <ClaudeCodeSetupEmptyPanel
+          state={claudeCodePreflight}
+          loading={claudeCodePreflightLoading}
+          cliStatus={claudeCodeCLI}
+          tokenDraft={claudeTokenDraft}
+          tokenSaving={claudeTokenSaving}
+          onTokenDraftChange={onClaudeTokenDraftChange}
+          onSaveToken={onSaveClaudeCodeToken}
+          onTest={onTestClaudeCode}
+        />
+      )}
       {isAgentChat && (agentRouteUnavailable || selectedAgentUnavailable) && (
         <AgentSetupHints adapters={agentAdapters} selectedID={selectedAgent?.id} />
       )}
@@ -2539,34 +2614,7 @@ function AgentSetupHints({ adapters, selectedID }: { adapters: AgentAdapterRecor
               alignItems: "start",
             }}
           >
-            <div style={{ minWidth: 0 }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span style={{ color: adapter.available ? "var(--green)" : "var(--red)", display: "inline-flex", flexShrink: 0 }}>
-                  <Icon d={adapter.available ? Icons.check : Icons.x} size={11} />
-                </span>
-                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                  {adapter.name}
-                </span>
-              </div>
-              <div style={{ marginTop: 3, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {adapter.managed ? `managed ${adapter.managed_package || adapter.command}` : `checks ${adapter.command}`}
-              </div>
-            </div>
-            <div style={{ minWidth: 0, fontSize: 11, color: "var(--t2)", lineHeight: 1.45 }}>
-              <div style={{ color: adapter.available ? "var(--green)" : "var(--t1)" }}>
-                {adapter.available ? agentReadyLabel(adapter) : hint.action}
-              </div>
-              {!adapter.available && adapter.error && (
-                <div style={{ marginTop: 3, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                  {adapter.error}
-                </div>
-              )}
-              {adapter.docs_url && (
-                <a href={adapter.docs_url} target="_blank" rel="noreferrer" style={{ display: "inline-flex", marginTop: 5, color: "var(--teal)", textDecoration: "none" }}>
-                  setup docs
-                </a>
-              )}
-            </div>
+            <ExternalAgentSetupSummary adapter={adapter} hint={hint} />
           </div>
         );
       })}
@@ -2574,16 +2622,501 @@ function AgentSetupHints({ adapters, selectedID }: { adapters: AgentAdapterRecor
   );
 }
 
-function agentSetupHint(adapter: AgentAdapterRecord): { action: string } {
+function ExternalAgentSetupSummary({
+  adapter,
+  hint,
+}: {
+  adapter: AgentAdapterRecord;
+  hint: ReturnType<typeof agentSetupHint>;
+}) {
+  return (
+    <>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ color: adapter.available ? "var(--green)" : "var(--red)", display: "inline-flex", flexShrink: 0 }}>
+            <Icon d={adapter.available ? Icons.check : Icons.x} size={11} />
+          </span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {adapter.name}
+          </span>
+        </div>
+        <div style={{ marginTop: 3, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {hint.label}
+        </div>
+      </div>
+      <div style={{ minWidth: 0, fontSize: 11, color: "var(--t2)", lineHeight: 1.45 }}>
+        <div style={{ color: adapter.available ? "var(--green)" : "var(--t1)" }}>
+          {adapter.available ? agentReadyLabel(adapter) : hint.action}
+        </div>
+        {!adapter.available && hint.commands.length > 0 && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 7 }}>
+            {hint.commands.map((command) => (
+              <CopyCommandLink key={command.command} command={command.command} label={command.label} />
+            ))}
+          </div>
+        )}
+        {!adapter.available && adapter.error && (
+          <div style={{ marginTop: 6, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {adapter.error}
+          </div>
+        )}
+        {hint.note && (
+          <div style={{ marginTop: 5, color: "var(--t3)" }}>{hint.note}</div>
+        )}
+        {adapter.docs_url && (
+          <a href={adapter.docs_url} target="_blank" rel="noreferrer" style={{ display: "inline-flex", marginTop: 5, color: "var(--teal)", textDecoration: "none" }}>
+            setup docs
+          </a>
+        )}
+      </div>
+    </>
+  );
+}
+
+function CopyCommandLink({ command, label }: { command: string; label?: string }) {
+  async function copyCommand() {
+    try {
+      await navigator.clipboard?.writeText(command);
+    } catch {
+      // Clipboard access can be unavailable in tests or locked-down
+      // webviews. The command remains visible and selectable.
+    }
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => void copyCommand()}
+      title={`Copy ${command}`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        border: 0,
+        background: "transparent",
+        color: "var(--teal)",
+        padding: 0,
+        cursor: "pointer",
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+      }}
+    >
+      <span>{label || command}</span>
+      <Icon d={Icons.copy} size={11} />
+    </button>
+  );
+}
+
+type ClaudeCodePreflightState = {
+  title: string;
+  body: string;
+  detail?: string;
+  blockSend: boolean;
+  tone: "amber" | "red";
+  adapterInstalled: boolean;
+  tokenStatus: "not_saved" | "saved_needs_check" | "invalid";
+  cliSignedIn: boolean;
+};
+
+function claudeCodePreflightState(
+  adapter: AgentAdapterRecord | undefined,
+  health: AgentAdapterHealthRecord | null,
+): ClaudeCodePreflightState | null {
+  if (!adapter || adapter.id !== "claude_code") return null;
+  const hasSavedCredential = Boolean(adapter.credential_configured);
+  const cliSignedIn = adapter.auth_status === "ok";
+  const adapterInstalled = adapter.available && health?.status !== "not_installed";
+  const tokenVerified = hasSavedCredential && health?.status === "ready";
+  const tokenStatus: ClaudeCodePreflightState["tokenStatus"] = hasSavedCredential
+    ? (health?.status === "auth_required" || health?.status === "error" ? "invalid" : "saved_needs_check")
+    : "not_saved";
+  if (tokenVerified) {
+    return null;
+  }
+  const base = { adapterInstalled, tokenStatus, cliSignedIn };
+
+  if (!adapter.available || health?.status === "not_installed") {
+    return {
+      title: "Set up Claude Code before sending",
+      body: "Install Claude Code, then paste the one-time token printed in Terminal by `claude setup-token`.",
+      detail: health?.hint || adapter.error || "Hecate can manage the ACP launcher, but the Claude Code CLI still needs to be installed and signed in.",
+      blockSend: true,
+      tone: "amber",
+      ...base,
+    };
+  }
+
+  if (health?.status === "auth_required" || (adapter.auth_status === "unauthenticated" && hasSavedCredential)) {
+    return {
+      title: "Claude Code needs sign-in",
+      body: "Hecate has a Claude Code token saved, but the adapter still reports authentication required. Generate a fresh token and save it here.",
+      detail: health?.hint || adapter.auth_error,
+      blockSend: true,
+      tone: "amber",
+      ...base,
+    };
+  }
+
+  if (adapter.auth_status === "billing") {
+    return {
+      title: "Claude Code billing needs attention",
+      body: "Claude Code reported a billing or subscription problem. Test the adapter, then fix the Claude account before sending.",
+      detail: adapter.auth_error || health?.hint || health?.error,
+      blockSend: true,
+      tone: "red",
+      ...base,
+    };
+  }
+
+  if (!hasSavedCredential) {
+    return {
+      title: "Set up Claude Code token before sending",
+      body: cliSignedIn
+        ? "Claude Code is signed in for normal CLI use, but Hecate needs its own adapter token before it can start Claude ACP sessions."
+        : "Claude Code needs an adapter-visible token before Hecate can start Claude ACP sessions.",
+      detail: adapter.auth_error || health?.hint || health?.error,
+      blockSend: true,
+      tone: "amber",
+      ...base,
+    };
+  }
+
+  return {
+    title: "Check Claude Code setup before sending",
+    body: "Hecate has a Claude Code token saved, but it has not been verified by the adapter yet. Check auth or save a fresh token before sending.",
+    detail: adapter.auth_error || health?.hint || health?.error,
+    blockSend: true,
+    tone: "amber",
+    ...base,
+  };
+}
+
+function ClaudeCodeSetupFacts({ state }: { state: ClaudeCodePreflightState }) {
+  const tokenLabel = state.tokenStatus === "not_saved"
+    ? "token not saved"
+    : state.tokenStatus === "invalid"
+      ? "token invalid"
+      : "token saved, needs check";
+  const tokenColor = state.tokenStatus === "invalid" ? "var(--danger)" : "var(--amber)";
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10, marginTop: 5 }}>
+      <span style={{ color: state.adapterInstalled ? "var(--teal)" : "var(--t3)" }}>
+        adapter {state.adapterInstalled ? "installed" : "not installed"}
+      </span>
+      <span style={{ color: tokenColor }}>{tokenLabel}</span>
+      {state.cliSignedIn && <span style={{ color: "var(--t3)" }}>CLI signed in</span>}
+    </div>
+  );
+}
+
+function claudeCodeSetupTokenCommand(status?: AgentAdapterSetupCommandStatus): string {
+  if (status?.path && status.path.includes("@anthropic-ai/claude-code")) {
+    return `${status.path} setup-token`;
+  }
+  if (!status?.available) {
+    return "npx -y @anthropic-ai/claude-code setup-token";
+  }
+  return "claude setup-token";
+}
+
+function ClaudeCodePreflightCard({
+  state,
+  loading,
+  onCopyInstall,
+  onCopySetup,
+  onOpenSetup,
+  onTest,
+}: {
+  state: ClaudeCodePreflightState;
+  loading: boolean;
+  onCopyInstall: () => void;
+  onCopySetup: () => void;
+  onOpenSetup: () => void;
+  onTest: () => void;
+}) {
+  const color = state.tone === "red" ? "var(--danger)" : "var(--amber)";
+  const border = state.tone === "red" ? "rgba(239, 68, 68, 0.32)" : "rgba(245, 191, 79, 0.35)";
+  const background = state.tone === "red" ? "rgba(239, 68, 68, 0.08)" : "rgba(245, 191, 79, 0.08)";
+
+  return (
+    <div
+      data-testid="claude-code-preflight"
+      style={{
+        maxWidth: 820,
+        margin: "0 auto 8px",
+        border: `1px solid ${border}`,
+        borderRadius: "var(--radius-sm)",
+        background,
+        padding: "9px 10px",
+        display: "grid",
+        gap: 8,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ color, fontWeight: 700, fontSize: 12 }}>
+            {state.title}
+          </div>
+          <div style={{ color: "var(--t1)", fontSize: 12, lineHeight: 1.45, marginTop: 3 }}>
+            {state.body}
+          </div>
+          {state.detail && (
+            <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.4, marginTop: 4 }}>
+              {state.detail}
+            </div>
+          )}
+          <ClaudeCodeSetupFacts state={state} />
+        </div>
+        <button type="button" className="btn btn-primary btn-sm" onClick={onOpenSetup} style={{ flexShrink: 0 }}>
+          Open setup
+        </button>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 6 }}>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onCopyInstall}>
+          Copy check command
+        </button>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onCopySetup}>
+          Copy setup command
+        </button>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onTest} disabled={loading}>
+          {loading ? "Checking auth..." : "Check auth"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ClaudeCodeSetupEmptyPanel(props: {
+  state: ClaudeCodePreflightState;
+  loading: boolean;
+  cliStatus?: AgentAdapterSetupCommandStatus;
+  tokenDraft: string;
+  tokenSaving: boolean;
+  onTokenDraftChange: (value: string) => void;
+  onSaveToken: () => void;
+  onTest: () => void;
+}) {
+  const commandStatus = props.cliStatus;
+  const claudeInstalled = Boolean(commandStatus?.available);
+  const tokenCommand = claudeCodeSetupTokenCommand(commandStatus);
+  const canSave = props.tokenDraft.trim().length > 0 && !props.tokenSaving;
+  return (
+    <div style={{
+      // Match the local-provider onboarding surface: the empty state
+      // is the setup flow, while the composer stays out of the way
+      // until the external agent can actually run.
+      margin: "18px auto 0",
+      maxWidth: 620,
+      textAlign: "left",
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius)",
+      background: "var(--bg2)",
+      overflow: "hidden",
+    }} data-testid="claude-code-preflight">
+      <ClaudeCodeSetupRow
+        label="Install"
+        title="Prepare Claude Code"
+        detail="Hecate can run Claude Code through npx; a global `claude` install also works."
+        command="npx -y @anthropic-ai/claude-code --version"
+        done={claudeInstalled}
+        statusText={claudeInstalled ? `Available${commandStatus?.path ? ` via ${commandStatus.path}` : ""}` : undefined}
+      />
+      <ClaudeCodeSetupRow
+        label="Auth"
+        title="Create an adapter token"
+        detail="Copy this command into Terminal. After you click Authorize in the browser, return to Terminal and copy the token printed there. It is shown only once."
+        command={tokenCommand}
+      />
+      <div style={{
+        padding: "10px 12px",
+        borderTop: "1px solid var(--border)",
+        display: "grid",
+        gridTemplateColumns: "minmax(120px, 0.7fr) minmax(0, 1.3fr)",
+        gap: 10,
+        alignItems: "start",
+      }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ color: "var(--amber)", display: "inline-flex", flexShrink: 0 }}>
+              <Icon d={Icons.keys} size={11} />
+            </span>
+            <span style={{ fontSize: 12, fontWeight: 600, color: "var(--t1)" }}>
+              Save token
+            </span>
+          </div>
+          <div style={{ marginTop: 3, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+            CLAUDE_CODE_OAUTH_TOKEN
+          </div>
+        </div>
+        <div style={{ minWidth: 0, fontSize: 11, color: "var(--t2)", lineHeight: 1.45 }}>
+          <div>Paste the token from Terminal here. If you closed Terminal or missed the token, run the token command again to generate a fresh one.</div>
+          <div style={{ marginTop: 4, color: "var(--t3)" }}>
+            Save validates the token with Claude Code before Hecate stores it.
+          </div>
+          {props.state.detail && (
+            <div style={{ marginTop: 4, color: "var(--t3)" }}>{props.state.detail}</div>
+          )}
+          <ClaudeCodeSetupFacts state={props.state} />
+          <input
+            aria-label="Claude Code OAuth token"
+            value={props.tokenDraft}
+            onChange={(event) => props.onTokenDraftChange(event.currentTarget.value)}
+            placeholder="Paste token from claude setup-token"
+            type="password"
+            spellCheck={false}
+            autoComplete="off"
+            style={{
+              width: "100%",
+              marginTop: 8,
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-sm)",
+              background: "var(--bg1)",
+              color: "var(--t1)",
+              padding: "7px 8px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              outline: "none",
+            }}
+          />
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 8 }}>
+            <button type="button" className="btn btn-primary btn-sm" onClick={props.onSaveToken} disabled={!canSave}>
+              {props.tokenSaving ? "Checking auth..." : "Save"}
+            </button>
+            <button type="button" className="btn btn-ghost btn-sm" onClick={props.onTest} disabled={props.loading}>
+              {props.loading ? "Checking auth..." : "Check auth"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ClaudeCodeSetupRow({
+  label,
+  title,
+  detail,
+  command,
+  done = false,
+  statusText,
+}: {
+  label: string;
+  title: string;
+  detail: string;
+  command: string;
+  done?: boolean;
+  statusText?: string;
+}) {
+  async function copyCommand() {
+    try {
+      await navigator.clipboard?.writeText(command);
+    } catch {
+      // Clipboard access can be unavailable in tests or locked-down
+      // webviews. The command is still visible and selectable.
+    }
+  }
+
+  return (
+    <div style={{
+      padding: "10px 12px",
+      borderTop: label === "Install" ? 0 : "1px solid var(--border)",
+      display: "grid",
+      gridTemplateColumns: "minmax(120px, 0.7fr) minmax(0, 1.3fr)",
+      gap: 10,
+      alignItems: "start",
+    }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ color: done ? "var(--green)" : "var(--teal)", display: "inline-flex", flexShrink: 0 }}>
+            <Icon d={done ? Icons.check : Icons.terminal} size={11} />
+          </span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--t1)" }}>
+            {title}
+          </span>
+        </div>
+        <div style={{ marginTop: 3, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+          {label}
+        </div>
+      </div>
+      <div style={{ minWidth: 0, fontSize: 11, color: "var(--t2)", lineHeight: 1.45 }}>
+        <div>{detail}</div>
+        {done ? (
+          <div style={{ marginTop: 7 }}>
+            <code style={{ fontFamily: "var(--font-mono)", color: "var(--t2)" }}>{command}</code>
+            {statusText && <div style={{ marginTop: 4, color: "var(--green)" }}>{statusText}</div>}
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void copyCommand()}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              marginTop: 8,
+              padding: 0,
+              border: 0,
+              background: "transparent",
+              color: "var(--teal)",
+              cursor: "pointer",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              maxWidth: "100%",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+            title={`Copy ${command}`}
+          >
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{command}</span>
+            <Icon d={Icons.copy} size={12} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function agentSetupHint(adapter: AgentAdapterRecord): {
+  label: string;
+  action: string;
+  commands: Array<{ command: string; label?: string }>;
+  note?: string;
+} {
   switch (adapter.id) {
     case "codex":
-      return { action: "Install Node/npm so Hecate can create its managed Codex ACP launcher, then authenticate the underlying Codex CLI." };
+      return {
+        label: adapter.managed ? `managed ${adapter.managed_package || adapter.command}` : `checks ${adapter.command}`,
+        action: "Install and sign in to Codex. Hecate manages the ACP launcher separately when Node/npm is available.",
+        commands: [
+          { command: "npm install -g @openai/codex", label: "npm install -g @openai/codex" },
+          { command: "codex login", label: "codex login" },
+        ],
+        note: "No Hecate token is needed; Codex uses its own CLI login or OpenAI API key.",
+      };
     case "claude_code":
-      return { action: "Install Node/npm so Hecate can create its managed Claude ACP launcher, then authenticate the underlying Claude agent." };
+      return {
+        label: adapter.managed ? `managed ${adapter.managed_package || adapter.command}` : `checks ${adapter.command}`,
+        action: "Prepare Claude Code through npx or a global install, create a one-time adapter token, then paste it in the guided setup above.",
+        commands: [
+          { command: "npx -y @anthropic-ai/claude-code --version", label: "check with npx" },
+          { command: "npx -y @anthropic-ai/claude-code setup-token", label: "create token with npx" },
+        ],
+        note: "Claude Code needs a Hecate-visible token even if the normal CLI is already signed in.",
+      };
     case "cursor_agent":
-      return { action: "Install Cursor Agent, make sure `cursor-agent` is on PATH, then run `cursor-agent login` or set `CURSOR_API_KEY`." };
+      return {
+        label: `checks ${adapter.command}`,
+        action: "Install Cursor Agent from Cursor, make sure `cursor-agent` is on PATH, then sign in.",
+        commands: [
+          { command: "cursor-agent login", label: "cursor-agent login" },
+        ],
+        note: "You can also set CURSOR_API_KEY for the adapter environment.",
+      };
     default:
-      return { action: `Install ${adapter.name}, make sure \`${adapter.command}\` is on PATH, then refresh this view.` };
+      return {
+        label: adapter.managed ? `managed ${adapter.managed_package || adapter.command}` : `checks ${adapter.command}`,
+        action: `Install ${adapter.name}, make sure \`${adapter.command}\` is on PATH, then refresh this view.`,
+        commands: [],
+      };
   }
 }
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -281,11 +281,72 @@ describe("SettingsView external agents tab", () => {
     expect(await screen.findByText(/list failed: 500/)).toBeTruthy();
   });
 
-  // Adapter status panel — surfaces the on-demand probe result. The
-  // section is hidden when no adapters are registered (no point
-  // showing an empty card); otherwise each row exposes a Test button
-  // that calls actions.probeAgentAdapter, plus inline diagnostic
-  // copy when a result exists.
+  it("keeps the Anthropic provider key card visible through transient settings refreshes", async () => {
+    const { state, actions, user } = setup({
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            preset_id: "anthropic",
+            kind: "cloud",
+            protocol: "anthropic",
+            base_url: "https://api.anthropic.com",
+            credential_configured: true,
+          },
+        ],
+        policy_rules: [],
+        pricebook: [],
+        events: [],
+      },
+    });
+    const { rerender } = render(<SettingsView state={state} actions={actions} />);
+    await user.click(screen.getByRole("button", { name: "External agents" }));
+
+    expect(await screen.findByTestId("anthropic-provider-key-card")).toBeTruthy();
+
+    rerender(<SettingsView state={{ ...state, settingsConfig: { ...state.settingsConfig!, providers: [] } }} actions={actions} />);
+
+    expect(screen.getByTestId("anthropic-provider-key-card")).toBeTruthy();
+  });
+
+  it("saves and clears the Anthropic provider key from External agents settings", async () => {
+    const setProviderAPIKey = vi.fn(async () => undefined);
+    const { state, actions, user } = setup({
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            preset_id: "anthropic",
+            kind: "cloud",
+            protocol: "anthropic",
+            base_url: "https://api.anthropic.com",
+            credential_configured: true,
+          },
+        ],
+        policy_rules: [],
+        pricebook: [],
+        events: [],
+      },
+    }, { setProviderAPIKey });
+    render(<SettingsView state={state} actions={actions} />);
+    await user.click(screen.getByRole("button", { name: "External agents" }));
+
+    await user.type(await screen.findByLabelText("Anthropic API key"), "sk-ant-new");
+    await user.click(screen.getByRole("button", { name: "Update key" }));
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(setProviderAPIKey).toHaveBeenNthCalledWith(1, "anthropic", "sk-ant-new");
+    expect(setProviderAPIKey).toHaveBeenNthCalledWith(2, "anthropic", "");
+  });
+
+  // Adapter status panel — surfaces auto-probe results when the tab
+  // opens. The section is hidden when no adapters are registered (no
+  // point showing an empty card); otherwise each row renders inline
+  // diagnostic copy when a result exists.
   describe("adapter status panel", () => {
     function withAdapter(overrides: Record<string, unknown> = {}) {
       return {
@@ -311,21 +372,20 @@ describe("SettingsView external agents tab", () => {
       expect(screen.queryByTestId("external-agents-adapters")).toBeNull();
     });
 
-    it("renders one row per adapter with a Test button", async () => {
+    it("renders one row per adapter without a manual test button", async () => {
       const { state, actions, user } = setup(withAdapter());
       render(<SettingsView state={state} actions={actions} />);
       await user.click(screen.getByRole("button", { name: "External agents" }));
       expect(await screen.findByTestId("external-agents-adapters")).toBeTruthy();
       expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
-      expect(screen.getByTestId("external-agents-test-codex")).toBeTruthy();
+      expect(screen.queryByTestId("external-agents-test-codex")).toBeNull();
     });
 
-    it("calls probeAgentAdapter with the row id when Test is clicked", async () => {
+    it("auto-runs adapter probes when the tab opens", async () => {
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions, user } = setup(withAdapter(), { probeAgentAdapter });
       render(<SettingsView state={state} actions={actions} />);
       await user.click(screen.getByRole("button", { name: "External agents" }));
-      await user.click(await screen.findByTestId("external-agents-test-codex"));
       expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
     });
 
@@ -372,15 +432,13 @@ describe("SettingsView external agents tab", () => {
       expect(screen.getByTestId("external-agents-adapter-cursor_agent-auth-detail")).toHaveTextContent("Run cursor-agent login");
     });
 
-    it("disables the Test button while a probe is in flight", async () => {
+    it("shows an inline checking status while a probe is in flight", async () => {
       const { state, actions, user } = setup(withAdapter({
         agentAdapterHealthLoadingByID: new Map([["codex", true]]),
       }));
       render(<SettingsView state={state} actions={actions} />);
       await user.click(screen.getByRole("button", { name: "External agents" }));
-      const button = await screen.findByTestId("external-agents-test-codex") as HTMLButtonElement;
-      expect(button.disabled).toBe(true);
-      expect(button.textContent).toMatch(/Testing/);
+      expect(await screen.findByTestId("external-agents-checking-codex")).toHaveTextContent(/checking/i);
     });
 
     it("shows Claude Code guided setup and saves the pasted token", async () => {
@@ -397,7 +455,7 @@ describe("SettingsView external agents tab", () => {
             status: "available",
             cost_mode: "external",
             auth_status: "unknown",
-            auth_error: "Use Test adapter; if Claude Code reports auth errors, set CLAUDE_CODE_OAUTH_TOKEN.",
+            auth_error: "Save a Claude Code token here; Hecate validates it before storing.",
           },
         ],
       }), { setAgentAdapterCredential, probeAgentAdapter });
@@ -406,10 +464,103 @@ describe("SettingsView external agents tab", () => {
 
       expect(await screen.findByTestId("claude-code-guided-setup")).toBeTruthy();
       await user.type(screen.getByLabelText("Claude Code OAuth token"), "claude-token");
-      await user.click(screen.getByRole("button", { name: "Save + test" }));
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       expect(setAgentAdapterCredential).toHaveBeenCalledWith("claude_code", "claude-token", "CLAUDE_CODE_OAUTH_TOKEN");
-      expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
+    });
+
+
+
+    it("keeps Claude Code token editing visible when the adapter handshake is ready but no token is configured", async () => {
+      const { state, actions, user } = setup(withAdapter({
+        agentAdapters: [
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            auth_status: "unknown",
+          },
+        ],
+        agentAdapterHealthByID: new Map([
+          ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
+        ]),
+      }));
+      render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+
+      expect(await screen.findByText("Claude Code guided setup")).toBeTruthy();
+      expect(screen.queryByText("Claude Code token verified")).toBeNull();
+      expect(screen.getByText("adapter installed")).toBeTruthy();
+      expect(screen.getByText("token not saved")).toBeTruthy();
+      expect(screen.getByLabelText("Claude Code OAuth token")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+    });
+
+    it("shows CLI sign-in separately from Hecate's adapter token", async () => {
+      const { state, actions, user } = setup(withAdapter({
+        agentAdapters: [
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            auth_status: "ok",
+          },
+        ],
+        agentAdapterHealthByID: new Map([
+          ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
+        ]),
+      }));
+      render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+
+      expect(await screen.findByText("Claude Code guided setup")).toBeTruthy();
+      expect(screen.getByText("adapter installed")).toBeTruthy();
+      expect(screen.getByText("token not saved")).toBeTruthy();
+      expect(screen.getByText("CLI signed in")).toBeTruthy();
+      expect(screen.queryByText("Claude Code token verified")).toBeNull();
+      expect(screen.getByLabelText("Claude Code OAuth token")).toBeTruthy();
+    });
+
+    it("shows a token-verified result after Claude Code token validation passes", async () => {
+      const { state, actions, user } = setup(withAdapter({
+        agentAdapters: [
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            auth_status: "unknown",
+            credential_configured: true,
+            credential_preview: "sk-a...SwAA",
+          },
+        ],
+        agentAdapterHealthByID: new Map([
+          ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
+        ]),
+      }));
+      render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+
+      expect(await screen.findByText("Claude Code token verified")).toBeTruthy();
+      expect(screen.getByText(/Hecate has a validated adapter token/)).toBeTruthy();
+      expect(screen.getByText("adapter installed")).toBeTruthy();
+      expect(screen.getByText("token valid")).toBeTruthy();
+      expect(screen.getByText(/Stored token/)).toBeTruthy();
+      expect(screen.getByText("Token valid.")).toBeTruthy();
+      expect(screen.queryByTestId("external-agents-adapter-claude_code-auth-warning")).toBeNull();
+      expect(screen.getByLabelText("Claude Code OAuth token")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Paste a replacement CLAUDE_CODE_OAUTH_TOKEN")).toBeTruthy();
     });
 
     it("can remove a stored Claude Code token", async () => {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -389,6 +389,20 @@ describe("SettingsView external agents tab", () => {
       expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
     });
 
+    it("auto-runs adapter probes when adapters arrive after the tab opens", async () => {
+      const probeAgentAdapter = vi.fn(async () => null);
+      const { state, actions, user } = setup({ agentAdapters: [] }, { probeAgentAdapter });
+      const { rerender } = render(<SettingsView state={state} actions={actions} />);
+      await user.click(screen.getByRole("button", { name: "External agents" }));
+      expect(probeAgentAdapter).not.toHaveBeenCalled();
+
+      const nextState = createRuntimeConsoleFixture(withAdapter());
+      rerender(<SettingsView state={nextState} actions={actions} />);
+      expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
+      rerender(<SettingsView state={{ ...nextState }} actions={actions} />);
+      expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
+    });
+
     it("renders the auth-required hint when the cached probe says auth is missing", async () => {
       const { state, actions, user } = setup(withAdapter({
         agentAdapterHealthByID: new Map([

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ModelRecord } from "../../types/runtime";
+import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ModelRecord } from "../../types/runtime";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
 import { PricebookTab } from "./PricebookTab";
 
@@ -478,14 +478,27 @@ function RetentionTab({ state, actions }: Props) {
 // only ExpiresAt removes them automatically. Revoke is the only
 // operator-driven removal path.
 //
-// The grant list is lazy-loaded on tab mount — operators rarely visit
-// this surface, so we don't fetch on every dashboard load.
+// Grants and adapter health are lazy-loaded on tab mount — operators
+// rarely visit this surface, so we don't fetch on every dashboard
+// load. Adapter probes run automatically here because this tab is a
+// readiness panel; "Save" validates Claude Code auth before storing
+// the token, so no separate Test button is needed.
 function ExternalAgentsTab({ state, actions }: Props) {
+  const liveAnthropicProvider = findAnthropicProvider(state.settingsConfig?.providers ?? []);
+  const [rememberedAnthropicProvider, setRememberedAnthropicProvider] = useState<ConfiguredProviderRecord | null>(liveAnthropicProvider);
+
+  useEffect(() => {
+    if (liveAnthropicProvider) setRememberedAnthropicProvider(liveAnthropicProvider);
+  }, [liveAnthropicProvider]);
+
   useEffect(() => {
     void actions.listAgentChatGrants();
-    // listAgentChatGrants is stable across renders; no need to put it
-    // in the deps. We also intentionally fire only once on tab mount —
-    // operators can re-fetch via the explicit Refresh button below.
+    for (const adapter of state.agentAdapters) {
+      void actions.probeAgentAdapter(adapter.id);
+    }
+    // Actions and agentAdapters are stable enough for this one-shot tab
+    // mount refresh. Operators can re-fetch grants via Refresh; adapter
+    // health refreshes the next time the tab mounts.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -541,6 +554,14 @@ function ExternalAgentsTab({ state, actions }: Props) {
 
   return (
     <>
+      {rememberedAnthropicProvider && (
+        <AnthropicProviderKeyCard
+          provider={rememberedAnthropicProvider}
+          onSave={(key) => actions.setProviderAPIKey(rememberedAnthropicProvider.id, key)}
+          onClear={() => actions.setProviderAPIKey(rememberedAnthropicProvider.id, "")}
+        />
+      )}
+
       <AdapterStatusSection state={state} actions={actions} />
 
       <SectionHeader
@@ -590,12 +611,107 @@ function ExternalAgentsTab({ state, actions }: Props) {
   );
 }
 
-// AdapterStatusSection lists the configured external-agent adapters
-// with a "Test" button per row. The button calls
-// actions.probeAgentAdapter, which spawns the adapter, completes the
-// ACP handshake, and returns a typed health classification. Probe
-// state is cached on the hook so leaving and returning to the tab
-// doesn't lose the last-known status.
+function findAnthropicProvider(providers: ConfiguredProviderRecord[]): ConfiguredProviderRecord | null {
+  return providers.find((provider) => (
+    provider.id === "anthropic" ||
+    provider.preset_id === "anthropic" ||
+    provider.protocol === "anthropic"
+  )) ?? null;
+}
+
+function AnthropicProviderKeyCard({
+  provider,
+  onSave,
+  onClear,
+}: {
+  provider: ConfiguredProviderRecord;
+  onSave: (key: string) => Promise<void>;
+  onClear: () => Promise<void>;
+}) {
+  const [key, setKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const configured = provider.credential_configured;
+
+  async function save() {
+    const trimmed = key.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    try {
+      await onSave(trimmed);
+      setKey("");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clear() {
+    setSaving(true);
+    try {
+      await onClear();
+      setKey("");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="card"
+      data-testid="anthropic-provider-key-card"
+      style={{
+        marginBottom: 24,
+        padding: "14px 16px",
+        borderColor: configured ? "rgba(0, 191, 179, 0.34)" : "var(--border)",
+        background: configured ? "rgba(0, 191, 179, 0.04)" : "var(--bg1)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 6 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--t0)" }}>Anthropic provider key</span>
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: configured ? "var(--teal)" : "var(--t3)",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {configured ? "saved" : "missing"}
+        </span>
+      </div>
+      <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45, marginBottom: 12 }}>
+        Used by Hecate Chat and direct Anthropic provider calls through {provider.name || "Anthropic"}. This is separate from the Claude Code adapter token below.
+      </div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={key}
+          onChange={(event) => setKey(event.target.value)}
+          placeholder={configured ? "Paste a new Anthropic API key" : "Paste Anthropic API key"}
+          type="password"
+          className="input"
+          style={{ flex: 1, minWidth: 220 }}
+          aria-label="Anthropic API key"
+        />
+        <button type="button" className="btn btn-primary btn-sm" onClick={() => void save()} disabled={saving || key.trim() === ""}>
+          {saving ? "Saving..." : configured ? "Update key" : "Save key"}
+        </button>
+        {configured && (
+          <button type="button" className="btn btn-danger btn-sm" onClick={() => void clear()} disabled={saving}>
+            Remove
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// AdapterStatusSection lists the configured external-agent adapters.
+// The parent tab auto-runs actions.probeAgentAdapter on mount, which
+// spawns each adapter, completes the ACP handshake, and returns a
+// typed health classification. For Claude Code, that handshake is
+// also the auth check: auth failures surface as `auth_required`.
+// Probe state is cached on the hook so leaving and returning to the
+// tab doesn't lose the last-known status.
 //
 // The section is read-only otherwise: adapter discovery and
 // availability are still owned by the dashboard fan-out's
@@ -610,7 +726,7 @@ function AdapterStatusSection({ state, actions }: Props) {
     <div style={{ marginBottom: 24 }} data-testid="external-agents-adapters">
       <SectionHeader
         title="Adapters"
-        description="Test that an external coding-agent adapter can start, complete the ACP handshake, and create a session. Surfaces auth-required failures the chat workspace would otherwise hide behind a generic error."
+        description="Checks adapter readiness and auth by starting the adapter, completing the ACP handshake, and creating a session. Auth-required failures show here before a chat fails."
         meta={`${adapters.length} adapter${adapters.length === 1 ? "" : "s"}`}
       />
       <div className="card" style={{ overflow: "hidden" }}>
@@ -621,7 +737,6 @@ function AdapterStatusSection({ state, actions }: Props) {
             divider={i < adapters.length - 1}
             health={state.agentAdapterHealthByID.get(adapter.id) ?? null}
             loading={Boolean(state.agentAdapterHealthLoadingByID.get(adapter.id))}
-            onTest={() => void actions.probeAgentAdapter(adapter.id)}
             onSaveCredential={(value) => actions.setAgentAdapterCredential(adapter.id, value, "CLAUDE_CODE_OAUTH_TOKEN")}
             onDeleteCredential={() => actions.deleteAgentAdapterCredential(adapter.id, "CLAUDE_CODE_OAUTH_TOKEN")}
             onCopyCommand={() => void actions.copyCommand("claude setup-token")}
@@ -637,7 +752,6 @@ function AdapterStatusRow({
   divider,
   health,
   loading,
-  onTest,
   onSaveCredential,
   onDeleteCredential,
   onCopyCommand,
@@ -646,7 +760,6 @@ function AdapterStatusRow({
   divider: boolean;
   health: AgentAdapterHealthRecord | null;
   loading: boolean;
-  onTest: () => void;
   onSaveCredential: (value: string) => Promise<boolean>;
   onDeleteCredential: () => Promise<boolean>;
   onCopyCommand: () => void;
@@ -657,6 +770,11 @@ function AdapterStatusRow({
   const dashboardChip = adapter.available ? null : { tone: "amber" as const, label: "missing" };
   const probeChip = health ? probeStatusChip(health.status) : null;
   const chip = probeChip ?? dashboardChip;
+  const probeVerifiedAuth = health?.status === "ready";
+  const displayAuthStatus = probeVerifiedAuth ? "ok" : adapter.auth_status;
+  const displayAuthError = probeVerifiedAuth ? "" : adapter.auth_error;
+  const adapterInstalled = adapter.available && health?.status !== "not_installed";
+  const tokenVerified = Boolean(adapter.credential_configured) && probeVerifiedAuth;
 
   return (
     <div
@@ -701,26 +819,26 @@ function AdapterStatusRow({
               outside tested range
             </span>
           )}
-          {adapter.auth_status && adapter.auth_status !== "ok" && (
+          {displayAuthStatus && displayAuthStatus !== "ok" && (
             <span
               data-testid={`external-agents-adapter-${adapter.id}-auth-warning`}
               style={{
                 fontFamily: "var(--font-mono)",
                 fontSize: 10,
-                color: adapter.auth_status === "billing" ? chipColor("red") : chipColor("amber"),
+                color: displayAuthStatus === "billing" ? chipColor("red") : chipColor("amber"),
                 textTransform: "uppercase",
                 letterSpacing: "0.04em",
               }}
-              title={adapter.auth_error || undefined}
+              title={displayAuthError || undefined}
             >
-              {adapter.auth_status === "billing" ? "billing" : adapter.auth_status === "unauthenticated" ? "auth required" : "auth unknown"}
+              {displayAuthStatus === "billing" ? "billing" : displayAuthStatus === "unauthenticated" ? "auth required" : "auth unknown"}
             </span>
           )}
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
           {adapter.command && <span>command <span style={{ color: "var(--t1)" }}>{adapter.command}</span></span>}
           {adapter.version && <span>version <span style={{ color: "var(--t1)" }}>{adapter.version}</span></span>}
-          {adapter.auth_status && <span>auth <span style={{ color: "var(--t1)" }}>{adapter.auth_status}</span></span>}
+          {displayAuthStatus && <span>auth <span style={{ color: "var(--t1)" }}>{displayAuthStatus}</span></span>}
           {health?.path && <span>path <span style={{ color: "var(--t1)" }}>{health.path}</span></span>}
           {health?.duration_ms !== undefined && <span>{health.duration_ms} ms</span>}
         </div>
@@ -743,40 +861,36 @@ function AdapterStatusRow({
             )}
           </div>
         )}
-        {!health && adapter.auth_error && (
+        {!health && displayAuthError && (
           <div
             data-testid={`external-agents-adapter-${adapter.id}-auth-detail`}
             style={{ marginTop: 6, fontSize: 11, color: "var(--t3)", lineHeight: 1.4 }}
           >
-            {adapter.auth_error}
+            {displayAuthError}
           </div>
         )}
         {adapter.id === "claude_code" && (
           <ClaudeCredentialSetup
             configured={Boolean(adapter.credential_configured)}
             preview={adapter.credential_preview}
-            authNeedsAttention={Boolean(
-              health?.status === "auth_required" ||
-              adapter.auth_status === "unauthenticated" ||
-              adapter.auth_status === "unknown"
-            )}
+            adapterReady={adapterInstalled}
+            tokenVerified={tokenVerified}
+            cliSignedIn={adapter.auth_status === "ok"}
+            health={health ?? undefined}
             onCopyCommand={onCopyCommand}
             onSave={onSaveCredential}
             onDelete={onDeleteCredential}
-            onTest={onTest}
           />
         )}
       </div>
-      <button
-        type="button"
-        className="btn btn-ghost btn-sm"
-        onClick={onTest}
-        disabled={loading}
-        data-testid={`external-agents-test-${adapter.id}`}
-        title={loading ? "Probing…" : "Spawn the adapter, complete the ACP handshake, and report status"}
-      >
-        <Icon d={Icons.refresh} size={13} /> {loading ? "Testing…" : "Test"}
-      </button>
+      {loading && (
+        <span
+          data-testid={`external-agents-checking-${adapter.id}`}
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)", whiteSpace: "nowrap" }}
+        >
+          checking…
+        </span>
+      )}
     </div>
   );
 }
@@ -784,27 +898,39 @@ function AdapterStatusRow({
 function ClaudeCredentialSetup({
   configured,
   preview,
-  authNeedsAttention,
+  adapterReady,
+  tokenVerified,
+  cliSignedIn,
+  health,
   onCopyCommand,
   onSave,
   onDelete,
-  onTest,
 }: {
   configured: boolean;
   preview?: string;
-  authNeedsAttention: boolean;
+  adapterReady: boolean;
+  tokenVerified: boolean;
+  cliSignedIn: boolean;
+  health?: AgentAdapterHealthRecord;
   onCopyCommand: () => void;
   onSave: (value: string) => Promise<boolean>;
   onDelete: () => Promise<boolean>;
-  onTest: () => void;
 }) {
   const [token, setToken] = useState("");
   const [saving, setSaving] = useState(false);
   const [removing, setRemoving] = useState(false);
-  if (!configured && !authNeedsAttention) {
-    return null;
-  }
-
+  const tone = tokenVerified ? "green" : health?.status === "error" ? "red" : "amber";
+  const accent = chipColor(tone);
+  const border = tokenVerified
+    ? "rgba(0, 191, 179, 0.32)"
+    : tone === "red"
+      ? "rgba(239, 68, 68, 0.3)"
+      : "rgba(245, 158, 11, 0.28)";
+  const background = tokenVerified
+    ? "rgba(0, 191, 179, 0.07)"
+    : tone === "red"
+      ? "rgba(239, 68, 68, 0.07)"
+      : "rgba(245, 158, 11, 0.06)";
   async function save() {
     const trimmed = token.trim();
     if (!trimmed) return;
@@ -812,7 +938,6 @@ function ClaudeCredentialSetup({
     try {
       if (await onSave(trimmed)) {
         setToken("");
-        onTest();
       }
     } finally {
       setSaving(false);
@@ -834,25 +959,50 @@ function ClaudeCredentialSetup({
       style={{
         marginTop: 10,
         padding: 10,
-        border: "1px solid rgba(245, 158, 11, 0.28)",
+        border: `1px solid ${border}`,
         borderRadius: 10,
-        background: "rgba(245, 158, 11, 0.06)",
+        background,
       }}
     >
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, marginBottom: 8 }}>
         <div>
-          <div style={{ fontSize: 11, fontWeight: 600, color: "var(--amber)" }}>Claude Code guided setup</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11, fontWeight: 600, color: accent }}>
+            <Icon d={tokenVerified ? Icons.check : Icons.keys} size={12} />
+            {tokenVerified ? "Claude Code token verified" : configured ? "Claude Code token saved" : "Claude Code guided setup"}
+          </div>
           <div style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.4 }}>
-            Run <code>claude setup-token</code>, paste the token here, then Hecate injects it only into Claude ACP.
+            {tokenVerified
+              ? "Hecate has a validated adapter token and can inject it only into Claude ACP sessions. You can still paste a replacement token below."
+              : configured
+                ? "Hecate has a token saved, but Claude Code auth has not been verified yet."
+                : cliSignedIn
+                  ? "Claude Code is signed in for normal CLI use, but Hecate still needs its own adapter token. Run claude setup-token and paste the token here."
+                  : "Run claude setup-token, paste the token here, then Hecate injects it only into Claude ACP."}
+          </div>
+          <div style={{ marginTop: 5, display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            <span style={{ color: adapterReady ? "var(--teal)" : "var(--t3)" }}>
+              adapter {adapterReady ? "installed" : "not verified"}
+            </span>
+            <span style={{ color: tokenVerified ? "var(--teal)" : "var(--amber)" }}>
+              token {tokenVerified ? "valid" : configured ? "saved, needs check" : "not saved"}
+            </span>
+            {cliSignedIn && !tokenVerified && (
+              <span style={{ color: "var(--t3)" }}>CLI signed in</span>
+            )}
           </div>
         </div>
-        <button type="button" className="btn btn-ghost btn-sm" onClick={onCopyCommand}>
-          Copy command
-        </button>
+        {!tokenVerified && (
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onCopyCommand}>
+            Copy command
+          </button>
+        )}
       </div>
       {configured && (
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8, fontSize: 11, color: "var(--t2)" }}>
           <span>Stored token {preview ? <span style={{ fontFamily: "var(--font-mono)", color: "var(--t1)" }}>{preview}</span> : "configured"}</span>
+          {tokenVerified && <span style={{ color: "var(--teal)" }}>Token valid.</span>}
+          {!tokenVerified && health?.status === "auth_required" && <span style={{ color: "var(--amber)" }}>Token saved, but Claude still reports auth required.</span>}
+          {!tokenVerified && health?.status === "error" && <span style={{ color: "var(--red)" }}>Token saved, but the auth check failed.</span>}
           <button type="button" className="btn btn-ghost btn-sm" onClick={() => void remove()} disabled={removing}>
             {removing ? "Removing..." : "Remove"}
           </button>
@@ -862,14 +1012,14 @@ function ClaudeCredentialSetup({
         <input
           value={token}
           onChange={(event) => setToken(event.target.value)}
-          placeholder="Paste CLAUDE_CODE_OAUTH_TOKEN"
+          placeholder={configured ? "Paste a replacement CLAUDE_CODE_OAUTH_TOKEN" : "Paste CLAUDE_CODE_OAUTH_TOKEN"}
           type="password"
           className="input"
           style={{ flex: 1, minWidth: 180 }}
           aria-label="Claude Code OAuth token"
         />
         <button type="button" className="btn btn-primary btn-sm" onClick={() => void save()} disabled={saving || token.trim() === ""}>
-          {saving ? "Saving..." : "Save + test"}
+          {saving ? "Checking auth..." : "Save"}
         </button>
       </div>
     </div>

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ModelRecord } from "../../types/runtime";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
@@ -486,19 +486,29 @@ function RetentionTab({ state, actions }: Props) {
 function ExternalAgentsTab({ state, actions }: Props) {
   const liveAnthropicProvider = findAnthropicProvider(state.settingsConfig?.providers ?? []);
   const [rememberedAnthropicProvider, setRememberedAnthropicProvider] = useState<ConfiguredProviderRecord | null>(liveAnthropicProvider);
+  const probedAdapterIDsRef = useRef<Set<string>>(new Set());
+  const adapterIDsKey = useMemo(() => state.agentAdapters.map((adapter) => adapter.id).sort().join(","), [state.agentAdapters]);
 
   useEffect(() => {
     if (liveAnthropicProvider) setRememberedAnthropicProvider(liveAnthropicProvider);
   }, [liveAnthropicProvider]);
 
   useEffect(() => {
-    void actions.listAgentChatGrants();
     for (const adapter of state.agentAdapters) {
+      if (probedAdapterIDsRef.current.has(adapter.id)) continue;
+      probedAdapterIDsRef.current.add(adapter.id);
       void actions.probeAgentAdapter(adapter.id);
     }
-    // Actions and agentAdapters are stable enough for this one-shot tab
-    // mount refresh. Operators can re-fetch grants via Refresh; adapter
-    // health refreshes the next time the tab mounts.
+    // `actions` is a view-model object and can be re-created by parent
+    // renders. Probe only when the adapter ID set changes; the ref prevents
+    // duplicate probes for IDs we've already checked in this tab instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapterIDsKey]);
+
+  useEffect(() => {
+    void actions.listAgentChatGrants();
+    // Grants are lazy-loaded once when the tab mounts; Refresh handles
+    // explicit re-fetches.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -739,12 +749,18 @@ function AdapterStatusSection({ state, actions }: Props) {
             loading={Boolean(state.agentAdapterHealthLoadingByID.get(adapter.id))}
             onSaveCredential={(value) => actions.setAgentAdapterCredential(adapter.id, value, "CLAUDE_CODE_OAUTH_TOKEN")}
             onDeleteCredential={() => actions.deleteAgentAdapterCredential(adapter.id, "CLAUDE_CODE_OAUTH_TOKEN")}
-            onCopyCommand={() => void actions.copyCommand("claude setup-token")}
+            onCopyCommand={() => void actions.copyCommand(claudeCodeSettingsTokenCommand(adapter))}
           />
         ))}
       </div>
     </div>
   );
+}
+
+function claudeCodeSettingsTokenCommand(adapter: AgentAdapterRecord): string {
+  const command = adapter.claude_code_cli?.command;
+  if (command) return `${command} setup-token`;
+  return "npx -y @anthropic-ai/claude-code setup-token";
 }
 
 function AdapterStatusRow({

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -62,6 +62,9 @@ type ErrorPayload = {
     operator_action?: string;
     request_id?: string;
     trace_id?: string;
+    status?: string;
+    stage?: string;
+    hint?: string;
   };
 };
 

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -249,11 +249,17 @@ export type AgentAdapterRecord = {
   auth_error?: string;
   credential_configured?: boolean;
   credential_preview?: string;
+  claude_code_cli?: AgentAdapterSetupCommandStatus;
 };
 
 export type AgentAdapterResponse = {
   object: string;
   data: AgentAdapterRecord[];
+};
+
+export type AgentAdapterSetupCommandStatus = {
+  available: boolean;
+  path?: string;
 };
 
 export type AgentChatSessionSummaryRecord = {

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -259,7 +259,8 @@ export type AgentAdapterResponse = {
 
 export type AgentAdapterSetupCommandStatus = {
   available: boolean;
-  path?: string;
+  command?: string;
+  executable_path?: string;
 };
 
 export type AgentChatSessionSummaryRecord = {


### PR DESCRIPTION
## Summary

This PR makes Claude Code onboarding much harder to misread by separating three states that were previously blurred together:

- whether the adapter command can be discovered/launched
- whether Claude Code has adapter-visible auth that Hecate can inject
- whether the operator has saved a valid Claude Code OAuth token in Hecate

The visible result is a guided Claude Code setup flow in Chats and Settings instead of a misleading ready/auth label. Settings keeps the token editor available for update/removal, validates token shape before saving, and reports saved-token state separately from adapter readiness. Chats now keep the External Agent setup screen visible until Claude Code has credentials Hecate can actually pass to the ACP adapter.

## Details

- Adds Claude Code setup helpers for CLI/npx detection and setup-command status.
- Extends adapter health/readiness responses with Claude setup and saved-token state.
- Validates `CLAUDE_CODE_OAUTH_TOKEN`-style values before saving them into the local secret store.
- Keeps Anthropic provider API keys separate from Claude Code adapter tokens in Settings copy and UI state.
- Refreshes External Agent onboarding copy for Claude Code, Codex, and Cursor so each adapter gets the right install/auth guidance.
- Adds `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES` plus `just dev-no-agent-adapters` / `just dev-agent-adapters` for manual smoke tests and e2e fixtures. This override is discovery-only: it changes Settings/Chats readiness surfaces but does not create fake runnable adapter processes.
- Documents the override in development, runtime API, and external-agent docs so manual smoke testing and e2e usage are discoverable.

## Tests

- `go test ./internal/agentadapters ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- ChatView.test.tsx SettingsView.test.tsx api.test.ts`

## Notes for reviewers

The discovery override intentionally does not make a forced-available adapter runnable. It is only for reproducing UI states like “no adapters installed” without uninstalling local tools. The API test `TestAgentAdaptersHonorsDiscoveryOverride` locks that `/hecate/v1/agent-adapters` reflects the override without relying on local machine state.
