### PR TITLE
Make Connections own model readiness

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -185,8 +185,9 @@ src/
     chats/              ChatView — interactive chat against the gateway
     transcript/         reusable transcript pieces for Chats and Task Detail: markdown, message rows, activity timeline, file diff review
     overview/           ConnectYourClient, ObservabilityView — request ledger + trace drilldown + Codex/Claude Code setup
-    settings/           SettingsView, PricebookTab — settings, pricing, retention, external-agent grants
-    providers/          ProvidersView — provider catalog + health
+    connections/        ConnectionsPanel — provider readiness, model capabilities, external-agent setup/grants
+    settings/           SettingsView, PricebookTab — pricing, retention, non-connection configuration
+    providers/          ProvidersView — detailed provider catalog/editor
     shared/             primitives, pickers, overlays; ui.tsx is a compatibility barrel
   lib/
     api.ts              fetch wrappers + streamTaskRun (SSE consumer)

--- a/docs/beta-roadmap.md
+++ b/docs/beta-roadmap.md
@@ -29,7 +29,7 @@ is released in alpha tags only after it merges.
 | Providers | Provider setup is self-explanatory: readiness cards, discovered/running/installed states, credential repair, duplicate endpoint handling, route blocking reasons, model discovery failures, local provider discovery, and optimistic edits/deletes where safe. |
 | Tasks | Task Detail is the canonical deep-debug view: clear run timeline, grouped advanced activity, approval cards, stdout/stderr/artifacts, retry/resume/cancel explanations, patch review, and chat-origin links. |
 | Observability | The UI answers "what happened?" without JSON archaeology: request ledger, route report, trace viewer, skipped providers, policy/budget denial, cost calculation, cache path, provider failure, and final outcome. |
-| Settings | Settings stays focused on pricebook, retention, model capability overrides/probes, External Agent readiness/grants, and OTel/export knobs when needed. |
+| Settings | Settings stays focused on pricebook, retention, and OTel/export knobs when needed. Provider readiness, model capability overrides/probes, and External Agent grants live in Connections. |
 | Costs | Costs clearly separates enforced gateway cost from adapter-reported usage. External Agent usage remains labelled as reported by adapter and not enforced by Hecate. |
 | Desktop app | Before beta, decide whether unsigned desktop bundles are acceptable. If not, complete signing/notarization or clearly keep desktop labelled alpha while the rest of Hecate enters beta. |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -236,7 +236,7 @@ just dev-agent-adapters 'claude_code=missing,codex=available,cursor_agent=missin
 
 The backing env var is `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`. It accepts
 `all=missing` or per-adapter entries using `missing` / `available`. This is
-discovery-only: it changes Settings and Chats readiness UI, but it does not
+discovery-only: it changes Connections and Chats readiness UI, but it does not
 create fake adapter processes or make a chat send succeed.
 
 ## Capturing documentation screenshots

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -148,7 +148,7 @@ just dev-agent-adapters 'claude_code=missing,codex=available,cursor_agent=missin
 
 Those recipes set `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`. The override is
 intentionally discovery-only: it lets Settings and Chats render missing /
-available states, but it does not create fake adapter processes or make a chat
+available states in Connections and Chats, but it does not create fake adapter processes or make a chat
 send succeed.
 
 ### Codex ACP

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -147,8 +147,8 @@ just dev-agent-adapters 'claude_code=missing,codex=available,cursor_agent=missin
 ```
 
 Those recipes set `GATEWAY_AGENT_ADAPTER_DISCOVERY_OVERRIDES`. The override is
-intentionally discovery-only: it lets Settings and Chats render missing /
-available states in Connections and Chats, but it does not create fake adapter processes or make a chat
+intentionally discovery-only: it lets Connections and Chats render missing /
+available states, but it does not create fake adapter processes or make a chat
 send succeed.
 
 ### Codex ACP

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -97,8 +97,8 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   after the active run settles; queued prompts are not durable until submitted.
 - Tools-on Hecate Chat currently blocks only models explicitly marked
   `tool_calling="none"`. Unknown local/custom models are labelled as unknown
-  and can be marked manually in Settings; automatic capability probing is not
-  shipped yet.
+  and can be marked manually in Connections; automatic capability probing is
+  not shipped yet.
 - Workspace modes and named Hecate Agent profiles are still roadmap items.
   Tools-on chat uses the selected workspace with the current built-in profile.
 - Tasks remains canonical for full run history, retry/resume, artifacts, and

--- a/docs/rfcs/external-adapter-approvals-v1.md
+++ b/docs/rfcs/external-adapter-approvals-v1.md
@@ -391,7 +391,7 @@ These need resolution before this draft can become v1.0 stable.
    - Status: open
 
 3. **What happens to in-flight grants when an adapter is removed from
-   `BuiltIns`?** Probably orphan and surface in Settings as "stale grants
+   `BuiltIns`?** Probably orphan and surface in Connections as "stale grants
    for unknown adapter `legacy_codex`." Confirm and document.
    - Status: open
 

--- a/docs/rfcs/external-agent-adapters.md
+++ b/docs/rfcs/external-agent-adapters.md
@@ -313,7 +313,7 @@ not a drop-in fit.
 - [x] Cancellation signals the ACP turn and marks the session/run cancelled.
 - [x] Session history is durable across gateway restarts when the chat-session backend is SQLite.
 - [x] Adapter readiness can distinguish missing binaries, auth/billing failures, and versions outside Hecate's tested range.
-- [x] Operator approvals are prompt-first by default and visible through REST, SSE, Settings grants, and Chats review UI.
+- [x] Operator approvals are prompt-first by default and visible through REST, SSE, Connections grants, and Chats review UI.
 - [x] Optional turn, wall-clock, and idle guardrails protect long-lived external-agent sessions.
 
 ## Future Enhancements

--- a/docs/rfcs/unified-chats-and-model-capabilities.md
+++ b/docs/rfcs/unified-chats-and-model-capabilities.md
@@ -134,7 +134,7 @@ Automatic probes should:
    load.
 5. Persist results as `source="probe"` with timestamp, provider, model, probe
    status, and any safe error summary.
-6. Surface probe state in Settings and the model picker: unknown, testing,
+6. Surface probe state in Connections and the model picker: unknown, testing,
    tools supported, no tools, failed.
 7. Let operators disable automatic probes globally or per provider/model.
 
@@ -201,7 +201,7 @@ For `runtime_kind="agent"` the first user message:
 
 1. Validates that tools are not explicitly disabled for the selected model
    (`tool_calling!="none"`). Unknown models are allowed by default for now;
-   Settings provides the operator-facing tools on/off switch.
+   Connections provides the operator-facing tools on/off switch.
 2. Applies the selected Hecate Agent profile.
 3. Creates a visible task with `execution_kind="agent_loop"`.
 4. Marks the task origin as `origin_kind="agent_chat"` and
@@ -236,7 +236,7 @@ If tools are explicitly disabled for the selected model, the message endpoint re
 The UI copy is:
 
 ```text
-Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.
+Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Connections.
 ```
 
 ## Workspace Modes
@@ -320,7 +320,7 @@ Hecate Chat | External Agent
   / trace metadata and model-chat persistence.
 - **tools on** — Hecate Agent. This is the default. The selected
   provider/model enters Hecate's native task runtime unless the model is
-  explicitly marked "tools off" in Settings.
+  explicitly marked "tools off" in Connections.
 
 ### Hecate Agent
 
@@ -340,7 +340,7 @@ Shows:
 
 Send is disabled unless a workspace is selected. If the selected model has
 `tool_calling="none"`, the tools-on send path is disabled and the operator can
-either turn tools off for direct model chat or enable tools in Settings.
+either turn tools off for direct model chat or enable tools in Connections.
 
 When a Hecate Agent task-backed segment is running, provider/model controls are
 locked to that segment's snapshot and the chat composer treats the whole

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -521,7 +521,7 @@ candidate is paired with the route reason (`requested_model`, `pinned_provider`,
 `global_default_model`, etc.); skipped candidates carry `skip_reason` values
 such as `policy_denied`, `budget_denied`, `provider_rate_limited`,
 `provider_less_stable`, or `preflight_price_missing`. This keeps the operator
-debugging path consistent: Providers explains whether a route is possible now,
+debugging path consistent: Connections explains whether a route is possible now,
 and Observability explains how a specific request moved through the candidates.
 
 ### `GET /hecate/v1/settings/providers/local-discovery`
@@ -613,7 +613,7 @@ GET /v1/models
 `capabilities.tool_calling` is one of `unknown`, `none`, `basic`, or
 `parallel`. Hecate Agent treats tools as on by default and only blocks a model
 when the effective value is `none`. Local/custom models often report
-`unknown`; operators can use Settings → Model capabilities to explicitly turn
+`unknown`; operators can use Connections → Model capabilities to explicitly turn
 tools on or off for a provider/model pair.
 
 `metadata.readiness` is the backend-owned provider/model readiness snapshot for
@@ -749,7 +749,7 @@ GET /hecate/v1/agent-adapters
 the first semver-shaped token from stdout; it is absent when the adapter is
 missing or when the binary does not print a recognisable version string.
 `version_outside_range` is `true` when both `version` and `supported_range`
-are present and the version does not satisfy the constraint — the Settings UI
+are present and the version does not satisfy the constraint — the Connections UI
 shows an amber "outside tested range" chip in that case.
 
 `auth_status` is a lightweight dashboard hint, not a full login check. Values:
@@ -774,7 +774,7 @@ until an adapter can supply structured usage.
 
 Re-runs discovery for one adapter, then performs the same end-to-end ACP probe
 as `/health`. The response includes the fresh catalog row plus the health
-result, so UIs can update a single Settings row after the operator logs in or
+result, so UIs can update a single Connections row after the operator logs in or
 installs a missing dependency.
 
 ```json
@@ -1339,7 +1339,7 @@ Hecate Agent-specific errors:
 | `409` | `agent_chat.session_stopping` | The session is still cancelling or closing; retry after it settles. |
 | `409` | `agent_chat.session_not_running` | A stop request was issued when no run was active. |
 | `422` | `model_not_configured` | The selected model is not currently reported by the selected provider. Choose a discovered model or refresh/fix provider discovery. |
-| `422` | `agent_chat.model_capability_required` | Tools are explicitly disabled for the selected model. Turn tools off for direct model chat or enable tools in Settings. |
+| `422` | `agent_chat.model_capability_required` | Tools are explicitly disabled for the selected model. Turn tools off for direct model chat or enable tools in Connections. |
 
 Client note: browser/operator clients may queue a prompt locally when they
 receive or predict `agent_chat.agent_session_busy`, but the server still

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,7 @@ Approvals are safety gates, not a sandbox.
 
 - Native task approvals block the run until the operator approves or rejects.
 - External-agent approvals are prompt-first by default when the adapter asks for permission.
-- Durable external-agent grants can be reviewed and revoked from Settings.
+- Durable external-agent grants can be reviewed and revoked from Connections.
 - Auto-approval modes are dangerous for interactive use because they let tool requests proceed without operator review.
 
 Review broad grants carefully, especially workspace-wide or adapter-wide grants for file writes, shell commands, Git commands, and network access.

--- a/internal/api/error_mapping.go
+++ b/internal/api/error_mapping.go
@@ -240,13 +240,13 @@ func gatewayErrorAction(code string) string {
 	case errCodePriceMissing:
 		return "Import or add a pricebook entry before routing cloud traffic for this model."
 	case errCodeProviderAuthFailed:
-		return "Update the provider credentials, then use Providers to test readiness again."
+		return "Update the provider credentials, then use Connections to test readiness again."
 	case errCodeProviderRateLimited:
 		return "Wait for the provider cooldown, reduce concurrency, or choose another provider/model."
 	case errCodeProviderUnavailable:
 		return "Check provider health, endpoint URL, local server status, or fail over to another provider."
 	case errCodeRouteImpossible:
-		return "Open Providers to inspect readiness checks, discover models, or enable a routable provider."
+		return "Open Connections to inspect readiness checks, discover models, or enable a routable provider."
 	case errCodeUnsupportedModel:
 		return "Choose a discovered model for the selected provider, or switch provider routing back to Auto."
 	case errCodeForbidden:

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -36,7 +36,7 @@ func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
 	if strings.Contains(message, "not available") || strings.Contains(message, "not configured") {
 		details := ErrorDetails{
 			UserMessage:    "The selected model is not available from the selected provider.",
-			OperatorAction: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",
+			OperatorAction: "Choose a discovered model, refresh provider status, or open Connections to fix model discovery.",
 		}
 		var readinessErr modelReadinessError
 		if asModelReadinessError(err, &readinessErr) {
@@ -78,7 +78,7 @@ func modelReadinessErrorDetails(readiness gateway.ProviderModelReadiness) ErrorD
 		details.UserMessage = readiness.Message
 	}
 	if details.OperatorAction == "" {
-		details.OperatorAction = "Choose a discovered model, refresh provider status, or open Providers to fix model discovery."
+		details.OperatorAction = "Choose a discovered model, refresh provider status, or open Connections to fix model discovery."
 	}
 	return details
 }

--- a/internal/api/handler_agent_chat_errors.go
+++ b/internal/api/handler_agent_chat_errors.go
@@ -100,7 +100,7 @@ func writeAgentChatRuntimeMismatch(w http.ResponseWriter, message string) {
 func writeAgentChatAdapterNotFound(w http.ResponseWriter, adapterID string) {
 	WriteErrorDetails(w, http.StatusBadRequest, errCodeAgentAdapterNotFound, fmt.Sprintf("agent adapter %q not found", adapterID), ErrorDetails{
 		UserMessage:    "The selected external agent is not configured.",
-		OperatorAction: "Open Settings and test the external agent adapter, or choose another agent.",
+		OperatorAction: "Open Connections and test the external agent adapter, or choose another agent.",
 	})
 }
 

--- a/internal/api/handler_agent_chat_hecate.go
+++ b/internal/api/handler_agent_chat_hecate.go
@@ -52,7 +52,7 @@ func (h *Handler) handleCreateHecateAgentChatMessage(w http.ResponseWriter, r *h
 		caps = resolved
 	}
 	if !modelcaps.ToolCapable(caps) {
-		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Settings.", ErrorDetails{
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Connections.", ErrorDetails{
 			Fields: map[string]any{
 				"provider":     session.Provider,
 				"model":        session.Model,

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -190,9 +190,9 @@ func defaultErrorAction(code string) string {
 	case errCodeAgentSessionBusy:
 		return "Open the backing task, resolve the pending approval, or stop the run before sending another message."
 	case errCodeModelCapability:
-		return "Turn tools off for direct model chat, test the model, or enable tool support in Settings."
+		return "Turn tools off for direct model chat, test the model, or enable tool support in Connections."
 	case errCodeModelNotConfigured:
-		return "Choose a discovered model, refresh provider status, or open Providers to fix model discovery."
+		return "Choose a discovered model, refresh provider status, or open Connections to fix model discovery."
 	case errCodeWorkspaceRequired:
 		return "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path."
 	case errCodeModelRequired:
@@ -202,7 +202,7 @@ func defaultErrorAction(code string) string {
 	case errCodeRuntimeMismatch:
 		return "Start a new chat or switch back to the runtime that created this session."
 	case errCodeAgentAdapterNotFound:
-		return "Open Settings and test the external agent adapter, or choose another agent."
+		return "Open Connections and test the external agent adapter, or choose another agent."
 	case errCodeSessionStopping:
 		return "Wait a moment, then retry the action."
 	case errCodeSessionNotRunning:

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -1150,7 +1150,7 @@ func providerReadinessOperatorAction(name, reason string) string {
 		return "Refresh provider status after configuration or startup settles."
 	default:
 		if name == "routing" {
-			return "Open Providers to inspect readiness checks and repair the blocked dependency."
+			return "Open Connections to inspect readiness checks and repair the blocked dependency."
 		}
 		return ""
 	}

--- a/ui/e2e/admin.spec.ts
+++ b/ui/e2e/admin.spec.ts
@@ -8,12 +8,12 @@ test.beforeEach(async ({ page }) => {
   await page.waitForSelector("text=Pricing");
 });
 
-test("renders the settings tabs (Model capabilities / Pricing / Retention)", async ({ page }) => {
-  for (const tab of ["Model capabilities", "Pricing", "Retention"]) {
+test("renders the settings tabs (Pricing / Retention)", async ({ page }) => {
+  for (const tab of ["Pricing", "Retention"]) {
     await expect(page.getByRole("button", { name: tab })).toBeVisible();
   }
-  // Removed tabs: Policy, MCP Cache, Tenants, Keys.
-  for (const removed of ["Policy", "MCP Cache", "Tenants", "Keys", "Balances", "Usage", "Clients"]) {
+  // Removed or relocated tabs: readiness lives in Connections; policy/cache/keys/costs live elsewhere.
+  for (const removed of ["Model capabilities", "Policy", "MCP Cache", "Tenants", "Keys", "Balances", "Usage", "Clients"]) {
     await expect(page.getByRole("button", { name: removed })).toHaveCount(0);
   }
 });

--- a/ui/e2e/admin.spec.ts
+++ b/ui/e2e/admin.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "./fixtures";
 
-// Settings workspace. Tabs: Model capabilities / Pricing / Retention.
+// Settings workspace. Tabs: Pricing / Retention.
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -230,7 +230,7 @@ function AuthenticatedShell({
               {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} onOpenTrace={openTraceFromChat} />}
               {activeWorkspace === "providers"     && <ProvidersView actions={actions} state={state} />}
               {activeWorkspace === "costs"         && <CostsView actions={actions} state={state} />}
-              {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} onNavigate={onSelectWorkspace} />}
+              {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} />}
             </Suspense>
           </div>
         </main>

--- a/ui/src/app/runtimeConsoleChatHelpers.test.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.test.ts
@@ -98,7 +98,7 @@ describe("humanizeChatError", () => {
     expect(humanizeChatError("workspace is required"))
       .toBe("Choose a workspace before using Hecate Chat tools or External Agent.");
     expect(humanizeChatError("model does not support tools"))
-      .toBe("This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Settings → Model capabilities.");
+      .toBe("This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.");
     expect(humanizeChatError('route request: no provider supports explicit model "gpt-5.4-mini"'))
       .toBe("No configured provider can route to gpt-5.4-mini. Choose another model or open Connections to repair provider readiness.");
     expect(humanizeChatError("no routable model for selected provider"))

--- a/ui/src/app/runtimeConsoleChatHelpers.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.ts
@@ -31,7 +31,7 @@ export function humanizeChatError(raw: string): string {
     return "Choose a workspace before using Hecate Chat tools or External Agent.";
   }
   if (/tool.?calling.*(unknown|none|unavailable|not supported)|model.*does not support.*tools?/i.test(raw)) {
-    return "This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Settings → Model capabilities.";
+    return "This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.";
   }
   const explicitModel = raw.match(/no provider supports explicit model ["“]?([^"”]+)["”]?/i);
   if (explicitModel) {

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -2113,7 +2113,7 @@ describe("humanizeChatError", () => {
     expect(humanizeChatError("workspace is required"))
       .toBe("Choose a workspace before using Hecate Chat tools or External Agent.");
     expect(humanizeChatError("tool calling support is unknown"))
-      .toBe("This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Settings → Model capabilities.");
+      .toBe("This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.");
     expect(humanizeChatError('route request: no provider supports explicit model "gpt-5.4-mini"'))
       .toBe("No configured provider can route to gpt-5.4-mini. Choose another model or open Connections to repair provider readiness.");
     expect(humanizeChatError("no routable model for selected provider"))

--- a/ui/src/features/chats/AgentApprovalModal.test.tsx
+++ b/ui/src/features/chats/AgentApprovalModal.test.tsx
@@ -104,7 +104,7 @@ describe("AgentApprovalModal", () => {
     const user = userEvent.setup();
 
     // Pick the broad scope.
-    await user.click(screen.getByTestId("agent-approval-modal-scope-adapter_tool"));
+    await user.click(await screen.findByTestId("agent-approval-modal-scope-adapter_tool"));
     expect(screen.getByTestId("agent-approval-modal-broad-warning")).toBeTruthy();
 
     // First submit click only arms — must not have called onResolve yet.

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -104,7 +104,7 @@ export function HecateToolsToggle({
   onChange: (enabled: boolean) => void;
 }) {
   const toolsOnTitle = toolsDisabledForModel
-    ? "Tools are disabled for this model in Settings. Enable them there or turn tools off for direct model chat."
+    ? "Tools are disabled for this model in Connections. Enable them there or turn tools off for direct model chat."
     : "Use Hecate's task runtime with tools, approvals, artifacts, and telemetry.";
   const title = enabled ? toolsOnTitle : "Chat directly with the selected model. No task run or tools.";
   return (

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2393,7 +2393,7 @@ describe("ChatView error display", () => {
     const openTrace = vi.fn();
     const { state, actions } = setup({
       chatError: "Incorrect API key provided",
-      chatErrorAction: "Rotate the provider key in Settings, then test readiness again.",
+      chatErrorAction: "Rotate the provider key in Connections, then test readiness again.",
       chatErrorCode: "provider_auth_failed",
       chatErrorRequestID: "req_1234567890abcdef",
       chatErrorStatus: 502,
@@ -2402,7 +2402,7 @@ describe("ChatView error display", () => {
     render(<ChatView state={state} actions={actions} onOpenTrace={openTrace} />);
     expect(screen.getByText("Provider credentials failed")).toBeTruthy();
     expect(screen.getByText("502 · provider_auth_failed")).toBeTruthy();
-    expect(screen.getByText(/Rotate the provider key in Settings/)).toBeTruthy();
+    expect(screen.getByText(/Rotate the provider key in Connections/)).toBeTruthy();
     expect(screen.getByText("req_123456")).toBeTruthy();
     expect(screen.getByText("trace_abcd")).toBeTruthy();
     screen.getByRole("button", { name: "Open trace" }).click();

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1231,7 +1231,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               lineHeight: 1.45,
             }}>
               <span>
-                Tools are disabled for this model in Connections. Turn tools off for direct chat, or enable tools in Model capabilities.
+                Tools are disabled for this model in Connections. Turn tools off for direct chat, or enable tools in Connections → Model capabilities.
               </span>
               <button
                 type="button"

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1231,7 +1231,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               lineHeight: 1.45,
             }}>
               <span>
-                Tools are disabled for this model in Settings. Turn tools off for direct chat, or enable tools in Model capabilities.
+                Tools are disabled for this model in Connections. Turn tools off for direct chat, or enable tools in Model capabilities.
               </span>
               <button
                 type="button"

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -3,6 +3,7 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { providerFleetRepairHint } from "../../lib/provider-readiness";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
 import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
+import { ModelCapabilitiesSection } from "./ModelCapabilitiesSection";
 
 type Props = {
   state: RuntimeConsoleViewModel["state"];
@@ -41,8 +42,8 @@ function SectionHeader({
 
 // ConnectionsPanel gathers the external-agent setup surfaces that sit next
 // to model-provider CRUD in the Connections workspace. It intentionally
-// remains exported for reuse by ProvidersView while the settings-only tabs
-// above stay focused on model capabilities, pricing, and retention.
+// remains exported for reuse by ProvidersView while Settings stays focused
+// on pricing, retention, and other non-connection configuration.
 //
 // Grants and adapter health are lazy-loaded on panel mount — operators
 // rarely visit this surface, so we don't fetch on every dashboard
@@ -140,6 +141,8 @@ export function ConnectionsPanel({
   return (
     <>
       {showProviderSummary && <ModelProviderConnectionsSection state={state} onNavigate={onNavigate} />}
+
+      <ModelCapabilitiesSection state={state} actions={actions} />
 
       {rememberedAnthropicProvider && (
         <AnthropicProviderKeyCard
@@ -438,7 +441,7 @@ function AdapterStatusSection({ state, actions }: Props) {
             loading={Boolean(state.agentAdapterHealthLoadingByID.get(adapter.id))}
             onSaveCredential={(value) => actions.setAgentAdapterCredential(adapter.id, value, "CLAUDE_CODE_OAUTH_TOKEN")}
             onDeleteCredential={() => actions.deleteAgentAdapterCredential(adapter.id, "CLAUDE_CODE_OAUTH_TOKEN")}
-            onCopyCommand={() => void actions.copyCommand(claudeCodeSettingsTokenCommand(adapter))}
+            onCopyCommand={() => void actions.copyCommand(claudeCodeSetupTokenCommand(adapter))}
           />
         ))}
       </div>
@@ -446,7 +449,7 @@ function AdapterStatusSection({ state, actions }: Props) {
   );
 }
 
-function claudeCodeSettingsTokenCommand(adapter: AgentAdapterRecord): string {
+function claudeCodeSetupTokenCommand(adapter: AgentAdapterRecord): string {
   const command = adapter.claude_code_cli?.command;
   if (command) return `${command} setup-token`;
   return "npx -y @anthropic-ai/claude-code setup-token";

--- a/ui/src/features/connections/ModelCapabilitiesSection.tsx
+++ b/ui/src/features/connections/ModelCapabilitiesSection.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useState, type ReactNode } from "react";
+import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import type { ModelRecord } from "../../types/runtime";
+
+type Props = {
+  state: RuntimeConsoleViewModel["state"];
+  actions: RuntimeConsoleViewModel["actions"];
+};
+
+function SectionHeader({
+  title,
+  description,
+  meta,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  meta?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 12, marginBottom: 12 }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", marginBottom: description ? 3 : 0 }}>{title}</div>
+        {description && (
+          <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>{description}</div>
+        )}
+      </div>
+      {meta && (
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)", whiteSpace: "nowrap" }}>{meta}</span>
+      )}
+      {actions && <div style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center" }}>{actions}</div>}
+    </div>
+  );
+}
+
+export function ModelCapabilitiesSection({ state, actions }: Props) {
+  const [query, setQuery] = useState("");
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return [...state.models]
+      .filter((model) => {
+        if (!q) return true;
+        const provider = model.metadata?.provider ?? "";
+        return model.id.toLowerCase().includes(q) || provider.toLowerCase().includes(q);
+      })
+      .sort((a, b) => {
+        const left = `${a.metadata?.provider ?? ""}/${a.id}`;
+        const right = `${b.metadata?.provider ?? ""}/${b.id}`;
+        return left.localeCompare(right);
+      });
+  }, [query, state.models]);
+
+  return (
+    <div className="card" style={{ padding: "14px 16px", marginBottom: 24 }} data-testid="connections-model-capabilities">
+      <SectionHeader
+        title="Model capabilities"
+        description="Control whether Hecate should try tools for each discovered model. Tools are on by default unless a model is explicitly marked off; use this when a local/custom model fails tool calls or when you want direct model chat only."
+        meta={`${rows.length} model${rows.length === 1 ? "" : "s"}`}
+      />
+
+      <div style={{ marginBottom: 14 }}>
+        <label style={{ display: "block", fontSize: 11, color: "var(--t3)", marginBottom: 6 }} htmlFor="model-capability-search">
+          Filter by model or provider
+        </label>
+        <input
+          id="model-capability-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="ollama, qwen, gpt..."
+          style={{
+            width: "100%",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--bg2)",
+            color: "var(--t0)",
+            fontSize: 12,
+            padding: "8px 10px",
+          }}
+        />
+      </div>
+
+      {rows.length === 0 ? (
+        <div style={{ padding: "20px", textAlign: "center", color: "var(--t3)", fontSize: 12 }}>
+          No models discovered yet. Add or start a provider, then refresh the dashboard.
+        </div>
+      ) : (
+        <div style={{ overflow: "hidden", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }} data-testid="model-capabilities-list">
+          {rows.map((model, index) => (
+            <ModelCapabilityRow
+              key={`${model.metadata?.provider ?? "unknown"}:${model.id}`}
+              model={model}
+              divider={index < rows.length - 1}
+              onToolsChange={(enabled) => {
+                const provider = model.metadata?.provider ?? "";
+                if (!provider) return;
+                void actions.upsertModelCapabilityOverride({
+                  provider,
+                  model: model.id,
+                  tool_calling: enabled ? "basic" : "none",
+                  streaming: model.metadata?.capabilities?.streaming,
+                  max_context_tokens: model.metadata?.capabilities?.max_context_tokens,
+                  note: enabled ? "Tools enabled from Connections." : "Tools disabled from Connections.",
+                });
+              }}
+              onClear={() => {
+                const provider = model.metadata?.provider ?? "";
+                if (!provider) return;
+                void actions.deleteModelCapabilityOverride(provider, model.id);
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModelCapabilityRow({
+  model,
+  divider,
+  onToolsChange,
+  onClear,
+}: {
+  model: ModelRecord;
+  divider: boolean;
+  onToolsChange: (enabled: boolean) => void;
+  onClear: () => void;
+}) {
+  const capabilities = model.metadata?.capabilities;
+  const provider = model.metadata?.provider ?? "unknown";
+  const toolCalling = capabilities?.tool_calling ?? "unknown";
+  const source = capabilities?.source ?? "unknown";
+  const toolsEnabled = toolCalling !== "none";
+  const toolTone: ChipTone = toolsEnabled ? "green" : "red";
+  const clearDisabled = source !== "operator_override";
+
+  return (
+    <div
+      data-testid={`model-capability-row-${provider}-${model.id}`}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "12px 14px",
+        borderBottom: divider ? "1px solid var(--border)" : "none",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 3 }}>
+          <span style={{ fontSize: 12, fontWeight: 500, color: "var(--t0)" }}>{model.id}</span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>·</span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t2)" }}>{provider}</span>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: chipColor(toolTone),
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            tools {toolsEnabled ? "on" : "off"}
+          </span>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+          <span>source <span style={{ color: "var(--t1)" }}>{source}</span></span>
+          {capabilities?.streaming !== undefined && <span>streaming <span style={{ color: "var(--t1)" }}>{capabilities.streaming ? "yes" : "no"}</span></span>}
+          {capabilities?.max_context_tokens !== undefined && <span>context <span style={{ color: "var(--t1)" }}>{capabilities.max_context_tokens.toLocaleString()}</span></span>}
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", alignItems: "center", gap: 6 }}>
+        <div
+          role="group"
+          aria-label={`Tools for ${model.id}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            border: "1px solid var(--border)",
+            borderRadius: "999px",
+            overflow: "hidden",
+            background: "var(--bg0)",
+            height: 30,
+          }}
+        >
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            aria-pressed={toolsEnabled}
+            onClick={() => onToolsChange(true)}
+            style={{
+              border: 0,
+              borderRadius: 0,
+              width: 70,
+              padding: "4px 0",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              background: toolsEnabled ? "var(--teal-bg)" : "transparent",
+              color: toolsEnabled ? "var(--teal)" : "var(--t3)",
+              justifyContent: "center",
+            }}
+          >
+            tools on
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            aria-pressed={!toolsEnabled}
+            onClick={() => onToolsChange(false)}
+            style={{
+              border: 0,
+              borderLeft: "1px solid var(--border)",
+              borderRadius: 0,
+              width: 70,
+              padding: "4px 0",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              background: !toolsEnabled ? "var(--bg3)" : "transparent",
+              color: !toolsEnabled ? "var(--t0)" : "var(--t3)",
+              justifyContent: "center",
+            }}
+          >
+            tools off
+          </button>
+        </div>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onClear} disabled={clearDisabled}>
+          Clear override
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ChipTone = "green" | "amber" | "red" | "muted";
+
+function chipColor(tone: ChipTone): string {
+  if (tone === "green") return "var(--green)";
+  if (tone === "amber") return "var(--amber)";
+  if (tone === "red") return "var(--red)";
+  return "var(--t3)";
+}

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -25,19 +25,20 @@ beforeEach(() => {
 // gating and the MCP cache was pure informational stats). Balances and
 // Usage live in the Costs workspace.
 describe("SettingsView tabs", () => {
-  it("renders Model capabilities / Pricing / Retention", () => {
+  it("renders Pricing / Retention", () => {
     const { state, actions } = setup();
     render(<SettingsView state={state} actions={actions} />);
-    for (const tab of ["Model capabilities", "Pricing", "Retention"]) {
+    for (const tab of ["Pricing", "Retention"]) {
       expect(screen.getByRole("button", { name: tab })).toBeTruthy();
     }
     expect(screen.queryByRole("button", { name: "Connections" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Model capabilities" })).toBeNull();
   });
 
-  it("starts on the first visible tab (Model capabilities)", () => {
+  it("starts on the first visible tab (Pricing)", () => {
     const { state, actions } = setup();
     render(<SettingsView state={state} actions={actions} />);
-    expect(screen.getByText(/Control whether Hecate should try tools for each model/i)).toBeTruthy();
+    expect(screen.getByText(/Manage cloud-model pricebook entries/i)).toBeTruthy();
   });
 
   it("switches to retention tab on click", async () => {
@@ -45,91 +46,6 @@ describe("SettingsView tabs", () => {
     render(<SettingsView state={state} actions={actions} />);
     await user.click(screen.getByRole("button", { name: "Retention" }));
     expect(await screen.findByText(/Subsystems to prune/i)).toBeTruthy();
-  });
-});
-
-describe("SettingsView model capabilities tab", () => {
-  const modelState = {
-    models: [
-      {
-        id: "qwen2.5-coder",
-        owned_by: "ollama",
-        metadata: {
-          provider: "ollama",
-          provider_kind: "local",
-          capabilities: { tool_calling: "unknown", streaming: true, source: "provider" },
-        },
-      },
-      {
-        id: "gpt-4o-mini",
-        owned_by: "openai",
-        metadata: {
-          provider: "openai",
-          provider_kind: "cloud",
-          capabilities: { tool_calling: "parallel", streaming: true, source: "catalog" },
-        },
-      },
-    ],
-  };
-
-  it("renders capability rows with source and tool support", async () => {
-    const { state, actions, user } = setup(modelState);
-    render(<SettingsView state={state} actions={actions} />);
-    await user.click(screen.getByRole("button", { name: "Model capabilities" }));
-
-    expect(await screen.findByTestId("model-capabilities-list")).toBeTruthy();
-    expect(screen.getByText("qwen2.5-coder")).toBeTruthy();
-    expect(screen.getAllByText("tools on").length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("saves the tools switch for the selected provider/model", async () => {
-    const upsertModelCapabilityOverride = vi.fn(async () => true);
-    const { state, actions, user } = setup(modelState, { upsertModelCapabilityOverride });
-    render(<SettingsView state={state} actions={actions} />);
-    await user.click(screen.getByRole("button", { name: "Model capabilities" }));
-    const row = await screen.findByTestId("model-capability-row-ollama-qwen2.5-coder");
-
-    await user.click(within(row).getByRole("button", { name: "tools on" }));
-
-    expect(upsertModelCapabilityOverride).toHaveBeenCalledWith(expect.objectContaining({
-      provider: "ollama",
-      model: "qwen2.5-coder",
-      tool_calling: "basic",
-    }));
-  });
-
-  it("saves and clears operator overrides", async () => {
-    const upsertModelCapabilityOverride = vi.fn(async () => true);
-    const deleteModelCapabilityOverride = vi.fn(async () => true);
-    const { state, actions, user } = setup(
-      {
-        models: [
-          {
-            id: "local-tools",
-            owned_by: "ollama",
-            metadata: {
-              provider: "ollama",
-              provider_kind: "local",
-              capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
-            },
-          },
-        ],
-      },
-      { upsertModelCapabilityOverride, deleteModelCapabilityOverride },
-    );
-    render(<SettingsView state={state} actions={actions} />);
-    await user.click(screen.getByRole("button", { name: "Model capabilities" }));
-    const row = await screen.findByTestId("model-capability-row-ollama-local-tools");
-
-    await user.click(within(row).getByRole("button", { name: "tools off" }));
-    await user.click(within(row).getByRole("button", { name: "Clear override" }));
-
-    expect(upsertModelCapabilityOverride).toHaveBeenCalledWith(expect.objectContaining({
-      provider: "ollama",
-      model: "local-tools",
-      tool_calling: "none",
-    }));
-    expect(deleteModelCapabilityOverride).toHaveBeenCalledWith("ollama", "local-tools");
   });
 });
 
@@ -180,6 +96,29 @@ describe("SettingsView retention tab", () => {
 // features/costs/CostsView.test.tsx for the equivalent rendering tests.
 
 describe("Connections external-agent panel", () => {
+  const modelCapabilityState = {
+    models: [
+      {
+        id: "qwen2.5-coder",
+        owned_by: "ollama",
+        metadata: {
+          provider: "ollama",
+          provider_kind: "local",
+          capabilities: { tool_calling: "unknown", streaming: true, source: "provider" },
+        },
+      },
+      {
+        id: "gpt-4o-mini",
+        owned_by: "openai",
+        metadata: {
+          provider: "openai",
+          provider_kind: "cloud",
+          capabilities: { tool_calling: "parallel", streaming: true, source: "catalog" },
+        },
+      },
+    ],
+  };
+
   it("summarizes model provider connections and links to Connections when requested", async () => {
     const onNavigate = vi.fn();
     const { state, actions, user } = setup({
@@ -228,6 +167,66 @@ describe("Connections external-agent panel", () => {
 
     await user.click(within(card).getByRole("button", { name: "Open Connections" }));
     expect(onNavigate).toHaveBeenCalledWith("providers");
+  });
+
+  it("renders model capabilities inside Connections", async () => {
+    const { state, actions } = setup(modelCapabilityState);
+    render(<ConnectionsPanel state={state} actions={actions} />);
+
+    expect(await screen.findByTestId("connections-model-capabilities")).toBeTruthy();
+    expect(await screen.findByTestId("model-capabilities-list")).toBeTruthy();
+    expect(screen.getByText("qwen2.5-coder")).toBeTruthy();
+    expect(screen.getAllByText("tools on").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("saves the model tools switch from Connections", async () => {
+    const upsertModelCapabilityOverride = vi.fn(async () => true);
+    const { state, actions, user } = setup(modelCapabilityState, { upsertModelCapabilityOverride });
+    render(<ConnectionsPanel state={state} actions={actions} />);
+    const row = await screen.findByTestId("model-capability-row-ollama-qwen2.5-coder");
+
+    await user.click(within(row).getByRole("button", { name: "tools on" }));
+
+    expect(upsertModelCapabilityOverride).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "ollama",
+      model: "qwen2.5-coder",
+      tool_calling: "basic",
+      note: "Tools enabled from Connections.",
+    }));
+  });
+
+  it("saves and clears model capability overrides from Connections", async () => {
+    const upsertModelCapabilityOverride = vi.fn(async () => true);
+    const deleteModelCapabilityOverride = vi.fn(async () => true);
+    const { state, actions, user } = setup(
+      {
+        models: [
+          {
+            id: "local-tools",
+            owned_by: "ollama",
+            metadata: {
+              provider: "ollama",
+              provider_kind: "local",
+              capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
+            },
+          },
+        ],
+      },
+      { upsertModelCapabilityOverride, deleteModelCapabilityOverride },
+    );
+    render(<ConnectionsPanel state={state} actions={actions} />);
+    const row = await screen.findByTestId("model-capability-row-ollama-local-tools");
+
+    await user.click(within(row).getByRole("button", { name: "tools off" }));
+    await user.click(within(row).getByRole("button", { name: "Clear override" }));
+
+    expect(upsertModelCapabilityOverride).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "ollama",
+      model: "local-tools",
+      tool_calling: "none",
+      note: "Tools disabled from Connections.",
+    }));
+    expect(deleteModelCapabilityOverride).toHaveBeenCalledWith("ollama", "local-tools");
   });
 
   it("fires listAgentChatGrants when the tab opens", async () => {

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -1,6 +1,5 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import type { ModelRecord } from "../../types/runtime";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
 import { PricebookTab } from "./PricebookTab";
 
@@ -10,15 +9,14 @@ type Props = {
   onNavigate?: (workspace: "providers" | "runs" | "overview" | "settings" | "chats" | "costs") => void;
 };
 
-// Visible settings sub-tabs. Connections is now a top-level workspace;
-// Settings stays focused on configuration that does not belong to a
-// runtime connection surface. Balances and usage live in the Costs
-// workspace.
-const TABS = ["model_capabilities", "pricebook", "retention"] as const;
+// Visible settings sub-tabs. Connections is now a top-level workspace
+// for provider credentials, model capabilities, and external-agent setup.
+// Settings stays focused on app configuration that does not belong to a
+// runtime connection surface. Balances and usage live in Costs.
+const TABS = ["pricebook", "retention"] as const;
 type Tab = (typeof TABS)[number];
 const TAB_LABELS: Record<Tab, string> = {
   pricebook: "Pricing",
-  model_capabilities: "Model capabilities",
   retention: "Retention",
 };
 
@@ -65,9 +63,8 @@ export function SettingsView({ state, actions }: Props) {
 
       {/* Tab content */}
       <div style={{ flex: 1, overflowY: "auto", padding: 16 }}>
-        {tab === "pricebook"           && <PricebookTab state={state} actions={actions} />}
-        {tab === "model_capabilities" && <ModelCapabilitiesTab state={state} actions={actions} />}
-        {tab === "retention"           && <RetentionTab state={state} actions={actions} />}
+        {tab === "pricebook" && <PricebookTab state={state} actions={actions} />}
+        {tab === "retention" && <RetentionTab state={state} actions={actions} />}
       </div>
     </div>
   );
@@ -100,214 +97,6 @@ function SectionHeader({
   );
 }
 
-
-// ─── Model capabilities tab ───────────────────────────────────────────────────
-
-function ModelCapabilitiesTab({ state, actions }: Props) {
-  const [query, setQuery] = useState("");
-  const rows = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return [...state.models]
-      .filter((model) => {
-        if (!q) return true;
-        const provider = model.metadata?.provider ?? "";
-        return model.id.toLowerCase().includes(q) || provider.toLowerCase().includes(q);
-      })
-      .sort((a, b) => {
-        const left = `${a.metadata?.provider ?? ""}/${a.id}`;
-        const right = `${b.metadata?.provider ?? ""}/${b.id}`;
-        return left.localeCompare(right);
-      });
-  }, [query, state.models]);
-
-  return (
-    <>
-      <SectionHeader
-        title="Model capabilities"
-        description="Control whether Hecate should try tools for each model. Tools are on by default unless a model is explicitly marked off; use the switch when a local/custom model fails tool calls or when you want direct model chat only."
-        meta={`${rows.length} model${rows.length === 1 ? "" : "s"}`}
-      />
-
-      <div className="card" style={{ padding: "12px 14px", marginBottom: 14 }}>
-        <label style={{ display: "block", fontSize: 11, color: "var(--t3)", marginBottom: 6 }} htmlFor="model-capability-search">
-          Filter by model or provider
-        </label>
-        <input
-          id="model-capability-search"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="ollama, qwen, gpt..."
-          style={{
-            width: "100%",
-            border: "1px solid var(--border)",
-            borderRadius: "var(--radius-sm)",
-            background: "var(--bg2)",
-            color: "var(--t0)",
-            fontSize: 12,
-            padding: "8px 10px",
-          }}
-        />
-      </div>
-
-      {rows.length === 0 ? (
-        <div className="card" style={{ padding: "24px", textAlign: "center", color: "var(--t3)", fontSize: 12 }}>
-          No models discovered yet. Add or start a provider, then refresh the dashboard.
-        </div>
-      ) : (
-        <div className="card" style={{ overflow: "hidden" }} data-testid="model-capabilities-list">
-          {rows.map((model, index) => (
-            <ModelCapabilityRow
-              key={`${model.metadata?.provider ?? "unknown"}:${model.id}`}
-              model={model}
-              divider={index < rows.length - 1}
-              onToolsChange={(enabled) => {
-                const provider = model.metadata?.provider ?? "";
-                if (!provider) return;
-                void actions.upsertModelCapabilityOverride({
-                  provider,
-                  model: model.id,
-                  tool_calling: enabled ? "basic" : "none",
-                  streaming: model.metadata?.capabilities?.streaming,
-                  max_context_tokens: model.metadata?.capabilities?.max_context_tokens,
-                  note: enabled ? "Tools enabled from Settings." : "Tools disabled from Settings.",
-                });
-              }}
-              onClear={() => {
-                const provider = model.metadata?.provider ?? "";
-                if (!provider) return;
-                void actions.deleteModelCapabilityOverride(provider, model.id);
-              }}
-            />
-          ))}
-        </div>
-      )}
-    </>
-  );
-}
-
-function ModelCapabilityRow({
-  model,
-  divider,
-  onToolsChange,
-  onClear,
-}: {
-  model: ModelRecord;
-  divider: boolean;
-  onToolsChange: (enabled: boolean) => void;
-  onClear: () => void;
-}) {
-  const capabilities = model.metadata?.capabilities;
-  const provider = model.metadata?.provider ?? "unknown";
-  const toolCalling = capabilities?.tool_calling ?? "unknown";
-  const source = capabilities?.source ?? "unknown";
-  const toolsEnabled = toolCalling !== "none";
-  const toolTone: ChipTone = toolsEnabled ? "green" : "red";
-  const clearDisabled = source !== "operator_override";
-
-  return (
-    <div
-      data-testid={`model-capability-row-${provider}-${model.id}`}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        padding: "12px 14px",
-        borderBottom: divider ? "1px solid var(--border)" : "none",
-      }}
-    >
-      <div style={{ minWidth: 0, flex: 1 }}>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 3 }}>
-          <span style={{ fontSize: 12, fontWeight: 500, color: "var(--t0)" }}>{model.id}</span>
-          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>·</span>
-          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t2)" }}>{provider}</span>
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: 10,
-              color: chipColor(toolTone),
-              textTransform: "uppercase",
-              letterSpacing: "0.04em",
-            }}
-          >
-            tools {toolsEnabled ? "on" : "off"}
-          </span>
-        </div>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-          <span>source <span style={{ color: "var(--t1)" }}>{source}</span></span>
-          {capabilities?.streaming !== undefined && <span>streaming <span style={{ color: "var(--t1)" }}>{capabilities.streaming ? "yes" : "no"}</span></span>}
-          {capabilities?.max_context_tokens !== undefined && <span>context <span style={{ color: "var(--t1)" }}>{capabilities.max_context_tokens.toLocaleString()}</span></span>}
-        </div>
-      </div>
-      <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", alignItems: "center", gap: 6 }}>
-        <div
-          role="group"
-          aria-label={`Tools for ${model.id}`}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            border: "1px solid var(--border)",
-            borderRadius: "999px",
-            overflow: "hidden",
-            background: "var(--bg0)",
-            height: 30,
-          }}
-        >
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm"
-            aria-pressed={toolsEnabled}
-            onClick={() => onToolsChange(true)}
-            style={{
-              border: 0,
-              borderRadius: 0,
-              width: 70,
-              padding: "4px 0",
-              fontFamily: "var(--font-mono)",
-              fontSize: 10,
-              background: toolsEnabled ? "var(--teal-bg)" : "transparent",
-              color: toolsEnabled ? "var(--teal)" : "var(--t3)",
-              justifyContent: "center",
-            }}
-          >
-            tools on
-          </button>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm"
-            aria-pressed={!toolsEnabled}
-            onClick={() => onToolsChange(false)}
-            style={{
-              border: 0,
-              borderLeft: "1px solid var(--border)",
-              borderRadius: 0,
-              width: 70,
-              padding: "4px 0",
-              fontFamily: "var(--font-mono)",
-              fontSize: 10,
-              background: !toolsEnabled ? "var(--bg3)" : "transparent",
-              color: !toolsEnabled ? "var(--t0)" : "var(--t3)",
-              justifyContent: "center",
-            }}
-          >
-            tools off
-          </button>
-        </div>
-        <button type="button" className="btn btn-ghost btn-sm" onClick={onClear} disabled={clearDisabled}>
-          Clear override
-        </button>
-      </div>
-    </div>
-  );
-}
-
-type ChipTone = "green" | "amber" | "red" | "muted";
-
-function chipColor(tone: ChipTone): string {
-  if (tone === "green") return "var(--green)";
-  if (tone === "amber") return "var(--amber)";
-  if (tone === "red") return "var(--red)";
-  return "var(--t3)";
-}
 
 // ─── Retention tab ────────────────────────────────────────────────────────────
 

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -6,7 +6,6 @@ import { PricebookTab } from "./PricebookTab";
 type Props = {
   state: RuntimeConsoleViewModel["state"];
   actions: RuntimeConsoleViewModel["actions"];
-  onNavigate?: (workspace: "providers" | "runs" | "overview" | "settings" | "chats" | "costs") => void;
 };
 
 // Visible settings sub-tabs. Connections is now a top-level workspace

--- a/ui/src/lib/error-diagnostics.ts
+++ b/ui/src/lib/error-diagnostics.ts
@@ -67,7 +67,7 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
   },
   "agent_chat.model_capability_required": {
     title: "Tools unavailable for this model",
-    action: "Turn tools off for direct model chat, test the model, or enable tool support in Settings.",
+    action: "Turn tools off for direct model chat, test the model, or enable tool support in Connections.",
     tone: "warning",
   },
   "agent_chat.agent_session_busy": {
@@ -87,7 +87,7 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
   },
   "agent_chat.adapter_not_found": {
     title: "External agent is unavailable",
-    action: "Open Settings and test the external agent adapter, or choose another agent.",
+    action: "Open Connections and test the external agent adapter, or choose another agent.",
     tone: "warning",
   },
   "agent_chat.session_stopping": {

--- a/ui/src/lib/error-diagnostics.ts
+++ b/ui/src/lib/error-diagnostics.ts
@@ -62,7 +62,7 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
   },
   model_not_configured: {
     title: "Selected model is unavailable",
-    action: "Choose a discovered model, refresh provider status, or open Providers to fix model discovery.",
+    action: "Choose a discovered model, refresh provider status, or open Connections to fix model discovery.",
     tone: "warning",
   },
   "agent_chat.model_capability_required": {


### PR DESCRIPTION
## Summary

- Move model capability overrides from Settings into the Connections workspace
- Keep Settings focused on Pricing and Retention only
- Align chat repair copy, gateway/API operator actions, and docs so provider/model/external-agent readiness fixes point to Connections
- Update tests so model-capability behavior is covered through Connections instead of Settings

## Verification

- cd ui && bun run typecheck
- cd ui && bun run test -- SettingsView.test.tsx ChatView.test.tsx runtimeConsoleChatHelpers.test.ts useRuntimeConsole.test.tsx
- cd ui && bun run test
- go test ./internal/api ./internal/gateway
- go vet ./internal/api ./internal/gateway