### PR TITLE
refactor(ui): extract the canonical chat slice [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
 import { ApprovalsProvider } from "./state/approvals";
+import { ChatProvider } from "./state/chat";
 import { ModelChatProvider } from "./state/modelChat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
@@ -31,11 +32,13 @@ export default function App() {
       <UsageProvider>
         <ProvidersAndModelsProvider>
           <ModelChatProvider>
-            <RetentionProvider>
-              <ApprovalsProvider>
-                <AppConsole />
-              </ApprovalsProvider>
-            </RetentionProvider>
+            <ChatProvider>
+              <RetentionProvider>
+                <ApprovalsProvider>
+                  <AppConsole />
+                </ApprovalsProvider>
+              </RetentionProvider>
+            </ChatProvider>
           </ModelChatProvider>
         </ProvidersAndModelsProvider>
       </UsageProvider>

--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -1,0 +1,336 @@
+// chat slice: the canonical chat-domain state machine. Owns
+// session lists (agent + active session), composer state
+// (message body, model, filters, system prompt), in-flight chat
+// machinery (loading flag, streaming content, chat result,
+// pending tool calls + thread), the chat-error cluster, queued
+// chat messages, target routing (default target + per-session
+// override map), workspace + adapter selection, and the
+// pagination state for agent chat sessions.
+//
+// Eight fields are persisted via `usePersistedState`; the rest
+// are `useState` since they're in-flight or session-bound. One
+// field (providerFilter) keeps a legacy useState + mount-read
+// effect pattern — see the inline comment for the e2e timing
+// reason. The slice exposes raw setters; the shim coordinators
+// (submitChat, createChatSession, applyAgentChatSession, the SSE
+// event handler, …) compose these setters with cross-cut work
+// like dispatching notice banners and updating the approvals
+// slice.
+//
+// Five self-contained helpers live in the slice because they
+// only touch chat-slice state: removeQueuedChatMessage,
+// updateQueuedChatMessage, pruneQueuedChatMessagesForSessions,
+// clearChatErrorState, setChatErrorState.
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+
+import { ApiError, type ChatMessage } from "../../lib/api";
+import { parseStoredJSON, parseStoredString, usePersistedState } from "../../lib/persistedState";
+import type {
+  AgentChatSessionRecord,
+  AgentChatSessionsResponse,
+  ChatResponse,
+  ModelFilter,
+  ProviderFilter,
+} from "../../types/runtime";
+import {
+  type ChatTarget,
+  type HecateChatTarget,
+  type QueuedChatMessage,
+  parseChatTargetsBySessionID,
+  parseQueuedChatMessageList,
+  parseStoredChatTarget,
+  queuedChatMessagesStorageKey,
+  serializeChatTargetsBySessionID,
+} from "./_shared";
+import { humanizeChatError } from "../runtimeConsoleChatHelpers";
+
+export type PendingToolCall = {
+  id: string;
+  name: string;
+  arguments: string;
+  result: string;
+};
+
+export type ChatState = {
+  defaultChatTarget: ChatTarget;
+  chatTargetBySessionID: Map<string, HecateChatTarget>;
+  agentAdapterID: string;
+  agentWorkspace: string;
+  agentWorkspaceBranch: string;
+  agentChatSessions: AgentChatSessionsResponse["data"];
+  activeAgentChatSessionID: string;
+  activeAgentChatSession: AgentChatSessionRecord | null;
+  queuedChatMessages: QueuedChatMessage[];
+  model: string;
+  systemPrompt: string;
+  chatLoading: boolean;
+  agentChatCancelling: boolean;
+  streamingContent: string | null;
+  chatResult: ChatResponse | null;
+  pendingToolCalls: PendingToolCall[];
+  pendingThread: ChatMessage[] | null;
+  chatError: string;
+  chatErrorCode: string;
+  chatErrorStatus: number | null;
+  chatErrorAction: string;
+  chatErrorRequestID: string;
+  chatErrorTraceID: string;
+  modelFilter: ModelFilter;
+  providerFilter: ProviderFilter;
+};
+
+type SetStateAction<T> = T | ((prev: T) => T);
+type Setter<T> = (next: SetStateAction<T>) => void;
+
+export type ChatActions = {
+  setDefaultChatTarget: Setter<ChatTarget>;
+  setChatTargetBySessionID: Setter<Map<string, HecateChatTarget>>;
+  setAgentAdapterID: Setter<string>;
+  setAgentWorkspace: Setter<string>;
+  setAgentWorkspaceBranch: Setter<string>;
+  setAgentChatSessions: Setter<AgentChatSessionsResponse["data"]>;
+  setActiveAgentChatSessionID: Setter<string>;
+  setActiveAgentChatSession: Setter<AgentChatSessionRecord | null>;
+  setQueuedChatMessages: Setter<QueuedChatMessage[]>;
+  setModel: Setter<string>;
+  setSystemPrompt: Setter<string>;
+  setChatLoading: Setter<boolean>;
+  setAgentChatCancelling: Setter<boolean>;
+  setStreamingContent: Setter<string | null>;
+  setChatResult: Setter<ChatResponse | null>;
+  setPendingToolCalls: Setter<PendingToolCall[]>;
+  setPendingThread: Setter<ChatMessage[] | null>;
+  setModelFilter: Setter<ModelFilter>;
+  setProviderFilter: Setter<ProviderFilter>;
+  // Raw chat-error setter — three shim call sites need to write
+  // `chatError` directly (two with string literals for client-side
+  // validation messages, one with a `(current) => current || msg`
+  // updater that only writes if no earlier error landed). The
+  // bundled `setChatErrorState` helper below wraps with
+  // humanizeChatError + ApiError extraction; this setter doesn't.
+  setChatError: Setter<string>;
+  removeQueuedChatMessage: (id: string) => void;
+  updateQueuedChatMessage: (id: string, content: string) => void;
+  pruneQueuedChatMessagesForSessions: (sessionIDs: Iterable<string>) => void;
+  clearChatErrorState: () => void;
+  setChatErrorState: (error: unknown, fallback?: string) => void;
+};
+
+type ChatContextValue = {
+  state: ChatState;
+  actions: ChatActions;
+};
+
+const ChatContext = createContext<ChatContextValue | null>(null);
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [defaultChatTarget, setDefaultChatTarget] = usePersistedState<ChatTarget>(
+    "hecate.chatTarget",
+    parseStoredChatTarget,
+    "agent",
+  );
+  const [chatTargetBySessionID, setChatTargetBySessionID] = usePersistedState<Map<string, HecateChatTarget>>(
+    "hecate.chatTargetBySessionID",
+    parseStoredJSON(parseChatTargetsBySessionID),
+    new Map(),
+    { serialize: serializeChatTargetsBySessionID },
+  );
+  const [agentAdapterID, setAgentAdapterID] = usePersistedState(
+    "hecate.agentAdapterID",
+    parseStoredString,
+    "codex",
+  );
+  const [agentWorkspace, setAgentWorkspace] = usePersistedState(
+    "hecate.agentWorkspace",
+    parseStoredString,
+    "",
+  );
+  const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");
+  const [agentChatSessions, setAgentChatSessions] = useState<AgentChatSessionsResponse["data"]>([]);
+  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = usePersistedState(
+    "hecate.agentChatSessionID",
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
+  const [activeAgentChatSession, setActiveAgentChatSession] = useState<AgentChatSessionRecord | null>(null);
+  const [queuedChatMessages, setQueuedChatMessages] = usePersistedState<QueuedChatMessage[]>(
+    queuedChatMessagesStorageKey,
+    parseStoredJSON(parseQueuedChatMessageList),
+    [],
+    { shouldRemove: (v) => v.length === 0 },
+  );
+  const [model, setModel] = usePersistedState(
+    "hecate.model",
+    parseStoredString,
+    "",
+    { shouldRemove: (v) => v === "" },
+  );
+  const [systemPrompt, setSystemPrompt] = usePersistedState(
+    "hecate.systemPrompt",
+    parseStoredString,
+    "",
+  );
+  const [chatLoading, setChatLoading] = useState(false);
+  const [agentChatCancelling, setAgentChatCancelling] = useState(false);
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [chatResult, setChatResult] = useState<ChatResponse | null>(null);
+  const [pendingToolCalls, setPendingToolCalls] = useState<PendingToolCall[]>([]);
+  const [pendingThread, setPendingThread] = useState<ChatMessage[] | null>(null);
+  const [chatError, setChatError] = useState("");
+  const [chatErrorCode, setChatErrorCode] = useState("");
+  const [chatErrorStatus, setChatErrorStatus] = useState<number | null>(null);
+  const [chatErrorAction, setChatErrorAction] = useState("");
+  const [chatErrorRequestID, setChatErrorRequestID] = useState("");
+  const [chatErrorTraceID, setChatErrorTraceID] = useState("");
+  const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
+  // providerFilter is the lone holdout from the usePersistedState
+  // migration. Three e2e scenarios broke when it was migrated — the
+  // `test("...")` blocks that begin at chat.spec.ts:617 ("Hecate
+  // Agent local-provider onboarding…"), :767 ("…tools on, tools
+  // off, then tools on again…"), and :1288 ("selected-model
+  // readiness can switch to the backend-suggested fallback model").
+  // None of those tests set `hecate.providerFilter` directly; they
+  // exercise the auto-default cascade in useRuntimeConsole that
+  // reads providerFilter through a first-render closure and only
+  // fires its setProviderFilter when it sees "auto" there. With
+  // the legacy mount-read effect providerFilter is "auto" on
+  // render 1 and transitions on render 2, which is the window the
+  // cascade expects. Seeding the persisted value directly into the
+  // lazy initializer (what usePersistedState does) shifts the
+  // transition out from under that cascade.
+  //
+  // Restructuring the auto-default + scoped-validity effects so
+  // they do not depend on render-cycle timing is separate cleanup.
+  // Until that lands, providerFilter stays on the original useState
+  // + mount-read + write-on-change pattern.
+  const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
+  useEffect(() => {
+    const stored = window.localStorage.getItem("hecate.providerFilter");
+    if (stored) setProviderFilter(stored as ProviderFilter);
+  }, []);
+  useEffect(() => {
+    window.localStorage.setItem("hecate.providerFilter", providerFilter);
+  }, [providerFilter]);
+
+  // Mirror setters to refs so the helpers below don't re-bind every
+  // render. Helpers are exposed in the actions bag and consumers
+  // (the shim) destructure them once; keeping them referentially
+  // stable avoids invalidating downstream useCallback deps.
+  const setQueuedChatMessagesRef = useRef(setQueuedChatMessages);
+  setQueuedChatMessagesRef.current = setQueuedChatMessages;
+
+  const removeQueuedChatMessage = useCallback((id: string) => {
+    setQueuedChatMessagesRef.current((current) => current.filter((item) => item.id !== id));
+  }, []);
+  const updateQueuedChatMessage = useCallback((id: string, content: string) => {
+    setQueuedChatMessagesRef.current((current) => current.map((item) => (
+      item.id === id ? { ...item, content } : item
+    )));
+  }, []);
+  const pruneQueuedChatMessagesForSessions = useCallback((sessionIDs: Iterable<string>) => {
+    const valid = new Set(sessionIDs);
+    setQueuedChatMessagesRef.current((current) => current.filter((item) => valid.has(item.session_id)));
+  }, []);
+
+  const clearChatErrorState = useCallback(() => {
+    setChatError("");
+    setChatErrorCode("");
+    setChatErrorStatus(null);
+    setChatErrorAction("");
+    setChatErrorRequestID("");
+    setChatErrorTraceID("");
+  }, []);
+
+  const setChatErrorState = useCallback((error: unknown, fallback = "unknown request error") => {
+    const raw = error instanceof Error ? error.message : fallback;
+    setChatError(humanizeChatError(raw));
+    setChatErrorCode(error instanceof ApiError ? error.code : "");
+    setChatErrorStatus(error instanceof ApiError ? error.status : null);
+    setChatErrorAction(error instanceof ApiError ? error.operatorAction : "");
+    setChatErrorRequestID(error instanceof ApiError ? error.requestId : "");
+    setChatErrorTraceID(error instanceof ApiError ? error.traceId : "");
+  }, []);
+
+  const state = useMemo<ChatState>(() => ({
+    defaultChatTarget,
+    chatTargetBySessionID,
+    agentAdapterID,
+    agentWorkspace,
+    agentWorkspaceBranch,
+    agentChatSessions,
+    activeAgentChatSessionID,
+    activeAgentChatSession,
+    queuedChatMessages,
+    model,
+    systemPrompt,
+    chatLoading,
+    agentChatCancelling,
+    streamingContent,
+    chatResult,
+    pendingToolCalls,
+    pendingThread,
+    chatError,
+    chatErrorCode,
+    chatErrorStatus,
+    chatErrorAction,
+    chatErrorRequestID,
+    chatErrorTraceID,
+    modelFilter,
+    providerFilter,
+  }), [
+    defaultChatTarget, chatTargetBySessionID, agentAdapterID, agentWorkspace,
+    agentWorkspaceBranch, agentChatSessions, activeAgentChatSessionID,
+    activeAgentChatSession, queuedChatMessages, model, systemPrompt,
+    chatLoading, agentChatCancelling, streamingContent, chatResult,
+    pendingToolCalls, pendingThread, chatError, chatErrorCode,
+    chatErrorStatus, chatErrorAction, chatErrorRequestID, chatErrorTraceID,
+    modelFilter, providerFilter,
+  ]);
+
+  const actions = useMemo<ChatActions>(() => ({
+    setDefaultChatTarget,
+    setChatTargetBySessionID,
+    setAgentAdapterID,
+    setAgentWorkspace,
+    setAgentWorkspaceBranch,
+    setAgentChatSessions,
+    setActiveAgentChatSessionID,
+    setActiveAgentChatSession,
+    setQueuedChatMessages,
+    setModel,
+    setSystemPrompt,
+    setChatLoading,
+    setAgentChatCancelling,
+    setStreamingContent,
+    setChatResult,
+    setPendingToolCalls,
+    setPendingThread,
+    setModelFilter,
+    setProviderFilter,
+    setChatError,
+    removeQueuedChatMessage,
+    updateQueuedChatMessage,
+    pruneQueuedChatMessagesForSessions,
+    clearChatErrorState,
+    setChatErrorState,
+  }), [
+    setDefaultChatTarget, setChatTargetBySessionID, setAgentAdapterID,
+    setAgentWorkspace, setAgentChatSessions, setActiveAgentChatSessionID,
+    setQueuedChatMessages, setModel, setSystemPrompt,
+    removeQueuedChatMessage, updateQueuedChatMessage,
+    pruneQueuedChatMessagesForSessions, clearChatErrorState, setChatErrorState,
+  ]);
+
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}
+
+export function useChat(): ChatContextValue {
+  const ctx = useContext(ChatContext);
+  if (!ctx) {
+    throw new Error("useChat must be used inside a <ChatProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApprovalsProvider } from "./state/approvals";
+import { ChatProvider } from "./state/chat";
 import { ModelChatProvider } from "./state/modelChat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
@@ -11,19 +12,22 @@ import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
 // useRuntimeConsole consumes slice contexts (runtime, usage,
-// providersAndModels, modelChat, retention, approvals, and more
-// as slices are added). Every renderHook call needs the matching
-// providers above it; this wrapper composes them so the test
-// bodies don't have to thread the chain through each call.
+// providersAndModels, modelChat, chat, retention, approvals,
+// and more as slices are added). Every renderHook call needs
+// the matching providers above it; this wrapper composes them
+// so the test bodies don't have to thread the chain through
+// each call.
 function SliceProviders({ children }: { children: ReactNode }) {
   return (
     <RuntimeProvider>
       <UsageProvider>
         <ProvidersAndModelsProvider>
           <ModelChatProvider>
-            <RetentionProvider>
-              <ApprovalsProvider>{children}</ApprovalsProvider>
-            </RetentionProvider>
+            <ChatProvider>
+              <RetentionProvider>
+                <ApprovalsProvider>{children}</ApprovalsProvider>
+              </RetentionProvider>
+            </ChatProvider>
           </ModelChatProvider>
         </ProvidersAndModelsProvider>
       </UsageProvider>

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1,22 +1,15 @@
-import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from "react";
+import { useEffect, useMemo, useState, type SyntheticEvent } from "react";
 
-import { parseStoredJSON, parseStoredString, usePersistedState } from "../lib/persistedState";
 import {
   type ChatTarget,
   type HecateChatTarget,
   type QueuedChatMessage,
   normalizeStoredHecateChatTarget,
-  parseChatTargetsBySessionID,
-  parseQueuedChatMessageList,
-  parseStoredChatTarget,
-  queuedChatMessagesStorageKey,
-  serializeChatTargetsBySessionID,
 } from "./state/_shared";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
 import type { LocalProviderIssue } from "../lib/provider-issues";
 import { filterModelsByKind, filterModelsByProvider } from "../lib/runtime-utils";
 import {
-  ApiError,
   type ChatMessage,
   chooseWorkspaceDirectory as chooseWorkspaceDirectoryRequest,
   chatCompletionsStream,
@@ -63,6 +56,7 @@ import {
 } from "./runtimeConsoleChatHelpers";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
 import { useApprovals } from "./state/approvals";
+import { useChat } from "./state/chat";
 import { useModelChat } from "./state/modelChat";
 import { useProvidersAndModels } from "./state/providersAndModels";
 import { useRetention } from "./state/retention";
@@ -75,10 +69,8 @@ import type {
   AgentChatChangedFileDiffRecord,
   AgentChatChangedFileRecord,
   AgentChatSessionRecord,
-  AgentChatSessionsResponse,
   ChatResponse,
   ConfiguredStateResponse,
-  ModelFilter,
   ProviderFilter,
   RuntimeHeaders,
 } from "../types/runtime";
@@ -203,36 +195,68 @@ export function useRuntimeConsole() {
     setAgentAdapterApprovalMode,
   } = providersAndModels.actions;
 
-  const [defaultChatTarget, setDefaultChatTarget] = usePersistedState<ChatTarget>(
-    "hecate.chatTarget",
-    parseStoredChatTarget,
-    "agent",
-  );
-  const [chatTargetBySessionID, setChatTargetBySessionID] = usePersistedState<Map<string, HecateChatTarget>>(
-    "hecate.chatTargetBySessionID",
-    parseStoredJSON(parseChatTargetsBySessionID),
-    new Map(),
-    { serialize: serializeChatTargetsBySessionID },
-  );
-  const [agentAdapterID, setAgentAdapterID] = usePersistedState(
-    "hecate.agentAdapterID",
-    parseStoredString,
-    "codex",
-  );
-  const [agentWorkspace, setAgentWorkspace] = usePersistedState(
-    "hecate.agentWorkspace",
-    parseStoredString,
-    "",
-  );
-  const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState("");
-  const [agentChatSessions, setAgentChatSessions] = useState<AgentChatSessionsResponse["data"]>([]);
-  const [activeAgentChatSessionID, setActiveAgentChatSessionID] = usePersistedState(
-    "hecate.agentChatSessionID",
-    parseStoredString,
-    "",
-    { shouldRemove: (v) => v === "" },
-  );
-  const [activeAgentChatSession, setActiveAgentChatSession] = useState<AgentChatSessionRecord | null>(null);
+  // chat slice: the canonical chat-domain state. Owns session
+  // lists, composer state, in-flight chat machinery, queued
+  // messages, target routing, workspace + adapter selection, and
+  // the chat-error cluster. Legacy aliases below keep the shim
+  // coordinators (submitChat, createChatSession,
+  // applyAgentChatSession, the SSE event handler, …) reading
+  // the same as before the carve-out.
+  const chat = useChat();
+  const {
+    defaultChatTarget,
+    chatTargetBySessionID,
+    agentAdapterID,
+    agentWorkspace,
+    agentWorkspaceBranch,
+    agentChatSessions,
+    activeAgentChatSessionID,
+    activeAgentChatSession,
+    queuedChatMessages,
+    model,
+    systemPrompt,
+    chatLoading,
+    agentChatCancelling,
+    streamingContent,
+    chatResult,
+    pendingToolCalls,
+    pendingThread,
+    chatError,
+    chatErrorCode,
+    chatErrorStatus,
+    chatErrorAction,
+    chatErrorRequestID,
+    chatErrorTraceID,
+    modelFilter,
+    providerFilter,
+  } = chat.state;
+  const {
+    setDefaultChatTarget,
+    setChatTargetBySessionID,
+    setAgentAdapterID,
+    setAgentWorkspace,
+    setAgentWorkspaceBranch,
+    setAgentChatSessions,
+    setActiveAgentChatSessionID,
+    setActiveAgentChatSession,
+    setQueuedChatMessages,
+    setModel,
+    setSystemPrompt,
+    setChatLoading,
+    setAgentChatCancelling,
+    setStreamingContent,
+    setChatResult,
+    setPendingToolCalls,
+    setPendingThread,
+    setModelFilter,
+    setProviderFilter,
+    setChatError,
+    removeQueuedChatMessage,
+    updateQueuedChatMessage,
+    pruneQueuedChatMessagesForSessions,
+    clearChatErrorState,
+    setChatErrorState,
+  } = chat.actions;
   // Approvals state + actions live in the slice (app/state/approvals.tsx).
   // The slice owns the pending-banner map, the per-session mutation
   // version that protects the catch-up GET against races, the grant
@@ -243,32 +267,6 @@ export function useRuntimeConsole() {
   const approvals = useApprovals();
   const [settingsConfig, setSettingsConfig] = useState<ConfiguredStateResponse["data"] | null>(null);
 
-  const [model, setModel] = usePersistedState(
-    "hecate.model",
-    parseStoredString,
-    "",
-    { shouldRemove: (v) => v === "" },
-  );
-  const [queuedChatMessages, setQueuedChatMessages] = usePersistedState<QueuedChatMessage[]>(
-    queuedChatMessagesStorageKey,
-    parseStoredJSON(parseQueuedChatMessageList),
-    [],
-    { shouldRemove: (v) => v.length === 0 },
-  );
-  const queuedChatMessagesRef = useRef(queuedChatMessages);
-  const [systemPrompt, setSystemPrompt] = usePersistedState(
-    "hecate.systemPrompt",
-    parseStoredString,
-    "",
-  );
-  const [chatLoading, setChatLoading] = useState(false);
-  const [agentChatCancelling, setAgentChatCancelling] = useState(false);
-  const [streamingContent, setStreamingContent] = useState<string | null>(null);
-  const [chatResult, setChatResult] = useState<ChatResponse | null>(null);
-  // pendingToolCalls: model responded with tool_calls; waiting for user to fill results.
-  const [pendingToolCalls, setPendingToolCalls] = useState<Array<{ id: string; name: string; arguments: string; result: string }>>([]);
-  // Thread of messages that preceded the pending tool calls (history + user message + assistant tool_calls message).
-  const [pendingThread, setPendingThread] = useState<import("../lib/api").ChatMessage[] | null>(null);
   // modelChat slice: the model-chat-only session list + active
   // session + `loadMore` action. Marked for removal when the
   // model-chat path retires; legacy aliases below keep the shim
@@ -286,42 +284,6 @@ export function useRuntimeConsole() {
   const setActiveChatSessionID = modelChat.actions.setActiveID;
   const setActiveChatSession = modelChat.actions.setActiveSession;
   const loadMoreChatSessions = modelChat.actions.loadMore;
-  const [chatError, setChatError] = useState("");
-  const [chatErrorCode, setChatErrorCode] = useState("");
-  const [chatErrorStatus, setChatErrorStatus] = useState<number | null>(null);
-  const [chatErrorAction, setChatErrorAction] = useState("");
-  const [chatErrorRequestID, setChatErrorRequestID] = useState("");
-  const [chatErrorTraceID, setChatErrorTraceID] = useState("");
-  const [modelFilter, setModelFilter] = useState<ModelFilter>("all");
-  // FIXME: providerFilter is the lone holdout from the
-  // usePersistedState migration. Three e2e scenarios broke when it
-  // was migrated — the `test("...")` blocks that begin at
-  // chat.spec.ts:617 ("Hecate Agent local-provider onboarding…"),
-  // :767 ("…tools on, tools off, then tools on again…"), and :1288
-  // ("selected-model readiness can switch to the backend-suggested
-  // fallback model"). None of those tests set
-  // `hecate.providerFilter` directly; they exercise the
-  // auto-default cascade (lines 450+) that reads providerFilter
-  // through a first-render closure and only fires its
-  // setProviderFilter when it sees "auto" there. With the legacy
-  // mount-read effect providerFilter is "auto" on render 1 and
-  // transitions on render 2, which is the window the cascade
-  // expects. Seeding the persisted value directly into the lazy
-  // initializer (what usePersistedState does) shifts the
-  // transition out from under that cascade.
-  //
-  // Restructuring the auto-default + scoped-validity effects so
-  // they do not depend on render-cycle timing is separate cleanup.
-  // Until that lands here, keep providerFilter on the original
-  // useState + mount-read + write-on-change pattern.
-  const [providerFilter, setProviderFilter] = useState<ProviderFilter>("auto");
-  useEffect(() => {
-    const stored = window.localStorage.getItem("hecate.providerFilter");
-    if (stored) setProviderFilter(stored as ProviderFilter);
-  }, []);
-  useEffect(() => {
-    window.localStorage.setItem("hecate.providerFilter", providerFilter);
-  }, [providerFilter]);
 
   const [settingsError, setSettingsError] = useState("");
   const [notice, setNotice] = useState<NoticeState | null>(null);
@@ -394,13 +356,6 @@ export function useRuntimeConsole() {
     }
     setHecateRTKEnabledState(Boolean(activeAgentChatSession.rtk_enabled));
   }, [activeAgentChatSession?.id, activeAgentChatSession?.rtk_enabled]);
-
-  // Mirror queuedChatMessages into a ref so non-React callers
-  // (background fetches that resolve after unmount) can read the
-  // latest snapshot without going through state.
-  useEffect(() => {
-    queuedChatMessagesRef.current = queuedChatMessages;
-  }, [queuedChatMessages]);
 
   useEffect(() => {
     if (!notice) {
@@ -655,21 +610,6 @@ export function useRuntimeConsole() {
     await submitAgentChat();
   }
 
-  function removeQueuedChatMessage(id: string) {
-    setQueuedChatMessages((current) => current.filter((item) => item.id !== id));
-  }
-
-  function updateQueuedChatMessage(id: string, content: string) {
-    setQueuedChatMessages((current) => current.map((item) => (
-      item.id === id ? { ...item, content } : item
-    )));
-  }
-
-  function pruneQueuedChatMessagesForSessions(sessionIDs: Iterable<string>) {
-    const valid = new Set(sessionIDs);
-    setQueuedChatMessages((current) => current.filter((item) => valid.has(item.session_id)));
-  }
-
   function buildQueuedChatMessage(content: string, runtimeKind: ChatTarget, sessionID: string): QueuedChatMessage {
     return {
       id: `queued-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -719,25 +659,6 @@ export function useRuntimeConsole() {
   const upsertPendingApproval = approvals.actions.upsertPending;
   const removePendingApproval = approvals.actions.removePending;
   const refetchPendingApprovals = approvals.actions.refetchPending;
-
-  function clearChatErrorState() {
-    setChatError("");
-    setChatErrorCode("");
-    setChatErrorStatus(null);
-    setChatErrorAction("");
-    setChatErrorRequestID("");
-    setChatErrorTraceID("");
-  }
-
-  function setChatErrorState(error: unknown, fallback = "unknown request error") {
-    const raw = error instanceof Error ? error.message : fallback;
-    setChatError(humanizeChatError(raw));
-    setChatErrorCode(error instanceof ApiError ? error.code : "");
-    setChatErrorStatus(error instanceof ApiError ? error.status : null);
-    setChatErrorAction(error instanceof ApiError ? error.operatorAction : "");
-    setChatErrorRequestID(error instanceof ApiError ? error.requestId : "");
-    setChatErrorTraceID(error instanceof ApiError ? error.traceId : "");
-  }
 
   async function submitAgentChat(queued?: QueuedChatMessage) {
     const content = (queued?.content ?? message).trim();


### PR DESCRIPTION
## Summary

Canonical chat-domain slice. Owns 25 state fields plus five self-contained helpers, removing the bulk of remaining state from the god-hook.

This is the biggest single carve-out. After it lands, `useRuntimeConsole.ts` is mostly a coordination layer: SSE event handler, `submitChat`, `createChatSession`, `selectChatSession`, plus the dashboard fan-out. Domain state lives in slices.

## What's in the slice

```ts
type ChatState = {
  // Routing
  defaultChatTarget: ChatTarget;
  chatTargetBySessionID: Map<string, HecateChatTarget>;
  // Session lists
  agentChatSessions: AgentChatSessionsResponse["data"];
  activeAgentChatSessionID: string;
  activeAgentChatSession: AgentChatSessionRecord | null;
  // Workspace + adapter
  agentAdapterID: string;
  agentWorkspace: string;
  agentWorkspaceBranch: string;
  // Composer + queue
  model: string;
  modelFilter: ModelFilter;
  providerFilter: ProviderFilter;
  systemPrompt: string;
  queuedChatMessages: QueuedChatMessage[];
  // In-flight machinery
  chatLoading: boolean;
  agentChatCancelling: boolean;
  streamingContent: string | null;
  chatResult: ChatResponse | null;
  pendingToolCalls: PendingToolCall[];
  pendingThread: ChatMessage[] | null;
  // Chat-error cluster (six fields)
  chatError: string;
  chatErrorCode: string;
  chatErrorStatus: number | null;
  chatErrorAction: string;
  chatErrorRequestID: string;
  chatErrorTraceID: string;
};
```

**Persistence**: eight fields use `usePersistedState` (`hecate.chatTarget`, `hecate.chatTargetBySessionID`, `hecate.agentAdapterID`, `hecate.agentWorkspace`, `hecate.agentChatSessionID`, `hecate.queuedChatMessages`, `hecate.model`, `hecate.systemPrompt`). Same storage keys, same parsers, same fallbacks.

**`providerFilter` carve-out**: keeps its legacy `useState` + mount-read effect pattern. Long-form rationale lives inline next to the declaration; short version is that the auto-default cascade in `useRuntimeConsole` reads it through a first-render closure that depends on the legacy timing — seeding the persisted value into the lazy initializer (what `usePersistedState` does) shifts the transition out from under that cascade and broke three e2e scenarios when migrated.

## Slice helpers

| Helper | Why in slice |
|---|---|
| `removeQueuedChatMessage`, `updateQueuedChatMessage`, `pruneQueuedChatMessagesForSessions` | Pure `queuedChatMessages` ops |
| `clearChatErrorState` | Sets six chat-error fields to empty |
| `setChatErrorState(error, fallback?)` | Wraps with `humanizeChatError` + `ApiError` extraction |
| `setChatError` (raw setter) | Three shim call sites write inline literals or use a "keep-first-error" updater |

## What stays in the shim (deliberately)

- **`chatTarget` derivation** — touches multiple chat-slice fields plus the agent-session helper. Pure chat domain but threads through the AppShell prop-bag for now; moves out when the prop-drill retires.
- **`applyAgentChatSession`, `syncHecateSelectionFromSession`, `refreshAgentChatSession`** — composed actions that update several chat fields atomically. Will move into the slice once the shim is mostly composer-only.
- **Request coordinators** — `submitChat`, `createChatSession`, `selectChatSession`, `renameChatSession`, `deleteChatSession`, `cancelAgentChat`, the SSE event handler. They all cross-cut `notice` / `settingsError` / `settingsConfig` / `modelChat` / `approvals`. Coordinators move into named hooks in a later pass.

## useRuntimeConsole shim diff

- Drops **25 useState/usePersistedState declarations** + the `queuedChatMessagesRef` dead code + the local versions of the five self-contained helpers.
- Pulls slice values via `useChat()` and destructures into the same legacy identifiers (`defaultChatTarget`, `chatError`, …) so the shim coordinators read unchanged.
- Six imports retire: `useRef`, `parseStoredJSON`, `parseStoredString`, `usePersistedState`, `ApiError`, plus the four `_shared` parsers used only by the slice now and two type imports (`AgentChatSessionsResponse`, `ModelFilter`).
- Net file shrink: **−124 LOC** in `useRuntimeConsole.ts`.

## Tests

`useRuntimeConsole.test.tsx`'s `SliceProviders` composer grows to wrap `ChatProvider`:

```tsx
<RuntimeProvider>
  <UsageProvider>
    <ProvidersAndModelsProvider>
      <ModelChatProvider>
        <ChatProvider>
          <RetentionProvider>
            <ApprovalsProvider>{children}</ApprovalsProvider>
          </RetentionProvider>
        </ChatProvider>
      </ModelChatProvider>
    </ProvidersAndModelsProvider>
  </UsageProvider>
</RuntimeProvider>
```

Every assertion unchanged. Full UI suite green (824/824, 38 files); `useRuntimeConsole.test.tsx`'s 49 god-hook tests unchanged.

## External surface

Byte-for-byte stable. Every legacy `state.*` key and every legacy `actions.*` identifier the AppShell and views consume is present with the same shape. `ChatView`, `ProvidersView`, `ConnectionsPanel`, `SettingsView` weren't modified.

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/app/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `useRuntimeConsole.test.tsx` (49 tests) — every assertion unchanged
- [x] External surface diff: 25 `state.*` keys + slice-owned action identifiers byte-for-byte stable
- [x] `ChatView` + consumers untouched
- [x] Code / commit / PR body audited for plan-label leaks

## What's next

The god-hook is now thin enough that the prop-drill can retire. Workspace views can start reading their slice context directly, peeling the `{state, actions}` prop-bag off `AppShell` and the views one slice at a time.
