### PR TITLE
refactor(ui): retire the {state,actions} prop bag for context [skip desktop]

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect } from "react";
 
 import { ConsoleShell, getAvailableWorkspaces, WORKSPACE_IDS, type WorkspaceID } from "./AppShell";
+import { RuntimeConsoleContextProvider } from "./RuntimeConsoleContext";
 import { ApprovalsProvider } from "./state/approvals";
 import { ChatProvider } from "./state/chat";
 import { ModelChatProvider } from "./state/modelChat";
@@ -8,7 +9,6 @@ import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
 import { UsageProvider } from "./state/usage";
-import { useRuntimeConsole } from "./useRuntimeConsole";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
 
@@ -20,12 +20,10 @@ const VALID_WORKSPACE_IDS = new Set<WorkspaceID>(WORKSPACE_IDS);
 const parseWorkspaceID = (raw: string): WorkspaceID | null =>
   VALID_WORKSPACE_IDS.has(raw as WorkspaceID) ? (raw as WorkspaceID) : null;
 
-// The slice providers wrap the console body so useRuntimeConsole's
-// internal slice consumers (`useRetention`, …) see their context.
-// As more slices are added the wrapper chain grows here; once
-// prop-drill is retired and consumers read context directly, a
-// single `<RuntimeConsoleProviders>` composer will collapse this
-// chain.
+// Slice providers wrap RuntimeConsoleContextProvider so the shim
+// inside it can see slice contexts; the facade provider then
+// exposes the shim's `{state, actions}` shape to AppShell and
+// every workspace view through context — no prop-drilling.
 export default function App() {
   return (
     <RuntimeProvider>
@@ -35,7 +33,9 @@ export default function App() {
             <ChatProvider>
               <RetentionProvider>
                 <ApprovalsProvider>
-                  <AppConsole />
+                  <RuntimeConsoleContextProvider>
+                    <AppConsole />
+                  </RuntimeConsoleContextProvider>
                 </ApprovalsProvider>
               </RetentionProvider>
             </ChatProvider>
@@ -47,7 +47,6 @@ export default function App() {
 }
 
 function AppConsole() {
-  const { state, actions } = useRuntimeConsole();
   const [preferredWorkspace, setPreferredWorkspace] = usePersistedState<WorkspaceID>(
     WORKSPACE_STORAGE_KEY,
     parseWorkspaceID,
@@ -77,7 +76,7 @@ function AppConsole() {
     return installTauriDocumentMarkers();
   }, []);
 
-  return <ConsoleShell actions={actions} activeWorkspace={activeWorkspace} onSelectWorkspace={handleSelectWorkspace} state={state} />;
+  return <ConsoleShell activeWorkspace={activeWorkspace} onSelectWorkspace={handleSelectWorkspace} />;
 }
 
 export function installTauriDocumentMarkers(): () => void {

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConsoleShell, getAvailableWorkspaces } from "./AppShell";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../test/runtime-console-render";
 
 // Workspace lineup is fixed. Numeric keyboard workspace switching was
 // removed so text inputs, screen readers, and browser shortcuts own the
@@ -27,12 +28,10 @@ describe("ConsoleShell loading state", () => {
   it("renders the connecting splash while health is null and no error", () => {
     const state = createRuntimeConsoleFixture({ health: null, error: "" });
     render(
-      <ConsoleShell
-        activeWorkspace="overview"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
     expect(screen.getByText(/connecting/i)).toBeInTheDocument();
   });
@@ -62,12 +61,10 @@ describe("ConsoleShell titlebar", () => {
     Object.defineProperty(navigator, "platform", { configurable: true, value: "MacIntel" });
     const state = createRuntimeConsoleFixture();
     const { container } = render(
-      <ConsoleShell
-        activeWorkspace="overview"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
     const titlebar = container.querySelector(".hecate-titlebar");
     expect(titlebar).not.toBeNull();
@@ -79,12 +76,10 @@ describe("ConsoleShell titlebar", () => {
     Object.defineProperty(navigator, "platform", { configurable: true, value: "Linux x86_64" });
     const state = createRuntimeConsoleFixture();
     const { container } = render(
-      <ConsoleShell
-        activeWorkspace="overview"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
     expect(container.querySelector(".hecate-titlebar")).toBeNull();
   });
@@ -93,12 +88,10 @@ describe("ConsoleShell titlebar", () => {
     Object.defineProperty(navigator, "platform", { configurable: true, value: "MacIntel" });
     const state = createRuntimeConsoleFixture();
     const { container } = render(
-      <ConsoleShell
-        activeWorkspace="overview"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
     expect(container.querySelector(".hecate-titlebar")).toBeNull();
   });
@@ -111,12 +104,10 @@ describe("ConsoleShell navigation", () => {
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
     });
     render(
-      <ConsoleShell
-        activeWorkspace="chats"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     // The Chats workspace is a `lazy()` chunk per AppShell.tsx;
@@ -137,12 +128,10 @@ describe("ConsoleShell navigation", () => {
       agentWorkspaceBranch: "feature/agents",
     });
     render(
-      <ConsoleShell
-        activeWorkspace="chats"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     expect(screen.getByText("/Users/alice/dev/hecate")).toBeInTheDocument();
@@ -165,12 +154,10 @@ describe("ConsoleShell navigation", () => {
       },
     });
     render(
-      <ConsoleShell
-        activeWorkspace="chats"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     expect(screen.getByText("/Users/alice/dev/hecate")).toBeInTheDocument();
@@ -196,12 +183,10 @@ describe("ConsoleShell navigation", () => {
       },
     });
     render(
-      <ConsoleShell
-        activeWorkspace="chats"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     expect(screen.getByText("context 79% left")).toBeInTheDocument();
@@ -214,12 +199,10 @@ describe("ConsoleShell navigation", () => {
       agentWorkspaceBranch: "main",
     });
     render(
-      <ConsoleShell
-        activeWorkspace="chats"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     expect(screen.queryByText("/Users/alice/dev/hecate")).toBeNull();
@@ -264,12 +247,10 @@ describe("ConsoleShell theme toggle", () => {
     const state = createRuntimeConsoleFixture();
 
     render(
-      <ConsoleShell
-        activeWorkspace="settings"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="settings" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
@@ -282,12 +263,10 @@ describe("ConsoleShell theme toggle", () => {
     const state = createRuntimeConsoleFixture();
 
     render(
-      <ConsoleShell
-        activeWorkspace="settings"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="settings" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
 
     fireEvent.click(screen.getByRole("button", { name: /switch to light theme/i }));
@@ -321,12 +300,10 @@ describe("status bar version chip", () => {
       health: healthOverrides as never,
     });
     render(
-      <ConsoleShell
-        activeWorkspace="overview"
-        onSelectWorkspace={() => {}}
-        state={state}
-        actions={createRuntimeConsoleActions()}
-      />,
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />,
+        { state, actions: createRuntimeConsoleActions() },
+      ),
     );
   }
 

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useEffect, useState } from "react";
 
+import { useRuntimeConsoleContext } from "./RuntimeConsoleContext";
 import type { RuntimeConsoleViewModel } from "./useRuntimeConsole";
 import type { AgentChatUsageRecord } from "../types/runtime";
 import { UpdateBanner } from "../features/shared/UpdateBanner";
@@ -49,7 +50,6 @@ type WorkspaceDefinition = {
 };
 
 type ConsoleState = RuntimeConsoleViewModel["state"];
-type ConsoleActions = RuntimeConsoleViewModel["actions"];
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
 type TraceFocusRequest = { requestID: string; nonce: number };
 
@@ -154,14 +154,11 @@ export function getAvailableWorkspaces(): WorkspaceDefinition[] {
 export function ConsoleShell({
   activeWorkspace,
   onSelectWorkspace,
-  state,
-  actions,
 }: {
   activeWorkspace: WorkspaceID;
   onSelectWorkspace: (workspace: WorkspaceID) => void;
-  state: ConsoleState;
-  actions: ConsoleActions;
 }) {
+  const { state } = useRuntimeConsoleContext();
   // No auth: render the full console immediately. The brief
   // first-load splash stays so the workspace doesn't flash with
   // stale state before /healthz returns.
@@ -172,8 +169,6 @@ export function ConsoleShell({
     <AuthenticatedShell
       activeWorkspace={activeWorkspace}
       onSelectWorkspace={onSelectWorkspace}
-      state={state}
-      actions={actions}
     />
   );
 }
@@ -231,14 +226,11 @@ function AuthLoadingShell() {
 function AuthenticatedShell({
   activeWorkspace,
   onSelectWorkspace,
-  state,
-  actions,
 }: {
   activeWorkspace: WorkspaceID;
   onSelectWorkspace: (workspace: WorkspaceID) => void;
-  state: ConsoleState;
-  actions: ConsoleActions;
 }) {
+  const { state, actions } = useRuntimeConsoleContext();
   const workspaces = getAvailableWorkspaces();
   const [taskFocusRequest, setTaskFocusRequest] = useState<TaskFocusRequest | null>(null);
   const [traceFocusRequest, setTraceFocusRequest] = useState<TraceFocusRequest | null>(null);
@@ -320,12 +312,12 @@ function AuthenticatedShell({
           {state.error && <div className="page-banner page-banner--error">{state.error}</div>}
           <div className={`console-content${isBare ? " console-content--bare" : ""}`}>
             <Suspense fallback={<WorkspaceFallback />}>
-              {activeWorkspace === "overview"   && <ObservabilityView actions={actions} state={state} onNavigate={onSelectWorkspace} focusRequest={traceFocusRequest} />}
-              {activeWorkspace === "chats" && <ChatView actions={actions} state={state} onNavigate={onSelectWorkspace} onOpenTask={openTaskFromChat} onOpenTrace={openTraceFromChat} />}
+              {activeWorkspace === "overview"   && <ObservabilityView onNavigate={onSelectWorkspace} focusRequest={traceFocusRequest} />}
+              {activeWorkspace === "chats" && <ChatView onNavigate={onSelectWorkspace} onOpenTask={openTaskFromChat} onOpenTrace={openTraceFromChat} />}
               {activeWorkspace === "runs"          && <TasksView focusRequest={taskFocusRequest} onOpenAgentChat={openAgentChatFromTask} onOpenTrace={openTraceFromChat} />}
-              {activeWorkspace === "connections"     && <ProvidersView actions={actions} state={state} />}
-              {activeWorkspace === "usage"         && <UsageView actions={actions} state={state} />}
-              {activeWorkspace === "settings" && <SettingsView actions={actions} state={state} />}
+              {activeWorkspace === "connections"     && <ProvidersView />}
+              {activeWorkspace === "usage"         && <UsageView />}
+              {activeWorkspace === "settings" && <SettingsView />}
             </Suspense>
           </div>
         </main>

--- a/ui/src/app/RuntimeConsoleContext.tsx
+++ b/ui/src/app/RuntimeConsoleContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import { useRuntimeConsole, type RuntimeConsoleViewModel } from "./useRuntimeConsole";
+
+// The shim's external surface, exposed through context so workspace
+// views consume it directly instead of receiving it as a
+// {state, actions} prop bag drilled through AppShell. Identifiers
+// inside the views are unchanged — the destructure at each view's
+// top reads the same shape the prop bag did.
+export const RuntimeConsoleContext = createContext<RuntimeConsoleViewModel | null>(null);
+
+export function RuntimeConsoleContextProvider({ children }: { children: ReactNode }) {
+  const value = useRuntimeConsole();
+  return <RuntimeConsoleContext.Provider value={value}>{children}</RuntimeConsoleContext.Provider>;
+}
+
+export function useRuntimeConsoleContext(): RuntimeConsoleViewModel {
+  const ctx = useContext(RuntimeConsoleContext);
+  if (!ctx) {
+    throw new Error(
+      "useRuntimeConsoleContext must be used inside <RuntimeConsoleContextProvider>",
+    );
+  }
+  return ctx;
+}

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatView } from "./ChatView";
 import { discoverLocalProviders } from "../../lib/api";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
 
 vi.mock("../../lib/api", async importOriginal => {
   const actual = await importOriginal<typeof import("../../lib/api")>();
@@ -67,7 +68,7 @@ function setup(stateOverrides = {}, actionOverrides = {}) {
 describe("ChatView input", () => {
   it("renders Hecate first in the unified agent picker", async () => {
     const { state, actions } = setup();
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByRole("button", { name: "New Hecate chat" })).toBeTruthy();
     const picker = screen.getByRole("button", { name: "Choose agent for new chat" });
 
@@ -98,7 +99,7 @@ describe("ChatView input", () => {
         },
       ],
     }, { setChatTarget });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /settings/i }));
@@ -108,7 +109,7 @@ describe("ChatView input", () => {
     expect(setChatTarget).toHaveBeenCalledWith("model");
 
     const directState = setup({ ...state, chatTarget: "model" }, { setChatTarget }).state;
-    rerender(<ChatView state={directState} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: directState, actions }));
     expect(screen.getByRole("button", { name: "Tools off" })).toHaveTextContent("off");
 
     await user.click(screen.getByRole("button", { name: "Tools off" }));
@@ -131,7 +132,7 @@ describe("ChatView input", () => {
         messages: [],
       } as any,
     }, { setChatTarget });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /settings/i }));
@@ -158,7 +159,7 @@ describe("ChatView input", () => {
         },
       ],
     }, { setSystemPrompt });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /settings/i }));
@@ -188,7 +189,7 @@ describe("ChatView input", () => {
       } as any,
       model: "qwen2.5-coder",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Chat settings" }));
@@ -222,7 +223,7 @@ describe("ChatView input", () => {
       providerFilter: "ollama",
       model: "qwen2.5-coder",
     }, { setHecateRTKEnabled });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /settings/i }));
@@ -267,7 +268,7 @@ describe("ChatView input", () => {
         },
       ],
     }, { setHecateRTKEnabled });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "New Hecate chat" }));
@@ -275,7 +276,7 @@ describe("ChatView input", () => {
     await user.click(screen.getByRole("button", { name: "Compact command output on" }));
     expect(setHecateRTKEnabled).toHaveBeenCalledWith(false);
 
-    rerender(<ChatView state={{ ...state, hecateRTKEnabled: false }} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: { ...state, hecateRTKEnabled: false }, actions }));
     await user.click(screen.getByRole("button", { name: "Chat settings" }));
 
     expect(screen.queryByText("Compact command output is available")).toBeNull();
@@ -289,7 +290,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByText("SYSTEM PROMPT / AGENT INSTRUCTIONS")).toBeNull();
     expect(screen.queryByText("SYSTEM PROMPT / INSTRUCTIONS")).toBeNull();
@@ -324,7 +325,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { setAgentChatConfigOption });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Chat settings" }));
@@ -343,7 +344,7 @@ describe("ChatView input", () => {
 
   it("disables the send button when message is empty", () => {
     const { state, actions } = setup({ message: "" });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     fireEvent.click(screen.getByRole("button", { name: /new .* chat/i }));
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);
@@ -351,7 +352,7 @@ describe("ChatView input", () => {
 
   it("enables the send button when message has content", () => {
     const { state, actions } = setup({ chatTarget: "model", message: "hello" });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(false);
   });
@@ -362,7 +363,7 @@ describe("ChatView input", () => {
       model: "",
       message: "hello",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
@@ -377,7 +378,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText("No model provider configured")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
@@ -415,7 +416,7 @@ describe("ChatView input", () => {
         { id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama", provider_kind: "local" } },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getAllByText("Selected model is not available from this provider").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Ollama is configured, but it does not currently report "llama3.1:8b"/).length).toBeGreaterThan(0);
@@ -477,7 +478,7 @@ describe("ChatView input", () => {
         { id: "qwen2.5:7b", owned_by: "ollama", metadata: { provider: "ollama", provider_kind: "local" } },
       ],
     });
-    render(<ChatView state={state} actions={actions} onNavigate={onNavigate} />);
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
 
     expect(screen.getByText("Selected model is not available from this provider")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open Connections" })).toBeTruthy();
@@ -523,7 +524,7 @@ describe("ChatView input", () => {
         { id: "gpt-4o-mini", owned_by: "openai", metadata: { provider: "openai", provider_kind: "cloud" } },
       ],
     }, { setModel, setProviderFilter });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getAllByRole("button", { name: "Use gpt-4o-mini" })[0]);
@@ -541,7 +542,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} onNavigate={onNavigate} />);
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /Open Connections/i }));
@@ -582,7 +583,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("No routable model")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
@@ -638,7 +639,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { createProvider, loadDashboard });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     const quickAdd = await screen.findByRole("button", { name: /Add selected/i });
@@ -709,7 +710,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { createProvider, loadDashboard });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     expect(await screen.findByRole("button", { name: "Deselect Ollama" })).toHaveAttribute("aria-pressed", "true");
@@ -757,7 +758,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { createProvider, loadDashboard });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(await screen.findByText("Detected locally")).toBeTruthy();
     expect(screen.getByText("Ollama")).toBeTruthy();
@@ -819,7 +820,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { createProvider, loadDashboard });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(await screen.findByRole("button", { name: /Add selected/i }));
@@ -883,7 +884,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { createProvider, loadDashboard });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(await screen.findByRole("button", { name: /Add selected/i }));
@@ -902,7 +903,7 @@ describe("ChatView input", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: false, status: "missing", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText("Nothing runnable yet")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: "New Hecate chat" })).toBeTruthy();
@@ -936,7 +937,7 @@ describe("ChatView input", () => {
         },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /settings/i }));
@@ -1001,7 +1002,7 @@ describe("ChatView input", () => {
         messages: [],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByRole("button", { name: "Fixed provider: Ollama" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Fixed model: qwen2.5-coder" })).toBeNull();
@@ -1066,7 +1067,7 @@ describe("ChatView input", () => {
         messages: [],
       } as any,
     }, { setProviderFilter, setModel });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const controls = screen.getByLabelText("Hecate message controls");
     const provider = within(controls).getByRole("button", { name: "Provider picker: Ollama" });
@@ -1131,7 +1132,7 @@ describe("ChatView input", () => {
         messages: [],
       } as any,
     });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const fixedProvider = screen.getByRole("button", { name: "Fixed provider: Ollama" }) as HTMLButtonElement;
     const fixedModel = screen.getByRole("button", { name: "Fixed model: qwen2.5-coder" }) as HTMLButtonElement;
@@ -1143,7 +1144,7 @@ describe("ChatView input", () => {
     expect(screen.getByRole("button", { name: "Stop active task" })).toBeTruthy();
     expect(screen.getByText(/Hecate Chat is still working on this task/)).toBeTruthy();
 
-    rerender(<ChatView state={{ ...state, chatTarget: "model" }} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }));
     expect(document.querySelector('[aria-label="Fixed provider: Ollama"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Fixed model: qwen2.5-coder"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Model picker: smollm2:135m"]')).toBeNull();
@@ -1191,7 +1192,7 @@ describe("ChatView input", () => {
         messages: [],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} onOpenTask={onOpenTask} />);
+    render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
 
     expect(screen.getByRole("button", { name: "Fixed provider: Ollama" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fixed model: qwen2.5-coder" })).toBeTruthy();
@@ -1224,7 +1225,7 @@ describe("ChatView input", () => {
       ],
     }, { removeQueuedChatMessage, updateQueuedChatMessage });
 
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByLabelText("Queued messages")).toBeTruthy();
     const queuedInput = screen.getByLabelText("Queued message 1");
@@ -1266,7 +1267,7 @@ describe("ChatView input", () => {
       ],
     });
 
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByLabelText("Queued messages")).toBeTruthy();
     expect(screen.getByLabelText("Queued message 1")).toHaveValue("send this here");
@@ -1289,11 +1290,11 @@ describe("ChatView input", () => {
       ],
       model: "qwen2.5-coder",
     });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText(/Hecate Agent runs through task approvals and per-call sandboxing/)).toBeTruthy();
 
-    rerender(<ChatView state={{ ...state, chatTarget: "model" }} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }));
     expect(screen.queryByText(/Hecate Agent runs through task approvals and per-call sandboxing/)).toBeNull();
   });
 
@@ -1323,7 +1324,7 @@ describe("ChatView input", () => {
         },
       ],
     }, { upsertModelCapabilityOverride });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText(/Tools are disabled for this model/)).toBeTruthy();
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
@@ -1371,7 +1372,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} onOpenTask={onOpenTask} />);
+    render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
     const user = userEvent.setup();
     expect(screen.queryByRole("button", { name: /^Task task_hecate_/i })).toBeNull();
     expect(screen.getByText("Run hecate_abcde")).toBeTruthy();
@@ -1412,7 +1413,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} onOpenTask={onOpenTask} />);
+    render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
 
     expect(screen.getByText("Direct answer.")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Open Task latest/i })).toBeNull();
@@ -1471,7 +1472,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getAllByLabelText("Tools off segment using smollm2:135m")).toHaveLength(2);
     expect(screen.getByLabelText("Tools on segment using qwen2.5-coder")).toBeTruthy();
@@ -1517,7 +1518,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("completed · 1 tool")).toBeTruthy();
     expect(screen.getByText("Thinking")).toBeTruthy();
@@ -1572,7 +1573,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     }, { resolveTaskApproval });
-    render(<ChatView state={state} actions={actions} onOpenTask={onOpenTask} />);
+    render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
 
     expect(screen.getByTestId("hecate-task-approval-banner")).toBeTruthy();
     expect(screen.getByText("Approval required")).toBeTruthy();
@@ -1626,7 +1627,7 @@ describe("ChatView input", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByTestId("hecate-task-approval-banner")).toBeNull();
     expect(screen.queryByRole("button", { name: /Approve Agent tool call/i })).toBeNull();
@@ -1636,7 +1637,7 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     // Start with empty message so the assertion sees only what we typed.
     const { state, actions } = setup({ chatTarget: "model", message: "" }, { setMessage });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     fireEvent.click(screen.getByRole("button", { name: /new .* chat/i }));
     const ta = screen.getByPlaceholderText(/Message/i) as HTMLTextAreaElement;
     const user = userEvent.setup();
@@ -1661,7 +1662,7 @@ describe("ChatView input", () => {
         provider_calls: [],
       },
     }, { setMessage });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     let textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange(0, 0);
@@ -1669,20 +1670,20 @@ describe("ChatView input", () => {
     expect(setMessage).toHaveBeenLastCalledWith("second prompt");
 
     const latestState = { ...state, message: "second prompt" };
-    rerender(<ChatView state={latestState} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: latestState, actions }));
     textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange("second prompt".length, "second prompt".length);
     fireEvent.keyDown(textarea, { key: "ArrowUp" });
     expect(setMessage).toHaveBeenLastCalledWith("first prompt");
 
     const oldestState = { ...state, message: "first prompt" };
-    rerender(<ChatView state={oldestState} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: oldestState, actions }));
     textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange("first prompt".length, "first prompt".length);
     fireEvent.keyDown(textarea, { key: "ArrowDown" });
     expect(setMessage).toHaveBeenLastCalledWith("second prompt");
 
-    rerender(<ChatView state={latestState} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: latestState, actions }));
     textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange("second prompt".length, "second prompt".length);
     fireEvent.keyDown(textarea, { key: "ArrowDown" });
@@ -1704,7 +1705,7 @@ describe("ChatView input", () => {
         provider_calls: [],
       },
     }, { setMessage });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange(5, 5);
@@ -1727,14 +1728,14 @@ describe("ChatView input", () => {
         provider_calls: [],
       },
     }, { setMessage });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     let textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange("draft question".length, "draft question".length);
     fireEvent.keyDown(textarea, { key: "ArrowUp" });
     expect(setMessage).toHaveBeenLastCalledWith("previous prompt");
 
-    rerender(<ChatView state={{ ...state, message: "previous prompt" }} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: { ...state, message: "previous prompt" }, actions }));
     textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     textarea.setSelectionRange("previous prompt".length, "previous prompt".length);
     fireEvent.keyDown(textarea, { key: "ArrowDown" });
@@ -1745,7 +1746,7 @@ describe("ChatView input", () => {
 describe("ChatView Enter switch", () => {
   it("renders the segmented Enter/⌘+Enter or Ctrl+Enter switch", () => {
     const { state, actions } = setup();
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     // The switch is one of the toggle buttons in the input toolbar.
     const buttons = screen.getAllByRole("button");
     const labels = buttons.map(b => b.textContent?.trim()).filter(Boolean);
@@ -1763,7 +1764,7 @@ describe("ChatView chats sidebar", () => {
 
   it("shows 'No chats yet' when chatSessions is empty", () => {
     const { state, actions } = setup({ chatTarget: "model", chatSessions: [] });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/No chats yet/i)).toBeTruthy();
   });
 
@@ -1775,7 +1776,7 @@ describe("ChatView chats sidebar", () => {
         { id: "s2", title: "Second chat", message_count: 2, provider_call_count: 1, updated_at: daysAgo(10) } as any,
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText("Today")).toBeTruthy();
     expect(screen.getByText("Older")).toBeTruthy();
     expect(screen.getByText("First chat")).toBeTruthy();
@@ -1790,7 +1791,7 @@ describe("ChatView chats sidebar", () => {
         { id: "s2", title: "Draft release notes", message_count: 2, provider_call_count: 1, last_provider: "openai", updated_at: daysAgo(0) } as any,
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Search chats"), "anthropic");
     expect(screen.getByText("Budget check")).toBeTruthy();
@@ -1805,7 +1806,7 @@ describe("ChatView chats sidebar", () => {
         { id: "a2", title: "Cursor repro", adapter_id: "cursor_agent", status: "failed", message_count: 2, updated_at: daysAgo(0) } as any,
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Search chats"), "failed");
     expect(screen.getByText("Cursor repro")).toBeTruthy();
@@ -1820,7 +1821,7 @@ describe("ChatView chats sidebar", () => {
         { id: "a1", title: "Codex refactor", adapter_id: "codex", status: "completed", message_count: 4, updated_at: daysAgo(0) } as any,
       ],
     }, { renameChatSession });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Rename chat Codex refactor" }));
@@ -1837,7 +1838,7 @@ describe("ChatView chats sidebar", () => {
       chatTarget: "model",
       chatSessions: [{ id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any],
     }, { selectChatSession });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     const user = userEvent.setup();
     await user.click(screen.getByText("Pick me"));
     expect(selectChatSession).toHaveBeenCalledWith("s1");
@@ -1849,7 +1850,7 @@ describe("ChatView chats sidebar", () => {
       chatTarget: "model",
       chatSessions: [{ id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any],
     }, { selectChatSession });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     const user = userEvent.setup();
     const row = screen.getByRole("button", { name: /^Chat Pick me$/ });
     row.focus();
@@ -1863,10 +1864,10 @@ describe("ChatView chats sidebar", () => {
 describe("ChatView external-agent target", () => {
   it("shows the unsandboxed external-agent reminder in agent mode only", () => {
     const { state, actions } = setup({ chatTarget: "external_agent" });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/External agents run as your OS user/)).toBeTruthy();
 
-    rerender(<ChatView state={{ ...state, chatTarget: "model" }} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }));
     expect(screen.queryByText(/External agents run as your OS user/)).toBeNull();
   });
 
@@ -1880,7 +1881,7 @@ describe("ChatView external-agent target", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", managed: true, managed_package: "@zed-industries/codex-acp", available: false, status: "missing", error: "no local package runner found for @zed-industries/codex-acp", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Codex is unavailable")).toBeTruthy();
     expect(screen.getByText(/could not start Codex/)).toBeTruthy();
@@ -1967,7 +1968,7 @@ describe("ChatView external-agent target", () => {
       } as any,
     }, { setChatTarget, setAgentAdapterID, setNewChatAgent, setAgentChatConfigOption: vi.fn(async () => true) });
     const onOpenTrace = vi.fn();
-    render(<ChatView state={state} actions={actions} onOpenTrace={onOpenTrace} />);
+    render(withRuntimeConsole(<ChatView onOpenTrace={onOpenTrace} />, { state, actions }));
 
     expect(screen.queryByDisplayValue("/tmp/hecate")).toBeNull();
     expect(screen.getByRole("button", { name: /workspace/i })).toBeTruthy();
@@ -2031,7 +2032,7 @@ describe("ChatView external-agent target", () => {
         { id: "claude_code", name: "Claude Code", kind: "acp", command: "claude-agent-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { setNewChatAgent });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Choose agent for new chat" }));
@@ -2062,7 +2063,7 @@ describe("ChatView external-agent target", () => {
         },
       ],
     }, { setAgentAdapterCredential, probeAgentAdapter });
-    render(<ChatView state={state} actions={actions} onNavigate={onNavigate} />);
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
 
     expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
     expect(screen.getByText("Set up Claude Code")).toBeTruthy();
@@ -2115,7 +2116,7 @@ describe("ChatView external-agent target", () => {
         },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Set up Claude Code")).toBeTruthy();
     expect(screen.getAllByTestId("claude-code-preflight")).toHaveLength(1);
@@ -2143,7 +2144,7 @@ describe("ChatView external-agent target", () => {
         },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Available via /opt/homebrew/bin/claude")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "npx -y @anthropic-ai/claude-code --version" })).toBeNull();
@@ -2167,7 +2168,7 @@ describe("ChatView external-agent target", () => {
         },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
     expect(screen.getByText(/adapter-visible credential/i)).toBeTruthy();
@@ -2194,7 +2195,7 @@ describe("ChatView external-agent target", () => {
         ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 120 }],
       ]),
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByTestId("claude-code-preflight")).toBeTruthy();
     expect(screen.getByText("adapter installed")).toBeTruthy();
@@ -2224,7 +2225,7 @@ describe("ChatView external-agent target", () => {
         ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 120 }],
       ]),
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByTestId("claude-code-preflight")).toBeNull();
   });
@@ -2261,7 +2262,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Waiting for agent output...")).toBeTruthy();
     expect(screen.getAllByText("running").length).toBeGreaterThan(0);
@@ -2299,7 +2300,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("I’ll check the current worktree diff and summarize the changed files plus the important hunks.")).toBeTruthy();
     expect(screen.getByText("I’ll check the current worktree diff and summarize the changed files plus the important hunks.").parentElement?.querySelector("[aria-hidden='true']")).toBeTruthy();
@@ -2341,7 +2342,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("0.1234 USD")).toBeTruthy();
     expect(screen.getByText("42000/200000 context")).toBeTruthy();
@@ -2388,7 +2389,7 @@ describe("ChatView external-agent target", () => {
       } as any,
       model: "qwen2.5-coder",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     await userEvent.click(screen.getByRole("button", { name: "Chat settings" }));
 
@@ -2437,7 +2438,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     }, { listAgentChatMessageFiles, getAgentChatMessageFileDiff, revertAgentChatMessageFiles });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("files changed · 2 files changed, 6 insertions(+), 1 deletion(-)"));
@@ -2492,7 +2493,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     }, { listAgentChatMessageFiles, getAgentChatMessageFileDiff, revertAgentChatMessageFiles });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"));
@@ -2541,7 +2542,7 @@ describe("ChatView external-agent target", () => {
       getAgentChatMessageFileDiff: vi.fn(async () => null),
       revertAgentChatMessageFiles: vi.fn(async () => false),
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"));
@@ -2580,7 +2581,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     }, { listAgentChatMessageFiles, revertAgentChatMessageFiles });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"));
@@ -2612,7 +2613,7 @@ describe("ChatView external-agent target", () => {
         messages: [],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const stop = screen.getByRole("button", { name: "Stop external agent" }) as HTMLButtonElement;
     expect(stop.disabled).toBe(true);
@@ -2654,7 +2655,7 @@ describe("ChatView external-agent target", () => {
         ],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("agent run failed")).toBeTruthy();
     expect(screen.getAllByText("Claude Code usage limit: credit balance is too low").length).toBeGreaterThan(0);
@@ -2671,7 +2672,7 @@ describe("ChatView external-agent target", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { chooseAgentWorkspace });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByTitle("Choose workspace folder"));
@@ -2688,7 +2689,7 @@ describe("ChatView external-agent target", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     }, { chooseAgentWorkspace, setAgentWorkspace });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByTitle("Choose workspace folder"));
@@ -2707,7 +2708,7 @@ describe("ChatView external-agent target", () => {
         { id: "codex", name: "Codex", kind: "acp", command: "codex-acp", available: true, status: "available", cost_mode: "external" },
       ],
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(true);
@@ -2731,7 +2732,7 @@ describe("ChatView external-agent target", () => {
         },
       ],
     }, { chooseAgentWorkspace });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText(/Hecate uses the workspace as the working directory/)).toBeTruthy();
     const user = userEvent.setup();
@@ -2756,7 +2757,7 @@ describe("ChatView model target", () => {
         provider_calls: [],
       } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByRole("img", { name: "Completed task" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Incomplete task" })).toBeTruthy();
@@ -2792,7 +2793,7 @@ describe("ChatView model target", () => {
         { id: "gpt-4.1-mini", owned_by: "openai", metadata: { provider: "openai", provider_kind: "cloud" } },
       ],
     }, { setProviderFilter, setModel });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     const providerPicker = screen.getByRole("button", { name: /OpenAI/i }) as HTMLButtonElement;
@@ -2812,7 +2813,7 @@ describe("ChatView model target", () => {
 describe("ChatView error display", () => {
   it("renders chatError using InlineError styling", () => {
     const { state, actions } = setup({ chatError: "Provider returned 500" });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/Provider returned 500/)).toBeTruthy();
   });
 
@@ -2826,7 +2827,7 @@ describe("ChatView error display", () => {
       chatErrorStatus: 502,
       chatErrorTraceID: "trace_abcdef1234567890",
     });
-    render(<ChatView state={state} actions={actions} onOpenTrace={openTrace} />);
+    render(withRuntimeConsole(<ChatView onOpenTrace={openTrace} />, { state, actions }));
     expect(screen.getByText("Provider credentials failed")).toBeTruthy();
     expect(screen.getByText("502 · provider_auth_failed")).toBeTruthy();
     expect(screen.getByText(/Rotate the provider key in Connections/)).toBeTruthy();
@@ -2848,7 +2849,7 @@ describe("ChatView session title", () => {
       activeAgentChatSessionID: "",
       message: "",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getAllByText("No chats yet").length).toBeGreaterThan(0);
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
     expect(screen.queryByLabelText("Chat header actions")).toBeNull();
@@ -2859,7 +2860,7 @@ describe("ChatView session title", () => {
       chatTarget: "model",
       activeChatSession: { id: "s1", title: "Hello world", messages: [], provider_calls: [] } as any,
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText("Hello world")).toBeTruthy();
   });
 
@@ -2889,7 +2890,7 @@ describe("ChatView session title", () => {
       } as any,
     });
 
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Repo work")).toBeTruthy();
     expect(screen.getByText("Tools on · /Users/alice/dev/hecate")).toBeTruthy();
@@ -2904,7 +2905,7 @@ describe("ChatView New chat button", () => {
     const createChatSession = vi.fn();
     const { state, actions } = setup({}, { createChatSession });
     const user = userEvent.setup();
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     await user.click(screen.getByRole("button", { name: /new .* chat/i }));
     expect(createChatSession).toHaveBeenCalled();
     const textarea = screen.getByPlaceholderText(/^Message…/i);
@@ -2925,7 +2926,7 @@ describe("ChatView session focus", () => {
       chatSessions: [{ id: "s2", title: "Pick me", message_count: 0, provider_call_count: 0 } as any],
     }, { selectChatSession });
     const user = userEvent.setup();
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     // Move focus elsewhere to detect the jump.
     const searchInput = screen.getByRole("textbox", { name: "Search chats" });
     searchInput.focus();
@@ -2937,7 +2938,7 @@ describe("ChatView session focus", () => {
       activeChatSessionID: "s2",
       activeChatSession: { id: "s2", title: "Pick me", messages: [], provider_calls: [] } as any,
     }).state;
-    rerender(<ChatView state={nextState} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: nextState, actions }));
     const textarea = screen.getByPlaceholderText(/^Message…/i);
     await waitFor(() => expect(document.activeElement).toBe(textarea));
     expect(selectChatSession).toHaveBeenCalledWith("s2");
@@ -2947,11 +2948,11 @@ describe("ChatView session focus", () => {
     // Initial-load and API-driven session arrivals must not steal
     // focus — page-level shortcuts depend on it. Asserts the negative.
     const { state, actions } = setup({ chatTarget: "model", activeChatSessionID: "" });
-    const { rerender } = render(<ChatView state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     const searchInput = screen.getByRole("textbox", { name: "Search chats" });
     searchInput.focus();
     const next = { ...state, activeChatSessionID: "s1" };
-    rerender(<ChatView state={next} actions={actions} />);
+    rerender(withRuntimeConsole(<ChatView />, { state: next, actions }));
     // Focus must STAY on the search input — the effect should not have
     // jumped to the textarea on a programmatic ID transition.
     expect(document.activeElement).toBe(searchInput);
@@ -2968,7 +2969,7 @@ describe("ChatView history pagination", () => {
         { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
       ],
     }, { loadMoreChatSessions });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByRole("button", { name: "Load earlier chats" })).toBeNull();
     expect(loadMoreChatSessions).not.toHaveBeenCalled();
@@ -2983,7 +2984,7 @@ describe("ChatView history pagination", () => {
         { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
       ],
     }, { loadMoreChatSessions });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.type(screen.getByRole("textbox", { name: "Search chats" }), "older match");
@@ -3002,7 +3003,7 @@ describe("ChatView agent approvals", () => {
       chatTarget: "external_agent",
       agentAdapterApprovalMode: "auto",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByTestId("agent-approval-auto-banner")).toBeTruthy();
   });
 
@@ -3011,7 +3012,7 @@ describe("ChatView agent approvals", () => {
       chatTarget: "external_agent",
       agentAdapterApprovalMode: "prompt",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.queryByTestId("agent-approval-auto-banner")).toBeNull();
   });
 
@@ -3020,7 +3021,7 @@ describe("ChatView agent approvals", () => {
       chatTarget: "model",
       agentAdapterApprovalMode: "auto",
     });
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.queryByTestId("agent-approval-auto-banner")).toBeNull();
   });
 
@@ -3056,7 +3057,7 @@ describe("ChatView agent approvals", () => {
       },
       { getAgentChatApproval },
     );
-    render(<ChatView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     // Only the active session's pending row is visible — banner must
     // not bleed approvals from other sessions.
@@ -3093,7 +3094,7 @@ describe("ChatView agent approvals", () => {
       },
       { getAgentChatApproval },
     );
-    const view = render(<ChatView state={externalState} actions={actions} />);
+    const view = render(withRuntimeConsole(<ChatView />, { state: externalState, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByTestId("agent-approval-banner-review"));
@@ -3108,7 +3109,7 @@ describe("ChatView agent approvals", () => {
       },
       { getAgentChatApproval },
     );
-    view.rerender(<ChatView state={hecateState} actions={actions} />);
+    view.rerender(withRuntimeConsole(<ChatView />, { state: hecateState, actions }));
 
     expect(getAgentChatApproval).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { ReactNode, SyntheticEvent } from "react";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
@@ -22,8 +23,6 @@ import { AgentSetupHints, ClaudeCodePreflightCard, ClaudeCodeSetupEmptyPanel, cl
 import type { ClaudeCodePreflightState } from "./ClaudeCodeSetup";
 
 type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
@@ -84,7 +83,8 @@ type HecateTaskApproval = {
   createdAt?: string;
 };
 
-export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }: Props) {
+export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
+  const { state, actions } = useRuntimeConsoleContext();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   // approvalModalID is the per-banner-click open state for the
   // approval modal. The modal itself fetches the full row on mount;
@@ -1655,8 +1655,6 @@ export function ChatView({ state, actions, onNavigate, onOpenTask, onOpenTrace }
       )}
       <AddProviderModal
         open={addProviderOpen}
-        state={state}
-        actions={actions}
         onClose={() => setAddProviderOpen(false)}
       />
     </div>

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { claudeCodeSetupTokenCommand } from "../../lib/claude-code-setup";
 import { formatLocaleDateTime } from "../../lib/format";
@@ -8,8 +9,6 @@ import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
 import { ModelCapabilitiesSection } from "./ModelCapabilitiesSection";
 
 type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings" | "chats" | "usage") => void;
 };
 
@@ -53,11 +52,10 @@ function SectionHeader({
 // readiness panel; "Save" validates Claude Code auth before storing
 // the token, so no separate Test button is needed.
 export function ConnectionsPanel({
-  state,
-  actions,
   onNavigate,
   showProviderSummary = true,
 }: Props & { showProviderSummary?: boolean }) {
+  const { state, actions } = useRuntimeConsoleContext();
   const liveAnthropicProvider = findAnthropicProvider(state.settingsConfig?.providers ?? []);
   const [rememberedAnthropicProvider, setRememberedAnthropicProvider] = useState<ConfiguredProviderRecord | null>(liveAnthropicProvider);
   const probedAdapterIDsRef = useRef<Set<string>>(new Set());
@@ -144,7 +142,7 @@ export function ConnectionsPanel({
     <>
       {showProviderSummary && <ModelProviderConnectionsSection state={state} onNavigate={onNavigate} />}
 
-      <ModelCapabilitiesSection state={state} actions={actions} />
+      <ModelCapabilitiesSection />
 
       {rememberedAnthropicProvider && (
         <AnthropicProviderKeyCard
@@ -470,7 +468,10 @@ function AnthropicProviderKeyCard({
 // availability are still owned by the dashboard fan-out's
 // /hecate/v1/agent-adapters response. We just surface the additional
 // per-adapter "can I actually use this?" check here.
-function AdapterStatusSection({ state, actions }: Props) {
+function AdapterStatusSection({ state, actions }: {
+  state: RuntimeConsoleViewModel["state"];
+  actions: RuntimeConsoleViewModel["actions"];
+}) {
   const adapters = state.agentAdapters;
   if (!adapters || adapters.length === 0) {
     return null;

--- a/ui/src/features/connections/ModelCapabilitiesSection.tsx
+++ b/ui/src/features/connections/ModelCapabilitiesSection.tsx
@@ -1,12 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
-import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import { formatInteger } from "../../lib/format";
 import type { ModelRecord } from "../../types/runtime";
-
-type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
-};
 
 function SectionHeader({
   title,
@@ -35,7 +30,8 @@ function SectionHeader({
   );
 }
 
-export function ModelCapabilitiesSection({ state, actions }: Props) {
+export function ModelCapabilitiesSection() {
+  const { state, actions } = useRuntimeConsoleContext();
   const [query, setQuery] = useState("");
   const rows = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ObservabilityView } from "./ObservabilityView";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
 
 function setViewportWidth(px: number) {
   Object.defineProperty(window, "innerWidth", { value: px, configurable: true });
@@ -70,7 +71,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     expect(container.textContent).toMatch(/Observability/);
@@ -84,7 +85,7 @@ describe("ObservabilityView", () => {
   it("calls /hecate/v1/system/stats and /hecate/v1/traces on mount", async () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     await act(async () => {
-      render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
     });
     await waitFor(() => {
       const urls = fetchMock.mock.calls.map(([u]) => String(u));
@@ -109,7 +110,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -140,7 +141,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -186,7 +187,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
 
@@ -203,7 +204,10 @@ describe("ObservabilityView", () => {
     let container = null as unknown as HTMLElement;
     await act(async () => {
       const result = render(
-        <ObservabilityView state={state} actions={createRuntimeConsoleActions()} onNavigate={onNavigate} />,
+        withRuntimeConsole(
+          <ObservabilityView onNavigate={onNavigate} />,
+          { state, actions: createRuntimeConsoleActions() },
+        ),
       );
       container = result.container;
     });
@@ -233,7 +237,7 @@ describe("ObservabilityView", () => {
     });
 
     const state = createRuntimeConsoleFixture({ session: localSession });
-    const { container } = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+    const { container } = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
 
     expect(container.textContent).toMatch(/Loading traces/);
     expect(container.textContent).not.toMatch(/No traces yet/);
@@ -274,7 +278,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -316,7 +320,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -342,7 +346,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -374,7 +378,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -413,7 +417,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -437,7 +441,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -465,7 +469,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -502,7 +506,7 @@ describe("ObservabilityView", () => {
     });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -544,7 +548,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -582,7 +586,7 @@ describe("ObservabilityView", () => {
     });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -625,7 +629,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession, usageEvents: [] });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -661,11 +665,10 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     await act(async () => {
       render(
-        <ObservabilityView
-          state={state}
-          actions={createRuntimeConsoleActions()}
-          focusRequest={{ requestID: "req-focus-from-chat", nonce: 1 }}
-        />,
+        withRuntimeConsole(
+          <ObservabilityView focusRequest={{ requestID: "req-focus-from-chat", nonce: 1 }} />,
+          { state, actions: createRuntimeConsoleActions() },
+        ),
       );
     });
 
@@ -683,7 +686,7 @@ describe("ObservabilityView", () => {
     ]));
     const state = createRuntimeConsoleFixture({ session: localSession });
     await act(async () => {
-      render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
     });
     await waitFor(() => {
       // The table truncates to 8 chars for display.
@@ -710,7 +713,7 @@ describe("ObservabilityView", () => {
     });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -740,7 +743,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -776,7 +779,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -810,7 +813,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -874,7 +877,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -947,7 +950,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {
@@ -970,7 +973,7 @@ describe("ObservabilityView", () => {
     const state = createRuntimeConsoleFixture({ session: localSession, usageEvents: [] });
     let container = null as unknown as HTMLElement;
     await act(async () => {
-      const result = render(<ObservabilityView state={state} actions={createRuntimeConsoleActions()} />);
+      const result = render(withRuntimeConsole(<ObservabilityView />, { state, actions: createRuntimeConsoleActions() }));
       container = result.container;
     });
     await waitFor(() => {

--- a/ui/src/features/overview/ObservabilityView.tsx
+++ b/ui/src/features/overview/ObservabilityView.tsx
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 
-import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import { getMCPCacheStats, getRecentTraces, getRuntimeStats, getTrace } from "../../lib/api";
 import {
   buildSpanWaterfall,
@@ -46,8 +46,6 @@ import {
 } from "./observability/styles";
 
 type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
   // Optional escape hatch the empty-state "Open Chats" button uses.
   // AppShell wires it to onSelectWorkspace; in tests it's omitted and
   // the button no-ops.
@@ -63,7 +61,8 @@ type TraceGroup = {
   latencyMs?: number;
 };
 
-export function ObservabilityView({ state, onNavigate, focusRequest }: Props) {
+export function ObservabilityView({ onNavigate, focusRequest }: Props) {
+  const { state } = useRuntimeConsoleContext();
   const [runtimeStats, setRuntimeStats] = useState<RuntimeStatsResponse["data"] | null>(null);
   const [mcpCacheStats, setMCPCacheStats] = useState<MCPCacheStatsResponse["data"] | null>(null);
   const [traces, setTraces] = useState<TraceListItem[]>([]);

--- a/ui/src/features/providers/AddProviderModal.tsx
+++ b/ui/src/features/providers/AddProviderModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolvedBaseURL } from "../../lib/provider-utils";
 import type { LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -7,8 +7,6 @@ import { BrandAvatar, Icon, Icons, InlineError, Modal } from "../shared/ui";
 
 type Props = {
   open: boolean;
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
   onClose: () => void;
 };
 
@@ -21,7 +19,8 @@ type AddFormState = {
   protocol: string;
 };
 
-export function AddProviderModal({ open, state, actions, onClose }: Props) {
+export function AddProviderModal({ open, onClose }: Props) {
+  const { state, actions } = useRuntimeConsoleContext();
   const [step, setStep] = useState<"pick" | "form">("pick");
   const [pickTab, setPickTab] = useState<"cloud" | "local">("local");
   const [preset, setPreset] = useState<ProviderPresetRecord | null>(null);

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -6,6 +6,7 @@ import { ProvidersView } from "./ProvidersView";
 import { AddProviderModal } from "./AddProviderModal";
 import { discoverLocalProviders } from "../../lib/api";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type { ConfiguredProviderRecord, ProviderPresetRecord, ProviderRecord } from "../../types/runtime";
 
 vi.mock("../../lib/api", async importOriginal => {
@@ -101,7 +102,7 @@ describe("ProvidersView empty state", () => {
       providers: [],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     expect(screen.getByText("No model providers configured")).toBeTruthy();
     expect(screen.getByText("Add a local or cloud provider to start routing requests")).toBeTruthy();
@@ -126,7 +127,7 @@ describe("ProvidersView delete", () => {
       providers: [makeStatus("ollama")],
     });
 
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     const trashBtn = screen.getByTitle("Remove Ollama");
@@ -151,7 +152,7 @@ describe("ProvidersView add provider modal", () => {
       providers: [],
     });
     const actions = createRuntimeConsoleActions();
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
     return { actions };
   }
 
@@ -212,7 +213,7 @@ describe("ProvidersView add provider modal", () => {
       providers: [],
     });
     const actions = { ...createRuntimeConsoleActions(), createProvider };
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getAllByText("Add provider")[0]);
@@ -273,7 +274,7 @@ describe("ProvidersView add provider modal", () => {
       providers: [],
     });
     const actions = { ...createRuntimeConsoleActions(), createProvider };
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getAllByText("Add provider")[0]);
@@ -300,7 +301,7 @@ describe("ProvidersView edit modal", () => {
       },
       providers: [makeStatus("anthropic", { kind: "cloud", healthy: true, status: "healthy" })],
     });
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Anthropic"));
@@ -321,7 +322,7 @@ describe("ProvidersView edit modal", () => {
       providers: [makeStatus("anthropic", { kind: "cloud", healthy: true, status: "healthy" })],
     });
     const actions = { ...createRuntimeConsoleActions(), setProviderAPIKey };
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Anthropic"));
@@ -348,7 +349,7 @@ describe("ProvidersView edit modal", () => {
       providers: [makeStatus("ollama", { kind: "local", healthy: true, status: "healthy" })],
     });
     const actions = { ...createRuntimeConsoleActions(), setProviderBaseURL };
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Ollama"));
@@ -372,7 +373,7 @@ describe("ProvidersView edit modal", () => {
       },
       providers: [makeStatus("ollama", { kind: "local", healthy: true, status: "healthy" })],
     });
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Ollama"));
@@ -390,7 +391,7 @@ describe("ProvidersView edit modal", () => {
       },
       providers: [makeStatus("ollama", { kind: "local", healthy: true, status: "healthy", models: ["m1", "m2"], model_count: 2 })],
     });
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Ollama"));
@@ -419,7 +420,7 @@ describe("ProvidersView table renders", () => {
       ],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     expect(screen.getByText("Anthropic")).toBeTruthy();
     expect(screen.getByText("Ollama")).toBeTruthy();
@@ -469,7 +470,7 @@ describe("ProvidersView table renders", () => {
     });
     const user = userEvent.setup();
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     expect(screen.getByText(/1 provider needs attention/)).toBeTruthy();
     await user.click(screen.getByRole("button", { name: "Open provider" }));
@@ -503,7 +504,7 @@ describe("ProvidersView table renders", () => {
     const actions = { ...createRuntimeConsoleActions(), refreshProviders };
     const user = userEvent.setup();
 
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
     await user.click(screen.getByRole("button", { name: "Refresh providers" }));
 
     expect(refreshProviders).toHaveBeenCalledTimes(1);
@@ -548,7 +549,7 @@ describe("ProvidersView table renders", () => {
       ],
     });
 
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     expect(await screen.findByTestId("external-agents-adapters")).toBeTruthy();
     expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
@@ -568,7 +569,7 @@ describe("ProvidersView table renders", () => {
       providers: [makeStatus("ollama")],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     const user = userEvent.setup();
     // Open the Add modal, then pick "Custom" so the Endpoint URL field is editable.
@@ -609,7 +610,7 @@ describe("ProvidersView table renders", () => {
     });
     const actions = { ...createRuntimeConsoleActions(), createProvider };
 
-    render(<ProvidersView state={state} actions={actions} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getAllByText("Add provider")[0]);
@@ -655,7 +656,7 @@ describe("ProvidersView table renders", () => {
     });
     const actions = { ...createRuntimeConsoleActions(), createProvider };
 
-    render(<AddProviderModal open state={state} actions={actions} onClose={() => {}} />);
+    render(withRuntimeConsole(<AddProviderModal open onClose={() => {}} />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Cloud" }));
@@ -700,11 +701,11 @@ describe("ProvidersView table renders", () => {
     });
     const actions = createRuntimeConsoleActions();
 
-    const { rerender } = render(<AddProviderModal open state={state} actions={actions} onClose={() => {}} />);
+    const { rerender } = render(withRuntimeConsole(<AddProviderModal open onClose={() => {}} />, { state, actions }));
     expect(await screen.findByText("local probe failed")).toBeTruthy();
 
-    rerender(<AddProviderModal open={false} state={state} actions={actions} onClose={() => {}} />);
-    rerender(<AddProviderModal open state={state} actions={actions} onClose={() => {}} />);
+    rerender(withRuntimeConsole(<AddProviderModal open={false} onClose={() => {}} />, { state, actions }));
+    rerender(withRuntimeConsole(<AddProviderModal open onClose={() => {}} />, { state, actions }));
 
     await waitFor(() => expect(screen.queryByText("local probe failed")).toBeNull());
     expect(await screen.findByText("Running")).toBeTruthy();
@@ -728,10 +729,10 @@ describe("ProvidersView table renders", () => {
     const actions = createRuntimeConsoleActions();
     const initialDiscoveryCalls = vi.mocked(discoverLocalProviders).mock.calls.length;
 
-    const { rerender } = render(<AddProviderModal open state={state} actions={actions} onClose={() => {}} />);
+    const { rerender } = render(withRuntimeConsole(<AddProviderModal open onClose={() => {}} />, { state, actions }));
     await waitFor(() => expect(discoverLocalProviders).toHaveBeenCalledTimes(initialDiscoveryCalls + 1));
-    rerender(<AddProviderModal open={false} state={state} actions={actions} onClose={() => {}} />);
-    rerender(<AddProviderModal open state={state} actions={actions} onClose={() => {}} />);
+    rerender(withRuntimeConsole(<AddProviderModal open={false} onClose={() => {}} />, { state, actions }));
+    rerender(withRuntimeConsole(<AddProviderModal open onClose={() => {}} />, { state, actions }));
     await waitFor(() => expect(discoverLocalProviders).toHaveBeenCalledTimes(initialDiscoveryCalls + 2));
 
     resolveFast({
@@ -784,7 +785,7 @@ describe("ProvidersView table renders", () => {
       providers: [],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     const user = userEvent.setup();
     await user.click(screen.getAllByText("Add provider")[0]);
@@ -808,7 +809,7 @@ describe("ProvidersView table renders", () => {
       providers: [],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     expect(screen.getAllByText(/lmstudio/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Discovery pending")).toBeTruthy();
@@ -862,7 +863,7 @@ describe("ProvidersView table renders", () => {
       ],
     });
 
-    render(<ProvidersView state={state} actions={createRuntimeConsoleActions()} />);
+    render(withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }));
 
     // Health column shows "Down" for circuit-open providers.
     expect(screen.getByText("Down")).toBeTruthy();

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { formatLocaleTime } from "../../lib/format";
 import { providerFleetRepairHint, providerReadinessMeaning, providerRepairActionLabel } from "../../lib/provider-readiness";
@@ -8,11 +9,6 @@ import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/
 import { Badge, BrandAvatar, ConfirmModal, Icon, Icons, Modal } from "../shared/ui";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { AddProviderModal } from "./AddProviderModal";
-
-type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
-};
 
 const PROVIDER_POLL_INTERVAL_MS = 30_000;
 
@@ -61,7 +57,8 @@ function resolveCredentialBadge(
   return { status: "warn", label: "Missing" };
 }
 
-export function ProvidersView({ state, actions }: Props) {
+export function ProvidersView() {
+  const { state, actions } = useRuntimeConsoleContext();
   const [selectedID, setSelectedID] = useState<string | null>(null);
   const [pendingKey, setPendingKey] = useState("");
   const [pendingURL, setPendingURL] = useState("");
@@ -492,8 +489,6 @@ export function ProvidersView({ state, actions }: Props) {
 
         <div style={{ marginTop: configuredProviders.length === 0 ? 28 : 8 }}>
           <ConnectionsPanel
-            state={state}
-            actions={actions}
             showProviderSummary={false}
           />
         </div>
@@ -763,8 +758,6 @@ export function ProvidersView({ state, actions }: Props) {
 
       <AddProviderModal
         open={addProviderOpen}
-        state={state}
-        actions={actions}
         onClose={() => setAddProviderOpen(false)}
       />
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { SettingsView } from "./SettingsView";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
 
 function setup(stateOverrides = {}, actionOverrides = {}) {
   const state = createRuntimeConsoleFixture(stateOverrides);
@@ -26,7 +27,7 @@ beforeEach(() => {
 describe("SettingsView", () => {
   it("renders maintenance cleanup without legacy tabs", () => {
     const { state, actions } = setup();
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     expect(screen.getByText("Maintenance")).toBeTruthy();
     expect(screen.getByText(/Clean up old local runtime data/i)).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retention" })).toBeNull();
@@ -37,7 +38,7 @@ describe("SettingsView", () => {
 
   it("starts on the cleanup controls", () => {
     const { state, actions } = setup();
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     expect(screen.getByText(/Run cleanup/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /Clean up now/i })).toBeTruthy();
   });
@@ -48,7 +49,7 @@ describe("SettingsView", () => {
     // screen. Without this effect the list stays empty forever.
     const loadRetentionRuns = vi.fn().mockResolvedValue(undefined);
     const { state, actions } = setup({}, { loadRetentionRuns });
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     expect(loadRetentionRuns).toHaveBeenCalledTimes(1);
   });
 });
@@ -56,7 +57,7 @@ describe("SettingsView", () => {
 describe("SettingsView maintenance cleanup", () => {
   it("shows known subsystems as toggle chips", async () => {
     const { state, actions } = setup();
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     for (const sub of ["Trace snapshots", "Usage events", "Audit events"]) {
       expect(await screen.findByText(sub)).toBeTruthy();
     }
@@ -65,7 +66,7 @@ describe("SettingsView maintenance cleanup", () => {
   it("clicking a chip calls setRetentionSubsystems", async () => {
     const setRetentionSubsystems = vi.fn();
     const { state, actions, user } = setup({}, { setRetentionSubsystems });
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     await user.click(await screen.findByText("Audit events"));
     expect(setRetentionSubsystems).toHaveBeenCalledWith("audit_events");
   });
@@ -73,7 +74,7 @@ describe("SettingsView maintenance cleanup", () => {
   it("'Clean up now' button triggers runRetention action", async () => {
     const runRetention = vi.fn(async () => undefined);
     const { state, actions, user } = setup({}, { runRetention });
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
     await user.click(await screen.findByRole("button", { name: /Clean up now/i }));
     expect(runRetention).toHaveBeenCalled();
   });
@@ -85,7 +86,7 @@ describe("SettingsView maintenance cleanup", () => {
         trigger: "manual",
       },
     });
-    render(<SettingsView state={state} actions={actions} />);
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
     expect(await screen.findByText(/Last run/i)).toBeTruthy();
     expect(screen.getByText("0 removed")).toBeTruthy();
@@ -156,7 +157,7 @@ describe("Connections external-agent panel", () => {
         { id: "claude-sonnet", owned_by: "anthropic" },
       ],
     });
-    render(<ConnectionsPanel state={state} actions={actions} onNavigate={onNavigate} />);
+    render(withRuntimeConsole(<ConnectionsPanel onNavigate={onNavigate} />, { state, actions }));
 
     const card = await screen.findByTestId("connections-model-providers");
     expect(within(card).getByText("Model providers")).toBeTruthy();
@@ -172,7 +173,7 @@ describe("Connections external-agent panel", () => {
 
   it("renders model capabilities inside Connections", async () => {
     const { state, actions } = setup(modelCapabilityState);
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
     expect(await screen.findByTestId("connections-model-capabilities")).toBeTruthy();
     expect(await screen.findByTestId("model-capabilities-list")).toBeTruthy();
@@ -183,7 +184,7 @@ describe("Connections external-agent panel", () => {
   it("saves the model tools switch from Connections", async () => {
     const upsertModelCapabilityOverride = vi.fn(async () => true);
     const { state, actions, user } = setup(modelCapabilityState, { upsertModelCapabilityOverride });
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     const row = await screen.findByTestId("model-capability-row-ollama-qwen2.5-coder");
 
     await user.click(within(row).getByRole("button", { name: "tools on" }));
@@ -215,7 +216,7 @@ describe("Connections external-agent panel", () => {
       },
       { upsertModelCapabilityOverride, deleteModelCapabilityOverride },
     );
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     const row = await screen.findByTestId("model-capability-row-ollama-local-tools");
 
     await user.click(within(row).getByRole("button", { name: "tools off" }));
@@ -233,13 +234,13 @@ describe("Connections external-agent panel", () => {
   it("fires listAgentChatGrants when the tab opens", async () => {
     const listAgentChatGrants = vi.fn(async () => undefined);
     const { state, actions } = setup({}, { listAgentChatGrants });
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     expect(listAgentChatGrants).toHaveBeenCalled();
   });
 
   it("renders the empty-state copy when there are no grants", async () => {
     const { state, actions } = setup();
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     expect(await screen.findByTestId("external-agents-empty")).toBeTruthy();
   });
 
@@ -267,7 +268,7 @@ describe("Connections external-agent panel", () => {
         },
       ],
     });
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     expect(await screen.findByTestId("external-agents-list")).toBeTruthy();
     // Scope decision-tone assertions to row content so they don't
     // accidentally match the section description above.
@@ -294,7 +295,7 @@ describe("Connections external-agent panel", () => {
       },
       { deleteAgentChatGrant },
     );
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     await user.click(await screen.findByTestId("external-agents-revoke-g-7"));
     expect(deleteAgentChatGrant).not.toHaveBeenCalled();
     await user.click(await screen.findByTestId("external-agents-confirm-revoke-g-7"));
@@ -318,7 +319,7 @@ describe("Connections external-agent panel", () => {
       },
       { deleteAgentChatGrant },
     );
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     await user.click(await screen.findByTestId("external-agents-revoke-g-8"));
     expect(await screen.findByTestId("external-agents-confirm-revoke-g-8")).toBeTruthy();
     await user.click(await screen.findByTestId("external-agents-cancel-revoke-g-8"));
@@ -330,7 +331,7 @@ describe("Connections external-agent panel", () => {
     const { state, actions } = setup({
       agentChatGrantsError: "list failed: 500",
     });
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
     expect(await screen.findByText(/list failed: 500/)).toBeTruthy();
   });
 
@@ -353,11 +354,11 @@ describe("Connections external-agent panel", () => {
         events: [],
       },
     });
-    const { rerender } = render(<ConnectionsPanel state={state} actions={actions} />);
+    const { rerender } = render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
     expect(await screen.findByTestId("anthropic-provider-key-card")).toBeTruthy();
 
-    rerender(<ConnectionsPanel state={{ ...state, settingsConfig: { ...state.settingsConfig!, providers: [] } }} actions={actions} />);
+    rerender(withRuntimeConsole(<ConnectionsPanel />, { state: { ...state, settingsConfig: { ...state.settingsConfig!, providers: [] } }, actions }));
 
     expect(screen.getByTestId("anthropic-provider-key-card")).toBeTruthy();
   });
@@ -382,7 +383,7 @@ describe("Connections external-agent panel", () => {
         events: [],
       },
     }, { setProviderAPIKey });
-    render(<ConnectionsPanel state={state} actions={actions} />);
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
     await user.type(await screen.findByLabelText("Anthropic API key"), "sk-ant-new");
     await user.click(screen.getByRole("button", { name: "Update key" }));
@@ -416,13 +417,13 @@ describe("Connections external-agent panel", () => {
 
     it("hides the panel when no adapters are registered", async () => {
       const { state, actions } = setup({ agentAdapters: [] });
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(screen.queryByTestId("external-agents-adapters")).toBeNull();
     });
 
     it("renders one row per adapter without a manual test button", async () => {
       const { state, actions } = setup(withAdapter());
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(await screen.findByTestId("external-agents-adapters")).toBeTruthy();
       expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
       expect(screen.queryByTestId("external-agents-test-codex")).toBeNull();
@@ -431,20 +432,20 @@ describe("Connections external-agent panel", () => {
     it("auto-runs adapter probes when the tab opens", async () => {
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions } = setup(withAdapter(), { probeAgentAdapter });
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
     });
 
     it("auto-runs adapter probes when adapters arrive after the tab opens", async () => {
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions } = setup({ agentAdapters: [] }, { probeAgentAdapter });
-      const { rerender } = render(<ConnectionsPanel state={state} actions={actions} />);
+      const { rerender } = render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(probeAgentAdapter).not.toHaveBeenCalled();
 
       const nextState = createRuntimeConsoleFixture(withAdapter());
-      rerender(<ConnectionsPanel state={nextState} actions={actions} />);
+      rerender(withRuntimeConsole(<ConnectionsPanel />, { state: nextState, actions }));
       expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
-      rerender(<ConnectionsPanel state={{ ...nextState }} actions={actions} />);
+      rerender(withRuntimeConsole(<ConnectionsPanel />, { state: { ...nextState }, actions }));
       expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
     });
 
@@ -462,7 +463,7 @@ describe("Connections external-agent panel", () => {
           }],
         ]),
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       const detail = await screen.findByTestId("external-agents-adapter-codex-detail");
       expect(within(detail).getByText("Run codex login")).toBeTruthy();
       expect(within(detail).getByText(/Authentication required/)).toBeTruthy();
@@ -484,7 +485,7 @@ describe("Connections external-agent panel", () => {
           },
         ],
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(await screen.findByTestId("external-agents-adapter-cursor_agent-auth-warning")).toHaveTextContent("auth required");
       expect(screen.getByTestId("external-agents-adapter-cursor_agent-auth-detail")).toHaveTextContent("Run cursor-agent login");
     });
@@ -493,7 +494,7 @@ describe("Connections external-agent panel", () => {
       const { state, actions } = setup(withAdapter({
         agentAdapterHealthLoadingByID: new Map([["codex", true]]),
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(await screen.findByTestId("external-agents-checking-codex")).toHaveTextContent(/checking/i);
     });
 
@@ -515,7 +516,7 @@ describe("Connections external-agent panel", () => {
           },
         ],
       }), { setAgentAdapterCredential, probeAgentAdapter });
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       expect(await screen.findByTestId("claude-code-guided-setup")).toBeTruthy();
       await user.type(screen.getByLabelText("Claude Code OAuth token"), "claude-token");
@@ -544,7 +545,7 @@ describe("Connections external-agent panel", () => {
           ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
         ]),
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       expect(await screen.findByText("Claude Code guided setup")).toBeTruthy();
       expect(screen.queryByText("Claude Code token verified")).toBeNull();
@@ -572,7 +573,7 @@ describe("Connections external-agent panel", () => {
           ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
         ]),
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       expect(await screen.findByText("Claude Code guided setup")).toBeTruthy();
       expect(screen.getByText("adapter installed")).toBeTruthy();
@@ -602,7 +603,7 @@ describe("Connections external-agent panel", () => {
           ["claude_code", { adapter_id: "claude_code", status: "ready", stage: "ready", duration_ms: 629 }],
         ]),
       }));
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       expect(await screen.findByText("Claude Code token verified")).toBeTruthy();
       expect(screen.getByText(/Hecate has a validated adapter token/)).toBeTruthy();
@@ -632,7 +633,7 @@ describe("Connections external-agent panel", () => {
           },
         ],
       }), { deleteAgentAdapterCredential });
-      render(<ConnectionsPanel state={state} actions={actions} />);
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       await user.click(await screen.findByRole("button", { name: "Remove" }));
 
       expect(deleteAgentAdapterCredential).toHaveBeenCalledWith("claude_code", "CLAUDE_CODE_OAUTH_TOKEN");

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useRef, type ReactNode } from "react";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
 
-type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
-};
-
-export function SettingsView({ state, actions }: Props) {
+export function SettingsView() {
+  const { state, actions } = useRuntimeConsoleContext();
   // Retention runs aren't in the boot-time dashboard snapshot —
   // fetch on first SettingsView mount so the user doesn't see a
   // permanently empty list. `actions` (and the functions on it)
@@ -113,7 +110,10 @@ function relativeTime(iso: string): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
-function RetentionSettings({ state, actions }: Props) {
+function RetentionSettings({ state, actions }: {
+  state: RuntimeConsoleViewModel["state"];
+  actions: RuntimeConsoleViewModel["actions"];
+}) {
   const runs = state.retentionRuns ?? [];
   const lastRun = state.retentionLastRun;
   const lastRunResults = lastRun?.results ?? [];

--- a/ui/src/features/usage/UsageView.test.tsx
+++ b/ui/src/features/usage/UsageView.test.tsx
@@ -3,13 +3,14 @@ import { describe, expect, it } from "vitest";
 
 import { UsageView } from "./UsageView";
 import { createRuntimeConsoleActions, createRuntimeConsoleFixture } from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
 
 const localSession = { label: "Local" };
 
 function setup(stateOverrides: Record<string, unknown> = {}) {
   const state = createRuntimeConsoleFixture({ session: localSession, ...stateOverrides });
   const actions = createRuntimeConsoleActions();
-  render(<UsageView state={state} actions={actions} />);
+  render(withRuntimeConsole(<UsageView />, { state, actions }));
 }
 
 describe("UsageView", () => {

--- a/ui/src/features/usage/UsageView.tsx
+++ b/ui/src/features/usage/UsageView.tsx
@@ -1,13 +1,8 @@
 import type { ReactNode } from "react";
-import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import { formatInteger, formatLocaleTime, formatMicrosUSD } from "../../lib/format";
 import type { UsageEventRecord } from "../../types/runtime";
 import { CopyBtn } from "../shared/ui";
-
-type Props = {
-  state: RuntimeConsoleViewModel["state"];
-  actions: RuntimeConsoleViewModel["actions"];
-};
 
 type UsageEntry = UsageEventRecord;
 type UsageTotals = {
@@ -19,7 +14,8 @@ type UsageTotals = {
 
 // Only cross-chat Hecate-controlled provider calls belong here; active-chat
 // adapter usage lives in ChatView where the reported values have context.
-export function UsageView({ state }: Props) {
+export function UsageView() {
+  const { state } = useRuntimeConsoleContext();
   const usageEvents = state.usageEvents ?? [];
   const providerKindByID = new Map((state.settingsConfig?.providers ?? []).map(provider => [provider.id, provider.kind]));
   const cloudEvents = usageEvents.filter(entry => usageEventIsCloud(entry, providerKindByID));

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement, ReactNode } from "react";
+
+import { RuntimeConsoleContext } from "../app/RuntimeConsoleContext";
+import type { RuntimeConsoleViewModel } from "../app/useRuntimeConsole";
+
+// Wraps a render target in <RuntimeConsoleContext.Provider> so views
+// that read state/actions through useRuntimeConsoleContext() see a
+// fixture instead of the real hook. Used by per-view tests where the
+// component-under-test used to take `state` + `actions` as props.
+export function withRuntimeConsole(
+  ui: ReactElement,
+  ctx: { state: RuntimeConsoleViewModel["state"]; actions: RuntimeConsoleViewModel["actions"] },
+): ReactNode {
+  return <RuntimeConsoleContext.Provider value={ctx}>{ui}</RuntimeConsoleContext.Provider>;
+}


### PR DESCRIPTION
## Summary

Retires the `{state, actions}` prop-bag the AppShell used to drill from the god-hook into every workspace view. After this PR, views call `useRuntimeConsoleContext()` at the top of their body and read the same identifiers — bodies don't change.

After Phase-4 sliced the god-hook into per-domain providers (#117 → #122), the shim's external `RuntimeConsoleViewModel` was still passed as props from `App.tsx` → `AppShell` → `ChatView` / `ObservabilityView` / `ProvidersView` / `UsageView` / `SettingsView`. That hop was the entire point of Phase 5 in the cleanup plan.

## What's new

**`ui/src/app/RuntimeConsoleContext.tsx`** — a thin facade:

```ts
export const RuntimeConsoleContext = createContext<RuntimeConsoleViewModel | null>(null);

export function RuntimeConsoleContextProvider({ children }: { children: ReactNode }) {
  const value = useRuntimeConsole();
  return <RuntimeConsoleContext.Provider value={value}>{children}</RuntimeConsoleContext.Provider>;
}

export function useRuntimeConsoleContext(): RuntimeConsoleViewModel {
  const ctx = useContext(RuntimeConsoleContext);
  if (!ctx) throw new Error("useRuntimeConsoleContext must be used inside <RuntimeConsoleContextProvider>");
  return ctx;
}
```

The provider calls `useRuntimeConsole()` once and exposes the result through Context. Views consume via `useRuntimeConsoleContext()` and destructure into the same identifiers (`state`, `actions`) the prop bag carried.

## App.tsx

The slice-provider chain is unchanged, except `<RuntimeConsoleContextProvider>` now wraps `<AppConsole>` inside it. The shim still reads its slice contexts; the facade then surfaces the shim's view-model to AppShell and below.

```diff
-                 <AppConsole />
+                 <RuntimeConsoleContextProvider>
+                   <AppConsole />
+                 </RuntimeConsoleContextProvider>
```

`AppConsole` drops `const { state, actions } = useRuntimeConsole();` and renders `<ConsoleShell activeWorkspace=… onSelectWorkspace=…>` with no other props.

## AppShell.tsx

- `ConsoleShell` and `AuthenticatedShell` drop `state` + `actions` from their prop signatures.
- Both read `useRuntimeConsoleContext()` internally.
- The 5 workspace views the shell renders (`ChatView`, `ObservabilityView`, `ProvidersView`, `UsageView`, `SettingsView`) are now rendered without `state`/`actions` props.

## View files

Each of the 5 workspace views plus `AddProviderModal`, `ConnectionsPanel`, and `ModelCapabilitiesSection` lose the `state`/`actions` prop pair from their `Props` type and add `const { state, actions } = useRuntimeConsoleContext();` at the body top. Same identifiers downstream — bodies are unchanged.

Internal helpers inside a view module (`RetentionSettings`, `AdapterStatusSection`, `ModelProviderConnectionsSection`, `providerLabelForHecateChat`) that take `state` explicitly from their parent stay as-is — they're not part of the AppShell prop-drill and shouldn't pull context themselves.

## Tests

New helper `ui/src/test/runtime-console-render.tsx`:

```ts
export function withRuntimeConsole(
  ui: ReactElement,
  ctx: { state: RuntimeConsoleViewModel["state"]; actions: RuntimeConsoleViewModel["actions"] },
): ReactNode {
  return <RuntimeConsoleContext.Provider value={ctx}>{ui}</RuntimeConsoleContext.Provider>;
}
```

Every existing render call in the 6 affected test files is rewritten mechanically:

```diff
- render(<ChatView state={state} actions={actions} onNavigate={fn} />);
+ render(withRuntimeConsole(<ChatView onNavigate={fn} />, { state, actions }));
```

The fixtures (`createRuntimeConsoleFixture` / `createRuntimeConsoleActions`) are unchanged; the wrapper only changes how the fixture pair is injected.

| Test file | render sites rewritten |
|---|---|
| `ui/src/app/AppShell.test.tsx` | 12 |
| `ui/src/features/chats/ChatView.test.tsx` | 104 |
| `ui/src/features/overview/ObservabilityView.test.tsx` | 25 |
| `ui/src/features/providers/ProvidersView.test.tsx` | 26 |
| `ui/src/features/settings/SettingsView.test.tsx` | 34 |
| `ui/src/features/usage/UsageView.test.tsx` | 1 |

## External surface

Byte-for-byte stable. The runtime shape of `useRuntimeConsole()` is unchanged; only its caller moved from `AppConsole` to `RuntimeConsoleContextProvider`. Every `state.*` key and every `actions.*` identifier views consume is present and identical.

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `bun run test:e2e` — 60/60 chromium pass
- [x] `useRuntimeConsole.test.tsx` (49 god-hook tests) unchanged
- [x] External surface diff: prop bag retired; views' body identifiers unchanged
- [x] No plan-label leaks in commit message, PR body, or code comments

## Why `[skip desktop]`

Pure TS module + tests under `ui/src/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## What's next

With the prop bag gone, `ChatView.tsx` (3443 LOC) is the next target — per-concern split into sidebar / composer / header / transcript / quick-providers, sized to keep `ChatView.test.tsx` (3115 LOC) passing unchanged at each step.
