### PR TITLE
fix(readiness): unify provider repair states

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -129,6 +129,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   to a dead-end warning. If the backend provides a suggested replacement model,
   expose it as an action and reset the provider route to "All providers" before
   selecting it, because the suggested model may belong to a different provider.
+- Chat send blockers should flow through `resolveChatSetupRepairState` in
+  `ui/src/lib/chat-setup-readiness.ts`. Keep the empty state, composer notice,
+  and disabled-send copy aligned there instead of adding one-off branches to
+  `ChatView`.
 - Agent Chat readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -37,6 +37,14 @@ The UI should prefer those fields over local guesswork whenever they are
 present; client-side inference is only a fallback for stale sessions or older
 payloads.
 
+The chat setup surface has one repair contract shared by the empty state, the
+composer notice, and disabled-send copy. When a prompt cannot be sent, the UI
+should pick one primary operator action: **Go to Connections**, **Choose
+workspace**, **Enable tools**, **Use suggested model**, or **Open setup** for a
+coding-agent adapter. Avoid adding local one-off blockers in the Chat view; put
+new send blockers behind the shared readiness resolver so the same reason and
+CTA are visible before and after the transcript has messages.
+
 Hecate Chat also has one per-chat **Instructions** field. With tools off, the
 instructions are sent as the direct model turn's `system_prompt`. With tools
 on, the same text becomes the per-task system prompt for the Hecate-owned

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -45,6 +45,12 @@ coding-agent adapter. Avoid adding local one-off blockers in the Chat view; put
 new send blockers behind the shared readiness resolver so the same reason and
 CTA are visible before and after the transcript has messages.
 
+Connections owns the provider repair workflow that backs those chat actions.
+If the chat CTA sends an operator to Connections, the summary card should show
+the same root cause and a concrete first action: add a provider, open the
+blocked provider, or refresh provider/model discovery after the operator starts
+a local runtime or fixes an upstream account.
+
 Hecate Chat also has one per-chat **Instructions** field. With tools off, the
 instructions are sent as the direct model turn's `system_prompt`. With tools
 on, the same text becomes the per-task system prompt for the Hecate-owned

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -265,6 +265,14 @@ and an `operator_action` that can be shown directly in the UI.
 Route reports in the trace inspector reuse the same readiness vocabulary when
 they explain why a provider/model candidate was skipped.
 
+Connections is the canonical repair surface for provider and model readiness.
+The top summary card should tell the operator whether the provider fleet is
+ready for chat or name the next repair, while the provider rows carry the full
+credential, discovery, health, routing, and model-count details. Chats should
+link back to Connections rather than duplicating provider-editing controls,
+except for safe one-click repairs such as accepting a backend-suggested model
+or enabling a model-capability override.
+
 The Chats workspace consumes the same readiness model at composition time. A
 provider can be configured and healthy while the selected model is still not
 routable, usually because discovery reports a different local model set or a

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -266,12 +266,14 @@ Route reports in the trace inspector reuse the same readiness vocabulary when
 they explain why a provider/model candidate was skipped.
 
 Connections is the canonical repair surface for provider and model readiness.
-The top summary card should tell the operator whether the provider fleet is
-ready for chat or name the next repair, while the provider rows carry the full
-credential, discovery, health, routing, and model-count details. Chats should
-link back to Connections rather than duplicating provider-editing controls,
-except for safe one-click repairs such as accepting a backend-suggested model
-or enabling a model-capability override.
+The top summary card tells the operator whether the provider fleet is ready for
+chat or names the next repair, while the provider rows carry the full
+credential, discovery, health, routing, and model-count details. The summary can
+offer safe first-step actions such as **Add provider**, **Open provider**, or
+**Refresh providers**; deeper edits still happen in the provider detail panel.
+Chats link back to Connections rather than duplicating provider-editing
+controls, except for safe one-click repairs such as accepting a
+backend-suggested model or enabling a model-capability override.
 
 The Chats workspace consumes the same readiness model at composition time. A
 provider can be configured and healthy while the selected model is still not

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -608,6 +608,86 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 	}
 }
 
+func TestProviderStatusReadinessContractCoversRepairReasons(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	disabled := false
+	noModelsProvider := &fakeProvider{
+		name:      "emptylocal",
+		noDefault: true,
+		capabilities: providers.Capabilities{
+			Name:            "emptylocal",
+			Kind:            providers.KindLocal,
+			DiscoverySource: "upstream_v1_models",
+		},
+	}
+	selfReferentialProvider := &fakeProvider{
+		name:      "loopback",
+		noDefault: true,
+		baseURL:   "http://127.0.0.1:8765/v1",
+		capabilities: providers.Capabilities{
+			Name: "loopback",
+			Kind: providers.KindLocal,
+		},
+	}
+	disabledProvider := &fakeProvider{
+		name:      "disabled",
+		noDefault: true,
+		enabled:   &disabled,
+		capabilities: providers.Capabilities{
+			Name: "disabled",
+			Kind: providers.KindLocal,
+		},
+	}
+
+	registry := providers.NewRegistry(noModelsProvider, selfReferentialProvider, disabledProvider)
+	providerCatalog := catalog.NewRegistryCatalogWithSelfAddr(registry, nil, "127.0.0.1:8765")
+	budgetStore := governor.NewMemoryBudgetStore()
+	service := gateway.NewService(gateway.Dependencies{
+		Logger:    logger,
+		Router:    router.NewRuleRouter("", providerCatalog),
+		Catalog:   providerCatalog,
+		Governor:  governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, budgetStore, budgetStore),
+		Providers: registry,
+		Pricebook: billing.NewStaticPricebook(config.ProvidersConfig{
+			OpenAICompatible: []config.OpenAICompatibleProviderConfig{
+				{Name: "emptylocal", Kind: "local"},
+				{Name: "loopback", Kind: "local"},
+				{Name: "disabled", Kind: "local"},
+			},
+		}, defaultPricebookForTests()),
+		Tracer: profiler.NewInMemoryTracer(nil),
+	})
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, service, nil, nil, nil))
+	client := newAPITestClient(t, handler)
+
+	response := mustRequestJSON[ProviderStatusResponse](client, http.MethodGet, "/hecate/v1/providers/status", "")
+	emptyLocal := findProviderStatusItem(t, response.Data, "emptylocal")
+	assertReadinessSummary(t, emptyLocal, "blocked", "no_models", true)
+	assertProviderReadinessCheck(t, emptyLocal, "models", "blocked", "no_models")
+	assertProviderReadinessCheck(t, emptyLocal, "routing", "blocked", "no_models")
+
+	loopback := findProviderStatusItem(t, response.Data, "loopback")
+	assertReadinessSummary(t, loopback, "blocked", "provider_unhealthy", true)
+	assertProviderReadinessCheck(t, loopback, "models", "blocked", "self_referential")
+	assertProviderReadinessCheck(t, loopback, "routing", "blocked", "provider_unhealthy")
+
+	disabledItem := findProviderStatusItem(t, response.Data, "disabled")
+	assertReadinessSummary(t, disabledItem, "blocked", "provider_disabled", true)
+	assertProviderReadinessCheck(t, disabledItem, "models", "blocked", "provider_disabled")
+	assertProviderReadinessCheck(t, disabledItem, "routing", "blocked", "provider_disabled")
+}
+
+func findProviderStatusItem(t *testing.T, items []ProviderStatusResponseItem, name string) ProviderStatusResponseItem {
+	t.Helper()
+	for _, item := range items {
+		if item.Name == name {
+			return item
+		}
+	}
+	t.Fatalf("missing provider status item %q in %#v", name, items)
+	return ProviderStatusResponseItem{}
+}
+
 func assertReadinessSummary(t *testing.T, item ProviderStatusResponseItem, status, reason string, wantAction bool) {
 	t.Helper()
 	if item.Readiness.Status != status {
@@ -5886,6 +5966,8 @@ type fakeProvider struct {
 	capsErr      error
 	baseURL      string
 	credential   providers.CredentialState
+	enabled      *bool
+	noDefault    bool
 }
 
 func (p *fakeProvider) Name() string {
@@ -5903,6 +5985,9 @@ func (p *fakeProvider) Kind() providers.Kind {
 }
 
 func (p *fakeProvider) DefaultModel() string {
+	if p.noDefault {
+		return ""
+	}
 	if p.defaultModel != "" {
 		return p.defaultModel
 	}
@@ -5910,6 +5995,13 @@ func (p *fakeProvider) DefaultModel() string {
 		return p.capabilities.DefaultModel
 	}
 	return "gpt-4o-mini"
+}
+
+func (p *fakeProvider) Enabled() bool {
+	if p.enabled != nil {
+		return *p.enabled
+	}
+	return true
 }
 
 func (p *fakeProvider) BaseURL() string {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -534,6 +534,7 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.Readiness.Status != "ok" || item.Readiness.Reason != "ready" {
 				t.Fatalf("openai readiness = %#v, want ok/ready", item.Readiness)
 			}
+			assertReadinessSummary(t, item, "ok", "ready", false)
 			assertProviderReadinessCheck(t, item, "credentials", "ok", "configured")
 			assertProviderReadinessCheck(t, item, "models", "ok", "models_discovered")
 			assertProviderReadinessCheck(t, item, "health", "ok", "healthy")
@@ -553,6 +554,7 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.Readiness.Status != "blocked" || item.Readiness.Reason != "provider_unhealthy" {
 				t.Fatalf("ollama readiness = %#v, want blocked/provider_unhealthy", item.Readiness)
 			}
+			assertReadinessSummary(t, item, "blocked", "provider_unhealthy", true)
 			assertProviderReadinessCheck(t, item, "credentials", "ok", "not_required")
 			assertProviderReadinessCheck(t, item, "health", "blocked", "provider_unhealthy")
 			assertProviderReadinessCheck(t, item, "routing", "blocked", "provider_unhealthy")
@@ -571,6 +573,7 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.Readiness.Status != "blocked" || item.Readiness.Reason != "credential_missing" {
 				t.Fatalf("anthropic readiness = %#v, want blocked/credential_missing", item.Readiness)
 			}
+			assertReadinessSummary(t, item, "blocked", "credential_missing", true)
 			assertProviderReadinessCheck(t, item, "credentials", "blocked", "credential_missing")
 			assertProviderReadinessCheck(t, item, "routing", "blocked", "credential_missing")
 			foundCredentialBlocked = true
@@ -585,6 +588,7 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 			if item.Readiness.Status != "warning" || item.Readiness.Reason != "default_model_only" {
 				t.Fatalf("openrouter readiness = %#v, want warning/default_model_only", item.Readiness)
 			}
+			assertReadinessSummary(t, item, "warning", "default_model_only", true)
 			assertProviderReadinessCheck(t, item, "models", "warning", "default_model_only")
 			assertProviderReadinessCheck(t, item, "routing", "ok", "routable")
 			foundDefaultOnly = true
@@ -601,6 +605,25 @@ func TestProviderStatusReturnsHealthAndDiscoveryFreshness(t *testing.T) {
 	}
 	if !foundDefaultOnly {
 		t.Fatalf("missing default-only provider entry: %#v", response.Data)
+	}
+}
+
+func assertReadinessSummary(t *testing.T, item ProviderStatusResponseItem, status, reason string, wantAction bool) {
+	t.Helper()
+	if item.Readiness.Status != status {
+		t.Fatalf("%s readiness status = %q, want %q", item.Name, item.Readiness.Status, status)
+	}
+	if item.Readiness.Reason != reason {
+		t.Fatalf("%s readiness reason = %q, want %q", item.Name, item.Readiness.Reason, reason)
+	}
+	if item.Readiness.Message == "" {
+		t.Fatalf("%s readiness message is empty", item.Name)
+	}
+	if wantAction && item.Readiness.OperatorAction == "" {
+		t.Fatalf("%s readiness operator_action is empty for status %q", item.Name, status)
+	}
+	if !wantAction && item.Readiness.OperatorAction != "" {
+		t.Fatalf("%s readiness operator_action = %q, want empty", item.Name, item.Readiness.OperatorAction)
 	}
 }
 

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -40,6 +40,18 @@ test("send button becomes enabled when message has content", async ({ page }) =>
   await expect(page.locator("button[type='submit']")).toBeEnabled();
 });
 
+test("empty Hecate Chat points operators to Connections before send", async ({ page }) => {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await mockGatewayAPIs(page);
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Add a model provider or install a supported coding-agent CLI before sending a message.")).toBeVisible();
+  await page.getByRole("button", { name: "Go to Connections" }).click();
+  await expect(page.locator(".hecate-activitybar [aria-current='page']")).toHaveAttribute("aria-label", /Connections/);
+});
+
 test("model picker opens and lists models from mock data", async ({ page }) => {
   await switchToModel(page);
   // Wait for models to load, then open the picker

--- a/ui/e2e/providers.spec.ts
+++ b/ui/e2e/providers.spec.ts
@@ -34,6 +34,60 @@ test("empty state shows the placeholder and an Add provider CTA", async ({ page 
   await expect(page.getByRole("button", { name: /add provider/i }).first()).toBeVisible();
 });
 
+test("readiness repair card opens a blocked provider from Connections", async ({ page }) => {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await mockGatewayAPIs(page, {
+    settingsConfig: {
+      providers: [
+        { id: "anthropic", name: "Anthropic", preset_id: "anthropic", kind: "cloud", protocol: "anthropic", base_url: "https://api.anthropic.com/v1", enabled: true, credential_configured: false },
+      ],
+      tenants: [],
+      api_keys: [],
+      policy_rules: [],
+    },
+  });
+  await page.route("/hecate/v1/providers/status*", route => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      object: "provider_status",
+      data: [
+        {
+          name: "anthropic",
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          credential_ready: false,
+          credential_state: "missing",
+          routing_ready: false,
+          routing_blocked_reason: "credential_missing",
+          models: ["claude-sonnet-4-6"],
+          model_count: 1,
+          readiness: {
+            status: "blocked",
+            reason: "credential_missing",
+            message: "Anthropic needs an API key before Hecate can route requests.",
+            operator_action: "Add or rotate the provider API key in Connections.",
+          },
+          readiness_checks: [
+            { name: "credentials", status: "blocked", reason: "credential_missing", message: "Add credentials before Hecate can route requests to this provider." },
+            { name: "routing", status: "blocked", reason: "credential_missing", message: "Routing is blocked until credentials are configured." },
+          ],
+        },
+      ],
+    }),
+  }));
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  await page.locator(".hecate-activitybar [aria-label^='Connections']").click();
+
+  await expect(page.getByTestId("connections-provider-readiness-meaning")).toContainText("1 provider needs attention");
+  await expect(page.getByText("Next: Add or rotate the provider API key in Connections.")).toBeVisible();
+  await page.getByRole("button", { name: "Open provider" }).click();
+  await expect(page.getByRole("dialog")).toContainText("Anthropic · cloud");
+});
+
 test("Add provider modal opens on the Local tab by default", async ({ page }) => {
   await page.getByRole("button", { name: /add provider/i }).first().click();
   // Ollama is a Local preset — its visibility proves the Local tab is

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -197,7 +197,7 @@ describe("ChatView input", () => {
       ],
     });
     render(<ChatView state={state} actions={actions} />);
-    expect(screen.getByText("No routable model")).toBeTruthy();
+    expect(screen.getByText("No provider configured")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Go to Connections/i })).toBeTruthy();
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
@@ -1073,7 +1073,7 @@ describe("ChatView input", () => {
     render(<ChatView state={state} actions={actions} />);
 
     expect(screen.getByRole("button", { name: "tools on" })).toBeTruthy();
-    expect(screen.getByText(/Tools are disabled for this model/)).toBeTruthy();
+    expect(screen.getAllByText(/Tools are disabled for this model/).length).toBeGreaterThan(0);
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);
 
@@ -1744,7 +1744,7 @@ describe("ChatView external-agent target", () => {
     });
     render(<ChatView state={state} actions={actions} />);
 
-    expect(screen.getByText("Start a chat")).toBeTruthy();
+    expect(screen.getByText("Set up Claude Code")).toBeTruthy();
     expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
     expect(document.querySelector("button[type='submit']")).toBeTruthy();
   });
@@ -2289,7 +2289,8 @@ describe("ChatView external-agent target", () => {
     expect(send.disabled).toBe(true);
   });
 
-  it("explains why Hecate Chat cannot send with tools before workspace selection", () => {
+  it("explains why Hecate Chat cannot send with tools before workspace selection", async () => {
+    const chooseAgentWorkspace = vi.fn(async () => "/tmp/hecate");
     const { state, actions } = setup({
       chatTarget: "agent",
       message: "inspect repo",
@@ -2305,11 +2306,15 @@ describe("ChatView external-agent target", () => {
           },
         },
       ],
-    });
+    }, { chooseAgentWorkspace });
     render(<ChatView state={state} actions={actions} />);
 
-    expect(screen.getByText(/Choose a workspace before sending/)).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Choose workspace" })).toBeTruthy();
+    expect(screen.getAllByText(/Hecate uses the workspace as the working directory/).length).toBeGreaterThan(0);
+    const user = userEvent.setup();
+    const workspaceButtons = screen.getAllByRole("button", { name: "Choose workspace" });
+    expect(workspaceButtons.length).toBeGreaterThan(0);
+    await user.click(workspaceButtons[0]);
+    expect(chooseAgentWorkspace).toHaveBeenCalled();
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);
   });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1073,7 +1073,7 @@ describe("ChatView input", () => {
     render(<ChatView state={state} actions={actions} />);
 
     expect(screen.getByRole("button", { name: "tools on" })).toBeTruthy();
-    expect(screen.getAllByText(/Tools are disabled for this model/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Tools are disabled for this model/)).toBeTruthy();
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);
 
@@ -2309,11 +2309,9 @@ describe("ChatView external-agent target", () => {
     }, { chooseAgentWorkspace });
     render(<ChatView state={state} actions={actions} />);
 
-    expect(screen.getAllByText(/Hecate uses the workspace as the working directory/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Hecate uses the workspace as the working directory/)).toBeTruthy();
     const user = userEvent.setup();
-    const workspaceButtons = screen.getAllByRole("button", { name: "Choose workspace" });
-    expect(workspaceButtons.length).toBeGreaterThan(0);
-    await user.click(workspaceButtons[0]);
+    await user.click(screen.getByRole("button", { name: "Choose workspace" }));
     expect(chooseAgentWorkspace).toHaveBeenCalled();
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -308,7 +308,9 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
     claudeCodeSetupRequired: Boolean(claudeCodePreflight?.blockSend),
   });
   const composerVisible = (isExternalAgentChat || (isHecateChat && hecateChatModelReady)) && !showClaudeCodeEmptyPreflight;
-  const composerRepair = composerVisible ? composerVisibleRepair(chatSetupRepair) : null;
+  const composerRepair = composerVisible && !emptyStateAlreadyShowsRepair(chatSetupRepair, visibleMessages.length)
+    ? composerVisibleRepair(chatSetupRepair)
+    : null;
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const sendDisabled = !state.message.trim()
@@ -2097,6 +2099,7 @@ function ChatEmptyState({
   onTestClaudeCode: () => void;
 }) {
   const hecateModelUnavailable = isHecateChat && (modelRouteUnavailable || Boolean(selectedModelIssue));
+  const setupRepairForEmpty = setupRepair?.action === "enable_tools" ? null : setupRepair;
   const title = claudeCodePreflight
       ? "Set up Claude Code"
       : isAgentChat && selectedAgentUnavailable
@@ -2107,8 +2110,8 @@ function ChatEmptyState({
         ? "Nothing runnable yet"
         : selectedModelIssue
           ? selectedModelIssue.title
-        : setupRepair
-          ? setupRepair.title
+        : setupRepairForEmpty
+          ? setupRepairForEmpty.title
         : hecateModelUnavailable
           ? "No routable model"
         : "Start a chat";
@@ -2122,13 +2125,13 @@ function ChatEmptyState({
         ? "Add a model provider or install a supported coding-agent CLI before sending a message."
         : selectedModelIssue
           ? selectedModelIssue.message
-        : setupRepair
-          ? setupRepair.message
+        : setupRepairForEmpty
+          ? setupRepairForEmpty.message
         : hecateModelUnavailable
           ? "Add a provider with discovered models before sending through Hecate."
         : "Send a message to start this chat.";
-  const emptyRepairAction = setupRepair && !claudeCodePreflight && setupRepair.action !== "enable_tools"
-    ? setupRepair
+  const emptyRepairAction = setupRepairForEmpty && !claudeCodePreflight
+    ? setupRepairForEmpty
     : null;
 
   function runEmptyRepairAction() {
@@ -2497,10 +2500,19 @@ function composerVisibleRepair(repair: ChatSetupRepairState | null): ChatSetupRe
     case "workspace_required":
     case "tools_disabled":
     case "external_agent_unavailable":
+    case "claude_code_setup":
       return repair;
     default:
       return null;
   }
+}
+
+function emptyStateAlreadyShowsRepair(repair: ChatSetupRepairState | null, visibleMessageCount: number): boolean {
+  if (!repair || visibleMessageCount > 0) return false;
+  // The tools-disabled repair needs the composer notice because that notice
+  // owns the capability-write busy/disabled state. Other empty-chat repairs
+  // already render the same copy and CTA in ChatEmptyState.
+  return repair.action !== "enable_tools";
 }
 
 function repairActionIcon(repair: ChatSetupRepairState) {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2486,6 +2486,7 @@ function autoProviderRouteRepairHint(
     action: allLocal
       ? "Start the local provider process, pull or load a model, then refresh Connections."
       : "Open Connections to fix credentials, health, or model discovery, then refresh.",
+    actionKind: "refresh_providers",
     tone: "amber",
   };
 }

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { SyntheticEvent } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
+import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import { providerRepairHint, type ProviderRepairHint } from "../../lib/provider-readiness";
@@ -294,7 +295,20 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
     && !state.activeAgentChatSessionID
     && visibleMessages.length === 0
     && Boolean(claudeCodePreflight?.blockSend);
+  const chatSetupRepair = resolveChatSetupRepairState({
+    target: state.chatTarget,
+    hasConfiguredProviders,
+    modelRouteUnavailable,
+    selectedModelIssue,
+    toolsDisabledForModel: hecateAgentToolsDisabledForModel,
+    workspace: state.agentWorkspace,
+    selectedAgentName: selectedAgent?.name,
+    selectedAgentAvailable: Boolean(selectedAgent?.available),
+    anyAgentAvailable: availableAgents.length > 0,
+    claudeCodeSetupRequired: Boolean(claudeCodePreflight?.blockSend),
+  });
   const composerVisible = (isExternalAgentChat || (isHecateChat && hecateChatModelReady)) && !showClaudeCodeEmptyPreflight;
+  const composerRepair = composerVisible ? composerVisibleRepair(chatSetupRepair) : null;
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const sendDisabled = !state.message.trim()
@@ -1121,6 +1135,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               isExternalAgentChat={isExternalAgentChat}
               claudeCodePreflight={showClaudeCodeEmptyPreflight ? claudeCodePreflight : null}
               claudeCodePreflightLoading={selectedAgentHealthLoading}
+              setupRepair={chatSetupRepair}
               modelRouteUnavailable={modelRouteUnavailable}
               selectedModelIssue={selectedModelIssue}
               agentRouteUnavailable={isExternalAgentChat && agentRouteUnavailable}
@@ -1149,6 +1164,8 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
                 actions.setProviderFilter("auto");
                 actions.setModel(model);
               }}
+              onChooseWorkspace={() => void chooseWorkspace()}
+              onOpenAgentSetup={openClaudeCodeSetup}
               onQuickAddLocalProviders={quickAddLocalProviders}
               onRefreshQuickLocalProviders={refreshQuickLocalProviders}
               onSwitchTarget={actions.setChatTarget}
@@ -1218,57 +1235,26 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
               onTest={() => void actions.probeAgentAdapter("claude_code")}
             />
           )}
-          {isHecateAgentChat && hecateChatModelValue && hecateAgentToolsDisabledForModel && (
-            <div style={{
-              maxWidth: 820,
-              margin: "0 auto 8px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
-              fontSize: 12,
-              color: "var(--amber)",
-              lineHeight: 1.45,
-            }}>
-              <span>
-                Tools are disabled for this model in Connections. Turn tools off for direct chat, or enable tools in Connections → Model capabilities.
-              </span>
-              <button
-                type="button"
-                className="btn btn-ghost btn-sm"
-                onClick={() => void enableToolsForSelectedModel()}
-                disabled={!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving}
-                title={selectedCapabilityProvider ? `Enable tools for ${selectedCapabilityProvider}/${selectedCapabilityModel}` : "Choose a concrete provider before enabling tools"}
-                style={{ flexShrink: 0, color: "var(--amber)", borderColor: "rgba(245, 191, 79, 0.35)" }}
-              >
-                {capabilitySaving ? "Saving..." : "Enable tools"}
-              </button>
-            </div>
-          )}
-          {isAgentChat && !state.agentWorkspace.trim() && (
-            <div style={{
-              maxWidth: 820,
-              margin: "0 auto 8px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
-              fontSize: 12,
-              color: "var(--amber)",
-              lineHeight: 1.45,
-            }}>
-              <span>
-                Choose a workspace before sending. Hecate uses it as the working directory for this chat.
-              </span>
-              <button
-                type="button"
-                className="btn btn-ghost btn-sm"
-                onClick={chooseWorkspace}
-                style={{ flexShrink: 0, color: "var(--amber)", borderColor: "rgba(245, 191, 79, 0.35)" }}
-              >
-                Choose workspace
-              </button>
-            </div>
+          {composerRepair && (
+            <ChatSetupRepairNotice
+              repair={composerRepair}
+              actionBusy={composerRepair.action === "enable_tools" && capabilitySaving}
+              actionDisabled={composerRepair.action === "enable_tools" && (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving)}
+              actionTitle={composerRepair.action === "enable_tools" && selectedCapabilityProvider
+                ? `Enable tools for ${selectedCapabilityProvider}/${selectedCapabilityModel}`
+                : undefined}
+              onAction={(repair) => {
+                if (repair.action === "choose_workspace") {
+                  void chooseWorkspace();
+                } else if (repair.action === "enable_tools") {
+                  void enableToolsForSelectedModel();
+                } else if (repair.action === "open_agent_setup") {
+                  openClaudeCodeSetup();
+                } else if (repair.action === "open_connections") {
+                  onNavigate?.("providers");
+                }
+              }}
+            />
           )}
           {activeQueuedChatMessages.length > 0 && (
             <div
@@ -2041,6 +2027,7 @@ function ChatEmptyState({
   isExternalAgentChat,
   claudeCodePreflight,
   claudeCodePreflightLoading,
+  setupRepair,
   modelRouteUnavailable,
   selectedModelIssue,
   agentRouteUnavailable,
@@ -2060,6 +2047,8 @@ function ChatEmptyState({
   quickAddingProviders,
   onOpenProviders,
   onUseSuggestedModel,
+  onChooseWorkspace,
+  onOpenAgentSetup,
   onQuickAddLocalProviders,
   onRefreshQuickLocalProviders,
   onSwitchTarget,
@@ -2075,6 +2064,7 @@ function ChatEmptyState({
   isExternalAgentChat: boolean;
   claudeCodePreflight: ClaudeCodePreflightState | null;
   claudeCodePreflightLoading: boolean;
+  setupRepair: ChatSetupRepairState | null;
   modelRouteUnavailable: boolean;
   selectedModelIssue: SelectedModelIssue | null;
   agentRouteUnavailable: boolean;
@@ -2094,6 +2084,8 @@ function ChatEmptyState({
   quickAddingProviders: boolean;
   onOpenProviders: () => void;
   onUseSuggestedModel: (model: string) => void;
+  onChooseWorkspace: () => void;
+  onOpenAgentSetup: () => void;
   onQuickAddLocalProviders: (providers: LocalProviderDiscoveryRecord[]) => void;
   onRefreshQuickLocalProviders: () => void;
   onSwitchTarget: (target: "model" | "agent" | "external_agent") => void;
@@ -2115,6 +2107,8 @@ function ChatEmptyState({
         ? "Nothing runnable yet"
         : selectedModelIssue
           ? selectedModelIssue.title
+        : setupRepair
+          ? setupRepair.title
         : hecateModelUnavailable
           ? "No routable model"
         : "Start a chat";
@@ -2128,9 +2122,36 @@ function ChatEmptyState({
         ? "Add a model provider or install a supported coding-agent CLI before sending a message."
         : selectedModelIssue
           ? selectedModelIssue.message
+        : setupRepair
+          ? setupRepair.message
         : hecateModelUnavailable
           ? "Add a provider with discovered models before sending through Hecate."
         : "Send a message to start this chat.";
+  const emptyRepairAction = setupRepair && !claudeCodePreflight && setupRepair.action !== "enable_tools"
+    ? setupRepair
+    : null;
+
+  function runEmptyRepairAction() {
+    if (!emptyRepairAction) return;
+    switch (emptyRepairAction.action) {
+      case "open_connections":
+        onOpenProviders();
+        return;
+      case "use_suggested_model":
+        if (emptyRepairAction.suggestedModel) onUseSuggestedModel(emptyRepairAction.suggestedModel);
+        return;
+      case "choose_workspace":
+        onChooseWorkspace();
+        return;
+      case "open_agent_setup":
+        onOpenAgentSetup();
+        return;
+      case "enable_tools":
+        // Tools-enabled repair is handled by the composer notice, where we
+        // can disable the action while capability override writes are busy.
+        return;
+    }
+  }
 
   return (
     <div style={{ padding: "48px 16px", maxWidth: 820, margin: "0 auto", textAlign: "center" }}>
@@ -2162,9 +2183,18 @@ function ChatEmptyState({
       {isHecateChat && selectedModelIssue && (
         <SelectedModelReadinessNotice issue={selectedModelIssue} compact onUseSuggestedModel={onUseSuggestedModel} />
       )}
-      {(modelRouteUnavailable || selectedModelIssue || agentRouteUnavailable) && (
+      {(emptyRepairAction || modelRouteUnavailable || selectedModelIssue || agentRouteUnavailable) && (
         <div style={{ display: "flex", justifyContent: "center", gap: 8, marginTop: 14, flexWrap: "wrap" }}>
-          {(modelRouteUnavailable || selectedModelIssue) && isHecateChat && (
+          {emptyRepairAction && (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={runEmptyRepairAction}
+              type="button"
+              style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <Icon d={repairActionIcon(emptyRepairAction)} size={13} /> {emptyRepairAction.actionLabel}
+            </button>
+          )}
+          {!emptyRepairAction && (modelRouteUnavailable || selectedModelIssue) && isHecateChat && (
             <button
               className="btn btn-primary btn-sm"
               onClick={onOpenProviders}
@@ -2201,6 +2231,53 @@ function ChatEmptyState({
           onRefresh={onRefreshQuickLocalProviders}
         />
       )}
+    </div>
+  );
+}
+
+function ChatSetupRepairNotice({
+  repair,
+  actionBusy = false,
+  actionDisabled = false,
+  actionTitle,
+  onAction,
+}: {
+  repair: ChatSetupRepairState;
+  actionBusy?: boolean;
+  actionDisabled?: boolean;
+  actionTitle?: string;
+  onAction: (repair: ChatSetupRepairState) => void;
+}) {
+  return (
+    <div style={{
+      maxWidth: 820,
+      margin: "0 auto 8px",
+      border: "1px solid rgba(245, 191, 79, 0.28)",
+      borderRadius: "var(--radius-sm)",
+      background: "rgba(245, 191, 79, 0.055)",
+      padding: "8px 10px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 12,
+      fontSize: 12,
+      color: "var(--t2)",
+      lineHeight: 1.45,
+    }}>
+      <span style={{ minWidth: 0 }}>
+        <strong style={{ color: "var(--amber)", marginRight: 6 }}>{repair.title}.</strong>
+        {repair.message}
+      </span>
+      <button
+        type="button"
+        className="btn btn-ghost btn-sm"
+        onClick={() => onAction(repair)}
+        disabled={actionDisabled}
+        title={actionTitle}
+        style={{ flexShrink: 0, color: "var(--amber)", borderColor: "rgba(245, 191, 79, 0.35)" }}
+      >
+        {actionBusy ? "Saving..." : repair.actionLabel}
+      </button>
     </div>
   );
 }
@@ -2411,6 +2488,33 @@ function autoProviderRouteRepairHint(
       : "Open Connections to fix credentials, health, or model discovery, then refresh.",
     tone: "amber",
   };
+}
+
+function composerVisibleRepair(repair: ChatSetupRepairState | null): ChatSetupRepairState | null {
+  if (!repair) return null;
+  switch (repair.kind) {
+    case "workspace_required":
+    case "tools_disabled":
+    case "external_agent_unavailable":
+      return repair;
+    default:
+      return null;
+  }
+}
+
+function repairActionIcon(repair: ChatSetupRepairState) {
+  switch (repair.action) {
+    case "choose_workspace":
+      return Icons.folder;
+    case "open_agent_setup":
+      return Icons.terminal;
+    case "use_suggested_model":
+      return Icons.model;
+    case "open_connections":
+    case "enable_tools":
+      return Icons.providers;
+  }
+  return Icons.providers;
 }
 
 function selectedModelNoticeDetails(

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import { providerFleetRepairHint } from "../../lib/provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning } from "../../lib/provider-readiness";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
 import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
 import { ModelCapabilitiesSection } from "./ModelCapabilitiesSection";
@@ -217,6 +217,13 @@ function ModelProviderConnectionsSection({
   const statusByName = new Map(state.providers.map((provider) => [provider.name, provider]));
   const repair = providerFleetRepairHint(configuredProviders, statusByName);
   const repairLabel = repair?.tone === "muted" ? "Ready for chat" : "Next repair";
+  const readinessSummary = providerReadinessMeaning({
+    configuredCount: configuredProviders.length,
+    readyCount: readyProviders,
+    blockedCount: blockedProviders,
+    modelCount,
+    repair,
+  });
 
   return (
     <div className="card" style={{ padding: "14px 16px", marginBottom: 24 }} data-testid="connections-model-providers">
@@ -288,6 +295,17 @@ function ModelProviderConnectionsSection({
         <ConnectionStat label="Ready" value={String(readyProviders)} hint="routing-ready" tone={readyProviders > 0 ? "green" : "muted"} />
         <ConnectionStat label="Needs attention" value={String(blockedProviders)} hint="blocked providers" tone={blockedProviders > 0 ? "amber" : "muted"} />
         <ConnectionStat label="Models" value={String(modelCount)} hint="discovered" />
+      </div>
+      <div
+        data-testid="connections-provider-readiness-meaning"
+        style={{
+          marginTop: 10,
+          fontSize: 11,
+          color: readinessSummary.tone === "amber" ? "var(--amber)" : "var(--t3)",
+          lineHeight: 1.45,
+        }}
+      >
+        {readinessSummary.message}
       </div>
     </div>
   );

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -216,6 +216,7 @@ function ModelProviderConnectionsSection({
   const modelCount = state.models.length || knownStatuses.reduce((sum, provider) => sum + (provider.model_count ?? provider.models?.length ?? 0), 0);
   const statusByName = new Map(state.providers.map((provider) => [provider.name, provider]));
   const repair = providerFleetRepairHint(configuredProviders, statusByName);
+  const repairLabel = repair?.tone === "muted" ? "Ready for chat" : "Next repair";
 
   return (
     <div className="card" style={{ padding: "14px 16px", marginBottom: 24 }} data-testid="connections-model-providers">
@@ -233,6 +234,7 @@ function ModelProviderConnectionsSection({
       />
       {repair && (
         <div
+          data-testid="connections-provider-repair"
           style={{
             marginBottom: 12,
             border: "1px solid var(--border)",
@@ -241,15 +243,38 @@ function ModelProviderConnectionsSection({
             padding: "9px 10px",
           }}
         >
-          <div style={{ display: "flex", gap: 8, alignItems: "baseline", marginBottom: 3 }}>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 3 }}>
+            <span style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              color: repair.tone === "amber" ? "var(--amber)" : "var(--green)",
+              whiteSpace: "nowrap",
+            }}>
+              {repairLabel}
+            </span>
             <span style={{ fontSize: 11, fontWeight: 600, color: repair.tone === "amber" ? "var(--amber)" : "var(--t1)" }}>
               {repair.title}
             </span>
-            <span style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
+            {repair.tone !== "muted" && onNavigate && (
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => onNavigate("providers")}
+                style={{ marginLeft: "auto", padding: "2px 7px" }}
+              >
+                Open provider list
+              </button>
+            )}
+          </div>
+          <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>{repair.message}</div>
+          <div style={{ marginTop: 5, fontSize: 10, color: repair.tone === "amber" ? "var(--amber)" : "var(--t3)", fontFamily: "var(--font-mono)" }}>
+            {repair.tone === "muted" ? "Status" : "Next"} ·{" "}
+            <span style={{ color: repair.tone === "muted" ? "var(--t3)" : "var(--amber)" }}>
               {repair.action}
             </span>
           </div>
-          <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>{repair.message}</div>
         </div>
       )}
       <div

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import { providerFleetRepairHint, providerReadinessMeaning } from "../../lib/provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel } from "../../lib/provider-readiness";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
 import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
 import { ModelCapabilitiesSection } from "./ModelCapabilitiesSection";
@@ -314,16 +314,7 @@ function ModelProviderConnectionsSection({
 
 function providerRepairButtonLabel(hint: ReturnType<typeof providerFleetRepairHint>): string | null {
   if (!hint || hint.tone === "muted") return null;
-  switch (hint.actionKind) {
-    case "add_provider":
-      return "Add provider";
-    case "open_provider":
-      return "Open provider";
-    case "refresh_providers":
-      return "Refresh providers";
-    case "none":
-      return null;
-  }
+  return providerRepairActionLabel(hint.actionKind);
 }
 
 function ConnectionStat({

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -217,6 +217,7 @@ function ModelProviderConnectionsSection({
   const statusByName = new Map(state.providers.map((provider) => [provider.name, provider]));
   const repair = providerFleetRepairHint(configuredProviders, statusByName);
   const repairLabel = repair?.tone === "muted" ? "Ready for chat" : "Next repair";
+  const repairButton = providerRepairButtonLabel(repair);
   const readinessSummary = providerReadinessMeaning({
     configuredCount: configuredProviders.length,
     readyCount: readyProviders,
@@ -264,14 +265,14 @@ function ModelProviderConnectionsSection({
             <span style={{ fontSize: 11, fontWeight: 600, color: repair.tone === "amber" ? "var(--amber)" : "var(--t1)" }}>
               {repair.title}
             </span>
-            {repair.tone !== "muted" && onNavigate && (
+            {repairButton && onNavigate && (
               <button
                 type="button"
                 className="btn btn-ghost btn-sm"
                 onClick={() => onNavigate("providers")}
                 style={{ marginLeft: "auto", padding: "2px 7px" }}
               >
-                Open provider list
+                {repairButton}
               </button>
             )}
           </div>
@@ -309,6 +310,20 @@ function ModelProviderConnectionsSection({
       </div>
     </div>
   );
+}
+
+function providerRepairButtonLabel(hint: ReturnType<typeof providerFleetRepairHint>): string | null {
+  if (!hint || hint.tone === "muted") return null;
+  switch (hint.actionKind) {
+    case "add_provider":
+      return "Add provider";
+    case "open_provider":
+      return "Open provider";
+    case "refresh_providers":
+      return "Refresh providers";
+    case "none":
+      return null;
+  }
 }
 
 function ConnectionStat({

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -203,6 +203,12 @@ describe("ObservabilityView", () => {
     expect(container.textContent).toMatch(/Route/);
     expect(container.textContent).not.toMatch(/Fallback/);
     expect(container.textContent).toMatch(/Requested model/);
+    await act(async () => {
+      fireEvent.click(container.querySelector("tbody tr") as HTMLElement);
+    });
+    expect(container.textContent).toMatch(/Provider/);
+    expect(container.textContent).toMatch(/Model/);
+    expect(container.textContent).toMatch(/gpt-4o-mini/);
   });
 
   it("folds fallback source into the compact route column", async () => {

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -417,6 +417,8 @@ export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
     <TraceDetail
       selectedID={selectedID}
       selectedTrace={selectedTrace}
+      selectedProvider={selectedTrace ? traceProvider(selectedTrace) : ""}
+      selectedModel={selectedTrace ? traceModel(selectedTrace) : ""}
       ledger={ledgerByRequest.get(selectedID)}
       traceDetail={traceDetail}
       traceFetching={traceFetching}

--- a/ui/src/features/overview/observability/TraceDetail.tsx
+++ b/ui/src/features/overview/observability/TraceDetail.tsx
@@ -23,6 +23,8 @@ type LedgerEntry = NonNullable<RuntimeConsoleViewModel["state"]["requestLedger"]
 type TraceDetailProps = {
   selectedID: string;
   selectedTrace?: TraceListItem;
+  selectedProvider?: string;
+  selectedModel?: string;
   ledger?: LedgerEntry;
   traceDetail: TraceResponse["data"] | null;
   traceFetching: boolean;
@@ -35,7 +37,7 @@ type TraceDetailProps = {
 };
 
 export function TraceDetail({
-  selectedTrace, ledger, traceDetail, traceFetching,
+  selectedTrace, selectedProvider, selectedModel, ledger, traceDetail, traceFetching,
   waterfall, traceTimeline, expandedSpanID, setExpandedSpanID,
   phaseFilter, setPhaseFilter,
 }: TraceDetailProps) {
@@ -52,7 +54,7 @@ export function TraceDetail({
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
       {/* Live status grid */}
       <div style={{
-        display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12,
+        display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 12,
         padding: 12, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)",
       }}>
         <div>
@@ -64,6 +66,18 @@ export function TraceDetail({
         <div>
           <div className="kicker" style={{ marginBottom: 4 }}>Latency</div>
           <div style={{ fontSize: 12, color: "var(--t0)", fontFamily: "var(--font-mono)" }}>{latency}</div>
+        </div>
+        <div>
+          <div className="kicker" style={{ marginBottom: 4 }}>Provider</div>
+          <div style={{ fontSize: 12, color: selectedProvider ? "var(--t0)" : "var(--t3)", fontFamily: "var(--font-mono)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {selectedProvider || "—"}
+          </div>
+        </div>
+        <div>
+          <div className="kicker" style={{ marginBottom: 4 }}>Model</div>
+          <div style={{ fontSize: 12, color: selectedModel ? "var(--t0)" : "var(--t3)", fontFamily: "var(--font-mono)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {selectedModel || "—"}
+          </div>
         </div>
         <div>
           <div className="kicker" style={{ marginBottom: 4 }}>Tokens</div>

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -424,6 +424,75 @@ describe("ProvidersView table renders", () => {
     expect(screen.queryByRole("switch")).toBeNull();
   });
 
+  it("surfaces readiness repair buttons from the summary card", async () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("anthropic", { kind: "cloud", credential_configured: false })],
+      },
+      providers: [
+        makeStatus("anthropic", {
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          routing_ready: false,
+          routing_blocked_reason: "credential_missing",
+          readiness: {
+            status: "blocked",
+            reason: "credential_missing",
+            message: "Anthropic needs an API key.",
+            operator_action: "Add or rotate the provider API key in Connections.",
+          },
+          readiness_checks: [
+            { name: "credentials", status: "blocked", reason: "credential_missing", message: "Missing key." },
+          ],
+        }),
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+
+    expect(screen.getByText(/1 provider needs attention/)).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Open provider" }));
+    expect(screen.getByText(/Anthropic · cloud/)).toBeTruthy();
+  });
+
+  it("lets the readiness summary refresh model discovery", async () => {
+    const refreshProviders = vi.fn(async () => undefined);
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: false,
+          routing_blocked_reason: "no_models",
+          models: [],
+          model_count: 0,
+          readiness_checks: [
+            { name: "models", status: "blocked", reason: "no_models", message: "No models were discovered." },
+          ],
+        }),
+      ],
+    });
+    const actions = { ...createRuntimeConsoleActions(), refreshProviders };
+    const user = userEvent.setup();
+
+    render(<ProvidersView state={state} actions={actions} />);
+    await user.click(screen.getByRole("button", { name: "Refresh providers" }));
+
+    expect(refreshProviders).toHaveBeenCalledTimes(1);
+  });
+
   it("renders external-agent readiness and grants in the Connections workspace", async () => {
     const listAgentChatGrants = vi.fn(async () => undefined);
     const probeAgentAdapter = vi.fn(async () => null);

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -411,6 +411,7 @@ describe("ProvidersView table renders", () => {
     expect(within(summary).getByText("Model provider readiness")).toBeTruthy();
     expect(within(summary).getAllByText("2").length).toBeGreaterThanOrEqual(1);
     expect(within(summary).getByText("No configured provider setup issue needs repair.")).toBeTruthy();
+    expect(within(summary).getByTestId("connections-provider-readiness-meaning")).toHaveTextContent("2 providers ready with 2 discovered models.");
 
     // Health badges: both providers report healthy. Credentials are split
     // into a separate column so cloud (Configured) and local (Not required)

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import { providerFleetRepairHint } from "../../lib/provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning } from "../../lib/provider-readiness";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
@@ -135,7 +135,15 @@ export function ProvidersView({ state, actions }: Props) {
     const status = statusByName.get(provider.id);
     return sum + (status?.model_count ?? status?.models?.length ?? 0);
   }, 0);
-  const nextReadinessStep = resolveNextReadinessStep(configuredProviders, statusByName);
+  const fleetRepair = providerFleetRepairHint(configuredProviders, statusByName);
+  const nextReadinessStep = resolveNextReadinessStep(fleetRepair);
+  const readinessMeaning = providerReadinessMeaning({
+    configuredCount: configuredProviders.length,
+    readyCount: readyProviderCount,
+    blockedCount: blockedProviderCount,
+    modelCount: discoveredModelCount,
+    repair: fleetRepair,
+  });
 
   const selectedConfig = selectedID ? configuredByID.get(selectedID) ?? null : null;
   const selectedStatus = selectedID ? statusByName.get(selectedID) : null;
@@ -395,6 +403,17 @@ export function ProvidersView({ state, actions }: Props) {
               <ConnectionStat label="Ready" value={String(readyProviderCount)} hint="routing-ready" tone={readyProviderCount > 0 ? "green" : "muted"} />
               <ConnectionStat label="Needs attention" value={String(blockedProviderCount)} hint="blocked providers" tone={blockedProviderCount > 0 ? "amber" : "muted"} />
               <ConnectionStat label="Models" value={String(discoveredModelCount)} hint="discovered" tone={discoveredModelCount > 0 ? "green" : "muted"} />
+            </div>
+            <div
+              data-testid="connections-provider-readiness-meaning"
+              style={{
+                marginTop: 10,
+                fontSize: 11,
+                color: readinessMeaning.tone === "amber" ? "var(--amber)" : "var(--t3)",
+                lineHeight: 1.45,
+              }}
+            >
+              {readinessMeaning.message}
             </div>
           </div>
         )}
@@ -804,10 +823,8 @@ function isProviderNeedsAttention(
 }
 
 function resolveNextReadinessStep(
-  providers: NonNullable<RuntimeConsoleViewModel["state"]["settingsConfig"]>["providers"],
-  statusByName: Map<string, RuntimeConsoleViewModel["state"]["providers"][number]>,
+  hint: ReturnType<typeof providerFleetRepairHint>,
 ): { text: string; tone: ConnectionStatTone } | null {
-  const hint = providerFleetRepairHint(providers, statusByName);
   if (!hint) return null;
   return {
     tone: hint.tone === "amber" || hint.tone === "red" ? "amber" : "muted",

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -144,6 +144,23 @@ export function ProvidersView({ state, actions }: Props) {
     modelCount: discoveredModelCount,
     repair: fleetRepair,
   });
+  const readinessAction = providerRepairButton(fleetRepair);
+  const runReadinessAction = () => {
+    if (!fleetRepair) return;
+    switch (fleetRepair.actionKind) {
+      case "add_provider":
+        setAddProviderOpen(true);
+        break;
+      case "open_provider":
+        if (fleetRepair.providerID) setSelectedID(fleetRepair.providerID);
+        break;
+      case "refresh_providers":
+        void actions.refreshProviders();
+        break;
+      case "none":
+        break;
+    }
+  };
 
   const selectedConfig = selectedID ? configuredByID.get(selectedID) ?? null : null;
   const selectedStatus = selectedID ? statusByName.get(selectedID) : null;
@@ -377,18 +394,30 @@ export function ProvidersView({ state, actions }: Props) {
                   Checks credentials, discovery, health, routing, and selected-model repair paths before a chat fails.
                 </div>
               </div>
-              {nextReadinessStep && (
-                <div
-                  style={{
-                    marginLeft: "auto",
-                    maxWidth: 420,
-                    fontSize: 11,
-                    color: nextReadinessStep.tone === "amber" ? "var(--amber)" : "var(--t2)",
-                    lineHeight: 1.45,
-                    textAlign: "right",
-                  }}
-                >
-                  {nextReadinessStep.text}
+              {(nextReadinessStep || readinessAction) && (
+                <div style={{ marginLeft: "auto", maxWidth: 460, display: "flex", gap: 10, alignItems: "center", justifyContent: "flex-end" }}>
+                  {nextReadinessStep && (
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: nextReadinessStep.tone === "amber" ? "var(--amber)" : "var(--t2)",
+                        lineHeight: 1.45,
+                        textAlign: "right",
+                      }}
+                    >
+                      {nextReadinessStep.text}
+                    </div>
+                  )}
+                  {readinessAction && (
+                    <button
+                      type="button"
+                      className={readinessAction.tone === "primary" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"}
+                      onClick={runReadinessAction}
+                      style={{ whiteSpace: "nowrap" }}
+                    >
+                      {readinessAction.label}
+                    </button>
+                  )}
                 </div>
               )}
             </div>
@@ -830,6 +859,22 @@ function resolveNextReadinessStep(
     tone: hint.tone === "amber" || hint.tone === "red" ? "amber" : "muted",
     text: hint.tone === "muted" ? hint.message : `${hint.message} ${hint.action}`,
   };
+}
+
+function providerRepairButton(
+  hint: ReturnType<typeof providerFleetRepairHint>,
+): { label: string; tone: "primary" | "ghost" } | null {
+  if (!hint || hint.tone === "muted") return null;
+  switch (hint.actionKind) {
+    case "add_provider":
+      return { label: "Add provider", tone: "primary" };
+    case "open_provider":
+      return { label: "Open provider", tone: "ghost" };
+    case "refresh_providers":
+      return { label: "Refresh providers", tone: "ghost" };
+    case "none":
+      return null;
+  }
 }
 
 function formatProviderTime(value: string): string {

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
-import { providerFleetRepairHint, providerReadinessMeaning } from "../../lib/provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel } from "../../lib/provider-readiness";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
@@ -865,16 +865,9 @@ function providerRepairButton(
   hint: ReturnType<typeof providerFleetRepairHint>,
 ): { label: string; tone: "primary" | "ghost" } | null {
   if (!hint || hint.tone === "muted") return null;
-  switch (hint.actionKind) {
-    case "add_provider":
-      return { label: "Add provider", tone: "primary" };
-    case "open_provider":
-      return { label: "Open provider", tone: "ghost" };
-    case "refresh_providers":
-      return { label: "Refresh providers", tone: "ghost" };
-    case "none":
-      return null;
-  }
+  const label = providerRepairActionLabel(hint.actionKind);
+  if (!label) return null;
+  return { label, tone: hint.actionKind === "add_provider" ? "primary" : "ghost" };
 }
 
 function formatProviderTime(value: string): string {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -164,6 +164,8 @@ describe("Connections external-agent panel", () => {
     expect(within(card).getByText("2 configured")).toBeTruthy();
     expect(within(card).getByText("Ready")).toBeTruthy();
     expect(within(card).getByText("Needs attention")).toBeTruthy();
+    expect(within(card).getByTestId("connections-provider-repair")).toHaveTextContent("Next repair");
+    expect(within(card).getByTestId("connections-provider-repair")).toHaveTextContent("Provider blocked");
 
     await user.click(within(card).getByRole("button", { name: "Open Connections" }));
     expect(onNavigate).toHaveBeenCalledWith("providers");

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveChatSetupRepairState } from "./chat-setup-readiness";
+
+describe("resolveChatSetupRepairState", () => {
+  const base = {
+    hasConfiguredProviders: true,
+    modelRouteUnavailable: false,
+    selectedModelIssue: null,
+    toolsDisabledForModel: false,
+    workspace: "/repo",
+    selectedAgentAvailable: true,
+    anyAgentAvailable: true,
+    claudeCodeSetupRequired: false,
+  };
+
+  it("points chats without configured providers to Connections", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "model",
+      hasConfiguredProviders: false,
+      modelRouteUnavailable: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "no_provider",
+      title: "No provider configured",
+      action: "open_connections",
+      actionLabel: "Go to Connections",
+    });
+  });
+
+  it("uses backend suggested models as the primary selected-model repair", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "agent",
+      selectedModelIssue: {
+        title: "Selected model is not ready",
+        message: "Anthropic needs credentials.",
+        providerLabel: "Anthropic",
+        model: "claude-sonnet-4-6",
+        suggestedModel: "gpt-4o-mini",
+        details: [],
+        steps: [],
+      },
+    });
+
+    expect(repair).toMatchObject({
+      kind: "selected_model_not_ready",
+      action: "use_suggested_model",
+      actionLabel: "Use gpt-4o-mini",
+      suggestedModel: "gpt-4o-mini",
+    });
+  });
+
+  it("blocks Hecate Agent when tools are disabled for the selected model", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "agent",
+      toolsDisabledForModel: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "tools_disabled",
+      action: "enable_tools",
+      title: "Tools are disabled for this model",
+    });
+  });
+
+  it("requires a workspace for task-backed Hecate Agent chats", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "agent",
+      workspace: "",
+    });
+
+    expect(repair).toMatchObject({
+      kind: "workspace_required",
+      action: "choose_workspace",
+      actionLabel: "Choose workspace",
+    });
+  });
+
+  it("routes unavailable external agents to Connections", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentName: "Codex",
+      selectedAgentAvailable: false,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "external_agent_unavailable",
+      title: "Codex is unavailable",
+      action: "open_connections",
+    });
+  });
+
+  it("routes Claude Code credential setup to the guided setup action", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentName: "Claude Code",
+      claudeCodeSetupRequired: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "claude_code_setup",
+      action: "open_agent_setup",
+      actionLabel: "Open setup",
+    });
+  });
+});

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -1,0 +1,138 @@
+import type { SelectedModelIssue } from "./provider-issues";
+
+export type ChatSetupTarget = "model" | "agent" | "external_agent";
+
+export type ChatSetupRepairKind =
+  | "no_provider"
+  | "no_routable_model"
+  | "selected_model_not_ready"
+  | "tools_disabled"
+  | "workspace_required"
+  | "external_agent_unavailable"
+  | "claude_code_setup";
+
+export type ChatSetupRepairAction =
+  | "open_connections"
+  | "choose_workspace"
+  | "enable_tools"
+  | "use_suggested_model"
+  | "open_agent_setup";
+
+export type ChatSetupRepairState = {
+  kind: ChatSetupRepairKind;
+  title: string;
+  message: string;
+  action: ChatSetupRepairAction;
+  actionLabel: string;
+  tone: "amber" | "red";
+  suggestedModel?: string;
+};
+
+export function resolveChatSetupRepairState({
+  target,
+  hasConfiguredProviders,
+  modelRouteUnavailable,
+  selectedModelIssue,
+  toolsDisabledForModel,
+  workspace,
+  selectedAgentName,
+  selectedAgentAvailable,
+  anyAgentAvailable,
+  claudeCodeSetupRequired,
+}: {
+  target: ChatSetupTarget;
+  hasConfiguredProviders: boolean;
+  modelRouteUnavailable: boolean;
+  selectedModelIssue: SelectedModelIssue | null;
+  toolsDisabledForModel: boolean;
+  workspace: string;
+  selectedAgentName?: string;
+  selectedAgentAvailable: boolean;
+  anyAgentAvailable: boolean;
+  claudeCodeSetupRequired: boolean;
+}): ChatSetupRepairState | null {
+  if (target === "external_agent") {
+    if (!anyAgentAvailable || !selectedAgentAvailable) {
+      const agent = selectedAgentName || "Selected agent";
+      return {
+        kind: "external_agent_unavailable",
+        title: anyAgentAvailable ? `${agent} is unavailable` : "No available coding agent",
+        message: anyAgentAvailable
+          ? `Hecate cannot start ${agent} because its CLI or adapter runner is not ready in this environment.`
+          : "Install or connect a supported coding agent before starting an External Agent chat.",
+        action: "open_connections",
+        actionLabel: "Open Connections",
+        tone: "amber",
+      };
+    }
+    if (claudeCodeSetupRequired) {
+      return {
+        kind: "claude_code_setup",
+        title: "Set up Claude Code",
+        message: "Claude Code needs an adapter-visible credential before Hecate can start a session.",
+        action: "open_agent_setup",
+        actionLabel: "Open setup",
+        tone: "amber",
+      };
+    }
+    if (!workspace.trim()) {
+      return workspaceRepair();
+    }
+    return null;
+  }
+
+  if (modelRouteUnavailable) {
+    return {
+      kind: hasConfiguredProviders ? "no_routable_model" : "no_provider",
+      title: hasConfiguredProviders ? "No routable model" : "No provider configured",
+      message: hasConfiguredProviders
+        ? "Hecate can see provider configuration, but no provider currently reports a routable model."
+        : "Add a model provider before sending through Hecate.",
+      action: "open_connections",
+      actionLabel: "Go to Connections",
+      tone: "amber",
+    };
+  }
+
+  if (selectedModelIssue) {
+    return {
+      kind: "selected_model_not_ready",
+      title: selectedModelIssue.title,
+      message: selectedModelIssue.message,
+      action: selectedModelIssue.suggestedModel ? "use_suggested_model" : "open_connections",
+      actionLabel: selectedModelIssue.suggestedModel
+        ? `Use ${selectedModelIssue.suggestedModel}`
+        : "Open Connections",
+      tone: "amber",
+      suggestedModel: selectedModelIssue.suggestedModel,
+    };
+  }
+
+  if (target === "agent" && toolsDisabledForModel) {
+    return {
+      kind: "tools_disabled",
+      title: "Tools are disabled for this model",
+      message: "Turn tools off for direct chat, or enable tool-calling for this provider/model in Connections.",
+      action: "enable_tools",
+      actionLabel: "Enable tools",
+      tone: "amber",
+    };
+  }
+
+  if (target === "agent" && !workspace.trim()) {
+    return workspaceRepair();
+  }
+
+  return null;
+}
+
+function workspaceRepair(): ChatSetupRepairState {
+  return {
+    kind: "workspace_required",
+    title: "Choose a workspace",
+    message: "Hecate uses the workspace as the working directory for this chat.",
+    action: "choose_workspace",
+    actionLabel: "Choose workspace",
+    tone: "amber",
+  };
+}

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { providerFleetRepairHint, providerRepairHint, readinessRecommendation } from "./provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning, providerRepairHint, readinessRecommendation } from "./provider-readiness";
 
 describe("readinessRecommendation", () => {
   it("uses backend operator_action before local fallback copy", () => {
@@ -29,6 +29,8 @@ describe("providerRepairHint", () => {
 
     expect(hint.title).toBe("Credentials required");
     expect(hint.action).toContain("API key");
+    expect(hint.actionKind).toBe("open_provider");
+    expect(hint.providerID).toBe("anthropic");
     expect(hint.tone).toBe("amber");
   });
 
@@ -59,6 +61,7 @@ describe("providerRepairHint", () => {
 
     expect(hint.title).toBe("No models discovered");
     expect(hint.action).toContain("Pull or load");
+    expect(hint.actionKind).toBe("refresh_providers");
   });
 
   it("uses friendlier titles for blocked readiness checks", () => {
@@ -122,5 +125,48 @@ describe("providerFleetRepairHint", () => {
     expect(providerFleetRepairHint([
       { id: "anthropic", name: "Anthropic", kind: "cloud", credential_configured: true },
     ], statuses)?.message).toContain("No configured provider setup issue");
+  });
+
+  it("returns an add-provider action when the fleet is empty", () => {
+    const hint = providerFleetRepairHint([], new Map());
+
+    expect(hint).toMatchObject({
+      title: "No provider configured",
+      actionKind: "add_provider",
+      tone: "amber",
+    });
+  });
+});
+
+describe("providerReadinessMeaning", () => {
+  it("explains empty, blocked, no-model, and ready fleet states", () => {
+    expect(providerReadinessMeaning({
+      configuredCount: 0,
+      readyCount: 0,
+      blockedCount: 0,
+      modelCount: 0,
+    }).message).toContain("No model providers");
+
+    expect(providerReadinessMeaning({
+      configuredCount: 2,
+      readyCount: 1,
+      blockedCount: 1,
+      modelCount: 1,
+      repair: { title: "Credentials required", message: "", action: "Add an API key.", actionKind: "open_provider", tone: "amber" },
+    }).message).toContain("Next: Add an API key.");
+
+    expect(providerReadinessMeaning({
+      configuredCount: 1,
+      readyCount: 1,
+      blockedCount: 0,
+      modelCount: 0,
+    }).message).toContain("no models");
+
+    expect(providerReadinessMeaning({
+      configuredCount: 1,
+      readyCount: 1,
+      blockedCount: 0,
+      modelCount: 2,
+    }).message).toContain("1 provider ready with 2 discovered models");
   });
 });

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { providerFleetRepairHint, providerReadinessMeaning, providerRepairHint, readinessRecommendation } from "./provider-readiness";
+import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel, providerRepairHint, readinessRecommendation } from "./provider-readiness";
 
 describe("readinessRecommendation", () => {
   it("uses backend operator_action before local fallback copy", () => {
@@ -108,6 +108,21 @@ describe("providerRepairHint", () => {
     expect(hint.message).toContain("Missing credentials");
     expect(hint.message).not.toContain("credential_missing");
   });
+
+  it("does not expose runtime provider names as selectable configured-provider ids", () => {
+    const hint = providerRepairHint({
+      runtimeProvider: {
+        name: "runtime display name",
+        kind: "local",
+        healthy: true,
+        status: "healthy",
+        readiness_checks: [{ name: "credentials", status: "blocked", reason: "self_referential" }],
+      },
+    });
+
+    expect(hint.actionKind).toBe("refresh_providers");
+    expect(hint.providerID).toBeUndefined();
+  });
 });
 
 describe("providerFleetRepairHint", () => {
@@ -156,6 +171,14 @@ describe("providerReadinessMeaning", () => {
     }).message).toContain("Next: Add an API key.");
 
     expect(providerReadinessMeaning({
+      configuredCount: 2,
+      readyCount: 0,
+      blockedCount: 1,
+      modelCount: 1,
+      repair: null,
+    }).message).toContain("Providers exist");
+
+    expect(providerReadinessMeaning({
       configuredCount: 1,
       readyCount: 1,
       blockedCount: 0,
@@ -168,5 +191,14 @@ describe("providerReadinessMeaning", () => {
       blockedCount: 0,
       modelCount: 2,
     }).message).toContain("1 provider ready with 2 discovered models");
+  });
+});
+
+describe("providerRepairActionLabel", () => {
+  it("keeps repair action labels canonical", () => {
+    expect(providerRepairActionLabel("add_provider")).toBe("Add provider");
+    expect(providerRepairActionLabel("open_provider")).toBe("Open provider");
+    expect(providerRepairActionLabel("refresh_providers")).toBe("Refresh providers");
+    expect(providerRepairActionLabel("none")).toBeNull();
   });
 });

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -26,7 +26,7 @@ export function providerReadinessMeaning({
   if (configuredCount === 0) {
     return { message: "No model providers are configured yet. Add one provider before starting Hecate Chat.", tone: "amber" };
   }
-  if (blockedCount > 0 && repair?.tone !== "muted") {
+  if (blockedCount > 0 && repair && repair.tone !== "muted") {
     return { message: `${blockedCount} provider${blockedCount === 1 ? " needs" : "s need"} attention. Next: ${repair?.action || "open the provider list."}`, tone: "amber" };
   }
   if (readyCount === 0) {
@@ -106,24 +106,26 @@ export function providerRepairHint({
 
   if (runtimeProvider?.readiness?.status === "blocked") {
     const blockedCheck = firstBlockedReadinessCheck(runtimeProvider.readiness_checks ?? []);
+    const actionKind = actionableProviderAction(readinessActionKind(blockedCheck), configuredProvider?.id);
     return {
       title: "Provider blocked",
       message: runtimeProvider.readiness.message || `${name} is not routable right now.`,
       action: runtimeProvider.readiness.operator_action || firstReadinessAction(runtimeProvider.readiness_checks) || "Open Connections and inspect the blocked readiness check.",
-      actionKind: readinessActionKind(blockedCheck) ?? "open_provider",
-      providerID: configuredProvider?.id ?? runtimeProvider.name,
+      actionKind,
+      providerID: configuredProvider?.id,
       tone: "amber",
     };
   }
 
   const blockedCheck = firstBlockedReadinessCheck(runtimeProvider?.readiness_checks ?? []);
   if (blockedCheck) {
+    const actionKind = actionableProviderAction(readinessActionKind(blockedCheck), configuredProvider?.id);
     return {
       title: readinessTitle(blockedCheck),
       message: blockedCheck.message || `${name} has a blocked readiness check.`,
       action: readinessRecommendation(blockedCheck) || "Open Connections and inspect provider readiness.",
-      actionKind: readinessActionKind(blockedCheck) ?? "open_provider",
-      providerID: configuredProvider?.id ?? runtimeProvider?.name,
+      actionKind,
+      providerID: configuredProvider?.id,
       tone: "amber",
     };
   }
@@ -134,8 +136,8 @@ export function providerRepairHint({
       title: "Routing blocked",
       message: `${name} is configured, but routing is blocked: ${reason}.`,
       action: "Open Connections and inspect routing, health, and discovery details.",
-      actionKind: "open_provider",
-      providerID: configuredProvider?.id ?? runtimeProvider.name,
+      actionKind: actionableProviderAction("open_provider", configuredProvider?.id),
+      providerID: configuredProvider?.id,
       tone: "amber",
     };
   }
@@ -146,7 +148,7 @@ export function providerRepairHint({
       message: `${name} is reachable, but Hecate has not discovered any models from it yet.`,
       action: isLocal ? "Pull or load a model in the local provider, then refresh Connections." : "Confirm the account has model access, then refresh Connections.",
       actionKind: "refresh_providers",
-      providerID: configuredProvider?.id ?? runtimeProvider.name,
+      providerID: configuredProvider?.id,
       tone: "amber",
     };
   }
@@ -157,7 +159,7 @@ export function providerRepairHint({
       message: `${name} is currently down or cooling down after failures.`,
       action: isLocal ? "Start the local provider process and refresh Connections." : "Check the upstream endpoint, credentials, and provider status.",
       actionKind: "refresh_providers",
-      providerID: configuredProvider?.id ?? runtimeProvider.name,
+      providerID: configuredProvider?.id,
       tone: "amber",
     };
   }
@@ -168,7 +170,7 @@ export function providerRepairHint({
       message: `${name} has no provider setup issue that needs repair.`,
       action: "No repair needed.",
       actionKind: "none",
-      providerID: configuredProvider?.id ?? runtimeProvider?.name,
+      providerID: configuredProvider?.id,
       tone: "muted",
     };
   }
@@ -209,6 +211,29 @@ export function providerFleetRepairHint(
     actionKind: "add_provider",
     tone: "amber",
   };
+}
+
+export function providerRepairActionLabel(actionKind: ProviderRepairHint["actionKind"]): string | null {
+  switch (actionKind) {
+    case "add_provider":
+      return "Add provider";
+    case "open_provider":
+      return "Open provider";
+    case "refresh_providers":
+      return "Refresh providers";
+    case "none":
+      return null;
+  }
+}
+
+function actionableProviderAction(
+  actionKind: ProviderRepairHint["actionKind"] | null,
+  configuredProviderID?: string,
+): ProviderRepairHint["actionKind"] {
+  if (actionKind === "open_provider" && !configuredProviderID) {
+    return "refresh_providers";
+  }
+  return actionKind ?? (configuredProviderID ? "open_provider" : "refresh_providers");
 }
 
 function firstBlockedReadinessCheck(checks: ProviderReadinessCheckRecord[]): ProviderReadinessCheckRecord | null {

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -8,6 +8,34 @@ export type ProviderRepairHint = {
   tone: "muted" | "green" | "amber" | "red";
 };
 
+export function providerReadinessMeaning({
+  configuredCount,
+  readyCount,
+  blockedCount,
+  modelCount,
+  repair,
+}: {
+  configuredCount: number;
+  readyCount: number;
+  blockedCount: number;
+  modelCount: number;
+  repair?: ProviderRepairHint | null;
+}): { message: string; tone: "muted" | "amber" } {
+  if (configuredCount === 0) {
+    return { message: "No model providers are configured yet. Add one provider before starting Hecate Chat.", tone: "amber" };
+  }
+  if (blockedCount > 0 && repair?.tone !== "muted") {
+    return { message: `${blockedCount} provider${blockedCount === 1 ? "" : "s"} need attention. Next: ${repair?.action || "open the provider list."}`, tone: "amber" };
+  }
+  if (readyCount === 0) {
+    return { message: "Providers exist, but none are ready to route chat requests yet.", tone: "amber" };
+  }
+  if (modelCount === 0) {
+    return { message: "Providers are reachable, but no models have been discovered yet.", tone: "amber" };
+  }
+  return { message: `${readyCount} provider${readyCount === 1 ? "" : "s"} ready with ${modelCount} discovered model${modelCount === 1 ? "" : "s"}.`, tone: "muted" };
+}
+
 export function readinessRecommendation(check: ProviderReadinessCheckRecord): string {
   if (check.operator_action) return check.operator_action;
 

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -5,6 +5,8 @@ export type ProviderRepairHint = {
   title: string;
   message: string;
   action: string;
+  actionKind: "add_provider" | "open_provider" | "refresh_providers" | "none";
+  providerID?: string;
   tone: "muted" | "green" | "amber" | "red";
 };
 
@@ -25,7 +27,7 @@ export function providerReadinessMeaning({
     return { message: "No model providers are configured yet. Add one provider before starting Hecate Chat.", tone: "amber" };
   }
   if (blockedCount > 0 && repair?.tone !== "muted") {
-    return { message: `${blockedCount} provider${blockedCount === 1 ? "" : "s"} need attention. Next: ${repair?.action || "open the provider list."}`, tone: "amber" };
+    return { message: `${blockedCount} provider${blockedCount === 1 ? " needs" : "s need"} attention. Next: ${repair?.action || "open the provider list."}`, tone: "amber" };
   }
   if (readyCount === 0) {
     return { message: "Providers exist, but none are ready to route chat requests yet.", tone: "amber" };
@@ -85,6 +87,8 @@ export function providerRepairHint({
       title: "Credentials required",
       message: `${name} is configured but cannot route requests until an API key is saved.`,
       action: "Add or rotate the provider API key in Connections.",
+      actionKind: "open_provider",
+      providerID: configuredProvider.id,
       tone: "amber",
     };
   }
@@ -94,15 +98,20 @@ export function providerRepairHint({
       title: "No models discovered",
       message: `${name} is configured, but Hecate does not have a current model-discovery result for it yet.`,
       action: isLocal ? "Start the local provider process, pull or load a model, then refresh Connections." : "Confirm the account has model access, then refresh Connections.",
+      actionKind: "refresh_providers",
+      providerID: configuredProvider.id,
       tone: "amber",
     };
   }
 
   if (runtimeProvider?.readiness?.status === "blocked") {
+    const blockedCheck = firstBlockedReadinessCheck(runtimeProvider.readiness_checks ?? []);
     return {
       title: "Provider blocked",
       message: runtimeProvider.readiness.message || `${name} is not routable right now.`,
       action: runtimeProvider.readiness.operator_action || firstReadinessAction(runtimeProvider.readiness_checks) || "Open Connections and inspect the blocked readiness check.",
+      actionKind: readinessActionKind(blockedCheck) ?? "open_provider",
+      providerID: configuredProvider?.id ?? runtimeProvider.name,
       tone: "amber",
     };
   }
@@ -113,6 +122,8 @@ export function providerRepairHint({
       title: readinessTitle(blockedCheck),
       message: blockedCheck.message || `${name} has a blocked readiness check.`,
       action: readinessRecommendation(blockedCheck) || "Open Connections and inspect provider readiness.",
+      actionKind: readinessActionKind(blockedCheck) ?? "open_provider",
+      providerID: configuredProvider?.id ?? runtimeProvider?.name,
       tone: "amber",
     };
   }
@@ -123,6 +134,8 @@ export function providerRepairHint({
       title: "Routing blocked",
       message: `${name} is configured, but routing is blocked: ${reason}.`,
       action: "Open Connections and inspect routing, health, and discovery details.",
+      actionKind: "open_provider",
+      providerID: configuredProvider?.id ?? runtimeProvider.name,
       tone: "amber",
     };
   }
@@ -132,6 +145,8 @@ export function providerRepairHint({
       title: "No models discovered",
       message: `${name} is reachable, but Hecate has not discovered any models from it yet.`,
       action: isLocal ? "Pull or load a model in the local provider, then refresh Connections." : "Confirm the account has model access, then refresh Connections.",
+      actionKind: "refresh_providers",
+      providerID: configuredProvider?.id ?? runtimeProvider.name,
       tone: "amber",
     };
   }
@@ -141,6 +156,8 @@ export function providerRepairHint({
       title: "Provider unavailable",
       message: `${name} is currently down or cooling down after failures.`,
       action: isLocal ? "Start the local provider process and refresh Connections." : "Check the upstream endpoint, credentials, and provider status.",
+      actionKind: "refresh_providers",
+      providerID: configuredProvider?.id ?? runtimeProvider.name,
       tone: "amber",
     };
   }
@@ -150,6 +167,8 @@ export function providerRepairHint({
       title: "Ready",
       message: `${name} has no provider setup issue that needs repair.`,
       action: "No repair needed.",
+      actionKind: "none",
+      providerID: configuredProvider?.id ?? runtimeProvider?.name,
       tone: "muted",
     };
   }
@@ -158,6 +177,7 @@ export function providerRepairHint({
     title: "No provider selected",
     message: "Choose or add a provider before sending model traffic.",
     action: "Add a provider in Connections.",
+    actionKind: "add_provider",
     tone: "amber",
   };
 }
@@ -178,10 +198,17 @@ export function providerFleetRepairHint(
       title: "Ready",
       message: "No configured provider setup issue needs repair.",
       action: "No repair needed.",
+      actionKind: "none",
       tone: "muted",
     };
   }
-  return null;
+  return {
+    title: "No provider configured",
+    message: "Add a model provider before starting Hecate Chat.",
+    action: "Add a provider in Connections.",
+    actionKind: "add_provider",
+    tone: "amber",
+  };
 }
 
 function firstBlockedReadinessCheck(checks: ProviderReadinessCheckRecord[]): ProviderReadinessCheckRecord | null {
@@ -195,6 +222,24 @@ function firstReadinessAction(checks?: ProviderReadinessCheckRecord[]): string {
     if (action) return action;
   }
   return "";
+}
+
+function readinessActionKind(check: ProviderReadinessCheckRecord | null): ProviderRepairHint["actionKind"] | null {
+  switch (check?.reason) {
+    case "credential_missing":
+    case "provider_disabled":
+    case "self_referential":
+      return "open_provider";
+    case "no_models":
+    case "discovery_failed":
+    case "provider_unhealthy":
+    case "provider_rate_limited":
+    case "circuit_open":
+    case "recovery_probe":
+      return "refresh_providers";
+    default:
+      return null;
+  }
 }
 
 function titleizeReadinessName(value: string): string {


### PR DESCRIPTION
## Summary

- Unify chat setup and provider readiness repair states so blocked Hecate Chat sends point operators to Connections with the same root cause shown in provider setup.
- Add actionable provider repair hints for adding providers, opening blocked provider details, and refreshing provider/model discovery.
- Surface the same readiness guidance in Connections, Providers, and chat setup states, with backend/API tests for important repair reasons.

## Details

This keeps the provider readiness contract as the canonical source for setup failures and teaches the UI how to turn that contract into safe next actions. Operators now see more specific guidance for missing credentials, no discovered models, disabled providers, self-referential local routes, and backend-reported routing blockers.

The PR also expands tests around those contracts and repair paths so future provider-readiness changes do not drift between backend responses, Connections copy, Providers actions, and Chat setup CTAs.

## Verification

- `just verify`
