### PR TITLE
refactor(ui): extract the approvals slice (pending + grants + version ref) [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
+import { ApprovalsProvider } from "./state/approvals";
 import { RetentionProvider } from "./state/retention";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 import { usePersistedState } from "../lib/persistedState";
@@ -23,7 +24,9 @@ const parseWorkspaceID = (raw: string): WorkspaceID | null =>
 export default function App() {
   return (
     <RetentionProvider>
-      <AppConsole />
+      <ApprovalsProvider>
+        <AppConsole />
+      </ApprovalsProvider>
     </RetentionProvider>
   );
 }

--- a/ui/src/app/state/approvals.tsx
+++ b/ui/src/app/state/approvals.tsx
@@ -1,0 +1,294 @@
+// Approvals slice: pending agent-chat approval banners + grant
+// list. Owns four state fields plus an internal mutation-version
+// ref that protects the catch-up GET against races with the SSE
+// stream and optimistic local actions.
+//
+// State map invariant: `pendingBySessionID` is replaced (never
+// mutated in place) on update; React reference equality is the
+// re-render trigger. Empty arrays are deleted from the map so
+// `.get(sessionID)?.length` reads as "no pending banner" without
+// a separate empty-vs-missing branch.
+//
+// Race protection: each mutator (upsert, remove) bumps a per-
+// session version counter in a ref. `refetchPending` snapshots
+// the version before its request and compares after; a mismatch
+// means a live SSE update or optimistic local action landed
+// during the catch-up, so we ignore the stale GET rather than
+// clobbering newer state.
+//
+// Cross-slice concerns: action requests can fail; the slice
+// returns discriminated Results so callers route success / error
+// to the global `notice` banner without the slice importing it.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, useRef, type ReactNode } from "react";
+
+import {
+  type AgentChatGrantFilter,
+  cancelAgentChatApproval as cancelAgentChatApprovalRequest,
+  deleteAgentChatGrant as deleteAgentChatGrantRequest,
+  getAgentChatApproval as getAgentChatApprovalRequest,
+  listAgentChatApprovals as listAgentChatApprovalsRequest,
+  listAgentChatGrants as listAgentChatGrantsRequest,
+  type ResolveAgentChatApprovalPayload,
+  resolveAgentChatApproval as resolveAgentChatApprovalRequest,
+} from "../../lib/api";
+import { approvalRecordToPending } from "../runtimeConsoleChatHelpers";
+import type {
+  AgentChatApprovalRecord,
+  AgentChatGrantRecord,
+  PendingAgentApproval,
+} from "../../types/runtime";
+
+export type ApprovalsState = {
+  pendingBySessionID: Map<string, PendingAgentApproval[]>;
+  grants: AgentChatGrantRecord[];
+  grantsLoading: boolean;
+  grantsError: string;
+};
+
+export type ApprovalActionResult = { ok: true } | { ok: false; error: string };
+export type GetApprovalResult =
+  | { ok: true; record: AgentChatApprovalRecord }
+  | { ok: false; error: string };
+
+export type ApprovalsActions = {
+  // Mutation API — called from the SSE stream handler + the
+  // session-select catch-up. Synchronous; no cross-cut.
+  setPendingForSession: (sessionID: string, rows: PendingAgentApproval[]) => void;
+  upsertPending: (event: PendingAgentApproval) => void;
+  removePending: (sessionID: string, approvalID: string) => void;
+  refetchPending: (sessionID: string) => Promise<void>;
+  // Request API — return Results so callers can wire notice/UI
+  // feedback without the slice importing them.
+  getApproval: (sessionID: string, approvalID: string) => Promise<GetApprovalResult>;
+  resolveApproval: (
+    sessionID: string,
+    approvalID: string,
+    decision: ResolveAgentChatApprovalPayload,
+  ) => Promise<ApprovalActionResult>;
+  cancelApproval: (sessionID: string, approvalID: string) => Promise<ApprovalActionResult>;
+  // Grants — error state lives inside the slice (grantsError)
+  // because Connections renders it inline; no Result needed for
+  // loadGrants.
+  loadGrants: (filter?: AgentChatGrantFilter) => Promise<void>;
+  deleteGrant: (grantID: string) => Promise<ApprovalActionResult>;
+};
+
+type ApprovalsContextValue = {
+  state: ApprovalsState;
+  actions: ApprovalsActions;
+};
+
+type Action =
+  | { type: "pending/setForSession"; sessionID: string; rows: PendingAgentApproval[] }
+  | { type: "pending/upsert"; event: PendingAgentApproval }
+  | { type: "pending/remove"; sessionID: string; approvalID: string }
+  | { type: "grants/loadStart" }
+  | { type: "grants/loaded"; rows: AgentChatGrantRecord[] }
+  | { type: "grants/loadFailed"; error: string }
+  | { type: "grants/removed"; grantID: string };
+
+const initialState: ApprovalsState = {
+  pendingBySessionID: new Map(),
+  grants: [],
+  grantsLoading: false,
+  grantsError: "",
+};
+
+function reducer(state: ApprovalsState, action: Action): ApprovalsState {
+  switch (action.type) {
+    case "pending/setForSession": {
+      const next = new Map(state.pendingBySessionID);
+      if (action.rows.length === 0) {
+        next.delete(action.sessionID);
+      } else {
+        next.set(action.sessionID, action.rows);
+      }
+      return { ...state, pendingBySessionID: next };
+    }
+    case "pending/upsert": {
+      const next = new Map(state.pendingBySessionID);
+      const existing = next.get(action.event.session_id) ?? [];
+      const filtered = existing.filter((row) => row.approval_id !== action.event.approval_id);
+      filtered.push(action.event);
+      next.set(action.event.session_id, filtered);
+      return { ...state, pendingBySessionID: next };
+    }
+    case "pending/remove": {
+      const existing = state.pendingBySessionID.get(action.sessionID);
+      if (!existing) return state;
+      const filtered = existing.filter((row) => row.approval_id !== action.approvalID);
+      if (filtered.length === existing.length) return state;
+      const next = new Map(state.pendingBySessionID);
+      if (filtered.length === 0) {
+        next.delete(action.sessionID);
+      } else {
+        next.set(action.sessionID, filtered);
+      }
+      return { ...state, pendingBySessionID: next };
+    }
+    case "grants/loadStart":
+      return { ...state, grantsLoading: true, grantsError: "" };
+    case "grants/loaded":
+      return { ...state, grants: action.rows, grantsLoading: false };
+    case "grants/loadFailed":
+      return { ...state, grantsLoading: false, grantsError: action.error };
+    case "grants/removed":
+      return {
+        ...state,
+        grants: state.grants.filter((grant) => grant.id !== action.grantID),
+      };
+  }
+}
+
+const ApprovalsContext = createContext<ApprovalsContextValue | null>(null);
+
+export function ApprovalsProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  // Per-session mutation version. Lives outside the reducer
+  // because every live mutation needs to bump it synchronously
+  // before refetchPending captures the "before" snapshot; folding
+  // it into a useReducer action would mean a separate render
+  // pass between the bump and the read.
+  const versionBySessionID = useRef<Map<string, number>>(new Map());
+
+  const bumpVersion = useCallback((sessionID: string) => {
+    const current = versionBySessionID.current.get(sessionID) ?? 0;
+    versionBySessionID.current.set(sessionID, current + 1);
+  }, []);
+
+  const setPendingForSession = useCallback((sessionID: string, rows: PendingAgentApproval[]) => {
+    dispatch({ type: "pending/setForSession", sessionID, rows });
+  }, []);
+
+  const upsertPending = useCallback((event: PendingAgentApproval) => {
+    bumpVersion(event.session_id);
+    dispatch({ type: "pending/upsert", event });
+  }, [bumpVersion]);
+
+  const removePending = useCallback((sessionID: string, approvalID: string) => {
+    bumpVersion(sessionID);
+    dispatch({ type: "pending/remove", sessionID, approvalID });
+  }, [bumpVersion]);
+
+  const refetchPending = useCallback(async (sessionID: string) => {
+    if (!sessionID) return;
+    const startedAtVersion = versionBySessionID.current.get(sessionID) ?? 0;
+    try {
+      const result = await listAgentChatApprovalsRequest(sessionID, "pending");
+      const currentVersion = versionBySessionID.current.get(sessionID) ?? 0;
+      if (currentVersion !== startedAtVersion) {
+        // A live SSE update or optimistic local action landed
+        // during this catch-up. Ignore the stale GET rather than
+        // clearing a newer pending approval or re-adding one
+        // that was just resolved.
+        return;
+      }
+      const rows = (result.data ?? []).map(approvalRecordToPending);
+      dispatch({ type: "pending/setForSession", sessionID, rows });
+    } catch {
+      // Banner is best-effort; failure here just means the
+      // operator doesn't see the catch-up state until the next
+      // reconnect.
+    }
+  }, []);
+
+  const getApproval = useCallback(async (
+    sessionID: string,
+    approvalID: string,
+  ): Promise<GetApprovalResult> => {
+    try {
+      const payload = await getAgentChatApprovalRequest(sessionID, approvalID);
+      return { ok: true, record: payload.data };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to load approval." };
+    }
+  }, []);
+
+  const resolveApproval = useCallback(async (
+    sessionID: string,
+    approvalID: string,
+    decision: ResolveAgentChatApprovalPayload,
+  ): Promise<ApprovalActionResult> => {
+    try {
+      await resolveAgentChatApprovalRequest(sessionID, approvalID, decision);
+      // Optimistic removal: the SSE `approval.resolved` event will
+      // also fire and remove the row, but updating immediately
+      // keeps the banner snappy when the operator closes the modal.
+      bumpVersion(sessionID);
+      dispatch({ type: "pending/remove", sessionID, approvalID });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to resolve approval." };
+    }
+  }, [bumpVersion]);
+
+  const cancelApproval = useCallback(async (
+    sessionID: string,
+    approvalID: string,
+  ): Promise<ApprovalActionResult> => {
+    try {
+      await cancelAgentChatApprovalRequest(sessionID, approvalID);
+      bumpVersion(sessionID);
+      dispatch({ type: "pending/remove", sessionID, approvalID });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to cancel approval." };
+    }
+  }, [bumpVersion]);
+
+  const loadGrants = useCallback(async (filter: AgentChatGrantFilter = {}): Promise<void> => {
+    dispatch({ type: "grants/loadStart" });
+    try {
+      const payload = await listAgentChatGrantsRequest(filter);
+      dispatch({ type: "grants/loaded", rows: payload.data ?? [] });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "failed to load grants";
+      dispatch({ type: "grants/loadFailed", error: msg });
+    }
+  }, []);
+
+  const deleteGrant = useCallback(async (grantID: string): Promise<ApprovalActionResult> => {
+    try {
+      await deleteAgentChatGrantRequest(grantID);
+      dispatch({ type: "grants/removed", grantID });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to revoke grant." };
+    }
+  }, []);
+
+  const actions = useMemo<ApprovalsActions>(() => ({
+    setPendingForSession,
+    upsertPending,
+    removePending,
+    refetchPending,
+    getApproval,
+    resolveApproval,
+    cancelApproval,
+    loadGrants,
+    deleteGrant,
+  }), [
+    setPendingForSession,
+    upsertPending,
+    removePending,
+    refetchPending,
+    getApproval,
+    resolveApproval,
+    cancelApproval,
+    loadGrants,
+    deleteGrant,
+  ]);
+
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <ApprovalsContext.Provider value={value}>{children}</ApprovalsContext.Provider>;
+}
+
+export function useApprovals(): ApprovalsContextValue {
+  const ctx = useContext(ApprovalsContext);
+  if (!ctx) {
+    throw new Error("useApprovals must be used inside an <ApprovalsProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -1,16 +1,25 @@
 import { act, renderHook, waitFor, type RenderHookOptions } from "@testing-library/react";
+import { type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApprovalsProvider } from "./state/approvals";
 import { RetentionProvider } from "./state/retention";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
-// useRuntimeConsole now consumes slice contexts (retention is the
-// first one to land). Every renderHook call needs the matching
-// providers above it; this helper composes them so the test bodies
-// don't have to thread a wrapper through each call. As more slices
-// are added the wrapper chain grows here.
+// useRuntimeConsole consumes slice contexts (retention, approvals,
+// and more as slices are added). Every renderHook call needs the
+// matching providers above it; this wrapper composes them so the
+// test bodies don't have to thread the chain through each call.
+function SliceProviders({ children }: { children: ReactNode }) {
+  return (
+    <RetentionProvider>
+      <ApprovalsProvider>{children}</ApprovalsProvider>
+    </RetentionProvider>
+  );
+}
+
 function renderRuntimeConsoleHook(options?: Omit<RenderHookOptions<unknown>, "wrapper">) {
-  return renderHook(() => useRuntimeConsole(), { ...options, wrapper: RetentionProvider });
+  return renderHook(() => useRuntimeConsole(), { ...options, wrapper: SliceProviders });
 }
 
 // Single-user mode: every endpoint is unauthenticated and the gateway

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -29,20 +29,14 @@ import {
   getUsageEvents,
   getUsageSummary,
   setProviderAPIKey as setProviderAPIKeyRequest,
-  cancelAgentChatApproval as cancelAgentChatApprovalRequest,
   cancelAgentChatSession as cancelAgentChatSessionRequest,
-  deleteAgentChatGrant as deleteAgentChatGrantRequest,
   getAgentChatMessageFileDiff as getAgentChatMessageFileDiffRequest,
-  getAgentChatApproval as getAgentChatApprovalRequest,
   listAgentChatMessageFiles as listAgentChatMessageFilesRequest,
-  listAgentChatApprovals as listAgentChatApprovalsRequest,
-  listAgentChatGrants as listAgentChatGrantsRequest,
   probeAgentAdapter as probeAgentAdapterRequest,
   setAgentAdapterCredential as setAgentAdapterCredentialRequest,
   deleteAgentAdapterCredential as deleteAgentAdapterCredentialRequest,
   revertAgentChatMessageFiles as revertAgentChatMessageFilesRequest,
   resolveTaskApproval as resolveTaskApprovalRequest,
-  resolveAgentChatApproval as resolveAgentChatApprovalRequest,
   upsertPolicyRule as upsertPolicyRuleRequest,
   createProvider as createProviderRequest,
   deleteModelCapabilityOverride as deleteModelCapabilityOverrideRequest,
@@ -61,9 +55,8 @@ import {
   setProviderCustomName as setProviderCustomNameRequest,
   upsertModelCapabilityOverride as upsertModelCapabilityOverrideRequest,
 } from "../lib/api";
-import type { PolicyRuleUpsertPayload, ResolveAgentChatApprovalPayload, ResolveTaskApprovalPayload, AgentChatGrantFilter, ModelCapabilityUpsertPayload } from "../lib/api";
+import type { PolicyRuleUpsertPayload, ResolveAgentChatApprovalPayload, ResolveTaskApprovalPayload, ModelCapabilityUpsertPayload } from "../lib/api";
 import {
-  approvalRecordToPending,
   buildAssistantToolCallMessage,
   buildSyntheticChatResult,
   defaultModelForProvider,
@@ -74,6 +67,7 @@ import {
   renderAgentChatSessionSummary,
 } from "./runtimeConsoleChatHelpers";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
+import { useApprovals } from "./state/approvals";
 import { useRetention } from "./state/retention";
 import type {
   AgentAdapterHealthRecord,
@@ -82,8 +76,6 @@ import type {
   AgentChatActivityRecord,
   AgentChatChangedFileDiffRecord,
   AgentChatChangedFileRecord,
-  AgentChatGrantRecord,
-  PendingAgentApproval,
   AgentChatSessionRecord,
   AgentChatSessionsResponse,
   ChatResponse,
@@ -187,25 +179,14 @@ export function useRuntimeConsole() {
     { shouldRemove: (v) => v === "" },
   );
   const [activeAgentChatSession, setActiveAgentChatSession] = useState<AgentChatSessionRecord | null>(null);
-  // pendingApprovalsBySessionID stores the banner-essentials view of
-  // pending approvals, keyed by session id. Values are projected to
-  // the same shape carried by the SSE `approval.requested` event so the
-  // banner doesn't need to know whether a row came from the initial
-  // GET-list refetch or from a streamed event. The full row (ACP
-  // options, scope choices, diff preview, …) is fetched on modal open
-  // — keeping the map lean.
-  //
-  // The Map instance is always replaced on update (never mutated in
-  // place); React reference equality is the re-render trigger.
-  const [pendingApprovalsBySessionID, setPendingApprovalsBySessionID] = useState<
-    Map<string, PendingAgentApproval[]>
-  >(() => new Map());
-  const pendingApprovalsVersionBySessionID = useRef<Map<string, number>>(new Map());
-  // agentChatGrants holds the most recent listAgentChatGrants result
-  // for Connections. Lazy-loaded by the action, not on hook mount.
-  const [agentChatGrants, setAgentChatGrants] = useState<AgentChatGrantRecord[]>([]);
-  const [agentChatGrantsLoading, setAgentChatGrantsLoading] = useState(false);
-  const [agentChatGrantsError, setAgentChatGrantsError] = useState("");
+  // Approvals state + actions live in the slice (app/state/approvals.tsx).
+  // The slice owns the pending-banner map, the per-session mutation
+  // version that protects the catch-up GET against races, the grant
+  // list, and the request actions. The shim below re-exports the
+  // state under the legacy `state.{pendingApprovalsBySessionID,
+  // agentChatGrants,agentChatGrantsLoading,agentChatGrantsError}`
+  // keys and the actions under their legacy identifiers.
+  const approvals = useApprovals();
   // agentAdapterApprovalMode mirrors the runtime-stats field of the
   // same name. Empty until the dashboard fan-out resolves. The Chats
   // workspace surfaces a danger banner when this is "auto" — every
@@ -700,84 +681,13 @@ export function useRuntimeConsole() {
     applyAgentChatSession(payload.data);
   }
 
-  // setPendingApprovalsForSession atomically replaces the pending list
-  // for a session. The catch-up path only calls this when no live SSE
-  // or optimistic local update landed while the request was in flight;
-  // otherwise the GET result may be stale relative to the stream.
-  function setPendingApprovalsForSession(
-    sessionID: string,
-    rows: PendingAgentApproval[],
-  ) {
-    setPendingApprovalsBySessionID((current) => {
-      const next = new Map(current);
-      if (rows.length === 0) {
-        next.delete(sessionID);
-      } else {
-        next.set(sessionID, rows);
-      }
-      return next;
-    });
-  }
-
-  function bumpPendingApprovalsVersion(sessionID: string) {
-    const current = pendingApprovalsVersionBySessionID.current.get(sessionID) ?? 0;
-    pendingApprovalsVersionBySessionID.current.set(sessionID, current + 1);
-  }
-
-  function upsertPendingApproval(event: PendingAgentApproval) {
-    bumpPendingApprovalsVersion(event.session_id);
-    setPendingApprovalsBySessionID((current) => {
-      const next = new Map(current);
-      const existing = next.get(event.session_id) ?? [];
-      const filtered = existing.filter((row) => row.approval_id !== event.approval_id);
-      filtered.push(event);
-      next.set(event.session_id, filtered);
-      return next;
-    });
-  }
-
-  function removePendingApproval(sessionID: string, approvalID: string) {
-    bumpPendingApprovalsVersion(sessionID);
-    setPendingApprovalsBySessionID((current) => {
-      const existing = current.get(sessionID);
-      if (!existing) return current;
-      const filtered = existing.filter((row) => row.approval_id !== approvalID);
-      if (filtered.length === existing.length) return current;
-      const next = new Map(current);
-      if (filtered.length === 0) {
-        next.delete(sessionID);
-      } else {
-        next.set(sessionID, filtered);
-      }
-      return next;
-    });
-  }
-
-  // refetchPendingApprovals is the catch-up path. Called when an
-  // operator selects a session: any approvals created or resolved while
-  // the SSE stream was disconnected (or before this session was
-  // active) are reconciled in one round trip. Subsequent SSE events
-  // mutate this same map.
-  async function refetchPendingApprovals(sessionID: string) {
-    if (!sessionID) return;
-    const startedAtVersion = pendingApprovalsVersionBySessionID.current.get(sessionID) ?? 0;
-    try {
-      const result = await listAgentChatApprovalsRequest(sessionID, "pending");
-      const currentVersion = pendingApprovalsVersionBySessionID.current.get(sessionID) ?? 0;
-      if (currentVersion !== startedAtVersion) {
-        // A live SSE update or optimistic local action landed while
-        // this catch-up request was in flight. Ignore the stale GET
-        // result rather than clearing a newer pending approval or
-        // re-adding one that was just resolved.
-        return;
-      }
-      const rows = (result.data ?? []).map(approvalRecordToPending);
-      setPendingApprovalsForSession(sessionID, rows);
-    } catch {
-      // Banner is best-effort; failure here just means the operator
-      // doesn't see the catch-up state until the next reconnect.
-    }
-  }
+  // Mutation API thin-aliases for the SSE stream handler + catch-up
+  // path below. The slice owns the state + version-ref machinery;
+  // these names stay stable so the call sites read the same way as
+  // before the carve-out.
+  const upsertPendingApproval = approvals.actions.upsertPending;
+  const removePendingApproval = approvals.actions.removePending;
+  const refetchPendingApprovals = approvals.actions.refetchPending;
 
   function clearChatErrorState() {
     setChatError("");
@@ -1406,18 +1316,20 @@ export function useRuntimeConsole() {
 
   // getAgentChatApproval is the modal-open path: fetches the full
   // approval row (ACP options, scope choices, decision_note, …).
-  // Returns null on failure so the caller can render an error state.
+  // Returns null on failure so the caller can render an error state;
+  // the slice's getApproval returns a discriminated Result that the
+  // shim unwraps into the legacy `record | null` shape and routes
+  // the error string to the global notice banner.
   async function getAgentChatApproval(
     sessionID: string,
     approvalID: string,
   ): Promise<AgentChatApprovalRecord | null> {
-    try {
-      const payload = await getAgentChatApprovalRequest(sessionID, approvalID);
-      return payload.data;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to load approval.");
+    const result = await approvals.actions.getApproval(sessionID, approvalID);
+    if (!result.ok) {
+      setNoticeMessage("error", result.error);
       return null;
     }
+    return result.record;
   }
 
   async function resolveAgentChatApproval(
@@ -1425,28 +1337,15 @@ export function useRuntimeConsole() {
     approvalID: string,
     decision: ResolveAgentChatApprovalPayload,
   ): Promise<boolean> {
-    try {
-      await resolveAgentChatApprovalRequest(sessionID, approvalID, decision);
-      // Optimistic removal: the SSE `approval.resolved` event will
-      // also fire and remove the row, but updating immediately keeps
-      // the banner snappy when the operator closes the modal.
-      removePendingApproval(sessionID, approvalID);
-      return true;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to resolve approval.");
-      return false;
-    }
+    const result = await approvals.actions.resolveApproval(sessionID, approvalID, decision);
+    if (!result.ok) setNoticeMessage("error", result.error);
+    return result.ok;
   }
 
   async function cancelAgentChatApproval(sessionID: string, approvalID: string): Promise<boolean> {
-    try {
-      await cancelAgentChatApprovalRequest(sessionID, approvalID);
-      removePendingApproval(sessionID, approvalID);
-      return true;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to cancel approval.");
-      return false;
-    }
+    const result = await approvals.actions.cancelApproval(sessionID, approvalID);
+    if (!result.ok) setNoticeMessage("error", result.error);
+    return result.ok;
   }
 
   async function resolveTaskApproval(
@@ -1581,30 +1480,16 @@ export function useRuntimeConsole() {
     }
   }
 
-  async function listAgentChatGrants(filter: AgentChatGrantFilter = {}): Promise<void> {
-    setAgentChatGrantsLoading(true);
-    setAgentChatGrantsError("");
-    try {
-      const payload = await listAgentChatGrantsRequest(filter);
-      setAgentChatGrants(payload.data ?? []);
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : "failed to load grants";
-      setAgentChatGrantsError(msg);
-    } finally {
-      setAgentChatGrantsLoading(false);
-    }
-  }
+  const listAgentChatGrants = approvals.actions.loadGrants;
 
   async function deleteAgentChatGrant(grantID: string): Promise<boolean> {
-    try {
-      await deleteAgentChatGrantRequest(grantID);
-      setAgentChatGrants((current) => current.filter((g) => g.id !== grantID));
+    const result = await approvals.actions.deleteGrant(grantID);
+    if (result.ok) {
       setNoticeMessage("success", "Grant revoked.");
-      return true;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to revoke grant.");
-      return false;
+    } else {
+      setNoticeMessage("error", result.error);
     }
+    return result.ok;
   }
 
   async function listAgentChatMessageFiles(sessionID: string, messageID: string): Promise<AgentChatChangedFileRecord[]> {
@@ -1868,10 +1753,10 @@ export function useRuntimeConsole() {
       chatSessionsHasMore,
       chatSessionsLoadingMore,
       visibleModels,
-      pendingApprovalsBySessionID,
-      agentChatGrants,
-      agentChatGrantsLoading,
-      agentChatGrantsError,
+      pendingApprovalsBySessionID: approvals.state.pendingBySessionID,
+      agentChatGrants: approvals.state.grants,
+      agentChatGrantsLoading: approvals.state.grantsLoading,
+      agentChatGrantsError: approvals.state.grantsError,
       agentAdapterApprovalMode,
       agentAdapterHealthByID,
       agentAdapterHealthLoadingByID,


### PR DESCRIPTION
## Summary

Second slice carved out of `useRuntimeConsole`. Owns the agent-chat approvals domain: pending-banner map, grants list, plus the per-session mutation-version ref that protects the catch-up `GET` against races with the SSE stream and optimistic local actions.

## What's new

**`ui/src/app/state/approvals.tsx`** (~280 LOC):

```ts
type ApprovalsState = {
  pendingBySessionID: Map<string, PendingAgentApproval[]>;
  grants: AgentChatGrantRecord[];
  grantsLoading: boolean;
  grantsError: string;
};

export function ApprovalsProvider({ children }) { /* useReducer + ref + actions */ }
export function useApprovals(): { state, actions };
```

Two API shapes inside `actions`:

| Shape | Members | Why |
|---|---|---|
| **Mutators** (sync) | `setPendingForSession`, `upsertPending`, `removePending`, `refetchPending` | Called from the SSE stream handler and the session-select catch-up. No cross-cut. |
| **Requests** (return Result) | `getApproval`, `resolveApproval`, `cancelApproval`, `loadGrants`, `deleteGrant` | Views call them; success/error routes to the global `notice` banner in the shim. |

`loadGrants` is the one exception that keeps error state in-slice (`grantsError`) because Connections renders it inline rather than via a toast.

## Race protection (worth reviewing)

The per-session mutation-version `ref` lives **outside** `useReducer` because every live mutation (`upsertPending`, `removePending`, resolve, cancel) bumps it synchronously before `refetchPending` captures the "before" snapshot. Threading it through `useReducer` would mean an extra render pass between the bump and the read — exactly the window the race is designed to close.

```ts
const startedAtVersion = versionBySessionID.current.get(sessionID) ?? 0;
const result = await listAgentChatApprovalsRequest(sessionID, "pending");
const currentVersion = versionBySessionID.current.get(sessionID) ?? 0;
if (currentVersion !== startedAtVersion) return; // stale GET — drop it
dispatch({ type: "pending/setForSession", sessionID, rows });
```

## useRuntimeConsole shim

Drops:
- 4 useState declarations (`pendingApprovalsBySessionID`, `agentChatGrants`, `agentChatGrantsLoading`, `agentChatGrantsError`)
- the `pendingApprovalsVersionBySessionID` ref
- 4 internal helpers (`setPendingApprovalsForSession`, `bumpPendingApprovalsVersion`, `upsertPendingApproval`, `removePendingApproval`, `refetchPendingApprovals`)
- 6 request-helper imports + `approvalRecordToPending` + 4 type imports

Replaces with thin aliases over `approvals.actions.*` so the SSE handler + catch-up call sites read identically. Action wrappers (`getAgentChatApproval`, `resolveAgentChatApproval`, `cancelAgentChatApproval`, `deleteAgentChatGrant`) become Result-unwrapping shims that preserve the legacy external shapes (`record | null`, `boolean`).

## Tests

`useRuntimeConsole.test.tsx`'s wrapper grows from `RetentionProvider` to a `SliceProviders` composer:

```tsx
function SliceProviders({ children }) {
  return (
    <RetentionProvider>
      <ApprovalsProvider>{children}</ApprovalsProvider>
    </RetentionProvider>
  );
}
```

Every assertion unchanged. The full suite passes (824/824, 38 files).

## External surface

Byte-for-byte stable. `state.{pendingApprovalsBySessionID, agentChatGrants, agentChatGrantsLoading, agentChatGrantsError}` keys present, `actions.{getAgentChatApproval, resolveAgentChatApproval, cancelAgentChatApproval, listAgentChatGrants, deleteAgentChatGrant}` identifiers present. `ChatView` and `ConnectionsPanel` weren't modified.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: keys + action identifiers + types byte-for-byte stable
- [x] `ChatView` + `ConnectionsPanel` consumers untouched
