### PR TITLE
ci(tauri): [skip desktop] PR-title opt-out for the desktop bundle matrix [skip desktop]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       typescript: ${{ steps.filter.outputs.typescript }}
       tauri: ${{ steps.filter.outputs.tauri }}
       desktop: ${{ steps.filter.outputs.desktop }}
+      desktop_force: ${{ steps.filter.outputs.desktop_force }}
       workflow: ${{ steps.filter.outputs.workflow }}
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -90,6 +91,30 @@ jobs:
               - 'cmd/hecate/**'
               - 'cmd/hecate-acp/**'
               - 'ui/**'
+              - 'embed.go'
+              - '.goreleaser.yaml'
+              - 'Dockerfile.release'
+              - '.github/workflows/_tauri-shared.yml'
+              - '.github/workflows/tauri-build.yml'
+              - '.github/workflows/release.yml'
+            # `desktop_force` is the subset of `desktop` that the
+            # author-side `[skip desktop]` marker CAN'T override —
+            # anything outside `ui/**`. These files change the native
+            # build inputs (Rust sources, capabilities, sidecar
+            # binaries, packaging recipes), so the matrix has to run
+            # to verify they still compile and bundle. The marker is
+            # honoured only when the only `desktop`-matching change
+            # is in `ui/**`.
+            desktop_force:
+              - 'tauri/**'
+              - 'scripts/resolve-tauri-version.ts'
+              - 'scripts/stamp-version.ts'
+              - 'scripts/tauri-smoke.ts'
+              - 'Justfile'
+              - 'go.mod'
+              - 'go.sum'
+              - 'cmd/hecate/**'
+              - 'cmd/hecate-acp/**'
               - 'embed.go'
               - '.goreleaser.yaml'
               - 'Dockerfile.release'
@@ -441,14 +466,24 @@ jobs:
     # filter for symmetry). Skips the macOS / Windows / Linux bundle
     # matrix only — the cheap Tauri Rust tests above still run so a
     # Rust-side regression can't slip through this knob.
+    #
+    # The marker is only honoured when the desktop-relevant change is
+    # ui/**-only. If the PR ALSO touches `tauri/**`, build scripts,
+    # the gateway binaries, or release packaging files, `desktop_force`
+    # fires and the matrix runs regardless of the marker — a
+    # `[skip desktop]` on a PR that bumps `tauri.conf.json` is a lie
+    # we want CI to call out.
     if: |
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.title, '[skip desktop]') &&
       (
-        needs.changes.outputs.desktop == 'true' ||
-        needs.changes.outputs.workflow == 'true'
+        needs.changes.outputs.workflow == 'true' ||
+        needs.changes.outputs.desktop_force == 'true' ||
+        (
+          needs.changes.outputs.desktop == 'true' &&
+          !contains(github.event.pull_request.title, '[skip desktop]')
+        )
       ) &&
       contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
       contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -434,10 +434,18 @@ jobs:
       - docker-smoke
       - typescript
       - typescript-e2e
+    # `[skip desktop]` in the PR title is an explicit opt-out for
+    # changes the author knows can't affect the desktop build (most
+    # pure-UI refactors that still touch `ui/**` and would otherwise
+    # trip the `desktop` path filter — the marker name matches that
+    # filter for symmetry). Skips the macOS / Windows / Linux bundle
+    # matrix only — the cheap Tauri Rust tests above still run so a
+    # Rust-side regression can't slip through this knob.
     if: |
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.title, '[skip desktop]') &&
       (
         needs.changes.outputs.desktop == 'true' ||
         needs.changes.outputs.workflow == 'true'

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -260,6 +260,15 @@ skip by path filter) before it starts, and it does not upload unsigned bundles.
 `tauri-build.yml` is manual-only for explicit desktop reruns/debugging; dispatch
 it from a PR branch when a reviewer needs a pre-merge bundle to test-launch.
 
+Author override: putting `[skip desktop]` anywhere in the PR title skips the
+3-OS desktop bundle matrix for that PR. The marker name mirrors the `desktop`
+path filter — same vocabulary on both sides of the gate. The cheap Linux-only
+Tauri Rust tests still run, so a Rust-side regression can't slip through. Use
+only when you're sure the change can't affect the desktop build (most pure-UI
+refactors that still touch `ui/**` and would otherwise trip the `desktop` path
+filter). The gate lives next to the `if:` block in `test.yml`'s `tauri-desktop`
+job.
+
 **Release-run behaviour:** `concurrency: cancel-in-progress: false` — a half-cancelled release is worse than waiting. The `tauri` job has `needs: goreleaser` so the GitHub Release entry exists before tauri-action's upload tries to attach to it.
 
 ### Pipeline footguns

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -263,11 +263,17 @@ it from a PR branch when a reviewer needs a pre-merge bundle to test-launch.
 Author override: putting `[skip desktop]` anywhere in the PR title skips the
 3-OS desktop bundle matrix for that PR. The marker name mirrors the `desktop`
 path filter — same vocabulary on both sides of the gate. The cheap Linux-only
-Tauri Rust tests still run, so a Rust-side regression can't slip through. Use
-only when you're sure the change can't affect the desktop build (most pure-UI
-refactors that still touch `ui/**` and would otherwise trip the `desktop` path
-filter). The gate lives next to the `if:` block in `test.yml`'s `tauri-desktop`
-job.
+Tauri Rust tests still run, so a Rust-side regression can't slip through.
+
+The marker is only honoured when the desktop-relevant change is `ui/**`-only.
+The workflow defines a tighter `desktop_force` filter — `tauri/**`, build
+scripts (`scripts/{resolve-tauri-version,stamp-version,tauri-smoke}.ts`,
+`Justfile`), gateway binaries (`cmd/hecate{,-acp}/**`, `go.{mod,sum}`,
+`embed.go`), and packaging files (`.goreleaser.yaml`, `Dockerfile.release`,
+the three desktop workflow files). When any of those change the matrix runs
+regardless of the marker, so a `[skip desktop]` on a PR that also bumps, say,
+`tauri.conf.json` doesn't slip through. The gate lives next to the `if:`
+block in `test.yml`'s `tauri-desktop` job.
 
 **Release-run behaviour:** `concurrency: cancel-in-progress: false` — a half-cancelled release is worse than waiting. The `tauri` job has `needs: goreleaser` so the GitHub Release entry exists before tauri-action's upload tries to attach to it.
 


### PR DESCRIPTION
## Summary

Adds an author-side opt-out for the 3-OS desktop bundle matrix. Putting `[skip desktop]` anywhere in the PR title skips the `tauri-desktop` job — but only when the desktop-relevant change is `ui/**`-only. PRs that also touch native build inputs (`tauri/**`, build scripts, gateway binaries, packaging files) run the matrix regardless of the marker. The Linux-only Tauri Rust tests above the gate always run.

### Why

The `desktop` path filter in `test.yml` matches any `ui/**` change, so a pure-UI refactor (CSS rename, JSX reorder) triggers the full macOS / Windows / Linux packaging matrix. Path filters can't tell "genuinely cross-cuts the desktop build" from "doesn't" — the marker lets the author declare it explicitly when they know.

### Why the safety guard

The first cut of the marker trusted the title blindly. The recent #114 fix wired window-drag through the ACL with edits in BOTH `tauri/**` and `ui/**`; a stray `[skip desktop]` there would have silently skipped the bundle smoke even though the PR materially changed native build inputs. To prevent that class of mistake, the gate now distinguishes between:

| Filter | Files | Marker honoured? |
|---|---|---|
| `desktop` | `tauri/**`, scripts, `Justfile`, gateway binaries, `ui/**`, packaging, desktop workflows | varies |
| `desktop_force` | identical to `desktop` **minus** `ui/**` | never |

The matrix runs when `workflow` matched, or `desktop_force` matched (marker ignored), or `desktop` matched and the marker is absent.

### Truth table

| Files changed | Marker | Result |
|---|---|---|
| `ui/**` only | absent | matrix runs |
| `ui/**` only | `[skip desktop]` | **matrix skips** ← the only path that opts out |
| `tauri/**` (with or without `ui/**`) | absent | matrix runs |
| `tauri/**` (with or without `ui/**`) | `[skip desktop]` | matrix runs anyway (marker ignored) |
| nothing in `desktop` filter | either | matrix skips (status quo) |

### Naming

`[skip desktop]` mirrors the `desktop` path filter — same vocabulary on both sides of the gate. Framework-agnostic, so it stays right if Tauri ever gets swapped.

### Scope

Skips only the expensive bundle matrix. `test-tauri-rust` (Linux, cargo check + cargo test, ~2 min) runs unchanged so Rust-side regressions can't slip through this knob.

### Self-validation

This PR's title carries the marker. The branch touches only `.github/workflows/test.yml` and `docs-ai/skills/tauri/SKILL.md` — neither in `desktop_force`'s set, but the workflow file change makes `changes.outputs.workflow == true`, which forces the matrix to run regardless of the marker. So this PR's own CI is the "marker ignored when workflow changed" path. A future pure-UI PR will exercise the "marker honoured" path.

## Test plan

- [x] YAML parses (`bunx js-yaml` round-trip)
- [x] Tauri skill updated with the new author override (`docs-ai/skills/tauri/SKILL.md` PR-run-behaviour section, including the `desktop_force` list)
- [ ] CI confirms the matrix runs on this PR (workflow change forces it) and Tauri Rust tests pass
- [ ] A follow-up pure-UI PR with the marker exercises the actual skip path
