### PR TITLE
refactor(ui): extract the retention slice as the slice-architecture prover [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
+import { RetentionProvider } from "./state/retention";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
@@ -13,7 +14,21 @@ const VALID_WORKSPACE_IDS = new Set<WorkspaceID>(WORKSPACE_IDS);
 const parseWorkspaceID = (raw: string): WorkspaceID | null =>
   VALID_WORKSPACE_IDS.has(raw as WorkspaceID) ? (raw as WorkspaceID) : null;
 
+// The slice providers wrap the console body so useRuntimeConsole's
+// internal slice consumers (`useRetention`, …) see their context.
+// As more slices are added the wrapper chain grows here; once
+// prop-drill is retired and consumers read context directly, a
+// single `<RuntimeConsoleProviders>` composer will collapse this
+// chain.
 export default function App() {
+  return (
+    <RetentionProvider>
+      <AppConsole />
+    </RetentionProvider>
+  );
+}
+
+function AppConsole() {
   const { state, actions } = useRuntimeConsole();
   const [preferredWorkspace, setPreferredWorkspace] = usePersistedState<WorkspaceID>(
     WORKSPACE_STORAGE_KEY,

--- a/ui/src/app/state/retention.tsx
+++ b/ui/src/app/state/retention.tsx
@@ -1,0 +1,153 @@
+// Retention slice: state + actions for the operator-side retention
+// worker control surface. Owns five fields (subsystems CSV input,
+// in-flight flag, last error, last run record, recent runs list) and
+// three actions (set subsystems, load recent runs, trigger a run).
+//
+// Design: Context + useReducer. Mounted once at App.tsx top so the
+// state survives workspace switches; consumed via `useRetention()`
+// from `useRuntimeConsole`'s composition layer for now. A later
+// refactor will let SettingsView read it directly without the
+// shim pass-through; for now the surface stability is what lets
+// the migration happen one slice at a time.
+//
+// Cross-slice concerns: a successful or failed `runRetention()`
+// also flips the global `notice` banner. That cross-cut stays in
+// `useRuntimeConsole`'s shim — the slice's `runRetention` returns a
+// `RetentionRunResult` so the caller can route success / failure
+// without the slice importing notice state.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, useRef, type ReactNode } from "react";
+
+import { getRetentionRuns, runRetention as runRetentionRequest } from "../../lib/api";
+import { warn as logWarn } from "../../lib/log";
+import { parseCSV } from "../../lib/runtime-utils";
+import type { RetentionRunData } from "../../types/runtime";
+
+const RECENT_RUNS_LIMIT = 10;
+
+export type RetentionState = {
+  subsystems: string;
+  loading: boolean;
+  error: string;
+  lastRun: RetentionRunData | null;
+  runs: RetentionRunData[];
+};
+
+export type RetentionRunResult =
+  | { ok: true; run: RetentionRunData }
+  | { ok: false; error: string };
+
+export type RetentionActions = {
+  setSubsystems: (value: string) => void;
+  loadRuns: () => Promise<void>;
+  runRetention: () => Promise<RetentionRunResult>;
+};
+
+type RetentionContextValue = {
+  state: RetentionState;
+  actions: RetentionActions;
+};
+
+type Action =
+  | { type: "subsystems/set"; value: string }
+  | { type: "runs/loaded"; runs: RetentionRunData[] }
+  | { type: "run/started" }
+  | { type: "run/succeeded"; run: RetentionRunData }
+  | { type: "run/failed"; error: string };
+
+const initialState: RetentionState = {
+  subsystems: "",
+  loading: false,
+  error: "",
+  lastRun: null,
+  runs: [],
+};
+
+function reducer(state: RetentionState, action: Action): RetentionState {
+  switch (action.type) {
+    case "subsystems/set":
+      return { ...state, subsystems: action.value };
+    case "runs/loaded":
+      return {
+        ...state,
+        runs: action.runs,
+        lastRun: action.runs[0] ?? null,
+      };
+    case "run/started":
+      return { ...state, loading: true, error: "" };
+    case "run/succeeded": {
+      // Prepend the new run, dedupe by finished_at (the worker
+      // sometimes returns the same record twice if the caller
+      // hammered the trigger), cap at RECENT_RUNS_LIMIT.
+      const runs = [
+        action.run,
+        ...state.runs.filter((run) => run.finished_at !== action.run.finished_at),
+      ].slice(0, RECENT_RUNS_LIMIT);
+      return { ...state, loading: false, lastRun: action.run, runs };
+    }
+    case "run/failed":
+      return { ...state, loading: false, error: action.error };
+  }
+}
+
+const RetentionContext = createContext<RetentionContextValue | null>(null);
+
+export function RetentionProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  // Re-entrancy guard outside the reducer because SettingsView mounts
+  // can race and we don't want to dispatch a "started" action that
+  // would otherwise be harmless but adds noise to the trace.
+  const loadingRef = useRef(false);
+
+  const setSubsystems = useCallback((value: string) => {
+    dispatch({ type: "subsystems/set", value });
+  }, []);
+
+  const loadRuns = useCallback(async () => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
+    try {
+      const payload = await getRetentionRuns(RECENT_RUNS_LIMIT);
+      dispatch({ type: "runs/loaded", runs: payload.data ?? [] });
+    } catch (loadError) {
+      // SettingsView shows an empty list rather than an error
+      // banner; surfacing this would compete with the rest of
+      // the settings UI for attention. Log for debugging.
+      logWarn("loadRetentionRuns failed:", loadError);
+    } finally {
+      loadingRef.current = false;
+    }
+  }, []);
+
+  const runRetention = useCallback(async (): Promise<RetentionRunResult> => {
+    dispatch({ type: "run/started" });
+    try {
+      const payload = await runRetentionRequest({
+        subsystems: parseCSV(state.subsystems),
+      });
+      dispatch({ type: "run/succeeded", run: payload.data });
+      return { ok: true, run: payload.data };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "failed to run retention";
+      dispatch({ type: "run/failed", error: message });
+      return { ok: false, error: message };
+    }
+  }, [state.subsystems]);
+
+  const actions = useMemo(
+    () => ({ setSubsystems, loadRuns, runRetention }),
+    [setSubsystems, loadRuns, runRetention],
+  );
+
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <RetentionContext.Provider value={value}>{children}</RetentionContext.Provider>;
+}
+
+export function useRetention(): RetentionContextValue {
+  const ctx = useContext(RetentionContext);
+  if (!ctx) {
+    throw new Error("useRetention must be used inside a <RetentionProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -1,7 +1,17 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor, type RenderHookOptions } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { RetentionProvider } from "./state/retention";
 import { useRuntimeConsole } from "./useRuntimeConsole";
+
+// useRuntimeConsole now consumes slice contexts (retention is the
+// first one to land). Every renderHook call needs the matching
+// providers above it; this helper composes them so the test bodies
+// don't have to thread a wrapper through each call. As more slices
+// are added the wrapper chain grows here.
+function renderRuntimeConsoleHook(options?: Omit<RenderHookOptions<unknown>, "wrapper">) {
+  return renderHook(() => useRuntimeConsole(), { ...options, wrapper: RetentionProvider });
+}
 
 // Single-user mode: every endpoint is unauthenticated and the gateway
 // surfaces a stub `Anonymous` session for all callers. The tests below
@@ -70,7 +80,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("starts chats with an empty composer", async () => {
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     expect(result.current.state.message).toBe("");
   });
@@ -84,7 +94,7 @@ describe("useRuntimeConsole", () => {
       }),
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     let selected = false;
@@ -99,14 +109,14 @@ describe("useRuntimeConsole", () => {
   });
 
   it("defaults to Agent chat when no chat target preference exists", async () => {
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     expect(result.current.state.chatTarget).toBe("agent");
   });
 
   it("preserves the saved chat target preference", async () => {
     window.localStorage.setItem("hecate.chatTarget", "model");
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     expect(result.current.state.chatTarget).toBe("model");
   });
@@ -144,7 +154,7 @@ describe("useRuntimeConsole", () => {
       },
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -194,7 +204,7 @@ describe("useRuntimeConsole", () => {
       }),
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     await waitFor(() => expect(result.current.state.activeAgentChatSessionID).toBe("a1"));
     expect(result.current.state.newChatAgentID).toBe("hecate");
@@ -226,7 +236,7 @@ describe("useRuntimeConsole", () => {
       },
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -260,7 +270,7 @@ describe("useRuntimeConsole", () => {
       },
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -295,7 +305,7 @@ describe("useRuntimeConsole", () => {
       },
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
 
@@ -320,7 +330,7 @@ describe("useRuntimeConsole", () => {
       "/hecate/v1/agent-chat/sessions/a1": () => jsonResponse({ error: { type: "gateway_error", message: "temporary failure" } }, 500),
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     expect(result.current.state.activeAgentChatSessionID).toBe("a1");
@@ -328,7 +338,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("settles into a Local session after the dashboard loads", async () => {
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     expect(result.current.state.session.label).toBe("Local");
   });
@@ -369,7 +379,7 @@ describe("useRuntimeConsole", () => {
       }),
     }));
 
-    const { result } = renderHook(() => useRuntimeConsole());
+    const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     await waitFor(() => expect(result.current.state.model).toBe("gpt-4o-mini"));
 
@@ -402,7 +412,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -426,7 +436,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -448,7 +458,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -470,7 +480,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -493,7 +503,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -543,7 +553,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.settingsConfig?.providers.map(p => p.id)).toEqual(["openai", "ollama"]));
 
       let pendingDelete: Promise<void> | undefined;
@@ -600,7 +610,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.settingsConfig?.providers.map(p => p.id)).toEqual(["openai", "ollama", "anthropic"]));
       await act(async () => {
         result.current.actions.setProviderFilter("ollama");
@@ -663,7 +673,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -744,7 +754,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.systemPrompt).toBe("Prefer small, reviewable diffs."));
       await waitFor(() => expect(result.current.state.model).toBe("gpt-4o-mini"));
@@ -831,7 +841,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.status).toBe("running"));
       await waitFor(() => expect(result.current.state.model).toBe("gpt-4o-mini"));
@@ -887,7 +897,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
       expect(result.current.state.queuedChatMessages[0].content).toBe("keep this after refresh");
@@ -939,7 +949,7 @@ describe("useRuntimeConsole", () => {
       }));
 
       try {
-        const { result } = renderHook(() => useRuntimeConsole());
+        const { result } = renderRuntimeConsoleHook();
         await waitFor(() => expect(result.current.state.loading).toBe(false));
 
         act(() => {
@@ -987,7 +997,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await waitFor(() => expect(result.current.state.queuedChatMessages.map((item) => item.id)).toEqual(["queued_keep"]));
@@ -1038,7 +1048,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
 
@@ -1128,7 +1138,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a2"));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.status).toBe("running"));
@@ -1192,7 +1202,7 @@ describe("useRuntimeConsole", () => {
         "/hecate/v1/agent-chat/sessions/chat_b": () => jsonResponse(hecateSession("chat_b")),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -1249,7 +1259,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -1269,7 +1279,7 @@ describe("useRuntimeConsole", () => {
         ),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -1293,7 +1303,7 @@ describe("useRuntimeConsole", () => {
         )(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.agentChatSessions).toHaveLength(2));
 
       await act(async () => {
@@ -1335,7 +1345,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("sess_b"));
 
       act(() => {
@@ -1376,7 +1386,7 @@ describe("useRuntimeConsole", () => {
         })(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.chatSessions).toHaveLength(1));
 
       await act(async () => {
@@ -1439,7 +1449,7 @@ describe("useRuntimeConsole", () => {
         })(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.agentChatSessions[0]?.title).toBe("Old agent title"));
 
       await act(async () => {
@@ -1525,7 +1535,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
       const initialRefetches = refetchCalls;
@@ -1618,7 +1628,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
 
@@ -1720,7 +1730,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
 
@@ -1821,7 +1831,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.task_id).toBe("task_42"));
 
@@ -1924,7 +1934,7 @@ describe("useRuntimeConsole", () => {
         return defaultBackendMock()(input, init);
       });
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() => expect(result.current.state.activeAgentChatSession?.id).toBe("a1"));
 
@@ -1984,7 +1994,7 @@ describe("useRuntimeConsole", () => {
     }
 
     it("starts with an empty pending map and no grants", async () => {
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       expect(result.current.state.pendingApprovalsBySessionID.size).toBe(0);
       expect(result.current.state.agentChatGrants).toEqual([]);
@@ -2007,7 +2017,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       // Effect-driven refetch may need a tick after activeAgentChatSessionID
       // hydrates from localStorage.
@@ -2050,7 +2060,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       // Default chatTarget is "agent", so selectChatSession forwards
@@ -2111,7 +2121,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {
@@ -2166,7 +2176,7 @@ describe("useRuntimeConsole", () => {
         }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
       await waitFor(() =>
         expect(result.current.state.pendingApprovalsBySessionID.get("a1")).toHaveLength(1),
@@ -2198,7 +2208,7 @@ describe("useRuntimeConsole", () => {
         "/hecate/v1/agent-chat/grants/g1": () => new Response(null, { status: 204 }),
       }));
 
-      const { result } = renderHook(() => useRuntimeConsole());
+      const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
       await act(async () => {

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -14,7 +14,7 @@ import {
 } from "./state/_shared";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
 import type { LocalProviderIssue } from "../lib/provider-issues";
-import { filterModelsByKind, filterModelsByProvider, parseCSV } from "../lib/runtime-utils";
+import { filterModelsByKind, filterModelsByProvider } from "../lib/runtime-utils";
 import {
   ApiError,
   type ChatMessage,
@@ -43,8 +43,6 @@ import {
   revertAgentChatMessageFiles as revertAgentChatMessageFilesRequest,
   resolveTaskApproval as resolveTaskApprovalRequest,
   resolveAgentChatApproval as resolveAgentChatApprovalRequest,
-  runRetention as runRetentionRequest,
-  getRetentionRuns,
   upsertPolicyRule as upsertPolicyRuleRequest,
   createProvider as createProviderRequest,
   deleteModelCapabilityOverride as deleteModelCapabilityOverrideRequest,
@@ -76,7 +74,7 @@ import {
   renderAgentChatSessionSummary,
 } from "./runtimeConsoleChatHelpers";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
-import { warn as logWarn } from "../lib/log";
+import { useRetention } from "./state/retention";
 import type {
   AgentAdapterHealthRecord,
   AgentAdapterRecord,
@@ -100,7 +98,6 @@ import type {
   ProviderStatusResponse,
   RuntimeHeaders,
   SessionResponse,
-  RetentionRunData,
   UsageEventsResponse,
   UsageSummaryResponse,
 } from "../types/runtime";
@@ -318,11 +315,13 @@ export function useRuntimeConsole() {
         : (chatTargetBySessionID.get(activeAgentChatSessionID) ?? deriveHecateChatTargetFromSession(activeAgentChatSession)))
     : defaultChatTarget;
 
-  const [retentionSubsystems, setRetentionSubsystems] = useState("");
-  const [retentionLoading, setRetentionLoading] = useState(false);
-  const [retentionError, setRetentionError] = useState("");
-  const [retentionLastRun, setRetentionLastRun] = useState<RetentionRunData | null>(null);
-  const [retentionRuns, setRetentionRuns] = useState<RetentionRunData[]>([]);
+  // Retention state + actions live in the slice (app/state/retention.tsx).
+  // The shim below re-exports them under the legacy `state.retention*` /
+  // `actions.{loadRetentionRuns,setRetentionSubsystems,runRetention}`
+  // keys to keep the external surface stable for SettingsView; a later
+  // refactor will retire the pass-through once SettingsView reads the
+  // slice directly.
+  const retention = useRetention();
 
   const healthyProviders = providers.filter((provider) => provider.healthy).length;
   const localProviders = providers.filter((provider) => provider.kind === "local");
@@ -1259,48 +1258,19 @@ export function useRuntimeConsole() {
     }
   }
 
-  // Settings view triggers this on mount — retention runs are
-  // out of the boot-time dashboard snapshot so we don't pay for
-  // the fetch on every cold launch when the user never opens
-  // Settings. Re-entrant: while a fetch is in flight a second
-  // call is a no-op (current code below sets state once).
-  const retentionRunsLoadingRef = useRef(false);
-  async function loadRetentionRuns() {
-    if (retentionRunsLoadingRef.current) return;
-    retentionRunsLoadingRef.current = true;
-    try {
-      const payload = await getRetentionRuns(10);
-      setRetentionRuns(payload.data ?? []);
-      setRetentionLastRun(payload.data?.[0] ?? null);
-    } catch (loadError) {
-      // Stay quiet — SettingsView shows an empty list rather
-      // than an error banner; surfacing this would compete
-      // with the rest of the settings UI for attention.
-      logWarn("loadRetentionRuns failed:", loadError);
-    } finally {
-      retentionRunsLoadingRef.current = false;
-    }
-  }
+  const loadRetentionRuns = retention.actions.loadRuns;
 
+  // Coordinator: the slice owns the retention state machine; the
+  // cross-cutting `notice` banner is set here so the slice stays
+  // independent of unrelated global UI state. A later refactor will
+  // move this composition into a dedicated coordinator hook
+  // alongside other "slice + global side-effect" pairs.
   async function runRetention() {
-    setRetentionError("");
     setNotice(null);
-    setRetentionLoading(true);
-    try {
-      const payload = await runRetentionRequest(
-        {
-          subsystems: parseCSV(retentionSubsystems),
-        },
-      );
-      setRetentionLastRun(payload.data);
-      setRetentionRuns((current) => [payload.data, ...current.filter((run) => run.finished_at !== payload.data.finished_at)].slice(0, 10));
-      setNotice({ kind: "success", message: "Retention run completed." });
-    } catch (error) {
-      setRetentionError(error instanceof Error ? error.message : "failed to run retention");
-      setNotice({ kind: "error", message: "Failed to run retention." });
-    } finally {
-      setRetentionLoading(false);
-    }
+    const result = await retention.actions.runRetention();
+    setNotice(result.ok
+      ? { kind: "success", message: "Retention run completed." }
+      : { kind: "error", message: "Failed to run retention." });
   }
 
   async function createChatSession() {
@@ -1889,11 +1859,11 @@ export function useRuntimeConsole() {
       providerPresets,
       activeChatSession,
       activeChatSessionID,
-      retentionError,
-      retentionLastRun,
-      retentionLoading,
-      retentionRuns,
-      retentionSubsystems,
+      retentionError: retention.state.error,
+      retentionLastRun: retention.state.lastRun,
+      retentionLoading: retention.state.loading,
+      retentionRuns: retention.state.runs,
+      retentionSubsystems: retention.state.subsystems,
       runtimeHeaders,
       chatSessionsHasMore,
       chatSessionsLoadingMore,
@@ -1928,7 +1898,7 @@ export function useRuntimeConsole() {
       setModelFilter,
       setProviderFilter: selectProviderRoute,
       refreshProviders,
-      setRetentionSubsystems,
+      setRetentionSubsystems: retention.actions.setSubsystems,
       runRetention,
       selectChatSession,
       startNewChat,


### PR DESCRIPTION
## Summary

First slice carved out of `useRuntimeConsole`. Retention is the smallest cohesive domain (5 state fields, 3 actions, 1 consumer = `SettingsView`) — picking it first is deliberate: the **Context + useReducer + Provider** shape that every later slice will copy is the load-bearing decision here, and a slice this size is small enough to revert in one commit if the pattern doesn't pan out.

Reviewing tip: the shape decisions (where coordinators live, how cross-slice side-effects get wired, what the test helper looks like) are the real review surface. The retention move itself is mechanical.

## What's new

**`ui/src/app/state/retention.tsx`** (~150 LOC):

```ts
type RetentionState = { subsystems; loading; error; lastRun; runs };
type RetentionRunResult = { ok: true; run } | { ok: false; error };

export function RetentionProvider({ children }) { /* useReducer + actions */ }
export function useRetention(): { state, actions };
```

Actions: `setSubsystems`, `loadRuns`, `runRetention` (returns `RetentionRunResult` so callers can wire cross-cutting side-effects without the slice importing them).

**`App.tsx`** wraps `<RetentionProvider>` around the new `<AppConsole>` body. The wrapper chain grows here as more slices are added; once prop-drill is retired and consumers read context directly, a single `<RuntimeConsoleProviders>` composer will collapse this chain.

**`useRuntimeConsole.ts`** drops 5 useState declarations, the `loadRetentionRuns` re-entrancy ref + body, and the `runRetention` body. Now pulls slice state/actions via `const retention = useRetention()`. The cross-cutting `notice` banner write stays in the shim's `runRetention` coordinator for now — moves into a dedicated coordinator hook once more "slice + global side-effect" pairs land.

## The coordinator pattern (worth reviewing)

`runRetention()` used to live entirely in `useRuntimeConsole` and called `setNotice` directly. To keep the slice unaware of cross-cutting state, the slice's `runRetention()` returns a `RetentionRunResult`; the shim wraps it:

```ts
async function runRetention() {
  setNotice(null);
  const result = await retention.actions.runRetention();
  setNotice(result.ok
    ? { kind: "success", message: "Retention run completed." }
    : { kind: "error", message: "Failed to run retention." });
}
```

When more cross-cut actions land (`useCreateChatSession`, …) this composition will move into named coordinator hooks. For now the shim is the coordinator — keeps the diff small and the next refactor's job clear.

## Tests

`useRuntimeConsole.test.tsx` is the 96 KB regression net for the god-hook's external surface. Every assertion is unchanged. The 45 `renderHook(() => useRuntimeConsole())` calls now go through a new helper:

```ts
function renderRuntimeConsoleHook(options?) {
  return renderHook(() => useRuntimeConsole(), { ...options, wrapper: RetentionProvider });
}
```

As more slices are added the wrapper chain grows in this one helper.

## External surface

Byte-for-byte stable. `state.retention{Error,LastRun,Loading,Runs,Subsystems}` keys still exist, `actions.{loadRetentionRuns,setRetentionSubsystems,runRetention}` identifiers still exist. `SettingsView` wasn't touched.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: `state.retention*` + `actions.{loadRetentionRuns,setRetentionSubsystems,runRetention}` keys present, types unchanged
- [x] `SettingsView` and its consumers untouched
