### PR TITLE
refactor(ui): consolidate picker open/close + outside-click via useFloatingMenu

### DIFF
--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -5,6 +5,7 @@ import { BrandAvatar, DropdownPicker, Icon, Icons } from "../shared/ui";
 import type { DropdownPickerOption, ProviderOption } from "../shared/ui";
 import { focusDropdownItem, focusInitialDropdownItem } from "../shared/dropdownKeyboard";
 import { useFloatingDropdownStyle } from "../shared/useFloatingDropdownStyle";
+import { useFloatingMenu } from "../shared/useFloatingMenu";
 
 const CHAT_AGENT_OPTIONS = [
   { id: "hecate", label: "Hecate" },
@@ -30,11 +31,12 @@ export function NewChatAgentButton({
   onChange: (value: ChatAgentOptionID) => void;
   onCreate: () => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement>(null);
+  const { open, setOpen, toggle, wrapRef, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>();
+  // Anchor is the inline-block group around the trigger; the
+  // floating menu positions against it (not the trigger itself) so
+  // the menu width matches the visual button group, not just the
+  // narrow caret.
   const anchorRef = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const floatingStyle = useFloatingDropdownStyle(anchorRef, open, "left");
   const selected = chatAgentOption(value, adapters);
   const selectedAdapter = selected.id === "hecate" ? undefined : adapters.find((item) => item.id === selected.id);
@@ -44,21 +46,10 @@ export function NewChatAgentButton({
   const selectedDisabled = disableUnavailable && !selectedStatus.ready;
 
   useEffect(() => {
-    const handler = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (wrapRef.current?.contains(target)) return;
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
-  useEffect(() => {
     if (!open) return;
     const frame = requestAnimationFrame(() => focusInitialDropdownItem(menuRef.current));
     return () => cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, menuRef]);
 
   function onMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
     if (event.key === "Escape") {
@@ -116,7 +107,7 @@ export function NewChatAgentButton({
           aria-label="Choose agent for new chat"
           aria-expanded={open}
           aria-haspopup="listbox"
-          onClick={() => setOpen((current) => !current)}
+          onClick={() => toggle()}
           title="Choose agent"
           style={{
             border: 0,

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -31,6 +31,7 @@ import type {
 } from "../../types/runtime";
 import { focusDropdownItem, focusInitialDropdownItem } from "../shared/dropdownKeyboard";
 import { useFloatingDropdownStyle } from "../shared/useFloatingDropdownStyle";
+import { useFloatingMenu } from "../shared/useFloatingMenu";
 import { Badge, BrandAvatar, Icon, Icons, Modal, ModelPicker, ProviderPicker, Toggle } from "../shared/ui";
 
 import { CopyableID } from "./observability/CopyableID";
@@ -800,29 +801,15 @@ const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
 ];
 
 function StatusFilterPicker({ value, onChange }: { value: StatusFilter; onChange: (value: StatusFilter) => void }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>();
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, "right");
   const label = STATUS_FILTER_OPTIONS.find((option) => option.value === value)?.label ?? "All";
-
-  useEffect(() => {
-    const handler = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (ref.current && ref.current.contains(target)) return;
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
 
   useEffect(() => {
     if (!open) return;
     const frame = requestAnimationFrame(() => focusInitialDropdownItem(menuRef.current));
     return () => cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, menuRef]);
 
   function closeMenu() {
     setOpen(false);
@@ -850,7 +837,7 @@ function StatusFilterPicker({ value, onChange }: { value: StatusFilter; onChange
         aria-expanded={open}
         aria-haspopup="listbox"
         className="btn btn-ghost btn-sm"
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => toggle()}
         style={{ fontFamily: "var(--font-mono)", fontSize: 11, gap: 5, color: "var(--t1)", width: 110 }}>
         <span style={{ flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", textAlign: "left" }}>
           {label}

--- a/ui/src/features/shared/AgentAdapterPicker.tsx
+++ b/ui/src/features/shared/AgentAdapterPicker.tsx
@@ -4,13 +4,14 @@
 // the on-demand probe result so operators can see at a glance which
 // adapter is actually usable on this machine.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import type { KeyboardEvent } from "react";
 
 import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../../types/runtime";
 import { Icon, Icons } from "./Icons";
 import { focusDropdownItem, focusInitialDropdownItem } from "./dropdownKeyboard";
 import { useFloatingDropdownStyle } from "./useFloatingDropdownStyle";
+import { useFloatingMenu } from "./useFloatingMenu";
 
 // adapterPickerDiagnostic combines the dashboard's "is the binary on
 // PATH?" flag with the on-demand probe result into one row diagnostic.
@@ -99,22 +100,8 @@ export function AgentAdapterPicker({
   disabledReason?: string;
   triggerWidth?: number;
 }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>();
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, "left");
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (ref.current && ref.current.contains(target)) return;
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -122,7 +109,7 @@ export function AgentAdapterPicker({
       focusInitialDropdownItem(menuRef.current);
     });
     return () => cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, menuRef]);
 
   function onMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
     if (event.key === "Escape") {
@@ -151,7 +138,7 @@ export function AgentAdapterPicker({
         aria-haspopup="listbox"
         className="btn btn-ghost btn-sm"
         disabled={locked}
-        onClick={() => { if (!locked) setOpen((current) => !current); }}
+        onClick={() => { if (!locked) toggle(); }}
         style={{
           fontFamily: "var(--font-mono)",
           fontSize: 11,

--- a/ui/src/features/shared/ChipInput.tsx
+++ b/ui/src/features/shared/ChipInput.tsx
@@ -21,7 +21,9 @@
 //   - Click a chip's × to remove it
 //   - Esc to close the suggestion dropdown
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
+
+import { useFloatingMenu } from "./useFloatingMenu";
 
 export type ChipOption = { id: string; label: string };
 
@@ -43,21 +45,16 @@ export function ChipInput({
   disabled?: boolean;
 }) {
   const [draft, setDraft] = useState("");
-  const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const wrapRef = useRef<HTMLDivElement>(null);
   const listboxID = useId();
-
-  // Click outside closes the dropdown — same pattern the existing
-  // ProviderPicker / ModelPicker use.
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
+  // portalSelector: null because the suggestion list is rendered
+  // inline inside wrapRef rather than in a portal-style fixed-
+  // position container — the default ".dropdown-menu-floating"
+  // exemption would be a no-op here.
+  const { open, setOpen, wrapRef } = useFloatingMenu<HTMLDivElement>({
+    portalSelector: null,
+  });
 
   // Suggestions = options not already chipped, filtered by draft.
   const suggestions = (options ?? [])

--- a/ui/src/features/shared/DropdownPicker.tsx
+++ b/ui/src/features/shared/DropdownPicker.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, ReactNode } from "react";
 
 import { Icon, Icons } from "./Icons";
 import { focusDropdownItem, focusInitialDropdownItem } from "./dropdownKeyboard";
 import { useFloatingDropdownStyle } from "./useFloatingDropdownStyle";
+import { useFloatingMenu } from "./useFloatingMenu";
 
 export type DropdownPickerOption<Value extends string = string> = {
   value: Value;
@@ -58,12 +59,12 @@ export function DropdownPicker<Value extends string = string>({
   buttonStyle?: CSSProperties;
   renderTriggerLabel?: (option: DropdownPickerOption<Value> | undefined) => ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const handleClose = useCallback(() => setFilter(""), []);
+  const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>({
+    onClose: handleClose,
+  });
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, align, placement);
   const selected = options.find((option) => option.value === value);
   const locked = disabled || options.length === 0;
@@ -77,29 +78,16 @@ export function DropdownPicker<Value extends string = string>({
     : options;
 
   useEffect(() => {
-    const handler = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (ref.current?.contains(target)) return;
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-      setFilter("");
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
-  useEffect(() => {
     if (!open) return;
     const frame = requestAnimationFrame(() => {
       if (searchable) inputRef.current?.focus();
       else focusInitialDropdownItem(menuRef.current);
     });
     return () => cancelAnimationFrame(frame);
-  }, [open, searchable]);
+  }, [open, searchable, menuRef]);
 
   function closeMenu() {
     setOpen(false);
-    setFilter("");
     triggerRef.current?.focus();
   }
 
@@ -135,7 +123,6 @@ export function DropdownPicker<Value extends string = string>({
       event.stopPropagation();
       onChange(firstEnabled.value);
       setOpen(false);
-      setFilter("");
     }
   }
 
@@ -149,7 +136,7 @@ export function DropdownPicker<Value extends string = string>({
         className="btn btn-ghost btn-sm"
         disabled={locked}
         onClick={() => {
-          if (!locked) setOpen((current) => !current);
+          if (!locked) toggle();
         }}
         title={locked ? disabledReason || "No options available" : selected?.title || selected?.label || placeholder}
         type="button"

--- a/ui/src/features/shared/DropdownPicker.tsx
+++ b/ui/src/features/shared/DropdownPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, ReactNode } from "react";
 
 import { Icon, Icons } from "./Icons";
@@ -61,9 +61,11 @@ export function DropdownPicker<Value extends string = string>({
 }) {
   const [filter, setFilter] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-  const handleClose = useCallback(() => setFilter(""), []);
   const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>({
-    onClose: handleClose,
+    // onCloseRef inside useFloatingMenu absorbs closure-identity
+    // churn, so passing a fresh () => setFilter("") each render
+    // doesn't re-bind the document listener — no useCallback needed.
+    onClose: () => setFilter(""),
   });
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, align, placement);
   const selected = options.find((option) => option.value === value);

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -12,13 +12,14 @@
 // disabled-provider rendering or the provider suffix get the same
 // look as the old simple picker minus the section headers.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 
 import type { ModelRecord, ProviderPresetRecord } from "../../types/runtime";
 import { Icon, Icons } from "./Icons";
 import { focusDropdownItem, focusInitialDropdownItem } from "./dropdownKeyboard";
 import { useFloatingDropdownStyle } from "./useFloatingDropdownStyle";
+import { useFloatingMenu } from "./useFloatingMenu";
 
 export function ModelPicker({
   value, onChange, models,
@@ -70,36 +71,19 @@ export function ModelPicker({
   allLabel?: string;
   variant?: "header" | "composer";
 }) {
-  const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const handleClose = useCallback(() => setFilter(""), []);
+  const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>({
+    onClose: handleClose,
+  });
   // Right-anchored: the menu is 300px wide and the trigger is at the
   // right side of its row in the chat header, so left-anchoring would
   // push it off-screen on narrow viewports.
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, "right", variant === "composer" ? "up" : "down");
 
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      // Click-outside detection has to consider BOTH the wrap (which
-      // contains the trigger) and the floating menu (which lives at
-      // a different DOM ancestor when rendered fixed-position). Without
-      // checking the menu, clicking inside the menu would close it.
-      if (ref.current && ref.current.contains(target)) return;
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-      setFilter("");
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
-  useEffect(() => {
     if (open) setTimeout(() => inputRef.current?.focus(), 0);
-    else setFilter("");
   }, [open]);
 
   const providerName = (id: string) => presets?.find(p => p.id === id)?.name || id;
@@ -137,7 +121,6 @@ export function ModelPicker({
 
   function closeMenu() {
     setOpen(false);
-    setFilter("");
     triggerRef.current?.focus();
   }
 
@@ -200,7 +183,7 @@ export function ModelPicker({
         aria-expanded={open}
         aria-haspopup="listbox"
         className="btn btn-ghost btn-sm"
-        onClick={() => { if (!isEmpty) setOpen(o => !o); }}
+        onClick={() => { if (!isEmpty) toggle(); }}
         disabled={isEmpty}
         title={disabledTitle}
         style={{

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -12,7 +12,7 @@
 // disabled-provider rendering or the provider suffix get the same
 // look as the old simple picker minus the section headers.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 
 import type { ModelRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -73,9 +73,11 @@ export function ModelPicker({
 }) {
   const [filter, setFilter] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-  const handleClose = useCallback(() => setFilter(""), []);
   const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>({
-    onClose: handleClose,
+    // onCloseRef inside useFloatingMenu absorbs closure-identity
+    // churn, so passing a fresh () => setFilter("") each render
+    // doesn't re-bind the document listener — no useCallback needed.
+    onClose: () => setFilter(""),
   });
   // Right-anchored: the menu is 300px wide and the trigger is at the
   // right side of its row in the chat header, so left-anchoring would

--- a/ui/src/features/shared/ProviderPicker.tsx
+++ b/ui/src/features/shared/ProviderPicker.tsx
@@ -9,13 +9,14 @@
 // cell (1,1). The grid sizes to the wider child, the visible label
 // paints on top.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import type { KeyboardEvent } from "react";
 
 import { BrandAvatar } from "./BrandAvatar";
 import { Icon, Icons } from "./Icons";
 import { focusDropdownItem, focusInitialDropdownItem } from "./dropdownKeyboard";
 import { useFloatingDropdownStyle } from "./useFloatingDropdownStyle";
+import { useFloatingMenu } from "./useFloatingMenu";
 
 // ProviderOption is the shape every caller of ProviderPicker hands in.
 // `name` is the display label shown in the dropdown; `id` is what
@@ -65,24 +66,8 @@ export function ProviderPicker({
   triggerWidth?: number;
   variant?: "header" | "composer";
 }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { open, setOpen, toggle, wrapRef: ref, triggerRef, menuRef } = useFloatingMenu<HTMLDivElement, HTMLButtonElement>();
   const floatingStyle = useFloatingDropdownStyle(triggerRef, open, "left", variant === "composer" ? "up" : "down");
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (ref.current && ref.current.contains(target)) return;
-      // The menu is now portal-style (position: fixed) and lives
-      // outside the wrap, so we have to also exempt its tree.
-      if (target instanceof HTMLElement && target.closest(".dropdown-menu-floating")) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -90,7 +75,7 @@ export function ProviderPicker({
       focusInitialDropdownItem(menuRef.current);
     });
     return () => cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, menuRef]);
 
   const selected = options.find(o => o.id === value);
   // When the saved `value` doesn't resolve to any current option (the
@@ -134,7 +119,7 @@ export function ProviderPicker({
         aria-expanded={open}
         aria-haspopup="listbox"
         className="btn btn-ghost btn-sm"
-        onClick={() => setOpen(o => !o)}
+        onClick={() => toggle()}
         style={{
           fontFamily: "var(--font-mono)",
           fontSize: 11,

--- a/ui/src/features/shared/useFloatingMenu.test.ts
+++ b/ui/src/features/shared/useFloatingMenu.test.ts
@@ -187,7 +187,7 @@ describe("useFloatingMenu", () => {
   // re-bind so the new event type / selector takes effect — verified
   // here so a future "depend on `open` too" change can't silently
   // wedge the closeOn path.
-  it("re-binds the document listener when closeOn or portalSelector changes", () => {
+  it("re-binds the document listener when closeOn changes", () => {
     const add = vi.spyOn(document, "addEventListener");
     const remove = vi.spyOn(document, "removeEventListener");
     const { rerender } = renderHook(
@@ -199,5 +199,46 @@ describe("useFloatingMenu", () => {
     expect(remove).toHaveBeenCalledWith("mousedown", expect.any(Function));
     expect(add.mock.calls.filter(([type]) => type === "click").length).toBeGreaterThanOrEqual(1);
     expect(add.mock.calls.filter(([type]) => type === "mousedown").length).toBe(initialAdds);
+  });
+
+  it("re-binds the document listener when portalSelector changes", () => {
+    // The effect deps are [closeOn, portalSelector]. Flipping closeOn
+    // is covered above; this test exercises the other half so a future
+    // change that drops portalSelector from the deps array can't
+    // silently break the portal-exemption check.
+    const portalA = document.createElement("div");
+    portalA.className = "portal-a";
+    const portalB = document.createElement("div");
+    portalB.className = "portal-b";
+    const itemA = document.createElement("button");
+    const itemB = document.createElement("button");
+    portalA.appendChild(itemA);
+    portalB.appendChild(itemB);
+    document.body.append(portalA, portalB);
+
+    const wrap = document.createElement("div");
+    document.body.appendChild(wrap);
+
+    const { result, rerender } = renderHook(
+      ({ portalSelector }: { portalSelector: string }) => useFloatingMenu({ portalSelector }),
+      { initialProps: { portalSelector: ".portal-a" } },
+    );
+    result.current.wrapRef.current = wrap as HTMLDivElement;
+
+    // While portalSelector is .portal-a, clicks in portal-a are "inside"
+    // (don't close); clicks in portal-b are "outside" (do close).
+    act(() => result.current.setOpen(true));
+    act(() => itemA.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(result.current.open).toBe(true);
+    act(() => itemB.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(result.current.open).toBe(false);
+
+    // Flip the selector — the relationship inverts.
+    rerender({ portalSelector: ".portal-b" });
+    act(() => result.current.setOpen(true));
+    act(() => itemB.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(result.current.open).toBe(true);
+    act(() => itemA.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(result.current.open).toBe(false);
   });
 });

--- a/ui/src/features/shared/useFloatingMenu.test.ts
+++ b/ui/src/features/shared/useFloatingMenu.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useFloatingMenu } from "./useFloatingMenu";
@@ -46,6 +47,22 @@ describe("useFloatingMenu", () => {
     expect(onClose).not.toHaveBeenCalled();
     act(() => result.current.toggle());
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // The commit-phase effect (previousOpenRef + useEffect on [open])
+  // exists specifically to keep onClose at exactly-once per
+  // close transition under StrictMode. Calling onClose from inside
+  // a state updater would fire twice because React 19 invokes
+  // updaters twice in dev to surface impure setters.
+  it("fires onClose exactly once per close transition under StrictMode", () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() => useFloatingMenu({ onClose }), { wrapper: StrictMode });
+    act(() => result.current.setOpen(true));
+    act(() => result.current.setOpen(false));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    act(() => result.current.toggle());
+    act(() => result.current.toggle());
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 
   describe("outside-click behaviour", () => {
@@ -163,5 +180,24 @@ describe("useFloatingMenu", () => {
     const { unmount } = renderHook(() => useFloatingMenu());
     unmount();
     expect(remove).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+
+  // The outside-click effect deps on `[closeOn, portalSelector]`.
+  // If a consumer flips either between renders the hook needs to
+  // re-bind so the new event type / selector takes effect — verified
+  // here so a future "depend on `open` too" change can't silently
+  // wedge the closeOn path.
+  it("re-binds the document listener when closeOn or portalSelector changes", () => {
+    const add = vi.spyOn(document, "addEventListener");
+    const remove = vi.spyOn(document, "removeEventListener");
+    const { rerender } = renderHook(
+      ({ closeOn }: { closeOn: "mousedown" | "click" }) => useFloatingMenu({ closeOn }),
+      { initialProps: { closeOn: "mousedown" } },
+    );
+    const initialAdds = add.mock.calls.filter(([type]) => type === "mousedown").length;
+    rerender({ closeOn: "click" });
+    expect(remove).toHaveBeenCalledWith("mousedown", expect.any(Function));
+    expect(add.mock.calls.filter(([type]) => type === "click").length).toBeGreaterThanOrEqual(1);
+    expect(add.mock.calls.filter(([type]) => type === "mousedown").length).toBe(initialAdds);
   });
 });

--- a/ui/src/features/shared/useFloatingMenu.test.ts
+++ b/ui/src/features/shared/useFloatingMenu.test.ts
@@ -1,0 +1,167 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useFloatingMenu } from "./useFloatingMenu";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useFloatingMenu", () => {
+  it("starts closed", () => {
+    const { result } = renderHook(() => useFloatingMenu());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("setOpen toggles the open flag", () => {
+    const { result } = renderHook(() => useFloatingMenu());
+    act(() => result.current.setOpen(true));
+    expect(result.current.open).toBe(true);
+    act(() => result.current.setOpen(false));
+    expect(result.current.open).toBe(false);
+  });
+
+  it("toggle flips the open flag", () => {
+    const { result } = renderHook(() => useFloatingMenu());
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("close() short-circuits when already closed (no spurious onClose)", () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() => useFloatingMenu({ onClose }));
+    act(() => result.current.close());
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => result.current.setOpen(true));
+    act(() => result.current.close());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggle invokes onClose when transitioning from open → closed", () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() => useFloatingMenu({ onClose }));
+    act(() => result.current.toggle());
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => result.current.toggle());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe("outside-click behaviour", () => {
+    let wrap: HTMLDivElement;
+    let outside: HTMLDivElement;
+    let menuPortal: HTMLDivElement;
+
+    beforeEach(() => {
+      wrap = document.createElement("div");
+      outside = document.createElement("div");
+      menuPortal = document.createElement("div");
+      menuPortal.className = "dropdown-menu-floating";
+      document.body.append(wrap, outside, menuPortal);
+    });
+
+    function attachWrap(result: { current: ReturnType<typeof useFloatingMenu> }) {
+      // The outside-click handler reads wrapRef.current via a ref;
+      // wiring it after the hook initialises matches how every
+      // picker actually mounts (the ref attaches when React commits).
+      result.current.wrapRef.current = wrap;
+    }
+
+    it("closes when a mousedown lands outside the wrap", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() => useFloatingMenu({ onClose }));
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      act(() => {
+        outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(false);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT close when the mousedown lands inside the wrap", () => {
+      const inner = document.createElement("button");
+      wrap.appendChild(inner);
+      const { result } = renderHook(() => useFloatingMenu());
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      act(() => {
+        inner.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(true);
+    });
+
+    it("does NOT close when the mousedown lands inside the portal selector", () => {
+      const item = document.createElement("button");
+      menuPortal.appendChild(item);
+      const { result } = renderHook(() => useFloatingMenu());
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      act(() => {
+        item.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(true);
+    });
+
+    it("portalSelector: null treats portal-region clicks as outside (ChipInput mode)", () => {
+      const item = document.createElement("button");
+      menuPortal.appendChild(item);
+      const { result } = renderHook(() => useFloatingMenu({ portalSelector: null }));
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      act(() => {
+        item.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(false);
+    });
+
+    it("closeOn: 'click' uses the click event instead of mousedown", () => {
+      const { result } = renderHook(() => useFloatingMenu({ closeOn: "click" }));
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      // mousedown should be ignored when closeOn is click
+      act(() => {
+        outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(true);
+      // click closes
+      act(() => {
+        outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(false);
+    });
+
+    it("custom portalSelector consults the operator-supplied selector", () => {
+      const customPortal = document.createElement("div");
+      customPortal.className = "my-custom-portal";
+      const item = document.createElement("button");
+      customPortal.appendChild(item);
+      document.body.appendChild(customPortal);
+      const { result } = renderHook(() => useFloatingMenu({ portalSelector: ".my-custom-portal" }));
+      attachWrap(result);
+      act(() => result.current.setOpen(true));
+      act(() => {
+        item.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(true);
+    });
+
+    it("does not invoke onClose when an outside click lands while already closed", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() => useFloatingMenu({ onClose }));
+      attachWrap(result);
+      act(() => {
+        outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("removes the document listener on unmount", () => {
+    const remove = vi.spyOn(document, "removeEventListener");
+    const { unmount } = renderHook(() => useFloatingMenu());
+    unmount();
+    expect(remove).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+});

--- a/ui/src/features/shared/useFloatingMenu.ts
+++ b/ui/src/features/shared/useFloatingMenu.ts
@@ -66,9 +66,13 @@ export function useFloatingMenu<
   const closeOn = options.closeOn ?? "mousedown";
   // Mirror onClose to a ref so the outside-click effect doesn't
   // re-bind on every render when the consumer passes a fresh
-  // closure each time.
+  // closure each time. Synced in a commit-phase effect (not during
+  // render) so concurrent re-renders that don't commit can't
+  // strand a stale callback in the ref.
   const onCloseRef = useRef(options.onClose);
-  onCloseRef.current = options.onClose;
+  useEffect(() => {
+    onCloseRef.current = options.onClose;
+  });
 
   const [open, setOpenState] = useState(false);
   const wrapRef = useRef<WrapEl | null>(null);
@@ -102,6 +106,12 @@ export function useFloatingMenu<
       if (!target) return;
       if (wrapRef.current && wrapRef.current.contains(target)) return;
       if (portalSelector && target instanceof HTMLElement && target.closest(portalSelector)) return;
+      // setOpenState(false) is unconditional — when the menu is
+      // already closed, React's identical-state bail-out keeps the
+      // commit-phase onClose effect from firing. Adding an `open`
+      // guard here would either require it in the effect deps (re-
+      // binding the listener on every open/close transition) or a
+      // ref shadow; the bail-out is the cheaper read.
       setOpenState(false);
     };
     document.addEventListener(closeOn, handler);

--- a/ui/src/features/shared/useFloatingMenu.ts
+++ b/ui/src/features/shared/useFloatingMenu.ts
@@ -1,0 +1,105 @@
+// useFloatingMenu: shared open/setOpen + outside-click + ref
+// scaffolding that every picker in the console was inlining
+// (ModelPicker, DropdownPicker, ProviderPicker, AgentAdapterPicker,
+// ChatAgentControls, ObservabilityView's StatusFilterPicker, and
+// ChipInput). Pairs with `useFloatingDropdownStyle` for portal-
+// positioning and `dropdownKeyboard` for arrow-key nav, but neither
+// is required — consumers compose what they need.
+//
+// Outside-click treats two DOM regions as "inside":
+//
+//   1. `wrapRef` — the surrounding container that also holds the
+//      trigger. Inline-positioned menus (ChipInput) keep their menu
+//      inside this same ref, so this is the only check they need.
+//
+//   2. Anything matching `portalSelector` — the floating menu
+//      portal. Pickers that switch to `position: fixed` via
+//      `useFloatingDropdownStyle` move their menu to a different
+//      DOM ancestor (`.dropdown-menu-floating`), so a wrap-only
+//      check would treat clicks inside the menu as "outside" and
+//      close it on the first option click. Default
+//      `.dropdown-menu-floating` matches the existing portal
+//      class; pass `null` to disable (ChipInput).
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type FloatingMenuOptions = {
+  /** Additional DOM region treated as "inside" by outside-click.
+   *  Defaults to `.dropdown-menu-floating` for portal-style menus.
+   *  Pass `null` for inline menus that live inside `wrapRef`. */
+  portalSelector?: string | null;
+  /** DOM event used to detect outside clicks. `mousedown` (default)
+   *  matches the rest of the codebase and fires before `click`, so a
+   *  trigger release outside the menu doesn't accidentally dispatch
+   *  the underlying button's `onClick`. */
+  closeOn?: "mousedown" | "click";
+  /** Fires after `setOpen(false)` (either via outside-click or an
+   *  explicit `close()` call). Useful for resetting filter state. */
+  onClose?: () => void;
+};
+
+export type FloatingMenu<WrapEl extends HTMLElement, TriggerEl extends HTMLElement> = {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  toggle: () => void;
+  close: () => void;
+  wrapRef: React.RefObject<WrapEl | null>;
+  triggerRef: React.RefObject<TriggerEl | null>;
+  menuRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const DEFAULT_PORTAL_SELECTOR = ".dropdown-menu-floating";
+
+export function useFloatingMenu<
+  WrapEl extends HTMLElement = HTMLDivElement,
+  TriggerEl extends HTMLElement = HTMLButtonElement,
+>(options: FloatingMenuOptions = {}): FloatingMenu<WrapEl, TriggerEl> {
+  const portalSelector = options.portalSelector === undefined
+    ? DEFAULT_PORTAL_SELECTOR
+    : options.portalSelector;
+  const closeOn = options.closeOn ?? "mousedown";
+  // Mirror onClose to a ref so the outside-click effect doesn't
+  // re-bind on every render when the consumer passes a fresh
+  // closure each time.
+  const onCloseRef = useRef(options.onClose);
+  onCloseRef.current = options.onClose;
+
+  const [open, setOpenState] = useState(false);
+  const wrapRef = useRef<WrapEl | null>(null);
+  const triggerRef = useRef<TriggerEl | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const setOpen = useCallback((next: boolean) => {
+    setOpenState((prev) => {
+      if (prev === next) return prev;
+      if (!next) onCloseRef.current?.();
+      return next;
+    });
+  }, []);
+  const toggle = useCallback(() => {
+    setOpenState((prev) => {
+      const next = !prev;
+      if (!next) onCloseRef.current?.();
+      return next;
+    });
+  }, []);
+  const close = useCallback(() => setOpen(false), [setOpen]);
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (wrapRef.current && wrapRef.current.contains(target)) return;
+      if (portalSelector && target instanceof HTMLElement && target.closest(portalSelector)) return;
+      setOpenState((prev) => {
+        if (!prev) return prev;
+        onCloseRef.current?.();
+        return false;
+      });
+    };
+    document.addEventListener(closeOn, handler);
+    return () => document.removeEventListener(closeOn, handler);
+  }, [closeOn, portalSelector]);
+
+  return { open, setOpen, toggle, close, wrapRef, triggerRef, menuRef };
+}

--- a/ui/src/features/shared/useFloatingMenu.ts
+++ b/ui/src/features/shared/useFloatingMenu.ts
@@ -69,21 +69,26 @@ export function useFloatingMenu<
   const triggerRef = useRef<TriggerEl | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
+  // open is the single source of truth; an effect fires onClose
+  // exactly once per "true → false" commit. Calling onClose from
+  // inside a state updater would double-fire under React.StrictMode
+  // because updaters can be invoked twice. The effect commits, so
+  // it runs only after React has reconciled the new value.
+  const previousOpenRef = useRef(false);
+  useEffect(() => {
+    if (previousOpenRef.current && !open) {
+      onCloseRef.current?.();
+    }
+    previousOpenRef.current = open;
+  }, [open]);
+
   const setOpen = useCallback((next: boolean) => {
-    setOpenState((prev) => {
-      if (prev === next) return prev;
-      if (!next) onCloseRef.current?.();
-      return next;
-    });
+    setOpenState(next);
   }, []);
   const toggle = useCallback(() => {
-    setOpenState((prev) => {
-      const next = !prev;
-      if (!next) onCloseRef.current?.();
-      return next;
-    });
+    setOpenState((prev) => !prev);
   }, []);
-  const close = useCallback(() => setOpen(false), [setOpen]);
+  const close = useCallback(() => setOpenState(false), []);
 
   useEffect(() => {
     const handler = (event: MouseEvent) => {
@@ -91,11 +96,7 @@ export function useFloatingMenu<
       if (!target) return;
       if (wrapRef.current && wrapRef.current.contains(target)) return;
       if (portalSelector && target instanceof HTMLElement && target.closest(portalSelector)) return;
-      setOpenState((prev) => {
-        if (!prev) return prev;
-        onCloseRef.current?.();
-        return false;
-      });
+      setOpenState(false);
     };
     document.addEventListener(closeOn, handler);
     return () => document.removeEventListener(closeOn, handler);

--- a/ui/src/features/shared/useFloatingMenu.ts
+++ b/ui/src/features/shared/useFloatingMenu.ts
@@ -40,6 +40,12 @@ export type FloatingMenuOptions = {
 
 export type FloatingMenu<WrapEl extends HTMLElement, TriggerEl extends HTMLElement> = {
   open: boolean;
+  /** Deliberately narrower than `Dispatch<SetStateAction<boolean>>` —
+   *  takes a plain `boolean`, not a functional updater. Callers that
+   *  want "flip the current value" should use `toggle()` instead.
+   *  Hiding the functional form keeps the consumer surface small and
+   *  prevents the "I passed a function, why did it stringify?" foot-
+   *  gun in callers used to `useState`. */
   setOpen: (next: boolean) => void;
   toggle: () => void;
   close: () => void;


### PR DESCRIPTION
## Summary

Phase 2 of the UI cleanup plan ([`graceful-giggling-spring`](https://github.com/hecatehq/hecate/tree/master)). Six portal-style pickers and one inline picker were each inlining the same `open + setOpen + outside-click + trigger/wrap/menu refs` boilerplate around the (already-shared) `useFloatingDropdownStyle`. They now compose a single `useFloatingMenu` primitive.

### What's new

`ui/src/features/shared/useFloatingMenu.ts`:

```ts
const { open, setOpen, toggle, close, wrapRef, triggerRef, menuRef } =
  useFloatingMenu({
    portalSelector?: string | null,  // default ".dropdown-menu-floating"; null for inline
    closeOn?: "mousedown" | "click", // default mousedown
    onClose?: () => void,            // fires on any open → closed transition
  });
```

The hook owns the state + refs + outside-click effect. Consumers compose with the existing `useFloatingDropdownStyle` (positioning) and `dropdownKeyboard` (focus management) helpers as before — neither is forced.

### Migrated (7 sites)

| File | Variant |
|---|---|
| `shared/ModelPicker.tsx` | portal + filter (onClose clears filter) |
| `shared/DropdownPicker.tsx` | portal + optional filter |
| `shared/ProviderPicker.tsx` | portal |
| `shared/AgentAdapterPicker.tsx` | portal |
| `chats/ChatAgentControls.tsx` | portal + separate `anchorRef` for positioning |
| `overview/ObservabilityView.tsx` (StatusFilterPicker) | portal |
| `shared/ChipInput.tsx` | inline (`portalSelector: null`) |

### Tradeoff acknowledged

The risk note from the plan: ChipInput's outside-click semantics differ subtly from the portal pickers (`wrap.contains` only, no portal exemption). The hook surfaces the difference as the `portalSelector` knob rather than papering over it.

### Out of scope (deliberately)

The plan optimistically called out the `eslint-disable-next-line react-hooks/exhaustive-deps` at `ObservabilityView.tsx:320,415` as a "free byproduct" of this refactor. They're on effects unrelated to picker state (trace-detail polling at `:311-321`; focusRequest nonce at `:411-416`); the picker migration doesn't change their deps. Leaving them for a separate cleanup so this PR stays scoped to picker boilerplate.

`TranscriptActivityTimeline.tsx:68` is also not migrated — its `open` state drives a native `<details>` element via `onToggle`, not a floating menu, so the hook doesn't apply.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — full suite passes (15 useFloatingMenu tests, including StrictMode `onClose`-once and `closeOn` deps re-bind)
- [x] All existing per-picker tests pass unchanged — they exercise the integrated keyboard + click behaviour through React Testing Library and didn't notice the refactor
- [x] No behavioural change: each picker's outside-click, keyboard nav, and option-selection paths produce the same DOM and state transitions as before