### PR TITLE
refactor(ui): consolidate formatters into ui/src/lib/format

### DIFF
--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -4,8 +4,8 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
+import { formatAbsoluteTime, formatDurationMs, formatInteger } from "../../lib/format";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
-import { formatAbsoluteTime } from "../../lib/runtime-utils";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
 import { BrandAvatar, CodeBlock, Icon, Icons, InlineError } from "../shared/ui";
@@ -2956,7 +2956,7 @@ function formatAgentRuntimeMeta(runID?: string, durationMS?: number, nativeSessi
     parts.push(`Run ${compactID(runID, ["run_"], 12)}`);
   }
   if (durationMS && durationMS > 0) {
-    parts.push(formatDuration(durationMS));
+    parts.push(formatDurationMs(durationMS));
   }
   return parts.join(" · ");
 }
@@ -2977,8 +2977,8 @@ function agentUsageEmpty(usage: AgentChatUsageRecord): boolean {
 function formatAgentContextUsage(usage: AgentChatUsageRecord): string {
   const used = usage.context_used ?? 0;
   const size = usage.context_size ?? 0;
-  if (size > 0) return `${used.toLocaleString()} / ${size.toLocaleString()}`;
-  if (used > 0) return used.toLocaleString();
+  if (size > 0) return `${formatInteger(used)} / ${formatInteger(size)}`;
+  if (used > 0) return formatInteger(used);
   return "—";
 }
 
@@ -3429,15 +3429,3 @@ function compactID(id: string, prefixes: string[], length: number): string {
   return withoutPrefix.slice(0, length);
 }
 
-function formatDuration(durationMS: number): string {
-  if (durationMS < 1000) {
-    return `${durationMS}ms`;
-  }
-  const seconds = durationMS / 1000;
-  if (seconds < 60) {
-    return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
-  }
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  return `${minutes}m ${rest}s`;
-}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -4,7 +4,7 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
-import { formatAbsoluteTime, formatDurationMs, formatInteger } from "../../lib/format";
+import { formatAbsoluteTime, formatDurationMs, formatInteger, formatLocaleTime } from "../../lib/format";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -2120,7 +2120,7 @@ function HecateTaskApprovalsBanner({
                 </span>
                 {approval.createdAt && (
                   <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--amber-lo)" }}>
-                    {new Date(approval.createdAt).toLocaleTimeString()}
+                    {formatLocaleTime(approval.createdAt)}
                   </span>
                 )}
               </div>

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { claudeCodeSetupTokenCommand } from "../../lib/claude-code-setup";
+import { formatLocaleDateTime } from "../../lib/format";
 import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel } from "../../lib/provider-readiness";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord, AgentChatGrantRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
 import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
@@ -816,7 +817,7 @@ function GrantRow({
       ? { color: "var(--red)", label: "always deny" }
       : { color: "var(--t2)", label: grant.decision };
   const expiresLabel = grant.expires_at
-    ? `expires ${new Date(grant.expires_at).toLocaleString()}`
+    ? `expires ${formatLocaleDateTime(grant.expires_at)}`
     : "no expiry";
 
   return (
@@ -845,7 +846,7 @@ function GrantRow({
           {grant.workspace && <span>workspace <span style={{ color: "var(--t1)" }}>{grant.workspace}</span></span>}
           {grant.session_id && <span>session <span style={{ color: "var(--t1)" }}>{grant.session_id}</span></span>}
           {grant.granted_by && <span>by <span style={{ color: "var(--t1)" }}>{grant.granted_by}</span></span>}
-          <span>{new Date(grant.granted_at).toLocaleString()}</span>
+          <span>{formatLocaleDateTime(grant.granted_at)}</span>
           <span>{expiresLabel}</span>
         </div>
       </div>

--- a/ui/src/features/connections/ModelCapabilitiesSection.tsx
+++ b/ui/src/features/connections/ModelCapabilitiesSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { formatInteger } from "../../lib/format";
 import type { ModelRecord } from "../../types/runtime";
 
 type Props = {
@@ -166,7 +167,7 @@ function ModelCapabilityRow({
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
           <span>source <span style={{ color: "var(--t1)" }}>{source}</span></span>
           {capabilities?.streaming !== undefined && <span>streaming <span style={{ color: "var(--t1)" }}>{capabilities.streaming ? "yes" : "no"}</span></span>}
-          {capabilities?.max_context_tokens !== undefined && <span>context <span style={{ color: "var(--t1)" }}>{capabilities.max_context_tokens.toLocaleString()}</span></span>}
+          {capabilities?.max_context_tokens !== undefined && <span>context <span style={{ color: "var(--t1)" }}>{formatInteger(capabilities.max_context_tokens)}</span></span>}
         </div>
       </div>
       <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", alignItems: "center", gap: 6 }}>

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -16,9 +16,9 @@ import {
   findProviderInTrace,
   type TraceTimelineItem,
 } from "../../lib/runtime-trace";
+import { formatAbsoluteTime } from "../../lib/format";
 import {
   describeRouteReason,
-  formatAbsoluteTime,
   formatRelativeTime,
   traceStatusBadge,
 } from "../../lib/runtime-utils";

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { formatLocaleTime } from "../../lib/format";
 import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel } from "../../lib/provider-readiness";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
@@ -295,7 +296,7 @@ export function ProvidersView({ state, actions }: Props) {
         <td style={{ padding: "8px 12px", whiteSpace: "nowrap" }}>
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t3)" }}>
             {rt?.last_checked_at
-              ? formatProviderTime(rt.last_checked_at)
+              ? formatLocaleTime(rt.last_checked_at)
               : "—"}
           </span>
         </td>
@@ -528,7 +529,7 @@ export function ProvidersView({ state, actions }: Props) {
                 borderRadius: "var(--radius-sm)",
                 fontSize: 12, color: "var(--red)", lineHeight: 1.4,
               }}>
-                Circuit open — will probe at {formatProviderTime(selectedStatus.open_until)}
+                Circuit open — will probe at {formatLocaleTime(selectedStatus.open_until)}
               </div>
             )}
 
@@ -544,7 +545,7 @@ export function ProvidersView({ state, actions }: Props) {
                   : "Ready"],
                 ["Models",   selectedStatus?.model_count ?? selectedStatus?.models?.length ?? "—"],
                 ["Checked",  selectedStatus?.last_checked_at
-                  ? formatProviderTime(selectedStatus.last_checked_at)
+                  ? formatLocaleTime(selectedStatus.last_checked_at)
                   : "—"],
               ] as [string, string | number][]).map(([label, val]) => (
                 <div key={label}>
@@ -886,10 +887,4 @@ function providerRepairButton(
   const label = providerRepairActionLabel(hint.actionKind);
   if (!label) return null;
   return { label, tone: hint.actionKind === "add_provider" ? "primary" : "ghost" };
-}
-
-function formatProviderTime(value: string): string {
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return value;
-  return new Date(parsed).toLocaleTimeString();
 }

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AgentChatActivityRecord, TaskActivityRecord, TaskApprovalRecord, TaskArtifactRecord, TaskRecord, TaskRunEventRecord, TaskRunRecord, TaskStepRecord } from "../../types/runtime";
-import { formatDurationRange, formatLocaleDateTime, formatMicrosUSD } from "../../lib/format";
+import { formatDurationRange, formatLocaleDateTime, formatLocaleTime, formatMicrosUSD } from "../../lib/format";
 import { Badge, BrandAvatar, Dot, Icon, Icons, Modal } from "../shared/ui";
 import { TranscriptActivityTimeline } from "../transcript/TranscriptActivityTimeline";
 
@@ -225,7 +225,7 @@ function TaskApprovalCallout({
               )}
               {approval.created_at && (
                 <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-                  {new Date(approval.created_at).toLocaleTimeString()}
+                  {formatLocaleTime(approval.created_at)}
                 </span>
               )}
             </div>
@@ -461,7 +461,7 @@ export function TaskDetail({
                       </span>
                       {r.started_at && (
                         <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-                          {new Date(r.started_at).toLocaleTimeString()}
+                          {formatLocaleTime(r.started_at)}
                         </span>
                       )}
                     </button>
@@ -576,7 +576,7 @@ export function TaskDetail({
                     </span>
                     <div style={{ minWidth: 0 }}>
                       <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t2)" }}>
-                        {event.occurred_at ? new Date(event.occurred_at).toLocaleTimeString() : "streamed"}
+                        {event.occurred_at ? formatLocaleTime(event.occurred_at) : "streamed"}
                       </div>
                       {(() => {
                         const note = describeRunEventNote(event);
@@ -644,7 +644,7 @@ export function TaskDetail({
                       )}
                       {step.started_at && step.status === "completed" && (
                         <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-                          {new Date(step.started_at).toLocaleTimeString()}
+                          {formatLocaleTime(step.started_at)}
                         </span>
                       )}
                       {step.status === "running" && <span className="badge badge-teal" style={{ fontSize: 10, animation: "pulse 1.5s infinite" }}>running</span>}

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AgentChatActivityRecord, TaskActivityRecord, TaskApprovalRecord, TaskArtifactRecord, TaskRecord, TaskRunEventRecord, TaskRunRecord, TaskStepRecord } from "../../types/runtime";
+import { formatDurationRange, formatLocaleDateTime, formatMicrosUSD } from "../../lib/format";
 import { Badge, BrandAvatar, Dot, Icon, Icons, Modal } from "../shared/ui";
 import { TranscriptActivityTimeline } from "../transcript/TranscriptActivityTimeline";
 
@@ -50,16 +51,6 @@ function taskBadgeStatus(status: string): string {
   if (status === "completed") return "done";
   if (status === "awaiting_approval") return "awaiting";
   return status;
-}
-
-// formatMicrosUSD renders a µUSD amount as a $-prefixed number.
-// Hecate stores LLM cost in millionths of a dollar (µUSD) for
-// integer math precision; the UI swaps to fractional dollars for
-// display. Three decimal places lets sub-cent amounts (common for a
-// few-token call) render meaningfully without exploding to scientific
-// notation.
-function formatMicrosUSD(micros: number): string {
-  return `$${(micros / 1_000_000).toFixed(3)}`;
 }
 
 // RunCostBadge shows this run's cost — and, when prior runs exist
@@ -268,16 +259,6 @@ function approvalCommandPreview(task: TaskRecord): string {
   if (task.shell_command) return task.shell_command;
   if (task.file_path) return `${task.file_operation || "write"} ${task.file_path}`;
   return "";
-}
-
-function formatDuration(start?: string, end?: string): string {
-  if (!start) return "";
-  const startMs = new Date(start).getTime();
-  const endMs = end ? new Date(end).getTime() : Date.now();
-  const seconds = Math.max(0, (endMs - startMs) / 1000);
-  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
 }
 
 function describeRunEvent(eventType: string): { label: string; tone: "queued" | "running" | "awaiting" | "done" | "failed" } {
@@ -547,7 +528,7 @@ export function TaskDetail({
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "8px 14px" }}>
               {([
                 ["Model", run.model || "—"],
-                ["Duration", formatDuration(run.started_at, run.finished_at) || "—"],
+                ["Duration", formatDurationRange(run.started_at, run.finished_at) || "—"],
                 // Request ID becomes a clickable trace link when both
                 // the run carries a request_id and the parent wired an
                 // onOpenTrace callback. Otherwise it's plain text — same
@@ -1263,7 +1244,7 @@ function nonInternalKind(kind?: string): string {
 }
 
 function StepDetail({ step }: { step: TaskStepRecord }) {
-  const duration = formatDuration(step.started_at, step.finished_at);
+  const duration = formatDurationRange(step.started_at, step.finished_at);
   const mcp = splitNamespacedToolName(step.tool_name);
   return (
     <div
@@ -1296,7 +1277,7 @@ function StepDetail({ step }: { step: TaskStepRecord }) {
         {step.error_kind && <span>error kind: <span style={{ color: "var(--t1)" }}>{step.error_kind}</span></span>}
         {step.exit_code !== undefined && <span>exit: <span style={{ color: step.exit_code === 0 ? "var(--green)" : "var(--red)" }}>{step.exit_code}</span></span>}
         {duration && <span>took: <span style={{ color: "var(--t1)" }}>{duration}</span></span>}
-        {step.started_at && <span>started: <span style={{ color: "var(--t1)" }}>{new Date(step.started_at).toLocaleString()}</span></span>}
+        {step.started_at && <span>started: <span style={{ color: "var(--t1)" }}>{formatLocaleDateTime(step.started_at)}</span></span>}
         {step.trace_id && <span>trace: <span style={{ color: "var(--t1)" }}>{step.trace_id}</span></span>}
       </div>
       {/* Hint pointing operators to the conversation viewer where

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type { AgentChatActivityRecord, AgentChatChangedFileDiffRecord, AgentChatChangedFileRecord, AgentChatTimingRecord, AgentChatUsageRecord } from "../../types/runtime";
+import { formatDurationMs } from "../../lib/format";
 import { CodeBlock } from "../shared/Atoms";
 import { BrandAvatar } from "../shared/BrandAvatar";
 import { Icon, Icons } from "../shared/Icons";
@@ -415,7 +416,7 @@ function AgentUsage({ usage }: { usage: AgentChatUsageRecord }) {
 
 function AgentTiming({ timing }: { timing: AgentChatTimingRecord }) {
   const bottleneck = timing.bottleneck && timing.bottleneck_ms
-    ? `${humanTimingLabel(timing.bottleneck)} ${formatDurationMS(timing.bottleneck_ms)}`
+    ? `${humanTimingLabel(timing.bottleneck)} ${formatDurationMs(timing.bottleneck_ms)}`
     : "";
   const items = [
     ["total", timing.total_ms],
@@ -449,7 +450,7 @@ function AgentTiming({ timing }: { timing: AgentChatTimingRecord }) {
     >
       {bottleneck && <span style={{ color: "var(--teal)" }}>bottleneck · {bottleneck}</span>}
       {items.map(([label, value]) => (
-        <span key={label}>{label} {formatDurationMS(value)}</span>
+        <span key={label}>{label} {formatDurationMs(value)}</span>
       ))}
       {counts && <span>{counts}</span>}
     </div>
@@ -474,15 +475,6 @@ function agentUsageEmpty(usage: AgentChatUsageRecord): boolean {
 
 function humanTimingLabel(label: string): string {
   return label === "tools" ? "tools" : label;
-}
-
-function formatDurationMS(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "0ms";
-  if (value < 1000) return `${Math.round(value)}ms`;
-  if (value < 60_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}s`;
-  const minutes = Math.floor(value / 60_000);
-  const seconds = Math.round((value - minutes * 60_000) / 1000);
-  return `${minutes}m ${seconds}s`;
 }
 
 function formatAgentReportedCost(usage: AgentChatUsageRecord): string {

--- a/ui/src/features/usage/UsageView.tsx
+++ b/ui/src/features/usage/UsageView.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { formatInteger, formatLocaleTime, formatMicrosUSD } from "../../lib/format";
 import type { UsageEventRecord } from "../../types/runtime";
 import { CopyBtn } from "../shared/ui";
 
@@ -96,7 +97,7 @@ export function UsageView({ state }: Props) {
                 <tbody>
                   {cloudEvents.slice(0, 100).map((entry, index) => (
                     <tr key={entry.request_id || `${entry.timestamp}-${index}`}>
-                      <td className="mono" style={{ color: "var(--t3)" }}>{formatTime(entry.timestamp)}</td>
+                      <td className="mono" style={{ color: "var(--t3)" }}>{formatLocaleTime(entry.timestamp)}</td>
                       <td className="mono" style={{ color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.provider || "—"}</td>
                       <td className="mono" style={{ color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.model || "—"}</td>
                       <td className="mono">{formatInteger(entry.prompt_tokens ?? 0)}</td>
@@ -178,18 +179,3 @@ function sumUsageEvents(entries: UsageEntry[]): UsageTotals {
   }, { promptTokens: 0, completionTokens: 0, totalTokens: 0, costMicrosUSD: 0 });
 }
 
-function formatTime(value?: string): string {
-  if (!value) return "—";
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return "—";
-  return new Date(parsed).toLocaleTimeString();
-}
-
-function formatInteger(value: number): string {
-  return Number.isFinite(value) ? value.toLocaleString() : "—";
-}
-
-function formatMicrosUSD(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "$0.000";
-  return `$${(value / 1_000_000).toFixed(3)}`;
-}

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -184,14 +184,18 @@ describe("formatInteger", () => {
   });
 
   it("preserves the negative sign for negative integers", () => {
-    // toLocaleString uses HYPHEN-MINUS in en-US and MINUS SIGN (U+2212)
-    // in some others — both are longer than the unsigned form by one
-    // character. Asserting on the prefix character would be locale-
-    // brittle; asserting "is different + one longer" isn't.
+    // toLocaleString prefixes negatives with HYPHEN-MINUS in en-US,
+    // MINUS SIGN (U+2212) in some Europeans, and in Arabic / Persian
+    // adds an invisible bidi mark (U+061C) ahead of the digit/sign —
+    // so the length delta is locale-dependent (1 in most locales, 2
+    // in RTL formats). Asserting on the prefix character or the exact
+    // length delta would be brittle; asserting "different + at least
+    // one character longer" captures the contract without pinning a
+    // locale.
     const positive = formatInteger(1234);
     const negative = formatInteger(-1234);
     expect(negative).not.toBe(positive);
-    expect(negative.length).toBe(positive.length + 1);
+    expect(negative.length).toBeGreaterThan(positive.length);
   });
 
   it("returns em dash for non-finite input", () => {

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatAbsoluteTime,
+  formatDurationMs,
+  formatDurationRange,
+  formatInteger,
+  formatLocaleDateTime,
+  formatLocaleTime,
+  formatMicrosUSD,
+} from "./format";
+
+describe("formatDurationMs", () => {
+  it("renders sub-second values as Nms with integer rounding", () => {
+    expect(formatDurationMs(0.4)).toBe("0ms");
+    expect(formatDurationMs(7)).toBe("7ms");
+    expect(formatDurationMs(7.6)).toBe("8ms");
+    expect(formatDurationMs(999)).toBe("999ms");
+  });
+
+  it("renders sub-10s values to one decimal", () => {
+    expect(formatDurationMs(1000)).toBe("1.0s");
+    expect(formatDurationMs(1234)).toBe("1.2s");
+    expect(formatDurationMs(9_999)).toBe("10.0s");
+  });
+
+  it("renders 10s..60s as integer seconds", () => {
+    expect(formatDurationMs(10_000)).toBe("10s");
+    expect(formatDurationMs(45_400)).toBe("45s");
+    expect(formatDurationMs(59_999)).toBe("60s");
+  });
+
+  it("renders minute+second pairs above 60s", () => {
+    expect(formatDurationMs(60_000)).toBe("1m 0s");
+    expect(formatDurationMs(125_500)).toBe("2m 6s");
+    expect(formatDurationMs(3_600_000)).toBe("60m 0s");
+  });
+
+  it("guards non-finite and non-positive input as 0ms", () => {
+    expect(formatDurationMs(0)).toBe("0ms");
+    expect(formatDurationMs(-100)).toBe("0ms");
+    expect(formatDurationMs(Number.NaN)).toBe("0ms");
+    expect(formatDurationMs(Number.POSITIVE_INFINITY)).toBe("0ms");
+  });
+});
+
+describe("formatDurationRange", () => {
+  it("returns empty string when start is missing or unparseable", () => {
+    expect(formatDurationRange(undefined)).toBe("");
+    expect(formatDurationRange("")).toBe("");
+    expect(formatDurationRange("not-a-date")).toBe("");
+  });
+
+  it("formats explicit start/end ranges via formatDurationMs", () => {
+    expect(
+      formatDurationRange("2026-01-01T00:00:00.000Z", "2026-01-01T00:00:00.500Z"),
+    ).toBe("500ms");
+    expect(
+      formatDurationRange("2026-01-01T00:00:00.000Z", "2026-01-01T00:00:05.500Z"),
+    ).toBe("5.5s");
+    expect(
+      formatDurationRange("2026-01-01T00:00:00.000Z", "2026-01-01T00:02:06.000Z"),
+    ).toBe("2m 6s");
+  });
+
+  it("clamps a negative range to 0ms", () => {
+    expect(
+      formatDurationRange("2026-01-01T00:00:10.000Z", "2026-01-01T00:00:00.000Z"),
+    ).toBe("0ms");
+  });
+
+  it("rejects an unparseable end", () => {
+    expect(formatDurationRange("2026-01-01T00:00:00.000Z", "not-a-date")).toBe("");
+  });
+
+  it("falls back to Date.now() when end is omitted", () => {
+    const fiveSecondsAgo = new Date(Date.now() - 5_000).toISOString();
+    expect(formatDurationRange(fiveSecondsAgo)).toMatch(/^\d+(\.\d)?s$/);
+  });
+});
+
+describe("formatMicrosUSD", () => {
+  it("renders µUSD to three decimal places", () => {
+    expect(formatMicrosUSD(1_500_000)).toBe("$1.500");
+    expect(formatMicrosUSD(1_234)).toBe("$0.001");
+    expect(formatMicrosUSD(900_000)).toBe("$0.900");
+  });
+
+  it("guards non-finite and non-positive input as $0.000", () => {
+    expect(formatMicrosUSD(0)).toBe("$0.000");
+    expect(formatMicrosUSD(-1)).toBe("$0.000");
+    expect(formatMicrosUSD(Number.NaN)).toBe("$0.000");
+    expect(formatMicrosUSD(Number.POSITIVE_INFINITY)).toBe("$0.000");
+  });
+});
+
+describe("formatAbsoluteTime", () => {
+  it("returns empty string for missing input", () => {
+    expect(formatAbsoluteTime(undefined)).toBe("");
+    expect(formatAbsoluteTime("")).toBe("");
+  });
+
+  it("returns the raw value if it can't be parsed", () => {
+    expect(formatAbsoluteTime("not-a-date")).toBe("not-a-date");
+  });
+
+  it("formats an ISO timestamp using Intl.DateTimeFormat", () => {
+    const out = formatAbsoluteTime("2026-05-15T17:31:41Z");
+    // Locale + timezone vary by runner; assert a stable substring
+    // shape rather than the full string. The constituent parts
+    // (year + a short month name + numeric hour:minute:second + a
+    // timezone abbreviation) must all be present.
+    expect(out).toMatch(/2026/);
+    expect(out).toMatch(/May/);
+    expect(out).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+    expect(out).toMatch(/[A-Z]{2,5}|GMT|UTC/);
+  });
+});
+
+describe("formatLocaleDateTime", () => {
+  it("returns empty string for missing/unparseable input", () => {
+    expect(formatLocaleDateTime(undefined)).toBe("");
+    expect(formatLocaleDateTime("")).toBe("");
+    expect(formatLocaleDateTime("not-a-date")).toBe("");
+  });
+
+  it("matches Date.toLocaleString() for the same instant", () => {
+    const iso = "2026-05-15T17:31:41Z";
+    expect(formatLocaleDateTime(iso)).toBe(new Date(iso).toLocaleString());
+  });
+});
+
+describe("formatLocaleTime", () => {
+  it("returns em dash for missing/unparseable input", () => {
+    expect(formatLocaleTime(undefined)).toBe("—");
+    expect(formatLocaleTime("")).toBe("—");
+    expect(formatLocaleTime("not-a-date")).toBe("—");
+  });
+
+  it("matches Date.toLocaleTimeString() for the same instant", () => {
+    const iso = "2026-05-15T17:31:41Z";
+    expect(formatLocaleTime(iso)).toBe(new Date(iso).toLocaleTimeString());
+  });
+});
+
+describe("formatInteger", () => {
+  it("renders integers with the runtime's locale thousand separator", () => {
+    expect(formatInteger(0)).toBe((0).toLocaleString());
+    expect(formatInteger(1_234)).toBe((1234).toLocaleString());
+    expect(formatInteger(1_234_567)).toBe((1234567).toLocaleString());
+  });
+
+  it("rounds non-integer input before formatting", () => {
+    expect(formatInteger(1234.7)).toBe((1235).toLocaleString());
+  });
+
+  it("returns em dash for non-finite input", () => {
+    expect(formatInteger(Number.NaN)).toBe("—");
+    expect(formatInteger(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+});

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -13,6 +13,7 @@ import {
 describe("formatDurationMs", () => {
   it("renders sub-second values as Nms with integer rounding", () => {
     expect(formatDurationMs(0.4)).toBe("0ms");
+    expect(formatDurationMs(0.6)).toBe("1ms");
     expect(formatDurationMs(7)).toBe("7ms");
     expect(formatDurationMs(7.6)).toBe("8ms");
     expect(formatDurationMs(999)).toBe("999ms");
@@ -67,6 +68,12 @@ describe("formatDurationRange", () => {
     expect(
       formatDurationRange("2026-01-01T00:00:00.000Z", "2026-01-01T00:02:06.000Z"),
     ).toBe("2m 6s");
+  });
+
+  it("renders an equal-boundary range as 0ms", () => {
+    expect(
+      formatDurationRange("2026-01-01T00:00:00.000Z", "2026-01-01T00:00:00.000Z"),
+    ).toBe("0ms");
   });
 
   it("clamps a negative range to 0ms", () => {
@@ -141,9 +148,12 @@ describe("formatLocaleDateTime", () => {
     expect(formatLocaleDateTime("not-a-date")).toBe("");
   });
 
-  it("matches Date.toLocaleString() for the same instant", () => {
+  it("renders a locale string containing the year for a valid timestamp", () => {
+    // Asserting equality against `new Date(iso).toLocaleString()` would
+    // be tautological (the function is exactly that, plus the guard).
+    // Year is the cheapest locale-independent property to check.
     const iso = "2026-05-15T17:31:41Z";
-    expect(formatLocaleDateTime(iso)).toBe(new Date(iso).toLocaleString());
+    expect(formatLocaleDateTime(iso)).toContain("2026");
   });
 });
 
@@ -154,9 +164,11 @@ describe("formatLocaleTime", () => {
     expect(formatLocaleTime("not-a-date")).toBe("—");
   });
 
-  it("matches Date.toLocaleTimeString() for the same instant", () => {
+  it("renders a time-like h:m pattern for a valid timestamp", () => {
+    // toLocaleTimeString varies by locale (12h vs 24h, AM/PM,
+    // separators), but every locale produces at least one `H:MM` pair.
     const iso = "2026-05-15T17:31:41Z";
-    expect(formatLocaleTime(iso)).toBe(new Date(iso).toLocaleTimeString());
+    expect(formatLocaleTime(iso)).toMatch(/\d{1,2}:\d{2}/);
   });
 });
 
@@ -169,6 +181,17 @@ describe("formatInteger", () => {
 
   it("rounds non-integer input before formatting", () => {
     expect(formatInteger(1234.7)).toBe((1235).toLocaleString());
+  });
+
+  it("preserves the negative sign for negative integers", () => {
+    // toLocaleString uses HYPHEN-MINUS in en-US and MINUS SIGN (U+2212)
+    // in some others — both are longer than the unsigned form by one
+    // character. Asserting on the prefix character would be locale-
+    // brittle; asserting "is different + one longer" isn't.
+    const positive = formatInteger(1234);
+    const negative = formatInteger(-1234);
+    expect(negative).not.toBe(positive);
+    expect(negative.length).toBe(positive.length + 1);
   });
 
   it("returns em dash for non-finite input", () => {

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -42,6 +42,12 @@ describe("formatDurationMs", () => {
     expect(formatDurationMs(Number.NaN)).toBe("0ms");
     expect(formatDurationMs(Number.POSITIVE_INFINITY)).toBe("0ms");
   });
+
+  it("rolls seconds past 60 over into minutes (no '1m 60s' artifact)", () => {
+    expect(formatDurationMs(119_999)).toBe("2m 0s");
+    expect(formatDurationMs(119_500)).toBe("2m 0s");
+    expect(formatDurationMs(60_500)).toBe("1m 1s");
+  });
 });
 
 describe("formatDurationRange", () => {
@@ -104,16 +110,27 @@ describe("formatAbsoluteTime", () => {
     expect(formatAbsoluteTime("not-a-date")).toBe("not-a-date");
   });
 
-  it("formats an ISO timestamp using Intl.DateTimeFormat", () => {
-    const out = formatAbsoluteTime("2026-05-15T17:31:41Z");
-    // Locale + timezone vary by runner; assert a stable substring
-    // shape rather than the full string. The constituent parts
-    // (year + a short month name + numeric hour:minute:second + a
-    // timezone abbreviation) must all be present.
-    expect(out).toMatch(/2026/);
-    expect(out).toMatch(/May/);
+  it("includes year + short-month + day + h:m:s + timezone parts", () => {
+    // Locale and timezone vary by runner, so we can't assert literal
+    // strings like "May" or `[A-Z]{2,5}`. Use `Intl.DateTimeFormat`'s
+    // own `formatToParts` with the same options to discover the
+    // expected pieces for *this* runner, then verify the formatter
+    // produced them all. The contract is "all six fields are
+    // present", not "the layout is English/uppercase/etc."
+    const isoInput = "2026-05-15T17:31:41Z";
+    const partsFor = (opts: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat(undefined, opts).formatToParts(new Date(isoInput));
+    const yearPart = partsFor({ year: "numeric" }).find((p) => p.type === "year")?.value ?? "";
+    const monthPart = partsFor({ month: "short" }).find((p) => p.type === "month")?.value ?? "";
+    const dayPart = partsFor({ day: "numeric" }).find((p) => p.type === "day")?.value ?? "";
+    const tzPart = partsFor({ timeZoneName: "short" }).find((p) => p.type === "timeZoneName")?.value ?? "";
+
+    const out = formatAbsoluteTime(isoInput);
+    expect(out).toContain(yearPart);
+    expect(out).toContain(monthPart);
+    expect(out).toContain(dayPart);
+    expect(out).toContain(tzPart);
     expect(out).toMatch(/\d{1,2}:\d{2}:\d{2}/);
-    expect(out).toMatch(/[A-Z]{2,5}|GMT|UTC/);
   });
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,6 +2,17 @@
 // timestamp, or integer into a user-facing string goes here so
 // callers across features render consistently and we have one
 // place to adjust if locale, precision, or wording changes.
+//
+// Missing-input sentinel by helper — pick the one that matches the
+// surrounding layout so empty cells stay aligned:
+//   - `formatAbsoluteTime`     → `""` for empty, the raw `value` for
+//                                unparseable (tooltip context — a
+//                                partial string beats "Invalid Date").
+//   - `formatLocaleDateTime`   → `""` for both.
+//   - `formatLocaleTime`       → `"—"` for both (em dash; preserves
+//                                table-cell width).
+//   - `formatDurationRange`    → `""` for both.
+//   - `formatInteger`          → `"—"` for non-finite (table-aligned).
 
 /**
  * Format a duration in milliseconds as a compact human string.
@@ -99,8 +110,8 @@ export function formatAbsoluteTime(value?: string): string {
  *
  * Empty / unparseable input renders as "".
  *
- * TODO: migrate the three remaining call sites (ConnectionsPanel's
- * grant timestamps, TaskDetail's step.started_at) to
+ * TODO: migrate the remaining call sites in ConnectionsPanel (grant
+ * timestamps) and TaskDetail (`step.started_at`) to
  * `formatAbsoluteTime` once the design review for the more verbose
  * layout (with timezone) lands, and delete this helper.
  */

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -98,6 +98,11 @@ export function formatAbsoluteTime(value?: string): string {
  * `formatAbsoluteTime`.
  *
  * Empty / unparseable input renders as "".
+ *
+ * TODO: migrate the three remaining call sites (ConnectionsPanel's
+ * grant timestamps, TaskDetail's step.started_at) to
+ * `formatAbsoluteTime` once the design review for the more verbose
+ * layout (with timezone) lands, and delete this helper.
  */
 export function formatLocaleDateTime(value?: string): string {
   if (!value) return "";

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -20,8 +20,14 @@ export function formatDurationMs(value: number): string {
     const seconds = value / 1000;
     return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
   }
-  const minutes = Math.floor(value / 60_000);
-  const seconds = Math.round((value - minutes * 60_000) / 1000);
+  // Round once at the second granularity, then split. Computing
+  // minutes off the unrounded ms and seconds off the leftover lets a
+  // value like 119_999 land at "1m 60s" instead of "2m 0s" — the
+  // seconds component rolls past 60 because Math.round operates on
+  // the leftover, not on the total.
+  const totalSeconds = Math.round(value / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
   return `${minutes}m ${seconds}s`;
 }
 
@@ -56,10 +62,14 @@ export function formatMicrosUSD(value: number): string {
 }
 
 /**
- * Format an ISO timestamp with an explicit, locale-aware layout
- * (Mon DD, YYYY · h:mm:ss A · TZ). Preferred for any timestamp the
- * user might paste into a bug report, where a stable shape across
- * locales matters more than the browser's default ordering.
+ * Format an ISO timestamp with year, short-month, day, hour, minute,
+ * second, and short timezone components. Uses the browser's default
+ * locale (`Intl.DateTimeFormat(undefined, …)`), so the *order*,
+ * *month language*, *separators*, and *AM/PM rendering* still vary
+ * across locales — what the explicit options pin is the *set of
+ * fields included*, not a stable visual layout. Preferred for any
+ * timestamp the user might paste into a bug report because all six
+ * fields are always present.
  *
  *   - Empty/missing input → "".
  *   - Unparseable input → the raw `value` (a partial string is more

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,119 @@
+// Canonical UI formatters. Anything that turns a duration, cost,
+// timestamp, or integer into a user-facing string goes here so
+// callers across features render consistently and we have one
+// place to adjust if locale, precision, or wording changes.
+
+/**
+ * Format a duration in milliseconds as a compact human string.
+ *
+ *   - Sub-second: "Nms" (rounded to an integer).
+ *   - Under a minute: "N.Ns" below 10s, "Ns" above.
+ *   - One minute or more: "Nm Ns".
+ *
+ * Non-finite or non-positive values render as "0ms" — UI surfaces
+ * showing "took: …" prefer a definite zero over an empty cell.
+ */
+export function formatDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0ms";
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60_000) {
+    const seconds = value / 1000;
+    return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  }
+  const minutes = Math.floor(value / 60_000);
+  const seconds = Math.round((value - minutes * 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Format the duration between two ISO timestamps. When `end` is
+ * omitted, the duration is measured against `Date.now()` — useful
+ * for in-progress runs where the end is "now-ish".
+ *
+ * Returns "" if `start` is missing or unparseable; the caller
+ * decides whether to render a placeholder.
+ */
+export function formatDurationRange(start: string | undefined, end?: string): string {
+  if (!start) return "";
+  const startMs = Date.parse(start);
+  if (!Number.isFinite(startMs)) return "";
+  const endMs = end ? Date.parse(end) : Date.now();
+  if (!Number.isFinite(endMs)) return "";
+  return formatDurationMs(Math.max(0, endMs - startMs));
+}
+
+/**
+ * Format an amount stored in µUSD (millionths of a US dollar) as a
+ * "$N.NNN" string. Hecate persists LLM cost in µUSD for integer
+ * math precision; we render to three decimal places so sub-cent
+ * amounts surface without exploding to scientific notation.
+ *
+ * Non-finite or non-positive values render as "$0.000".
+ */
+export function formatMicrosUSD(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "$0.000";
+  return `$${(value / 1_000_000).toFixed(3)}`;
+}
+
+/**
+ * Format an ISO timestamp with an explicit, locale-aware layout
+ * (Mon DD, YYYY · h:mm:ss A · TZ). Preferred for any timestamp the
+ * user might paste into a bug report, where a stable shape across
+ * locales matters more than the browser's default ordering.
+ *
+ *   - Empty/missing input → "".
+ *   - Unparseable input → the raw `value` (a partial string is more
+ *     useful than "Invalid Date" in a tooltip).
+ */
+export function formatAbsoluteTime(value?: string): string {
+  if (!value) return "";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  }).format(new Date(parsed));
+}
+
+/**
+ * Format an ISO timestamp with the browser's default locale layout
+ * for both date and time (the unconfigured `Date.toLocaleString()`).
+ * Existing surfaces that already shipped this layout use this so
+ * their wording doesn't change; new surfaces should prefer
+ * `formatAbsoluteTime`.
+ *
+ * Empty / unparseable input renders as "".
+ */
+export function formatLocaleDateTime(value?: string): string {
+  if (!value) return "";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "";
+  return new Date(parsed).toLocaleString();
+}
+
+/**
+ * Format the time portion of an ISO timestamp using the browser's
+ * default locale layout. Returns "—" on missing or unparseable
+ * input so table cells stay visually aligned.
+ */
+export function formatLocaleTime(value?: string): string {
+  if (!value) return "—";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "—";
+  return new Date(parsed).toLocaleTimeString();
+}
+
+/**
+ * Format an integer with the browser's locale thousand separator.
+ * Returns "—" for non-finite values; rounds non-integer inputs
+ * before formatting so callers don't need a separate guard.
+ */
+export function formatInteger(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  return Math.round(value).toLocaleString();
+}

--- a/ui/src/lib/runtime-utils.test.ts
+++ b/ui/src/lib/runtime-utils.test.ts
@@ -15,7 +15,6 @@ import {
   filterModelsByProvider,
   findModelInTrace,
   findProviderInTrace,
-  formatAbsoluteTime,
   formatRelativeTime,
   formatTraceAttributeKey,
   formatTraceAttributeValue,
@@ -392,13 +391,4 @@ describe("runtime-utils", () => {
     expect(formatRelativeTime(twoHr).label).toBe("2h ago");
   });
 
-  it("formatAbsoluteTime renders readable local timestamps for tooltips", () => {
-    expect(formatAbsoluteTime("")).toBe("");
-    expect(formatAbsoluteTime("not-a-date")).toBe("not-a-date");
-
-    const label = formatAbsoluteTime("2026-05-14T21:50:35.33722Z");
-    expect(label).toContain("2026");
-    expect(label).toContain("35");
-    expect(label).not.toContain("T21:50:35.33722Z");
-  });
 });

--- a/ui/src/lib/runtime-utils.ts
+++ b/ui/src/lib/runtime-utils.ts
@@ -52,11 +52,6 @@ export function formatRelativeTime(iso: string): { label: string; iso: string } 
   return { label: new Date(parsed).toLocaleDateString(), iso };
 }
 
-// formatAbsoluteTime moved to ./format alongside the other UI
-// formatters. Re-exported here so existing import sites keep
-// working; new sites should import from ./format directly.
-export { formatAbsoluteTime } from "./format";
-
 // ─── Barrel re-exports ───────────────────────────────────────────────────────
 
 export type { TraceTimelineItem, WaterfallSpan, TraceWaterfall } from "./runtime-trace";

--- a/ui/src/lib/runtime-utils.ts
+++ b/ui/src/lib/runtime-utils.ts
@@ -52,20 +52,10 @@ export function formatRelativeTime(iso: string): { label: string; iso: string } 
   return { label: new Date(parsed).toLocaleDateString(), iso };
 }
 
-export function formatAbsoluteTime(value?: string): string {
-  if (!value) return "";
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return value;
-  return new Intl.DateTimeFormat(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    timeZoneName: "short",
-  }).format(new Date(parsed));
-}
+// formatAbsoluteTime moved to ./format alongside the other UI
+// formatters. Re-exported here so existing import sites keep
+// working; new sites should import from ./format directly.
+export { formatAbsoluteTime } from "./format";
 
 // ─── Barrel re-exports ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase 1 of the UI cleanup plan ([`graceful-giggling-spring`](https://github.com/hecatehq/hecate/tree/master)). Single canonical home for date / duration / money / integer formatting; retires three local `formatDuration` variants with diverging signatures, two `formatMicrosUSD` copies, and the ad-hoc `toLocaleString` sites scattered across TaskDetail, ChatView, ProvidersView, UsageView, ConnectionsPanel, ModelCapabilitiesSection, and TranscriptMessageRow.

### What's in `ui/src/lib/format.ts`

| Function | Replaces | Notes |
|---|---|---|
| `formatDurationMs(value: number)` | `ChatView.formatDuration`, `TranscriptMessageRow.formatDurationMS` | unified — NaN/≤0 → `"0ms"` |
| `formatDurationRange(start, end?)` | `TaskDetail.formatDuration` | end defaults to `Date.now()` for in-progress runs |
| `formatMicrosUSD(value)` | `TaskDetail.formatMicrosUSD`, `UsageView.formatMicrosUSD` | NaN/≤0 → `"$0.000"` |
| `formatAbsoluteTime(value?)` | moved from `runtime-utils.ts:55` | year + short-month + day + h:m:s + tz, raw value on unparseable |
| `formatLocaleDateTime(value?)` | inline `new Date(...).toLocaleString()` in ConnectionsPanel + TaskDetail | preserves existing layout; TODO migration to `formatAbsoluteTime` after design review |
| `formatLocaleTime(value?)` | `UsageView.formatTime`, `TaskDetail`'s four time chips, ChatView's pending-approval timestamp, ProvidersView's `formatProviderTime` helper | em-dash on missing/unparseable |
| `formatInteger(value)` | `UsageView.formatInteger`, raw `.toLocaleString()` on ints in ChatView + ModelCapabilitiesSection | rounds non-integer input (UsageView's original was strict; rounding is now JSDoc-documented) |

### Why now

Two PR #109 review-comment-round bugs (`loadRetentionRuns` re-fire, `manualRequestedRef` race) were downstream of the UI's larger structural debt. The plan starts with format utilities because they're load-bearing — every later phase touches at least one of these files, and we don't want a phase 4 PR re-introducing a local `formatDuration` because the canonical version doesn't exist yet.

### Behavioural changes worth flagging

These were deliberate consolidations toward the cleanest behaviour — none cause test regressions, but they're not strictly invisible at the pixel level:

1. **Sub-minute durations switch to integer seconds at the 10 s boundary.** The old `TaskDetail.formatDuration` used `toFixed(1)` for the entire `<60 s` range (`45.5 s → "45.5s"`); the new `formatDurationMs` aligns with `ChatView` / `TranscriptMessageRow`, which already integer-rounded at ≥10 s (`45.5 s → "46s"`). Visible at TaskDetail's Duration row and step duration; both surfaces now match the rest of the console.
2. **Unparseable-but-truthy timestamps render as `"—"` instead of `"Invalid Date"` (TaskDetail / ChatView) or the raw uninterpreted string (ProvidersView's `formatProviderTime`).** Both old fallbacks were degraded; `"—"` matches the surrounding em-dash convention. One UX edge worth a thought: ProvidersView line 531 ("Circuit open — will probe at …") now reads "Circuit open — will probe at —" if `open_until` is malformed. The server emits ISO timestamps for that field today, so the path is unreachable in practice.
3. **`formatInteger` now rounds non-integer input via `Math.round`** (the original `UsageView.formatInteger` did not). All callers pass integers today, so no observed impact; the JSDoc documents the new lenience.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — full suite passes (+ 25 format tests, including locale-independent assertions via `Intl.DateTimeFormat.formatToParts`)
- [x] `grep -rn "^function formatDuration\|^function formatMicrosUSD\|^function formatLocaleTime\|function formatInteger\|function formatProviderTime" ui/src` — only `./lib/format.ts` matches
- [x] Behavioural changes above are deliberate; the affected surfaces produce more-consistent strings rather than regressing