### PR TITLE
feat(ui): add OS-aware console themes

### DIFF
--- a/ui/e2e/admin.spec.ts
+++ b/ui/e2e/admin.spec.ts
@@ -1,19 +1,19 @@
 import { expect, test } from "./fixtures";
 
-// Settings workspace. Tabs: Pricing / Retention.
+// Settings workspace. Connections owns provider/model setup; Usage owns
+// cloud-token accounting. Settings is intentionally scoped to maintenance.
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
   await page.locator(".hecate-activitybar [aria-label^='Settings']").click();
-  await page.waitForSelector("text=Pricing");
+  await page.waitForSelector("text=Retention");
 });
 
-test("renders the settings tabs (Pricing / Retention)", async ({ page }) => {
-  for (const tab of ["Pricing", "Retention"]) {
-    await expect(page.getByRole("button", { name: tab })).toBeVisible();
-  }
-  // Removed or relocated tabs: readiness lives in Connections; policy/cache/keys/costs live elsewhere.
-  for (const removed of ["Model capabilities", "Policy", "MCP Cache", "Tenants", "Keys", "Balances", "Usage", "Clients"]) {
+test("renders Settings as retention-only", async ({ page }) => {
+  await expect(page.getByRole("button", { name: "Retention" })).toBeVisible();
+  // Removed or relocated tabs: readiness lives in Connections, usage lives
+  // in the Usage workspace, and pricing/budgeting is no longer configured.
+  for (const removed of ["Pricing", "Model capabilities", "Policy", "MCP Cache", "Tenants", "Keys", "Balances", "Clients"]) {
     await expect(page.getByRole("button", { name: removed })).toHaveCount(0);
   }
 });
@@ -29,7 +29,7 @@ test("Settings nav button uses the 'Settings' label, not 'Admin'", async ({ page
 
 test("retention tab shows known subsystem chips", async ({ page }) => {
   await page.getByRole("button", { name: "Retention" }).click();
-  for (const sub of ["trace_snapshots", "budget_events", "audit_events"]) {
+  for (const sub of ["trace_snapshots", "usage_events", "audit_events"]) {
     await expect(page.locator(`text=${sub}`).first()).toBeVisible();
   }
 });
@@ -50,128 +50,7 @@ test("retention 'Run now' fires POST request", async ({ page }) => {
   await expect.poll(() => posted).toBe(true);
 });
 
-test("Costs workspace shows the empty ledger state", async ({ page }) => {
-  await page.locator(".hecate-activitybar [aria-label^='Costs']").click();
-  await expect(page.locator("text=No usage events recorded yet")).toBeVisible();
-});
-
-test("Costs workspace shows the settings-required hint when budget is missing", async ({ page }) => {
-  await page.route("/hecate/v1/costs/budget*", r => r.fulfill({ status: 404, body: "" }));
-  await page.goto("/");
-  await page.waitForSelector(".hecate-activitybar");
-  await page.locator(".hecate-activitybar [aria-label^='Costs']").click();
-  // Either shows the hint (no budget) or shows budget data — both are acceptable.
-  const ok = await Promise.race([
-    page.locator("text=Budget data unavailable").first().waitFor({ timeout: 1000 }).then(() => true).catch(() => false),
-    page.locator("text=No usage events recorded yet").first().waitFor({ timeout: 1000 }).then(() => true).catch(() => false),
-  ]);
-  expect(ok).toBe(true);
-});
-
-// Pricebook import: Open pricebook tab → preview is fetched on mount →
-// "Import all" opens the consent dialog → Apply triggers POST /apply.
-// This is the only end-to-end exercise of the import flow; the unit
-// test in useRuntimeConsole.test.tsx pins notice wording but never
-// renders the modal or clicks through.
-test("pricebook import all triggers preview + apply round-trip", async ({ page }) => {
-  // Mock the preview to propose adding a price for an existing
-  // catalog model. The MOCK_MODELS fixture has gpt-4o-mini in the
-  // catalog with no pricebook entry, so this will classify as `added`
-  // and the row will appear as "unpriced" in the table — letting the
-  // consent dialog include it.
-  let previewHits = 0;
-  await page.route("/hecate/v1/settings/pricebook/import/preview", async route => {
-    if (route.request().method() !== "POST") return route.continue();
-    previewHits++;
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        object: "settings_pricebook_import_diff",
-        data: {
-          added: [
-            {
-              provider: "openai",
-              model: "gpt-4o-mini",
-              input_micros_usd_per_million_tokens: 150_000,
-              output_micros_usd_per_million_tokens: 600_000,
-              cached_input_micros_usd_per_million_tokens: 75_000,
-              source: "imported",
-            },
-          ],
-          updated: [],
-          skipped: [],
-          unchanged: 0,
-          applied: [],
-          failed: [],
-          fetched_at: "2026-04-25T00:00:00Z",
-        },
-      }),
-    });
-  });
-
-  let applyURL = "";
-  let applyBody = "";
-  await page.route("/hecate/v1/settings/pricebook/import/apply", async route => {
-    if (route.request().method() !== "POST") return route.continue();
-    applyURL = route.request().url();
-    applyBody = route.request().postData() ?? "";
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        object: "settings_pricebook_import_diff",
-        data: {
-          added: [],
-          updated: [],
-          skipped: [],
-          unchanged: 0,
-          applied: [
-            {
-              provider: "openai",
-              model: "gpt-4o-mini",
-              input_micros_usd_per_million_tokens: 150_000,
-              output_micros_usd_per_million_tokens: 600_000,
-              cached_input_micros_usd_per_million_tokens: 75_000,
-              source: "imported",
-            },
-          ],
-          failed: [],
-          fetched_at: "2026-04-25T00:00:00Z",
-        },
-      }),
-    });
-  });
-
-  // Pricing is the first visible Settings tab, so it has already
-  // mounted once during beforeEach — before our route handler was
-  // registered. Toggle to Retention and back so the mount-time
-  // preview fetch fires under the test's mocked route.
-  await page.getByRole("button", { name: "Retention" }).click();
-  await page.getByRole("button", { name: "Pricing" }).click();
-  // Preview is fetched on mount of the tab; the "Import all" button
-  // becomes enabled once the diff arrives. Without this assertion, a
-  // future regression that drops the mount-time preview fetch would go
-  // unnoticed.
-  await expect.poll(() => previewHits, { timeout: 5_000 }).toBeGreaterThanOrEqual(1);
-
-  const importAll = page.getByRole("button", { name: /Import all/i });
-  await expect(importAll).toBeEnabled();
-  await importAll.click();
-
-  // Consent modal: assert it opened and contains the proposed change.
-  await expect(page.getByText("Update pricebook")).toBeVisible();
-  await expect(page.getByText("gpt-4o-mini").first()).toBeVisible();
-
-  // Apply with the pre-selected key. The button label includes the
-  // count, which doubles as a sanity check that selection state landed.
-  const applyBtn = page.getByRole("button", { name: /Apply 1 change/i });
-  await expect(applyBtn).toBeEnabled();
-  await applyBtn.click();
-
-  await expect.poll(() => applyURL).toContain("/hecate/v1/settings/pricebook/import/apply");
-  // The body MUST carry the explicit key list — a regression that drops
-  // `keys` and applies blanket changes would silently overwrite manual
-  // rows the operator never consented to.
-  expect(JSON.parse(applyBody)).toEqual({ keys: ["openai/gpt-4o-mini"] });
+test("Usage workspace shows the empty usage state", async ({ page }) => {
+  await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
+  await expect(page.locator("text=No cloud usage recorded yet")).toBeVisible();
 });

--- a/ui/e2e/shell.spec.ts
+++ b/ui/e2e/shell.spec.ts
@@ -9,7 +9,7 @@ test("renders the activity bar with all workspace buttons", async ({ page }) => 
   const nav = page.locator(".hecate-activitybar");
   await expect(nav).toBeVisible();
 
-  for (const label of ["Chats", "Connections", "Tasks", "Observability", "Costs", "Settings"]) {
+  for (const label of ["Chats", "Connections", "Tasks", "Observability", "Usage", "Settings"]) {
     await expect(nav.locator(`[aria-label^="${label}"]`)).toBeVisible();
   }
 });
@@ -49,11 +49,11 @@ test("number keys do not switch workspaces while the app is focused", async ({ p
   );
 });
 
-test("Costs nav button activates the Costs workspace", async ({ page }) => {
-  await page.locator(".hecate-activitybar [aria-label^='Costs']").click();
+test("Usage nav button activates the Usage workspace", async ({ page }) => {
+  await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
   await expect(page.locator(".hecate-activitybar [aria-current='page']")).toHaveAttribute(
     "aria-label",
-    /Costs/,
+    /Usage/,
   );
 });
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,15 +3,31 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0c0e12" />
     <title>Hecate Runtime Console</title>
-    <!-- Paint the app background before styles.css and the JS bundle land
-         so the page never flashes browser-default white on first load. The
-         color and color-scheme are duplicated in styles.css; keep them in
-         sync. -->
+    <!-- Theme preload: applies either the explicit saved theme or the OS
+         color-scheme before paint, so the page never flashes the wrong
+         palette while styles.css and the JS bundle load. styles.css owns
+         the actual token values; this script only flips the data-theme
+         attribute. -->
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("hecate.theme");
+          if (t !== "light" && t !== "dark") {
+            t = window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+          }
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (_) {
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+      })();
+    </script>
     <style>
-      html, body { margin: 0; background: oklch(0.09 0.008 240); color-scheme: dark; }
+      html, body { margin: 0; }
+      html[data-theme="dark"], html[data-theme="dark"] body { background: oklch(0.105 0.010 245); color-scheme: dark; }
+      html[data-theme="light"], html[data-theme="light"] body { background: oklch(0.99 0.002 240); color-scheme: light; }
     </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -84,7 +84,7 @@
 /* Status bar */
 .hecate-statusbar {
   background: var(--teal);
-  color: var(--bg0);
+  color: var(--accent-fg);
   display: flex;
   align-items: center;
   padding: 0 10px;

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConsoleShell, getAvailableWorkspaces } from "./AppShell";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../test/runtime-console-fixture";
@@ -158,6 +158,77 @@ describe("ConsoleShell navigation", () => {
 
     expect(screen.queryByText("/Users/alice/dev/hecate")).toBeNull();
     expect(screen.queryByText("git:main")).toBeNull();
+  });
+});
+
+describe("ConsoleShell theme toggle", () => {
+  function stubColorScheme(matchesLight: boolean) {
+    const listeners = new Set<() => void>();
+    const query = {
+      matches: matchesLight,
+      media: "(prefers-color-scheme: light)",
+      onchange: null,
+      addEventListener: vi.fn((_event: string, listener: () => void) => {
+        listeners.add(listener);
+      }),
+      removeEventListener: vi.fn((_event: string, listener: () => void) => {
+        listeners.delete(listener);
+      }),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+    vi.stubGlobal("matchMedia", vi.fn(() => query));
+    return query;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    vi.unstubAllGlobals();
+  });
+
+  it("follows the OS theme when no preference is saved", () => {
+    stubColorScheme(true);
+    const state = createRuntimeConsoleFixture();
+
+    render(
+      <ConsoleShell
+        activeWorkspace="settings"
+        onSelectWorkspace={() => {}}
+        state={state}
+        actions={createRuntimeConsoleActions()}
+      />,
+    );
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(localStorage.getItem("hecate.theme")).toBeNull();
+  });
+
+  it("toggles the document theme and persists the choice", () => {
+    stubColorScheme(false);
+    document.documentElement.setAttribute("data-theme", "dark");
+    const state = createRuntimeConsoleFixture();
+
+    render(
+      <ConsoleShell
+        activeWorkspace="settings"
+        onSelectWorkspace={() => {}}
+        state={state}
+        actions={createRuntimeConsoleActions()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /switch to light theme/i }));
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(localStorage.getItem("hecate.theme")).toBe("light");
+    expect(screen.getByRole("button", { name: /switch to dark theme/i })).toBeInTheDocument();
   });
 });
 

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 
 import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
 import type { AgentChatUsageRecord } from "../types/runtime";
@@ -68,6 +68,71 @@ function SvgIcon({ d, size = 18 }: { d: string | string[]; size?: number }) {
     </svg>
   );
 }
+
+// Theme — follows the OS by default and persists only an explicit user
+// override. The bootstrap script in index.html sets data-theme before
+// paint; this hook keeps React state, DOM, localStorage, and live OS
+// color-scheme changes in sync afterward.
+type Theme = "dark" | "light";
+type ThemePreference = Theme | "system";
+const THEME_KEY = "hecate.theme";
+
+function readStoredThemePreference(): ThemePreference {
+  if (typeof localStorage === "undefined") return "system";
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    return stored === "light" || stored === "dark" ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function preferredSystemTheme(): Theme {
+  if (typeof window === "undefined" || !window.matchMedia) return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+function useTheme(): [Theme, () => void] {
+  const [preference, setPreference] = useState<ThemePreference>(readStoredThemePreference);
+  const [systemTheme, setSystemTheme] = useState<Theme>(preferredSystemTheme);
+  const theme = preference === "system" ? systemTheme : preference;
+
+  useEffect(() => {
+    const query = window.matchMedia?.("(prefers-color-scheme: light)");
+    if (!query) return;
+    const update = () => setSystemTheme(query.matches ? "light" : "dark");
+    update();
+    query.addEventListener?.("change", update);
+    return () => query.removeEventListener?.("change", update);
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+    try {
+      if (preference === "system") localStorage.removeItem(THEME_KEY);
+      else localStorage.setItem(THEME_KEY, preference);
+    } catch { /* private mode etc. */ }
+  }, [preference, theme]);
+
+  return [theme, () => setPreference(theme === "dark" ? "light" : "dark")];
+}
+
+// Sun / moon glyphs for the theme toggle. Match the stroke-only style
+// of the activity-bar icons so the toggle reads as part of the rail.
+const SunIcon = (
+  <SvgIcon d={[
+    "M12 3v2", "M12 19v2", "M4.22 4.22l1.42 1.42", "M18.36 18.36l1.42 1.42",
+    "M3 12h2", "M19 12h2", "M4.22 19.78l1.42-1.42", "M18.36 5.64l1.42-1.42",
+    "M12 8a4 4 0 100 8 4 4 0 000-8z",
+  ]} />
+);
+const MoonIcon = (
+  <SvgIcon d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+);
 
 type WorkspaceLineupEntry = WorkspaceDefinition;
 const WS: Record<WorkspaceID, WorkspaceLineupEntry> = {
@@ -176,6 +241,7 @@ function AuthenticatedShell({
   const workspaces = getAvailableWorkspaces();
   const [taskFocusRequest, setTaskFocusRequest] = useState<TaskFocusRequest | null>(null);
   const [traceFocusRequest, setTraceFocusRequest] = useState<TraceFocusRequest | null>(null);
+  const [theme, toggleTheme] = useTheme();
 
   function openTaskFromChat(taskID: string, runID?: string) {
     setTaskFocusRequest({ taskID, runID, nonce: Date.now() });
@@ -215,6 +281,18 @@ function AuthenticatedShell({
               {ws.icon}
             </button>
           ))}
+          {/* Pin theme toggle to the bottom of the rail. The flex spacer
+              keeps it visually separated from workspace icons regardless
+              of how many workspaces are registered. */}
+          <span style={{ flex: 1 }} />
+          <button
+            aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+            className="hecate-activitybtn"
+            onClick={toggleTheme}
+            title={`Theme: ${theme}`}
+            type="button">
+            {theme === "dark" ? SunIcon : MoonIcon}
+          </button>
         </nav>
 
         {/* Main content */}

--- a/ui/src/features/shared/BrandAvatar.tsx
+++ b/ui/src/features/shared/BrandAvatar.tsx
@@ -56,8 +56,7 @@ const BRAND_ICONS: Record<string, BrandIconSpec> = {
   xai: { component: Xai, monochrome: true },
 };
 
-const MONOCHROME_ICON_FILTER = "brightness(0) invert(1) opacity(0.88)";
-const MONOCHROME_ICON_COLOR = "rgba(255, 255, 255, 0.88)";
+const MONOCHROME_ICON_COLOR = "var(--mono-icon)";
 
 export function BrandAvatar({
   brand,
@@ -90,7 +89,6 @@ export function BrandAvatar({
         style={{
           color: icon.monochrome ? MONOCHROME_ICON_COLOR : undefined,
           display: "block",
-          filter: icon.monochrome ? MONOCHROME_ICON_FILTER : undefined,
         }}
       />
     )

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4,39 +4,46 @@ body { margin: 0; }
 :root {
   color-scheme: dark;
 
-  --bg0: oklch(0.09 0.008 240);
-  --bg1: oklch(0.115 0.008 240);
-  --bg2: oklch(0.148 0.008 240);
-  --bg3: oklch(0.185 0.008 240);
-  --bg4: oklch(0.22 0.010 240);
+  --bg0: oklch(0.105 0.010 245);
+  --bg1: oklch(0.130 0.010 245);
+  --bg2: oklch(0.165 0.011 245);
+  --bg3: oklch(0.205 0.012 245);
+  --bg4: oklch(0.255 0.013 245);
 
-  --border: oklch(0.24 0.008 240);
-  --border2: oklch(0.30 0.008 240);
+  --border: oklch(0.31 0.010 245);
+  --border2: oklch(0.39 0.012 245);
 
-  --t0: oklch(0.93 0.004 240);
-  --t1: oklch(0.68 0.007 240);
-  --t2: oklch(0.46 0.007 240);
-  --t3: oklch(0.32 0.006 240);
+  --t0: oklch(0.95 0.004 245);
+  --t1: oklch(0.78 0.007 245);
+  --t2: oklch(0.62 0.007 245);
+  --t3: oklch(0.49 0.006 245);
+  --t4: oklch(0.38 0.006 245);
+  --mono-icon: oklch(0.95 0.004 245);
 
-  --teal: oklch(0.68 0.13 185);
-  --teal-lo: oklch(0.45 0.09 185);
-  --teal-bg: oklch(0.16 0.04 185);
-  --teal-border: oklch(0.28 0.07 185);
+  --teal: oklch(0.72 0.14 185);
+  --teal-lo: oklch(0.58 0.10 185);
+  --teal-bg: oklch(0.19 0.05 185);
+  --teal-border: oklch(0.36 0.08 185);
 
-  --amber: oklch(0.76 0.13 85);
-  --amber-lo: oklch(0.48 0.09 85);
-  --amber-bg: oklch(0.16 0.04 85);
-  --amber-border: oklch(0.28 0.07 85);
+  --amber: oklch(0.80 0.14 85);
+  --amber-lo: oklch(0.62 0.10 85);
+  --amber-bg: oklch(0.20 0.05 85);
+  --amber-border: oklch(0.38 0.08 85);
 
-  --red: oklch(0.62 0.17 25);
-  --red-lo: oklch(0.42 0.11 25);
-  --red-bg: oklch(0.16 0.05 25);
-  --red-border: oklch(0.28 0.08 25);
+  --red: oklch(0.68 0.18 25);
+  --red-lo: oklch(0.56 0.12 25);
+  --red-bg: oklch(0.19 0.06 25);
+  --red-border: oklch(0.38 0.09 25);
 
-  --green: oklch(0.70 0.14 145);
-  --green-lo: oklch(0.45 0.09 145);
-  --green-bg: oklch(0.16 0.04 145);
-  --green-border: oklch(0.28 0.07 145);
+  --green: oklch(0.74 0.14 145);
+  --green-lo: oklch(0.60 0.10 145);
+  --green-bg: oklch(0.19 0.05 145);
+  --green-border: oklch(0.36 0.08 145);
+
+  /* On-accent foreground. Sits on top of --teal (primary buttons,
+     status bar). Theme-aware so light mode swaps to a near-white
+     ink without the app having to special-case it. */
+  --accent-fg: oklch(0.12 0.02 185);
 
   /* Scrim — translucent overlay rendered behind modal/slide-over
      surfaces. One opacity for the whole app so backdrops feel
@@ -86,6 +93,65 @@ body { margin: 0; }
   --warning: var(--amber);
   --danger: var(--red);
   --shadow: 0 4px 12px oklch(0% 0 0 / 0.3);
+}
+
+/* ─── Light theme ─────────────────────────────────────────────────────────
+ * Activated by `data-theme="light"` on <html>. Inverts the lightness ramp
+ * of bg0…bg4 (paper-white → light grey) and t0…t3 (near-black → light
+ * grey), and dials each accent down so saturated chroma stays legible on
+ * a light surface. The tinted *-bg pairs become very pale washes so badge
+ * backgrounds read as a hint of color, not a saturated block.
+ *
+ * The brand-* hex tokens are intentionally not overridden: vendor logo
+ * colors look fine on either surface.
+ */
+html[data-theme="light"] {
+  color-scheme: light;
+
+  --bg0: oklch(0.985 0.004 245);
+  --bg1: oklch(0.965 0.005 245);
+  --bg2: oklch(0.940 0.006 245);
+  --bg3: oklch(0.905 0.008 245);
+  --bg4: oklch(0.865 0.010 245);
+
+  --border: oklch(0.825 0.010 245);
+  --border2: oklch(0.735 0.014 245);
+
+  --t0: oklch(0.205 0.016 245);
+  --t1: oklch(0.355 0.014 245);
+  --t2: oklch(0.500 0.012 245);
+  --t3: oklch(0.635 0.010 245);
+  --t4: oklch(0.760 0.008 245);
+  --mono-icon: oklch(0.18 0.014 245);
+
+  --teal: oklch(0.50 0.13 185);
+  --teal-lo: oklch(0.39 0.09 185);
+  --teal-bg: oklch(0.94 0.045 185);
+  --teal-border: oklch(0.75 0.08 185);
+
+  --amber: oklch(0.58 0.14 75);
+  --amber-lo: oklch(0.46 0.10 75);
+  --amber-bg: oklch(0.94 0.055 85);
+  --amber-border: oklch(0.77 0.09 85);
+
+  --red: oklch(0.50 0.18 25);
+  --red-lo: oklch(0.40 0.12 25);
+  --red-bg: oklch(0.94 0.045 25);
+  --red-border: oklch(0.76 0.09 25);
+
+  --green: oklch(0.48 0.14 145);
+  --green-lo: oklch(0.39 0.10 145);
+  --green-bg: oklch(0.94 0.045 145);
+  --green-border: oklch(0.75 0.08 145);
+
+  --accent-fg: oklch(0.99 0.002 240);
+
+  --scrim: oklch(0 0 0 / 0.32);
+
+  --shadow-popover:  0 2px 8px oklch(0 0 0 / 0.10);
+  --shadow-dropdown: 0 4px 12px oklch(0 0 0 / 0.08);
+  --shadow-modal:    0 12px 40px oklch(0 0 0 / 0.18);
+  --shadow:          0 4px 12px oklch(0 0 0 / 0.10);
 }
 
 html, body, #root { height: 100%; overflow: hidden; }
@@ -158,13 +224,13 @@ button, input, select, textarea { font: inherit; }
   transition: background 0.1s, border-color 0.1s, color 0.1s; white-space: nowrap;
 }
 .btn:hover { background: var(--bg4); border-color: var(--border2); }
-.btn:disabled { opacity: 0.5; cursor: default; pointer-events: none; }
-.btn-primary { background: var(--teal); border-color: var(--teal); color: var(--bg0); }
-.btn-primary:hover { background: oklch(0.72 0.13 185); border-color: oklch(0.72 0.13 185); }
+.btn:disabled { opacity: 0.68; cursor: default; pointer-events: none; }
+.btn-primary { background: var(--teal); border-color: var(--teal); color: var(--accent-fg); }
+.btn-primary:hover { background: oklch(0.76 0.14 185); border-color: oklch(0.76 0.14 185); }
 .btn-ghost { background: transparent; border-color: transparent; color: var(--t1); }
 .btn-ghost:hover { background: var(--bg3); color: var(--t0); border-color: transparent; }
 .btn-danger { background: var(--red-bg); border-color: var(--red-border); color: var(--red); }
-.btn-danger:hover { background: var(--red); color: var(--bg0); }
+.btn-danger:hover { background: var(--red); color: var(--accent-fg); }
 .btn-sm { padding: 4px 8px; font-size: 11px; }
 
 /* ─── Input / Select ─── */


### PR DESCRIPTION
## Summary

- Make the operator console follow the OS color scheme by default, while keeping an explicit activity-rail theme toggle for user overrides.
- Add a pre-paint theme bootstrap so the saved/system theme is applied before React loads, avoiding wrong-theme flash.
- Refresh the dark graphite palette, add a calmer light palette, and make monochrome brand icons theme-aware so they stay readable in both schemes.
- Add focused coverage for OS-default theme selection and persisted explicit theme toggles.

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/app/AppShell.test.tsx src/features/shared/ui.test.tsx`