### PR TITLE
refactor(workspace,acp): introduce Workspace abstraction + editor-owned mode negotiation

### DIFF
--- a/cmd/hecate-acp/main.go
+++ b/cmd/hecate-acp/main.go
@@ -105,7 +105,7 @@ func configFromEnv() (bridgeConfig, error) {
 		GatewayURL:    firstNonEmpty(gatewayURL, defaultGatewayURL),
 		AgentName:     firstNonEmpty(os.Getenv("HECATE_AGENT_NAME"), "Hecate"),
 		AgentVersion:  version.Version,
-		WorkspaceMode: firstNonEmpty(os.Getenv("HECATE_WORKSPACE_MODE"), "hecate-owned"),
+		WorkspaceMode: firstNonEmpty(os.Getenv("HECATE_WORKSPACE_MODE"), acp.WorkspaceModeAuto),
 		ApprovalRoute: firstNonEmpty(os.Getenv("HECATE_APPROVAL_ROUTE"), "editor"),
 		OTel:          bridgeOTelFromEnv(),
 	}

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -53,11 +53,14 @@ Implemented:
 
 Not implemented yet:
 
-- Editor-owned workspace reverse-RPC calls. Hecate-owned mode is the current
-  implementation: work runs through the gateway task runtime. The future
-  editor-owned mode would let an ACP host such as Zed or JetBrains own file and
-  terminal operations through ACP reverse-RPC, including terminal lifecycle
-  calls like create, output, wait-for-exit, kill, and release.
+- End-to-end editor-owned workspace routing. The bridge negotiates the
+  `editor-owned` workspace mode with the client at `initialize` (see
+  [Configuration](#configuration)), and the workspace abstraction has both
+  `LocalWorkspace` and `ACPWorkspace` implementations — but the gateway-side
+  orchestrator still uses the local workspace in every mode. Wiring the
+  bridge↔gateway transport that routes `fs/*` and `terminal/*` reverse-RPC
+  through to the editor's filesystem and terminal panes lands in a follow-up
+  RFC.
 - Registry packaging for a specific editor.
 - Headless compatibility tests against a real Zed or JetBrains ACP host.
 - Durable editor-side session reattachment after bridge restart. The gateway
@@ -367,14 +370,26 @@ for that behavior.
 |---|---:|---|
 | `HECATE_GATEWAY_URL` | auto-discover, then `http://127.0.0.1:8765` | Gateway base URL the bridge talks to. Set explicitly to bypass runtime-state discovery. |
 | `HECATE_AGENT_NAME` | `Hecate` | Agent display name advertised during initialize. |
-| `HECATE_WORKSPACE_MODE` | `hecate-owned` | Future workspace ownership mode. |
+| `HECATE_WORKSPACE_MODE` | `auto` | Workspace ownership. `auto` (default) follows ACP capability negotiation. `hecate-owned` forces the gateway host to own file writes and terminal execution. `editor-owned` requires the editor to own them via reverse-RPC and fails the handshake when the editor cannot. |
 | `HECATE_APPROVAL_ROUTE` | `editor` | `editor` sends approval gates to ACP `session/request_permission`; other values leave approvals for the Hecate operator UI. |
 
-`HECATE_WORKSPACE_MODE=editor-owned` is not implemented yet. When it lands, it
-belongs to this editor-host bridge scope: the editor would own file writes and
-terminal execution through ACP reverse-RPC. It is separate from
-[External agent adapters](external-agent-adapters.md), where Hecate itself
-launches Codex / Claude / Cursor-style adapters from Chats.
+`HECATE_WORKSPACE_MODE` resolves at `initialize` time. In `auto` mode the bridge
+picks `editor-owned` when the editor declares `clientCapabilities.fs.readTextFile`,
+`clientCapabilities.fs.writeTextFile`, **and** `clientCapabilities.terminal`;
+otherwise it falls back to `hecate-owned`. Setting the variable to `editor-owned`
+explicitly is the same check, but the bridge fails `initialize` instead of
+silently falling back when those capabilities are missing — useful when an
+operator wants to guarantee writes flow through the editor's review UI.
+
+**Status:** capability negotiation is wired today, but the bridge↔gateway
+transport that would route reverse-RPC end-to-end is not yet implemented. In
+`editor-owned` mode the bridge negotiates the capability with the editor but
+the orchestrator still uses the local workspace. The transport piece lands in
+a follow-up RFC.
+
+This is separate from [External agent adapters](external-agent-adapters.md),
+where Hecate itself launches Codex / Claude / Cursor-style adapters from
+Chats.
 
 ### Bridge telemetry
 

--- a/internal/acp/capabilities.go
+++ b/internal/acp/capabilities.go
@@ -8,15 +8,30 @@ type InitializeParams struct {
 }
 
 // ClientCapabilities advertises which optional ACP surfaces the editor
-// supports. v0 only requires the permissions capability.
+// supports. v0 only requires the permissions capability; fs and
+// terminal are consulted by the workspace-mode resolver to decide
+// whether `editor-owned` mode is actually viable.
 type ClientCapabilities struct {
 	FS          *FSCapability         `json:"fs,omitempty"`
 	Terminal    *TerminalCapability   `json:"terminal,omitempty"`
 	Permissions *PermissionCapability `json:"permissions,omitempty"`
 }
 
-type FSCapability struct{}
+// FSCapability mirrors the ACP spec's fs capability block. Both fields
+// are independently advertised by the editor; Hecate's editor-owned
+// mode requires both because reverse-RPC reads + writes are the whole
+// point of that mode.
+type FSCapability struct {
+	ReadTextFile  bool `json:"readTextFile,omitempty"`
+	WriteTextFile bool `json:"writeTextFile,omitempty"`
+}
+
+// TerminalCapability is present-or-absent in the ACP spec — the
+// editor either supports terminal/* or it doesn't.
 type TerminalCapability struct{}
+
+// PermissionCapability is present-or-absent in the ACP spec — the
+// editor either supports session/request_permission or it doesn't.
 type PermissionCapability struct{}
 
 // ClientInfo is human-readable metadata the editor sends for

--- a/internal/acp/dispatcher.go
+++ b/internal/acp/dispatcher.go
@@ -165,7 +165,6 @@ func (d *Dispatcher) handleInitialize(ctx context.Context, req *Request) *Respon
 	if err != nil {
 		return errorResponse(req.ID, ErrorInvalidRequest, err.Error(), nil)
 	}
-	d.workspaceMode = resolvedMode
 
 	models, err := d.gateway.ListModels(ctx)
 	if err != nil {
@@ -192,6 +191,11 @@ func (d *Dispatcher) handleInitialize(ctx context.Context, req *Request) *Respon
 		},
 		AvailableModels: descriptions,
 	}
+	// Commit the negotiated mode only after the rest of initialize
+	// has succeeded — otherwise a downstream failure (gateway
+	// unreachable, etc.) leaves WorkspaceMode() reporting a value
+	// the handshake never actually confirmed.
+	d.workspaceMode = resolvedMode
 	d.initialized = true
 	return resultResponse(req.ID, result)
 }

--- a/internal/acp/dispatcher.go
+++ b/internal/acp/dispatcher.go
@@ -22,6 +22,13 @@ type Dispatcher struct {
 	nextPermissionSequence int64
 	pendingPermissions     map[string]pendingPermission
 	requestedApprovalIDs   map[string]string
+
+	// nextCallSequence + pendingCalls back the generic reverse-RPC
+	// path used by Dispatcher.Call (see dispatcher_call.go).
+	// Separate from the permission-flow state so the two response
+	// dispatches stay decoupled.
+	nextCallSequence int64
+	pendingCalls     map[string]chan *Response
 }
 
 type pendingPermission struct {
@@ -88,6 +95,14 @@ func (d *Dispatcher) Handle(ctx context.Context, req *Request) *Response {
 func (d *Dispatcher) HandleResponse(ctx context.Context, resp *Response) {
 	id := responseIDKey(resp.ID)
 	if id == "" {
+		return
+	}
+	// Generic reverse-RPC responses (fs/*, terminal/*, …) route to
+	// the per-call channel registered by Dispatcher.Call. The
+	// permission flow's takePendingPermission below remains the
+	// fallback so existing behavior is unchanged.
+	if ch := d.deliverPendingCall(id); ch != nil {
+		ch <- resp
 		return
 	}
 	pending, ok := d.takePendingPermission(id)

--- a/internal/acp/dispatcher.go
+++ b/internal/acp/dispatcher.go
@@ -16,7 +16,8 @@ type Dispatcher struct {
 	cfg      Config
 	emit     func(*Request)
 
-	initialized bool
+	initialized   bool
+	workspaceMode string
 
 	mu                     sync.Mutex
 	nextPermissionSequence int64
@@ -51,7 +52,7 @@ func NewDispatcher(gateway GatewayClient, sessions *SessionStore, cfg Config) *D
 		cfg.AgentName = "Hecate"
 	}
 	if cfg.WorkspaceMode == "" {
-		cfg.WorkspaceMode = "hecate-owned"
+		cfg.WorkspaceMode = WorkspaceModeAuto
 	}
 	if cfg.ApprovalRoute == "" {
 		cfg.ApprovalRoute = "editor"
@@ -67,6 +68,17 @@ func NewDispatcher(gateway GatewayClient, sessions *SessionStore, cfg Config) *D
 
 func (d *Dispatcher) SetEmitter(emit func(*Request)) {
 	d.emit = emit
+}
+
+// WorkspaceMode returns the workspace ownership mode negotiated during
+// initialize, or the configured value if initialize has not run yet.
+// Useful for telemetry, logging, and (once reverse-RPC transport ships)
+// gateway-side workspace selection.
+func (d *Dispatcher) WorkspaceMode() string {
+	if d.workspaceMode != "" {
+		return d.workspaceMode
+	}
+	return d.cfg.WorkspaceMode
 }
 
 // Handle dispatches one incoming request.
@@ -148,6 +160,12 @@ func (d *Dispatcher) handleInitialize(ctx context.Context, req *Request) *Respon
 		return errorResponse(req.ID, ErrorInvalidRequest,
 			"editor must declare permissions capability — Hecate's approval gates require session/request_permission support", nil)
 	}
+
+	resolvedMode, err := ResolveWorkspaceMode(d.cfg.WorkspaceMode, params.ClientCaps)
+	if err != nil {
+		return errorResponse(req.ID, ErrorInvalidRequest, err.Error(), nil)
+	}
+	d.workspaceMode = resolvedMode
 
 	models, err := d.gateway.ListModels(ctx)
 	if err != nil {

--- a/internal/acp/dispatcher_call.go
+++ b/internal/acp/dispatcher_call.go
@@ -1,0 +1,122 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Call sends an outbound JSON-RPC request to the connected ACP client
+// and blocks until the response arrives (or ctx is cancelled).
+// Used by the bridge to issue reverse-RPC calls — `fs/read`,
+// `fs/write`, `terminal/create`, `terminal/output`, etc. — back to
+// the editor when the operator opts into editor-owned workspace mode.
+//
+// The existing permission-request path (session/request_permission)
+// stays unchanged: it's tracked through pendingPermissions and
+// resolved server-side against the gateway's approval queue. Call
+// is the general-purpose primitive for everything else — its
+// response routes to a per-call channel that this function blocks
+// on, so the caller's goroutine model is "just await the result."
+//
+// Concurrency: Call may be invoked from any goroutine. Each
+// outstanding call holds one slot in pendingCalls keyed by request
+// id; HandleResponse delivers the matching Response and removes
+// the slot. ctx.Done() releases the caller and removes the slot
+// without waiting for a response that may never arrive.
+func (d *Dispatcher) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if d.emit == nil {
+		return nil, errors.New("acp: dispatcher has no emitter; outbound RPC not possible")
+	}
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("acp: marshal %s params: %w", method, err)
+	}
+
+	id, idRaw := d.nextCallID()
+	wait := make(chan *Response, 1)
+	d.registerPendingCall(id, wait)
+
+	req := &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      &idRaw,
+		Method:  method,
+		Params:  rawParams,
+	}
+	d.emit(req)
+
+	select {
+	case resp := <-wait:
+		if resp == nil {
+			return nil, fmt.Errorf("acp: %s: nil response", method)
+		}
+		if resp.Error != nil {
+			return nil, &CallError{Method: method, Code: resp.Error.Code, Message: resp.Error.Message, Data: resp.Error.Data}
+		}
+		return resp.Result, nil
+	case <-ctx.Done():
+		d.cancelPendingCall(id)
+		return nil, ctx.Err()
+	}
+}
+
+// CallError is the typed error returned by Call when the remote side
+// answered with a JSON-RPC error envelope. Callers can errors.As() to
+// inspect Code (e.g. method-not-found vs editor-denied).
+type CallError struct {
+	Method  string
+	Code    int
+	Message string
+	Data    json.RawMessage
+}
+
+func (e *CallError) Error() string {
+	return fmt.Sprintf("acp: %s rejected (code %d): %s", e.Method, e.Code, e.Message)
+}
+
+// nextCallID allocates the next outbound-call request id. Format
+// "call-N" is namespaced away from the permission flow's "permission-N"
+// so the two pending maps stay non-overlapping by construction.
+func (d *Dispatcher) nextCallID() (string, json.RawMessage) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.nextCallSequence++
+	id := fmt.Sprintf("call-%d", d.nextCallSequence)
+	// Marshal once; the raw bytes ride along on the outbound
+	// envelope. Quote-escape via json.Marshal so the id renders as
+	// a JSON string in the wire envelope.
+	raw, _ := json.Marshal(id)
+	return id, raw
+}
+
+func (d *Dispatcher) registerPendingCall(id string, wait chan *Response) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.pendingCalls == nil {
+		d.pendingCalls = make(map[string]chan *Response)
+	}
+	d.pendingCalls[id] = wait
+}
+
+func (d *Dispatcher) cancelPendingCall(id string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.pendingCalls, id)
+}
+
+// deliverPendingCall returns the channel for an outstanding outbound
+// call and removes it from the pending map. Used by HandleResponse
+// to route reply payloads. Returns nil when the id doesn't match an
+// outstanding call (i.e. the response is for the permission flow or
+// for a call we've already cancelled).
+func (d *Dispatcher) deliverPendingCall(id string) chan *Response {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	ch, ok := d.pendingCalls[id]
+	if !ok {
+		return nil
+	}
+	delete(d.pendingCalls, id)
+	return ch
+}

--- a/internal/acp/dispatcher_call_test.go
+++ b/internal/acp/dispatcher_call_test.go
@@ -1,0 +1,229 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestDispatcherCall_RoundTripsResultPayload drives the happy path:
+// the bridge emits an outbound request, the fake editor replies with
+// a JSON result, Call returns that payload.
+func TestDispatcherCall_RoundTripsResultPayload(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(nil, NewSessionStore(), Config{})
+
+	emitted := make(chan *Request, 1)
+	d.SetEmitter(func(req *Request) { emitted <- req })
+
+	resultCh := make(chan json.RawMessage, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		raw, err := d.Call(context.Background(), "fs/read", map[string]any{
+			"path": "README.md",
+		})
+		errCh <- err
+		resultCh <- raw
+	}()
+
+	// Editor side: receive the outbound request, send a response
+	// with the matching id.
+	var req *Request
+	select {
+	case req = <-emitted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher never emitted the outbound request")
+	}
+	if req.Method != "fs/read" {
+		t.Fatalf("emitted method = %q; want fs/read", req.Method)
+	}
+	if req.ID == nil {
+		t.Fatal("outbound request must carry an id (not a notification)")
+	}
+
+	d.HandleResponse(context.Background(), &Response{
+		JSONRPC: JSONRPCVersion,
+		ID:      req.ID,
+		Result:  json.RawMessage(`{"content":"file body"}`),
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	raw := <-resultCh
+	if !strings.Contains(string(raw), "file body") {
+		t.Fatalf("result = %s; want to contain 'file body'", raw)
+	}
+}
+
+// TestDispatcherCall_ConvertsRPCErrorToCallError covers the failure
+// path: editor replies with an error envelope, Call returns a typed
+// *CallError that callers can errors.As against to inspect the code.
+func TestDispatcherCall_ConvertsRPCErrorToCallError(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(nil, NewSessionStore(), Config{})
+
+	emitted := make(chan *Request, 1)
+	d.SetEmitter(func(req *Request) { emitted <- req })
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := d.Call(context.Background(), "fs/write", map[string]any{"path": "x"})
+		errCh <- err
+	}()
+
+	req := <-emitted
+	d.HandleResponse(context.Background(), &Response{
+		JSONRPC: JSONRPCVersion,
+		ID:      req.ID,
+		Error:   &RPCError{Code: -32603, Message: "permission denied"},
+	})
+
+	err := <-errCh
+	var callErr *CallError
+	if !errors.As(err, &callErr) {
+		t.Fatalf("Call error type = %T; want *CallError", err)
+	}
+	if callErr.Code != -32603 {
+		t.Fatalf("CallError.Code = %d; want -32603", callErr.Code)
+	}
+	if !strings.Contains(callErr.Error(), "permission denied") {
+		t.Fatalf("CallError.Error() = %q", callErr.Error())
+	}
+}
+
+// TestDispatcherCall_HonorsContextCancellation confirms a cancelled
+// context releases the caller without waiting for a response that
+// may never come — important when an editor crashes mid-RPC.
+func TestDispatcherCall_HonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(nil, NewSessionStore(), Config{})
+
+	emitted := make(chan *Request, 1)
+	d.SetEmitter(func(req *Request) { emitted <- req })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := d.Call(ctx, "terminal/create", nil)
+		errCh <- err
+	}()
+	<-emitted // ensure the request was emitted before cancelling
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v; want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancellation did not release Call within 2s")
+	}
+}
+
+// TestDispatcherCall_ConcurrentCallsRouteByID asserts that two
+// concurrent outbound calls each receive their own matching response,
+// not each other's. The dispatcher uses per-call channels keyed by
+// id; this test pins that invariant.
+func TestDispatcherCall_ConcurrentCallsRouteByID(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(nil, NewSessionStore(), Config{})
+
+	type emitted struct{ req *Request }
+	emit := make(chan emitted, 4)
+	d.SetEmitter(func(req *Request) { emit <- emitted{req} })
+
+	type call struct {
+		got json.RawMessage
+		err error
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	results := make([]call, 2)
+	for i := range results {
+		i := i
+		go func() {
+			defer wg.Done()
+			raw, err := d.Call(context.Background(), "fs/read", map[string]any{"path": i})
+			results[i] = call{got: raw, err: err}
+		}()
+	}
+
+	// Collect the two emitted requests, reply in reverse order to
+	// make sure responses route by id, not by FIFO arrival.
+	var first, second emitted
+	first = <-emit
+	second = <-emit
+	d.HandleResponse(context.Background(), &Response{
+		JSONRPC: JSONRPCVersion, ID: second.req.ID,
+		Result: json.RawMessage(`{"answer":"second"}`),
+	})
+	d.HandleResponse(context.Background(), &Response{
+		JSONRPC: JSONRPCVersion, ID: first.req.ID,
+		Result: json.RawMessage(`{"answer":"first"}`),
+	})
+
+	wg.Wait()
+	// Whichever goroutine emitted `first` should have received
+	// `first`'s response and likewise for `second`. We don't know
+	// goroutine order so just confirm both completed successfully
+	// and got distinct payloads.
+	if results[0].err != nil || results[1].err != nil {
+		t.Fatalf("Call errors: %v / %v", results[0].err, results[1].err)
+	}
+	if string(results[0].got) == string(results[1].got) {
+		t.Fatalf("concurrent calls got identical payloads %q — responses routed incorrectly", results[0].got)
+	}
+}
+
+// Sanity guard: ensure permission-flow responses still route to the
+// permission handler after the generic-call addition. Routes a
+// response carrying a permission id through HandleResponse and
+// confirms the pendingPermissions entry is consumed — which only
+// happens when the permission branch (not the generic-call branch)
+// matched the id.
+func TestDispatcherCall_PermissionFlowStillRoutes(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(nil, NewSessionStore(), Config{})
+
+	id, ok := d.trackPendingPermission(PermissionRequestParams{
+		SessionID:  "s1",
+		TaskID:     "t1",
+		RunID:      "r1",
+		ApprovalID: "a1",
+	})
+	if !ok {
+		t.Fatal("trackPendingPermission did not accept a fresh request")
+	}
+	if _, ok := d.takePendingPermission(id); !ok {
+		t.Fatal("invariant: the entry should be present before HandleResponse")
+	}
+	// Re-track so HandleResponse has something to consume — and so
+	// we can observe whether it consumed it. Re-tracking the same
+	// approvalKey re-uses the existing id (dedupe behavior), which
+	// is fine; we only care that the new pending entry is the one
+	// HandleResponse takes.
+	d.mu.Lock()
+	d.pendingPermissions[id] = pendingPermission{SessionID: "s1", TaskID: "t1", RunID: "r1", ApprovalID: "a1"}
+	d.mu.Unlock()
+
+	idRaw, _ := json.Marshal(id)
+	idMsg := json.RawMessage(idRaw)
+	d.HandleResponse(context.Background(), &Response{
+		JSONRPC: JSONRPCVersion,
+		ID:      &idMsg,
+		Error:   &RPCError{Code: -32603, Message: "denied"},
+	})
+
+	// After HandleResponse routes the response to the permission
+	// branch, the pendingPermissions entry must be gone. If the
+	// generic-call branch had grabbed the id instead (a bug),
+	// pendingPermissions would still hold it.
+	if _, ok := d.takePendingPermission(id); ok {
+		t.Fatal("HandleResponse did not consume the permission entry — generic-call branch may have hijacked the id")
+	}
+}

--- a/internal/acp/dispatcher_test.go
+++ b/internal/acp/dispatcher_test.go
@@ -190,6 +190,27 @@ func TestInitialize_EditorOwnedModeRequiresClientCaps(t *testing.T) {
 	}
 }
 
+func TestInitialize_DoesNotCommitWorkspaceModeWhenGatewayUnreachable(t *testing.T) {
+	// ResolveWorkspaceMode would succeed (auto + permissions-only caps
+	// → hecate-owned), but ListModels fails. WorkspaceMode() must
+	// still report the configured value, not the value that was almost
+	// negotiated — initialize did not succeed.
+	gw := &fakeGateway{modelsErr: errors.New("connection refused")}
+	d := NewDispatcher(gw, NewSessionStore(), Config{ApprovalRoute: "editor", WorkspaceMode: WorkspaceModeHecateOwned})
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  initParams(t, true),
+	})
+	if resp.Error == nil || resp.Error.Code != ErrorGatewayUnreachable {
+		t.Fatalf("expected ErrorGatewayUnreachable, got %v", resp.Error)
+	}
+	if d.WorkspaceMode() != WorkspaceModeHecateOwned {
+		t.Fatalf("WorkspaceMode() = %q; want configured value %q after failed init", d.WorkspaceMode(), WorkspaceModeHecateOwned)
+	}
+}
+
 func TestInitialize_AutoFallsBackToHecateOwnedWhenCapsMissing(t *testing.T) {
 	gw := &fakeGateway{models: []string{"m"}}
 	d := NewDispatcher(gw, NewSessionStore(), Config{ApprovalRoute: "editor"}) // WorkspaceMode empty → auto

--- a/internal/acp/dispatcher_test.go
+++ b/internal/acp/dispatcher_test.go
@@ -167,6 +167,75 @@ func TestInitialize_GatewayUnreachable(t *testing.T) {
 	}
 }
 
+func TestInitialize_EditorOwnedModeRequiresClientCaps(t *testing.T) {
+	gw := &fakeGateway{models: []string{"m"}}
+	d := NewDispatcher(gw, NewSessionStore(), Config{
+		ApprovalRoute: "editor",
+		WorkspaceMode: WorkspaceModeEditorOwned,
+	})
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  initParams(t, true), // permissions only — no fs/terminal
+	})
+	if resp.Error == nil || resp.Error.Code != ErrorInvalidRequest {
+		t.Fatalf("expected ErrorInvalidRequest, got %v", resp.Error)
+	}
+	if !strings.Contains(resp.Error.Message, "editor-owned") {
+		t.Fatalf("message = %q; want to mention editor-owned", resp.Error.Message)
+	}
+	if d.WorkspaceMode() != WorkspaceModeEditorOwned {
+		t.Fatalf("WorkspaceMode() = %q after failed init; want the configured value to remain (%q)", d.WorkspaceMode(), WorkspaceModeEditorOwned)
+	}
+}
+
+func TestInitialize_AutoFallsBackToHecateOwnedWhenCapsMissing(t *testing.T) {
+	gw := &fakeGateway{models: []string{"m"}}
+	d := NewDispatcher(gw, NewSessionStore(), Config{ApprovalRoute: "editor"}) // WorkspaceMode empty → auto
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  initParams(t, true),
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error = %v", resp.Error)
+	}
+	if d.WorkspaceMode() != WorkspaceModeHecateOwned {
+		t.Fatalf("WorkspaceMode() = %q; want %q after auto with no fs/terminal caps", d.WorkspaceMode(), WorkspaceModeHecateOwned)
+	}
+}
+
+func TestInitialize_AutoChoosesEditorOwnedWhenCapsPresent(t *testing.T) {
+	gw := &fakeGateway{models: []string{"m"}}
+	d := NewDispatcher(gw, NewSessionStore(), Config{ApprovalRoute: "editor"})
+	params := InitializeParams{
+		ProtocolVersion: DeclaredProtocolVersion,
+		ClientCaps: ClientCapabilities{
+			Permissions: &PermissionCapability{},
+			FS:          &FSCapability{ReadTextFile: true, WriteTextFile: true},
+			Terminal:    &TerminalCapability{},
+		},
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  raw,
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error = %v", resp.Error)
+	}
+	if d.WorkspaceMode() != WorkspaceModeEditorOwned {
+		t.Fatalf("WorkspaceMode() = %q; want %q with full client caps", d.WorkspaceMode(), WorkspaceModeEditorOwned)
+	}
+}
+
 func TestInitialize_TwiceRejects(t *testing.T) {
 	gw := &fakeGateway{models: []string{}}
 	d := NewDispatcher(gw, NewSessionStore(), Config{ApprovalRoute: "editor"})

--- a/internal/acp/workspace_mode.go
+++ b/internal/acp/workspace_mode.go
@@ -1,0 +1,62 @@
+package acp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Workspace ownership modes. The bridge advertises one of these to the
+// orchestrator (via Dispatcher.WorkspaceMode) after capability
+// negotiation completes; the orchestrator then picks LocalWorkspace
+// (hecate-owned) or ACPWorkspace (editor-owned) when transport for the
+// latter ships in a follow-up. Today the wire is negotiated; the
+// orchestrator-side routing is still hecate-owned in all modes.
+const (
+	WorkspaceModeAuto        = "auto"
+	WorkspaceModeHecateOwned = "hecate-owned"
+	WorkspaceModeEditorOwned = "editor-owned"
+)
+
+// ResolveWorkspaceMode picks the effective workspace ownership for one
+// bridge connection. `configured` is the HECATE_WORKSPACE_MODE value
+// (empty == auto, case-insensitive); `caps` is what the editor
+// advertised during initialize.
+//
+//   - hecate-owned: the gateway host owns the workspace. No editor
+//     capabilities required.
+//   - editor-owned: the editor owns file writes and terminal execution
+//     via ACP reverse-RPC. Requires fs.readTextFile, fs.writeTextFile,
+//     and terminal on the client.
+//   - auto: prefer editor-owned when the editor declares all required
+//     reverse-RPC capabilities; otherwise fall back to hecate-owned.
+//
+// Returns an error only when the operator forces `editor-owned` but the
+// editor is missing the capabilities required to honour it. We fail the
+// initialize handshake in that case rather than silently downgrading —
+// the config is wrong and the operator wants to see it immediately.
+func ResolveWorkspaceMode(configured string, caps ClientCapabilities) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(configured))
+	switch normalized {
+	case "", WorkspaceModeAuto:
+		if editorCanHostWorkspace(caps) {
+			return WorkspaceModeEditorOwned, nil
+		}
+		return WorkspaceModeHecateOwned, nil
+	case WorkspaceModeHecateOwned:
+		return WorkspaceModeHecateOwned, nil
+	case WorkspaceModeEditorOwned:
+		if !editorCanHostWorkspace(caps) {
+			return "", fmt.Errorf("HECATE_WORKSPACE_MODE=editor-owned requires the editor to declare clientCapabilities.fs.readTextFile, clientCapabilities.fs.writeTextFile, and clientCapabilities.terminal during initialize")
+		}
+		return WorkspaceModeEditorOwned, nil
+	default:
+		return "", fmt.Errorf("invalid HECATE_WORKSPACE_MODE %q: must be one of auto, hecate-owned, editor-owned", configured)
+	}
+}
+
+func editorCanHostWorkspace(caps ClientCapabilities) bool {
+	if caps.FS == nil || caps.Terminal == nil {
+		return false
+	}
+	return caps.FS.ReadTextFile && caps.FS.WriteTextFile
+}

--- a/internal/acp/workspace_mode_test.go
+++ b/internal/acp/workspace_mode_test.go
@@ -1,0 +1,130 @@
+package acp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveWorkspaceMode(t *testing.T) {
+	t.Parallel()
+	fullCaps := ClientCapabilities{
+		FS:       &FSCapability{ReadTextFile: true, WriteTextFile: true},
+		Terminal: &TerminalCapability{},
+	}
+	readOnlyCaps := ClientCapabilities{
+		FS:       &FSCapability{ReadTextFile: true},
+		Terminal: &TerminalCapability{},
+	}
+	noTerminalCaps := ClientCapabilities{
+		FS: &FSCapability{ReadTextFile: true, WriteTextFile: true},
+	}
+
+	tests := []struct {
+		name       string
+		configured string
+		caps       ClientCapabilities
+		want       string
+		wantErr    string // substring; empty means no error
+	}{
+		{
+			name:       "empty configured falls through to auto",
+			configured: "",
+			caps:       fullCaps,
+			want:       WorkspaceModeEditorOwned,
+		},
+		{
+			name:       "auto with full caps picks editor-owned",
+			configured: "auto",
+			caps:       fullCaps,
+			want:       WorkspaceModeEditorOwned,
+		},
+		{
+			name:       "auto without caps falls back to hecate-owned",
+			configured: "auto",
+			caps:       ClientCapabilities{Permissions: &PermissionCapability{}},
+			want:       WorkspaceModeHecateOwned,
+		},
+		{
+			name:       "auto with read-only fs falls back to hecate-owned",
+			configured: "auto",
+			caps:       readOnlyCaps,
+			want:       WorkspaceModeHecateOwned,
+		},
+		{
+			name:       "auto with fs but no terminal falls back to hecate-owned",
+			configured: "auto",
+			caps:       noTerminalCaps,
+			want:       WorkspaceModeHecateOwned,
+		},
+		{
+			name:       "hecate-owned ignores caps",
+			configured: "hecate-owned",
+			caps:       fullCaps,
+			want:       WorkspaceModeHecateOwned,
+		},
+		{
+			name:       "editor-owned with full caps",
+			configured: "editor-owned",
+			caps:       fullCaps,
+			want:       WorkspaceModeEditorOwned,
+		},
+		{
+			name:       "editor-owned missing writeTextFile rejects",
+			configured: "editor-owned",
+			caps:       readOnlyCaps,
+			wantErr:    "writeTextFile",
+		},
+		{
+			name:       "editor-owned missing terminal rejects",
+			configured: "editor-owned",
+			caps:       noTerminalCaps,
+			wantErr:    "terminal",
+		},
+		{
+			name:       "editor-owned with empty caps rejects",
+			configured: "editor-owned",
+			caps:       ClientCapabilities{Permissions: &PermissionCapability{}},
+			wantErr:    "editor-owned",
+		},
+		{
+			name:       "mode is case-insensitive",
+			configured: "EDITOR-OWNED",
+			caps:       fullCaps,
+			want:       WorkspaceModeEditorOwned,
+		},
+		{
+			name:       "leading whitespace tolerated",
+			configured: "  hecate-owned  ",
+			caps:       fullCaps,
+			want:       WorkspaceModeHecateOwned,
+		},
+		{
+			name:       "unknown mode rejected",
+			configured: "shared",
+			caps:       fullCaps,
+			wantErr:    "invalid HECATE_WORKSPACE_MODE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveWorkspaceMode(tt.configured, tt.caps)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveWorkspaceMode(%q, ...) = (%q, nil); want error containing %q", tt.configured, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q; want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveWorkspaceMode(%q, ...) error = %v; want %q", tt.configured, err, tt.want)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveWorkspaceMode(%q, ...) = %q; want %q", tt.configured, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/executor.go
+++ b/internal/orchestrator/executor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hecate/agent-runtime/internal/sandbox"
 	"github.com/hecate/agent-runtime/internal/telemetry"
+	"github.com/hecate/agent-runtime/internal/workspace"
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
@@ -227,11 +228,11 @@ func (e *StubExecutor) Execute(_ context.Context, spec ExecutionSpec) (*Executio
 }
 
 type ShellExecutor struct {
-	sandbox sandbox.Executor
+	workspace workspace.Workspace
 }
 
-func NewShellExecutor(exec sandbox.Executor) *ShellExecutor {
-	return &ShellExecutor{sandbox: ensureSandboxExecutor(exec)}
+func NewShellExecutor(ws workspace.Workspace) *ShellExecutor {
+	return &ShellExecutor{workspace: ensureWorkspace(ws)}
 }
 
 func (e *ShellExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*ExecutionResult, error) {
@@ -242,7 +243,7 @@ func (e *ShellExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*Execu
 	if command == "" {
 		return nil, fmt.Errorf("shell command is required")
 	}
-	return executeStreamingCommand(ctx, e.sandbox, spec, streamingCommandSpec{
+	return executeStreamingCommand(ctx, e.workspace, spec, streamingCommandSpec{
 		command:           command,
 		kind:              "shell",
 		title:             "Shell command",
@@ -261,11 +262,11 @@ func shellErrorKind(err error) string {
 }
 
 type FileExecutor struct {
-	sandbox sandbox.Executor
+	workspace workspace.Workspace
 }
 
-func NewFileExecutor(exec sandbox.Executor) *FileExecutor {
-	return &FileExecutor{sandbox: ensureSandboxExecutor(exec)}
+func NewFileExecutor(ws workspace.Workspace) *FileExecutor {
+	return &FileExecutor{workspace: ensureWorkspace(ws)}
 }
 
 func (e *FileExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*ExecutionResult, error) {
@@ -295,9 +296,9 @@ func (e *FileExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*Execut
 	)
 	switch operation {
 	case "write":
-		fileResult, err = e.sandbox.WriteFile(ctx, request)
+		fileResult, err = e.workspace.WriteFile(ctx, request)
 	case "append":
-		fileResult, err = e.sandbox.AppendFile(ctx, request)
+		fileResult, err = e.workspace.AppendFile(ctx, request)
 	default:
 		return fileFailure(spec, operation, spec.Task.FilePath, fmt.Sprintf("unsupported file operation %q", operation), "file_operation_unsupported"), nil
 	}
@@ -324,11 +325,11 @@ func (e *FileExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*Execut
 }
 
 type GitExecutor struct {
-	sandbox sandbox.Executor
+	workspace workspace.Workspace
 }
 
-func NewGitExecutor(exec sandbox.Executor) *GitExecutor {
-	return &GitExecutor{sandbox: ensureSandboxExecutor(exec)}
+func NewGitExecutor(ws workspace.Workspace) *GitExecutor {
+	return &GitExecutor{workspace: ensureWorkspace(ws)}
 }
 
 func (e *GitExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*ExecutionResult, error) {
@@ -339,7 +340,7 @@ func (e *GitExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*Executi
 	if command == "" {
 		return nil, fmt.Errorf("git command is required")
 	}
-	return executeStreamingCommand(ctx, e.sandbox, spec, streamingCommandSpec{
+	return executeStreamingCommand(ctx, e.workspace, spec, streamingCommandSpec{
 		command:           "git " + command,
 		displayCommand:    command,
 		kind:              "git",
@@ -372,7 +373,7 @@ type streamingCommandSpec struct {
 	defaultErrorKind  string
 }
 
-func executeStreamingCommand(ctx context.Context, exec sandbox.Executor, spec ExecutionSpec, commandSpec streamingCommandSpec) (*ExecutionResult, error) {
+func executeStreamingCommand(ctx context.Context, ws workspace.Workspace, spec ExecutionSpec, commandSpec streamingCommandSpec) (*ExecutionResult, error) {
 	timeout := commandTimeout(spec.Task)
 	workingDirectory := commandWorkingDirectory(spec.Task)
 	policy := taskPolicy(spec)
@@ -432,7 +433,7 @@ func executeStreamingCommand(ctx context.Context, exec sandbox.Executor, spec Ex
 
 	var stdoutOffset int
 	var stderrOffset int
-	resultData, err := exec.RunStreaming(ctx, sandbox.Command{
+	resultData, err := ws.RunStreaming(ctx, sandbox.Command{
 		Command:          commandSpec.command,
 		WorkingDirectory: workingDirectory,
 		Timeout:          time.Duration(timeout) * time.Millisecond,
@@ -635,11 +636,16 @@ func shellEventSummary(status string, exitCode int, lastError string) string {
 	}
 }
 
-func ensureSandboxExecutor(exec sandbox.Executor) sandbox.Executor {
-	if exec == nil {
-		return sandbox.NewLocalExecutor()
+// ensureWorkspace returns a usable Workspace, defaulting to a fresh
+// LocalWorkspace when the caller didn't supply one. The orchestrator
+// historically tolerated a nil sandbox.Executor by falling back to
+// the local impl; preserve that for callers wiring the orchestrator
+// from tests and small one-shot scripts.
+func ensureWorkspace(ws workspace.Workspace) workspace.Workspace {
+	if ws == nil {
+		return workspace.NewLocalWorkspace()
 	}
-	return exec
+	return ws
 }
 
 func commandTimeout(task types.Task) int {

--- a/internal/orchestrator/executor_agent_loop_test.go
+++ b/internal/orchestrator/executor_agent_loop_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hecate/agent-runtime/internal/sandbox"
+	"github.com/hecate/agent-runtime/internal/workspace"
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
@@ -1167,7 +1167,7 @@ func TestAgentLoop_FileEditToolUsesExactReplacementAndPatchArtifact(t *testing.T
 			makeChatResp(makeAssistantMsg("Updated main.go.")),
 		},
 	}
-	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, NewFileExecutor(sandbox.NewLocalExecutor()), &stubExecutor{}, 8, nil, HTTPRequestPolicy{})
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, NewFileExecutor(workspace.NewLocalWorkspace()), &stubExecutor{}, 8, nil, HTTPRequestPolicy{})
 	spec := newAgentLoopSpec(t)
 	spec.Task.WorkingDirectory = dir
 	spec.Task.SandboxAllowedRoot = dir
@@ -1285,7 +1285,7 @@ func TestAgentLoop_FileEditCanProposePatchWithoutApplying(t *testing.T) {
 			makeChatResp(makeAssistantMsg("Patch proposed.")),
 		},
 	}
-	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, NewFileExecutor(sandbox.NewLocalExecutor()), &stubExecutor{}, 8, nil, HTTPRequestPolicy{})
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, NewFileExecutor(workspace.NewLocalWorkspace()), &stubExecutor{}, 8, nil, HTTPRequestPolicy{})
 	spec := newAgentLoopSpec(t)
 	spec.Task.WorkingDirectory = dir
 	spec.Task.SandboxAllowedRoot = dir

--- a/internal/orchestrator/executor_helpers_test.go
+++ b/internal/orchestrator/executor_helpers_test.go
@@ -511,6 +511,15 @@ func (f *fakeStreamingSandbox) AppendFile(_ context.Context, _ sandbox.FileReque
 	return sandbox.FileResult{}, nil
 }
 
+// OpenTerminal isn't exercised by the shell / file / git executor
+// paths under test today, but the workspace.Workspace interface
+// requires it. Return a not-implemented error so any future test
+// that hits this fake by accident sees a clear failure instead of
+// a panic.
+func (f *fakeStreamingSandbox) OpenTerminal(_ context.Context, _ workspace.TerminalOptions) (workspace.Terminal, error) {
+	return nil, errors.New("fakeStreamingSandbox: OpenTerminal not implemented for this test")
+}
+
 func deterministicIDGenerator() func(string) string {
 	counters := make(map[string]int)
 	return func(prefix string) string {

--- a/internal/orchestrator/executor_helpers_test.go
+++ b/internal/orchestrator/executor_helpers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hecate/agent-runtime/internal/sandbox"
 	"github.com/hecate/agent-runtime/internal/telemetry"
+	"github.com/hecate/agent-runtime/internal/workspace"
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
@@ -122,7 +123,7 @@ func TestFileExecutorCreatesPatchArtifactAndEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	var events []capturedRunEvent
-	exec := NewFileExecutor(sandbox.NewLocalExecutor())
+	exec := NewFileExecutor(workspace.NewLocalWorkspace())
 	result, err := exec.Execute(context.Background(), ExecutionSpec{
 		Task: types.Task{
 			ID:                 "task-1",

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/hecate/agent-runtime/internal/profiler"
-	"github.com/hecate/agent-runtime/internal/sandbox"
 	"github.com/hecate/agent-runtime/internal/taskstate"
 	"github.com/hecate/agent-runtime/internal/telemetry"
+	"github.com/hecate/agent-runtime/internal/workspace"
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
@@ -204,7 +204,7 @@ func NewRunner(logger *slog.Logger, store taskstate.Store, tracer profiler.Trace
 	if tracer == nil {
 		tracer = profiler.NewInMemoryTracer(nil)
 	}
-	worker := sandbox.NewLocalExecutor()
+	worker := workspace.NewLocalWorkspace()
 	queueBuffer := cfg.QueueBuffer
 	if queueBuffer <= 0 {
 		queueBuffer = 128

--- a/internal/sandbox/exec.go
+++ b/internal/sandbox/exec.go
@@ -708,3 +708,20 @@ func envInt64(key string, fallback int64) int64 {
 	}
 	return v
 }
+
+// ResolveWorkingDirectory is the public wrapper around the existing
+// resolveWorkingDirectory helper. It exists so other packages
+// (specifically internal/workspace's LocalWorkspace.OpenTerminal) can
+// reuse the working-directory escape check without re-implementing
+// it. The implementation hasn't changed; only its visibility has.
+func ResolveWorkingDirectory(workingDirectory string, policy Policy) (string, error) {
+	return resolveWorkingDirectory(workingDirectory, policy)
+}
+
+// SanitizedEnv is the public wrapper around sanitisedEnv. Same shape
+// as the rationale for ResolveWorkingDirectory above: workspace-level
+// callers spawn processes too and need the same allowlisted env to
+// avoid leaking gateway secrets into child processes.
+func SanitizedEnv() []string {
+	return sanitisedEnv()
+}

--- a/internal/workspace/acp.go
+++ b/internal/workspace/acp.go
@@ -1,0 +1,392 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Caller is the narrow surface of acp.Dispatcher that ACPWorkspace
+// consumes. Defined here so the workspace package depends on the
+// behavior (send a JSON-RPC call, await a response) rather than the
+// full Dispatcher type — and so tests can mock outbound RPC without
+// spinning up an entire bridge.
+//
+// In production, ACPWorkspace is constructed with *acp.Dispatcher as
+// the Caller. The dispatcher's Call method blocks until the editor
+// answers or ctx is cancelled.
+type Caller interface {
+	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
+}
+
+// ACPWorkspace is the editor-owned implementation. Every file or
+// process operation dispatches to the connected ACP editor as a
+// reverse-RPC call — fs/write_text_file, terminal/create, and so on
+// — so the editor's native filesystem and terminal subsystems own
+// the actual side effects. The Hecate sandbox is bypassed in this
+// mode by design: the editor enforces its own permission model
+// (Zed's project-trust gates, JetBrains' AI assistant prompts, …).
+//
+// One ACPWorkspace per session — the session id rides in every
+// outbound params payload because ACP's reverse-RPC surface is
+// session-scoped. Constructing one without a sessionID produces a
+// workspace that returns errors on every method; this is intentional
+// so the wiring step (HECATE_WORKSPACE_MODE=editor-owned) fails
+// loudly rather than silently corrupting state.
+type ACPWorkspace struct {
+	caller    Caller
+	sessionID string
+}
+
+// NewACPWorkspace constructs the editor-owned workspace. sessionID is
+// the ACP session id carried in every outbound params payload —
+// editors route the call to the matching session on their side.
+func NewACPWorkspace(caller Caller, sessionID string) *ACPWorkspace {
+	return &ACPWorkspace{caller: caller, sessionID: sessionID}
+}
+
+// Compile-time interface conformance — same guard LocalWorkspace
+// carries. If a future change drifts the method shapes, the build
+// catches it instead of the runtime.
+var (
+	_ Workspace = (*ACPWorkspace)(nil)
+	_ Permitter = (*ACPWorkspace)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// File operations
+// ---------------------------------------------------------------------------
+
+type acpFSWriteParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}
+
+type acpFSReadParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+}
+
+type acpFSReadResult struct {
+	Content string `json:"content"`
+}
+
+// WriteFile dispatches an fs/write_text_file reverse-RPC. The editor
+// is responsible for resolving the path against its project root,
+// running its own permission prompts if necessary, and writing the
+// file through its native APIs (which integrates with editor undo,
+// buffer reload, and file watchers).
+func (w *ACPWorkspace) WriteFile(ctx context.Context, req FileRequest) (FileResult, error) {
+	if err := w.ensureWired(); err != nil {
+		return FileResult{}, err
+	}
+	resolvedPath := joinWorkspacePath(req.WorkingDirectory, req.Path)
+	if _, err := w.caller.Call(ctx, "fs/write_text_file", acpFSWriteParams{
+		SessionID: w.sessionID,
+		Path:      resolvedPath,
+		Content:   req.Content,
+	}); err != nil {
+		return FileResult{}, err
+	}
+	return FileResult{
+		Path:         resolvedPath,
+		BytesWritten: len(req.Content),
+	}, nil
+}
+
+// AppendFile is read + concatenate + write. ACP doesn't define an
+// append primitive (fs/append_text_file isn't part of the spec), so
+// we round-trip through fs/read_text_file. Slower than the local
+// path, but operators rarely append in the editor-owned scenario.
+func (w *ACPWorkspace) AppendFile(ctx context.Context, req FileRequest) (FileResult, error) {
+	if err := w.ensureWired(); err != nil {
+		return FileResult{}, err
+	}
+	resolvedPath := joinWorkspacePath(req.WorkingDirectory, req.Path)
+	existing, err := w.readFile(ctx, resolvedPath)
+	// fs/read_text_file returns a not-found error for missing files;
+	// treat as empty so callers don't have to special-case append-on-new.
+	if err != nil && !isACPNotFound(err) {
+		return FileResult{}, err
+	}
+	combined := existing + req.Content
+	if _, err := w.caller.Call(ctx, "fs/write_text_file", acpFSWriteParams{
+		SessionID: w.sessionID,
+		Path:      resolvedPath,
+		Content:   combined,
+	}); err != nil {
+		return FileResult{}, err
+	}
+	return FileResult{
+		Path:         resolvedPath,
+		BytesWritten: len(req.Content),
+	}, nil
+}
+
+func (w *ACPWorkspace) readFile(ctx context.Context, path string) (string, error) {
+	raw, err := w.caller.Call(ctx, "fs/read_text_file", acpFSReadParams{
+		SessionID: w.sessionID,
+		Path:      path,
+	})
+	if err != nil {
+		return "", err
+	}
+	var out acpFSReadResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return "", fmt.Errorf("acp: decode fs/read_text_file response: %w", err)
+	}
+	return out.Content, nil
+}
+
+// ---------------------------------------------------------------------------
+// Commands (one-shot)
+// ---------------------------------------------------------------------------
+
+type acpTerminalCreateParams struct {
+	SessionID string            `json:"sessionId"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Cwd       string            `json:"cwd,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+}
+
+type acpTerminalCreateResult struct {
+	TerminalID string `json:"terminalId"`
+}
+
+type acpTerminalIDParams struct {
+	SessionID  string `json:"sessionId"`
+	TerminalID string `json:"terminalId"`
+}
+
+type acpTerminalOutputResult struct {
+	Stdout    string `json:"stdout"`
+	Stderr    string `json:"stderr"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type acpTerminalWaitResult struct {
+	ExitCode int    `json:"exitCode"`
+	Signal   string `json:"signal,omitempty"`
+}
+
+// Run executes a command synchronously by creating a terminal,
+// waiting for exit, draining final output, and releasing the
+// terminal. Result.Stdout / Stderr carry the captured output.
+func (w *ACPWorkspace) Run(ctx context.Context, command Command) (Result, error) {
+	return w.RunStreaming(ctx, command, nil)
+}
+
+// RunStreaming creates an editor-side terminal, polls terminal/output
+// at a small cadence while the process runs, calls onChunk for each
+// new slice of output, then drains the final output after exit. The
+// editor is responsible for the actual process spawn — Hecate is just
+// the orchestration layer.
+//
+// onChunk may be nil; the captured output still lands in the returned
+// Result for the orchestrator's artifact pipeline.
+func (w *ACPWorkspace) RunStreaming(ctx context.Context, command Command, onChunk func(OutputChunk)) (Result, error) {
+	if err := w.ensureWired(); err != nil {
+		return Result{}, err
+	}
+	terminalID, err := w.createTerminal(ctx, acpTerminalCreateParams{
+		SessionID: w.sessionID,
+		Command:   "sh",
+		Args:      []string{"-lc", command.Command},
+		Cwd:       command.WorkingDirectory,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	defer w.releaseTerminal(context.Background(), terminalID) // best-effort release on every exit path
+
+	var stdoutBuf, stderrBuf strings.Builder
+	waitDone := make(chan acpTerminalWaitResult, 1)
+	waitErr := make(chan error, 1)
+	go func() {
+		raw, err := w.caller.Call(ctx, "terminal/wait_for_exit", acpTerminalIDParams{
+			SessionID:  w.sessionID,
+			TerminalID: terminalID,
+		})
+		if err != nil {
+			waitErr <- err
+			return
+		}
+		var wr acpTerminalWaitResult
+		if jerr := json.Unmarshal(raw, &wr); jerr != nil {
+			waitErr <- jerr
+			return
+		}
+		waitDone <- wr
+	}()
+
+	// Polling loop: drain terminal/output until either the wait
+	// goroutine reports exit or ctx is cancelled. 100ms cadence is
+	// a compromise between responsiveness and round-trip overhead;
+	// the editor side typically responds in <10ms so polling cost
+	// is the dominant factor.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case wr := <-waitDone:
+			// One last drain to capture any trailing output the
+			// editor buffered between the previous poll and exit.
+			w.drainOnce(ctx, terminalID, &stdoutBuf, &stderrBuf, onChunk)
+			return Result{
+				Stdout:   stdoutBuf.String(),
+				Stderr:   stderrBuf.String(),
+				ExitCode: wr.ExitCode,
+			}, nil
+		case err := <-waitErr:
+			return Result{Stdout: stdoutBuf.String(), Stderr: stderrBuf.String()}, err
+		case <-ctx.Done():
+			// Attempt a kill so the editor doesn't leak a child
+			// process; ignore the kill error — the caller's
+			// real error is ctx.Err().
+			_, _ = w.caller.Call(context.Background(), "terminal/kill", acpTerminalIDParams{
+				SessionID:  w.sessionID,
+				TerminalID: terminalID,
+			})
+			return Result{Stdout: stdoutBuf.String(), Stderr: stderrBuf.String()}, ctx.Err()
+		case <-ticker.C:
+			w.drainOnce(ctx, terminalID, &stdoutBuf, &stderrBuf, onChunk)
+		}
+	}
+}
+
+// drainOnce fetches the editor-side terminal's accumulated output
+// since the last drain and appends it to the local buffers. ACP's
+// terminal/output returns the FULL buffer each time today; we track
+// what we've already seen by length so onChunk only sees the delta.
+//
+// (When the spec stabilizes a delta-style stream method we'll switch
+// to that; the current polling model is forward-compat — the buffers
+// stay correct either way.)
+func (w *ACPWorkspace) drainOnce(ctx context.Context, terminalID string, stdoutBuf, stderrBuf *strings.Builder, onChunk func(OutputChunk)) {
+	raw, err := w.caller.Call(ctx, "terminal/output", acpTerminalIDParams{
+		SessionID:  w.sessionID,
+		TerminalID: terminalID,
+	})
+	if err != nil {
+		return // best-effort; the next tick retries
+	}
+	var out acpTerminalOutputResult
+	if jerr := json.Unmarshal(raw, &out); jerr != nil {
+		return
+	}
+	if delta := stringSuffixAfter(stdoutBuf, out.Stdout); delta != "" {
+		stdoutBuf.WriteString(delta)
+		if onChunk != nil {
+			onChunk(OutputChunk{Stream: "stdout", Text: delta})
+		}
+	}
+	if delta := stringSuffixAfter(stderrBuf, out.Stderr); delta != "" {
+		stderrBuf.WriteString(delta)
+		if onChunk != nil {
+			onChunk(OutputChunk{Stream: "stderr", Text: delta})
+		}
+	}
+}
+
+// createTerminal sends terminal/create and returns the editor-assigned
+// terminal id. Pulled out of Run/RunStreaming so OpenTerminal can
+// share it.
+func (w *ACPWorkspace) createTerminal(ctx context.Context, params acpTerminalCreateParams) (string, error) {
+	raw, err := w.caller.Call(ctx, "terminal/create", params)
+	if err != nil {
+		return "", err
+	}
+	var out acpTerminalCreateResult
+	if jerr := json.Unmarshal(raw, &out); jerr != nil {
+		return "", fmt.Errorf("acp: decode terminal/create response: %w", jerr)
+	}
+	if strings.TrimSpace(out.TerminalID) == "" {
+		return "", errors.New("acp: terminal/create returned empty terminalId")
+	}
+	return out.TerminalID, nil
+}
+
+func (w *ACPWorkspace) releaseTerminal(ctx context.Context, terminalID string) {
+	_, _ = w.caller.Call(ctx, "terminal/release", acpTerminalIDParams{
+		SessionID:  w.sessionID,
+		TerminalID: terminalID,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Wiring helpers
+// ---------------------------------------------------------------------------
+
+func (w *ACPWorkspace) ensureWired() error {
+	if w == nil || w.caller == nil {
+		return errors.New("acp workspace: dispatcher is not wired")
+	}
+	if w.sessionID == "" {
+		return errors.New("acp workspace: session id is empty")
+	}
+	return nil
+}
+
+// joinWorkspacePath normalizes the (workingDir, path) pair into a
+// single path string the editor can resolve. Conservative: when
+// workingDir is empty we return path as-is so absolute paths flow
+// through unchanged.
+func joinWorkspacePath(workingDir, path string) string {
+	if workingDir == "" {
+		return path
+	}
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+	return strings.TrimRight(workingDir, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+// stringSuffixAfter returns the portion of next that comes after the
+// already-seen prefix in seen. Used by drainOnce to compute deltas
+// from the editor's full-buffer responses. When the buffers
+// unexpectedly diverge (editor truncated, restart, etc.) we treat
+// the entire next as the delta — over-reports rather than drops.
+func stringSuffixAfter(seen *strings.Builder, next string) string {
+	prefix := seen.String()
+	if strings.HasPrefix(next, prefix) {
+		return next[len(prefix):]
+	}
+	return next
+}
+
+// once captures one-time release wiring used by OpenTerminal's
+// returned handle. Exposed via the local type to avoid pulling in
+// sync.Once at the public method signatures.
+type once struct {
+	mu   sync.Mutex
+	done bool
+}
+
+func (o *once) doOnce(fn func()) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.done {
+		return
+	}
+	o.done = true
+	fn()
+}
+
+// isACPNotFound reports whether err is the editor's "no such file"
+// response. ACP doesn't fully nail this down; we recognize the
+// JSON-RPC method-not-found code (-32601) by exclusion and look for
+// the well-known not-found sentinel in the message. Adjusted as the
+// editor side stabilizes.
+func isACPNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "no such file")
+}

--- a/internal/workspace/acp.go
+++ b/internal/workspace/acp.go
@@ -194,16 +194,25 @@ func (w *ACPWorkspace) RunStreaming(ctx context.Context, command Command, onChun
 	if err := w.ensureWired(); err != nil {
 		return Result{}, err
 	}
+	shellCommand, shellArgs := acpRunShellSpec(command.Command)
 	terminalID, err := w.createTerminal(ctx, acpTerminalCreateParams{
 		SessionID: w.sessionID,
-		Command:   "sh",
-		Args:      []string{"-lc", command.Command},
+		Command:   shellCommand,
+		Args:      shellArgs,
 		Cwd:       command.WorkingDirectory,
 	})
 	if err != nil {
 		return Result{}, err
 	}
-	defer w.releaseTerminal(context.Background(), terminalID) // best-effort release on every exit path
+	defer func() {
+		// Bounded best-effort release. Using a fresh context (not
+		// the caller's, which may already be cancelled) lets the
+		// release run on every exit path; the timeout protects
+		// against a wedged editor pinning Run/RunStreaming forever.
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		w.releaseTerminal(releaseCtx, terminalID)
+	}()
 
 	var stdoutBuf, stderrBuf strings.Builder
 	waitDone := make(chan acpTerminalWaitResult, 1)

--- a/internal/workspace/acp_permission.go
+++ b/internal/workspace/acp_permission.go
@@ -1,0 +1,55 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type acpPermissionParams struct {
+	SessionID string         `json:"sessionId"`
+	Tool      string         `json:"tool"`
+	Action    string         `json:"action"`
+	Details   map[string]any `json:"details,omitempty"`
+	RiskLevel string         `json:"riskLevel,omitempty"`
+}
+
+type acpPermissionResult struct {
+	Granted bool   `json:"granted"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// RequestPermission forwards the gate to session/request_permission
+// on the editor side. The editor renders its own modal — Zed's
+// project trust prompt, JetBrains' AI assistant approval card — and
+// the operator's answer flows back here as the function's return
+// value. Blocking on the operator is fine because this is per-tool
+// invocation; the agent loop is already blocked waiting for the tool
+// result and the editor controls the UI cadence.
+//
+// On the local side, LocalWorkspace evaluates a static Policy and
+// returns synchronously; this method is intentionally not symmetric
+// with that — the static Policy lives in the request's Details map
+// for whichever workspace ends up handling it.
+func (w *ACPWorkspace) RequestPermission(ctx context.Context, req PermissionRequest) (PermissionDecision, error) {
+	if err := w.ensureWired(); err != nil {
+		return PermissionDecision{}, err
+	}
+	raw, err := w.caller.Call(ctx, "session/request_permission", acpPermissionParams{
+		SessionID: w.sessionID,
+		Tool:      req.Tool,
+		Action:    req.Action,
+		Details:   req.Details,
+		RiskLevel: req.RiskLevel,
+	})
+	if err != nil {
+		return PermissionDecision{}, err
+	}
+	var result acpPermissionResult
+	if jerr := json.Unmarshal(raw, &result); jerr != nil {
+		return PermissionDecision{}, jerr
+	}
+	return PermissionDecision{
+		Granted: result.Granted,
+		Reason:  result.Reason,
+	}, nil
+}

--- a/internal/workspace/acp_terminal.go
+++ b/internal/workspace/acp_terminal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -32,13 +33,16 @@ func (w *ACPWorkspace) OpenTerminal(ctx context.Context, opts TerminalOptions) (
 	}
 
 	pollCtx, cancelPoll := context.WithCancel(context.Background())
+	waitCtx, cancelWait := context.WithCancel(context.Background())
 	term := &acpTerminal{
 		caller:     w.caller,
 		sessionID:  w.sessionID,
 		terminalID: terminalID,
 		output:     make(chan OutputChunk, 64),
 		exit:       make(chan struct{}),
+		pollDone:   make(chan struct{}),
 		cancelPoll: cancelPoll,
+		cancelWait: cancelWait,
 	}
 	// Polling goroutine drains terminal/output until the editor
 	// reports exit or the caller closes the terminal. Mirrors the
@@ -47,7 +51,10 @@ func (w *ACPWorkspace) OpenTerminal(ctx context.Context, opts TerminalOptions) (
 	go term.pollOutput(pollCtx)
 	// Wait goroutine resolves terminal/wait_for_exit so
 	// WaitForExit callers don't each have to issue their own RPC.
-	go term.awaitExit()
+	// waitCtx lets Close cancel a hung RPC if the editor never
+	// responds — without it, awaitExit would leak forever on
+	// transport loss.
+	go term.awaitExit(waitCtx)
 
 	return term, nil
 }
@@ -66,6 +73,21 @@ func terminalSpawnSpec(opts TerminalOptions) (string, []string) {
 	return opts.Command, opts.Args
 }
 
+// acpRunShellSpec wraps a freeform shell string for ACP terminal/create.
+// Run/RunStreaming receive Command.Command as a single shell line
+// ("git status", "cd repo && make test"), so the editor needs a shell
+// to parse and execute it. We pick based on the gateway's GOOS —
+// which today equals the editor host's GOOS (the bridge always runs
+// loopback per cmd/hecate-acp/main.go). Cross-host editors are a
+// future RFC; when they land they'll negotiate shell flavor through
+// ACP capabilities.
+func acpRunShellSpec(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/C", command}
+	}
+	return "sh", []string{"-lc", command}
+}
+
 // acpTerminal is the editor-owned Terminal handle returned by
 // ACPWorkspace.OpenTerminal. Each handle owns one terminal id, one
 // polling goroutine, and one wait goroutine. Close serializes
@@ -76,8 +98,9 @@ type acpTerminal struct {
 	sessionID  string
 	terminalID string
 
-	output chan OutputChunk
-	exit   chan struct{}
+	output   chan OutputChunk
+	exit     chan struct{}
+	pollDone chan struct{} // closed by pollOutput when it returns
 
 	// stdout/stderr seen-so-far buffers track what we've already
 	// streamed via Output() — same shape as ACPWorkspace.drainOnce
@@ -90,6 +113,7 @@ type acpTerminal struct {
 	exitErr    error
 
 	cancelPoll func()
+	cancelWait func()
 
 	closeOnce sync.Once
 }
@@ -112,15 +136,20 @@ func (t *acpTerminal) WaitForExit(ctx context.Context) (Result, error) {
 	case <-ctx.Done():
 		return Result{}, ctx.Err()
 	}
+	// pollOutput may still be running concurrently — even though
+	// exit closed, the poller doesn't bail until Close cancels it.
+	// Take bufMu while snapshotting so we don't race a concurrent
+	// WriteString on the builders.
+	t.bufMu.Lock()
+	stdout := t.stdoutBuf.String()
+	stderr := t.stderrBuf.String()
+	t.bufMu.Unlock()
 	if t.exitErr != nil {
-		return Result{
-			Stdout: t.stdoutBuf.String(),
-			Stderr: t.stderrBuf.String(),
-		}, t.exitErr
+		return Result{Stdout: stdout, Stderr: stderr}, t.exitErr
 	}
 	return Result{
-		Stdout:   t.stdoutBuf.String(),
-		Stderr:   t.stderrBuf.String(),
+		Stdout:   stdout,
+		Stderr:   stderr,
 		ExitCode: t.exitResult.ExitCode,
 	}, nil
 }
@@ -141,14 +170,23 @@ func (t *acpTerminal) Close(ctx context.Context) error {
 		// Stop the polling goroutine before releasing the handle
 		// so terminal/output calls don't race terminal/release.
 		t.cancelPoll()
+		// Wait for the poller to actually return before closing
+		// t.output — otherwise a late publishChunk could panic on
+		// send-to-closed-channel.
+		<-t.pollDone
 		// Wait for the editor-side process to actually exit. The
 		// wait goroutine closes t.exit when terminal/wait_for_exit
 		// returns; bound the wait so a wedged editor doesn't pin
-		// Close forever.
+		// Close forever. If we time out or ctx cancels, cancel the
+		// wait RPC explicitly so its goroutine doesn't leak.
 		select {
 		case <-t.exit:
 		case <-time.After(5 * time.Second):
+			t.cancelWait()
+			<-t.exit
 		case <-ctx.Done():
+			t.cancelWait()
+			<-t.exit
 		}
 		_, releaseErr = t.caller.Call(ctx, "terminal/release", acpTerminalIDParams{
 			SessionID:  t.sessionID,
@@ -162,41 +200,52 @@ func (t *acpTerminal) Close(ctx context.Context) error {
 // pollOutput is the streaming side of the terminal handle. Same
 // cadence and same delta-by-prefix logic as ACPWorkspace.drainOnce
 // uses for one-shot Run; differences are (a) we keep going until
-// cancelPoll fires (Close was called), and (b) we deliver chunks
-// through the channel rather than calling onChunk.
+// cancelPoll fires (Close was called) or the wait goroutine observes
+// exit, and (b) we deliver chunks through the channel rather than
+// calling onChunk.
 func (t *acpTerminal) pollOutput(ctx context.Context) {
+	defer close(t.pollDone)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-t.exit:
+			// One last drain so WaitForExit sees any trailing
+			// output buffered between the previous tick and exit.
+			t.drainOnce(ctx)
+			return
 		case <-ticker.C:
 		}
-		raw, err := t.caller.Call(ctx, "terminal/output", acpTerminalIDParams{
-			SessionID:  t.sessionID,
-			TerminalID: t.terminalID,
-		})
-		if err != nil {
-			// Best-effort polling — the editor may have already
-			// released the terminal; the wait goroutine will
-			// observe the exit shortly and we'll bail out.
-			continue
-		}
-		var out acpTerminalOutputResult
-		if jerr := json.Unmarshal(raw, &out); jerr != nil {
-			continue
-		}
-		t.bufMu.Lock()
-		if delta := stringSuffixAfter(&t.stdoutBuf, out.Stdout); delta != "" {
-			t.stdoutBuf.WriteString(delta)
-			t.publishChunk(OutputChunk{Stream: "stdout", Text: delta})
-		}
-		if delta := stringSuffixAfter(&t.stderrBuf, out.Stderr); delta != "" {
-			t.stderrBuf.WriteString(delta)
-			t.publishChunk(OutputChunk{Stream: "stderr", Text: delta})
-		}
-		t.bufMu.Unlock()
+		t.drainOnce(ctx)
+	}
+}
+
+func (t *acpTerminal) drainOnce(ctx context.Context) {
+	raw, err := t.caller.Call(ctx, "terminal/output", acpTerminalIDParams{
+		SessionID:  t.sessionID,
+		TerminalID: t.terminalID,
+	})
+	if err != nil {
+		// Best-effort polling — the editor may have already
+		// released the terminal; the wait goroutine will
+		// observe the exit shortly and we'll bail out.
+		return
+	}
+	var out acpTerminalOutputResult
+	if jerr := json.Unmarshal(raw, &out); jerr != nil {
+		return
+	}
+	t.bufMu.Lock()
+	defer t.bufMu.Unlock()
+	if delta := stringSuffixAfter(&t.stdoutBuf, out.Stdout); delta != "" {
+		t.stdoutBuf.WriteString(delta)
+		t.publishChunk(OutputChunk{Stream: "stdout", Text: delta})
+	}
+	if delta := stringSuffixAfter(&t.stderrBuf, out.Stderr); delta != "" {
+		t.stderrBuf.WriteString(delta)
+		t.publishChunk(OutputChunk{Stream: "stderr", Text: delta})
 	}
 }
 
@@ -211,8 +260,8 @@ func (t *acpTerminal) publishChunk(chunk OutputChunk) {
 	}
 }
 
-func (t *acpTerminal) awaitExit() {
-	raw, err := t.caller.Call(context.Background(), "terminal/wait_for_exit", acpTerminalIDParams{
+func (t *acpTerminal) awaitExit(ctx context.Context) {
+	raw, err := t.caller.Call(ctx, "terminal/wait_for_exit", acpTerminalIDParams{
 		SessionID:  t.sessionID,
 		TerminalID: t.terminalID,
 	})

--- a/internal/workspace/acp_terminal.go
+++ b/internal/workspace/acp_terminal.go
@@ -1,0 +1,228 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OpenTerminal asks the editor to spawn a long-lived terminal and
+// returns a handle that polls terminal/output for streaming reads
+// and dispatches terminal/wait_for_exit / terminal/kill / terminal/
+// release on demand. The editor owns the actual child process —
+// rendering it in its terminal pane, surfacing it in its UI — and
+// Hecate just orchestrates.
+func (w *ACPWorkspace) OpenTerminal(ctx context.Context, opts TerminalOptions) (Terminal, error) {
+	if err := w.ensureWired(); err != nil {
+		return nil, err
+	}
+	command, args := terminalSpawnSpec(opts)
+	terminalID, err := w.createTerminal(ctx, acpTerminalCreateParams{
+		SessionID: w.sessionID,
+		Command:   command,
+		Args:      args,
+		Cwd:       opts.WorkingDirectory,
+		Env:       opts.Env,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pollCtx, cancelPoll := context.WithCancel(context.Background())
+	term := &acpTerminal{
+		caller:     w.caller,
+		sessionID:  w.sessionID,
+		terminalID: terminalID,
+		output:     make(chan OutputChunk, 64),
+		exit:       make(chan struct{}),
+		cancelPoll: cancelPoll,
+	}
+	// Polling goroutine drains terminal/output until the editor
+	// reports exit or the caller closes the terminal. Mirrors the
+	// LocalWorkspace.OpenTerminal goroutine model — Output() is a
+	// channel callers can range over.
+	go term.pollOutput(pollCtx)
+	// Wait goroutine resolves terminal/wait_for_exit so
+	// WaitForExit callers don't each have to issue their own RPC.
+	go term.awaitExit()
+
+	return term, nil
+}
+
+// terminalSpawnSpec picks the (command, args) pair the editor should
+// spawn. Mirrors the LocalWorkspace behavior: empty Command means
+// "interactive shell," Args are passed through unchanged. The
+// editor's terminal subsystem is responsible for shell selection —
+// Zed defaults to the user's $SHELL, JetBrains uses its terminal
+// settings — so we only need to pass an empty command to signal "no
+// override."
+func terminalSpawnSpec(opts TerminalOptions) (string, []string) {
+	if opts.Command == "" {
+		return "", nil
+	}
+	return opts.Command, opts.Args
+}
+
+// acpTerminal is the editor-owned Terminal handle returned by
+// ACPWorkspace.OpenTerminal. Each handle owns one terminal id, one
+// polling goroutine, and one wait goroutine. Close serializes
+// teardown through a sync.Once so concurrent Kill / WaitForExit /
+// Close don't race on terminal/release.
+type acpTerminal struct {
+	caller     Caller
+	sessionID  string
+	terminalID string
+
+	output chan OutputChunk
+	exit   chan struct{}
+
+	// stdout/stderr seen-so-far buffers track what we've already
+	// streamed via Output() — same shape as ACPWorkspace.drainOnce
+	// uses for one-shot Run.
+	bufMu     sync.Mutex
+	stdoutBuf strings.Builder
+	stderrBuf strings.Builder
+
+	exitResult acpTerminalWaitResult
+	exitErr    error
+
+	cancelPoll func()
+
+	closeOnce sync.Once
+}
+
+func (t *acpTerminal) ID() string                 { return t.terminalID }
+func (t *acpTerminal) Output() <-chan OutputChunk { return t.output }
+
+func (t *acpTerminal) Write(_ context.Context, _ string) error {
+	// ACP's terminal surface today is read-only from the agent's
+	// perspective — there's no terminal/input or terminal/write
+	// method. Long-lived interactive terminals driven by the agent
+	// aren't part of the v1 reverse-RPC contract. Surface this
+	// explicitly so callers don't silently lose stdin.
+	return errors.New("acp workspace: terminal stdin is not supported by the current ACP surface")
+}
+
+func (t *acpTerminal) WaitForExit(ctx context.Context) (Result, error) {
+	select {
+	case <-t.exit:
+	case <-ctx.Done():
+		return Result{}, ctx.Err()
+	}
+	if t.exitErr != nil {
+		return Result{
+			Stdout: t.stdoutBuf.String(),
+			Stderr: t.stderrBuf.String(),
+		}, t.exitErr
+	}
+	return Result{
+		Stdout:   t.stdoutBuf.String(),
+		Stderr:   t.stderrBuf.String(),
+		ExitCode: t.exitResult.ExitCode,
+	}, nil
+}
+
+func (t *acpTerminal) Kill(ctx context.Context) error {
+	_, err := t.caller.Call(ctx, "terminal/kill", acpTerminalIDParams{
+		SessionID:  t.sessionID,
+		TerminalID: t.terminalID,
+	})
+	return err
+}
+
+func (t *acpTerminal) Close(ctx context.Context) error {
+	var releaseErr error
+	t.closeOnce.Do(func() {
+		// Kill is best-effort: the process may already have exited.
+		_ = t.Kill(ctx)
+		// Stop the polling goroutine before releasing the handle
+		// so terminal/output calls don't race terminal/release.
+		t.cancelPoll()
+		// Wait for the editor-side process to actually exit. The
+		// wait goroutine closes t.exit when terminal/wait_for_exit
+		// returns; bound the wait so a wedged editor doesn't pin
+		// Close forever.
+		select {
+		case <-t.exit:
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+		}
+		_, releaseErr = t.caller.Call(ctx, "terminal/release", acpTerminalIDParams{
+			SessionID:  t.sessionID,
+			TerminalID: t.terminalID,
+		})
+		close(t.output)
+	})
+	return releaseErr
+}
+
+// pollOutput is the streaming side of the terminal handle. Same
+// cadence and same delta-by-prefix logic as ACPWorkspace.drainOnce
+// uses for one-shot Run; differences are (a) we keep going until
+// cancelPoll fires (Close was called), and (b) we deliver chunks
+// through the channel rather than calling onChunk.
+func (t *acpTerminal) pollOutput(ctx context.Context) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		raw, err := t.caller.Call(ctx, "terminal/output", acpTerminalIDParams{
+			SessionID:  t.sessionID,
+			TerminalID: t.terminalID,
+		})
+		if err != nil {
+			// Best-effort polling — the editor may have already
+			// released the terminal; the wait goroutine will
+			// observe the exit shortly and we'll bail out.
+			continue
+		}
+		var out acpTerminalOutputResult
+		if jerr := json.Unmarshal(raw, &out); jerr != nil {
+			continue
+		}
+		t.bufMu.Lock()
+		if delta := stringSuffixAfter(&t.stdoutBuf, out.Stdout); delta != "" {
+			t.stdoutBuf.WriteString(delta)
+			t.publishChunk(OutputChunk{Stream: "stdout", Text: delta})
+		}
+		if delta := stringSuffixAfter(&t.stderrBuf, out.Stderr); delta != "" {
+			t.stderrBuf.WriteString(delta)
+			t.publishChunk(OutputChunk{Stream: "stderr", Text: delta})
+		}
+		t.bufMu.Unlock()
+	}
+}
+
+func (t *acpTerminal) publishChunk(chunk OutputChunk) {
+	// Non-blocking publish: if the consumer is slow we'd rather
+	// drop than wedge the poller. Bounded channel + drop-on-full
+	// matches what real editors expect from a "tail this terminal"
+	// surface anyway.
+	select {
+	case t.output <- chunk:
+	default:
+	}
+}
+
+func (t *acpTerminal) awaitExit() {
+	raw, err := t.caller.Call(context.Background(), "terminal/wait_for_exit", acpTerminalIDParams{
+		SessionID:  t.sessionID,
+		TerminalID: t.terminalID,
+	})
+	if err != nil {
+		t.exitErr = err
+		close(t.exit)
+		return
+	}
+	if jerr := json.Unmarshal(raw, &t.exitResult); jerr != nil {
+		t.exitErr = jerr
+	}
+	close(t.exit)
+}

--- a/internal/workspace/acp_test.go
+++ b/internal/workspace/acp_test.go
@@ -1,0 +1,278 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeCaller is a hand-rolled mock for the Caller interface so the
+// ACPWorkspace tests don't have to spin up an entire acp.Dispatcher
+// + stdio pump. Each call records the method and params, then
+// returns the next queued response (or runs the next queued handler
+// for tests that need to react to the params).
+type fakeCaller struct {
+	mu    sync.Mutex
+	calls []fakeCall
+
+	// Handler queue: tests register one handler per expected
+	// outbound RPC. The fake pops them in FIFO order. If a call
+	// arrives with no queued handler, the fake returns a clear
+	// error so the test sees "unexpected RPC" instead of a panic.
+	handlers []fakeHandler
+}
+
+type fakeCall struct {
+	method string
+	params any
+}
+
+type fakeHandler func(method string, params any) (json.RawMessage, error)
+
+func (f *fakeCaller) expect(handler fakeHandler) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = append(f.handlers, handler)
+}
+
+func (f *fakeCaller) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeCall{method: method, params: params})
+	if len(f.handlers) == 0 {
+		f.mu.Unlock()
+		return nil, errors.New("fakeCaller: no queued handler for " + method)
+	}
+	handler := f.handlers[0]
+	f.handlers = f.handlers[1:]
+	f.mu.Unlock()
+	return handler(method, params)
+}
+
+func (f *fakeCaller) callMethods() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	for i, c := range f.calls {
+		out[i] = c.method
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// File operations
+// ---------------------------------------------------------------------------
+
+func TestACPWorkspace_WriteFileSendsFSWrite(t *testing.T) {
+	t.Parallel()
+	caller := &fakeCaller{}
+	caller.expect(func(method string, params any) (json.RawMessage, error) {
+		if method != "fs/write_text_file" {
+			t.Errorf("method = %q; want fs/write_text_file", method)
+		}
+		p, ok := params.(acpFSWriteParams)
+		if !ok {
+			t.Fatalf("params type = %T; want acpFSWriteParams", params)
+		}
+		if p.Path != "/projects/demo/README.md" {
+			t.Errorf("path = %q", p.Path)
+		}
+		if p.Content != "hello" {
+			t.Errorf("content = %q", p.Content)
+		}
+		return json.RawMessage(`{}`), nil
+	})
+	ws := NewACPWorkspace(caller, "session-1")
+	res, err := ws.WriteFile(context.Background(), FileRequest{
+		Path:             "README.md",
+		Content:          "hello",
+		WorkingDirectory: "/projects/demo",
+	})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if res.BytesWritten != 5 {
+		t.Fatalf("BytesWritten = %d; want 5", res.BytesWritten)
+	}
+}
+
+func TestACPWorkspace_AppendFileReadsThenWrites(t *testing.T) {
+	t.Parallel()
+	caller := &fakeCaller{}
+	caller.expect(func(method string, params any) (json.RawMessage, error) {
+		if method != "fs/read_text_file" {
+			t.Errorf("first method = %q; want fs/read_text_file", method)
+		}
+		return json.RawMessage(`{"content":"existing\n"}`), nil
+	})
+	caller.expect(func(method string, params any) (json.RawMessage, error) {
+		if method != "fs/write_text_file" {
+			t.Errorf("second method = %q; want fs/write_text_file", method)
+		}
+		p := params.(acpFSWriteParams)
+		if p.Content != "existing\nappended" {
+			t.Errorf("combined content = %q", p.Content)
+		}
+		return json.RawMessage(`{}`), nil
+	})
+	ws := NewACPWorkspace(caller, "session-1")
+	_, err := ws.AppendFile(context.Background(), FileRequest{
+		Path:    "notes.txt",
+		Content: "appended",
+	})
+	if err != nil {
+		t.Fatalf("AppendFile: %v", err)
+	}
+}
+
+func TestACPWorkspace_AppendFileTreatsNotFoundAsEmpty(t *testing.T) {
+	t.Parallel()
+	caller := &fakeCaller{}
+	caller.expect(func(string, any) (json.RawMessage, error) {
+		return nil, errors.New("acp: fs/read_text_file rejected (code -32603): file not found")
+	})
+	caller.expect(func(method string, params any) (json.RawMessage, error) {
+		if method != "fs/write_text_file" {
+			t.Errorf("second method = %q", method)
+		}
+		p := params.(acpFSWriteParams)
+		if p.Content != "fresh" {
+			t.Errorf("content = %q; want exactly the appended bytes (not-found should be treated as empty)", p.Content)
+		}
+		return json.RawMessage(`{}`), nil
+	})
+	ws := NewACPWorkspace(caller, "session-1")
+	if _, err := ws.AppendFile(context.Background(), FileRequest{
+		Path:    "new.txt",
+		Content: "fresh",
+	}); err != nil {
+		t.Fatalf("AppendFile: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Run path
+// ---------------------------------------------------------------------------
+
+func TestACPWorkspace_RunCreatesWaitsReleases(t *testing.T) {
+	t.Parallel()
+	caller := &fakeCaller{}
+	caller.expect(func(method string, _ any) (json.RawMessage, error) {
+		if method != "terminal/create" {
+			t.Errorf("step 1 method = %q; want terminal/create", method)
+		}
+		return json.RawMessage(`{"terminalId":"term-1"}`), nil
+	})
+	caller.expect(func(method string, _ any) (json.RawMessage, error) {
+		if method != "terminal/wait_for_exit" {
+			t.Errorf("step 2 method = %q; want terminal/wait_for_exit", method)
+		}
+		// Small sleep so the polling loop has a chance to issue a
+		// terminal/output call before exit drains the loop.
+		time.Sleep(150 * time.Millisecond)
+		return json.RawMessage(`{"exitCode":0}`), nil
+	})
+	caller.expect(func(method string, _ any) (json.RawMessage, error) {
+		if method != "terminal/output" {
+			t.Errorf("polling step = %q; want terminal/output", method)
+		}
+		return json.RawMessage(`{"stdout":"hello","stderr":""}`), nil
+	})
+	caller.expect(func(method string, _ any) (json.RawMessage, error) {
+		// Final drain after exit.
+		if method != "terminal/output" {
+			t.Errorf("final drain = %q; want terminal/output", method)
+		}
+		return json.RawMessage(`{"stdout":"hello world","stderr":""}`), nil
+	})
+	caller.expect(func(method string, _ any) (json.RawMessage, error) {
+		if method != "terminal/release" {
+			t.Errorf("teardown = %q; want terminal/release", method)
+		}
+		return json.RawMessage(`{}`), nil
+	})
+
+	ws := NewACPWorkspace(caller, "session-1")
+	res, err := ws.Run(context.Background(), Command{
+		Command:          "echo hello world",
+		WorkingDirectory: "/projects/demo",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "hello world") {
+		t.Fatalf("stdout = %q; want to contain 'hello world'", res.Stdout)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit = %d; want 0", res.ExitCode)
+	}
+
+	// Confirm the canonical method order — sanity guard against a
+	// future refactor that subtly reorders the wire flow.
+	got := caller.callMethods()
+	want := []string{"terminal/create", "terminal/wait_for_exit", "terminal/output", "terminal/output", "terminal/release"}
+	if len(got) < len(want) {
+		t.Fatalf("methods = %v; want at least %v", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Permission gate
+// ---------------------------------------------------------------------------
+
+func TestACPWorkspace_RequestPermissionForwardsToEditor(t *testing.T) {
+	t.Parallel()
+	caller := &fakeCaller{}
+	caller.expect(func(method string, params any) (json.RawMessage, error) {
+		if method != "session/request_permission" {
+			t.Errorf("method = %q", method)
+		}
+		p := params.(acpPermissionParams)
+		if p.Tool != "shell" {
+			t.Errorf("tool = %q", p.Tool)
+		}
+		return json.RawMessage(`{"granted":false,"reason":"user clicked deny"}`), nil
+	})
+	ws := NewACPWorkspace(caller, "session-1")
+	decision, err := ws.RequestPermission(context.Background(), PermissionRequest{
+		Tool:   "shell",
+		Action: "git push",
+	})
+	if err != nil {
+		t.Fatalf("RequestPermission: %v", err)
+	}
+	if decision.Granted {
+		t.Fatal("expected denial")
+	}
+	if !strings.Contains(decision.Reason, "user clicked deny") {
+		t.Fatalf("reason = %q", decision.Reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wiring guards
+// ---------------------------------------------------------------------------
+
+func TestACPWorkspace_RejectsEmptySession(t *testing.T) {
+	t.Parallel()
+	ws := NewACPWorkspace(&fakeCaller{}, "") // no session id
+	_, err := ws.WriteFile(context.Background(), FileRequest{Path: "x.txt"})
+	if err == nil {
+		t.Fatal("expected error for empty session id; got nil")
+	}
+	if !strings.Contains(err.Error(), "session id") {
+		t.Fatalf("error = %q; want to mention session id", err.Error())
+	}
+}
+
+func TestACPWorkspace_RejectsNilCaller(t *testing.T) {
+	t.Parallel()
+	ws := NewACPWorkspace(nil, "s1")
+	_, err := ws.WriteFile(context.Background(), FileRequest{Path: "x.txt"})
+	if err == nil {
+		t.Fatal("expected error for nil caller")
+	}
+}

--- a/internal/workspace/local.go
+++ b/internal/workspace/local.go
@@ -1,0 +1,56 @@
+package workspace
+
+import (
+	"context"
+
+	"github.com/hecate/agent-runtime/internal/sandbox"
+)
+
+// LocalWorkspace is the on-host implementation. Every method delegates
+// to sandbox.LocalExecutor today; the wrapper exists so the call
+// graph already routes through the workspace abstraction and the
+// later swap to ACPWorkspace is a one-line wire-up.
+//
+// Stateless: LocalExecutor itself holds no state per call, and any
+// future per-workspace state (caches, telemetry context) belongs on
+// LocalWorkspace, not behind it.
+type LocalWorkspace struct {
+	exec *sandbox.LocalExecutor
+}
+
+// NewLocalWorkspace constructs the local implementation around a fresh
+// sandbox.LocalExecutor.
+func NewLocalWorkspace() *LocalWorkspace {
+	return &LocalWorkspace{exec: sandbox.NewLocalExecutor()}
+}
+
+// NewLocalWorkspaceFromExecutor wraps an existing executor. Used by
+// tests and by call sites that want to inject a stubbed executor for
+// behavioral isolation.
+func NewLocalWorkspaceFromExecutor(exec *sandbox.LocalExecutor) *LocalWorkspace {
+	if exec == nil {
+		exec = sandbox.NewLocalExecutor()
+	}
+	return &LocalWorkspace{exec: exec}
+}
+
+func (w *LocalWorkspace) Run(ctx context.Context, command Command) (Result, error) {
+	return w.exec.Run(ctx, command)
+}
+
+func (w *LocalWorkspace) RunStreaming(ctx context.Context, command Command, onChunk func(OutputChunk)) (Result, error) {
+	return w.exec.RunStreaming(ctx, command, onChunk)
+}
+
+func (w *LocalWorkspace) WriteFile(ctx context.Context, request FileRequest) (FileResult, error) {
+	return w.exec.WriteFile(ctx, request)
+}
+
+func (w *LocalWorkspace) AppendFile(ctx context.Context, request FileRequest) (FileResult, error) {
+	return w.exec.AppendFile(ctx, request)
+}
+
+// Compile-time check that LocalWorkspace satisfies the Workspace
+// interface. Catches accidental method-signature drift between the
+// interface and the implementation at build time.
+var _ Workspace = (*LocalWorkspace)(nil)

--- a/internal/workspace/local_permission.go
+++ b/internal/workspace/local_permission.go
@@ -1,0 +1,53 @@
+package workspace
+
+import (
+	"context"
+)
+
+// RequestPermission evaluates the static Policy attached to the
+// request's Details ("policy"-typed value when present) and returns
+// a grant/deny decision synchronously. No operator prompt: the local
+// workspace's gate is the same policy the one-shot Run path already
+// enforces at spawn time.
+//
+// The ACPWorkspace counterpart (added later in the refactor) forwards
+// the request to session/request_permission on the editor instead;
+// the contract from the caller's perspective is unchanged either way
+// — block until you have a PermissionDecision, then proceed only on
+// Granted.
+//
+// Today's mapping (kept narrow on purpose):
+//   - file_write / file_delete: denied when Policy.ReadOnly is true.
+//   - network_fetch: denied when Policy.Network is false.
+//   - everything else: granted, with reason "no static rule".
+//
+// LocalWorkspace deliberately doesn't try to be Hecate's full
+// approval system — that lives in pkg/types.ApprovalState and the
+// orchestrator's runner. Permitter is the workspace-level gate; the
+// approval system is the operator-level one. The two run in series:
+// workspace permit → approval queue → run.
+func (w *LocalWorkspace) RequestPermission(_ context.Context, req PermissionRequest) (PermissionDecision, error) {
+	policy, _ := req.Details["policy"].(Policy)
+	switch req.Tool {
+	case "file_write", "file_delete", "file_append":
+		if policy.ReadOnly {
+			return PermissionDecision{
+				Granted: false,
+				Reason:  "sandbox policy: read-only",
+			}, nil
+		}
+	case "network_fetch":
+		if !policy.Network {
+			return PermissionDecision{
+				Granted: false,
+				Reason:  "sandbox policy: network disabled",
+			}, nil
+		}
+	}
+	return PermissionDecision{Granted: true, Reason: "local workspace: no static rule denied"}, nil
+}
+
+// Compile-time check that LocalWorkspace satisfies the optional
+// Permitter interface. Callers that need the dynamic-gate surface
+// can type-assert.
+var _ Permitter = (*LocalWorkspace)(nil)

--- a/internal/workspace/local_permission_test.go
+++ b/internal/workspace/local_permission_test.go
@@ -1,0 +1,86 @@
+package workspace
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLocalWorkspace_RequestPermission(t *testing.T) {
+	t.Parallel()
+	ws := NewLocalWorkspace()
+
+	cases := []struct {
+		name    string
+		req     PermissionRequest
+		wantOK  bool
+		wantSub string
+	}{
+		{
+			name: "file_write blocked by read-only policy",
+			req: PermissionRequest{
+				Tool:    "file_write",
+				Action:  "write README.md",
+				Details: map[string]any{"policy": Policy{ReadOnly: true}},
+			},
+			wantOK:  false,
+			wantSub: "read-only",
+		},
+		{
+			name: "file_write granted with writable policy",
+			req: PermissionRequest{
+				Tool:    "file_write",
+				Action:  "write README.md",
+				Details: map[string]any{"policy": Policy{ReadOnly: false}},
+			},
+			wantOK: true,
+		},
+		{
+			name: "network_fetch blocked when network disabled",
+			req: PermissionRequest{
+				Tool:    "network_fetch",
+				Action:  "fetch https://example.com",
+				Details: map[string]any{"policy": Policy{Network: false}},
+			},
+			wantOK:  false,
+			wantSub: "network disabled",
+		},
+		{
+			name: "shell tool granted by default",
+			req: PermissionRequest{
+				Tool:   "shell",
+				Action: "ls",
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			decision, err := ws.RequestPermission(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("RequestPermission: %v", err)
+			}
+			if decision.Granted != tc.wantOK {
+				t.Fatalf("Granted = %v; want %v (reason: %q)", decision.Granted, tc.wantOK, decision.Reason)
+			}
+			if tc.wantSub != "" && !contains(decision.Reason, tc.wantSub) {
+				t.Fatalf("Reason = %q; want to contain %q", decision.Reason, tc.wantSub)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/workspace/local_terminal.go
+++ b/internal/workspace/local_terminal.go
@@ -1,0 +1,274 @@
+package workspace
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/hecate/agent-runtime/internal/sandbox"
+)
+
+// localTerminal is the on-host implementation. Each terminal owns a
+// child process plus three goroutines (stdout/stderr readers and a
+// wait-for-exit). Closing serializes through closeOnce so concurrent
+// Kill / Close / WaitForExit don't race the cleanup.
+type localTerminal struct {
+	id     string
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+
+	output chan OutputChunk
+
+	exitOnce sync.Once
+	exit     chan struct{}
+	result   atomic.Pointer[Result]
+	waitErr  atomic.Pointer[error]
+
+	closeOnce sync.Once
+}
+
+// nextTerminalID is bumped per terminal for a workspace-unique handle.
+// Local-only counter; cross-process uniqueness isn't required.
+var nextTerminalID atomic.Uint64
+
+// OpenTerminal spawns a long-lived process under the workspace's
+// sandbox policy. The returned Terminal handle MUST be Close'd by the
+// caller once it's done observing output and exit — failing to call
+// Close leaks the reader goroutines and the OS file descriptors for
+// the pipes.
+func (w *LocalWorkspace) OpenTerminal(ctx context.Context, opts TerminalOptions) (Terminal, error) {
+	cmd, err := buildTerminalCommand(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open stdout: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open stderr: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start terminal: %w", err)
+	}
+
+	t := &localTerminal{
+		id:     fmt.Sprintf("term_%d", nextTerminalID.Add(1)),
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		output: make(chan OutputChunk, 64),
+		exit:   make(chan struct{}),
+	}
+
+	// Reader goroutines forward stdout / stderr into the merged
+	// output channel. They exit when the pipes close (process exit
+	// or explicit Close). pumpDone tracks both pumps so we can
+	// close the output channel exactly once after both drain.
+	var pumpDone sync.WaitGroup
+	pumpDone.Add(2)
+	go t.pump(&pumpDone, t.stdout, "stdout")
+	go t.pump(&pumpDone, t.stderr, "stderr")
+	go func() {
+		pumpDone.Wait()
+		close(t.output)
+	}()
+
+	// Wait goroutine captures exit status; everyone observing the
+	// terminal goes through atomic.Pointer reads to see the result
+	// once it's published.
+	go func() {
+		err := cmd.Wait()
+		var result Result
+		if cmd.ProcessState != nil {
+			result.ExitCode = cmd.ProcessState.ExitCode()
+		}
+		t.result.Store(&result)
+		if err != nil {
+			// Filter the predictable "exit status N" wrapping
+			// — the operator can read ExitCode directly. Surface
+			// only the IO-layer errors (signal kills, pipe
+			// failures) that genuinely need a Wait()-side error.
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.waitErr.Store(&err)
+			}
+		}
+		close(t.exit)
+	}()
+
+	return t, nil
+}
+
+func (t *localTerminal) ID() string { return t.id }
+
+func (t *localTerminal) Output() <-chan OutputChunk { return t.output }
+
+func (t *localTerminal) Write(ctx context.Context, input string) error {
+	if t.stdin == nil {
+		return errors.New("stdin is closed")
+	}
+	// Honor context cancellation by writing in a goroutine and
+	// racing against ctx.Done — the writer holds a reference to
+	// the pipe so a cancelled write doesn't pile up zombie
+	// goroutines.
+	done := make(chan error, 1)
+	go func() {
+		_, err := t.stdin.Write([]byte(input))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (t *localTerminal) WaitForExit(ctx context.Context) (Result, error) {
+	select {
+	case <-t.exit:
+	case <-ctx.Done():
+		return Result{}, ctx.Err()
+	}
+	if r := t.result.Load(); r != nil {
+		out := *r
+		if e := t.waitErr.Load(); e != nil {
+			return out, *e
+		}
+		return out, nil
+	}
+	return Result{}, errors.New("terminal exited without recording result")
+}
+
+func (t *localTerminal) Kill(_ context.Context) error {
+	if t.cmd == nil || t.cmd.Process == nil {
+		return nil
+	}
+	if runtime.GOOS == "windows" {
+		// Process.Kill on Windows sends a TerminateProcess; same
+		// effect as our unix SIGTERM in this code path.
+		return t.cmd.Process.Kill()
+	}
+	// SIGTERM first — gives the child a chance to clean up. The
+	// caller can poll WaitForExit with a deadline and escalate to
+	// Kill() (which is SIGKILL via os.Process.Kill) if the child
+	// refuses to exit.
+	if err := t.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		// Process is gone already; treat as a no-op.
+		if errors.Is(err, syscall.ESRCH) || errors.Is(err, syscall.EINVAL) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (t *localTerminal) Close(ctx context.Context) error {
+	var closeErr error
+	t.closeOnce.Do(func() {
+		// Send SIGTERM if the process is still running, then wait
+		// for the readers and the Wait goroutine to drain. This
+		// guarantees Close blocks until all goroutines are
+		// reclaimed — no leaks even on early-exit error paths.
+		_ = t.Kill(ctx)
+
+		// Closing stdin first unblocks any pump that's reading
+		// from the same fd table. The OS will close stdout/stderr
+		// when the child fully exits; we don't force-close those
+		// here because some pumps may still be draining the last
+		// buffered bytes.
+		if t.stdin != nil {
+			_ = t.stdin.Close()
+		}
+
+		// Wait for exit with a small upper bound so Close is not
+		// a forever-block on a wedged process. Operators who need
+		// hard-kill semantics can Kill() then Close().
+		select {
+		case <-t.exit:
+		case <-ctx.Done():
+			closeErr = ctx.Err()
+		case <-time.After(5 * time.Second):
+			// Escalate to SIGKILL — the child ignored SIGTERM.
+			if t.cmd != nil && t.cmd.Process != nil {
+				_ = t.cmd.Process.Kill()
+			}
+			<-t.exit
+		}
+	})
+	return closeErr
+}
+
+func (t *localTerminal) pump(wg *sync.WaitGroup, r io.ReadCloser, stream string) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(r)
+	// Allow long lines (build output, stack traces); the default
+	// 64 KiB cap is too tight for compiler errors.
+	scanner.Buffer(make([]byte, 0, 16*1024), 1024*1024)
+	for scanner.Scan() {
+		t.output <- OutputChunk{Stream: stream, Text: scanner.Text() + "\n"}
+	}
+	// scanner.Err() is intentionally dropped — the most common
+	// "error" here is io.EOF wrapped by os/exec when the child
+	// closes the fd, which is the expected end-of-stream signal
+	// and not a real failure mode.
+}
+
+// buildTerminalCommand resolves the working directory and policy gates
+// before returning an exec.Cmd ready to start. Mirrors sandbox.Command
+// semantics where reasonable, but the long-lived nature of a terminal
+// means we don't apply Timeout — caller controls lifetime via
+// Kill/Close.
+func buildTerminalCommand(opts TerminalOptions) (*exec.Cmd, error) {
+	// Working-directory escape is the most common mis-configuration
+	// surface; reject before spawn so the caller doesn't get a
+	// confusing post-spawn permission error. Reuses the same
+	// sandbox helper one-shot Run uses, so the two paths can't
+	// diverge.
+	resolvedDir, err := sandbox.ResolveWorkingDirectory(opts.WorkingDirectory, opts.Policy)
+	if err != nil {
+		return nil, err
+	}
+
+	var cmd *exec.Cmd
+	switch {
+	case opts.Command == "" && runtime.GOOS == "windows":
+		cmd = exec.Command("cmd.exe")
+	case opts.Command == "":
+		cmd = exec.Command("sh", "-i")
+	default:
+		cmd = exec.Command(opts.Command, opts.Args...)
+	}
+
+	cmd.Dir = resolvedDir
+
+	// Build env: sandbox's sanitized base set + caller overrides.
+	// Operators who want to inject secrets should use the credential
+	// plumbing, not Env — but we honor the override here for
+	// completeness.
+	env := sandbox.SanitizedEnv()
+	for k, v := range opts.Env {
+		env = append(env, k+"="+v)
+	}
+	cmd.Env = env
+	return cmd, nil
+}

--- a/internal/workspace/local_terminal.go
+++ b/internal/workspace/local_terminal.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -29,13 +30,25 @@ type localTerminal struct {
 
 	output chan OutputChunk
 
-	exitOnce sync.Once
-	exit     chan struct{}
-	result   atomic.Pointer[Result]
-	waitErr  atomic.Pointer[error]
+	exit    chan struct{}
+	result  atomic.Pointer[Result]
+	waitErr atomic.Pointer[error]
+
+	// Retained stdout/stderr for WaitForExit. Bounded so a chatty
+	// child doesn't grow this without limit; once the cap is hit we
+	// stop retaining (but the Output() channel continues to receive
+	// chunks, subject to its own drop-on-full policy).
+	bufMu     sync.Mutex
+	stdoutBuf strings.Builder
+	stderrBuf strings.Builder
 
 	closeOnce sync.Once
 }
+
+// localTerminalBufLimit caps the retained stdout/stderr that
+// WaitForExit returns. Mirrors a sensible upper bound for "captured
+// command output" without letting a runaway child OOM the gateway.
+const localTerminalBufLimit = 256 * 1024
 
 // nextTerminalID is bumped per terminal for a workspace-unique handle.
 // Local-only counter; cross-process uniqueness isn't required.
@@ -122,25 +135,17 @@ func (t *localTerminal) ID() string { return t.id }
 
 func (t *localTerminal) Output() <-chan OutputChunk { return t.output }
 
-func (t *localTerminal) Write(ctx context.Context, input string) error {
+func (t *localTerminal) Write(_ context.Context, input string) error {
 	if t.stdin == nil {
 		return errors.New("stdin is closed")
 	}
-	// Honor context cancellation by writing in a goroutine and
-	// racing against ctx.Done — the writer holds a reference to
-	// the pipe so a cancelled write doesn't pile up zombie
-	// goroutines.
-	done := make(chan error, 1)
-	go func() {
-		_, err := t.stdin.Write([]byte(input))
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	// Synchronous write: an *os.File-backed pipe doesn't honor a
+	// deadline cleanly, and a goroutine-based ctx race would leak
+	// the inner write if the pipe blocks. Callers who need to
+	// unblock a stuck stdin should Kill or Close — those close the
+	// pipe and the write returns.
+	_, err := t.stdin.Write([]byte(input))
+	return err
 }
 
 func (t *localTerminal) WaitForExit(ctx context.Context) (Result, error) {
@@ -149,14 +154,21 @@ func (t *localTerminal) WaitForExit(ctx context.Context) (Result, error) {
 	case <-ctx.Done():
 		return Result{}, ctx.Err()
 	}
-	if r := t.result.Load(); r != nil {
-		out := *r
-		if e := t.waitErr.Load(); e != nil {
-			return out, *e
-		}
-		return out, nil
+	r := t.result.Load()
+	if r == nil {
+		return Result{}, errors.New("terminal exited without recording result")
 	}
-	return Result{}, errors.New("terminal exited without recording result")
+	t.bufMu.Lock()
+	out := Result{
+		Stdout:   t.stdoutBuf.String(),
+		Stderr:   t.stderrBuf.String(),
+		ExitCode: r.ExitCode,
+	}
+	t.bufMu.Unlock()
+	if e := t.waitErr.Load(); e != nil {
+		return out, *e
+	}
+	return out, nil
 }
 
 func (t *localTerminal) Kill(_ context.Context) error {
@@ -225,7 +237,26 @@ func (t *localTerminal) pump(wg *sync.WaitGroup, r io.ReadCloser, stream string)
 	// 64 KiB cap is too tight for compiler errors.
 	scanner.Buffer(make([]byte, 0, 16*1024), 1024*1024)
 	for scanner.Scan() {
-		t.output <- OutputChunk{Stream: stream, Text: scanner.Text() + "\n"}
+		text := scanner.Text() + "\n"
+		// Retain into the bounded WaitForExit buffer first so a
+		// slow Output() consumer doesn't lose the captured copy.
+		t.bufMu.Lock()
+		buf := &t.stdoutBuf
+		if stream == "stderr" {
+			buf = &t.stderrBuf
+		}
+		if buf.Len() < localTerminalBufLimit {
+			buf.WriteString(text)
+		}
+		t.bufMu.Unlock()
+		// Non-blocking publish: an absent or slow consumer of
+		// Output() drops chunks rather than wedging the pump and
+		// (through it) cmd.Wait — which would prevent t.exit
+		// closing and pin Close past its escalation deadline.
+		select {
+		case t.output <- OutputChunk{Stream: stream, Text: text}:
+		default:
+		}
 	}
 	// scanner.Err() is intentionally dropped — the most common
 	// "error" here is io.EOF wrapped by os/exec when the child

--- a/internal/workspace/local_terminal_test.go
+++ b/internal/workspace/local_terminal_test.go
@@ -137,6 +137,44 @@ func TestLocalTerminal_CloseKillsRunningProcess(t *testing.T) {
 	}
 }
 
+// TestLocalTerminal_WaitForExitRetainsBoundedOutput confirms WaitForExit
+// returns captured stdout/stderr even when the caller never consumes
+// Output() — the documented bounded-retention contract. Mirrors the
+// behavior ACPWorkspace.acpTerminal already had, and the asymmetry
+// Copilot flagged on PR #107.
+func TestLocalTerminal_WaitForExitRetainsBoundedOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell semantics")
+	}
+	t.Parallel()
+
+	ws := NewLocalWorkspace()
+	dir := t.TempDir()
+	term, err := ws.OpenTerminal(context.Background(), TerminalOptions{
+		Command:          "sh",
+		Args:             []string{"-c", "printf out && printf err 1>&2"},
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+	t.Cleanup(func() { _ = term.Close(context.Background()) })
+
+	// Note: we intentionally do not consume Output() here — the
+	// retention path must work even when the channel buffer fills.
+	result, err := term.WaitForExit(context.Background())
+	if err != nil {
+		t.Fatalf("WaitForExit: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "out") {
+		t.Fatalf("Result.Stdout = %q; want to contain %q", result.Stdout, "out")
+	}
+	if !strings.Contains(result.Stderr, "err") {
+		t.Fatalf("Result.Stderr = %q; want to contain %q", result.Stderr, "err")
+	}
+}
+
 func TestLocalTerminal_RejectsOutsideAllowedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/local_terminal_test.go
+++ b/internal/workspace/local_terminal_test.go
@@ -1,0 +1,153 @@
+package workspace
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLocalTerminal_OneShotCaptureExit drives a terminal through the
+// happy path: spawn a short command, read its output, observe a clean
+// exit, close cleanly. Skipped on Windows because the command shape
+// here is unix-specific.
+func TestLocalTerminal_OneShotCaptureExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell semantics; covered separately")
+	}
+	t.Parallel()
+
+	ws := NewLocalWorkspace()
+	t.Cleanup(func() { /* no global state to tear down */ })
+
+	dir := t.TempDir()
+	term, err := ws.OpenTerminal(context.Background(), TerminalOptions{
+		Command:          "sh",
+		Args:             []string{"-c", "printf hello && printf world 1>&2"},
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+	t.Cleanup(func() { _ = term.Close(context.Background()) })
+
+	var stdoutBuf, stderrBuf strings.Builder
+	done := make(chan struct{})
+	go func() {
+		for chunk := range term.Output() {
+			switch chunk.Stream {
+			case "stdout":
+				stdoutBuf.WriteString(chunk.Text)
+			case "stderr":
+				stderrBuf.WriteString(chunk.Text)
+			}
+		}
+		close(done)
+	}()
+
+	result, err := term.WaitForExit(context.Background())
+	if err != nil {
+		t.Fatalf("WaitForExit: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit = %d; want 0", result.ExitCode)
+	}
+	// Wait for the reader to drain after exit; output close is what
+	// signals "no more bytes coming."
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("output channel never closed after exit")
+	}
+	if !strings.Contains(stdoutBuf.String(), "hello") {
+		t.Fatalf("stdout = %q; want to contain hello", stdoutBuf.String())
+	}
+	if !strings.Contains(stderrBuf.String(), "world") {
+		t.Fatalf("stderr = %q; want to contain world", stderrBuf.String())
+	}
+}
+
+// TestLocalTerminal_StdinDrivesProcess writes a line to stdin and
+// confirms the child echoes it back. Locks the stdin path that
+// editor-driven terminals will rely on once ACPWorkspace lands.
+func TestLocalTerminal_StdinDrivesProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell semantics")
+	}
+	t.Parallel()
+
+	ws := NewLocalWorkspace()
+	dir := t.TempDir()
+	term, err := ws.OpenTerminal(context.Background(), TerminalOptions{
+		// `cat` echoes stdin back to stdout until EOF.
+		Command:          "cat",
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+	t.Cleanup(func() { _ = term.Close(context.Background()) })
+
+	if err := term.Write(context.Background(), "ping\n"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got := ""
+	deadline := time.After(2 * time.Second)
+	for !strings.Contains(got, "ping") {
+		select {
+		case chunk := <-term.Output():
+			got += chunk.Text
+		case <-deadline:
+			t.Fatalf("never saw stdin echo; buffer=%q", got)
+		}
+	}
+}
+
+// TestLocalTerminal_CloseKillsRunningProcess verifies Close terminates
+// a still-running child. Important because callers leak goroutines
+// and file descriptors otherwise.
+func TestLocalTerminal_CloseKillsRunningProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix signal semantics")
+	}
+	t.Parallel()
+
+	ws := NewLocalWorkspace()
+	dir := t.TempDir()
+	term, err := ws.OpenTerminal(context.Background(), TerminalOptions{
+		Command:          "sleep",
+		Args:             []string{"60"},
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+
+	closeStart := time.Now()
+	if err := term.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed := time.Since(closeStart); elapsed > 6*time.Second {
+		t.Fatalf("Close took %v; want < 6s (escalation deadline)", elapsed)
+	}
+}
+
+func TestLocalTerminal_RejectsOutsideAllowedRoot(t *testing.T) {
+	t.Parallel()
+
+	ws := NewLocalWorkspace()
+	dir := t.TempDir()
+	_, err := ws.OpenTerminal(context.Background(), TerminalOptions{
+		Command:          "true",
+		WorkingDirectory: "/etc",
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err == nil {
+		t.Fatal("OpenTerminal succeeded with cwd outside AllowedRoot; expected sandbox refusal")
+	}
+}

--- a/internal/workspace/local_test.go
+++ b/internal/workspace/local_test.go
@@ -1,0 +1,77 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hecate/agent-runtime/internal/sandbox"
+)
+
+// Step 1 of the workspace refactor delivers a pass-through wrapper.
+// These tests confirm the wrapper actually routes to the underlying
+// sandbox executor — same inputs, same outputs — so the orchestrator
+// swap in step 2 can rely on the wrapper being a faithful proxy.
+
+func TestLocalWorkspace_RunDelegatesToSandbox(t *testing.T) {
+	t.Parallel()
+	ws := NewLocalWorkspace()
+
+	dir := t.TempDir()
+	result, err := ws.Run(context.Background(), Command{
+		Command:          "printf hello",
+		WorkingDirectory: dir,
+		Policy: Policy{
+			AllowedRoot: dir,
+			ReadOnly:    true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "hello" {
+		t.Fatalf("stdout = %q; want hello", result.Stdout)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit = %d; want 0", result.ExitCode)
+	}
+}
+
+func TestLocalWorkspace_WriteFileDelegatesToSandbox(t *testing.T) {
+	t.Parallel()
+	ws := NewLocalWorkspace()
+
+	dir := t.TempDir()
+	target := "note.txt"
+	_, err := ws.WriteFile(context.Background(), FileRequest{
+		Path:             target,
+		Content:          "hi from workspace",
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, target))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hi from workspace" {
+		t.Fatalf("file content = %q", got)
+	}
+}
+
+// Compile-time guard: a *sandbox.LocalExecutor isn't a Workspace
+// directly (Workspace lives in this package), but a LocalWorkspace
+// wrapping one is. Locks the invariant that step 2's swap from
+// `sandbox.Executor` to `workspace.Workspace` won't accidentally
+// accept the wrong type.
+func TestLocalWorkspace_InterfaceSatisfaction(t *testing.T) {
+	t.Parallel()
+	var ws Workspace = NewLocalWorkspaceFromExecutor(sandbox.NewLocalExecutor())
+	if ws == nil {
+		t.Fatal("LocalWorkspace did not satisfy Workspace")
+	}
+}

--- a/internal/workspace/permission.go
+++ b/internal/workspace/permission.go
@@ -1,0 +1,67 @@
+package workspace
+
+import "context"
+
+// PermissionRequest is the dynamic-gate input the agent asks the
+// workspace about before taking a potentially risky action. Today's
+// LocalWorkspace evaluates these against the static Policy; the
+// future ACPWorkspace forwards them to session/request_permission on
+// the connected editor and blocks on the operator's answer.
+//
+// The structure is intentionally narrow: Tool + Action + a small
+// Details map. Adding fields requires touching every implementation
+// and every caller, so the shape is kept minimal and the structured
+// payload rides in Details.
+type PermissionRequest struct {
+	// Tool is the action class. Stable string vocabulary so the
+	// ACP editor side can route to consistent UI: "shell",
+	// "file_write", "file_delete", "terminal_create",
+	// "network_fetch", and so on.
+	Tool string
+
+	// Action is the human-readable summary the editor renders. Free
+	// text in the operator's language ("write README.md", "run `git
+	// push`"). Not used for policy decisions.
+	Action string
+
+	// Details carries structured arguments — the path being written,
+	// the command being run, the URL being fetched. LocalWorkspace
+	// reads specific keys ("path", "command", "url"); ACPWorkspace
+	// forwards the whole map verbatim.
+	Details map[string]any
+
+	// RiskLevel hints to the editor UI how prominently to render the
+	// prompt. "low" / "medium" / "high". Optional; defaults to
+	// "medium" when empty. Not used for the grant decision.
+	RiskLevel string
+}
+
+// PermissionDecision is the gate output. The orchestrator inspects
+// Granted; when false, the requested action MUST NOT happen and the
+// agent receives Reason as the rejection message.
+type PermissionDecision struct {
+	// Granted is the bottom line. When true, the agent proceeds with
+	// the requested action. When false, the agent surfaces Reason to
+	// the model and either retries with a different action or
+	// terminates the step.
+	Granted bool
+
+	// Reason is the human-readable explanation. For grants, it's
+	// usually empty or "auto-approved by policy"; for denials, it's
+	// the operator's typed-in reason (ACPWorkspace) or the policy
+	// rule name (LocalWorkspace).
+	Reason string
+}
+
+// Permitter is the optional permission-gate surface. Workspace
+// implementations that don't enforce dynamic permissions (or that
+// rely entirely on Policy evaluated up front) can omit this
+// interface; callers use a type assertion. Today LocalWorkspace
+// implements Permitter as a thin wrapper around Policy, and
+// ACPWorkspace will implement it by forwarding to the editor.
+//
+// The interface is split from Workspace so the broader Workspace
+// surface stays stable when permission semantics evolve.
+type Permitter interface {
+	RequestPermission(ctx context.Context, req PermissionRequest) (PermissionDecision, error)
+}

--- a/internal/workspace/terminal.go
+++ b/internal/workspace/terminal.go
@@ -1,0 +1,82 @@
+package workspace
+
+import (
+	"context"
+)
+
+// TerminalOptions configures a new long-lived terminal session. Unlike
+// the one-shot Run / RunStreaming surface, the caller drives a
+// Terminal interactively — write to stdin, observe streaming output,
+// kill or wait for exit on demand.
+//
+// ACP's terminal/create RPC maps onto this directly; the LocalWorkspace
+// implementation spawns the command under the existing sandbox policy
+// gates and keeps the process alive until the caller calls Close.
+type TerminalOptions struct {
+	// Command is the program to execute. When empty, an interactive
+	// shell is started (sh -i on unix, cmd.exe on windows). The
+	// shell case is what ACP editors expect when an agent asks for a
+	// terminal pane it can drive.
+	Command string
+
+	// Args are additional arguments passed to Command. Ignored when
+	// Command is empty.
+	Args []string
+
+	// WorkingDirectory is the spawn cwd. Resolved against
+	// Policy.AllowedRoot via the same machinery as one-shot Run.
+	WorkingDirectory string
+
+	// Policy gates spawn-time decisions (working-directory escape,
+	// network access for commands that hint at it). The editor-owned
+	// ACPWorkspace ignores Policy; the LocalWorkspace honors it.
+	Policy Policy
+
+	// Env is additional environment to merge on top of the sanitized
+	// base set. Keys collide with the sanitized set on a last-write
+	// basis; operators should treat this as override-only and not as
+	// a way to pass secrets (use the credential plumbing instead).
+	Env map[string]string
+}
+
+// Terminal is a long-lived spawn handle. Lifecycle:
+//
+//	t, err := ws.OpenTerminal(ctx, opts)        // spawn
+//	go consume(t.Output())                       // stream stdout/stderr
+//	t.Write(ctx, "echo hello\n")                 // optional stdin
+//	result, err := t.WaitForExit(ctx)            // block until done
+//	t.Close(ctx)                                 // release the handle
+//
+// Closing a terminal whose process is still running implies Kill
+// before release. Callers MUST call Close once per OpenTerminal to
+// free goroutines and OS handles.
+type Terminal interface {
+	// ID is a workspace-unique handle, suitable for telemetry and
+	// for cross-referencing ACP terminal/* RPCs. Stable for the
+	// lifetime of the terminal.
+	ID() string
+
+	// Output is the merged stdout+stderr stream. Each chunk carries
+	// its origin in OutputChunk.Stream ("stdout" or "stderr"). The
+	// channel closes when the process exits and the readers drain.
+	Output() <-chan OutputChunk
+
+	// Write sends bytes to the process's stdin. Returns an error
+	// when stdin has been closed (process exited, or the caller
+	// explicitly closed the terminal).
+	Write(ctx context.Context, input string) error
+
+	// WaitForExit blocks until the process exits, returning its
+	// captured exit code and any retained stdout/stderr buffers.
+	// Safe to call concurrently with Output consumers; only the
+	// first call returns a real Result.
+	WaitForExit(ctx context.Context) (Result, error)
+
+	// Kill sends SIGTERM (or the platform equivalent) and returns
+	// immediately. Use WaitForExit afterward to observe the result.
+	Kill(ctx context.Context) error
+
+	// Close releases the terminal. If the process is still running,
+	// Close kills it first. Subsequent calls are no-ops.
+	Close(ctx context.Context) error
+}

--- a/internal/workspace/terminal.go
+++ b/internal/workspace/terminal.go
@@ -58,18 +58,27 @@ type Terminal interface {
 
 	// Output is the merged stdout+stderr stream. Each chunk carries
 	// its origin in OutputChunk.Stream ("stdout" or "stderr"). The
-	// channel closes when the process exits and the readers drain.
+	// channel is bounded and publishes are non-blocking — a slow
+	// or absent consumer drops chunks rather than wedging the
+	// terminal. Callers who need the full transcript should
+	// consume Output() with a goroutine and / or rely on the
+	// bounded retention surfaced by WaitForExit.
 	Output() <-chan OutputChunk
 
-	// Write sends bytes to the process's stdin. Returns an error
-	// when stdin has been closed (process exited, or the caller
-	// explicitly closed the terminal).
+	// Write sends bytes to the process's stdin. Blocks until the
+	// write completes or stdin is closed (process exit, Kill, or
+	// Close). The ctx is reserved for future deadline support;
+	// today implementations do not honor it for the inner write.
 	Write(ctx context.Context, input string) error
 
-	// WaitForExit blocks until the process exits, returning its
-	// captured exit code and any retained stdout/stderr buffers.
-	// Safe to call concurrently with Output consumers; only the
-	// first call returns a real Result.
+	// WaitForExit blocks until the process exits and returns its
+	// exit code plus a bounded snapshot of the stdout / stderr the
+	// implementation retained. Retention is best-effort and capped
+	// per implementation (currently 256 KiB per stream on
+	// LocalWorkspace; ACPWorkspace mirrors the editor's
+	// terminal/output response). Callers who require the full
+	// transcript should consume Output() instead. Safe to call
+	// concurrently with Output() consumers.
 	WaitForExit(ctx context.Context) (Result, error)
 
 	// Kill sends SIGTERM (or the platform equivalent) and returns

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,52 @@
+// Package workspace is the abstraction over whatever owns the files and
+// processes the agent operates on. It exists so the orchestrator can be
+// driven by either:
+//
+//   - LocalWorkspace, which is today's behavior: file writes land on the
+//     host filesystem under Policy.AllowedRoot and shell commands run
+//     through the existing sandbox shell wrapper. HTTP chat and
+//     agent_loop tasks use this path.
+//
+//   - ACPWorkspace (added later in the refactor), which dispatches
+//     file and terminal operations back to the connected ACP editor
+//     as reverse-RPC calls. Used by `hecate-acp` when the operator
+//     opts into editor-owned mode.
+//
+// The interface is a 1:1 mirror of sandbox.Executor today; the
+// additional ACP-shaped primitives (long-lived terminals, dynamic
+// permission gates) land in later commits without breaking call sites
+// that only need the four methods below.
+package workspace
+
+import (
+	"context"
+
+	"github.com/hecate/agent-runtime/internal/sandbox"
+)
+
+// Re-export sandbox value types so call sites can stay in the
+// workspace package after the refactor moves callers off
+// sandbox.Executor. The aliases are zero-cost — Go treats them as
+// the same type — and they collapse to nothing if the sandbox
+// package ever absorbs into workspace.
+type (
+	Command     = sandbox.Command
+	FileRequest = sandbox.FileRequest
+	Result      = sandbox.Result
+	FileResult  = sandbox.FileResult
+	OutputChunk = sandbox.OutputChunk
+	Policy      = sandbox.Policy
+)
+
+// Workspace is the boundary between the orchestrator and whatever owns
+// the agent's filesystem and processes. The four methods mirror the
+// current sandbox.Executor surface so the swap from
+// `sandbox.Executor` → `workspace.Workspace` at the orchestrator
+// layer is mechanical. ACP-shaped additions (OpenTerminal,
+// RequestPermission) land later in the refactor.
+type Workspace interface {
+	Run(ctx context.Context, command Command) (Result, error)
+	RunStreaming(ctx context.Context, command Command, onChunk func(OutputChunk)) (Result, error)
+	WriteFile(ctx context.Context, request FileRequest) (FileResult, error)
+	AppendFile(ctx context.Context, request FileRequest) (FileResult, error)
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -39,14 +39,17 @@ type (
 )
 
 // Workspace is the boundary between the orchestrator and whatever owns
-// the agent's filesystem and processes. The four methods mirror the
-// current sandbox.Executor surface so the swap from
-// `sandbox.Executor` → `workspace.Workspace` at the orchestrator
-// layer is mechanical. ACP-shaped additions (OpenTerminal,
-// RequestPermission) land later in the refactor.
+// the agent's filesystem and processes. The four file/run methods
+// mirror the current sandbox.Executor surface. OpenTerminal adds the
+// long-lived terminal primitive that ACP editors expect for
+// interactive panes. The dynamic-permission gate
+// (PermissionRequest / PermissionDecision) lives on the optional
+// Permitter interface (see permission.go) so implementations that
+// rely solely on static Policy don't have to ship a stub method.
 type Workspace interface {
 	Run(ctx context.Context, command Command) (Result, error)
 	RunStreaming(ctx context.Context, command Command, onChunk func(OutputChunk)) (Result, error)
 	WriteFile(ctx context.Context, request FileRequest) (FileResult, error)
 	AppendFile(ctx context.Context, request FileRequest) (FileResult, error)
+	OpenTerminal(ctx context.Context, opts TerminalOptions) (Terminal, error)
 }


### PR DESCRIPTION
## Summary

Refactors the orchestrator's executor boundary into a `workspace.Workspace`
interface, adds an editor-owned ACP implementation behind it, and wires
`HECATE_WORKSPACE_MODE` capability negotiation into the bridge's `initialize`
handshake. This is the prep work for editor-owned ACP sessions where Zed,
JetBrains, or another ACP host owns file writes and terminal execution via
reverse-RPC.

**This PR negotiates the wire and ships both workspace implementations. It
does not yet route reverse-RPC end-to-end** — the gateway-side orchestrator
still uses `LocalWorkspace` in every mode. The transport piece (bridge↔gateway
duplex IPC so the orchestrator can reach back through the bridge to the
editor) is the subject of a follow-up RFC.

### What changed

- New `internal/workspace` package with a `Workspace` interface, a
  `LocalWorkspace` wrapping the existing sandbox, and a new `ACPWorkspace`
  that dispatches reverse-RPC (`fs/read_text_file`, `fs/write_text_file`,
  `terminal/create`, `terminal/output`, `terminal/wait_for_exit`,
  `terminal/kill`, `terminal/release`, `session/request_permission`).
- New `Terminal` + `Permitter` interfaces — long-lived terminals with a
  streaming chunk channel, plus an optional permission gate that defers to
  the editor.
- Orchestrator dependency swap: `sandbox.Executor` → `workspace.Workspace`
  in three struct fields and four function signatures. No behavior change in
  the local path; the abstraction is the only delta.
- New `acp.Dispatcher.Call(ctx, method, params)` generic outbound reverse-RPC
  with per-call channel routing keyed by id. Separate id namespace from the
  permission flow so the two response paths stay decoupled.
- `acp.ResolveWorkspaceMode` + granular `FSCapability` fields
  (`readTextFile`, `writeTextFile`). Default flips from `hecate-owned` to
  `auto`. `editor-owned` mode fails `initialize` loudly when the editor lacks
  the required capabilities (`fs.readTextFile`, `fs.writeTextFile`,
  `terminal`) rather than silently downgrading.
- `docs/acp.md` updated: configuration table, status section flipped from
  "not implemented" to "wired but transport pending."

### What's deliberately out of scope

- The bridge↔gateway transport for reverse-RPC. Today the gateway-side
  orchestrator always uses `LocalWorkspace`; `ACPWorkspace` exists but isn't
  reachable from the orchestrator yet. A follow-up RFC will pick between
  WebSocket-on-existing-HTTP, UDS, and inverting the process layout so the
  dispatcher lives in the gateway and the bridge becomes a stdio relay.
- ACP auth (`env_var` method per the ACP auth-methods RFD). Deferred until
  the transport question is settled.

## Verification

- `go test ./... -race -count=1` — 1803 passed in 37 packages
- New `internal/acp/workspace_mode_test.go` covers the resolver matrix
  (auto fallback, editor-owned guard, case-insensitive parsing, invalid mode
  rejection)
- New dispatcher tests for the editor-owned-without-caps rejection, auto
  fallback to hecate-owned, and auto promotion to editor-owned with full caps