### PR TITLE
ci: gate desktop packaging behind tests

### DIFF
--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -153,7 +153,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           projectPath: tauri
-          args: --bundles ${{ matrix.bundles }}
+          args: >-
+            --bundles ${{ matrix.bundles }}
+            --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       # Tagged release build. Uploads bundles to the existing GitHub Release and
       # signs/notarizes when the corresponding secrets are configured.

--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -134,14 +134,13 @@ jobs:
       - name: Stamp Tauri version
         run: bun scripts/stamp-version.ts
 
-      # Single tauri-action call serves both modes:
-      #   - tagName empty  → build only (PR validation via tauri-build.yml)
-      #   - tagName set    → upload to the existing GitHub Release for that tag
-      #                      (release.yml after a `v*` tag push)
-      #
-      # macOS signing/notarization protections are documented in the
-      # env: block below.
-      - name: Build Tauri bundles
+      # Keep PR builds and release builds as separate steps. Setting signing
+      # variables to an empty string is not the same as omitting them: Tauri's
+      # bundler still treats some present-but-empty vars as "signing requested"
+      # and fails while decoding/importing them. PR validation must pass no
+      # signing/notarization env at all.
+      - name: Build Tauri bundles (unsigned PR)
+        if: inputs.tagName == ''
         uses: tauri-apps/tauri-action@v0
         env:
           # `github.token` is the per-job-run token, available in every
@@ -151,6 +150,17 @@ jobs:
           # inherit` — see that file's job-level comment for why
           # withholding inherit is the load-bearing protection
           # against PR-side secret exfiltration.
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          projectPath: tauri
+          args: --bundles ${{ matrix.bundles }}
+
+      # Tagged release build. Uploads bundles to the existing GitHub Release and
+      # signs/notarizes when the corresponding secrets are configured.
+      - name: Build Tauri bundles (signed release)
+        if: inputs.tagName != ''
+        uses: tauri-apps/tauri-action@v0
+        env:
           GITHUB_TOKEN: ${{ github.token }}
           # Apple signing/notarization secrets. Two independent
           # protections in series:
@@ -172,13 +182,13 @@ jobs:
           # keychain tauri-action creates on the runner — its value
           # never matters again. See docs/macos-signing.md for the
           # operator-side setup checklist.
-          APPLE_CERTIFICATE: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.APPLE_TEAM_ID || '' }}
-          KEYCHAIN_PASSWORD: ${{ matrix.os == 'macos-latest' && inputs.tagName != '' && secrets.KEYCHAIN_PASSWORD || '' }}
+          APPLE_CERTIFICATE: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
+          KEYCHAIN_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.KEYCHAIN_PASSWORD || '' }}
           # Updater signing key. Same caller-side / called-side
           # protection model as the Apple secrets above: scope to a
           # release-workflow run with a non-empty tagName. When set,
@@ -188,8 +198,8 @@ jobs:
           # secrets), unsigned bundles ship and the updater stays
           # inert. See docs/desktop-updater-signing.md for the
           # keypair custody checklist.
-          TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tagName != '' && secrets.TAURI_UPDATER_PRIVATE_KEY || '' }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.tagName != '' && secrets.TAURI_UPDATER_PRIVATE_KEY_PASSWORD || '' }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_UPDATER_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_UPDATER_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: tauri
           tagName: ${{ inputs.tagName }}

--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -2,7 +2,7 @@ name: tauri-shared
 
 # Reusable Tauri matrix build. Called by:
 #   - release.yml      (tagged release: tagName set → tauri-action uploads to GitHub Release)
-#   - tauri-build.yml  (PR validation: uploadArtifacts true → preserved as workflow artifact)
+#   - tauri-build.yml  (PR validation: build only; no release upload)
 #
 # When you change anything in this file, both callers pick it up
 # automatically. Keep their path filters wide enough to trigger on

--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -2,9 +2,10 @@ name: tauri-shared
 
 # Reusable Tauri matrix build. Called by:
 #   - release.yml      (tagged release: tagName set → tauri-action uploads to GitHub Release)
-#   - tauri-build.yml  (PR validation: build only; no release upload)
+#   - test.yml         (PR validation: build only; no release upload)
+#   - tauri-build.yml  (manual desktop rebuild/debug run from the Actions tab)
 #
-# When you change anything in this file, both callers pick it up
+# When you change anything in this file, all callers pick it up
 # automatically. Keep their path filters wide enough to trigger on
 # changes to this workflow itself.
 
@@ -17,7 +18,7 @@ on:
         required: false
         default: ''
       uploadArtifacts:
-        description: 'Upload built bundles as workflow artifacts (for PR runs).'
+        description: 'Upload built bundles as workflow artifacts for manual/debug callers.'
         type: boolean
         required: false
         default: false
@@ -25,8 +26,8 @@ on:
 # Maximum permissions any caller needs:
 #   - contents: write   tauri-action uploads bundles to a GitHub Release
 #                       (when called from release.yml with tagName set)
-# Callers that don't upload (PR validation via tauri-build.yml) restrict
-# this back down to contents: read at their own workflow-level block.
+# Release callers grant contents/actions write. Non-release callers do not pass
+# secrets and set uploadArtifacts=false, so the matrix only proves bundles build.
 permissions:
   contents: write
 

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -35,10 +35,13 @@ concurrency:
   group: tauri-build-${{ github.ref }}
   cancel-in-progress: true
 
-# PR validation only — no release upload. Restricts the GITHUB_TOKEN
-# below the contents: write that _tauri-shared.yml declares as its max.
+# Caller permissions must cover the maximum requested by the shared workflow.
+# GitHub validates reusable-workflow permissions at startup, before `if:` gates
+# can skip release-only jobs. PR builds still do not inherit repository secrets,
+# and fork PRs receive a read-only token regardless of this declaration.
 permissions:
-  contents: read
+  contents: write
+  actions: write
 
 jobs:
   tauri:
@@ -58,6 +61,7 @@ jobs:
     # `secrets.GITHUB_TOKEN` to keep working without any inherited
     # secret access.
     permissions:
-      contents: read
+      contents: write
+      actions: write
     with:
       uploadArtifacts: true

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,36 +1,13 @@
 name: tauri-build
 
-# PR-triggered Tauri matrix build. All build steps live in
-# _tauri-shared.yml — this file is just the trigger + caller.
-#
-# Path filter scopes the run to changes that could plausibly break the
-# Tauri pipeline; anything else skips the matrix entirely.
+# Manual Tauri matrix build. PR validation is gated behind the main
+# Test workflow so macOS/Windows/Linux packaging starts only after the
+# cheaper tests pass. Keep this workflow for explicit reruns/debugging
+# from the Actions tab.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'tauri/**'
-      - 'scripts/resolve-tauri-version.ts'
-      - 'scripts/stamp-version.ts'
-      - 'scripts/tauri-smoke.ts'
-      - 'Justfile'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/hecate/**'
-      - 'cmd/hecate-acp/**'
-      - 'ui/**'
-      - 'embed.go'              # //go:embed all:ui/dist — UI bundle into binary
-      - '.goreleaser.yaml'      # release config; tag-time goreleaser pipeline
-      - 'Dockerfile.release'    # GHCR image baseline; not Tauri but same release flow
-      - '.github/workflows/_tauri-shared.yml'
-      - '.github/workflows/tauri-build.yml'
-      - '.github/workflows/release.yml'
   workflow_dispatch:
 
-# Cancel queued/running PR runs when a new commit lands on the same ref.
-# A 30-minute matrix on every push during active dev burns minutes
-# fast otherwise.
 concurrency:
   group: tauri-build-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -64,4 +64,7 @@ jobs:
       contents: write
       actions: write
     with:
-      uploadArtifacts: true
+      # PR validation only needs to prove every desktop bundle can be built.
+      # Uploading the large unsigned bundles as workflow artifacts has proved
+      # flaky on GitHub's artifact service and does not affect release assets.
+      uploadArtifacts: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ui/package.json
-          cache: true
 
       - uses: actions/setup-go@v6
         with:
@@ -359,7 +358,6 @@ jobs:
           # Reads the version from package.json "packageManager" field so CI
           # always matches what's declared locally.
           bun-version-file: ui/package.json
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -393,7 +391,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ui/package.json
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,6 +420,9 @@ jobs:
 
   tauri-desktop:
     name: Tauri desktop bundles
+    # Keep this explicit list in sync with every cheap/required PR check. The
+    # desktop matrix is intentionally last so a failing unit/e2e/smoke check
+    # does not burn macOS/Windows/Linux packaging minutes.
     needs:
       - changes
       - test-tauri-rust

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       typescript: ${{ steps.filter.outputs.typescript }}
       tauri: ${{ steps.filter.outputs.tauri }}
+      desktop: ${{ steps.filter.outputs.desktop }}
       workflow: ${{ steps.filter.outputs.workflow }}
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -52,7 +53,7 @@ jobs:
           # silently drifts when one filter is updated without the other.
           filters: |
             workflow:
-              - '.github/workflows/test.yml'
+              - '.github/workflows/*.yml'
               - 'Justfile'
             docker:
               - 'Dockerfile'
@@ -78,6 +79,23 @@ jobs:
               - 'tauri/src-tauri/Cargo.toml'
               - 'tauri/src-tauri/Cargo.lock'
               - 'tauri/src-tauri/tauri.conf.json'
+            desktop:
+              - 'tauri/**'
+              - 'scripts/resolve-tauri-version.ts'
+              - 'scripts/stamp-version.ts'
+              - 'scripts/tauri-smoke.ts'
+              - 'Justfile'
+              - 'go.mod'
+              - 'go.sum'
+              - 'cmd/hecate/**'
+              - 'cmd/hecate-acp/**'
+              - 'ui/**'
+              - 'embed.go'
+              - '.goreleaser.yaml'
+              - 'Dockerfile.release'
+              - '.github/workflows/_tauri-shared.yml'
+              - '.github/workflows/tauri-build.yml'
+              - '.github/workflows/release.yml'
 
   test-tauri-rust:
     name: Tauri Rust tests
@@ -140,7 +158,9 @@ jobs:
           git diff --exit-code go.mod go.sum
 
       - name: Check formatting
-        run: test -z "$(gofmt -s -l $(git ls-files '*.go'))"
+        run: |
+          mapfile -t files < <(git ls-files '*.go')
+          test -z "$(gofmt -s -l "${files[@]}")"
 
       - name: Vet
         run: go vet ./...
@@ -400,3 +420,43 @@ jobs:
 
       - name: E2E tests
         run: bun run test:e2e
+
+  tauri-desktop:
+    name: Tauri desktop bundles
+    needs:
+      - changes
+      - test-tauri-rust
+      - lint-go
+      - test-go
+      - build-hecate
+      - e2e
+      - e2e-ollama
+      - docker-smoke
+      - typescript
+      - typescript-e2e
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      (
+        needs.changes.outputs.desktop == 'true' ||
+        needs.changes.outputs.workflow == 'true'
+      ) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.build-hecate.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.e2e.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.e2e-ollama.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.docker-smoke.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typescript.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typescript-e2e.result)
+    uses: ./.github/workflows/_tauri-shared.yml
+    permissions:
+      contents: write
+      actions: write
+    with:
+      # Desktop PR validation runs after the cheaper test matrix so failing
+      # unit/e2e checks don't burn macOS/Windows/Linux packaging minutes.
+      # Tagged release builds still upload signed bundles via release.yml.
+      uploadArtifacts: false

--- a/Justfile
+++ b/Justfile
@@ -317,13 +317,14 @@ tauri-version: tauri-install
 # Build versioned gateway and ACP sidecars for Tauri.
 tauri-build-sidecars: ui-build _go-cache
 	version=$(bun scripts/resolve-tauri-version.ts); \
+	goexe=$(go env GOEXE); \
 	if [ -z "$version" ]; then \
 	  echo "could not resolve Tauri sidecar version" && exit 1; \
 	fi; \
 	ldflags="-X github.com/hecate/agent-runtime/internal/version.Version=$version"; \
 	echo "building Tauri sidecars at version $version"; \
-	GOCACHE="$PWD/{{gocache}}" go build -ldflags "$ldflags" -o hecate ./cmd/hecate; \
-	GOCACHE="$PWD/{{gocache}}" go build -ldflags "$ldflags" -o hecate-acp ./cmd/hecate-acp
+	GOCACHE="$PWD/{{gocache}}" go build -ldflags "$ldflags" -o "hecate$goexe" ./cmd/hecate; \
+	GOCACHE="$PWD/{{gocache}}" go build -ldflags "$ldflags" -o "hecate-acp$goexe" ./cmd/hecate-acp
 
 # Build hecate + hecate-acp and stage them as Tauri sidecars. Pass an explicit
 # target triple in CI matrix builds; local builds auto-detect the host triple.

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -182,7 +182,8 @@ Three workflow files split responsibilities:
 |---|---|---|
 | `.github/workflows/_tauri-shared.yml` | `workflow_call` only | Reusable matrix build. Single source of truth for Tauri build steps. |
 | `.github/workflows/release.yml` | tag push (`v*`) | Goreleaser job, then calls `_tauri-shared.yml` with `tagName` set → bundles upload to the GitHub Release. |
-| `.github/workflows/tauri-build.yml` | PR to master | Calls `_tauri-shared.yml` with `uploadArtifacts: true` → bundles persist as workflow artifacts (14-day retention) for reviewer test-launch. |
+| `.github/workflows/test.yml` | PR / `master` push | Main test gate. Its `Tauri desktop bundles` job calls `_tauri-shared.yml` after cheaper checks pass or skip. |
+| `.github/workflows/tauri-build.yml` | manual dispatch | Explicit desktop rebuild/debug run from the Actions tab. |
 
 **Matrix** (same for both callers):
 
@@ -194,7 +195,14 @@ Three workflow files split responsibilities:
 
 **Steps per matrix leg** (in `_tauri-shared.yml`): Rust + Go + Bun setup → Linux Tauri 2 prereqs (webkit2gtk-4.1, libxdo, patchelf, …) → `just ui-install` → `just tauri-sidecar <matrix-target>` (builds `hecate` / `hecate-acp` with the tag injected, then stages them as `binaries/<name>-{triple}[.exe]`) → `cd tauri && bun install --frozen-lockfile` → `bun scripts/stamp-version.ts` → `tauri-apps/tauri-action@v0` (build, conditionally upload).
 
-**PR-run behaviour:** `concurrency: cancel-in-progress: true` cancels older runs on the same ref. `if: pull_request.draft == false` skips drafts. Trigger types: `[opened, synchronize, reopened, ready_for_review]` — no fire on title-only edits. Path filter scopes to changes that could plausibly break a Tauri build (`tauri/**`, `cmd/hecate/**`, `cmd/hecate-acp/**`, `ui/**`, `Justfile`, `scripts/resolve-tauri-version.ts`, `scripts/stamp-version.ts`, `.github/workflows/*.yml`).
+**PR-run behaviour:** `test.yml` owns PR validation. Its path filter scopes the
+desktop matrix to changes that could plausibly break a Tauri build (`tauri/**`,
+`cmd/hecate/**`, `cmd/hecate-acp/**`, `ui/**`, `Justfile`, version scripts,
+release packaging files, and `.github/workflows/*.yml`). The matrix waits for
+the cheaper Go, TypeScript, e2e, Docker smoke, and Tauri Rust jobs to pass (or
+skip by path filter) before it starts, and it does not upload unsigned bundles.
+`concurrency: cancel-in-progress: true` cancels older runs on the same ref.
+`tauri-build.yml` is manual-only for explicit desktop reruns/debugging.
 
 **Release-run behaviour:** `concurrency: cancel-in-progress: false` — a half-cancelled release is worse than waiting. The `tauri` job has `needs: goreleaser` so the GitHub Release entry exists before tauri-action's upload tries to attach to it.
 

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -202,7 +202,8 @@ release packaging files, and `.github/workflows/*.yml`). The matrix waits for
 the cheaper Go, TypeScript, e2e, Docker smoke, and Tauri Rust jobs to pass (or
 skip by path filter) before it starts, and it does not upload unsigned bundles.
 `concurrency: cancel-in-progress: true` cancels older runs on the same ref.
-`tauri-build.yml` is manual-only for explicit desktop reruns/debugging.
+`tauri-build.yml` is manual-only for explicit desktop reruns/debugging; dispatch
+it from a PR branch when a reviewer needs a pre-merge bundle to test-launch.
 
 **Release-run behaviour:** `concurrency: cancel-in-progress: false` — a half-cancelled release is worse than waiting. The `tauri` job has `needs: goreleaser` so the GitHub Release entry exists before tauri-action's upload tries to attach to it.
 
@@ -218,7 +219,7 @@ skip by path filter) before it starts, and it does not upload unsigned bundles.
 
 ### Code signing — macOS conditional, Windows not yet wired
 
-macOS bundles are signed with a Developer ID Application certificate and notarized by Apple **on release-workflow runs when the seven `APPLE_*` / `KEYCHAIN_PASSWORD` repo secrets are configured**. "Release-workflow run" = any invocation of `release.yml` (tag push or `workflow_dispatch`); both pass a non-empty `tagName` to the reusable workflow. The CI workflow in `.github/workflows/_tauri-shared.yml` reads the secrets via env, gated on two conditions in series: `matrix.os == 'macos-latest'` AND `inputs.tagName != ''`. PR-validation builds (called from `tauri-build.yml`, which deliberately doesn't `secrets: inherit`) always produce unsigned bundles by design — they're throwaway artifacts. Maintainer-side setup checklist for the secrets is in [`docs/macos-signing.md`](../../../docs/macos-signing.md), including a verification recipe and a rotation playbook. Operators downloading an unsigned build (PR validation, fork builds, releases cut before secrets landed) need right-click → Open on first launch.
+macOS bundles are signed with a Developer ID Application certificate and notarized by Apple **on release-workflow runs when the seven `APPLE_*` / `KEYCHAIN_PASSWORD` repo secrets are configured**. "Release-workflow run" = any invocation of `release.yml` (tag push or `workflow_dispatch`); both pass a non-empty `tagName` to the reusable workflow. The CI workflow in `.github/workflows/_tauri-shared.yml` reads the secrets via env, gated on two conditions in series: `matrix.os == 'macos-latest'` AND `inputs.tagName != ''`. PR validation in `test.yml` and manual `tauri-build.yml` rebuilds deliberately do not use `secrets: inherit`, so they always produce unsigned bundles by design — they're throwaway artifacts. Maintainer-side setup checklist for the secrets is in [`docs/macos-signing.md`](../../../docs/macos-signing.md), including a verification recipe and a rotation playbook. Operators downloading an unsigned build (PR validation, fork builds, releases cut before secrets landed) need right-click → Open on first launch.
 
 Windows MSI signing (Authenticode + EV cert ~$300+/yr) is not yet wired. SmartScreen warns until it lands; document in release notes.
 

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -76,6 +76,8 @@ matrix runs before the tag — it's the only way to find out a Windows-only or
 Linux-only regression without burning a release. Use the manual
 `.github/workflows/tauri-build.yml` workflow from the Actions tab only for an
 explicit desktop rebuild/debug run.
+If a reviewer needs to test-launch a bundle before merge, dispatch
+`.github/workflows/tauri-build.yml` manually from the PR branch.
 
 ### Manual local build (rarely needed)
 
@@ -90,7 +92,7 @@ Outputs land in `tauri/src-tauri/target/release/bundle/`. Use this for iterating
 - **Don't build manually then expect CI artifacts to match.** The CI matrix produces bundles signed differently (or unsigned) from a local build. Local artifacts are for debugging, not distribution.
 - **`0.1.0-alpha.N` is valid semver for Tauri**, but macOS `CFBundleShortVersionString` strips the pre-release suffix in the About dialog. That's expected — Tauri handles it internally.
 - **macOS bundles are signed + notarized only on release-workflow runs; PR-validation builds are unsigned by design.** "Release-workflow run" = any invocation of `release.yml` (tag push OR `workflow_dispatch`), both of which pass a non-empty `tagName` to the reusable workflow. Two protections in series:
-  - **Caller-side (load-bearing):** `tauri-build.yml` does NOT use `secrets: inherit` when calling the reusable workflow. The called workflow's `secrets.APPLE_*` references therefore resolve to empty unconditionally during PR validation — the secret values are not in the calling job's context, so even a same-repo PR that rewrites the called workflow can't read them. `release.yml` does inherit (it needs the credentials to actually sign).
+  - **Caller-side (load-bearing):** PR validation in `test.yml` and manual `tauri-build.yml` runs do NOT use `secrets: inherit` when calling the reusable workflow. The called workflow's `secrets.APPLE_*` references therefore resolve to empty unconditionally during PR/manual validation — the secret values are not in the calling job's context, so even a same-repo PR that rewrites the called workflow can't read them. `release.yml` does inherit (it needs the credentials to actually sign).
   - **Called-side (defense in depth):** the env block in `_tauri-shared.yml` gates each Apple secret on `matrix.os == 'macos-latest' && inputs.tagName != ''`. Belt-and-suspenders against future misconfiguration where some new caller might inherit secrets unintentionally.
   - The shared workflow uses `${{ github.token }}` instead of `${{ secrets.GITHUB_TOKEN }}` so it works in both modes — `github.token` is the per-job-run token, available in every workflow run without needing secrets-inherit.
 

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -62,9 +62,20 @@ The Tauri matrix doesn't need any local action — pushing the tag fires the wor
 
 ### Pre-tag validation
 
-`.github/workflows/tauri-build.yml` runs the same matrix on PRs (path-filtered to changes that could break it: `tauri/**`, `cmd/hecate/**`, `ui/**`, `Justfile`, `scripts/stamp-version.ts`, the workflows themselves). Bundles persist as workflow artifacts (14-day retention) so reviewers can download and test-launch from the run page.
+The main `.github/workflows/test.yml` workflow owns PR-time desktop validation.
+It path-filters desktop-impacting changes (`tauri/**`, `cmd/hecate/**`,
+`cmd/hecate-acp/**`, `ui/**`, `Justfile`, Tauri version scripts, release
+packaging files, and the workflows themselves), then starts the
+`Tauri desktop bundles` matrix only after the cheaper Go, TypeScript, e2e,
+Docker smoke, and Tauri Rust jobs pass or skip. The PR matrix proves the
+macOS, Linux, and Windows bundles build, but does not upload unsigned bundle
+artifacts.
 
-If the change set touches the desktop pipeline, prefer landing it via PR so the matrix runs before the tag — it's the only way to find out a Windows-only or Linux-only regression without burning a release.
+If the change set touches the desktop pipeline, prefer landing it via PR so the
+matrix runs before the tag — it's the only way to find out a Windows-only or
+Linux-only regression without burning a release. Use the manual
+`.github/workflows/tauri-build.yml` workflow from the Actions tab only for an
+explicit desktop rebuild/debug run.
 
 ### Manual local build (rarely needed)
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -11,7 +11,7 @@ launch `hecate-acp` themselves over stdio, but the gateway writes
 `hecate.runtime.json` into the app data directory so the bridge can discover the
 current dynamic gateway URL when `HECATE_GATEWAY_URL` is not set.
 
-Code: [`tauri/`](../tauri/) · agent guide: [`docs-ai/skills/tauri/SKILL.md`](../docs-ai/skills/tauri/SKILL.md) · CI: [`.github/workflows/release.yml`](../.github/workflows/release.yml), [`.github/workflows/tauri-build.yml`](../.github/workflows/tauri-build.yml).
+Code: [`tauri/`](../tauri/) · agent guide: [`docs-ai/skills/tauri/SKILL.md`](../docs-ai/skills/tauri/SKILL.md) · CI: [`.github/workflows/test.yml`](../.github/workflows/test.yml), [`.github/workflows/release.yml`](../.github/workflows/release.yml), [`.github/workflows/tauri-build.yml`](../.github/workflows/tauri-build.yml).
 
 ## Distribution
 
@@ -24,9 +24,12 @@ matrix legs in parallel and attaches bundles to the GitHub Release entry:
 | Linux x86_64 | `Hecate_X.Y.Z_amd64.deb`, `Hecate_X.Y.Z_amd64.AppImage` |
 | Windows x86_64 | `Hecate_X.Y.Z_x64_en-US.msi` |
 
-PR validation: [`tauri-build.yml`](../.github/workflows/tauri-build.yml) runs
-the same matrix on PRs touching the desktop pipeline and persists bundles as
-14-day workflow artifacts so reviewers can test-launch before merge.
+PR validation: [`test.yml`](../.github/workflows/test.yml) runs the desktop
+bundle matrix only after the cheaper Go, TypeScript, e2e, Docker smoke, and
+Tauri Rust checks pass or skip by path filter. PR validation proves that the
+macOS, Linux, and Windows bundles build, but does not upload unsigned bundles
+as workflow artifacts. [`tauri-build.yml`](../.github/workflows/tauri-build.yml)
+is manual-only for explicit desktop rebuild/debug runs from the Actions tab.
 
 ## Current state — `v0.1.0-alpha.29`
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -29,7 +29,9 @@ bundle matrix only after the cheaper Go, TypeScript, e2e, Docker smoke, and
 Tauri Rust checks pass or skip by path filter. PR validation proves that the
 macOS, Linux, and Windows bundles build, but does not upload unsigned bundles
 as workflow artifacts. [`tauri-build.yml`](../.github/workflows/tauri-build.yml)
-is manual-only for explicit desktop rebuild/debug runs from the Actions tab.
+is manual-only for explicit desktop rebuild/debug runs from the Actions tab. To
+test-launch a bundle before merge, dispatch `tauri-build.yml` manually from the
+PR branch.
 
 ## Current state — `v0.1.0-alpha.29`
 

--- a/docs/desktop-updater-signing.md
+++ b/docs/desktop-updater-signing.md
@@ -213,9 +213,10 @@ modes, in rough order of likelihood:
 - `TAURI_UPDATER_PRIVATE_KEY` and/or `TAURI_UPDATER_PRIVATE_KEY_PASSWORD`
   are not set in repo secrets — the build proceeds unsigned and
   the same missing-signature check trips. Confirm both secrets.
-- You're running PR validation (`tauri-build.yml`) instead of a
-  release tag. PR validation intentionally skips signing and
-  manifest publishing — that's working as designed.
+- You're running PR validation (`test.yml`'s desktop bundle gate) or a manual
+  `tauri-build.yml` rebuild instead of a release tag. Validation builds
+  intentionally skip signing and manifest publishing — that's working as
+  designed.
 
 **`publish-updater-website` failed at "Verify manifest is live at
 hecate.sh".** The release published, the GitHub Release has its

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,7 @@ The Tauri desktop app's local build (`just tauri-dev`) lives in
 - [Website](#website)
 - [Reset state](#reset-state)
 - [Testing](#testing)
+- [CI workflow](#ci-workflow)
 - [Project layout](#project-layout)
 - [Capturing documentation screenshots](#capturing-documentation-screenshots)
 
@@ -153,6 +154,35 @@ just release vX.Y.Z    # verify, then run the release script
 The race detector is the strongest correctness check (and the slowest); CI runs it on every push. `test-acp-smoke` starts a fake OpenAI-compatible upstream, the real `hecate` gateway, and the real `cmd/hecate-acp` stdio bridge, then verifies model discovery, same-task continuation, SSE updates, and editor approval round-trip behavior. The Go e2e suite also includes binary-level Agent Chat approval smokes for SQLite startup reconcile and durable grant persistence; run them with `go test -tags e2e -run 'TestApproval' ./e2e` when touching approval storage or cmd/hecate startup wiring. `test-docker-smoke` requires Docker but doesn't need any other infrastructure — it spins up its own compose project to avoid colliding with a developer's running stack. `test-tauri-smoke` builds only the packaged macOS `.app`, waits for the sidecar gateway to answer `/healthz`, quits Hecate, and confirms the sidecar exits; `test-tauri-acp-smoke` additionally runs the bundled `hecate-acp` without `HECATE_GATEWAY_URL` and verifies native runtime discovery through `hecate.runtime.json`. Both native smokes are opt-in because they open a real GUI window.
 
 Before cutting a public tag, run `just verify` and follow the checklist in [Release](release.md).
+
+## CI workflow
+
+GitHub Actions is split by surface so small changes do not wake the whole
+project:
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `test.yml` | PRs and pushes to `master` except markdown-only and website-only changes | Main quality gate: Go, UI, e2e, Docker smoke, Tauri Rust tests, and gated desktop bundle validation. |
+| `website.yml` | Website changes and release-manifest updates | Astro check/build and GitHub Pages deploy for [hecate.sh](https://hecate.sh). |
+| `links.yml` | PRs and pushes | Markdown link and Mermaid validation. |
+| `release.yml` | `v*` tags and manual dispatch | Goreleaser artifacts, Docker images, signed desktop bundles, updater manifest, website manifest publish. |
+| `tauri-build.yml` | Manual dispatch only | Explicit desktop bundle rebuild/debug run from the Actions tab. |
+
+The main `Test` workflow starts with a path filter. Go, TypeScript, Docker,
+and Tauri Rust jobs run only when their inputs changed, while workflow edits
+force the full matrix so CI changes test themselves.
+
+Desktop packaging is intentionally gated inside `test.yml`: the
+`Tauri desktop bundles` matrix waits for the cheaper Go, TypeScript, e2e,
+Docker smoke, and Tauri Rust jobs to pass (or skip by path filter) before
+building macOS, Linux, and Windows bundles. PR bundle validation does **not**
+upload unsigned artifacts; it only proves the bundles build. Release tags still
+upload signed/notarized artifacts through `release.yml`.
+
+This shape keeps PR feedback fast for normal code changes and avoids burning
+desktop runner minutes when a cheaper test has already failed. If a desktop
+packaging issue needs an explicit rerun, use the manual `tauri-build` workflow
+from the Actions tab.
 
 ### Skipping CI for inert changes
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,7 +182,8 @@ upload signed/notarized artifacts through `release.yml`.
 This shape keeps PR feedback fast for normal code changes and avoids burning
 desktop runner minutes when a cheaper test has already failed. If a desktop
 packaging issue needs an explicit rerun, use the manual `tauri-build` workflow
-from the Actions tab.
+from the Actions tab. If a reviewer needs a pre-merge bundle to test-launch,
+dispatch `tauri-build.yml` manually from the PR branch.
 
 ### Skipping CI for inert changes
 

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -16,13 +16,12 @@ non-empty `tagName` to the reusable workflow, satisfying the env
 gate. Such bundles launch on a clean Mac with no Gatekeeper warning
 and drag-install to `/Applications` without `xattr`-fiddling.
 
-Builds without the secrets — PR validation runs (intentionally; see
-`.github/workflows/tauri-build.yml` for why), fork PRs, releases cut
-before the secrets landed — produce **unsigned** `.dmg`s. Those are
-not a pipeline failure; they're the documented fallback when the
-signing inputs aren't available. Operators downloading an unsigned
-build need to right-click `Hecate.app` → **Open** to bypass
-Gatekeeper on first launch.
+Builds without the secrets — PR validation in `test.yml`, manual
+`tauri-build.yml` rebuilds, fork PRs, or releases cut before the secrets landed
+— produce **unsigned** `.dmg`s. Those are not a pipeline failure; they're the
+documented fallback when the signing inputs aren't available. Operators
+downloading an unsigned build need to right-click `Hecate.app` → **Open** to
+bypass Gatekeeper on first launch.
 
 The CI workflow (`.github/workflows/_tauri-shared.yml`) reads the
 secrets via env. Setup steps below are what gets the secrets in

--- a/docs/release.md
+++ b/docs/release.md
@@ -130,9 +130,10 @@ If a check is intentionally skipped, call it out in the release notes with the
 reason and the risk. Docker smoke and UI e2e are allowed to be slow; they are
 not optional for a public alpha build.
 
-The gate does **not** exercise the Tauri matrix. PR validation
-(`tauri-build.yml`) covers that on every PR touching the desktop pipeline;
-post-tag, the release matrix is the next opportunity to catch regressions.
+The local gate does **not** exercise the Tauri desktop bundle matrix. PR
+validation covers that inside `test.yml` for changes that touch the desktop
+pipeline, after the cheaper CI checks pass or skip. Post-tag, the release
+matrix is the next opportunity to catch regressions.
 
 ## Cut the release
 

--- a/tauri/src-tauri/gen/schemas/capabilities.json
+++ b/tauri/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Capability granted to the main application window","local":true,"windows":["main"],"permissions":["core:default"]}}
+{"default":{"identifier":"default","description":"Capability granted to the main application window","local":true,"windows":["main"],"permissions":["core:default","updater:default"]}}


### PR DESCRIPTION
## Summary

- Fix PR Tauri validation so unsigned PR bundles are build-checked but not uploaded as workflow artifacts.
- Move PR desktop packaging into the main Test workflow behind the cheaper Go, TypeScript, e2e, Docker smoke, and Tauri Rust checks.
- Keep `tauri-build.yml` as a manual-only desktop rebuild/debug workflow.
- Document the CI workflow split in development, desktop, release, and Tauri agent docs.

## Verification

- `ruby` YAML parse for `test.yml`, `tauri-build.yml`, `_tauri-shared.yml`, and `release.yml`
- `actionlint .github/workflows/test.yml .github/workflows/tauri-build.yml .github/workflows/_tauri-shared.yml .github/workflows/release.yml`

## Notes

This keeps release behavior unchanged: tagged releases still upload signed/notarized desktop artifacts through `release.yml`.