### PR TITLE
feat(ui): share provider readiness repair flow

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -126,7 +126,9 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   discovered-model count, health, blocked-by, last-error, and repair steps.
   The empty-state "compact" version may be shorter, but it must still include
   discovered-model count and at least a short remediation list; don't reduce it
-  to a dead-end warning.
+  to a dead-end warning. If the backend provides a suggested replacement model,
+  expose it as an action and reset the provider route to "All providers" before
+  selecting it, because the suggested model may belong to a different provider.
 - Agent Chat readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -24,8 +24,11 @@ near the composer with an **Open Connections** action; empty chats show a compac
 version in the empty state that still includes the discovered-model count,
 health/blocking/error diagnostics, and short remediation steps. The compact card
 is intentionally not just a warning — it should be enough to choose a discovered
-model, refresh local provider discovery, or jump to Connections for the full
-readiness checklist.
+model, accept a backend-suggested replacement when one is available, refresh
+local provider discovery, or jump to Connections for the full readiness
+checklist. Suggested replacement models reset the provider route to **All
+providers** because the fallback can belong to a different provider than the
+stale selection.
 
 The backend owns the readiness wording. `/hecate/v1/providers/status` returns a
 provider-level `readiness` summary plus detailed `readiness_checks`, and

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -273,7 +273,11 @@ cloud account does not expose that model. `/v1/models` includes
 before sending when a discovered model is still not usable because credentials,
 health, or routing are blocked. In that case Chats shows the selected model,
 provider route, backend readiness message, and next steps, and links the
-operator back to Connections for the full checklist. The same contract applies in the empty-chat state:
-compact readiness copy must still show the discovered-model count plus the
-highest-signal health/block/error diagnostics and a short repair path, so
-operators are not forced to send a doomed prompt or inspect raw provider JSON.
+operator back to Connections for the full checklist. If the backend supplies a
+suggested replacement model, Chats can offer it as a one-click repair and
+switch the route back to **All providers** so cross-provider fallbacks are not
+accidentally pinned to the stale provider. The same contract applies in the
+empty-chat state: compact readiness copy must still show the discovered-model
+count plus the highest-signal health/block/error diagnostics and a short repair
+path, so operators are not forced to send a doomed prompt or inspect raw
+provider JSON.

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -468,7 +468,8 @@ test("empty model chat can add all detected local providers in one click", async
   await page.getByRole("button", { name: "Add selected" }).click();
 
   await expect.poll(() => created.map(body => body.preset_id).sort()).toEqual(["lmstudio", "ollama"]);
-  await expect(page.getByText("Provider is configured")).toBeVisible();
+  await expect(page.getByText("No models discovered")).toBeVisible();
+  await expect(page.getByText(/Next: Start the local provider process, pull or load a model/)).toBeVisible();
   await expect(page.getByText("none discovered")).toBeVisible();
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
@@ -494,7 +495,7 @@ test("empty Hecate Agent chat can add all detected local providers in one click"
   await page.getByRole("button", { name: "Add selected" }).click();
 
   await expect.poll(() => created.map(body => body.preset_id).sort()).toEqual(["lmstudio", "ollama"]);
-  await expect(page.getByText("Provider is configured")).toBeVisible();
+  await expect(page.getByText("No models discovered")).toBeVisible();
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
 
@@ -1146,7 +1147,7 @@ test("configured provider with no models shows troubleshooting, not detected-pro
   await page.waitForSelector(".hecate-activitybar");
   await switchToModel(page);
 
-  await expect(page.getByText("Provider is configured")).toBeVisible();
+  await expect(page.getByText("No models discovered")).toBeVisible();
   await expect(page.getByText("none discovered")).toBeVisible();
   await expect(page.getByText(/Start the local provider app/)).toBeVisible();
   await expect(page.getByText("Detected locally")).toHaveCount(0);

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1153,6 +1153,91 @@ test("configured provider with no models shows troubleshooting, not detected-pro
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
 
+test("selected-model readiness can switch to the backend-suggested fallback model", async ({ page }) => {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await mockGatewayAPIs(page, {
+    settingsConfig: {
+      providers: [
+        { id: "anthropic", name: "Anthropic", preset_id: "anthropic", kind: "cloud", protocol: "anthropic", base_url: "https://api.anthropic.com/v1", enabled: true, credential_configured: false },
+        { id: "openai", name: "OpenAI", preset_id: "openai", kind: "cloud", protocol: "openai", base_url: "https://api.openai.com/v1", enabled: true, credential_configured: true },
+      ],
+      tenants: [],
+      api_keys: [],
+      policy_rules: [],
+    },
+  });
+  await page.route("/v1/models*", route => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      object: "list",
+      data: [
+        {
+          id: "claude-sonnet-4-6",
+          owned_by: "anthropic",
+          metadata: {
+            provider: "anthropic",
+            provider_kind: "cloud",
+            readiness: {
+              ready: false,
+              status: "blocked",
+              reason: "credential_missing",
+              message: "Anthropic needs credentials before this model can route.",
+              operator_action: "Add an Anthropic API key, or use a routable fallback.",
+              suggested_models: ["gpt-4o-mini"],
+            },
+          },
+        },
+        { id: "gpt-4o-mini", owned_by: "openai", metadata: { provider: "openai", provider_kind: "cloud" } },
+      ],
+    }),
+  }));
+  await page.route("/hecate/v1/providers/status*", route => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      object: "provider_status",
+      data: [
+        {
+          name: "anthropic",
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          models: ["claude-sonnet-4-6"],
+          model_count: 1,
+          routing_ready: false,
+          routing_blocked_reason: "credential_missing",
+        },
+        {
+          name: "openai",
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          models: ["gpt-4o-mini"],
+          model_count: 1,
+          routing_ready: true,
+        },
+      ],
+    }),
+  }));
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.providerFilter", "anthropic");
+    window.localStorage.setItem("hecate.model", "claude-sonnet-4-6");
+  });
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await expect(page.getByText("Selected model is not ready").first()).toBeVisible();
+  await page.getByRole("button", { name: "Use gpt-4o-mini" }).first().click();
+
+  await expect(page.getByRole("button", { name: /All providers/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /gpt-4o-mini/i })).toBeVisible();
+  await page.locator("textarea").fill("hello");
+  await expect(page.locator("button[type='submit']")).toBeEnabled();
+});
+
 // External-agent approval happy path. Seeds an active session with one
 // pending approval, then exercises the operator path: catch-up refetch
 // populates the banner, Review opens the modal, Allow resolves, and the

--- a/ui/e2e/provider-lifecycle.spec.ts
+++ b/ui/e2e/provider-lifecycle.spec.ts
@@ -29,7 +29,7 @@ test("adding and deleting a provider keeps chat available", async ({ page }) => 
   // the first-run provider discovery once configuration exists but no models
   // are routable yet.
   await page.locator(".hecate-activitybar [aria-label^='Chats']").click();
-  await expect(page.getByText("Provider is configured")).toBeVisible();
+  await expect(page.getByText("No models discovered")).toBeVisible();
   await expect(page.getByText("none discovered")).toBeVisible();
   await expect(page.locator("textarea")).toHaveCount(0);
 

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -59,10 +59,10 @@ describe("ConsoleShell navigation", () => {
     // (workspace nav buttons, statusbar) is not lazy and can
     // still be queried synchronously.
     expect(screen.getByRole("button", { name: "Chats" })).toBeEnabled();
-    expect(await screen.findByText(/Nothing runnable yet/i, undefined, { timeout: 5000 })).toBeInTheDocument();
+    expect(await screen.findByText(/Nothing runnable yet/i, undefined, { timeout: 10_000 })).toBeInTheDocument();
     expect(screen.queryByText(/No model providers configured/i)).toBeNull();
     expect(screen.getByRole("button", { name: /Go to Connections/i })).toBeInTheDocument();
-  }, 10_000);
+  }, 15_000);
 
   it("shows the selected agent workspace and git branch in the status bar", () => {
     const state = createRuntimeConsoleFixture({

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -62,7 +62,7 @@ describe("ConsoleShell navigation", () => {
     expect(await screen.findByText(/Nothing runnable yet/i, undefined, { timeout: 5000 })).toBeInTheDocument();
     expect(screen.queryByText(/No model providers configured/i)).toBeNull();
     expect(screen.getByRole("button", { name: /Go to Connections/i })).toBeInTheDocument();
-  });
+  }, 10_000);
 
   it("shows the selected agent workspace and git branch in the status bar", () => {
     const state = createRuntimeConsoleFixture({

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -76,7 +76,7 @@ describe("ChatView input", () => {
       "Claude Code· setup",
       "Cursor· setup",
     ]);
-  });
+  }, 10_000);
 
   it("toggles Hecate Chat between direct model chat and tool-backed agent mode", async () => {
     const setChatTarget = vi.fn();
@@ -302,6 +302,51 @@ describe("ChatView input", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Open Connections" }));
     expect(onNavigate).toHaveBeenCalledWith("providers");
+  });
+
+  it("offers the backend-suggested model as a one-click repair", async () => {
+    const setModel = vi.fn();
+    const setProviderFilter = vi.fn();
+    const { state, actions } = setup({
+      chatTarget: "model",
+      providerFilter: "anthropic",
+      model: "claude-sonnet-4-6",
+      message: "hello",
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          { id: "anthropic", name: "Anthropic", preset_id: "anthropic", kind: "cloud", protocol: "anthropic", base_url: "https://api.anthropic.com/v1", credential_configured: false },
+        ],
+        policy_rules: [],
+        pricebook: [],
+        events: [],
+      },
+      providerScopedModels: [
+        {
+          id: "claude-sonnet-4-6",
+          owned_by: "anthropic",
+          metadata: {
+            provider: "anthropic",
+            provider_kind: "cloud",
+            readiness: {
+              ready: false,
+              status: "blocked",
+              reason: "credential_missing",
+              message: "Anthropic needs credentials before this model can route.",
+              suggested_models: ["gpt-4o-mini"],
+            },
+          },
+        },
+        { id: "gpt-4o-mini", owned_by: "openai", metadata: { provider: "openai", provider_kind: "cloud" } },
+      ],
+    }, { setModel, setProviderFilter });
+    render(<ChatView state={state} actions={actions} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: "Use gpt-4o-mini" })[0]);
+
+    expect(setProviderFilter).toHaveBeenCalledWith("auto");
+    expect(setModel).toHaveBeenCalledWith("gpt-4o-mini");
   });
 
   it("opens Connections from the model empty state", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ChatView } from "./ChatView";
 import { discoverLocalProviders } from "../../lib/api";
@@ -12,6 +12,11 @@ vi.mock("../../lib/api", async importOriginal => {
     ...actual,
     discoverLocalProviders: vi.fn(async () => ({ object: "local_provider_discovery", data: [] })),
   };
+});
+
+afterEach(() => {
+  vi.mocked(discoverLocalProviders).mockReset();
+  vi.mocked(discoverLocalProviders).mockResolvedValue({ object: "local_provider_discovery", data: [] });
 });
 
 function setup(stateOverrides = {}, actionOverrides = {}) {
@@ -402,7 +407,9 @@ describe("ChatView input", () => {
     });
     render(<ChatView state={state} actions={actions} />);
 
-    expect(screen.getByText("Provider is configured")).toBeTruthy();
+    expect(screen.getByText("No models discovered")).toBeTruthy();
+    expect(screen.getAllByText("No models were discovered and no default model is configured.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Next: Start the provider and pull or load at least one model/).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Ollama").length).toBeGreaterThan(0);
     expect(screen.getByText("none discovered")).toBeTruthy();
     expect(screen.getAllByText("Credentials").length).toBeGreaterThan(0);

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1143,6 +1143,10 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                   setAddProviderOpen(true);
                 }
               }}
+              onUseSuggestedModel={(model) => {
+                actions.setProviderFilter("auto");
+                actions.setModel(model);
+              }}
               onQuickAddLocalProviders={quickAddLocalProviders}
               onRefreshQuickLocalProviders={refreshQuickLocalProviders}
               onSwitchTarget={actions.setChatTarget}
@@ -1190,7 +1194,14 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
           )}
           {isHecateChat && selectedModelIssue && (
             <div style={{ marginBottom: composerVisible ? 8 : 0 }}>
-              <SelectedModelReadinessNotice issue={selectedModelIssue} onOpenProviders={() => onNavigate?.("providers")} />
+              <SelectedModelReadinessNotice
+                issue={selectedModelIssue}
+                onOpenProviders={() => onNavigate?.("providers")}
+                onUseSuggestedModel={(model) => {
+                  actions.setProviderFilter("auto");
+                  actions.setModel(model);
+                }}
+              />
             </div>
           )}
           {composerVisible && (
@@ -2045,6 +2056,7 @@ function ChatEmptyState({
   quickLocalError,
   quickAddingProviders,
   onOpenProviders,
+  onUseSuggestedModel,
   onQuickAddLocalProviders,
   onRefreshQuickLocalProviders,
   onSwitchTarget,
@@ -2077,6 +2089,7 @@ function ChatEmptyState({
   quickLocalError: string;
   quickAddingProviders: boolean;
   onOpenProviders: () => void;
+  onUseSuggestedModel: (model: string) => void;
   onQuickAddLocalProviders: (providers: LocalProviderDiscoveryRecord[]) => void;
   onRefreshQuickLocalProviders: () => void;
   onSwitchTarget: (target: "model" | "agent" | "external_agent") => void;
@@ -2142,7 +2155,7 @@ function ChatEmptyState({
         />
       )}
       {isHecateChat && selectedModelIssue && (
-        <SelectedModelReadinessNotice issue={selectedModelIssue} compact />
+        <SelectedModelReadinessNotice issue={selectedModelIssue} compact onUseSuggestedModel={onUseSuggestedModel} />
       )}
       {(modelRouteUnavailable || selectedModelIssue || agentRouteUnavailable) && (
         <div style={{ display: "flex", justifyContent: "center", gap: 8, marginTop: 14, flexWrap: "wrap" }}>
@@ -2290,10 +2303,12 @@ function SelectedModelReadinessNotice({
   issue,
   compact = false,
   onOpenProviders,
+  onUseSuggestedModel,
 }: {
   issue: SelectedModelIssue;
   compact?: boolean;
   onOpenProviders?: () => void;
+  onUseSuggestedModel?: (model: string) => void;
 }) {
   return (
     <div style={{
@@ -2320,6 +2335,16 @@ function SelectedModelReadinessNotice({
               Open Connections
             </button>
           )}
+          {issue.suggestedModel && onUseSuggestedModel && (
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
+              style={{ flexShrink: 0 }}
+            >
+              Use {issue.suggestedModel}
+            </button>
+          )}
         </div>
       )}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8, marginTop: 10 }}>
@@ -2328,9 +2353,21 @@ function SelectedModelReadinessNotice({
         ))}
       </div>
       {compact ? (
-        <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
-          {issue.steps.slice(0, 2).map((step) => <li key={step}>{step}</li>)}
-        </ul>
+        <>
+          <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
+            {issue.steps.slice(0, 2).map((step) => <li key={step}>{step}</li>)}
+          </ul>
+          {issue.suggestedModel && onUseSuggestedModel && (
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
+              style={{ marginTop: 10 }}
+            >
+              Use {issue.suggestedModel}
+            </button>
+          )}
+        </>
       ) : (
         <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
           {issue.steps.map((step) => <li key={step}>{step}</li>)}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -4,6 +4,7 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
+import { providerRepairHint } from "../../lib/provider-readiness";
 import { describeCredentialState, describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -1128,6 +1129,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               selectedAgent={selectedAgent}
               selectedAgentUnavailable={selectedAgentUnavailable}
               hasConfiguredProviders={hasConfiguredProviders}
+              configuredProviders={configuredProviders}
               providerFilter={state.providerFilter}
               selectedConfiguredProvider={selectedConfiguredProvider}
               selectedRuntimeProvider={selectedRuntimeProvider}
@@ -2047,6 +2049,7 @@ function ChatEmptyState({
   selectedAgent,
   selectedAgentUnavailable,
   hasConfiguredProviders,
+  configuredProviders,
   providerFilter,
   selectedConfiguredProvider,
   selectedRuntimeProvider,
@@ -2080,6 +2083,7 @@ function ChatEmptyState({
   selectedAgent?: AgentAdapterRecord;
   selectedAgentUnavailable: boolean;
   hasConfiguredProviders: boolean;
+  configuredProviders: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"];
   providerFilter: string;
   selectedConfiguredProvider?: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"][number];
   selectedRuntimeProvider?: RuntimeConsoleViewModel["state"]["providers"][number];
@@ -2150,7 +2154,7 @@ function ChatEmptyState({
       {isHecateChat && modelRouteUnavailable && hasConfiguredProviders && (
         <ModelRouteTroubleshooting
           providerFilter={providerFilter}
-          configuredProvider={selectedConfiguredProvider}
+          configuredProvider={selectedConfiguredProvider ?? (providerFilter === "auto" ? configuredProviders[0] : undefined)}
           runtimeProvider={selectedRuntimeProvider}
         />
       )}
@@ -2219,6 +2223,7 @@ function ModelRouteTroubleshooting({
   const lastError = runtimeProvider?.last_error || "";
   const lastErrorClass = runtimeProvider?.last_error_class ? describeHealthErrorClass(runtimeProvider.last_error_class) : "";
   const discoverySource = runtimeProvider?.discovery_source || "";
+  const repair = providerRepairHint({ configuredProvider, runtimeProvider });
   const rawCredentialState = runtimeProvider?.credential_state
     ?? (configuredProvider?.kind === "local"
       ? "not_required"
@@ -2258,13 +2263,21 @@ function ModelRouteTroubleshooting({
     }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
         <span style={{ fontSize: 11, color: "var(--t2)", fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
-          Provider is configured
+          {repair.title}
         </span>
         <span style={{ fontSize: 11, color: "var(--t3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {providerName}
         </span>
       </div>
       <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.55 }}>
+        {repair.message}
+      </div>
+      {repair.action !== "No repair needed." && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "var(--amber)", lineHeight: 1.45 }}>
+          Next: {repair.action}
+        </div>
+      )}
+      <div style={{ marginTop: 8, fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
         Hecate can see the provider configuration, but no routable models are available yet.
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 8, marginTop: 10 }}>

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -4,7 +4,7 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
-import { providerRepairHint } from "../../lib/provider-readiness";
+import { providerRepairHint, type ProviderRepairHint } from "../../lib/provider-readiness";
 import { describeCredentialState, describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -2154,7 +2154,8 @@ function ChatEmptyState({
       {isHecateChat && modelRouteUnavailable && hasConfiguredProviders && (
         <ModelRouteTroubleshooting
           providerFilter={providerFilter}
-          configuredProvider={selectedConfiguredProvider ?? (providerFilter === "auto" ? configuredProviders[0] : undefined)}
+          configuredProvider={selectedConfiguredProvider}
+          configuredProviders={configuredProviders}
           runtimeProvider={selectedRuntimeProvider}
         />
       )}
@@ -2207,29 +2208,37 @@ function ChatEmptyState({
 function ModelRouteTroubleshooting({
   providerFilter,
   configuredProvider,
+  configuredProviders,
   runtimeProvider,
 }: {
   providerFilter: string;
   configuredProvider?: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"][number];
+  configuredProviders: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"];
   runtimeProvider?: RuntimeConsoleViewModel["state"]["providers"][number];
 }) {
+  const matchedConfiguredProvider = configuredProvider
+    ?? (providerFilter === "auto" && runtimeProvider
+      ? configuredProviders.find(provider => provider.id === runtimeProvider.name || provider.name === runtimeProvider.name)
+      : undefined);
+  const repair = providerFilter === "auto" && !runtimeProvider
+    ? autoProviderRouteRepairHint(configuredProviders)
+    : providerRepairHint({ configuredProvider: matchedConfiguredProvider, runtimeProvider });
   const providerName = providerFilter === "auto"
     ? "configured providers"
-    : configuredProvider?.name || runtimeProvider?.name || providerFilter;
-  const isLocal = configuredProvider?.kind === "local" || runtimeProvider?.kind === "local";
-  const endpoint = runtimeProvider?.base_url || configuredProvider?.base_url || "";
+    : matchedConfiguredProvider?.name || runtimeProvider?.name || providerFilter;
+  const isLocal = matchedConfiguredProvider?.kind === "local" || runtimeProvider?.kind === "local";
+  const endpoint = runtimeProvider?.base_url || matchedConfiguredProvider?.base_url || "";
   const modelCount = runtimeProvider?.model_count ?? runtimeProvider?.models?.length ?? 0;
   const blockedReason = runtimeProvider?.routing_blocked_reason ? describeRoutingBlockedReason(runtimeProvider.routing_blocked_reason) : "";
   const lastError = runtimeProvider?.last_error || "";
   const lastErrorClass = runtimeProvider?.last_error_class ? describeHealthErrorClass(runtimeProvider.last_error_class) : "";
   const discoverySource = runtimeProvider?.discovery_source || "";
-  const repair = providerRepairHint({ configuredProvider, runtimeProvider });
   const rawCredentialState = runtimeProvider?.credential_state
-    ?? (configuredProvider?.kind === "local"
+    ?? (matchedConfiguredProvider?.kind === "local"
       ? "not_required"
-      : configuredProvider?.credential_configured
+      : matchedConfiguredProvider?.credential_configured
         ? "configured"
-        : configuredProvider
+        : matchedConfiguredProvider
           ? "missing"
           : undefined);
   const credentialState = describeCredentialState(rawCredentialState);
@@ -2272,7 +2281,7 @@ function ModelRouteTroubleshooting({
       <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.55 }}>
         {repair.message}
       </div>
-      {repair.action !== "No repair needed." && (
+      {repair.tone !== "muted" && (
         <div style={{ marginTop: 6, fontSize: 11, color: "var(--amber)", lineHeight: 1.45 }}>
           Next: {repair.action}
         </div>
@@ -2388,6 +2397,20 @@ function SelectedModelReadinessNotice({
       )}
     </div>
   );
+}
+
+function autoProviderRouteRepairHint(
+  configuredProviders: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"],
+): ProviderRepairHint {
+  const allLocal = configuredProviders.length > 0 && configuredProviders.every(provider => provider.kind === "local");
+  return {
+    title: "No models discovered",
+    message: "Configured providers do not have a routable model yet.",
+    action: allLocal
+      ? "Start the local provider process, pull or load a model, then refresh Connections."
+      : "Open Connections to fix credentials, health, or model discovery, then refresh.",
+    tone: "amber",
+  };
 }
 
 function selectedModelNoticeDetails(

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { providerFleetRepairHint } from "../../lib/provider-readiness";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
 import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
 
@@ -210,6 +211,8 @@ function ModelProviderConnectionsSection({
   const readyProviders = knownStatuses.filter(isProviderReady).length;
   const blockedProviders = knownStatuses.filter(isProviderBlocked).length;
   const modelCount = state.models.length || knownStatuses.reduce((sum, provider) => sum + (provider.model_count ?? provider.models?.length ?? 0), 0);
+  const statusByName = new Map(state.providers.map((provider) => [provider.name, provider]));
+  const repair = providerFleetRepairHint(configuredProviders, statusByName);
 
   return (
     <div className="card" style={{ padding: "14px 16px", marginBottom: 24 }} data-testid="connections-model-providers">
@@ -225,6 +228,27 @@ function ModelProviderConnectionsSection({
           ) : undefined
         }
       />
+      {repair && (
+        <div
+          style={{
+            marginBottom: 12,
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            background: repair.tone === "amber" ? "var(--amber-bg)" : "var(--bg2)",
+            padding: "9px 10px",
+          }}
+        >
+          <div style={{ display: "flex", gap: 8, alignItems: "baseline", marginBottom: 3 }}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: repair.tone === "amber" ? "var(--amber)" : "var(--t1)" }}>
+              {repair.title}
+            </span>
+            <span style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
+              {repair.action}
+            </span>
+          </div>
+          <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>{repair.message}</div>
+        </div>
+      )}
       <div
         style={{
           display: "grid",

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -410,7 +410,7 @@ describe("ProvidersView table renders", () => {
     const summary = screen.getByTestId("connections-readiness-summary");
     expect(within(summary).getByText("Model provider readiness")).toBeTruthy();
     expect(within(summary).getAllByText("2").length).toBeGreaterThanOrEqual(1);
-    expect(within(summary).getByText("All configured provider records have a current readiness signal.")).toBeTruthy();
+    expect(within(summary).getByText("No configured provider setup issue needs repair.")).toBeTruthy();
 
     // Health badges: both providers report healthy. Credentials are split
     // into a separate column so cloud (Configured) and local (Not required)

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -777,7 +777,7 @@ describe("ProvidersView table renders", () => {
     expect(screen.getByText("Routing")).toBeTruthy();
     expect(screen.getByText("Routing is blocked while the provider cools down after a rate limit.")).toBeTruthy();
     expect(screen.getByText("Next: Use the backend-provided repair action.")).toBeTruthy();
-    expect(screen.getAllByText(/Next: wait for cooldown or temporarily route to another provider/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Next: Wait for cooldown or temporarily route to another provider/).length).toBeGreaterThan(0);
     expect(screen.getByText("Diagnostics")).toBeTruthy();
     expect(screen.getByText("connect: connection refused")).toBeTruthy();
     expect(screen.getAllByText("Not required").length).toBeGreaterThan(0);

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -811,7 +811,7 @@ function resolveNextReadinessStep(
   if (!hint) return null;
   return {
     tone: hint.tone === "amber" || hint.tone === "red" ? "amber" : "muted",
-    text: hint.action === "No repair needed." ? hint.message : `${hint.message} ${hint.action}`,
+    text: hint.tone === "muted" ? hint.message : `${hint.message} ${hint.action}`,
   };
 }
 

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { providerFleetRepairHint } from "../../lib/provider-readiness";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
@@ -806,25 +807,12 @@ function resolveNextReadinessStep(
   providers: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"],
   statusByName: Map<string, RuntimeConsoleViewModel["state"]["providers"][number]>,
 ): { text: string; tone: ConnectionStatTone } | null {
-  for (const provider of providers) {
-    const status = statusByName.get(provider.id);
-    if (provider.kind !== "local" && !provider.credential_configured) {
-      return { tone: "amber", text: `${provider.name || provider.id} needs an API key before it can route requests.` };
-    }
-    if (status?.routing_blocked_reason) {
-      return { tone: "amber", text: `${provider.name || provider.id}: ${describeRoutingBlockedReason(status.routing_blocked_reason)}.` };
-    }
-    if ((status?.model_count ?? status?.models?.length ?? 0) === 0 && status?.healthy) {
-      return { tone: "amber", text: `${provider.name || provider.id} is reachable but has no discovered models yet.` };
-    }
-    if (status?.status === "open" || status?.status === "unhealthy") {
-      return { tone: "amber", text: `${provider.name || provider.id} is down. Check its endpoint, credentials, or local process.` };
-    }
-  }
-  if (providers.length > 0) {
-    return { tone: "muted", text: "All configured provider records have a current readiness signal." };
-  }
-  return null;
+  const hint = providerFleetRepairHint(providers, statusByName);
+  if (!hint) return null;
+  return {
+    tone: hint.tone === "amber" || hint.tone === "red" ? "amber" : "muted",
+    text: hint.action === "No repair needed." ? hint.message : `${hint.message} ${hint.action}`,
+  };
 }
 
 function formatProviderTime(value: string): string {

--- a/ui/src/features/shared/ProviderReadiness.tsx
+++ b/ui/src/features/shared/ProviderReadiness.tsx
@@ -1,4 +1,5 @@
 import type { ProviderReadinessCheckRecord, ProviderReadinessSummaryRecord } from "../../types/runtime";
+import { readinessRecommendation } from "../../lib/provider-readiness";
 
 export function ProviderReadinessSummary({ readiness }: { readiness?: ProviderReadinessSummaryRecord }) {
   if (!readiness || (!readiness.message && !readiness.operator_action && !readiness.reason)) return null;
@@ -185,39 +186,6 @@ export function CompactProviderReadinessChecks({ checks }: { checks: ProviderRea
       })}
     </div>
   );
-}
-
-export function readinessRecommendation(check: ProviderReadinessCheckRecord): string {
-  if (check.operator_action) return check.operator_action;
-
-  switch (check.reason) {
-    case "credential_missing":
-      return "add or rotate this provider's API key.";
-    case "provider_disabled":
-      return check.name === "models"
-        ? "enable the provider before model discovery can run."
-        : "enable the provider when you want Hecate to route to it.";
-    case "self_referential":
-      return "change the base URL so it points at the provider, not Hecate.";
-    case "discovery_failed":
-      return "check the endpoint and refresh provider status after the server is reachable.";
-    case "default_model_only":
-      return "send a test request or refresh discovery to confirm the default model is real.";
-    case "no_models":
-      return "start the provider and pull/load at least one model.";
-    case "provider_slow":
-      return "keep it enabled if acceptable, or route to a faster provider.";
-    case "provider_rate_limited":
-      return "wait for cooldown or temporarily route to another provider.";
-    case "provider_unhealthy":
-      return "inspect the latest health error and provider server logs.";
-    case "circuit_open":
-      return "wait for recovery or test the provider after fixing the upstream issue.";
-    case "recovery_probe":
-      return "retry once the half-open probe succeeds.";
-    default:
-      return "";
-  }
 }
 
 function readinessColor(status?: string): string {

--- a/ui/src/lib/provider-issues.test.ts
+++ b/ui/src/lib/provider-issues.test.ts
@@ -97,6 +97,7 @@ describe("buildSelectedModelIssue", () => {
       { label: "Blocked by", value: "credential_missing" },
     ]));
     expect(issue?.steps.join(" ")).toContain("Add or rotate this provider's API key");
+    expect(issue?.suggestedModel).toBe("gpt-4o-mini");
   });
 
   it("explains a stale local model selection", () => {

--- a/ui/src/lib/provider-issues.ts
+++ b/ui/src/lib/provider-issues.ts
@@ -12,6 +12,7 @@ export type SelectedModelIssue = {
   message: string;
   providerLabel: string;
   model: string;
+  suggestedModel?: string;
   details: Array<{ label: string; value: string }>;
   steps: string[];
 };
@@ -92,6 +93,7 @@ export function buildSelectedModelIssue({
         message: readiness.message || `The selected model "${model}" is not routable right now.`,
         providerLabel,
         model,
+        suggestedModel: readiness.suggested_models?.[0],
         details,
         steps,
       };

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -60,6 +60,32 @@ describe("providerRepairHint", () => {
     expect(hint.title).toBe("No models discovered");
     expect(hint.action).toContain("Pull or load");
   });
+
+  it("uses friendlier titles for blocked readiness checks", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "ollama", name: "Ollama", kind: "local", credential_configured: false },
+      runtimeProvider: {
+        name: "ollama",
+        kind: "local",
+        healthy: true,
+        status: "healthy",
+        models: [],
+        model_count: 0,
+        readiness_checks: [{ name: "models", status: "blocked", reason: "no_models", message: "No models were discovered." }],
+      },
+    });
+
+    expect(hint.title).toBe("No models discovered");
+  });
+
+  it("treats configured providers without runtime discovery as needing models", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "ollama", name: "Ollama", kind: "local", credential_configured: false },
+    });
+
+    expect(hint.title).toBe("No models discovered");
+    expect(hint.action).toContain("refresh Connections");
+  });
 });
 
 describe("providerFleetRepairHint", () => {

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -86,6 +86,25 @@ describe("providerRepairHint", () => {
     expect(hint.title).toBe("No models discovered");
     expect(hint.action).toContain("refresh Connections");
   });
+
+  it("humanizes routing blocked reasons when readiness details are absent", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: true },
+      runtimeProvider: {
+        name: "anthropic",
+        kind: "cloud",
+        healthy: true,
+        status: "healthy",
+        models: ["claude"],
+        model_count: 1,
+        routing_blocked_reason: "credential_missing",
+      },
+    });
+
+    expect(hint.title).toBe("Routing blocked");
+    expect(hint.message).toContain("Missing credentials");
+    expect(hint.message).not.toContain("credential_missing");
+  });
 });
 
 describe("providerFleetRepairHint", () => {

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { providerFleetRepairHint, providerRepairHint, readinessRecommendation } from "./provider-readiness";
+
+describe("readinessRecommendation", () => {
+  it("uses backend operator_action before local fallback copy", () => {
+    expect(readinessRecommendation({
+      name: "health",
+      status: "blocked",
+      reason: "provider_unhealthy",
+      operator_action: "Restart Ollama, then refresh.",
+    })).toBe("Restart Ollama, then refresh.");
+  });
+
+  it("maps known readiness reasons to operator repair copy", () => {
+    expect(readinessRecommendation({ name: "credentials", status: "blocked", reason: "credential_missing" }))
+      .toContain("API key");
+    expect(readinessRecommendation({ name: "models", status: "blocked", reason: "no_models" }))
+      .toContain("pull or load");
+  });
+});
+
+describe("providerRepairHint", () => {
+  it("prioritizes missing credentials for cloud providers", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: false },
+      runtimeProvider: { name: "anthropic", kind: "cloud", healthy: true, status: "healthy", models: ["claude"], model_count: 1 },
+    });
+
+    expect(hint.title).toBe("Credentials required");
+    expect(hint.action).toContain("API key");
+    expect(hint.tone).toBe("amber");
+  });
+
+  it("uses backend readiness summary and blocked-check actions before generic routing copy", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "ollama", name: "Ollama", kind: "local", credential_configured: false },
+      runtimeProvider: {
+        name: "ollama",
+        kind: "local",
+        healthy: false,
+        status: "open",
+        routing_blocked_reason: "circuit_open",
+        readiness: { status: "blocked", message: "Ollama is cooling down.", operator_action: "Wait for cooldown." },
+        readiness_checks: [{ name: "routing", status: "blocked", reason: "circuit_open" }],
+      },
+    });
+
+    expect(hint.title).toBe("Provider blocked");
+    expect(hint.message).toBe("Ollama is cooling down.");
+    expect(hint.action).toBe("Wait for cooldown.");
+  });
+
+  it("explains reachable local providers with no discovered models", () => {
+    const hint = providerRepairHint({
+      configuredProvider: { id: "ollama", name: "Ollama", kind: "local", credential_configured: false },
+      runtimeProvider: { name: "ollama", kind: "local", healthy: true, status: "healthy", models: [], model_count: 0 },
+    });
+
+    expect(hint.title).toBe("No models discovered");
+    expect(hint.action).toContain("Pull or load");
+  });
+});
+
+describe("providerFleetRepairHint", () => {
+  it("returns the first provider repair action and a ready summary otherwise", () => {
+    const statuses = new Map([
+      ["anthropic", { name: "anthropic", kind: "cloud", healthy: true, status: "healthy", models: ["claude"], model_count: 1 }],
+      ["ollama", { name: "ollama", kind: "local", healthy: true, status: "healthy", models: [], model_count: 0 }],
+    ]);
+
+    expect(providerFleetRepairHint([
+      { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: true },
+      { id: "ollama", name: "Ollama", kind: "local", credential_configured: false },
+    ], statuses)?.title).toBe("No models discovered");
+
+    expect(providerFleetRepairHint([
+      { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: true },
+    ], statuses)?.message).toContain("current readiness signal");
+  });
+});

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -121,6 +121,6 @@ describe("providerFleetRepairHint", () => {
 
     expect(providerFleetRepairHint([
       { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: true },
-    ], statuses)?.message).toContain("current readiness signal");
+    ], statuses)?.message).toContain("No configured provider setup issue");
   });
 });

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -1,4 +1,5 @@
 import type { ConfiguredProviderRecord, ProviderReadinessCheckRecord, ProviderRecord } from "../types/runtime";
+import { describeRoutingBlockedReason } from "./runtime-routing";
 
 export type ProviderRepairHint = {
   title: string;
@@ -89,9 +90,10 @@ export function providerRepairHint({
   }
 
   if (runtimeProvider?.routing_blocked_reason) {
+    const reason = describeRoutingBlockedReason(runtimeProvider.routing_blocked_reason);
     return {
       title: "Routing blocked",
-      message: `${name} is configured, but routing is blocked by ${runtimeProvider.routing_blocked_reason}.`,
+      message: `${name} is configured, but routing is blocked: ${reason}.`,
       action: "Open Connections and inspect routing, health, and discovery details.",
       tone: "amber",
     };

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -60,6 +60,15 @@ export function providerRepairHint({
     };
   }
 
+  if (configuredProvider && !runtimeProvider) {
+    return {
+      title: "No models discovered",
+      message: `${name} is configured, but Hecate does not have a current model-discovery result for it yet.`,
+      action: isLocal ? "Start the local provider process, pull or load a model, then refresh Connections." : "Confirm the account has model access, then refresh Connections.",
+      tone: "amber",
+    };
+  }
+
   if (runtimeProvider?.readiness?.status === "blocked") {
     return {
       title: "Provider blocked",
@@ -72,7 +81,7 @@ export function providerRepairHint({
   const blockedCheck = firstBlockedReadinessCheck(runtimeProvider?.readiness_checks ?? []);
   if (blockedCheck) {
     return {
-      title: titleizeReadinessName(blockedCheck.name),
+      title: readinessTitle(blockedCheck),
       message: blockedCheck.message || `${name} has a blocked readiness check.`,
       action: readinessRecommendation(blockedCheck) || "Open Connections and inspect provider readiness.",
       tone: "amber",
@@ -164,4 +173,23 @@ function titleizeReadinessName(value: string): string {
     .filter(Boolean)
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function readinessTitle(check: ProviderReadinessCheckRecord): string {
+  switch (check.reason) {
+    case "credential_missing":
+      return "Credentials required";
+    case "no_models":
+      return "No models discovered";
+    case "discovery_failed":
+      return "Discovery failed";
+    case "provider_unhealthy":
+      return "Provider unavailable";
+    case "provider_rate_limited":
+      return "Provider rate limited";
+    case "self_referential":
+      return "Invalid endpoint";
+    default:
+      return titleizeReadinessName(check.name);
+  }
 }

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -120,7 +120,7 @@ export function providerRepairHint({
   if (configuredProvider || runtimeProvider) {
     return {
       title: "Ready",
-      message: `${name} has a current readiness signal.`,
+      message: `${name} has no provider setup issue that needs repair.`,
       action: "No repair needed.",
       tone: "muted",
     };
@@ -148,7 +148,7 @@ export function providerFleetRepairHint(
   if (providers.length > 0) {
     return {
       title: "Ready",
-      message: "All configured provider records have a current readiness signal.",
+      message: "No configured provider setup issue needs repair.",
       action: "No repair needed.",
       tone: "muted",
     };

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -1,0 +1,167 @@
+import type { ConfiguredProviderRecord, ProviderReadinessCheckRecord, ProviderRecord } from "../types/runtime";
+
+export type ProviderRepairHint = {
+  title: string;
+  message: string;
+  action: string;
+  tone: "muted" | "green" | "amber" | "red";
+};
+
+export function readinessRecommendation(check: ProviderReadinessCheckRecord): string {
+  if (check.operator_action) return check.operator_action;
+
+  switch (check.reason) {
+    case "credential_missing":
+      return "Add or rotate this provider's API key.";
+    case "provider_disabled":
+      return check.name === "models"
+        ? "Enable the provider before model discovery can run."
+        : "Enable the provider when you want Hecate to route to it.";
+    case "self_referential":
+      return "Change the base URL so it points at the provider, not Hecate.";
+    case "discovery_failed":
+      return "Check the endpoint, then refresh provider status after the server is reachable.";
+    case "default_model_only":
+      return "Send a test request or refresh discovery to confirm the default model is real.";
+    case "no_models":
+      return "Start the provider and pull or load at least one model.";
+    case "provider_slow":
+      return "Keep it enabled if acceptable, or route to a faster provider.";
+    case "provider_rate_limited":
+      return "Wait for cooldown or temporarily route to another provider.";
+    case "provider_unhealthy":
+      return "Inspect the latest health error and provider server logs.";
+    case "circuit_open":
+      return "Wait for recovery or test the provider after fixing the upstream issue.";
+    case "recovery_probe":
+      return "Retry once the half-open probe succeeds.";
+    default:
+      return "";
+  }
+}
+
+export function providerRepairHint({
+  configuredProvider,
+  runtimeProvider,
+}: {
+  configuredProvider?: Pick<ConfiguredProviderRecord, "id" | "name" | "kind" | "credential_configured">;
+  runtimeProvider?: ProviderRecord;
+}): ProviderRepairHint {
+  const name = configuredProvider?.name || runtimeProvider?.name || configuredProvider?.id || "Provider";
+  const isLocal = configuredProvider?.kind === "local" || runtimeProvider?.kind === "local";
+  const modelCount = runtimeProvider?.model_count ?? runtimeProvider?.models?.length ?? 0;
+
+  if (configuredProvider && !isLocal && !configuredProvider.credential_configured) {
+    return {
+      title: "Credentials required",
+      message: `${name} is configured but cannot route requests until an API key is saved.`,
+      action: "Add or rotate the provider API key in Connections.",
+      tone: "amber",
+    };
+  }
+
+  if (runtimeProvider?.readiness?.status === "blocked") {
+    return {
+      title: "Provider blocked",
+      message: runtimeProvider.readiness.message || `${name} is not routable right now.`,
+      action: runtimeProvider.readiness.operator_action || firstReadinessAction(runtimeProvider.readiness_checks) || "Open Connections and inspect the blocked readiness check.",
+      tone: "amber",
+    };
+  }
+
+  const blockedCheck = firstBlockedReadinessCheck(runtimeProvider?.readiness_checks ?? []);
+  if (blockedCheck) {
+    return {
+      title: titleizeReadinessName(blockedCheck.name),
+      message: blockedCheck.message || `${name} has a blocked readiness check.`,
+      action: readinessRecommendation(blockedCheck) || "Open Connections and inspect provider readiness.",
+      tone: "amber",
+    };
+  }
+
+  if (runtimeProvider?.routing_blocked_reason) {
+    return {
+      title: "Routing blocked",
+      message: `${name} is configured, but routing is blocked by ${runtimeProvider.routing_blocked_reason}.`,
+      action: "Open Connections and inspect routing, health, and discovery details.",
+      tone: "amber",
+    };
+  }
+
+  if (runtimeProvider && modelCount === 0 && runtimeProvider.healthy) {
+    return {
+      title: "No models discovered",
+      message: `${name} is reachable, but Hecate has not discovered any models from it yet.`,
+      action: isLocal ? "Pull or load a model in the local provider, then refresh Connections." : "Confirm the account has model access, then refresh Connections.",
+      tone: "amber",
+    };
+  }
+
+  if (runtimeProvider?.status === "open" || runtimeProvider?.status === "unhealthy" || runtimeProvider?.healthy === false) {
+    return {
+      title: "Provider unavailable",
+      message: `${name} is currently down or cooling down after failures.`,
+      action: isLocal ? "Start the local provider process and refresh Connections." : "Check the upstream endpoint, credentials, and provider status.",
+      tone: "amber",
+    };
+  }
+
+  if (configuredProvider || runtimeProvider) {
+    return {
+      title: "Ready",
+      message: `${name} has a current readiness signal.`,
+      action: "No repair needed.",
+      tone: "muted",
+    };
+  }
+
+  return {
+    title: "No provider selected",
+    message: "Choose or add a provider before sending model traffic.",
+    action: "Add a provider in Connections.",
+    tone: "amber",
+  };
+}
+
+export function providerFleetRepairHint(
+  providers: Array<Pick<ConfiguredProviderRecord, "id" | "name" | "kind" | "credential_configured">>,
+  statusByName: Map<string, ProviderRecord>,
+): ProviderRepairHint | null {
+  for (const provider of providers) {
+    const hint = providerRepairHint({
+      configuredProvider: provider,
+      runtimeProvider: statusByName.get(provider.id),
+    });
+    if (hint.tone !== "muted") return hint;
+  }
+  if (providers.length > 0) {
+    return {
+      title: "Ready",
+      message: "All configured provider records have a current readiness signal.",
+      action: "No repair needed.",
+      tone: "muted",
+    };
+  }
+  return null;
+}
+
+function firstBlockedReadinessCheck(checks: ProviderReadinessCheckRecord[]): ProviderReadinessCheckRecord | null {
+  return checks.find((check) => check.status === "blocked") ?? null;
+}
+
+function firstReadinessAction(checks?: ProviderReadinessCheckRecord[]): string {
+  if (!checks) return "";
+  for (const check of checks) {
+    const action = readinessRecommendation(check);
+    if (action) return action;
+  }
+  return "";
+}
+
+function titleizeReadinessName(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

- centralize provider/model readiness repair copy in a shared UI helper
- reuse the same repair hint in Connections, Providers, shared readiness components, and Chat troubleshooting
- let Chat accept backend-suggested replacement models as a one-click stale-model repair
- reset the provider route to All providers before applying a suggested model, because backend fallbacks can belong to a different provider
- explain configured-but-undiscovered providers as a no-model repair state after one-click local-provider setup
- document the suggested-model repair flow in user docs and UI agent guidance

## Tests

- cd ui && bun run typecheck
- cd ui && bun run test
- cd ui && bun run test:e2e
