### PR TITLE
feat(providers): expose readiness contracts

### DIFF
--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -27,6 +27,13 @@ is intentionally not just a warning — it should be enough to choose a discover
 model, refresh local provider discovery, or jump to Providers for the full
 readiness checklist.
 
+The backend owns the readiness wording. `/hecate/v1/providers/status` returns a
+provider-level `readiness` summary plus detailed `readiness_checks`, and
+`/v1/models` adds `metadata.readiness` for every discovered provider/model row.
+The UI should prefer those fields over local guesswork whenever they are
+present; client-side inference is only a fallback for stale sessions or older
+payloads.
+
 Hecate Chat also has one per-chat **Instructions** field. With tools off, the
 instructions are sent as the direct model turn's `system_prompt`. With tools
 on, the same text becomes the per-task system prompt for the Hecate-owned

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -243,6 +243,7 @@ returns:
 - `credential_ready` — whether credentials are configured or not required
 - `routing_ready` — whether the router can currently send traffic to it
 - `routing_blocked_reason` — stable reason when routing is blocked, such as `credential_missing`, `provider_disabled`, `provider_rate_limited`, `circuit_open`, `provider_unhealthy`, or `no_models`
+- `readiness` — compact provider-level summary for cards/tables with `status`, `reason`, operator-facing `message`, and optional `operator_action`
 - `readiness_checks` — a normalized checklist for `credentials`, `models`, `health`, and `routing`. Each check has `status` (`ok`, `warning`, `blocked`, or `unknown`), `reason`, an operator-facing `message`, and an optional `operator_action` repair step. Non-routing checks can use scoped reasons such as `default_model_only`, `discovery_failed`, `self_referential`, or `provider_slow`.
 - `model_count`, `discovery_source`, `last_checked_at`, and `last_error` for model-discovery freshness and failure context
 - `last_error_class`, `open_until`, `last_latency_ms`, `consecutive_failures`, `timeouts`, `server_errors`, `rate_limits`, `total_successes`, and `total_failures` for richer health debugging
@@ -267,10 +268,12 @@ they explain why a provider/model candidate was skipped.
 The Chats workspace consumes the same readiness model at composition time. A
 provider can be configured and healthy while the selected model is still not
 routable, usually because discovery reports a different local model set or a
-cloud account does not expose that model. In that case Chats blocks the
-composer before sending, shows the selected model, provider route, discovered
-model count, health, and next steps, and links the operator back to Providers
-for the full checklist. The same contract applies in the empty-chat state:
+cloud account does not expose that model. `/v1/models` includes
+`metadata.readiness` on each discovered provider/model row so Chats can block
+before sending when a discovered model is still not usable because credentials,
+health, or routing are blocked. In that case Chats shows the selected model,
+provider route, backend readiness message, and next steps, and links the
+operator back to Providers for the full checklist. The same contract applies in the empty-chat state:
 compact readiness copy must still show the discovered-model count plus the
 highest-signal health/block/error diagnostics and a short repair path, so
 operators are not forced to send a doomed prompt or inspect raw provider JSON.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -452,6 +452,11 @@ GET /hecate/v1/providers/status
       "credential_state": "not_required",
       "credential_ready": true,
       "routing_ready": true,
+      "readiness": {
+        "status": "ok",
+        "reason": "ready",
+        "message": "Provider \"ollama\" is ready for routing."
+      },
       "readiness_checks": [
         {
           "name": "credentials",
@@ -483,11 +488,16 @@ GET /hecate/v1/providers/status
 }
 ```
 
+`readiness` is the compact provider-level answer for cards and tables:
+`status` is `ok`, `warning`, `blocked`, or `unknown`; `reason` is stable enough
+for UI branching; `message` is safe to show directly to the operator; and
+`operator_action` appears when there is a repair step.
+
 `readiness_checks` is the canonical operator-facing checklist. It prevents
 clients from guessing readiness by combining unrelated raw fields. Check names
-are currently `credentials`, `models`, `health`, and `routing`; statuses are
-`ok`, `warning`, `blocked`, or `unknown`. `reason` is stable enough for UI
-branching, while `message` is safe to show directly to the operator.
+are currently `credentials`, `models`, `health`, and `routing`; statuses use the
+same `ok` / `warning` / `blocked` / `unknown` set. `reason` is stable enough for
+UI branching, while `message` is safe to show directly to the operator.
 When a check needs operator action, `operator_action` carries the canonical
 repair step; clients should prefer it over deriving their own copy from
 `reason`. For example `credential_missing` includes "add or rotate
@@ -582,6 +592,17 @@ GET /v1/models
           "streaming": true,
           "max_context_tokens": 32768,
           "source": "provider"
+        },
+        "readiness": {
+          "provider": "ollama",
+          "matched_provider": "ollama",
+          "model": "qwen2.5-coder",
+          "ready": true,
+          "status": "ok",
+          "reason": "model_available",
+          "message": "Provider \"ollama\" reports model \"qwen2.5-coder\".",
+          "routing_ready": true,
+          "provider_status": "healthy"
         }
       }
     }
@@ -594,6 +615,14 @@ GET /v1/models
 when the effective value is `none`. Local/custom models often report
 `unknown`; operators can use Settings → Model capabilities to explicitly turn
 tools on or off for a provider/model pair.
+
+`metadata.readiness` is the backend-owned provider/model readiness snapshot for
+that discovered row. Chats should use it before sending instead of inferring
+routeability from model names alone: a model can appear in discovery while its
+provider is credential-blocked, circuit-open, disabled, or otherwise not
+routable. When `ready=false`, show `message` and `operator_action` directly and
+use `reason`, `provider_status`, `provider_blocked_reason`, and
+`suggested_models` for compact diagnostics.
 
 ### `PUT /hecate/v1/model-capabilities/overrides`
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -618,7 +618,7 @@ tools on or off for a provider/model pair.
 
 `metadata.readiness` is the backend-owned provider/model readiness snapshot for
 that discovered row. Chats should use it before sending instead of inferring
-routeability from model names alone: a model can appear in discovery while its
+routability from model names alone: a model can appear in discovery while its
 provider is credential-blocked, circuit-open, disabled, or otherwise not
 routable. When `ready=false`, show `message` and `operator_action` directly and
 use `reason`, `provider_status`, `provider_blocked_reason`, and

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hecate/agent-runtime/internal/taskstate"
 	"github.com/hecate/agent-runtime/internal/telemetry"
 	"github.com/hecate/agent-runtime/internal/version"
+	"github.com/hecate/agent-runtime/pkg/types"
 )
 
 type Handler struct {
@@ -511,6 +512,7 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 				"default":          model.Default,
 				"discovery_source": model.DiscoverySource,
 				"capabilities":     caps,
+				"readiness":        renderModelReadiness(model.Readiness),
 			},
 		})
 	}
@@ -519,6 +521,23 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data:   data,
 	})
+}
+
+func renderModelReadiness(readiness types.ModelReadiness) ModelReadinessResponseItem {
+	return ModelReadinessResponseItem{
+		Provider:              readiness.Provider,
+		MatchedProvider:       readiness.MatchedProvider,
+		Model:                 readiness.Model,
+		Ready:                 readiness.Ready,
+		Status:                readiness.Status,
+		Reason:                readiness.Reason,
+		Message:               readiness.Message,
+		OperatorAction:        readiness.OperatorAction,
+		RoutingReady:          readiness.RoutingReady,
+		ProviderStatus:        readiness.ProviderStatus,
+		ProviderBlockedReason: readiness.ProviderBlockedReason,
+		SuggestedModels:       readiness.SuggestedModels,
+	}
 }
 
 // requireSettings verifies the settings backend is configured and writes a

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -58,6 +58,7 @@ func (h *Handler) HandleProviderStatus(w http.ResponseWriter, r *http.Request) {
 			Timeouts:            provider.Timeouts,
 			ServerErrors:        provider.ServerErrors,
 			RateLimits:          provider.RateLimits,
+			Readiness:           renderReadinessSummary(provider.Readiness),
 			ReadinessChecks:     renderProviderReadinessChecks(provider.ReadinessChecks),
 		}
 		if !provider.RefreshedAt.IsZero() {
@@ -76,6 +77,15 @@ func (h *Handler) HandleProviderStatus(w http.ResponseWriter, r *http.Request) {
 		Object: "provider_status",
 		Data:   data,
 	})
+}
+
+func renderReadinessSummary(summary types.ReadinessSummary) ReadinessSummaryResponseItem {
+	return ReadinessSummaryResponseItem{
+		Status:         summary.Status,
+		Reason:         summary.Reason,
+		Message:        summary.Message,
+		OperatorAction: summary.OperatorAction,
+	}
 }
 
 func renderProviderReadinessChecks(checks []types.ProviderReadinessCheck) []ProviderReadinessCheckResponseItem {

--- a/internal/api/handler_model_capabilities_test.go
+++ b/internal/api/handler_model_capabilities_test.go
@@ -18,6 +18,7 @@ func TestModelsExposeCapabilityPayloads(t *testing.T) {
 	handler := newModelCapabilityTestHandler(t)
 	models := mustRequestJSON[OpenAIModelsResponse](newTaskTestClient(t, handler), http.MethodGet, "/v1/models", "")
 	caps := modelCapabilitiesFromModels(t, models, "llama3.1:8b")
+	readiness := modelReadinessFromModels(t, models, "llama3.1:8b")
 
 	if caps["tool_calling"] != modelcaps.ToolCallingUnknown {
 		t.Fatalf("tool_calling = %#v, want unknown", caps["tool_calling"])
@@ -27,6 +28,9 @@ func TestModelsExposeCapabilityPayloads(t *testing.T) {
 	}
 	if caps["source"] != modelcaps.SourceProvider {
 		t.Fatalf("source = %#v, want provider", caps["source"])
+	}
+	if readiness["ready"] != true || readiness["status"] != "ok" || readiness["reason"] != "model_available" {
+		t.Fatalf("readiness = %#v, want ready model_available", readiness)
 	}
 }
 
@@ -102,6 +106,22 @@ func modelCapabilitiesFromModels(t *testing.T, models OpenAIModelsResponse, mode
 		raw, ok := item.Metadata["capabilities"].(map[string]any)
 		if !ok {
 			t.Fatalf("capabilities metadata for %s = %#v", modelID, item.Metadata["capabilities"])
+		}
+		return raw
+	}
+	t.Fatalf("model %q not found in %+v", modelID, models.Data)
+	return nil
+}
+
+func modelReadinessFromModels(t *testing.T, models OpenAIModelsResponse, modelID string) map[string]any {
+	t.Helper()
+	for _, item := range models.Data {
+		if item.ID != modelID {
+			continue
+		}
+		raw, ok := item.Metadata["readiness"].(map[string]any)
+		if !ok {
+			t.Fatalf("readiness metadata for %s = %#v", modelID, item.Metadata["readiness"])
 		}
 		return raw
 	}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -519,7 +519,30 @@ type ProviderStatusResponseItem struct {
 	Timeouts            int64                                `json:"timeouts,omitempty"`
 	ServerErrors        int64                                `json:"server_errors,omitempty"`
 	RateLimits          int64                                `json:"rate_limits,omitempty"`
+	Readiness           ReadinessSummaryResponseItem         `json:"readiness,omitempty"`
 	ReadinessChecks     []ProviderReadinessCheckResponseItem `json:"readiness_checks,omitempty"`
+}
+
+type ReadinessSummaryResponseItem struct {
+	Status         string `json:"status,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	Message        string `json:"message,omitempty"`
+	OperatorAction string `json:"operator_action,omitempty"`
+}
+
+type ModelReadinessResponseItem struct {
+	Provider              string   `json:"provider,omitempty"`
+	MatchedProvider       string   `json:"matched_provider,omitempty"`
+	Model                 string   `json:"model,omitempty"`
+	Ready                 bool     `json:"ready"`
+	Status                string   `json:"status,omitempty"`
+	Reason                string   `json:"reason,omitempty"`
+	Message               string   `json:"message,omitempty"`
+	OperatorAction        string   `json:"operator_action,omitempty"`
+	RoutingReady          bool     `json:"routing_ready"`
+	ProviderStatus        string   `json:"provider_status,omitempty"`
+	ProviderBlockedReason string   `json:"provider_blocked_reason,omitempty"`
+	SuggestedModels       []string `json:"suggested_models,omitempty"`
 }
 
 type ProviderReadinessCheckResponseItem struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -531,6 +531,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if !item.RoutingReady {
 				t.Fatalf("openai routing_ready = false, reason = %q", item.RoutingBlocked)
 			}
+			if item.Readiness.Status != "ok" || item.Readiness.Reason != "ready" {
+				t.Fatalf("openai readiness = %#v, want ok/ready", item.Readiness)
+			}
 			assertProviderReadinessCheck(t, item, "credentials", "ok", "configured")
 			assertProviderReadinessCheck(t, item, "models", "ok", "models_discovered")
 			assertProviderReadinessCheck(t, item, "health", "ok", "healthy")
@@ -547,6 +550,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.RoutingBlocked != "provider_unhealthy" {
 				t.Fatalf("ollama routing_blocked_reason = %q, want provider_unhealthy", item.RoutingBlocked)
 			}
+			if item.Readiness.Status != "blocked" || item.Readiness.Reason != "provider_unhealthy" {
+				t.Fatalf("ollama readiness = %#v, want blocked/provider_unhealthy", item.Readiness)
+			}
 			assertProviderReadinessCheck(t, item, "credentials", "ok", "not_required")
 			assertProviderReadinessCheck(t, item, "health", "blocked", "provider_unhealthy")
 			assertProviderReadinessCheck(t, item, "routing", "blocked", "provider_unhealthy")
@@ -562,6 +568,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.RoutingBlocked != "credential_missing" {
 				t.Fatalf("anthropic routing_blocked_reason = %q, want credential_missing", item.RoutingBlocked)
 			}
+			if item.Readiness.Status != "blocked" || item.Readiness.Reason != "credential_missing" {
+				t.Fatalf("anthropic readiness = %#v, want blocked/credential_missing", item.Readiness)
+			}
 			assertProviderReadinessCheck(t, item, "credentials", "blocked", "credential_missing")
 			assertProviderReadinessCheck(t, item, "routing", "blocked", "credential_missing")
 			foundCredentialBlocked = true
@@ -572,6 +581,9 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			}
 			if !item.RoutingReady {
 				t.Fatalf("openrouter routing_ready = false, reason = %q", item.RoutingBlocked)
+			}
+			if item.Readiness.Status != "warning" || item.Readiness.Reason != "default_model_only" {
+				t.Fatalf("openrouter readiness = %#v, want warning/default_model_only", item.Readiness)
 			}
 			assertProviderReadinessCheck(t, item, "models", "warning", "default_model_only")
 			assertProviderReadinessCheck(t, item, "routing", "ok", "routable")

--- a/internal/gateway/provider_model_readiness.go
+++ b/internal/gateway/provider_model_readiness.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hecate/agent-runtime/internal/catalog"
 	"github.com/hecate/agent-runtime/internal/providers"
+	"github.com/hecate/agent-runtime/pkg/types"
 )
 
 type ProviderModelReadiness struct {
@@ -21,6 +22,33 @@ type ProviderModelReadiness struct {
 	ProviderStatus        string
 	ProviderBlockedReason string
 	SuggestedModels       []string
+}
+
+func (r ProviderModelReadiness) ToModelReadiness() types.ModelReadiness {
+	return types.ModelReadiness{
+		Provider:              r.Provider,
+		MatchedProvider:       r.MatchedProvider,
+		Model:                 r.Model,
+		Ready:                 r.Ready,
+		Status:                providerModelReadinessStatus(r),
+		Reason:                r.Reason,
+		Message:               r.Message,
+		OperatorAction:        r.OperatorAction,
+		RoutingReady:          r.RoutingReady,
+		ProviderStatus:        r.ProviderStatus,
+		ProviderBlockedReason: r.ProviderBlockedReason,
+		SuggestedModels:       append([]string(nil), r.SuggestedModels...),
+	}
+}
+
+func providerModelReadinessStatus(readiness ProviderModelReadiness) string {
+	if readiness.Ready {
+		return "ok"
+	}
+	if readiness.ProviderStatus == "" && readiness.Reason == "" {
+		return "unknown"
+	}
+	return "blocked"
 }
 
 func providerModelReadiness(entries []catalog.Entry, provider, model string) ProviderModelReadiness {

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -920,14 +920,15 @@ func providerReadinessSummary(entry catalog.Entry, checks []types.ProviderReadin
 		}
 	}
 
-	var firstWarning, firstUnknown *types.ProviderReadinessCheck
+	var routingBlocked, firstBlocked, firstWarning, firstUnknown *types.ProviderReadinessCheck
 	for i := range checks {
 		check := &checks[i]
 		if check.Name == "routing" && check.Status == "blocked" {
-			return providerReadinessSummaryFromCheck("blocked", *check)
+			routingBlocked = check
+			continue
 		}
-		if check.Status == "blocked" {
-			return providerReadinessSummaryFromCheck("blocked", *check)
+		if check.Status == "blocked" && firstBlocked == nil {
+			firstBlocked = check
 		}
 		if check.Status == "warning" && firstWarning == nil {
 			firstWarning = check
@@ -935,6 +936,12 @@ func providerReadinessSummary(entry catalog.Entry, checks []types.ProviderReadin
 		if check.Status == "unknown" && firstUnknown == nil {
 			firstUnknown = check
 		}
+	}
+	if routingBlocked != nil {
+		return providerReadinessSummaryFromCheck("blocked", *routingBlocked)
+	}
+	if firstBlocked != nil {
+		return providerReadinessSummaryFromCheck("blocked", *firstBlocked)
 	}
 	if firstWarning != nil {
 		return providerReadinessSummaryFromCheck("warning", *firstWarning)

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -734,6 +734,7 @@ func (s *Service) ListModels(ctx context.Context) (*ModelsResult, error) {
 				OwnedBy:         entry.Name,
 				Default:         modelID == entry.DefaultModel,
 				DiscoverySource: entry.DiscoverySource,
+				Readiness:       providerModelReadinessForEntry(entry, entry.Name, modelID).ToModelReadiness(),
 			})
 		}
 	}
@@ -768,8 +769,9 @@ func (s *Service) ProviderStatus(ctx context.Context) (*ProviderStatusResult, er
 			ServerErrors:        entry.ServerErrors,
 			RateLimits:          entry.RateLimits,
 			Error:               entry.Error,
-			ReadinessChecks:     providerReadinessChecks(entry),
 		}
+		status.ReadinessChecks = providerReadinessChecks(entry)
+		status.Readiness = providerReadinessSummary(entry, status.ReadinessChecks)
 		if entry.RefreshedAt != "" {
 			if ts, err := time.Parse(time.RFC3339, entry.RefreshedAt); err == nil {
 				status.RefreshedAt = ts
@@ -905,6 +907,54 @@ func providerReadinessChecks(entry catalog.Entry) []types.ProviderReadinessCheck
 		providerModelDiscoveryCheck(entry),
 		providerHealthCheck(entry),
 		providerRoutingCheck(entry),
+	}
+}
+
+func providerReadinessSummary(entry catalog.Entry, checks []types.ProviderReadinessCheck) types.ReadinessSummary {
+	if len(checks) == 0 {
+		return types.ReadinessSummary{
+			Status:         "unknown",
+			Reason:         "unknown",
+			Message:        "Provider readiness has not been checked yet.",
+			OperatorAction: "Refresh provider status after configuration or startup settles.",
+		}
+	}
+
+	var firstWarning, firstUnknown *types.ProviderReadinessCheck
+	for i := range checks {
+		check := &checks[i]
+		if check.Name == "routing" && check.Status == "blocked" {
+			return providerReadinessSummaryFromCheck("blocked", *check)
+		}
+		if check.Status == "blocked" {
+			return providerReadinessSummaryFromCheck("blocked", *check)
+		}
+		if check.Status == "warning" && firstWarning == nil {
+			firstWarning = check
+		}
+		if check.Status == "unknown" && firstUnknown == nil {
+			firstUnknown = check
+		}
+	}
+	if firstWarning != nil {
+		return providerReadinessSummaryFromCheck("warning", *firstWarning)
+	}
+	if firstUnknown != nil {
+		return providerReadinessSummaryFromCheck("unknown", *firstUnknown)
+	}
+	return types.ReadinessSummary{
+		Status:  "ok",
+		Reason:  "ready",
+		Message: fmt.Sprintf("Provider %q is ready for routing.", entry.Name),
+	}
+}
+
+func providerReadinessSummaryFromCheck(status string, check types.ProviderReadinessCheck) types.ReadinessSummary {
+	return types.ReadinessSummary{
+		Status:         status,
+		Reason:         check.Reason,
+		Message:        check.Message,
+		OperatorAction: check.OperatorAction,
 	}
 }
 

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -221,12 +221,12 @@ func TestProviderReadinessSummary(t *testing.T) {
 			wantReason: "unknown",
 		},
 		{
-			name: "routing block wins over earlier warning",
+			name: "routing block wins over earlier block",
 			entry: catalog.Entry{
 				Name: "anthropic",
 			},
 			checks: []types.ProviderReadinessCheck{
-				{Name: "models", Status: "warning", Reason: "default_model_only", Message: "Default model only."},
+				{Name: "credentials", Status: "blocked", Reason: "credential_missing", Message: "Credentials are missing.", OperatorAction: "Add an API key."},
 				{Name: "routing", Status: "blocked", Reason: "credential_missing", Message: "Credentials are missing.", OperatorAction: "Add an API key."},
 			},
 			wantStatus: "blocked",

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -204,6 +204,85 @@ func TestProviderHealthCheckTreatsRoutableDegradedProvidersAsWarnings(t *testing
 	}
 }
 
+func TestProviderReadinessSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		entry      catalog.Entry
+		checks     []types.ProviderReadinessCheck
+		wantStatus string
+		wantReason string
+	}{
+		{
+			name:       "unknown when no checks exist",
+			entry:      catalog.Entry{Name: "ollama"},
+			wantStatus: "unknown",
+			wantReason: "unknown",
+		},
+		{
+			name: "routing block wins over earlier warning",
+			entry: catalog.Entry{
+				Name: "anthropic",
+			},
+			checks: []types.ProviderReadinessCheck{
+				{Name: "models", Status: "warning", Reason: "default_model_only", Message: "Default model only."},
+				{Name: "routing", Status: "blocked", Reason: "credential_missing", Message: "Credentials are missing.", OperatorAction: "Add an API key."},
+			},
+			wantStatus: "blocked",
+			wantReason: "credential_missing",
+		},
+		{
+			name: "first warning is surfaced when routable",
+			entry: catalog.Entry{
+				Name: "openrouter",
+			},
+			checks: []types.ProviderReadinessCheck{
+				{Name: "credentials", Status: "ok", Reason: "configured", Message: "Credentials configured."},
+				{Name: "models", Status: "warning", Reason: "default_model_only", Message: "Default model only."},
+				{Name: "routing", Status: "ok", Reason: "routable", Message: "Provider is routable."},
+			},
+			wantStatus: "warning",
+			wantReason: "default_model_only",
+		},
+		{
+			name: "all ok is ready",
+			entry: catalog.Entry{
+				Name: "ollama",
+			},
+			checks: []types.ProviderReadinessCheck{
+				{Name: "credentials", Status: "ok", Reason: "not_required", Message: "No credentials required."},
+				{Name: "models", Status: "ok", Reason: "models_discovered", Message: "Models discovered."},
+				{Name: "health", Status: "ok", Reason: "healthy", Message: "Provider is healthy."},
+				{Name: "routing", Status: "ok", Reason: "routable", Message: "Provider is routable."},
+			},
+			wantStatus: "ok",
+			wantReason: "ready",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerReadinessSummary(tt.entry, tt.checks)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tt.wantReason)
+			}
+			if got.Message == "" {
+				t.Fatal("message is empty")
+			}
+			if got.Status == "blocked" && got.OperatorAction == "" {
+				t.Fatalf("operator_action is empty for blocked summary: %#v", got)
+			}
+		})
+	}
+}
+
 func TestProviderModelReadiness(t *testing.T) {
 	t.Parallel()
 
@@ -235,6 +314,7 @@ func TestProviderModelReadiness(t *testing.T) {
 		wantReason          string
 		wantMatchedProvider string
 		wantBlockedReason   string
+		wantStatus          string
 		wantSuggestions     bool
 		rejectSuggestion    string
 	}{
@@ -246,6 +326,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantProvider:        "ollama",
 			wantReason:          "model_available",
 			wantMatchedProvider: "ollama",
+			wantStatus:          "ok",
 		},
 		{
 			name:                "explicit provider match returns canonical id",
@@ -255,6 +336,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantProvider:        "ollama",
 			wantReason:          "model_available",
 			wantMatchedProvider: "ollama",
+			wantStatus:          "ok",
 		},
 		{
 			name:                "explicit provider missing selected model",
@@ -263,6 +345,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantProvider:        "ollama",
 			wantReason:          "model_not_discovered",
 			wantMatchedProvider: "ollama",
+			wantStatus:          "blocked",
 		},
 		{
 			name:                "explicit provider blocked before model use",
@@ -272,6 +355,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantReason:          "provider_not_ready",
 			wantMatchedProvider: "anthropic",
 			wantBlockedReason:   "credential_missing",
+			wantStatus:          "blocked",
 			wantSuggestions:     true,
 		},
 		{
@@ -280,6 +364,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			model:        "llama3.1:8b",
 			wantProvider: "missing",
 			wantReason:   "provider_missing",
+			wantStatus:   "blocked",
 		},
 		{
 			name:                "auto finds routable provider",
@@ -288,12 +373,14 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantProvider:        "auto",
 			wantReason:          "auto_route_available",
 			wantMatchedProvider: "ollama",
+			wantStatus:          "ok",
 		},
 		{
 			name:            "auto cannot find selected model",
 			model:           "gpt-5.4-mini",
 			wantProvider:    "auto",
 			wantReason:      "model_not_discovered",
+			wantStatus:      "blocked",
 			wantSuggestions: true,
 		},
 		{
@@ -301,6 +388,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			provider:         "ollama",
 			wantProvider:     "ollama",
 			wantReason:       "model_required",
+			wantStatus:       "blocked",
 			wantSuggestions:  true,
 			rejectSuggestion: "claude-sonnet-4-5",
 		},
@@ -308,6 +396,7 @@ func TestProviderModelReadiness(t *testing.T) {
 			name:            "auto model required",
 			wantProvider:    "auto",
 			wantReason:      "model_required",
+			wantStatus:      "blocked",
 			wantSuggestions: true,
 		},
 	}
@@ -332,6 +421,9 @@ func TestProviderModelReadiness(t *testing.T) {
 			}
 			if got.ProviderBlockedReason != tt.wantBlockedReason {
 				t.Fatalf("provider_blocked_reason = %q, want %q", got.ProviderBlockedReason, tt.wantBlockedReason)
+			}
+			if rendered := got.ToModelReadiness(); rendered.Status != tt.wantStatus {
+				t.Fatalf("rendered status = %q, want %q for %#v", rendered.Status, tt.wantStatus, rendered)
 			}
 			if !got.Ready && got.OperatorAction == "" {
 				t.Fatalf("operator_action is empty for blocked readiness: %#v", got)

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -213,6 +213,7 @@ type ModelInfo struct {
 	Default         bool
 	DiscoverySource string
 	Capabilities    ModelCapabilities
+	Readiness       ModelReadiness
 }
 
 // ModelCapabilities is the operator-facing capability snapshot Hecate uses
@@ -223,6 +224,33 @@ type ModelCapabilities struct {
 	Streaming        bool   `json:"streaming,omitempty"`
 	MaxContextTokens int    `json:"max_context_tokens,omitempty"`
 	Source           string `json:"source,omitempty"`
+}
+
+// ReadinessSummary is the compact operator-facing answer to "can Hecate use
+// this thing right now?" Detailed checks remain available for drill-down.
+type ReadinessSummary struct {
+	Status         string
+	Reason         string
+	Message        string
+	OperatorAction string
+}
+
+// ModelReadiness explains whether a discovered provider/model pair can be used
+// for routing. It mirrors the gateway readiness contract without exposing the
+// gateway package to API/UI projection code.
+type ModelReadiness struct {
+	Provider              string
+	MatchedProvider       string
+	Model                 string
+	Ready                 bool
+	Status                string
+	Reason                string
+	Message               string
+	OperatorAction        string
+	RoutingReady          bool
+	ProviderStatus        string
+	ProviderBlockedReason string
+	SuggestedModels       []string
 }
 
 type ProviderStatus struct {
@@ -251,6 +279,7 @@ type ProviderStatus struct {
 	ServerErrors        int64
 	RateLimits          int64
 	Error               string
+	Readiness           ReadinessSummary
 	ReadinessChecks     []ProviderReadinessCheck
 }
 

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -677,6 +677,12 @@ describe("ProvidersView table renders", () => {
           credential_state: "not_required",
           routing_ready: false,
           routing_blocked_reason: "provider_rate_limited",
+          readiness: {
+            status: "blocked",
+            reason: "provider_rate_limited",
+            message: "Ollama is temporarily unavailable because it is rate limited.",
+            operator_action: "Wait for cooldown or route to another local provider.",
+          },
           readiness_checks: [
             { name: "credentials", status: "ok", reason: "not_required", message: "No credentials are required for this provider." },
             { name: "models", status: "ok", reason: "models_discovered", message: "1 model discovered." },
@@ -710,6 +716,9 @@ describe("ProvidersView table renders", () => {
 
     expect(screen.getByText(/Circuit open/)).toBeTruthy();
     expect(screen.getByText("Readiness")).toBeTruthy();
+    expect(screen.getByText("Readiness summary")).toBeTruthy();
+    expect(screen.getByText("Ollama is temporarily unavailable because it is rate limited.")).toBeTruthy();
+    expect(screen.getByText("Next: Wait for cooldown or route to another local provider.")).toBeTruthy();
     expect(screen.getAllByText("Credentials").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Models").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Health").length).toBeGreaterThan(0);

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
-import { ProviderReadinessChecklist } from "../shared/ProviderReadiness";
+import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
 import { Badge, BrandAvatar, ConfirmModal, Icon, Icons, Modal } from "../shared/ui";
 import { AddProviderModal } from "./AddProviderModal";
 
@@ -440,6 +440,8 @@ export function ProvidersView({ state, actions }: Props) {
                 </div>
               ))}
             </div>
+
+            <ProviderReadinessSummary readiness={selectedStatus?.readiness} />
 
             <ProviderReadinessChecklist checks={selectedStatus?.readiness_checks ?? []} />
 

--- a/ui/src/features/shared/ProviderReadiness.tsx
+++ b/ui/src/features/shared/ProviderReadiness.tsx
@@ -1,4 +1,60 @@
-import type { ProviderReadinessCheckRecord } from "../../types/runtime";
+import type { ProviderReadinessCheckRecord, ProviderReadinessSummaryRecord } from "../../types/runtime";
+
+export function ProviderReadinessSummary({ readiness }: { readiness?: ProviderReadinessSummaryRecord }) {
+  if (!readiness || (!readiness.message && !readiness.operator_action && !readiness.reason)) return null;
+
+  return (
+    <div style={{
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-sm)",
+      background: readinessSummaryBackground(readiness.status),
+      padding: "10px 12px",
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
+        <span style={{
+          width: 8,
+          height: 8,
+          borderRadius: 999,
+          background: readinessColor(readiness.status),
+          boxShadow: readiness.status === "ok" ? "0 0 10px rgba(96, 199, 112, 0.35)" : undefined,
+          flexShrink: 0,
+        }} />
+        <span style={{
+          fontSize: 10,
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}>
+          Readiness summary
+        </span>
+        {readiness.reason && (
+          <span style={{
+            fontSize: 10,
+            color: "var(--t3)",
+            fontFamily: "var(--font-mono)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            minWidth: 0,
+          }}>
+            {readiness.reason}
+          </span>
+        )}
+      </div>
+      {readiness.message && (
+        <div style={{ fontSize: 12, color: readinessTextColor(readiness.status), lineHeight: 1.45 }}>
+          {readiness.message}
+        </div>
+      )}
+      {readiness.operator_action && (
+        <div style={{ marginTop: 5, fontSize: 11, color: "var(--t2)", lineHeight: 1.45 }}>
+          Next: {readiness.operator_action}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function ProviderReadinessChecklist({ checks }: { checks: ProviderReadinessCheckRecord[] }) {
   if (checks.length === 0) return null;
@@ -185,6 +241,19 @@ function readinessTextColor(status?: string): string {
       return "var(--amber)";
     default:
       return "var(--t2)";
+  }
+}
+
+function readinessSummaryBackground(status?: string): string {
+  switch (status) {
+    case "blocked":
+      return "var(--red-bg)";
+    case "warning":
+      return "var(--amber-bg)";
+    case "ok":
+      return "var(--green-bg)";
+    default:
+      return "var(--bg2)";
   }
 }
 

--- a/ui/src/lib/provider-issues.test.ts
+++ b/ui/src/lib/provider-issues.test.ts
@@ -55,6 +55,50 @@ describe("buildSelectedModelIssue", () => {
     expect(issue).toBeNull();
   });
 
+  it("uses backend readiness metadata when a discovered model is not routable", () => {
+    const issue = buildSelectedModelIssue({
+      model: "claude-sonnet-4-6",
+      providerFilter: "anthropic",
+      selectableModels: [{
+        id: "claude-sonnet-4-6",
+        owned_by: "anthropic",
+        metadata: {
+          provider: "anthropic",
+          readiness: {
+            ready: false,
+            status: "blocked",
+            reason: "credential_missing",
+            message: "Provider \"anthropic\" is not routable for model \"claude-sonnet-4-6\".",
+            operator_action: "Add or rotate this provider's API key, then retry this model.",
+            provider_status: "healthy",
+            provider_blocked_reason: "credential_missing",
+            suggested_models: ["gpt-4o-mini"],
+          },
+        },
+      }],
+      configuredProvider: {
+        id: "anthropic",
+        name: "Anthropic",
+        kind: "cloud",
+        protocol: "anthropic",
+        base_url: "",
+        credential_configured: false,
+      },
+    });
+
+    expect(issue).toEqual(expect.objectContaining({
+      title: "Selected model is not ready",
+      providerLabel: "Anthropic",
+      model: "claude-sonnet-4-6",
+    }));
+    expect(issue?.message).toContain("not routable");
+    expect(issue?.details).toEqual(expect.arrayContaining([
+      { label: "Reason", value: "credential_missing" },
+      { label: "Blocked by", value: "credential_missing" },
+    ]));
+    expect(issue?.steps.join(" ")).toContain("Add or rotate this provider's API key");
+  });
+
   it("explains a stale local model selection", () => {
     const issue = buildSelectedModelIssue({
       model: "llama3.1:8b",

--- a/ui/src/lib/provider-issues.ts
+++ b/ui/src/lib/provider-issues.ts
@@ -52,7 +52,52 @@ export function buildSelectedModelIssue({
   if (!model) {
     return null;
   }
-  if (selectableModels.some((entry) => entry.id === model)) {
+  const matchingModels = selectableModels.filter((entry) => entry.id === model);
+  const providerMatches = providerFilter === "auto"
+    ? matchingModels
+    : matchingModels.filter((entry) => entry.metadata?.provider === providerFilter);
+  const readinessCandidates = providerMatches.length > 0 ? providerMatches : matchingModels;
+  if (readinessCandidates.length > 0) {
+    const readyCandidate = readinessCandidates.find((entry) => entry.metadata?.readiness?.ready !== false);
+    if (readyCandidate) {
+      return null;
+    }
+    const readiness = readinessCandidates[0]?.metadata?.readiness;
+    if (readiness) {
+      const providerLabel = providerFilter === "auto"
+        ? readiness.matched_provider || readiness.provider || "All providers"
+        : configuredProvider?.name || runtimeProvider?.name || providerFilter;
+      const details = [
+        { label: "Selected model", value: model },
+        { label: "Provider route", value: providerLabel },
+        { label: "Reason", value: readiness.reason || "not ready" },
+      ];
+      if (readiness.provider_status) {
+        details.push({ label: "Health", value: readiness.provider_status });
+      }
+      if (readiness.provider_blocked_reason) {
+        details.push({ label: "Blocked by", value: readiness.provider_blocked_reason });
+      }
+      if (readiness.suggested_models?.length) {
+        details.push({ label: "Try instead", value: readiness.suggested_models.slice(0, 3).join(", ") });
+      }
+      const steps = [
+        readiness.operator_action || "Open Providers to inspect readiness and repair the blocked dependency.",
+        readiness.suggested_models?.length
+          ? `Try ${readiness.suggested_models[0]} from the model picker.`
+          : "Refresh Providers after changing credentials, health, or local model availability.",
+      ].filter(Boolean);
+      return {
+        title: "Selected model is not ready",
+        message: readiness.message || `The selected model "${model}" is not routable right now.`,
+        providerLabel,
+        model,
+        details,
+        steps,
+      };
+    }
+  }
+  if (matchingModels.length > 0 && providerFilter === "auto") {
     return null;
   }
 

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -15,6 +15,7 @@ export type ModelRecord = {
     default?: boolean;
     discovery_source?: string;
     capabilities?: ModelCapabilitiesRecord;
+    readiness?: ModelReadinessRecord;
   };
 };
 
@@ -36,6 +37,21 @@ export type ModelCapabilityRecord = {
   source?: "unknown" | "catalog" | "provider" | "probe" | "operator_override" | string;
   note?: string;
   updated_at?: string;
+};
+
+export type ModelReadinessRecord = {
+  provider?: string;
+  matched_provider?: string;
+  model?: string;
+  ready: boolean;
+  status?: ProviderReadinessStatus;
+  reason?: string;
+  message?: string;
+  operator_action?: string;
+  routing_ready?: boolean;
+  provider_status?: string;
+  provider_blocked_reason?: string;
+  suggested_models?: string[];
 };
 
 export type ModelCapabilityResponse = {
@@ -170,10 +186,18 @@ export type ProviderRecord = {
   timeouts?: number;
   server_errors?: number;
   rate_limits?: number;
+  readiness?: ProviderReadinessSummaryRecord;
   readiness_checks?: ProviderReadinessCheckRecord[];
 };
 
 export type ProviderReadinessStatus = "ok" | "warning" | "blocked" | "unknown";
+
+export type ProviderReadinessSummaryRecord = {
+  status?: ProviderReadinessStatus;
+  reason?: string;
+  message?: string;
+  operator_action?: string;
+};
 
 export type ProviderReadinessCheckRecord = {
   name: string;


### PR DESCRIPTION
## Summary

This PR makes provider/model readiness a backend-owned contract instead of something the UI has to infer from several loosely related fields.

- Adds a compact provider-level readiness summary to /hecate/v1/providers/status while keeping the detailed readiness_checks checklist for drill-down.
- Adds per-model metadata.readiness to /v1/models so Chats can tell the difference between model is discovered and model is actually routable right now.
- Updates Chat selected-model diagnostics to prefer the backend readiness message/action when a selected model is blocked by credentials, health, circuit state, provider disabled state, or routing readiness.
- Adds a Providers detail readiness-summary card above the checklist so operators get the canonical message and repair action without reading raw checks first.
- Updates provider/chat/runtime API docs to describe the new contract.

## Why

Provider setup currently has too many states that look similar in the UI: installed, discovered, credential-blocked, unhealthy, no models, default-model-only, disabled, or not routable. This gives the backend one canonical place to decide and explain readiness, while still exposing detailed checks for debugging.

## Validation

- go vet ./pkg/types ./internal/gateway ./internal/api
- go test ./internal/gateway ./internal/api
- cd ui && bun run typecheck
- cd ui && bun run test