### PR TITLE
refactor(ui): extract the runtime + usage slices [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -3,6 +3,8 @@ import { useEffect, useLayoutEffect } from "react";
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
 import { ApprovalsProvider } from "./state/approvals";
 import { RetentionProvider } from "./state/retention";
+import { RuntimeProvider } from "./state/runtime";
+import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
@@ -23,11 +25,15 @@ const parseWorkspaceID = (raw: string): WorkspaceID | null =>
 // chain.
 export default function App() {
   return (
-    <RetentionProvider>
-      <ApprovalsProvider>
-        <AppConsole />
-      </ApprovalsProvider>
-    </RetentionProvider>
+    <RuntimeProvider>
+      <UsageProvider>
+        <RetentionProvider>
+          <ApprovalsProvider>
+            <AppConsole />
+          </ApprovalsProvider>
+        </RetentionProvider>
+      </UsageProvider>
+    </RuntimeProvider>
   );
 }
 

--- a/ui/src/app/state/runtime.tsx
+++ b/ui/src/app/state/runtime.tsx
@@ -1,0 +1,156 @@
+// Runtime slice: gateway health, session info, top-level
+// loading/error/message banners, runtime response headers
+// (request_id / trace_id), the copy-to-clipboard transient flag,
+// and the Hecate "rich tool kit" availability bits used by the
+// Chat composer.
+//
+// The slice exposes granular setters because the dashboard
+// loader, agent-chat session reapply path, chat-completion
+// post-processing, and operator-driven actions all set
+// individual fields at different times. The coordinator that
+// flips `hecateRTKEnabled` and PATCHes the session settings
+// stays in `useRuntimeConsole` for now — it couples runtime
+// state to the chats slice (`activeAgentChatSession`) which
+// hasn't been carved out yet.
+//
+// `copyCommand` lives in the slice because the clipboard
+// side-effect is self-contained (no cross-slice state); a
+// 1.5 s timeout clears the indicator so the consumer doesn't
+// have to thread one in.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+
+import type { HealthResponse, RuntimeHeaders, SessionResponse } from "../../types/runtime";
+
+export type RuntimeState = {
+  health: HealthResponse | null;
+  sessionInfo: SessionResponse["data"] | null;
+  loading: boolean;
+  error: string;
+  message: string;
+  runtimeHeaders: RuntimeHeaders | null;
+  copiedCommand: string;
+  hecateRTKEnabled: boolean;
+  hecateRTKAvailable: boolean;
+  hecateRTKPath: string;
+};
+
+export type RuntimeActions = {
+  setHealth: (value: HealthResponse | null) => void;
+  setSessionInfo: (value: SessionResponse["data"] | null) => void;
+  setLoading: (value: boolean) => void;
+  setError: (value: string) => void;
+  setMessage: (value: string) => void;
+  setRuntimeHeaders: (value: RuntimeHeaders | null) => void;
+  setHecateRTKEnabled: (value: boolean) => void;
+  setHecateRTKAvailable: (value: boolean) => void;
+  setHecateRTKPath: (value: string) => void;
+  copyCommand: (command: string) => Promise<void>;
+};
+
+type RuntimeContextValue = {
+  state: RuntimeState;
+  actions: RuntimeActions;
+};
+
+type Action =
+  | { type: "health/set"; value: HealthResponse | null }
+  | { type: "sessionInfo/set"; value: SessionResponse["data"] | null }
+  | { type: "loading/set"; value: boolean }
+  | { type: "error/set"; value: string }
+  | { type: "message/set"; value: string }
+  | { type: "runtimeHeaders/set"; value: RuntimeHeaders | null }
+  | { type: "copiedCommand/set"; value: string }
+  | { type: "copiedCommand/clearIf"; matching: string }
+  | { type: "hecateRTKEnabled/set"; value: boolean }
+  | { type: "hecateRTKAvailable/set"; value: boolean }
+  | { type: "hecateRTKPath/set"; value: string };
+
+const initialState: RuntimeState = {
+  health: null,
+  sessionInfo: null,
+  loading: true,
+  error: "",
+  message: "",
+  runtimeHeaders: null,
+  copiedCommand: "",
+  hecateRTKEnabled: false,
+  hecateRTKAvailable: false,
+  hecateRTKPath: "",
+};
+
+function reducer(state: RuntimeState, action: Action): RuntimeState {
+  switch (action.type) {
+    case "health/set":          return { ...state, health: action.value };
+    case "sessionInfo/set":     return { ...state, sessionInfo: action.value };
+    case "loading/set":         return { ...state, loading: action.value };
+    case "error/set":           return { ...state, error: action.value };
+    case "message/set":         return { ...state, message: action.value };
+    case "runtimeHeaders/set":  return { ...state, runtimeHeaders: action.value };
+    case "copiedCommand/set":   return { ...state, copiedCommand: action.value };
+    case "copiedCommand/clearIf":
+      return state.copiedCommand === action.matching ? { ...state, copiedCommand: "" } : state;
+    case "hecateRTKEnabled/set":   return { ...state, hecateRTKEnabled: action.value };
+    case "hecateRTKAvailable/set": return { ...state, hecateRTKAvailable: action.value };
+    case "hecateRTKPath/set":      return { ...state, hecateRTKPath: action.value };
+  }
+}
+
+const RuntimeContext = createContext<RuntimeContextValue | null>(null);
+
+const COPY_INDICATOR_MS = 1500;
+
+export function RuntimeProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setHealth = useCallback((value: HealthResponse | null) => dispatch({ type: "health/set", value }), []);
+  const setSessionInfo = useCallback((value: SessionResponse["data"] | null) => dispatch({ type: "sessionInfo/set", value }), []);
+  const setLoading = useCallback((value: boolean) => dispatch({ type: "loading/set", value }), []);
+  const setError = useCallback((value: string) => dispatch({ type: "error/set", value }), []);
+  const setMessage = useCallback((value: string) => dispatch({ type: "message/set", value }), []);
+  const setRuntimeHeaders = useCallback((value: RuntimeHeaders | null) => dispatch({ type: "runtimeHeaders/set", value }), []);
+  const setHecateRTKEnabled = useCallback((value: boolean) => dispatch({ type: "hecateRTKEnabled/set", value }), []);
+  const setHecateRTKAvailable = useCallback((value: boolean) => dispatch({ type: "hecateRTKAvailable/set", value }), []);
+  const setHecateRTKPath = useCallback((value: string) => dispatch({ type: "hecateRTKPath/set", value }), []);
+
+  const copyCommand = useCallback(async (command: string) => {
+    try {
+      await navigator.clipboard.writeText(command);
+      dispatch({ type: "copiedCommand/set", value: command });
+      window.setTimeout(() => {
+        dispatch({ type: "copiedCommand/clearIf", matching: command });
+      }, COPY_INDICATOR_MS);
+    } catch {
+      dispatch({ type: "copiedCommand/set", value: "" });
+    }
+  }, []);
+
+  const actions = useMemo<RuntimeActions>(() => ({
+    setHealth,
+    setSessionInfo,
+    setLoading,
+    setError,
+    setMessage,
+    setRuntimeHeaders,
+    setHecateRTKEnabled,
+    setHecateRTKAvailable,
+    setHecateRTKPath,
+    copyCommand,
+  }), [
+    setHealth, setSessionInfo, setLoading, setError, setMessage,
+    setRuntimeHeaders, setHecateRTKEnabled, setHecateRTKAvailable,
+    setHecateRTKPath, copyCommand,
+  ]);
+
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <RuntimeContext.Provider value={value}>{children}</RuntimeContext.Provider>;
+}
+
+export function useRuntime(): RuntimeContextValue {
+  const ctx = useContext(RuntimeContext);
+  if (!ctx) {
+    throw new Error("useRuntime must be used inside a <RuntimeProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/state/usage.tsx
+++ b/ui/src/app/state/usage.tsx
@@ -1,0 +1,69 @@
+// Usage slice: cost summary + recent events. Owns two state
+// fields and exposes a single applySnapshot action; the dashboard
+// loader fans the snapshot into here. Future direct fetches
+// (refresh button, filter changes) get their own actions when the
+// consuming views ask for them.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+
+import type { UsageEventsResponse, UsageSummaryResponse } from "../../types/runtime";
+
+export type UsageState = {
+  summary: UsageSummaryResponse["data"] | null;
+  events: UsageEventsResponse["data"];
+};
+
+export type UsageActions = {
+  setSummary: (summary: UsageSummaryResponse["data"] | null) => void;
+  setEvents: (events: UsageEventsResponse["data"]) => void;
+};
+
+type UsageContextValue = {
+  state: UsageState;
+  actions: UsageActions;
+};
+
+type Action =
+  | { type: "summary/set"; summary: UsageSummaryResponse["data"] | null }
+  | { type: "events/set"; events: UsageEventsResponse["data"] };
+
+const initialState: UsageState = {
+  summary: null,
+  events: [],
+};
+
+function reducer(state: UsageState, action: Action): UsageState {
+  switch (action.type) {
+    case "summary/set":
+      return { ...state, summary: action.summary };
+    case "events/set":
+      return { ...state, events: action.events };
+  }
+}
+
+const UsageContext = createContext<UsageContextValue | null>(null);
+
+export function UsageProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setSummary = useCallback((summary: UsageSummaryResponse["data"] | null) => {
+    dispatch({ type: "summary/set", summary });
+  }, []);
+
+  const setEvents = useCallback((events: UsageEventsResponse["data"]) => {
+    dispatch({ type: "events/set", events });
+  }, []);
+
+  const actions = useMemo<UsageActions>(() => ({ setSummary, setEvents }), [setSummary, setEvents]);
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <UsageContext.Provider value={value}>{children}</UsageContext.Provider>;
+}
+
+export function useUsage(): UsageContextValue {
+  const ctx = useContext(UsageContext);
+  if (!ctx) {
+    throw new Error("useUsage must be used inside a <UsageProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -4,17 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApprovalsProvider } from "./state/approvals";
 import { RetentionProvider } from "./state/retention";
+import { RuntimeProvider } from "./state/runtime";
+import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
-// useRuntimeConsole consumes slice contexts (retention, approvals,
-// and more as slices are added). Every renderHook call needs the
-// matching providers above it; this wrapper composes them so the
-// test bodies don't have to thread the chain through each call.
+// useRuntimeConsole consumes slice contexts (runtime, usage,
+// retention, approvals, and more as slices are added). Every
+// renderHook call needs the matching providers above it; this
+// wrapper composes them so the test bodies don't have to thread
+// the chain through each call.
 function SliceProviders({ children }: { children: ReactNode }) {
   return (
-    <RetentionProvider>
-      <ApprovalsProvider>{children}</ApprovalsProvider>
-    </RetentionProvider>
+    <RuntimeProvider>
+      <UsageProvider>
+        <RetentionProvider>
+          <ApprovalsProvider>{children}</ApprovalsProvider>
+        </RetentionProvider>
+      </UsageProvider>
+    </RuntimeProvider>
   );
 }
 

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -69,6 +69,8 @@ import {
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
 import { useApprovals } from "./state/approvals";
 import { useRetention } from "./state/retention";
+import { useRuntime } from "./state/runtime";
+import { useUsage } from "./state/usage";
 import type {
   AgentAdapterHealthRecord,
   AgentAdapterRecord,
@@ -82,16 +84,12 @@ import type {
   ChatSessionRecord,
   ChatSessionsResponse,
   ConfiguredStateResponse,
-  HealthResponse,
   ModelFilter,
   ModelResponse,
   ProviderPresetRecord,
   ProviderFilter,
   ProviderStatusResponse,
   RuntimeHeaders,
-  SessionResponse,
-  UsageEventsResponse,
-  UsageSummaryResponse,
 } from "../types/runtime";
 
 type NoticeState = {
@@ -141,7 +139,50 @@ function deriveHecateChatSelectionFromSession(session: AgentChatSessionRecord | 
 export { humanizeChatError };
 
 export function useRuntimeConsole() {
-  const [health, setHealth] = useState<HealthResponse | null>(null);
+  // Runtime slice: gateway health, session info, loading/error/
+  // message banners, runtime response headers, copy-to-clipboard
+  // transient, and the Hecate RTK availability bits. Aliased to
+  // legacy identifiers below so the rest of the hook body reads
+  // identically to its pre-slice form.
+  const runtime = useRuntime();
+  const {
+    health,
+    sessionInfo,
+    loading,
+    error,
+    message,
+    runtimeHeaders,
+    copiedCommand,
+    hecateRTKEnabled,
+    hecateRTKAvailable,
+    hecateRTKPath,
+  } = runtime.state;
+  const {
+    setHealth,
+    setSessionInfo,
+    setLoading,
+    setError,
+    setMessage,
+    setRuntimeHeaders,
+    setHecateRTKAvailable,
+    setHecateRTKPath,
+    copyCommand,
+  } = runtime.actions;
+  // Legacy alias: the previous code used `setHecateRTKEnabledState`
+  // for the raw state setter and reserved `setHecateRTKEnabled` for
+  // the coordinator below (PATCHes the session and rolls back on
+  // failure). Preserving the naming keeps the coordinator's body
+  // unchanged.
+  const setHecateRTKEnabledState = runtime.actions.setHecateRTKEnabled;
+
+  // Usage slice: cost summary + recent events. Aliased to legacy
+  // identifiers so the dashboard fan-out call sites read unchanged.
+  const usage = useUsage();
+  const usageSummary = usage.state.summary;
+  const usageEvents = usage.state.events;
+  const setUsageSummary = usage.actions.setSummary;
+  const setUsageEvents = usage.actions.setEvents;
+
   const [models, setModels] = useState<ModelResponse["data"]>([]);
   const [providers, setProviders] = useState<ProviderStatusResponse["data"]>([]);
   const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
@@ -168,9 +209,6 @@ export function useRuntimeConsole() {
     "",
   );
   const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");
-  const [hecateRTKEnabled, setHecateRTKEnabledState] = useState(false);
-  const [hecateRTKAvailable, setHecateRTKAvailable] = useState(false);
-  const [hecateRTKPath, setHecateRTKPath] = useState("");
   const [agentChatSessions, setAgentChatSessions] = useState<AgentChatSessionsResponse["data"]>([]);
   const [activeAgentChatSessionID, setActiveAgentChatSessionID] = usePersistedState(
     "hecate.agentChatSessionID",
@@ -204,11 +242,7 @@ export function useRuntimeConsole() {
   const [agentAdapterHealthLoadingByID, setAgentAdapterHealthLoadingByID] = useState<
     Map<string, true>
   >(() => new Map());
-  const [usageSummary, setUsageSummary] = useState<UsageSummaryResponse["data"] | null>(null);
-  const [usageEvents, setUsageEvents] = useState<UsageEventsResponse["data"]>([]);
   const [settingsConfig, setSettingsConfig] = useState<ConfiguredStateResponse["data"] | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
 
   const [model, setModel] = usePersistedState(
     "hecate.model",
@@ -216,7 +250,6 @@ export function useRuntimeConsole() {
     "",
     { shouldRemove: (v) => v === "" },
   );
-  const [message, setMessage] = useState("");
   const [queuedChatMessages, setQueuedChatMessages] = usePersistedState<QueuedChatMessage[]>(
     queuedChatMessagesStorageKey,
     parseStoredJSON(parseQueuedChatMessageList),
@@ -247,7 +280,6 @@ export function useRuntimeConsole() {
     { shouldRemove: (v) => v === "" },
   );
   const [activeChatSession, setActiveChatSession] = useState<ChatSessionRecord | null>(null);
-  const [runtimeHeaders, setRuntimeHeaders] = useState<RuntimeHeaders | null>(null);
   const [chatError, setChatError] = useState("");
   const [chatErrorCode, setChatErrorCode] = useState("");
   const [chatErrorStatus, setChatErrorStatus] = useState<number | null>(null);
@@ -284,9 +316,7 @@ export function useRuntimeConsole() {
   useEffect(() => {
     window.localStorage.setItem("hecate.providerFilter", providerFilter);
   }, [providerFilter]);
-  const [copiedCommand, setCopiedCommand] = useState("");
 
-  const [sessionInfo, setSessionInfo] = useState<SessionResponse["data"] | null>(null);
   const [settingsError, setSettingsError] = useState("");
   const [notice, setNotice] = useState<NoticeState | null>(null);
 
@@ -1154,18 +1184,6 @@ export function useRuntimeConsole() {
         await deletePolicyRuleRequest(id);
       },
     });
-  }
-
-  async function copyCommand(command: string) {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopiedCommand(command);
-      window.setTimeout(() => {
-        setCopiedCommand((current) => (current === command ? "" : current));
-      }, 1500);
-    } catch {
-      setCopiedCommand("");
-    }
   }
 
   const loadRetentionRuns = retention.actions.loadRuns;


### PR DESCRIPTION
## Summary

Carves out the **runtime** and **usage** slices from `useRuntimeConsole`. The third slice from the planned grouping — **providersAndModels** — stays in a follow-up PR: adding it here would push the diff past the 900-LOC stop condition called out in the cleanup plan, and it has the densest action surface (13 of the 20+ adapter / provider / model mutators) of any single slice carved out so far.

Each is mechanical; the architectural decisions are already settled by [#117](https://github.com/hecatehq/hecate/pull/117) (retention) and [#118](https://github.com/hecatehq/hecate/pull/118) (approvals).

## Runtime slice — `ui/src/app/state/runtime.tsx`

Owns:
- `health`, `sessionInfo` (dashboard-fed)
- `loading`, `error`, `message` (top-level banners)
- `runtimeHeaders` (request_id / trace_id; set after chat completion)
- `copiedCommand` + the 1.5 s timeout-driven clear
- `hecateRTKEnabled`, `hecateRTKAvailable`, `hecateRTKPath` (Hecate RTK availability bits)

Exposes granular setters because the dashboard loader, agent-chat session reapply path, chat-completion post-processing, and operator-driven actions all set individual fields at different times. `copyCommand` is the one coordinator-shape action that lives inside the slice — its clipboard side-effect is self-contained.

The `setHecateRTKEnabled` coordinator (PATCHes the session and rolls back on failure) stays in the shim because it couples runtime state to the chats slice (`activeAgentChatSession`), which hasn't been carved out yet.

## Usage slice — `ui/src/app/state/usage.tsx`

Smallest slice in the phase: two state fields (`summary`, `events`), two setters, no dedicated load actions. The dashboard fan-out hits the setters directly; future direct fetches (refresh button, filter changes) get their own actions when the consuming views ask for them.

## useRuntimeConsole shim changes

- Drops 11 useState declarations and the local `copyCommand` body.
- Pulls slice values via `useRuntime()` and `useUsage()`, then destructures into legacy identifiers so the rest of the hook body (dashboard fan-out, chat error clearing, RTK rollback path) reads unchanged.
- Preserves the `setHecateRTKEnabledState` (slice setter) vs `setHecateRTKEnabled` (coordinator) naming distinction the previous code used — keeps the coordinator's body untouched.
- Four type imports retire (`HealthResponse`, `SessionResponse`, `UsageEventsResponse`, `UsageSummaryResponse`). `RuntimeHeaders` stays — still referenced as a return type on the chat-completion path.

## App.tsx + tests

`App.tsx` wraps `RuntimeProvider` + `UsageProvider` around the existing `RetentionProvider`. `useRuntimeConsole.test.tsx`'s `SliceProviders` composer grows to match. Every assertion unchanged.

## External surface

Byte-for-byte stable. Every legacy `state.{health, sessionInfo, loading, error, message, runtimeHeaders, copiedCommand, hecateRTK*, usageSummary, usageEvents}` key and every legacy `actions.{setMessage, copyCommand, setHecateRTKEnabled}` identifier is present with the same shape.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: keys + action identifiers + types byte-for-byte stable

## Follow-up

`providersAndModels` slice (providers, providerPresets, models, agentAdapters, agentAdapterApprovalMode, agentAdapterHealthByID, agentAdapterHealthLoadingByID + ~13 actions including `refreshProviders`, `loadAgentAdapters`, `probeAgentAdapter`, `setProviderAPIKey`, the model-capability override trio, etc.) is the next PR. Estimated ~600-700 LOC on its own.
