### PR TITLE
refactor(ui): extract the providersAndModels slice [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
 import { ApprovalsProvider } from "./state/approvals";
+import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
 import { UsageProvider } from "./state/usage";
@@ -27,11 +28,13 @@ export default function App() {
   return (
     <RuntimeProvider>
       <UsageProvider>
-        <RetentionProvider>
-          <ApprovalsProvider>
-            <AppConsole />
-          </ApprovalsProvider>
-        </RetentionProvider>
+        <ProvidersAndModelsProvider>
+          <RetentionProvider>
+            <ApprovalsProvider>
+              <AppConsole />
+            </ApprovalsProvider>
+          </RetentionProvider>
+        </ProvidersAndModelsProvider>
       </UsageProvider>
     </RuntimeProvider>
   );

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -1,0 +1,323 @@
+// providersAndModels slice: provider status list, persisted-config
+// provider presets, model catalog, agent adapter list, and the
+// adapter-health / approval-mode bits that ride with them.
+//
+// Two API shapes inside `actions`:
+//
+//   - Low-level setters (set{Providers,ProviderPresets,Models,
+//     AgentAdapters,AgentAdapterApprovalMode}) accept the same
+//     `SetStateAction` shape as useState so the dashboard fan-out
+//     and shim coordinators (deleteProvider's rollback,
+//     credential-update merge, etc.) read identically to the
+//     pre-slice code.
+//   - Map mutators for the adapter-health map and the per-adapter
+//     loading flag avoid the "rebuild the whole map in the
+//     caller" boilerplate that every probe path used.
+//   - Domain actions (refreshProviders, probeAgentAdapter,
+//     setAgentAdapterCredential, deleteAgentAdapterCredential)
+//     own the API call + the state update. They return Results
+//     so the shim wires success / error to the global notice
+//     banner without the slice importing cross-cut state.
+//
+// What stays in the shim: provider-CRUD coordinators
+// (setProviderAPIKey / BaseURL / Name / CustomName, createProvider,
+// deleteProvider, the three model-capability-override actions) —
+// they all call loadDashboard() and cross several other slices'
+// state (settingsConfig, providerFilter, model, settingsError).
+// Moving them now would mean dragging those slices in too.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+
+import {
+  getProviders,
+  getModels,
+  probeAgentAdapter as probeAgentAdapterRequest,
+  setAgentAdapterCredential as setAgentAdapterCredentialRequest,
+  deleteAgentAdapterCredential as deleteAgentAdapterCredentialRequest,
+} from "../../lib/api";
+import type {
+  AgentAdapterHealthRecord,
+  AgentAdapterRecord,
+  ModelResponse,
+  ProviderPresetRecord,
+  ProviderStatusResponse,
+} from "../../types/runtime";
+
+export type ProvidersAndModelsState = {
+  providers: ProviderStatusResponse["data"];
+  providerPresets: ProviderPresetRecord[];
+  models: ModelResponse["data"];
+  agentAdapters: AgentAdapterRecord[];
+  agentAdapterApprovalMode: string;
+  agentAdapterHealthByID: Map<string, AgentAdapterHealthRecord>;
+  agentAdapterHealthLoadingByID: Map<string, true>;
+};
+
+type SetStateAction<T> = T | ((prev: T) => T);
+
+export type ProbeAdapterResult =
+  | { ok: true; health: AgentAdapterHealthRecord }
+  | { ok: false; error: string };
+
+export type AdapterCredentialResult =
+  | { ok: true; isClaudeCode: boolean }
+  | { ok: false; error: string };
+
+export type AdapterDeleteCredentialResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export type ProvidersAndModelsActions = {
+  setProviders: (next: SetStateAction<ProviderStatusResponse["data"]>) => void;
+  setProviderPresets: (next: SetStateAction<ProviderPresetRecord[]>) => void;
+  setModels: (next: SetStateAction<ModelResponse["data"]>) => void;
+  setAgentAdapters: (next: SetStateAction<AgentAdapterRecord[]>) => void;
+  setAgentAdapterApprovalMode: (value: string) => void;
+  setAgentAdapterHealth: (adapterID: string, record: AgentAdapterHealthRecord) => void;
+  clearAgentAdapterHealth: (adapterID: string) => void;
+  setAgentAdapterHealthLoading: (adapterID: string, loading: boolean) => void;
+  refreshProviders: () => Promise<void>;
+  probeAgentAdapter: (adapterID: string) => Promise<ProbeAdapterResult>;
+  setAgentAdapterCredential: (
+    adapterID: string,
+    value: string,
+    name?: string,
+  ) => Promise<AdapterCredentialResult>;
+  deleteAgentAdapterCredential: (
+    adapterID: string,
+    name: string,
+  ) => Promise<AdapterDeleteCredentialResult>;
+};
+
+type ProvidersAndModelsContextValue = {
+  state: ProvidersAndModelsState;
+  actions: ProvidersAndModelsActions;
+};
+
+type Action =
+  | { type: "providers/set"; next: SetStateAction<ProviderStatusResponse["data"]> }
+  | { type: "providerPresets/set"; next: SetStateAction<ProviderPresetRecord[]> }
+  | { type: "models/set"; next: SetStateAction<ModelResponse["data"]> }
+  | { type: "agentAdapters/set"; next: SetStateAction<AgentAdapterRecord[]> }
+  | { type: "agentAdapterApprovalMode/set"; value: string }
+  | { type: "agentAdapterHealth/set"; adapterID: string; record: AgentAdapterHealthRecord }
+  | { type: "agentAdapterHealth/clear"; adapterID: string }
+  | { type: "agentAdapterHealthLoading/set"; adapterID: string; loading: boolean };
+
+const initialState: ProvidersAndModelsState = {
+  providers: [],
+  providerPresets: [],
+  models: [],
+  agentAdapters: [],
+  agentAdapterApprovalMode: "",
+  agentAdapterHealthByID: new Map(),
+  agentAdapterHealthLoadingByID: new Map(),
+};
+
+function resolve<T>(prev: T, next: SetStateAction<T>): T {
+  return typeof next === "function" ? (next as (prev: T) => T)(prev) : next;
+}
+
+function reducer(state: ProvidersAndModelsState, action: Action): ProvidersAndModelsState {
+  switch (action.type) {
+    case "providers/set":
+      return { ...state, providers: resolve(state.providers, action.next) };
+    case "providerPresets/set":
+      return { ...state, providerPresets: resolve(state.providerPresets, action.next) };
+    case "models/set":
+      return { ...state, models: resolve(state.models, action.next) };
+    case "agentAdapters/set":
+      return { ...state, agentAdapters: resolve(state.agentAdapters, action.next) };
+    case "agentAdapterApprovalMode/set":
+      return { ...state, agentAdapterApprovalMode: action.value };
+    case "agentAdapterHealth/set": {
+      const next = new Map(state.agentAdapterHealthByID);
+      next.set(action.adapterID, action.record);
+      return { ...state, agentAdapterHealthByID: next };
+    }
+    case "agentAdapterHealth/clear": {
+      if (!state.agentAdapterHealthByID.has(action.adapterID)) return state;
+      const next = new Map(state.agentAdapterHealthByID);
+      next.delete(action.adapterID);
+      return { ...state, agentAdapterHealthByID: next };
+    }
+    case "agentAdapterHealthLoading/set": {
+      const map = state.agentAdapterHealthLoadingByID;
+      if (action.loading) {
+        const next = new Map(map);
+        next.set(action.adapterID, true);
+        return { ...state, agentAdapterHealthLoadingByID: next };
+      }
+      if (!map.has(action.adapterID)) return state;
+      const next = new Map(map);
+      next.delete(action.adapterID);
+      return { ...state, agentAdapterHealthLoadingByID: next };
+    }
+  }
+}
+
+const ProvidersAndModelsContext = createContext<ProvidersAndModelsContextValue | null>(null);
+
+export function ProvidersAndModelsProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setProviders = useCallback(
+    (next: SetStateAction<ProviderStatusResponse["data"]>) => dispatch({ type: "providers/set", next }),
+    [],
+  );
+  const setProviderPresets = useCallback(
+    (next: SetStateAction<ProviderPresetRecord[]>) => dispatch({ type: "providerPresets/set", next }),
+    [],
+  );
+  const setModels = useCallback(
+    (next: SetStateAction<ModelResponse["data"]>) => dispatch({ type: "models/set", next }),
+    [],
+  );
+  const setAgentAdapters = useCallback(
+    (next: SetStateAction<AgentAdapterRecord[]>) => dispatch({ type: "agentAdapters/set", next }),
+    [],
+  );
+  const setAgentAdapterApprovalMode = useCallback(
+    (value: string) => dispatch({ type: "agentAdapterApprovalMode/set", value }),
+    [],
+  );
+  const setAgentAdapterHealth = useCallback(
+    (adapterID: string, record: AgentAdapterHealthRecord) =>
+      dispatch({ type: "agentAdapterHealth/set", adapterID, record }),
+    [],
+  );
+  const clearAgentAdapterHealth = useCallback(
+    (adapterID: string) => dispatch({ type: "agentAdapterHealth/clear", adapterID }),
+    [],
+  );
+  const setAgentAdapterHealthLoading = useCallback(
+    (adapterID: string, loading: boolean) =>
+      dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading }),
+    [],
+  );
+
+  const refreshProviders = useCallback(async () => {
+    try {
+      const [pResult, mResult] = await Promise.allSettled([getProviders(), getModels()]);
+      if (pResult.status === "fulfilled") {
+        dispatch({ type: "providers/set", next: pResult.value.data ?? [] });
+      }
+      if (mResult.status === "fulfilled") {
+        dispatch({ type: "models/set", next: mResult.value.data ?? [] });
+      }
+    } catch {
+      // Best-effort background refresh — ignore errors.
+    }
+  }, []);
+
+  const probeAgentAdapter = useCallback(async (adapterID: string): Promise<ProbeAdapterResult> => {
+    if (!adapterID) return { ok: false, error: "Adapter id required to probe." };
+    dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: true });
+    try {
+      const payload = await probeAgentAdapterRequest(adapterID);
+      dispatch({ type: "agentAdapterHealth/set", adapterID, record: payload.data.health });
+      dispatch({
+        type: "agentAdapters/set",
+        next: (current) => current.map((item) => (item.id === adapterID ? payload.data.adapter : item)),
+      });
+      return { ok: true, health: payload.data.health };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to probe adapter." };
+    } finally {
+      dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: false });
+    }
+  }, []);
+
+  const setAgentAdapterCredential = useCallback(async (
+    adapterID: string,
+    value: string,
+    name?: string,
+  ): Promise<AdapterCredentialResult> => {
+    try {
+      const payload = await setAgentAdapterCredentialRequest(adapterID, value, name);
+      dispatch({
+        type: "agentAdapters/set",
+        next: (current) => current.map((item) => (item.id === adapterID
+          ? { ...item, credential_configured: payload.data.configured, credential_preview: payload.data.preview }
+          : item)),
+      });
+      const isClaudeCode = adapterID === "claude_code";
+      if (isClaudeCode && payload.data.configured) {
+        // Claude Code's credential check IS the readiness probe — the
+        // adapter validates the token at credential-set time, so a
+        // success here doubles as a healthy probe result and surfaces
+        // the green chip without a separate user action.
+        dispatch({
+          type: "agentAdapterHealth/set",
+          adapterID,
+          record: { adapter_id: adapterID, status: "ready", stage: "ready", duration_ms: 0 },
+        });
+      }
+      return { ok: true, isClaudeCode };
+    } catch (error) {
+      const fallback = adapterID === "claude_code"
+        ? "Failed to validate adapter credential."
+        : "Failed to save adapter credential.";
+      return { ok: false, error: error instanceof Error ? error.message : fallback };
+    }
+  }, []);
+
+  const deleteAgentAdapterCredential = useCallback(async (
+    adapterID: string,
+    name: string,
+  ): Promise<AdapterDeleteCredentialResult> => {
+    try {
+      await deleteAgentAdapterCredentialRequest(adapterID, name);
+      dispatch({
+        type: "agentAdapters/set",
+        next: (current) => current.map((item) => (item.id === adapterID
+          ? { ...item, credential_configured: false, credential_preview: undefined }
+          : item)),
+      });
+      dispatch({ type: "agentAdapterHealth/clear", adapterID });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : "Failed to remove adapter credential." };
+    }
+  }, []);
+
+  const actions = useMemo<ProvidersAndModelsActions>(() => ({
+    setProviders,
+    setProviderPresets,
+    setModels,
+    setAgentAdapters,
+    setAgentAdapterApprovalMode,
+    setAgentAdapterHealth,
+    clearAgentAdapterHealth,
+    setAgentAdapterHealthLoading,
+    refreshProviders,
+    probeAgentAdapter,
+    setAgentAdapterCredential,
+    deleteAgentAdapterCredential,
+  }), [
+    setProviders,
+    setProviderPresets,
+    setModels,
+    setAgentAdapters,
+    setAgentAdapterApprovalMode,
+    setAgentAdapterHealth,
+    clearAgentAdapterHealth,
+    setAgentAdapterHealthLoading,
+    refreshProviders,
+    probeAgentAdapter,
+    setAgentAdapterCredential,
+    deleteAgentAdapterCredential,
+  ]);
+
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <ProvidersAndModelsContext.Provider value={value}>{children}</ProvidersAndModelsContext.Provider>;
+}
+
+export function useProvidersAndModels(): ProvidersAndModelsContextValue {
+  const ctx = useContext(ProvidersAndModelsContext);
+  if (!ctx) {
+    throw new Error("useProvidersAndModels must be used inside a <ProvidersAndModelsProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -3,23 +3,26 @@ import { type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApprovalsProvider } from "./state/approvals";
+import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
 import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
 // useRuntimeConsole consumes slice contexts (runtime, usage,
-// retention, approvals, and more as slices are added). Every
-// renderHook call needs the matching providers above it; this
-// wrapper composes them so the test bodies don't have to thread
-// the chain through each call.
+// providersAndModels, retention, approvals, and more as slices
+// are added). Every renderHook call needs the matching providers
+// above it; this wrapper composes them so the test bodies don't
+// have to thread the chain through each call.
 function SliceProviders({ children }: { children: ReactNode }) {
   return (
     <RuntimeProvider>
       <UsageProvider>
-        <RetentionProvider>
-          <ApprovalsProvider>{children}</ApprovalsProvider>
-        </RetentionProvider>
+        <ProvidersAndModelsProvider>
+          <RetentionProvider>
+            <ApprovalsProvider>{children}</ApprovalsProvider>
+          </RetentionProvider>
+        </ProvidersAndModelsProvider>
       </UsageProvider>
     </RuntimeProvider>
   );

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -24,17 +24,12 @@ import {
   deletePolicyRule as deletePolicyRuleRequest,
   getChatSession,
   getChatSessions,
-  getModels,
-  getProviders,
   getUsageEvents,
   getUsageSummary,
   setProviderAPIKey as setProviderAPIKeyRequest,
   cancelAgentChatSession as cancelAgentChatSessionRequest,
   getAgentChatMessageFileDiff as getAgentChatMessageFileDiffRequest,
   listAgentChatMessageFiles as listAgentChatMessageFilesRequest,
-  probeAgentAdapter as probeAgentAdapterRequest,
-  setAgentAdapterCredential as setAgentAdapterCredentialRequest,
-  deleteAgentAdapterCredential as deleteAgentAdapterCredentialRequest,
   revertAgentChatMessageFiles as revertAgentChatMessageFilesRequest,
   resolveTaskApproval as resolveTaskApprovalRequest,
   upsertPolicyRule as upsertPolicyRuleRequest,
@@ -68,12 +63,12 @@ import {
 } from "./runtimeConsoleChatHelpers";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
 import { useApprovals } from "./state/approvals";
+import { useProvidersAndModels } from "./state/providersAndModels";
 import { useRetention } from "./state/retention";
 import { useRuntime } from "./state/runtime";
 import { useUsage } from "./state/usage";
 import type {
   AgentAdapterHealthRecord,
-  AgentAdapterRecord,
   AgentChatApprovalRecord,
   AgentChatActivityRecord,
   AgentChatChangedFileDiffRecord,
@@ -85,10 +80,7 @@ import type {
   ChatSessionsResponse,
   ConfiguredStateResponse,
   ModelFilter,
-  ModelResponse,
-  ProviderPresetRecord,
   ProviderFilter,
-  ProviderStatusResponse,
   RuntimeHeaders,
 } from "../types/runtime";
 
@@ -183,10 +175,35 @@ export function useRuntimeConsole() {
   const setUsageSummary = usage.actions.setSummary;
   const setUsageEvents = usage.actions.setEvents;
 
-  const [models, setModels] = useState<ModelResponse["data"]>([]);
-  const [providers, setProviders] = useState<ProviderStatusResponse["data"]>([]);
-  const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
-  const [agentAdapters, setAgentAdapters] = useState<AgentAdapterRecord[]>([]);
+  // providersAndModels slice: provider status, provider presets, model
+  // catalog, agent adapters, adapter-health map + per-adapter loading
+  // flag, and the adapter approval-mode banner state. The slice owns
+  // refreshProviders, probeAgentAdapter, setAgentAdapterCredential,
+  // and deleteAgentAdapterCredential — each returns a Result that the
+  // shim coordinators below unwrap into the legacy `boolean` /
+  // `record | null` external shapes. The provider-CRUD coordinators
+  // (setProviderAPIKey / BaseURL / Name / CustomName, createProvider,
+  // deleteProvider, the three model-capability-override actions) stay
+  // in the shim because they coordinate across loadDashboard and
+  // other slices' state (settingsConfig, providerFilter, model).
+  const providersAndModels = useProvidersAndModels();
+  const {
+    providers,
+    providerPresets,
+    models,
+    agentAdapters,
+    agentAdapterApprovalMode,
+    agentAdapterHealthByID,
+    agentAdapterHealthLoadingByID,
+  } = providersAndModels.state;
+  const {
+    setProviders,
+    setProviderPresets,
+    setModels,
+    setAgentAdapters,
+    setAgentAdapterApprovalMode,
+  } = providersAndModels.actions;
+
   const [defaultChatTarget, setDefaultChatTarget] = usePersistedState<ChatTarget>(
     "hecate.chatTarget",
     parseStoredChatTarget,
@@ -225,23 +242,6 @@ export function useRuntimeConsole() {
   // agentChatGrants,agentChatGrantsLoading,agentChatGrantsError}`
   // keys and the actions under their legacy identifiers.
   const approvals = useApprovals();
-  // agentAdapterApprovalMode mirrors the runtime-stats field of the
-  // same name. Empty until the dashboard fan-out resolves. The Chats
-  // workspace surfaces a danger banner when this is "auto" — every
-  // adapter RequestPermission is permitted without operator review.
-  const [agentAdapterApprovalMode, setAgentAdapterApprovalMode] = useState<string>("");
-  // agentAdapterHealthByID stores the most recent probe result per
-  // adapter, keyed by adapter id. Operators trigger a probe via the
-  // readiness probe in Connections and the result is
-  // cached here so the picker dropdown can show a status chip without
-  // re-running the probe. Map instance is replaced on update — same
-  // invariant as pendingApprovalsBySessionID.
-  const [agentAdapterHealthByID, setAgentAdapterHealthByID] = useState<
-    Map<string, AgentAdapterHealthRecord>
-  >(() => new Map());
-  const [agentAdapterHealthLoadingByID, setAgentAdapterHealthLoadingByID] = useState<
-    Map<string, true>
-  >(() => new Map());
   const [settingsConfig, setSettingsConfig] = useState<ConfiguredStateResponse["data"] | null>(null);
 
   const [model, setModel] = usePersistedState(
@@ -522,17 +522,12 @@ export function useRuntimeConsole() {
   // Studio. Skipped when no providers are configured — the providers
   // tab renders its empty state, there's nothing to converge.
   async function refreshProviders() {
+    // Gate the fetch on settingsConfig so a zero-provider boot
+    // doesn't trip a 200-with-empty-list round trip on every chat-
+    // workspace mount. The slice's refreshProviders unconditionally
+    // fetches once called.
     if ((settingsConfig?.providers?.length ?? 0) === 0) return;
-    try {
-      const [pResult, mResult] = await Promise.allSettled([
-        getProviders(),
-        getModels(),
-      ]);
-      if (pResult.status === "fulfilled") setProviders(pResult.value.data ?? []);
-      if (mResult.status === "fulfilled") setModels(mResult.value.data ?? []);
-    } catch {
-      // Best-effort background refresh — ignore errors.
-    }
+    await providersAndModels.actions.refreshProviders();
   }
 
   function buildChatPayload(messages: ChatMessage[], sessionID?: string) {
@@ -1576,74 +1571,32 @@ export function useRuntimeConsole() {
   // loading map is keyed by id so two adapters can be probing
   // concurrently without confusing the UI.
   async function probeAgentAdapter(adapterID: string): Promise<AgentAdapterHealthRecord | null> {
-    if (!adapterID) return null;
-    setAgentAdapterHealthLoadingByID((current) => {
-      const next = new Map(current);
-      next.set(adapterID, true);
-      return next;
-    });
-    try {
-      const payload = await probeAgentAdapterRequest(adapterID);
-      setAgentAdapterHealthByID((current) => {
-        const next = new Map(current);
-        next.set(adapterID, payload.data.health);
-        return next;
-      });
-      setAgentAdapters((current) => current.map((item) => item.id === adapterID ? payload.data.adapter : item));
-      return payload.data.health;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to probe adapter.");
+    const result = await providersAndModels.actions.probeAgentAdapter(adapterID);
+    if (!result.ok) {
+      setNoticeMessage("error", result.error);
       return null;
-    } finally {
-      setAgentAdapterHealthLoadingByID((current) => {
-        if (!current.has(adapterID)) return current;
-        const next = new Map(current);
-        next.delete(adapterID);
-        return next;
-      });
     }
+    return result.health;
   }
 
   async function setAgentAdapterCredential(adapterID: string, value: string, name?: string): Promise<boolean> {
-    try {
-      const payload = await setAgentAdapterCredentialRequest(adapterID, value, name);
-      setAgentAdapters((current) => current.map((item) => item.id === adapterID
-        ? { ...item, credential_configured: payload.data.configured, credential_preview: payload.data.preview }
-        : item));
-      if (adapterID === "claude_code" && payload.data.configured) {
-        setAgentAdapterHealthByID((current) => {
-          const next = new Map(current);
-          next.set(adapterID, { adapter_id: adapterID, status: "ready", stage: "ready", duration_ms: 0 });
-          return next;
-        });
-      }
-      setNoticeMessage("success", adapterID === "claude_code" ? "Claude Code verified." : "Adapter credential saved.");
-      return true;
-    } catch (error) {
-      const fallback = adapterID === "claude_code" ? "Failed to validate adapter credential." : "Failed to save adapter credential.";
-      setNoticeMessage("error", error instanceof Error ? error.message : fallback);
+    const result = await providersAndModels.actions.setAgentAdapterCredential(adapterID, value, name);
+    if (!result.ok) {
+      setNoticeMessage("error", result.error);
       return false;
     }
+    setNoticeMessage("success", result.isClaudeCode ? "Claude Code verified." : "Adapter credential saved.");
+    return true;
   }
 
   async function deleteAgentAdapterCredential(adapterID: string, name: string): Promise<boolean> {
-    try {
-      await deleteAgentAdapterCredentialRequest(adapterID, name);
-      setAgentAdapters((current) => current.map((item) => item.id === adapterID
-        ? { ...item, credential_configured: false, credential_preview: undefined }
-        : item));
-      setAgentAdapterHealthByID((current) => {
-        if (!current.has(adapterID)) return current;
-        const next = new Map(current);
-        next.delete(adapterID);
-        return next;
-      });
-      setNoticeMessage("success", "Adapter credential removed.");
-      return true;
-    } catch (error) {
-      setNoticeMessage("error", error instanceof Error ? error.message : "Failed to remove adapter credential.");
+    const result = await providersAndModels.actions.deleteAgentAdapterCredential(adapterID, name);
+    if (!result.ok) {
+      setNoticeMessage("error", result.error);
       return false;
     }
+    setNoticeMessage("success", "Adapter credential removed.");
+    return true;
   }
 
   async function renameChatSession(id: string, title: string) {


### PR DESCRIPTION
## Summary

Final state-only slice in the carve-out sequence (chats + chatSessions remain after this). Owns the provider status list, persisted-config provider presets, model catalog, agent adapter list, and the adapter-health / approval-mode bits that ride with them — **seven state fields** and **four self-contained domain actions**.

## What's new

**`ui/src/app/state/providersAndModels.tsx`** (~310 LOC) exposes three API shapes inside `actions`:

| Shape | Members | Why |
|---|---|---|
| **Low-level setters** | `setProviders`, `setProviderPresets`, `setModels`, `setAgentAdapters`, `setAgentAdapterApprovalMode` | Accept `SetStateAction` so the dashboard fan-out and shim coordinators (deleteProvider's rollback, credential-update merge, etc.) read identically to the pre-slice code. |
| **Map mutators** | `setAgentAdapterHealth`, `clearAgentAdapterHealth`, `setAgentAdapterHealthLoading` | Eliminates the "rebuild the whole `Map` in the caller" boilerplate that every probe path was duplicating. |
| **Domain actions** (Result-returning) | `refreshProviders`, `probeAgentAdapter`, `setAgentAdapterCredential`, `deleteAgentAdapterCredential` | Own the API call + state update. Shim coordinators unwrap into legacy `boolean` / `record \| null` external shapes and route success/error to the global notice banner. The `setAgentAdapterCredential` Result carries `isClaudeCode` so the shim picks the right success message without the slice importing Claude-Code-specific copy. |

## What stays in the shim (deliberately)

The provider-CRUD coordinators — `setProviderAPIKey`, `setProviderBaseURL`, `setProviderName`, `setProviderCustomName`, `createProvider`, `deleteProvider`, and the three model-capability-override actions. Each calls `loadDashboard()` and touches multiple slices' state (`settingsConfig`, `providerFilter`, `model`, `settingsError`); moving them now would mean dragging those slices in too. `loadDashboard` itself stays in the shim until the chats slice lands and the apply-snapshot path can be moved into a coordinator hook.

## useRuntimeConsole shim

- Drops 7 useState declarations and 4 action bodies.
- `state.{providers, providerPresets, models, agentAdapters, agentAdapterApprovalMode, agentAdapterHealthByID, agentAdapterHealthLoadingByID}` now project from `providersAndModels.state`. External keys unchanged.
- `actions.{refreshProviders, probeAgentAdapter, setAgentAdapterCredential, deleteAgentAdapterCredential}` become thin Result-unwrapping shims. External `boolean` / `null` shapes preserved.
- Five request-helper imports (`getProviders`, `getModels`, `probeAgentAdapterRequest`, `setAgentAdapterCredentialRequest`, `deleteAgentAdapterCredentialRequest`) and four type imports (`AgentAdapterRecord`, `ModelResponse`, `ProviderPresetRecord`, `ProviderStatusResponse`) retire.
- Net: 145-line file shrink in the shim, 41 net additions from the slice + tests = `+390 / -108` overall.

## Tests

`useRuntimeConsole.test.tsx`'s `SliceProviders` composer grows to wrap `ProvidersAndModelsProvider` inside the existing chain. Every assertion unchanged. Full UI suite green (824/824, 38 files); `useRuntimeConsole.test.tsx`'s 49 god-hook tests unchanged.

## External surface

Byte-for-byte stable. `state.{providers, providerPresets, models, agentAdapters, agentAdapterApprovalMode, agentAdapterHealthByID, agentAdapterHealthLoadingByID}` keys present, `actions.{refreshProviders, probeAgentAdapter, setAgentAdapterCredential, deleteAgentAdapterCredential}` identifiers present with the same shapes. `ChatView`, `ConnectionsPanel`, and `ProvidersView` weren't modified.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: keys + action identifiers + types byte-for-byte stable
- [x] `ChatView` + `ConnectionsPanel` + `ProvidersView` consumers untouched

## What's left in Phase 4

Only the chats + chatSessions slice (`activeAgentChatSession`, `activeChatSession`, queued chat messages, the chat target map, message composer state, …) remains in the god-hook. After that, the shim is a thin composer and Phase 5 starts: kill the prop-drill, let views read context directly.
