### PR TITLE
refactor(ui): carve out app/state/_shared.ts as the cross-slice home [skip desktop]

### DIFF
--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -1,0 +1,122 @@
+// Cross-slice types, storage keys, and storage-format normalize /
+// parse / serialize helpers. Shared by the per-domain hooks under
+// `app/state/` and by `useRuntimeConsole.ts` (which composes the
+// slices into the legacy view model).
+//
+// What's here: anything that's coupled to the on-disk localStorage
+// format. Types that live in `types/runtime.ts` (network response
+// shapes) stay there; the leak between "what the server sends" and
+// "what we persist" is intentional and minor.
+//
+// What's NOT here yet: session-derive helpers
+// (`deriveHecateChatTargetFromSession`,
+// `deriveHecateChatSelectionFromSession`,
+// `agentChatSession{IsExternal,IsBusy}`). Those are
+// agentChats-domain specific and move with the agentChats slice.
+
+import type { ProviderFilter } from "../../types/runtime";
+
+export type ChatTarget = "model" | "agent" | "external_agent";
+export type HecateChatTarget = "model" | "agent";
+
+export type QueuedChatMessage = {
+  id: string;
+  session_id: string;
+  content: string;
+  runtime_kind: ChatTarget;
+  provider_filter: ProviderFilter;
+  model: string;
+  workspace: string;
+  system_prompt: string;
+  adapter_id: string;
+  created_at: string;
+};
+
+export const queuedChatMessagesStorageKey = "hecate.queuedChatMessages";
+
+// Coercive normalizer — drops unknown values onto the safe default
+// rather than rejecting them. Used by code paths where the wider
+// type system has already vouched for the input (e.g. an
+// `AgentChatSessionRecord.runtime_kind` field straight off the
+// wire). For localStorage reads use the strict
+// `parseStoredChatTarget` below so corrupt keys get wiped.
+export function normalizeStoredChatTarget(value: string): ChatTarget {
+  switch (value) {
+    case "model":
+    case "agent":
+    case "external_agent":
+      return value;
+    default:
+      return "agent";
+  }
+}
+
+// Strict guard for the `hecate.chatTarget` localStorage key.
+// usePersistedState's contract is "loud failure replaces silent
+// shape-drift fallback" — return null so a corrupt key gets wiped
+// and the hook falls back to the explicit "agent" default rather
+// than silently coercing the bad value and re-persisting it.
+// normalizeStoredChatTarget (above) keeps its coercive behaviour
+// for non-storage sources where the wider type system has already
+// vouched for the input.
+export function parseStoredChatTarget(raw: string): ChatTarget | null {
+  return raw === "model" || raw === "agent" || raw === "external_agent" ? raw : null;
+}
+
+export function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
+  switch (value) {
+    case "model":
+    case "agent":
+      return value;
+    default:
+      return "";
+  }
+}
+
+// Structural guard for the queued-chat-messages localStorage payload.
+// The previous read helper massaged each missing field into an empty
+// string and re-persisted the half-zeroed record; the new contract
+// drops malformed *items* (preserving the rest of the queue) and
+// rejects the *whole array* if it isn't an array — `usePersistedState`
+// then wipes the key on the array-shape failure. Per-item filtering
+// is preserved because losing the entire queue to one corrupt entry
+// is worse than losing the bad entry.
+export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[] | null {
+  if (!Array.isArray(parsed)) return null;
+  return parsed.flatMap((item): QueuedChatMessage[] => {
+    if (!item || typeof item !== "object") return [];
+    const id = typeof item.id === "string" ? item.id : "";
+    const sessionID = typeof item.session_id === "string" ? item.session_id : "";
+    const content = typeof item.content === "string" ? item.content : "";
+    if (!id || !sessionID || !content.trim()) return [];
+    return [{
+      id,
+      session_id: sessionID,
+      content,
+      runtime_kind: normalizeStoredChatTarget(typeof item.runtime_kind === "string" ? item.runtime_kind : ""),
+      provider_filter: typeof item.provider_filter === "string" ? item.provider_filter as ProviderFilter : "auto",
+      model: typeof item.model === "string" ? item.model : "",
+      workspace: typeof item.workspace === "string" ? item.workspace : "",
+      system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
+      adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
+      created_at: typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
+    }];
+  });
+}
+
+// Structural guard for the per-session HecateChatTarget map. Stored as
+// a JSON object {sessionID: target}; rebuilt into a Map so the consuming
+// code can use Map semantics (.get / .set / iteration order).
+export function parseChatTargetsBySessionID(parsed: unknown): Map<string, HecateChatTarget> | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const entries = Object.entries(parsed as Record<string, unknown>)
+    .map(([sessionID, target]) =>
+      [sessionID, typeof target === "string" ? normalizeStoredHecateChatTarget(target) : ""] as const,
+    )
+    .filter((entry): entry is readonly [string, HecateChatTarget] => Boolean(entry[0] && entry[1]));
+  return new Map(entries);
+}
+
+export function serializeChatTargetsBySessionID(targets: Map<string, HecateChatTarget>): string {
+  return JSON.stringify(Object.fromEntries(targets));
+}

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1,6 +1,17 @@
 import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from "react";
 
 import { parseStoredJSON, parseStoredString, usePersistedState } from "../lib/persistedState";
+import {
+  type ChatTarget,
+  type HecateChatTarget,
+  type QueuedChatMessage,
+  normalizeStoredHecateChatTarget,
+  parseChatTargetsBySessionID,
+  parseQueuedChatMessageList,
+  parseStoredChatTarget,
+  queuedChatMessagesStorageKey,
+  serializeChatTargetsBySessionID,
+} from "./state/_shared";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
 import type { LocalProviderIssue } from "../lib/provider-issues";
 import { filterModelsByKind, filterModelsByProvider, parseCSV } from "../lib/runtime-utils";
@@ -98,105 +109,6 @@ type NoticeState = {
   kind: "success" | "error";
   message: string;
 };
-
-type ChatTarget = "model" | "agent" | "external_agent";
-type HecateChatTarget = "model" | "agent";
-type QueuedChatMessage = {
-  id: string;
-  session_id: string;
-  content: string;
-  runtime_kind: ChatTarget;
-  provider_filter: ProviderFilter;
-  model: string;
-  workspace: string;
-  system_prompt: string;
-  adapter_id: string;
-  created_at: string;
-};
-
-const queuedChatMessagesStorageKey = "hecate.queuedChatMessages";
-
-function normalizeStoredChatTarget(value: string): ChatTarget {
-  switch (value) {
-    case "model":
-    case "agent":
-    case "external_agent":
-      return value;
-    default:
-      return "agent";
-  }
-}
-
-// Strict guard for the `hecate.chatTarget` localStorage key.
-// usePersistedState's contract is "loud failure replaces silent
-// shape-drift fallback" — return null so a corrupt key gets wiped
-// and the hook falls back to the explicit "agent" default rather
-// than silently coercing the bad value and re-persisting it.
-// normalizeStoredChatTarget (above) keeps its coercive behaviour
-// for non-storage sources (e.g. the agent chat session's
-// `runtime_kind` field) where the wider type system has already
-// vouched for the input.
-function parseStoredChatTarget(raw: string): ChatTarget | null {
-  return raw === "model" || raw === "agent" || raw === "external_agent" ? raw : null;
-}
-
-function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
-  switch (value) {
-    case "model":
-    case "agent":
-      return value;
-    default:
-      return "";
-  }
-}
-
-// Structural guard for the queued-chat-messages localStorage payload.
-// The previous read helper massaged each missing field into an empty
-// string and re-persisted the half-zeroed record; the new contract
-// drops malformed *items* (preserving the rest of the queue) and
-// rejects the *whole array* if it isn't an array — `usePersistedState`
-// then wipes the key on the array-shape failure. Per-item filtering
-// is preserved because losing the entire queue to one corrupt entry
-// is worse than losing the bad entry.
-function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[] | null {
-  if (!Array.isArray(parsed)) return null;
-  return parsed.flatMap((item): QueuedChatMessage[] => {
-    if (!item || typeof item !== "object") return [];
-    const id = typeof item.id === "string" ? item.id : "";
-    const sessionID = typeof item.session_id === "string" ? item.session_id : "";
-    const content = typeof item.content === "string" ? item.content : "";
-    if (!id || !sessionID || !content.trim()) return [];
-    return [{
-      id,
-      session_id: sessionID,
-      content,
-      runtime_kind: normalizeStoredChatTarget(typeof item.runtime_kind === "string" ? item.runtime_kind : ""),
-      provider_filter: typeof item.provider_filter === "string" ? item.provider_filter as ProviderFilter : "auto",
-      model: typeof item.model === "string" ? item.model : "",
-      workspace: typeof item.workspace === "string" ? item.workspace : "",
-      system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
-      adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
-      created_at: typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
-    }];
-  });
-}
-
-// Structural guard for the per-session HecateChatTarget map. Stored as
-// a JSON object {sessionID: target}; rebuilt into a Map so the consuming
-// code can use Map semantics (.get / .set / iteration order).
-function parseChatTargetsBySessionID(parsed: unknown): Map<string, HecateChatTarget> | null {
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-  const entries = Object.entries(parsed as Record<string, unknown>)
-    .map(([sessionID, target]) =>
-      [sessionID, typeof target === "string" ? normalizeStoredHecateChatTarget(target) : ""] as const,
-    )
-    .filter((entry): entry is readonly [string, HecateChatTarget] => Boolean(entry[0] && entry[1]));
-  return new Map(entries);
-}
-
-function serializeChatTargetsBySessionID(targets: Map<string, HecateChatTarget>): string {
-  return JSON.stringify(Object.fromEntries(targets));
-}
 
 function agentChatSessionIsExternal(session: AgentChatSessionRecord | null): boolean {
   return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);


### PR DESCRIPTION
## Summary

Move-only scaffolding for the per-domain slice work that follows. Pulls the storage-format types + helpers out of `useRuntimeConsole.ts` into a new `ui/src/app/state/_shared.ts`. No behaviour change; the file is the new home for things every slice needs to know about the on-disk localStorage contract.

This is the leaf-first confidence-builder before the four slice extractions ([`retention`](https://github.com/hecatehq/hecate/tree/master), `approvals`, `providersAndModels` / `runtime` / `usage`, `agentChats` / `chatSessions`). Reviewers verify a move-only diff has no logic delta; the per-domain hooks that follow each get to focus on their own state machine rather than re-litigating the storage-format contract.

### What moves

| Symbol | Was | Now |
|---|---|---|
| `ChatTarget`, `HecateChatTarget`, `QueuedChatMessage` types | `useRuntimeConsole.ts` | `app/state/_shared.ts` |
| `queuedChatMessagesStorageKey` constant | same | same |
| `normalizeStoredChatTarget` (coercive — non-storage callers where the wider type system has already vouched for the input) | same | same |
| `parseStoredChatTarget` (strict — wipes corrupt keys per the `usePersistedState` contract) | same | same |
| `normalizeStoredHecateChatTarget` (Hecate-Chat subset) | same | same |
| `parseQueuedChatMessageList` (per-item filter + array-shape rejection) | same | same |
| `parseChatTargetsBySessionID` + `serializeChatTargetsBySessionID` | same | same |

### What stays

Session-derive helpers in `useRuntimeConsole.ts`: `agentChatSession{IsExternal,IsBusy}`, `deriveHecateChat{Target,Selection}FromSession`. Those are agentChats-domain-specific and move with the agentChats slice when it's carved out (sub-PR 4e).

### Diff shape

`useRuntimeConsole.ts` shrinks by 88 lines (one new import block, ~100 lines deleted). The new `_shared.ts` adds 133 (most of which is the rationale comments that were already in the source — carried over so future readers don't have to grep the git history for the "why").

### Why `[skip desktop]`

Pure TS module move under `ui/src/app/`. No `tauri/**`, no native build inputs. The marker honours the existing safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)): if I'd accidentally touched any `desktop_force` path the matrix would still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — full suite passes (`useRuntimeConsole.test.tsx` is the regression net for the storage helpers; it didn't notice the move)
- [x] Diff is move-only — `git diff` shows zero logic changes
- [x] `useRuntimeConsole` external `{state, actions}` shape unchanged