### PR TITLE
refactor(ui): extract the modelChat slice (marked-for-removal) [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
 import { ApprovalsProvider } from "./state/approvals";
+import { ModelChatProvider } from "./state/modelChat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
@@ -29,11 +30,13 @@ export default function App() {
     <RuntimeProvider>
       <UsageProvider>
         <ProvidersAndModelsProvider>
-          <RetentionProvider>
-            <ApprovalsProvider>
-              <AppConsole />
-            </ApprovalsProvider>
-          </RetentionProvider>
+          <ModelChatProvider>
+            <RetentionProvider>
+              <ApprovalsProvider>
+                <AppConsole />
+              </ApprovalsProvider>
+            </RetentionProvider>
+          </ModelChatProvider>
         </ProvidersAndModelsProvider>
       </UsageProvider>
     </RuntimeProvider>

--- a/ui/src/app/state/modelChat.tsx
+++ b/ui/src/app/state/modelChat.tsx
@@ -1,0 +1,150 @@
+// modelChat slice: state for today's `/hecate/v1/chat/sessions`
+// path. Pure data storage with one self-contained domain action
+// (`loadMore` — pagination append). The cross-cut session actions
+// (`selectChatSession`, `renameChatSession`, `deleteChatSession`)
+// stay in the shim because they branch between this slice and the
+// agent-chat slice based on session kind.
+//
+// Marked for removal: when the model-chat path retires, this
+// entire file plus its Provider plus the matching shim plumbing
+// gets deleted in a single PR. Keeping it as a separate slice
+// (rather than merging into the canonical chat slice) is what
+// makes that deletion mechanical.
+//
+// `activeID` is persisted via `usePersistedState` so a reload
+// returns the operator to the same model-chat session. The
+// reducer owns the non-persisted fields; the persisted ID lives
+// in its own hook alongside the reducer, exposed through the
+// same context value.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+
+import { getChatSessions } from "../../lib/api";
+import { parseStoredString, usePersistedState } from "../../lib/persistedState";
+import type { ChatSessionRecord, ChatSessionsResponse } from "../../types/runtime";
+
+const ACTIVE_ID_STORAGE_KEY = "hecate.chatSessionID";
+const LOAD_MORE_PAGE_SIZE = 20;
+
+export type ModelChatState = {
+  sessions: ChatSessionsResponse["data"];
+  hasMore: boolean;
+  loadingMore: boolean;
+  activeID: string;
+  activeSession: ChatSessionRecord | null;
+};
+
+type SetStateAction<T> = T | ((prev: T) => T);
+
+export type ModelChatActions = {
+  setSessions: (next: SetStateAction<ChatSessionsResponse["data"]>) => void;
+  setHasMore: (value: boolean) => void;
+  setActiveID: (value: string) => void;
+  setActiveSession: (next: SetStateAction<ChatSessionRecord | null>) => void;
+  loadMore: () => Promise<void>;
+};
+
+type ModelChatContextValue = {
+  state: ModelChatState;
+  actions: ModelChatActions;
+};
+
+type Action =
+  | { type: "sessions/set"; next: SetStateAction<ChatSessionsResponse["data"]> }
+  | { type: "hasMore/set"; value: boolean }
+  | { type: "activeSession/set"; next: SetStateAction<ChatSessionRecord | null> }
+  | { type: "loadMore/start" }
+  | { type: "loadMore/done"; rows: ChatSessionsResponse["data"]; hasMore: boolean }
+  | { type: "loadMore/fail" };
+
+type ReducerState = Omit<ModelChatState, "activeID">;
+
+const initialState: ReducerState = {
+  sessions: [],
+  hasMore: false,
+  loadingMore: false,
+  activeSession: null,
+};
+
+function resolve<T>(prev: T, next: SetStateAction<T>): T {
+  return typeof next === "function" ? (next as (prev: T) => T)(prev) : next;
+}
+
+function reducer(state: ReducerState, action: Action): ReducerState {
+  switch (action.type) {
+    case "sessions/set":
+      return { ...state, sessions: resolve(state.sessions, action.next) };
+    case "hasMore/set":
+      return { ...state, hasMore: action.value };
+    case "activeSession/set":
+      return { ...state, activeSession: resolve(state.activeSession, action.next) };
+    case "loadMore/start":
+      return { ...state, loadingMore: true };
+    case "loadMore/done":
+      return {
+        ...state,
+        loadingMore: false,
+        sessions: [...state.sessions, ...action.rows],
+        hasMore: action.hasMore,
+      };
+    case "loadMore/fail":
+      return { ...state, loadingMore: false };
+  }
+}
+
+const ModelChatContext = createContext<ModelChatContextValue | null>(null);
+
+export function ModelChatProvider({ children }: { children: ReactNode }) {
+  const [reducerState, dispatch] = useReducer(reducer, initialState);
+  const [activeID, setActiveIDPersisted] = usePersistedState<string>(
+    ACTIVE_ID_STORAGE_KEY,
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
+
+  const setSessions = useCallback(
+    (next: SetStateAction<ChatSessionsResponse["data"]>) => dispatch({ type: "sessions/set", next }),
+    [],
+  );
+  const setHasMore = useCallback((value: boolean) => dispatch({ type: "hasMore/set", value }), []);
+  const setActiveSession = useCallback(
+    (next: SetStateAction<ChatSessionRecord | null>) => dispatch({ type: "activeSession/set", next }),
+    [],
+  );
+  const setActiveID = useCallback((value: string) => setActiveIDPersisted(value), [setActiveIDPersisted]);
+
+  const loadMore = useCallback(async () => {
+    if (reducerState.loadingMore || !reducerState.hasMore) return;
+    dispatch({ type: "loadMore/start" });
+    try {
+      const result = await getChatSessions(LOAD_MORE_PAGE_SIZE, reducerState.sessions.length);
+      dispatch({
+        type: "loadMore/done",
+        rows: result.data ?? [],
+        hasMore: result.has_more ?? false,
+      });
+    } catch {
+      // Keep sidebar responsive; silently skip failed page loads.
+      dispatch({ type: "loadMore/fail" });
+    }
+  }, [reducerState.loadingMore, reducerState.hasMore, reducerState.sessions.length]);
+
+  const actions = useMemo<ModelChatActions>(
+    () => ({ setSessions, setHasMore, setActiveID, setActiveSession, loadMore }),
+    [setSessions, setHasMore, setActiveID, setActiveSession, loadMore],
+  );
+
+  const state: ModelChatState = useMemo(() => ({ ...reducerState, activeID }), [reducerState, activeID]);
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <ModelChatContext.Provider value={value}>{children}</ModelChatContext.Provider>;
+}
+
+export function useModelChat(): ModelChatContextValue {
+  const ctx = useContext(ModelChatContext);
+  if (!ctx) {
+    throw new Error("useModelChat must be used inside a <ModelChatProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApprovalsProvider } from "./state/approvals";
+import { ModelChatProvider } from "./state/modelChat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
@@ -10,18 +11,20 @@ import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
 // useRuntimeConsole consumes slice contexts (runtime, usage,
-// providersAndModels, retention, approvals, and more as slices
-// are added). Every renderHook call needs the matching providers
-// above it; this wrapper composes them so the test bodies don't
-// have to thread the chain through each call.
+// providersAndModels, modelChat, retention, approvals, and more
+// as slices are added). Every renderHook call needs the matching
+// providers above it; this wrapper composes them so the test
+// bodies don't have to thread the chain through each call.
 function SliceProviders({ children }: { children: ReactNode }) {
   return (
     <RuntimeProvider>
       <UsageProvider>
         <ProvidersAndModelsProvider>
-          <RetentionProvider>
-            <ApprovalsProvider>{children}</ApprovalsProvider>
-          </RetentionProvider>
+          <ModelChatProvider>
+            <RetentionProvider>
+              <ApprovalsProvider>{children}</ApprovalsProvider>
+            </RetentionProvider>
+          </ModelChatProvider>
         </ProvidersAndModelsProvider>
       </UsageProvider>
     </RuntimeProvider>

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -63,6 +63,7 @@ import {
 } from "./runtimeConsoleChatHelpers";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
 import { useApprovals } from "./state/approvals";
+import { useModelChat } from "./state/modelChat";
 import { useProvidersAndModels } from "./state/providersAndModels";
 import { useRetention } from "./state/retention";
 import { useRuntime } from "./state/runtime";
@@ -76,8 +77,6 @@ import type {
   AgentChatSessionRecord,
   AgentChatSessionsResponse,
   ChatResponse,
-  ChatSessionRecord,
-  ChatSessionsResponse,
   ConfiguredStateResponse,
   ModelFilter,
   ProviderFilter,
@@ -270,16 +269,23 @@ export function useRuntimeConsole() {
   const [pendingToolCalls, setPendingToolCalls] = useState<Array<{ id: string; name: string; arguments: string; result: string }>>([]);
   // Thread of messages that preceded the pending tool calls (history + user message + assistant tool_calls message).
   const [pendingThread, setPendingThread] = useState<import("../lib/api").ChatMessage[] | null>(null);
-  const [chatSessions, setChatSessions] = useState<ChatSessionsResponse["data"]>([]);
-  const [chatSessionsHasMore, setChatSessionsHasMore] = useState(false);
-  const [chatSessionsLoadingMore, setChatSessionsLoadingMore] = useState(false);
-  const [activeChatSessionID, setActiveChatSessionID] = usePersistedState(
-    "hecate.chatSessionID",
-    parseStoredString,
-    "",
-    { shouldRemove: (v) => v === "" },
-  );
-  const [activeChatSession, setActiveChatSession] = useState<ChatSessionRecord | null>(null);
+  // modelChat slice: the model-chat-only session list + active
+  // session + `loadMore` action. Marked for removal when the
+  // model-chat path retires; legacy aliases below keep the shim
+  // coordinators (selectChatSession, renameChatSession,
+  // deleteChatSession, createChatSession) reading the same as
+  // before the carve-out.
+  const modelChat = useModelChat();
+  const chatSessions = modelChat.state.sessions;
+  const chatSessionsHasMore = modelChat.state.hasMore;
+  const chatSessionsLoadingMore = modelChat.state.loadingMore;
+  const activeChatSessionID = modelChat.state.activeID;
+  const activeChatSession = modelChat.state.activeSession;
+  const setChatSessions = modelChat.actions.setSessions;
+  const setChatSessionsHasMore = modelChat.actions.setHasMore;
+  const setActiveChatSessionID = modelChat.actions.setActiveID;
+  const setActiveChatSession = modelChat.actions.setActiveSession;
+  const loadMoreChatSessions = modelChat.actions.loadMore;
   const [chatError, setChatError] = useState("");
   const [chatErrorCode, setChatErrorCode] = useState("");
   const [chatErrorStatus, setChatErrorStatus] = useState<number | null>(null);
@@ -1627,20 +1633,6 @@ export function useRuntimeConsole() {
       }
     } catch (error) {
       setNoticeMessage("error", error instanceof Error ? error.message : "Failed to rename chat.");
-    }
-  }
-
-  async function loadMoreChatSessions() {
-    if (chatSessionsLoadingMore || !chatSessionsHasMore) return;
-    setChatSessionsLoadingMore(true);
-    try {
-      const result = await getChatSessions(20, chatSessions.length);
-      setChatSessions((current) => [...current, ...(result.data ?? [])]);
-      setChatSessionsHasMore(result.has_more ?? false);
-    } catch {
-      // Keep sidebar responsive; silently skip failed page loads.
-    } finally {
-      setChatSessionsLoadingMore(false);
     }
   }
 


### PR DESCRIPTION
## Summary

Carves the model-chat-only state out of the god-hook. Owns the five state fields tied to today's `/hecate/v1/chat/sessions` surface plus the self-contained `loadMore` pagination action.

**Deliberately kept as its own slice** rather than folded into the canonical chat slice that follows. When the model-chat path retires, this entire file plus its Provider plus the matching shim plumbing gets deleted in a single PR. Keeping the state separate makes that future deletion mechanical instead of a hunt across a unified state machine.

## What's new

**`ui/src/app/state/modelChat.tsx`** (~155 LOC):

```ts
type ModelChatState = {
  sessions: ChatSessionsResponse["data"];
  hasMore: boolean;
  loadingMore: boolean;
  activeID: string;
  activeSession: ChatSessionRecord | null;
};

export function ModelChatProvider({ children }) { /* useReducer + usePersistedState */ }
export function useModelChat(): { state, actions };
```

Actions:
- Setters (`setSessions`, `setHasMore`, `setActiveID`, `setActiveSession`) accept `SetStateAction` so the dashboard fan-out and the cross-cut session coordinators (`renameChatSession`, `deleteChatSession`, `selectChatSession`, `createChatSession`) read identically to the pre-slice code.
- `loadMore()` is the one self-contained domain action: guards on `hasMore` + `loadingMore` and silently swallows fetch errors — matches the original sidebar behaviour where a failed page load leaves the existing rows in place.

**Persistence**: `activeID` lives in its own `usePersistedState` hook alongside the reducer (same storage key as before: `hecate.chatSessionID`), exposed through the same context value. The reducer owns the four non-persisted fields. Same pattern as the approvals slice's "ref outside reducer for race protection," just for storage instead of races.

## useRuntimeConsole shim

- Drops 5 useState declarations + the `loadMoreChatSessions` body.
- Pulls slice values via `useModelChat()` and destructures into legacy identifiers so the rest of the hook body (rename / delete / select / `createChatSession` / dashboard apply) reads unchanged.
- `ChatSessionRecord` and `ChatSessionsResponse` type imports retire — both live in the slice now.

## What stays in the shim (deliberately)

The cross-cut session coordinators — `selectChatSession`, `renameChatSession`, `deleteChatSession`, `createChatSession`. Each one branches on session kind (`isAgentSession`) and dispatches to either the modelChat slice or the agent-chat state (which still lives in the shim until the next slice lands). When the next slice ships, these coordinators thin out further. When the model-chat path retires, the model-chat branches get deleted entirely.

## Tests

`useRuntimeConsole.test.tsx`'s `SliceProviders` composer grows to wrap `ModelChatProvider`:

```tsx
<RuntimeProvider>
  <UsageProvider>
    <ProvidersAndModelsProvider>
      <ModelChatProvider>
        <RetentionProvider>
          <ApprovalsProvider>{children}</ApprovalsProvider>
        </RetentionProvider>
      </ModelChatProvider>
    </ProvidersAndModelsProvider>
  </UsageProvider>
</RuntimeProvider>
```

Every assertion unchanged. Full UI suite green (824/824, 38 files); `useRuntimeConsole.test.tsx`'s 49 god-hook tests unchanged.

## External surface

Byte-for-byte stable. `state.{chatSessions, chatSessionsHasMore, chatSessionsLoadingMore, activeChatSessionID, activeChatSession}` keys present, `actions.loadMoreChatSessions` identifier present. `ChatView`'s sidebar wasn't modified — it reads the same state keys.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: keys + action identifier + types byte-for-byte stable
- [x] `ChatView` consumers untouched

## What's next

The canonical chat slice. Owns everything left in the god-hook that touches chat state: agent chat sessions, queued messages, target routing, composer state, SSE stream handler, etc. The biggest remaining carve-out. After it lands, the god-hook becomes a thin composer and the prop-drill retirement starts.
