### PR TITLE
docs(refactoring,release): legacy-comment rule + post-release master sync note

### DIFF
--- a/docs-ai/tasks/refactoring.md
+++ b/docs-ai/tasks/refactoring.md
@@ -20,6 +20,15 @@ For non-trivial refactors:
 
 This makes every intermediate state shippable and every step independently revertible.
 
+## "Preserve existing behavior" comments need a tracker or a fix
+
+Comments like "preserves the existing layout", "kept on the legacy pattern", or "for backwards-compatibility" mark code as load-bearing debt — without a `TODO:` / `FIXME:` pointer, future readers can't tell intentional debt from accepted style, and the legacy state becomes invisible. Two options when you find yourself writing one:
+
+1. **Fix it in the same PR.** Migrate callers, delete the shim, drop the comment.
+2. **Tag it.** `TODO:` for a planned migration (with the condition that unblocks it — design sign-off, follow-up PR, dependency landing). `FIXME:` for a known bug whose proper fix is too large to bundle (with a pointer to the load-bearing change that retires it).
+
+A bare "preserves existing X" comment without one of the two is the worst of both worlds: the legacy is tolerated but invisible. Reviewer push-back: if the comment doesn't tell future-you when the legacy goes away, it doesn't belong yet.
+
 ## Verify no regressions
 
 Run the relevant verification ladder ([`../core/verification.md`](../core/verification.md)) **before** and **after** the refactor. Diff the results. For backend: race suite. For UI: typecheck plus test. The "passes before, passes after" claim is only as good as the evidence.

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -58,6 +58,8 @@ End state of a successful tag: the GitHub Release page has goreleaser tarballs +
 
 `just release` / `bun scripts/release.ts` handles the stamp automatically: after confirmation it calls `scripts/stamp-version.ts` with `TAURI_VERSION=<semver>`, commits the changed files (`Cargo.toml`, `package.json`, `tauri.conf.json`), then creates the annotated tag on that commit. CI re-runs the stamp from the tag name as a belt-and-suspenders measure (`stamp-version.ts` is idempotent).
 
+**The stamp commit lives only on the tag, not on master.** The script pushes the tag, not the branch. Meanwhile the release CI's `publish updater manifest` + `docs: update release references` jobs push their own commits to `master` on top of the pre-tag commit. So local `master` is left ahead of `origin/master` (carrying the orphan stamp commit) and behind it (missing the CI's post-tag commits). Run `git pull --ff-only origin master` once CI completes — it'll fast-forward over the orphan onto `origin/master`. Otherwise any branch cut from local master will inherit the orphan stamp and show a phantom version bump in its diff.
+
 The Tauri matrix doesn't need any local action — pushing the tag fires the workflow.
 
 ### Pre-tag validation


### PR DESCRIPTION
## Summary

Two small additions to `docs-ai/tasks/`:

1. **`refactoring.md`** — adds a rule: comments like "preserves the existing layout" or "kept on the legacy pattern" need either a `TODO:`/`FIXME:` tracker (with the condition that unblocks the migration) or the fix in the same PR. A bare legacy-preserve comment without one of those rots — future readers can't tell intentional debt from accepted style.

2. **`release.md`** — documents the post-release `git pull --ff-only origin master` step. The release script pushes the tag, not master; the release CI then adds its own post-tag commits (`publish updater manifest`, `docs: update release references`). Local master is left both ahead (orphan stamp commit) and behind (missing CI commits), and any branch cut from it inherits the orphan and shows a phantom version bump.

### Why

Both rules came out of the alpha.31 → PR #110/#112/#113 sequence:

- **Refactoring rule**: three "preserve existing layout"/"stays on the legacy pattern" comments slipped through PR #110/#112 reviews and had to be tagged retroactively. The rule prevents that class.
- **Release note**: PR #113 itself initially showed a phantom version bump because my local master was carrying the orphan stamp commit when I branched off it.

### Placement

Both live under `docs-ai/tasks/` (the conventions tier) rather than `AGENTS.md`, which `CLAUDE.md` scopes to map + recipes only.

## Test plan

- [x] Doc-only changes; no code touched.
- [x] `refactoring.md`: slots between "Reduce risk by sequencing" and "Verify no regressions".
- [x] `release.md`: lives under "Version stamping" right after the "CI re-runs the stamp from the tag name" sentence so the side effect on local master is co-located with the explanation of why the stamp commit only lives on the tag.
