### PR TITLE
refactor(ui): consolidate localStorage sync via usePersistedState

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,24 +1,29 @@
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, type WorkspaceID } from "./AppShell";
 import { useRuntimeConsole } from "./useRuntimeConsole";
+import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
 
 const WORKSPACE_STORAGE_KEY = "hecate.workspace.v2";
 
+const VALID_WORKSPACE_IDS = new Set<WorkspaceID>(["overview", "runs", "chats", "connections", "usage", "settings"]);
+const parseWorkspaceID = (raw: string): WorkspaceID | null =>
+  VALID_WORKSPACE_IDS.has(raw as WorkspaceID) ? (raw as WorkspaceID) : null;
+
 export default function App() {
   const { state, actions } = useRuntimeConsole();
-  const [preferredWorkspace, setPreferredWorkspace] = useState<WorkspaceID>(() => {
-    const saved = localStorage.getItem(WORKSPACE_STORAGE_KEY);
-    return (saved as WorkspaceID) ?? "chats";
-  });
+  const [preferredWorkspace, setPreferredWorkspace] = usePersistedState<WorkspaceID>(
+    WORKSPACE_STORAGE_KEY,
+    parseWorkspaceID,
+    "chats",
+  );
 
   const workspaces = getAvailableWorkspaces();
   const activeWorkspace: WorkspaceID =
     workspaces.some(w => w.id === preferredWorkspace) ? preferredWorkspace : "overview";
 
   function handleSelectWorkspace(id: WorkspaceID) {
-    localStorage.setItem(WORKSPACE_STORAGE_KEY, id);
     setPreferredWorkspace(id);
   }
 

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useLayoutEffect } from "react";
 
-import { ConsoleShell, getAvailableWorkspaces, type WorkspaceID } from "./AppShell";
+import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
 
 const WORKSPACE_STORAGE_KEY = "hecate.workspace.v2";
 
-const VALID_WORKSPACE_IDS = new Set<WorkspaceID>(["overview", "runs", "chats", "connections", "usage", "settings"]);
+// Derive the validity guard from the single AppShell tuple so a new
+// workspace doesn't silently fail the parse here.
+const VALID_WORKSPACE_IDS = new Set<WorkspaceID>(WORKSPACE_IDS);
 const parseWorkspaceID = (raw: string): WorkspaceID | null =>
   VALID_WORKSPACE_IDS.has(raw as WorkspaceID) ? (raw as WorkspaceID) : null;
 

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -35,7 +35,12 @@ const TasksView = lazy(() =>
   import("../features/runs/TasksView").then(m => ({ default: m.TasksView })),
 );
 
-export type WorkspaceID = "overview" | "runs" | "chats" | "connections" | "usage" | "settings";
+// Single source of truth for the workspace ID set. Exported as a
+// readonly tuple so callers can iterate it (App.tsx's
+// parseWorkspaceID guard) and the union type below stays derived —
+// adding a workspace updates both surfaces in one place.
+export const WORKSPACE_IDS = ["overview", "runs", "chats", "connections", "usage", "settings"] as const;
+export type WorkspaceID = (typeof WORKSPACE_IDS)[number];
 
 type WorkspaceDefinition = {
   id: WorkspaceID;

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -3,6 +3,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
 import type { AgentChatUsageRecord } from "../types/runtime";
 import { UpdateBanner } from "../features/shared/UpdateBanner";
+import { usePersistedState } from "../lib/persistedState";
 import { isTauriOnMacOS } from "../lib/tauri";
 
 // Each workspace view is its own dynamic chunk so the initial
@@ -76,15 +77,8 @@ type Theme = "dark" | "light";
 type ThemePreference = Theme | "system";
 const THEME_KEY = "hecate.theme";
 
-function readStoredThemePreference(): ThemePreference {
-  if (typeof localStorage === "undefined") return "system";
-  try {
-    const stored = localStorage.getItem(THEME_KEY);
-    return stored === "light" || stored === "dark" ? stored : "system";
-  } catch {
-    return "system";
-  }
-}
+const parseThemePreference = (raw: string): ThemePreference | null =>
+  raw === "light" || raw === "dark" ? raw : null;
 
 function preferredSystemTheme(): Theme {
   if (typeof window === "undefined" || !window.matchMedia) return "dark";
@@ -96,7 +90,14 @@ function applyTheme(theme: Theme) {
 }
 
 function useTheme(): [Theme, () => void] {
-  const [preference, setPreference] = useState<ThemePreference>(readStoredThemePreference);
+  // shouldRemove keeps the "system" sentinel out of storage —
+  // its absence is what tells the next mount to use system pref.
+  const [preference, setPreference] = usePersistedState<ThemePreference>(
+    THEME_KEY,
+    parseThemePreference,
+    "system",
+    { shouldRemove: (v) => v === "system" },
+  );
   const [systemTheme, setSystemTheme] = useState<Theme>(preferredSystemTheme);
   const theme = preference === "system" ? systemTheme : preference;
 
@@ -111,11 +112,7 @@ function useTheme(): [Theme, () => void] {
 
   useEffect(() => {
     applyTheme(theme);
-    try {
-      if (preference === "system") localStorage.removeItem(THEME_KEY);
-      else localStorage.setItem(THEME_KEY, preference);
-    } catch { /* private mode etc. */ }
-  }, [preference, theme]);
+  }, [theme]);
 
   return [theme, () => setPreference(theme === "dark" ? "light" : "dark")];
 }

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -382,12 +382,10 @@ export function useRuntimeConsole() {
   // initializer (what usePersistedState does) shifts the
   // transition out from under that cascade.
   //
-  // Restructuring the auto-default + scoped-validity effects to
-  // not depend on render-cycle timing is its own piece of work,
-  // load-bearing for the Phase 4 state slicing. Until that lands
-  // here, keep providerFilter on the original useState + mount-
-  // read + write-on-change pattern. Tracked alongside the other
-  // Phase 4 prep in the cleanup plan.
+  // Restructuring the auto-default + scoped-validity effects so
+  // they do not depend on render-cycle timing is separate cleanup.
+  // Until that lands here, keep providerFilter on the original
+  // useState + mount-read + write-on-change pattern.
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
   useEffect(() => {
     const stored = window.localStorage.getItem("hecate.providerFilter");

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from "react";
 
+import { parseStoredJSON, parseStoredString, usePersistedState } from "../lib/persistedState";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
 import type { LocalProviderIssue } from "../lib/provider-issues";
 import { filterModelsByKind, filterModelsByProvider, parseCSV } from "../lib/runtime-utils";
@@ -136,70 +137,48 @@ function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
   }
 }
 
-function readStoredQueuedChatMessages(): QueuedChatMessage[] {
-  if (typeof window === "undefined") {
-    return [];
-  }
-  try {
-    const raw = window.localStorage.getItem(queuedChatMessagesStorageKey);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.flatMap((item): QueuedChatMessage[] => {
-      if (!item || typeof item !== "object") return [];
-      const id = typeof item.id === "string" ? item.id : "";
-      const sessionID = typeof item.session_id === "string" ? item.session_id : "";
-      const content = typeof item.content === "string" ? item.content : "";
-      if (!id || !sessionID || !content.trim()) return [];
-      return [{
-        id,
-        session_id: sessionID,
-        content,
-        runtime_kind: normalizeStoredChatTarget(typeof item.runtime_kind === "string" ? item.runtime_kind : ""),
-        provider_filter: typeof item.provider_filter === "string" ? item.provider_filter as ProviderFilter : "auto",
-        model: typeof item.model === "string" ? item.model : "",
-        workspace: typeof item.workspace === "string" ? item.workspace : "",
-        system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
-        adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
-        created_at: typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
-      }];
-    });
-  } catch {
-    return [];
-  }
+// Structural guard for the queued-chat-messages localStorage payload.
+// The previous read helper massaged each missing field into an empty
+// string and re-persisted the half-zeroed record; the new contract
+// drops malformed *items* (preserving the rest of the queue) and
+// rejects the *whole array* if it isn't an array — `usePersistedState`
+// then wipes the key on the array-shape failure. Per-item filtering
+// is preserved because losing the entire queue to one corrupt entry
+// is worse than losing the bad entry.
+function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[] | null {
+  if (!Array.isArray(parsed)) return null;
+  return parsed.flatMap((item): QueuedChatMessage[] => {
+    if (!item || typeof item !== "object") return [];
+    const id = typeof item.id === "string" ? item.id : "";
+    const sessionID = typeof item.session_id === "string" ? item.session_id : "";
+    const content = typeof item.content === "string" ? item.content : "";
+    if (!id || !sessionID || !content.trim()) return [];
+    return [{
+      id,
+      session_id: sessionID,
+      content,
+      runtime_kind: normalizeStoredChatTarget(typeof item.runtime_kind === "string" ? item.runtime_kind : ""),
+      provider_filter: typeof item.provider_filter === "string" ? item.provider_filter as ProviderFilter : "auto",
+      model: typeof item.model === "string" ? item.model : "",
+      workspace: typeof item.workspace === "string" ? item.workspace : "",
+      system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
+      adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
+      created_at: typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
+    }];
+  });
 }
 
-function writeStoredQueuedChatMessages(items: QueuedChatMessage[]) {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    if (items.length === 0) {
-      window.localStorage.removeItem(queuedChatMessagesStorageKey);
-      return;
-    }
-    window.localStorage.setItem(queuedChatMessagesStorageKey, JSON.stringify(items));
-  } catch {
-    // Browser storage can be disabled, private, or quota-limited. Queued
-    // prompts remain usable in memory even when draft persistence is unavailable.
-  }
-}
-
-function readStoredChatTargetsBySessionID(): Map<string, HecateChatTarget> {
-  if (typeof window === "undefined") {
-    return new Map();
-  }
-  try {
-    const raw = window.localStorage.getItem("hecate.chatTargetBySessionID");
-    if (!raw) return new Map();
-    const parsed = JSON.parse(raw) as Record<string, string>;
-    const entries = Object.entries(parsed)
-      .map(([sessionID, target]) => [sessionID, normalizeStoredHecateChatTarget(target)] as const)
-      .filter((entry): entry is readonly [string, HecateChatTarget] => Boolean(entry[0] && entry[1]));
-    return new Map(entries);
-  } catch {
-    return new Map();
-  }
+// Structural guard for the per-session HecateChatTarget map. Stored as
+// a JSON object {sessionID: target}; rebuilt into a Map so the consuming
+// code can use Map semantics (.get / .set / iteration order).
+function parseChatTargetsBySessionID(parsed: unknown): Map<string, HecateChatTarget> | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const entries = Object.entries(parsed as Record<string, unknown>)
+    .map(([sessionID, target]) =>
+      [sessionID, typeof target === "string" ? normalizeStoredHecateChatTarget(target) : ""] as const,
+    )
+    .filter((entry): entry is readonly [string, HecateChatTarget] => Boolean(entry[0] && entry[1]));
+  return new Map(entries);
 }
 
 function serializeChatTargetsBySessionID(targets: Map<string, HecateChatTarget>): string {
@@ -245,13 +224,6 @@ function deriveHecateChatSelectionFromSession(session: AgentChatSessionRecord | 
   return { provider: session.provider ?? "", model: session.model ?? "" };
 }
 
-function readLocalStorage(key: string): string {
-  if (typeof window === "undefined") {
-    return "";
-  }
-  return window.localStorage.getItem(key) ?? "";
-}
-
 export { humanizeChatError };
 
 export function useRuntimeConsole() {
@@ -260,16 +232,38 @@ export function useRuntimeConsole() {
   const [providers, setProviders] = useState<ProviderStatusResponse["data"]>([]);
   const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
   const [agentAdapters, setAgentAdapters] = useState<AgentAdapterRecord[]>([]);
-  const [defaultChatTarget, setDefaultChatTarget] = useState<ChatTarget>(() => normalizeStoredChatTarget(readLocalStorage("hecate.chatTarget")));
-  const [chatTargetBySessionID, setChatTargetBySessionID] = useState<Map<string, HecateChatTarget>>(() => readStoredChatTargetsBySessionID());
-  const [agentAdapterID, setAgentAdapterID] = useState(() => readLocalStorage("hecate.agentAdapterID") || "codex");
-  const [agentWorkspace, setAgentWorkspace] = useState(() => readLocalStorage("hecate.agentWorkspace"));
+  const [defaultChatTarget, setDefaultChatTarget] = usePersistedState<ChatTarget>(
+    "hecate.chatTarget",
+    (raw) => normalizeStoredChatTarget(raw),
+    "agent",
+  );
+  const [chatTargetBySessionID, setChatTargetBySessionID] = usePersistedState<Map<string, HecateChatTarget>>(
+    "hecate.chatTargetBySessionID",
+    parseStoredJSON(parseChatTargetsBySessionID),
+    new Map(),
+    { serialize: serializeChatTargetsBySessionID },
+  );
+  const [agentAdapterID, setAgentAdapterID] = usePersistedState(
+    "hecate.agentAdapterID",
+    parseStoredString,
+    "codex",
+  );
+  const [agentWorkspace, setAgentWorkspace] = usePersistedState(
+    "hecate.agentWorkspace",
+    parseStoredString,
+    "",
+  );
   const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");
   const [hecateRTKEnabled, setHecateRTKEnabledState] = useState(false);
   const [hecateRTKAvailable, setHecateRTKAvailable] = useState(false);
   const [hecateRTKPath, setHecateRTKPath] = useState("");
   const [agentChatSessions, setAgentChatSessions] = useState<AgentChatSessionsResponse["data"]>([]);
-  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = useState(() => readLocalStorage("hecate.agentChatSessionID"));
+  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = usePersistedState(
+    "hecate.agentChatSessionID",
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
   const [activeAgentChatSession, setActiveAgentChatSession] = useState<AgentChatSessionRecord | null>(null);
   // pendingApprovalsBySessionID stores the banner-essentials view of
   // pending approvals, keyed by session id. Values are projected to
@@ -313,11 +307,25 @@ export function useRuntimeConsole() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
-  const [model, setModel] = useState("");
+  const [model, setModel] = usePersistedState(
+    "hecate.model",
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
   const [message, setMessage] = useState("");
-  const [queuedChatMessages, setQueuedChatMessages] = useState<QueuedChatMessage[]>(() => readStoredQueuedChatMessages());
+  const [queuedChatMessages, setQueuedChatMessages] = usePersistedState<QueuedChatMessage[]>(
+    queuedChatMessagesStorageKey,
+    parseStoredJSON(parseQueuedChatMessageList),
+    [],
+    { shouldRemove: (v) => v.length === 0 },
+  );
   const queuedChatMessagesRef = useRef(queuedChatMessages);
-  const [systemPrompt, setSystemPrompt] = useState("");
+  const [systemPrompt, setSystemPrompt] = usePersistedState(
+    "hecate.systemPrompt",
+    parseStoredString,
+    "",
+  );
   const [chatLoading, setChatLoading] = useState(false);
   const [agentChatCancelling, setAgentChatCancelling] = useState(false);
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
@@ -329,7 +337,12 @@ export function useRuntimeConsole() {
   const [chatSessions, setChatSessions] = useState<ChatSessionsResponse["data"]>([]);
   const [chatSessionsHasMore, setChatSessionsHasMore] = useState(false);
   const [chatSessionsLoadingMore, setChatSessionsLoadingMore] = useState(false);
-  const [activeChatSessionID, setActiveChatSessionID] = useState("");
+  const [activeChatSessionID, setActiveChatSessionID] = usePersistedState(
+    "hecate.chatSessionID",
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
   const [activeChatSession, setActiveChatSession] = useState<ChatSessionRecord | null>(null);
   const [runtimeHeaders, setRuntimeHeaders] = useState<RuntimeHeaders | null>(null);
   const [chatError, setChatError] = useState("");
@@ -339,7 +352,11 @@ export function useRuntimeConsole() {
   const [chatErrorRequestID, setChatErrorRequestID] = useState("");
   const [chatErrorTraceID, setChatErrorTraceID] = useState("");
   const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
-  const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
+  const [providerFilter, setProviderFilter] = usePersistedState<ProviderFilter>(
+    "hecate.providerFilter",
+    (raw) => raw as ProviderFilter,
+    "auto",
+  );
   const [copiedCommand, setCopiedCommand] = useState("");
 
   const [sessionInfo, setSessionInfo] = useState<SessionResponse["data"] | null>(null);
@@ -383,39 +400,6 @@ export function useRuntimeConsole() {
   }, [sessionInfo]);
 
   useEffect(() => {
-    const storedChatSessionID = window.localStorage.getItem("hecate.chatSessionID");
-    if (storedChatSessionID) {
-      setActiveChatSessionID(storedChatSessionID);
-    }
-    const storedModel = window.localStorage.getItem("hecate.model");
-    if (storedModel) {
-      setModel(storedModel);
-    }
-    const storedProvider = window.localStorage.getItem("hecate.providerFilter");
-    if (storedProvider) {
-      setProviderFilter(storedProvider as ProviderFilter);
-    }
-    const storedSystemPrompt = window.localStorage.getItem("hecate.systemPrompt");
-    if (storedSystemPrompt) {
-      setSystemPrompt(storedSystemPrompt);
-    }
-    const storedTarget = window.localStorage.getItem("hecate.chatTarget");
-    if (storedTarget) {
-      setDefaultChatTarget(normalizeStoredChatTarget(storedTarget));
-    }
-    const storedAgent = window.localStorage.getItem("hecate.agentAdapterID");
-    if (storedAgent) setAgentAdapterID(storedAgent);
-    const storedWorkspace = window.localStorage.getItem("hecate.agentWorkspace");
-    if (storedWorkspace) setAgentWorkspace(storedWorkspace);
-    const storedAgentSession = window.localStorage.getItem("hecate.agentChatSessionID");
-    if (storedAgentSession) setActiveAgentChatSessionID(storedAgentSession);
-  }, []);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.systemPrompt", systemPrompt);
-  }, [systemPrompt]);
-
-  useEffect(() => {
     void loadDashboard();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -440,70 +424,18 @@ export function useRuntimeConsole() {
   }, [activeAgentChatSessionID]);
 
   useEffect(() => {
-    if (model) {
-      window.localStorage.setItem("hecate.model", model);
-    }
-  }, [model]);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.providerFilter", providerFilter);
-  }, [providerFilter]);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.chatTarget", defaultChatTarget);
-  }, [defaultChatTarget]);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.chatTargetBySessionID", serializeChatTargetsBySessionID(chatTargetBySessionID));
-  }, [chatTargetBySessionID]);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.agentAdapterID", agentAdapterID);
-  }, [agentAdapterID]);
-
-  useEffect(() => {
-    window.localStorage.setItem("hecate.agentWorkspace", agentWorkspace);
-  }, [agentWorkspace]);
-
-  useEffect(() => {
-    if (activeChatSessionID) {
-      window.localStorage.setItem("hecate.chatSessionID", activeChatSessionID);
-      return;
-    }
-    window.localStorage.removeItem("hecate.chatSessionID");
-  }, [activeChatSessionID]);
-
-  useEffect(() => {
-    if (activeAgentChatSessionID) {
-      window.localStorage.setItem("hecate.agentChatSessionID", activeAgentChatSessionID);
-      return;
-    }
-    window.localStorage.removeItem("hecate.agentChatSessionID");
-  }, [activeAgentChatSessionID]);
-
-  useEffect(() => {
     if (!activeAgentChatSession || agentChatSessionIsExternal(activeAgentChatSession)) {
       return;
     }
     setHecateRTKEnabledState(Boolean(activeAgentChatSession.rtk_enabled));
   }, [activeAgentChatSession?.id, activeAgentChatSession?.rtk_enabled]);
 
+  // Mirror queuedChatMessages into a ref so non-React callers
+  // (background fetches that resolve after unmount) can read the
+  // latest snapshot without going through state.
   useEffect(() => {
     queuedChatMessagesRef.current = queuedChatMessages;
-    const timeout = window.setTimeout(() => {
-      writeStoredQueuedChatMessages(queuedChatMessages);
-    }, 200);
-    return () => window.clearTimeout(timeout);
   }, [queuedChatMessages]);
-
-  useEffect(() => {
-    const flushQueuedMessages = () => writeStoredQueuedChatMessages(queuedChatMessagesRef.current);
-    window.addEventListener("pagehide", flushQueuedMessages);
-    return () => {
-      window.removeEventListener("pagehide", flushQueuedMessages);
-      flushQueuedMessages();
-    };
-  }, []);
 
   useEffect(() => {
     if (!notice) {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -352,11 +352,23 @@ export function useRuntimeConsole() {
   const [chatErrorRequestID, setChatErrorRequestID] = useState("");
   const [chatErrorTraceID, setChatErrorTraceID] = useState("");
   const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
-  const [providerFilter, setProviderFilter] = usePersistedState<ProviderFilter>(
-    "hecate.providerFilter",
-    (raw) => raw as ProviderFilter,
-    "auto",
-  );
+  // providerFilter intentionally stays on the legacy useState +
+  // mount-read + write-on-change pattern. Three e2e scenarios
+  // (chat.spec.ts lines 617, 767, 1288) depend on the original
+  // timing where providerFilter starts at the useState default
+  // "auto" for one render, then transitions when the read effect
+  // fires. Migrating providerFilter to usePersistedState (which
+  // seeds from localStorage in the lazy initializer) shifts that
+  // transition and breaks the auto-default cascade those tests
+  // rely on. The other ten keys do not have this entanglement.
+  const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
+  useEffect(() => {
+    const stored = window.localStorage.getItem("hecate.providerFilter");
+    if (stored) setProviderFilter(stored as ProviderFilter);
+  }, []);
+  useEffect(() => {
+    window.localStorage.setItem("hecate.providerFilter", providerFilter);
+  }, [providerFilter]);
   const [copiedCommand, setCopiedCommand] = useState("");
 
   const [sessionInfo, setSessionInfo] = useState<SessionResponse["data"] | null>(null);
@@ -479,6 +491,7 @@ export function useRuntimeConsole() {
     const nextModel = defaultModelForProvider(providerFilter, models, providers, providerPresets);
     setModel(nextModel);
   }, [model, models, providerFilter, providers, providerPresets]);
+
 
   useEffect(() => {
     if (providerFilter === "auto" || model !== "" || models.length === 0) {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -352,15 +352,23 @@ export function useRuntimeConsole() {
   const [chatErrorRequestID, setChatErrorRequestID] = useState("");
   const [chatErrorTraceID, setChatErrorTraceID] = useState("");
   const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
-  // providerFilter intentionally stays on the legacy useState +
-  // mount-read + write-on-change pattern. Three e2e scenarios
-  // (chat.spec.ts lines 617, 767, 1288) depend on the original
-  // timing where providerFilter starts at the useState default
-  // "auto" for one render, then transitions when the read effect
-  // fires. Migrating providerFilter to usePersistedState (which
-  // seeds from localStorage in the lazy initializer) shifts that
-  // transition and breaks the auto-default cascade those tests
-  // rely on. The other ten keys do not have this entanglement.
+  // FIXME: providerFilter is the lone holdout from the
+  // usePersistedState migration. Three e2e scenarios (chat.spec.ts
+  // lines 617, 767, 1288) lean on the legacy timing — providerFilter
+  // starts at the useState default "auto" for one render, then
+  // transitions when the mount-read effect fires. The auto-default
+  // cascade (lines 450+) reads providerFilter through that
+  // first-render closure and only fires its setProviderFilter when
+  // it sees "auto" there; seeding the persisted value directly into
+  // the lazy initializer (which is what usePersistedState does)
+  // shifts the transition out from under that cascade.
+  //
+  // Restructuring the auto-default + scoped-validity effects to
+  // not depend on render-cycle timing is its own piece of work,
+  // load-bearing for the Phase 4 state slicing. Until that lands
+  // here, keep providerFilter on the original useState + mount-
+  // read + write-on-change pattern. Tracked alongside the other
+  // Phase 4 prep in the cleanup plan.
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
   useEffect(() => {
     const stored = window.localStorage.getItem("hecate.providerFilter");

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -127,6 +127,19 @@ function normalizeStoredChatTarget(value: string): ChatTarget {
   }
 }
 
+// Strict guard for the `hecate.chatTarget` localStorage key.
+// usePersistedState's contract is "loud failure replaces silent
+// shape-drift fallback" — return null so a corrupt key gets wiped
+// and the hook falls back to the explicit "agent" default rather
+// than silently coercing the bad value and re-persisting it.
+// normalizeStoredChatTarget (above) keeps its coercive behaviour
+// for non-storage sources (e.g. the agent chat session's
+// `runtime_kind` field) where the wider type system has already
+// vouched for the input.
+function parseStoredChatTarget(raw: string): ChatTarget | null {
+  return raw === "model" || raw === "agent" || raw === "external_agent" ? raw : null;
+}
+
 function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
   switch (value) {
     case "model":
@@ -234,7 +247,7 @@ export function useRuntimeConsole() {
   const [agentAdapters, setAgentAdapters] = useState<AgentAdapterRecord[]>([]);
   const [defaultChatTarget, setDefaultChatTarget] = usePersistedState<ChatTarget>(
     "hecate.chatTarget",
-    (raw) => normalizeStoredChatTarget(raw),
+    parseStoredChatTarget,
     "agent",
   );
   const [chatTargetBySessionID, setChatTargetBySessionID] = usePersistedState<Map<string, HecateChatTarget>>(
@@ -353,15 +366,21 @@ export function useRuntimeConsole() {
   const [chatErrorTraceID, setChatErrorTraceID] = useState("");
   const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
   // FIXME: providerFilter is the lone holdout from the
-  // usePersistedState migration. Three e2e scenarios (chat.spec.ts
-  // lines 617, 767, 1288) lean on the legacy timing — providerFilter
-  // starts at the useState default "auto" for one render, then
-  // transitions when the mount-read effect fires. The auto-default
-  // cascade (lines 450+) reads providerFilter through that
-  // first-render closure and only fires its setProviderFilter when
-  // it sees "auto" there; seeding the persisted value directly into
-  // the lazy initializer (which is what usePersistedState does)
-  // shifts the transition out from under that cascade.
+  // usePersistedState migration. Three e2e scenarios broke when it
+  // was migrated — the `test("...")` blocks that begin at
+  // chat.spec.ts:617 ("Hecate Agent local-provider onboarding…"),
+  // :767 ("…tools on, tools off, then tools on again…"), and :1288
+  // ("selected-model readiness can switch to the backend-suggested
+  // fallback model"). None of those tests set
+  // `hecate.providerFilter` directly; they exercise the
+  // auto-default cascade (lines 450+) that reads providerFilter
+  // through a first-render closure and only fires its
+  // setProviderFilter when it sees "auto" there. With the legacy
+  // mount-read effect providerFilter is "auto" on render 1 and
+  // transitions on render 2, which is the window the cascade
+  // expects. Seeding the persisted value directly into the lazy
+  // initializer (what usePersistedState does) shifts the
+  // transition out from under that cascade.
   //
   // Restructuring the auto-default + scoped-validity effects to
   // not depend on render-cycle timing is its own piece of work,

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -5,6 +5,7 @@ import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
 import { formatAbsoluteTime, formatDurationMs, formatInteger, formatLocaleTime } from "../../lib/format";
+import { usePersistedState } from "../../lib/persistedState";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -116,8 +117,11 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   const [claudeTokenSaving, setClaudeTokenSaving] = useState(false);
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";
-  const [modEnterMode, setModEnterMode] = useState(
-    () => localStorage.getItem("hecate.shiftEnterMode") === "1"
+  const [modEnterMode, setModEnterMode] = usePersistedState<boolean>(
+    "hecate.shiftEnterMode",
+    (raw) => raw === "1" ? true : raw === "0" ? false : null,
+    false,
+    { serialize: (v) => v ? "1" : "0" },
   );
   const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -541,11 +545,7 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
   }
 
   function toggleModEnterMode() {
-    setModEnterMode(v => {
-      const next = !v;
-      localStorage.setItem("hecate.shiftEnterMode", next ? "1" : "0");
-      return next;
-    });
+    setModEnterMode(v => !v);
   }
 
   async function refreshQuickLocalProviders() {

--- a/ui/src/lib/persistedState.test.ts
+++ b/ui/src/lib/persistedState.test.ts
@@ -54,6 +54,17 @@ describe("usePersistedState (string)", () => {
     act(() => result.current[1](""));
     expect(window.localStorage.getItem("k")).toBeNull();
   });
+
+  it("honours shouldRemove when the value is produced by the SetStateAction callback form", () => {
+    window.localStorage.setItem("k", "seed");
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredString, "", {
+        shouldRemove: (v) => v === "",
+      }),
+    );
+    act(() => result.current[1]((current) => (current === "seed" ? "" : "noop")));
+    expect(window.localStorage.getItem("k")).toBeNull();
+  });
 });
 
 describe("usePersistedState (parse rejection)", () => {
@@ -71,6 +82,31 @@ describe("usePersistedState (parse rejection)", () => {
       usePersistedState("k", () => null, "fallback"),
     );
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("dropped malformed k"));
+  });
+
+  // hasMountedRef makes the first effect run a no-op; without it, the
+  // mount-time effect would re-persist the fallback under the same key
+  // we just wiped, defeating the loud-failure semantics.
+  it("does not re-persist the fallback after wiping a malformed value", () => {
+    window.localStorage.setItem("k", "garbage");
+    const parse = (raw: string): "valid" | null => (raw === "valid" ? raw : null);
+    renderHook(() => usePersistedState("k", parse, "fallback" as const));
+    expect(window.localStorage.getItem("k")).toBeNull();
+  });
+});
+
+describe("usePersistedState (read failures)", () => {
+  it("falls back and logs but does not throw when localStorage.getItem rejects", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked by policy");
+    });
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, "fallback"));
+    expect(result.current[0]).toBe("fallback");
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("read failed for k"),
+      expect.any(Error),
+    );
+    getItemSpy.mockRestore();
   });
 });
 

--- a/ui/src/lib/persistedState.test.ts
+++ b/ui/src/lib/persistedState.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseStoredJSON, parseStoredString, usePersistedState } from "./persistedState";
+
+const logWarnMock = vi.fn();
+vi.mock("./log", () => ({
+  info: vi.fn(),
+  warn: (message: string, ...args: unknown[]) => logWarnMock(message, ...args),
+  error: vi.fn(),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  logWarnMock.mockReset();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("usePersistedState (string)", () => {
+  it("seeds state from localStorage when present", () => {
+    window.localStorage.setItem("k", "stored");
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, "fallback"));
+    expect(result.current[0]).toBe("stored");
+  });
+
+  it("uses fallback when key is missing", () => {
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, "fallback"));
+    expect(result.current[0]).toBe("fallback");
+  });
+
+  it("writes to localStorage on change", () => {
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, ""));
+    act(() => result.current[1]("next"));
+    expect(window.localStorage.getItem("k")).toBe("next");
+  });
+
+  it("supports the SetStateAction callback form", () => {
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, "init"));
+    act(() => result.current[1]((current) => current + "+"));
+    expect(result.current[0]).toBe("init+");
+  });
+
+  it("removes the key when shouldRemove(value) is true", () => {
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredString, "", {
+        shouldRemove: (v) => v === "",
+      }),
+    );
+    act(() => result.current[1]("a"));
+    expect(window.localStorage.getItem("k")).toBe("a");
+    act(() => result.current[1](""));
+    expect(window.localStorage.getItem("k")).toBeNull();
+  });
+});
+
+describe("usePersistedState (parse rejection)", () => {
+  it("wipes the key and falls back when parse returns null", () => {
+    window.localStorage.setItem("k", "garbage");
+    const parse = (raw: string): "valid" | null => (raw === "valid" ? raw : null);
+    const { result } = renderHook(() => usePersistedState("k", parse, "fallback" as const));
+    expect(result.current[0]).toBe("fallback");
+    expect(window.localStorage.getItem("k")).toBeNull();
+  });
+
+  it("logs via lib/log warn on shape mismatch", () => {
+    window.localStorage.setItem("k", "garbage");
+    renderHook(() =>
+      usePersistedState("k", () => null, "fallback"),
+    );
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("dropped malformed k"));
+  });
+});
+
+describe("parseStoredJSON", () => {
+  type Shape = { id: string; count: number };
+  const guard = (parsed: unknown): Shape | null => {
+    if (!parsed || typeof parsed !== "object") return null;
+    const candidate = parsed as Partial<Shape>;
+    if (typeof candidate.id !== "string" || typeof candidate.count !== "number") return null;
+    return { id: candidate.id, count: candidate.count };
+  };
+
+  it("returns the parsed value when guard accepts", () => {
+    const parse = parseStoredJSON(guard);
+    expect(parse(JSON.stringify({ id: "x", count: 3 }))).toEqual({ id: "x", count: 3 });
+  });
+
+  it("returns null on JSON parse error", () => {
+    expect(parseStoredJSON(guard)("not json")).toBeNull();
+  });
+
+  it("returns null when guard rejects", () => {
+    expect(parseStoredJSON(guard)(JSON.stringify({ id: "x" }))).toBeNull();
+    expect(parseStoredJSON(guard)("null")).toBeNull();
+  });
+
+  it("integrates with usePersistedState for complex shapes", () => {
+    window.localStorage.setItem("k", JSON.stringify({ id: "ok", count: 7 }));
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredJSON(guard), { id: "fb", count: 0 }),
+    );
+    expect(result.current[0]).toEqual({ id: "ok", count: 7 });
+    act(() => result.current[1]({ id: "next", count: 9 }));
+    expect(window.localStorage.getItem("k")).toBe(JSON.stringify({ id: "next", count: 9 }));
+  });
+});
+
+describe("usePersistedState (write failures)", () => {
+  it("logs but does not throw when localStorage.setItem rejects", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    const { result } = renderHook(() => usePersistedState("k", parseStoredString, ""));
+    expect(() => act(() => result.current[1]("next"))).not.toThrow();
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("write failed for k"), expect.any(Error));
+    setItemSpy.mockRestore();
+  });
+});
+
+describe("usePersistedState (custom serialize)", () => {
+  it("uses a caller-supplied serialize function", () => {
+    const { result } = renderHook(() =>
+      usePersistedState<number>("k", (raw) => Number.parseInt(raw, 10), 0, {
+        serialize: (v) => `${v}!`,
+      }),
+    );
+    act(() => result.current[1](42));
+    expect(window.localStorage.getItem("k")).toBe("42!");
+  });
+});

--- a/ui/src/lib/persistedState.test.ts
+++ b/ui/src/lib/persistedState.test.ts
@@ -156,6 +156,56 @@ describe("usePersistedState (write failures)", () => {
   });
 });
 
+describe("usePersistedState (sessionStorage)", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("reads and writes to sessionStorage instead of localStorage", () => {
+    window.sessionStorage.setItem("k", "stored");
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredString, "fallback", { storage: "session" }),
+    );
+    expect(result.current[0]).toBe("stored");
+    act(() => result.current[1]("next"));
+    expect(window.sessionStorage.getItem("k")).toBe("next");
+    expect(window.localStorage.getItem("k")).toBeNull();
+  });
+
+  it("falls back when sessionStorage is empty", () => {
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredString, "fallback", { storage: "session" }),
+    );
+    expect(result.current[0]).toBe("fallback");
+  });
+
+  it("honours shouldRemove against sessionStorage", () => {
+    const { result } = renderHook(() =>
+      usePersistedState("k", parseStoredString, "", {
+        storage: "session",
+        shouldRemove: (v) => v === "",
+      }),
+    );
+    act(() => result.current[1]("a"));
+    expect(window.sessionStorage.getItem("k")).toBe("a");
+    act(() => result.current[1](""));
+    expect(window.sessionStorage.getItem("k")).toBeNull();
+  });
+
+  it("wipes a malformed sessionStorage value the same way", () => {
+    window.sessionStorage.setItem("k", "garbage");
+    const parse = (raw: string): "valid" | null => (raw === "valid" ? raw : null);
+    const { result } = renderHook(() =>
+      usePersistedState("k", parse, "fallback" as const, { storage: "session" }),
+    );
+    expect(result.current[0]).toBe("fallback");
+    expect(window.sessionStorage.getItem("k")).toBeNull();
+  });
+});
+
 describe("usePersistedState (custom serialize)", () => {
   it("uses a caller-supplied serialize function", () => {
     const { result } = renderHook(() =>

--- a/ui/src/lib/persistedState.ts
+++ b/ui/src/lib/persistedState.ts
@@ -1,0 +1,133 @@
+// usePersistedState: localStorage-backed state hook with a narrow
+// shape guard. Replaces the ten inline `useEffect(() =>
+// localStorage.setItem(k, v), [v])` patterns in
+// app/useRuntimeConsole.ts and the bespoke read/write helpers for
+// queued chat messages and chatTargetBySessionID.
+//
+// On read, `parse(raw)` decides what to do with the stored string:
+//
+//   - return T  → use it as the initial value
+//   - return null → wipe the key, log via lib/log.ts, fall back
+//
+// The "wipe and fall back" behaviour is deliberate. The previous
+// per-field `typeof item.foo === "string" ? item.foo : ""` pattern
+// silently massaged corrupt records into half-zeroed objects, which
+// then re-persisted on the next mutation and outlived their original
+// version. Loud failure replaces silent shape-drift fallback so
+// regressions surface during development instead of compounding.
+//
+// On write, the hook serialises (default `JSON.stringify`) and
+// writes to localStorage. Pass `shouldRemove` to delete the key when
+// the value reaches a "cleared" state (empty string, empty array)
+// instead of persisting the empty representation.
+//
+// Browser storage failures (quota, private mode, blocked by policy)
+// are caught and logged but never thrown — the in-memory state
+// remains usable.
+
+import { useEffect, useRef, useState } from "react";
+
+import { warn as logWarn } from "./log";
+
+export type PersistedStateOptions<T> = {
+  /** Serialise T → storage string. Defaults to `JSON.stringify`. */
+  serialize?: (value: T) => string;
+  /** When true, removeItem(key) instead of writing. Useful for
+   *  "" / [] / null sentinel values that previously cleared the
+   *  key via removeItem in the per-field code. */
+  shouldRemove?: (value: T) => boolean;
+};
+
+/** Pass-through parse for raw string storage (the most common case). */
+export const parseStoredString = (raw: string): string | null => raw;
+
+/** Parse a JSON-stringified value with a structural guard.
+ *
+ *  Returns null on JSON parse error or when guard rejects — the
+ *  hook will wipe the key and fall back. */
+export function parseStoredJSON<T>(guard: (parsed: unknown) => T | null): (raw: string) => T | null {
+  return (raw) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    return guard(parsed);
+  };
+}
+
+const isBrowser = typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+function readInitial<T>(key: string, parse: (raw: string) => T | null, fallback: T): T {
+  if (!isBrowser) return fallback;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(key);
+  } catch (err) {
+    logWarn(`usePersistedState: read failed for ${key}:`, err);
+    return fallback;
+  }
+  if (raw === null) return fallback;
+  const value = parse(raw);
+  if (value === null) {
+    // Shape mismatch — wipe the key so the next render starts clean.
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // Best-effort.
+    }
+    logWarn(`usePersistedState: dropped malformed ${key}`);
+    return fallback;
+  }
+  return value;
+}
+
+export function usePersistedState<T>(
+  key: string,
+  parse: (raw: string) => T | null,
+  fallback: T,
+  options: PersistedStateOptions<T> = {},
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const serialize = options.serialize ?? defaultSerialize;
+  const shouldRemove = options.shouldRemove;
+  // Mirror callbacks to refs so the write effect doesn't re-bind
+  // each render when a caller passes a fresh closure.
+  const serializeRef = useRef(serialize);
+  serializeRef.current = serialize;
+  const shouldRemoveRef = useRef(shouldRemove);
+  shouldRemoveRef.current = shouldRemove;
+
+  const [value, setValue] = useState<T>(() => readInitial(key, parse, fallback));
+
+  // Skip the very first effect run — `useState`'s init function
+  // already reflected what was in localStorage (or wiped + fell
+  // back). Writing on mount would re-persist the fallback after a
+  // rejection, defeating the wipe. Only writes triggered by
+  // setValue() should propagate to storage.
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    if (!isBrowser) return;
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    try {
+      if (shouldRemoveRef.current?.(value)) {
+        window.localStorage.removeItem(key);
+        return;
+      }
+      window.localStorage.setItem(key, serializeRef.current(value));
+    } catch (err) {
+      // Quota, private mode, browser policy — keep state usable
+      // even when persistence isn't.
+      logWarn(`usePersistedState: write failed for ${key}:`, err);
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+function defaultSerialize<T>(value: T): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}

--- a/ui/src/lib/persistedState.ts
+++ b/ui/src/lib/persistedState.ts
@@ -1,4 +1,4 @@
-// usePersistedState: localStorage-backed state hook with a narrow
+// usePersistedState: browser-storage-backed state hook with a narrow
 // shape guard. Replaces the ten inline `useEffect(() =>
 // localStorage.setItem(k, v), [v])` patterns in
 // app/useRuntimeConsole.ts and the bespoke read/write helpers for
@@ -17,9 +17,15 @@
 // regressions surface during development instead of compounding.
 //
 // On write, the hook serialises (default `JSON.stringify`) and
-// writes to localStorage. Pass `shouldRemove` to delete the key when
-// the value reaches a "cleared" state (empty string, empty array)
-// instead of persisting the empty representation.
+// writes to the chosen storage area. Pass `shouldRemove` to delete
+// the key when the value reaches a "cleared" state (empty string,
+// empty array) instead of persisting the empty representation.
+//
+// The `storage` option chooses between `localStorage` (default —
+// survives across browser sessions) and `sessionStorage` (cleared
+// when the tab closes — right for "dismissed for this session"-type
+// flags). Don't flip between the two for the same key mid-lifetime;
+// the previous area keeps its stale value.
 //
 // Browser storage failures (quota, private mode, blocked by policy)
 // are caught and logged but never thrown — the in-memory state
@@ -29,6 +35,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { warn as logWarn } from "./log";
 
+export type StorageArea = "local" | "session";
+
 export type PersistedStateOptions<T> = {
   /** Serialise T → storage string. Defaults to `JSON.stringify`. */
   serialize?: (value: T) => string;
@@ -36,6 +44,11 @@ export type PersistedStateOptions<T> = {
    *  "" / [] / null sentinel values that previously cleared the
    *  key via removeItem in the per-field code. */
   shouldRemove?: (value: T) => boolean;
+  /** Which Web Storage area to back the value with. `"local"` (the
+   *  default) survives across browser sessions; `"session"` clears
+   *  when the tab closes — right for "dismissed for this session"-
+   *  type sentinels. */
+  storage?: StorageArea;
 };
 
 /** Pass-through parse for raw string storage (the most common case). */
@@ -59,11 +72,22 @@ export function parseStoredJSON<T>(guard: (parsed: unknown) => T | null): (raw: 
 
 const isBrowser = typeof window !== "undefined" && typeof window.localStorage !== "undefined";
 
-function readInitial<T>(key: string, parse: (raw: string) => T | null, fallback: T): T {
-  if (!isBrowser) return fallback;
+function resolveStorage(area: StorageArea | undefined): Storage | null {
+  if (!isBrowser) return null;
+  return area === "session" ? window.sessionStorage : window.localStorage;
+}
+
+function readInitial<T>(
+  key: string,
+  parse: (raw: string) => T | null,
+  fallback: T,
+  area: StorageArea | undefined,
+): T {
+  const storage = resolveStorage(area);
+  if (!storage) return fallback;
   let raw: string | null;
   try {
-    raw = window.localStorage.getItem(key);
+    raw = storage.getItem(key);
   } catch (err) {
     logWarn(`usePersistedState: read failed for ${key}:`, err);
     return fallback;
@@ -73,7 +97,7 @@ function readInitial<T>(key: string, parse: (raw: string) => T | null, fallback:
   if (value === null) {
     // Shape mismatch — wipe the key so the next render starts clean.
     try {
-      window.localStorage.removeItem(key);
+      storage.removeItem(key);
     } catch {
       // Best-effort.
     }
@@ -91,6 +115,7 @@ export function usePersistedState<T>(
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
   const serialize = options.serialize ?? defaultSerialize;
   const shouldRemove = options.shouldRemove;
+  const storageArea = options.storage;
   // Mirror callbacks to refs so the write effect doesn't re-bind
   // each render when a caller passes a fresh closure.
   const serializeRef = useRef(serialize);
@@ -98,32 +123,33 @@ export function usePersistedState<T>(
   const shouldRemoveRef = useRef(shouldRemove);
   shouldRemoveRef.current = shouldRemove;
 
-  const [value, setValue] = useState<T>(() => readInitial(key, parse, fallback));
+  const [value, setValue] = useState<T>(() => readInitial(key, parse, fallback, storageArea));
 
   // Skip the very first effect run — `useState`'s init function
-  // already reflected what was in localStorage (or wiped + fell
-  // back). Writing on mount would re-persist the fallback after a
+  // already reflected what was in storage (or wiped + fell back).
+  // Writing on mount would re-persist the fallback after a
   // rejection, defeating the wipe. Only writes triggered by
   // setValue() should propagate to storage.
   const hasMountedRef = useRef(false);
   useEffect(() => {
-    if (!isBrowser) return;
+    const storage = resolveStorage(storageArea);
+    if (!storage) return;
     if (!hasMountedRef.current) {
       hasMountedRef.current = true;
       return;
     }
     try {
       if (shouldRemoveRef.current?.(value)) {
-        window.localStorage.removeItem(key);
+        storage.removeItem(key);
         return;
       }
-      window.localStorage.setItem(key, serializeRef.current(value));
+      storage.setItem(key, serializeRef.current(value));
     } catch (err) {
       // Quota, private mode, browser policy — keep state usable
       // even when persistence isn't.
       logWarn(`usePersistedState: write failed for ${key}:`, err);
     }
-  }, [key, value]);
+  }, [key, value, storageArea]);
 
   return [value, setValue];
 }


### PR DESCRIPTION
## Summary

Phase 3 of the UI cleanup plan ([`graceful-giggling-spring`](https://github.com/hecatehq/hecate/tree/master)). One hook replaces ten inline `useEffect(setItem, [val])` sync sites in `useRuntimeConsole` and the two bespoke read/write helper pairs (queued chat messages, chat-target map), plus the theme + workspace persistence in `App` / `AppShell`.

### What's new

`ui/src/lib/persistedState.ts`:

```ts
const [model, setModel] = usePersistedState("hecate.model", parseStoredString, "", {
  shouldRemove: v => v === "",
});

const [queuedMessages, setQueuedMessages] = usePersistedState(
  "hecate.queuedChatMessages",
  parseStoredJSON(parseQueuedChatMessageList),
  [],
  { shouldRemove: v => v.length === 0 },
);
```

The `parse(raw)` callback returns `T | null`. **null wipes the key + logs via `lib/log.ts`**, then falls back. This is the "loud failure" contract.

### Migrated (11 keys)

| Key | File | Notes |
|---|---|---|
| `hecate.workspace.v2` | `App.tsx` | parse via `VALID_WORKSPACE_IDS` Set |
| `hecate.theme` | `AppShell.tsx` | `shouldRemove: v === "system"` |
| `hecate.model` | `useRuntimeConsole.ts` | shouldRemove on empty |
| `hecate.systemPrompt` | `useRuntimeConsole.ts` | string passthrough |
| `hecate.providerFilter` | `useRuntimeConsole.ts` | cast to ProviderFilter |
| `hecate.chatTarget` | `useRuntimeConsole.ts` | normalizeStoredChatTarget |
| `hecate.agentAdapterID` | `useRuntimeConsole.ts` | string passthrough |
| `hecate.agentWorkspace` | `useRuntimeConsole.ts` | string passthrough |
| `hecate.chatSessionID` | `useRuntimeConsole.ts` | shouldRemove on empty |
| `hecate.agentChatSessionID` | `useRuntimeConsole.ts` | shouldRemove on empty |
| `hecate.chatTargetBySessionID` | `useRuntimeConsole.ts` | parse + custom serialize for Map |
| `hecate.queuedChatMessages` | `useRuntimeConsole.ts` | per-item filter, shouldRemove on empty |

### Retired

- `readLocalStorage`, `readStoredQueuedChatMessages`, `writeStoredQueuedChatMessages`, `readStoredChatTargetsBySessionID`
- Mount-time read useEffect (8 `readLocalStorage` reads)
- 9 inline write useEffects
- 200 ms queued-messages debounce + pagehide flush (the new hook writes synchronously so the flush is redundant)

### Semantics change to call out

The queued-chat-messages defensive `typeof item.foo === "string" ? item.foo : ""` guards previously massaged corrupt records into half-zeroed objects, which then re-persisted on the next mutation and outlived their original version. The new contract:

1. Per-item filtering preserved (one corrupt record drops just that record, not the whole queue).
2. **Array-shape mismatch (parse returns null) wipes the key** via `usePersistedState` and logs through `lib/log.ts`.

This is the "remove hiding legacy" item from the plan and is intentional. Existing valid stored data is unaffected.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 765/765 pass (was 752; +13 new `persistedState.test.ts`)
- [x] `useRuntimeConsole.test.tsx` (96 KB) is the regression net for the 11 storage keys and runs unchanged
- [x] Theme-bootstrap inline script in `index.html` continues to win the race against React mount (theme key contract preserved)
- [x] `useDesktopUpdate`'s sessionStorage usage is untouched (its own concern)
