### PR TITLE
refactor(ui): extract ChatSidebar from ChatView [skip desktop]

### DIFF
--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -1,0 +1,335 @@
+import { useRef, useState } from "react";
+
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
+import { formatAbsoluteTime } from "../../lib/format";
+import type { AgentAdapterRecord, AgentChatSessionRecord } from "../../types/runtime";
+import { BrandAvatar, Icon, Icons } from "../shared/ui";
+
+import { NewChatAgentButton, chatAgentOption, chatAgentOptionStatus } from "./ChatAgentControls";
+import type { ChatAgentOptionID } from "./ChatAgentControls";
+
+export type SidebarSession = {
+  id: string;
+  title?: string;
+  message_count: number;
+  provider_call_count: number;
+  last_provider?: string;
+  last_model?: string;
+  agent_brand?: string;
+  agent_label?: string;
+  status_label?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type Props = {
+  isAgentChat: boolean;
+  // Session activation: ChatView wires this to clear the draft, focus
+  // the composer textarea, and dispatch selectChatSession. Keeping the
+  // coordination on the parent side avoids the sidebar reaching across
+  // the canvas for the composer ref.
+  onSelectSession: (sessionID: string) => void;
+  // New-chat creation. Gated on adapter readiness inside the sidebar.
+  onCreateChat: () => void;
+};
+
+export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Props) {
+  const { state, actions } = useRuntimeConsoleContext();
+  const [sidebarQuery, setSidebarQuery] = useState("");
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
+  const sidebarScrollRef = useRef<HTMLDivElement>(null);
+
+  const sessions: SidebarSession[] = isAgentChat
+    ? (state.agentChatSessions ?? []).map((s) => ({
+        id: s.id,
+        title: s.title,
+        message_count: s.message_count,
+        provider_call_count: 0,
+        last_provider: s.runtime_kind === "external_agent" || s.adapter_id ? s.adapter_id : s.provider,
+        last_model: s.runtime_kind === "external_agent" || s.adapter_id ? s.status : s.model,
+        agent_brand: sidebarSessionBrand(s),
+        agent_label: sidebarSessionAgentLabel(s, state.agentAdapters),
+        status_label: s.status,
+        created_at: s.created_at,
+        updated_at: s.updated_at,
+      }))
+    : (state.chatSessions ?? []).map((s) => ({
+      ...s,
+      agent_brand: s.last_provider,
+      agent_label: s.last_provider,
+    }));
+  const filteredSessions = filterSidebarSessions(sessions, sidebarQuery);
+  const groupedSessions = groupSidebarSessions(filteredSessions);
+  const activeSessionID = isAgentChat ? state.activeAgentChatSessionID : state.activeChatSessionID;
+
+  const newChatAgentID = state.newChatAgentID || "hecate";
+  const newChatAgentAdapter = newChatAgentID === "hecate" ? undefined : state.agentAdapters.find((adapter) => adapter.id === newChatAgentID);
+  const newChatAgentHealth = newChatAgentID === "hecate" ? undefined : state.agentAdapterHealthByID.get(newChatAgentID);
+  const newChatAgentStatus = chatAgentOptionStatus(newChatAgentID as ChatAgentOptionID, newChatAgentAdapter, newChatAgentHealth);
+  const newChatAgentReady = newChatAgentStatus.ready;
+
+  function handleSidebarScroll() {
+    const el = sidebarScrollRef.current;
+    if (isAgentChat || sidebarQuery.trim() || !el || !state.chatSessionsHasMore || state.chatSessionsLoadingMore) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    if (nearBottom) {
+      void actions.loadMoreChatSessions();
+    }
+  }
+
+  return (
+    <div style={{ width: 220, borderRight: "1px solid var(--border)", display: "flex", flexDirection: "column", flexShrink: 0, background: "var(--bg1)" }}>
+      <div style={{ height: "var(--topbar-h)", padding: "0 8px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", flexShrink: 0 }}>
+        <div style={{ display: "flex", gap: 6, width: "100%" }}>
+          <NewChatAgentButton
+            value={newChatAgentID}
+            adapters={state.agentAdapters}
+            healthByID={state.agentAdapterHealthByID}
+            disableUnavailable
+            onChange={(agentID) => actions.setNewChatAgent(agentID)}
+            onCreate={() => {
+              if (!newChatAgentReady) return;
+              onCreateChat();
+            }}
+          />
+        </div>
+      </div>
+      <div style={{ padding: "8px 12px 4px", fontFamily: "var(--font-mono)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
+        Chats{sessions.length > 0 ? ` · ${filteredSessions.length}${filteredSessions.length === sessions.length ? "" : `/${sessions.length}`}` : ""}
+      </div>
+      <div style={{ padding: "4px 8px 8px" }}>
+        <input
+          aria-label="Search chats"
+          className="input"
+          onChange={(e) => setSidebarQuery(e.target.value)}
+          placeholder="Search chats"
+          style={{ height: 28, fontSize: 12, padding: "0 8px" }}
+          value={sidebarQuery}
+        />
+      </div>
+      <div ref={sidebarScrollRef} onScroll={handleSidebarScroll} style={{ flex: 1, overflowY: "auto", padding: "2px 0 6px" }}>
+        {sessions.length === 0 && (
+          <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No chats yet</div>
+        )}
+        {sessions.length > 0 && filteredSessions.length === 0 && (
+          <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No matching chats</div>
+        )}
+        {groupedSessions.map((group) => (
+          <div key={group.label}>
+            <div style={{ padding: "8px 12px 3px", fontFamily: "var(--font-mono)", fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
+              {group.label}
+            </div>
+            {group.sessions.map(s => (
+              <div key={s.id}
+                role="button"
+                tabIndex={renamingId === s.id ? -1 : 0}
+                aria-current={(activeSessionID === s.id) ? "true" : undefined}
+                aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
+                onClick={() => {
+                  if (renamingId === s.id) return;
+                  onSelectSession(s.id);
+                }}
+                onKeyDown={e => {
+                  if (e.target !== e.currentTarget) return;
+                  if (renamingId === s.id) return;
+                  if (e.key !== "Enter" && e.key !== " ") return;
+                  e.preventDefault();
+                  onSelectSession(s.id);
+                }}
+                onFocus={() => setHoveredChatId(s.id)}
+                onBlur={e => {
+                  const nextFocus = e.relatedTarget;
+                  if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
+                    setHoveredChatId(null);
+                  }
+                }}
+                onMouseEnter={() => setHoveredChatId(s.id)}
+                onMouseLeave={() => setHoveredChatId(null)}
+                style={{
+                  padding: "8px 12px", cursor: "pointer",
+                  background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
+                  borderLeft: activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
+                  transition: "background 0.1s",
+                }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
+                  {renamingId === s.id ? (
+                    <input
+                      autoFocus
+                      value={renameValue}
+                      onChange={e => setRenameValue(e.target.value)}
+                      onClick={e => e.stopPropagation()}
+                      onKeyDown={e => {
+                        if (e.key === "Enter") { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }
+                        if (e.key === "Escape") setRenamingId(null);
+                      }}
+                      onBlur={() => { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }}
+                      style={{ flex: 1, minWidth: 0, height: 18, boxSizing: "border-box", fontSize: 12, background: "var(--bg3)", border: "1px solid var(--teal)", borderRadius: "var(--radius-sm)", color: "var(--t0)", padding: "0 4px", outline: "none", fontFamily: "var(--font-sans)", lineHeight: "16px" }}
+                    />
+                  ) : (
+                    <>
+                      <div style={{ flex: 1, minWidth: 0, fontSize: 12, lineHeight: "18px", color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)", fontWeight: activeSessionID === s.id ? 500 : 400, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {s.title || "Untitled"}
+                      </div>
+                      {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
+                        <span
+                          title={formatAbsoluteTime(s.updated_at || s.created_at)}
+                          style={{
+                            color: "var(--t3)",
+                            flexShrink: 0,
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 9,
+                            lineHeight: "18px",
+                          }}
+                        >
+                          {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
+                        </span>
+                      )}
+                      <div style={{ display: "flex", gap: 1, opacity: hoveredChatId === s.id ? 1 : 0, transition: "opacity 0.15s", flexShrink: 0 }}>
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          aria-label={`Rename chat ${s.title || "Untitled"}`}
+                          type="button"
+                          onClick={e => { e.stopPropagation(); setRenamingId(s.id); setRenameValue(s.title || ""); }}
+                          style={{ padding: "1px 3px" }}
+                          title="Rename"
+                        >
+                          <Icon d={Icons.edit} size={10} />
+                        </button>
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          aria-label={`Delete chat ${s.title || "Untitled"}`}
+                          type="button"
+                          onClick={e => { e.stopPropagation(); void actions.deleteChatSession(s.id); }}
+                          style={{ padding: "1px 3px", color: "var(--red)" }}
+                          title="Delete"
+                        >
+                          <Icon d={Icons.trash} size={10} />
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10, color: "var(--t3)", marginTop: 1, fontFamily: "var(--font-mono)" }}>
+                  <span>{s.message_count} msg</span>
+                  {isAgentChat && s.agent_brand && renamingId !== s.id && (
+                    <>
+                      <span style={{ color: "var(--t4)" }}>·</span>
+                      <BrandAvatar
+                        brand={s.agent_brand}
+                        fallback={s.agent_label || s.agent_brand}
+                        title={s.agent_label || s.agent_brand}
+                        boxed={false}
+                        size={13}
+                        style={{ flexShrink: 0 }}
+                      />
+                    </>
+                  )}
+                  {isAgentChat
+                    ? s.status_label && (
+                      <>
+                        <span style={{ color: "var(--t4)" }}>·</span>
+                        <span>{s.status_label}</span>
+                      </>
+                    )
+                    : (
+                      <>
+                        <span style={{ color: "var(--t4)" }}>·</span>
+                        <span>{s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}</span>
+                      </>
+                    )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+        {!isAgentChat && state.chatSessionsLoadingMore && (
+          <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--t3)", textAlign: "center" }}>Loading chats…</div>
+        )}
+        {!isAgentChat && state.chatSessionsHasMore && !state.chatSessionsLoadingMore && (
+          <div style={{ padding: "8px 12px" }}>
+            <button className="btn btn-ghost btn-sm" onClick={() => void actions.loadMoreChatSessions()} style={{ width: "100%", justifyContent: "center" }} type="button">
+              {sidebarQuery.trim() ? "Search earlier chats" : "Load earlier chats"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function filterSidebarSessions(sessions: SidebarSession[], query: string): SidebarSession[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return sessions;
+  return sessions.filter((session) => {
+    const searchable = [
+      session.title,
+      session.last_provider,
+      session.last_model,
+      session.agent_label,
+      session.status_label,
+    ].filter(Boolean).join(" ").toLowerCase();
+    return searchable.includes(needle);
+  });
+}
+
+export function sidebarSessionBrand(session: AgentChatSessionRecord): string | undefined {
+  if (session.runtime_kind === "external_agent" || session.adapter_id) {
+    return session.adapter_id;
+  }
+  if (session.runtime_kind === "agent") {
+    return "hecate";
+  }
+  return session.provider || session.model;
+}
+
+export function sidebarSessionAgentLabel(session: AgentChatSessionRecord, adapters: AgentAdapterRecord[]): string | undefined {
+  if (session.runtime_kind === "external_agent" || session.adapter_id) {
+    return chatAgentOption(session.adapter_id || "", adapters).label;
+  }
+  if (session.runtime_kind === "agent") {
+    return "Hecate";
+  }
+  return session.provider || session.model;
+}
+
+export function sidebarSessionTimeLabel(value?: string): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const now = new Date();
+  if (d.toDateString() === now.toDateString()) {
+    return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) return "yesterday";
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function groupSidebarSessions(sessions: SidebarSession[]): Array<{ label: string; sessions: SidebarSession[] }> {
+  const groups = new Map<string, SidebarSession[]>();
+  for (const session of sessions) {
+    const label = sidebarDateGroup(session.updated_at || session.created_at);
+    const group = groups.get(label) ?? [];
+    group.push(session);
+    groups.set(label, group);
+  }
+  return ["Today", "This week", "Older", "No date"]
+    .map((label) => ({ label, sessions: groups.get(label) ?? [] }))
+    .filter((group) => group.sessions.length > 0);
+}
+
+function sidebarDateGroup(value?: string): string {
+  if (!value) return "No date";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "No date";
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const chatDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const ageDays = Math.floor((today.getTime() - chatDay.getTime()) / 86_400_000);
+  if (ageDays <= 0) return "Today";
+  if (ageDays < 7) return "This week";
+  return "Older";
+}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -5,7 +5,7 @@ import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
-import { formatAbsoluteTime, formatDurationMs, formatInteger, formatLocaleTime } from "../../lib/format";
+import { formatDurationMs, formatInteger, formatLocaleTime } from "../../lib/format";
 import { usePersistedState } from "../../lib/persistedState";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
@@ -15,8 +15,8 @@ import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
 import { AgentApprovalAutoModeBanner, AgentApprovalsBanner } from "./AgentApprovalBanner";
 import { AgentApprovalModal } from "./AgentApprovalModal";
 import { AddProviderModal } from "../providers/AddProviderModal";
-import { ExternalAgentConfigControls, ExternalAgentSettingsControls, HecateModelConfigControl, HecateProviderConfigControl, LockedHecateModelSnapshot, NewChatAgentButton, chatAgentOption, chatAgentOptionStatus } from "./ChatAgentControls";
-import type { ChatAgentOptionID } from "./ChatAgentControls";
+import { ChatSidebar, sidebarSessionAgentLabel, sidebarSessionBrand } from "./ChatSidebar";
+import { ExternalAgentConfigControls, ExternalAgentSettingsControls, HecateModelConfigControl, HecateProviderConfigControl, LockedHecateModelSnapshot, chatAgentOption } from "./ChatAgentControls";
 import { ChatInstructionsPanel } from "./ChatInstructionsPanel";
 import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeInline, ChatNoticeRow } from "./ChatNotice";
 import { AgentSetupHints, ClaudeCodePreflightCard, ClaudeCodeSetupEmptyPanel, claudeCodePreflightState, claudeCodeSetupTokenCommand } from "./ClaudeCodeSetup";
@@ -61,20 +61,6 @@ type TranscriptItem =
   | { type: "segment"; key: string; segment: AgentChatSegmentRecord }
   | { type: "message"; key: string; message: VisibleChatMessage };
 
-type SidebarSession = {
-  id: string;
-  title?: string;
-  message_count: number;
-  provider_call_count: number;
-  last_provider?: string;
-  last_model?: string;
-  agent_brand?: string;
-  agent_label?: string;
-  status_label?: string;
-  created_at?: string;
-  updated_at?: string;
-};
-
 type HecateTaskApproval = {
   approvalID: string;
   title: string;
@@ -90,9 +76,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   // approval modal. The modal itself fetches the full row on mount;
   // we only carry the id here.
   const [approvalModalID, setApprovalModalID] = useState<string | null>(null);
-  const [renamingId, setRenamingId] = useState<string | null>(null);
-  const [renameValue, setRenameValue] = useState("");
-  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
   const [copiedMsgId, setCopiedMsgId] = useState<string | null>(null);
   const [atBottom, setAtBottom] = useState(true);
   const [workspaceEntryOpen, setWorkspaceEntryOpen] = useState(false);
@@ -106,7 +89,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   ));
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [workspacePathValue, setWorkspacePathValue] = useState("");
-  const [sidebarQuery, setSidebarQuery] = useState("");
   const [quickLocalProviders, setQuickLocalProviders] = useState<LocalProviderDiscoveryRecord[]>([]);
   const [quickLocalLoading, setQuickLocalLoading] = useState(false);
   const [quickLocalError, setQuickLocalError] = useState("");
@@ -127,7 +109,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const sidebarScrollRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
   const focusComposerAfterNewChatRef = useRef(false);
   const messageHistoryCursorRef = useRef<number | null>(null);
@@ -141,27 +122,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const isExternalAgentChat = activeSessionIsExternal || (!activeSessionIsHecate && state.chatTarget === "external_agent");
   const externalAgentHasConfigControls = Boolean(isExternalAgentChat && state.activeAgentChatSession?.config_options?.length);
   const instructionsAvailable = isHecateChat;
-  const sessions: SidebarSession[] = isAgentChat
-      ? (state.agentChatSessions ?? []).map((s) => ({
-        id: s.id,
-        title: s.title,
-        message_count: s.message_count,
-        provider_call_count: 0,
-        last_provider: s.runtime_kind === "external_agent" || s.adapter_id ? s.adapter_id : s.provider,
-        last_model: s.runtime_kind === "external_agent" || s.adapter_id ? s.status : s.model,
-        agent_brand: sidebarSessionBrand(s),
-        agent_label: sidebarSessionAgentLabel(s, state.agentAdapters),
-        status_label: s.status,
-        created_at: s.created_at,
-        updated_at: s.updated_at,
-      }))
-    : (state.chatSessions ?? []).map((s) => ({
-      ...s,
-      agent_brand: s.last_provider,
-      agent_label: s.last_provider,
-    }));
-  const filteredSessions = filterSidebarSessions(sessions, sidebarQuery);
-  const groupedSessions = groupSidebarSessions(filteredSessions);
   const activeSessionID = isAgentChat ? state.activeAgentChatSessionID : state.activeChatSessionID;
   const chatCanvasActive = Boolean(activeSessionID || draftChatOpen);
   const activeQueuedChatMessages = isAgentChat && activeSessionID
@@ -309,10 +269,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const agentRouteUnavailable = availableAgents.length === 0;
   const selectedAgentUnavailable = isExternalAgentChat && Boolean(selectedAgent) && !selectedAgent?.available;
   const newChatAgentID = state.newChatAgentID || "hecate";
-  const newChatAgentAdapter = newChatAgentID === "hecate" ? undefined : state.agentAdapters.find((adapter) => adapter.id === newChatAgentID);
-  const newChatAgentHealth = newChatAgentID === "hecate" ? undefined : state.agentAdapterHealthByID.get(newChatAgentID);
-  const newChatAgentStatus = chatAgentOptionStatus(newChatAgentID as ChatAgentOptionID, newChatAgentAdapter, newChatAgentHealth);
-  const newChatAgentReady = newChatAgentStatus.ready;
   const nothingRunnable = !state.loading && modelRouteUnavailable && agentRouteUnavailable;
   const activeHecateAgentSegment = activeTaskBackedHecateSegment(state.activeAgentChatSession);
   const hecateAgentBusy = isHecateChat && Boolean(activeHecateAgentSegment);
@@ -506,15 +462,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
     setAtBottom(isAtBottom);
     userScrolledRef.current = !isAtBottom;
-  }
-
-  function handleSidebarScroll() {
-    const el = sidebarScrollRef.current;
-    if (isAgentChat || sidebarQuery.trim() || !el || !state.chatSessionsHasMore || state.chatSessionsLoadingMore) return;
-    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
-    if (nearBottom) {
-      void actions.loadMoreChatSessions();
-    }
   }
 
   function scrollToBottom() {
@@ -724,193 +671,22 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
 
   return (
     <div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
-      {/* Conversation sidebar */}
       {sidebarOpen && (
-        <div style={{ width: 220, borderRight: "1px solid var(--border)", display: "flex", flexDirection: "column", flexShrink: 0, background: "var(--bg1)" }}>
-          <div style={{ height: "var(--topbar-h)", padding: "0 8px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", flexShrink: 0 }}>
-            <div style={{ display: "flex", gap: 6, width: "100%" }}>
-              <NewChatAgentButton
-                value={newChatAgentID}
-                adapters={state.agentAdapters}
-                healthByID={state.agentAdapterHealthByID}
-                disableUnavailable
-                onChange={(agentID) => actions.setNewChatAgent(agentID)}
-                onCreate={() => {
-                  if (!newChatAgentReady) return;
-                  setDraftChatOpen(true);
-                  setChatSettingsOpen(false);
-                  focusComposerWhenReady();
-                  void actions.createChatSession();
-                }}
-              />
-            </div>
-          </div>
-          <div style={{ padding: "8px 12px 4px", fontFamily: "var(--font-mono)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
-            Chats{sessions.length > 0 ? ` · ${filteredSessions.length}${filteredSessions.length === sessions.length ? "" : `/${sessions.length}`}` : ""}
-          </div>
-          <div style={{ padding: "4px 8px 8px" }}>
-            <input
-              aria-label="Search chats"
-              className="input"
-              onChange={(e) => setSidebarQuery(e.target.value)}
-              placeholder="Search chats"
-              style={{ height: 28, fontSize: 12, padding: "0 8px" }}
-              value={sidebarQuery}
-            />
-          </div>
-          <div ref={sidebarScrollRef} onScroll={handleSidebarScroll} style={{ flex: 1, overflowY: "auto", padding: "2px 0 6px" }}>
-            {sessions.length === 0 && (
-              <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No chats yet</div>
-            )}
-            {sessions.length > 0 && filteredSessions.length === 0 && (
-              <div style={{ padding: "16px 12px", fontSize: 12, color: "var(--t3)", textAlign: "center" }}>No matching chats</div>
-            )}
-            {groupedSessions.map((group) => (
-              <div key={group.label}>
-                <div style={{ padding: "8px 12px 3px", fontFamily: "var(--font-mono)", fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--t3)" }}>
-                  {group.label}
-                </div>
-                {group.sessions.map(s => (
-                  <div key={s.id}
-                    role="button"
-                    tabIndex={renamingId === s.id ? -1 : 0}
-                    aria-current={(activeSessionID === s.id) ? "true" : undefined}
-                    aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
-                    onClick={() => {
-                      if (renamingId === s.id) return;
-                      focusComposerWhenReady();
-                      setDraftChatOpen(false);
-                      void actions.selectChatSession(s.id);
-                      textareaRef.current?.focus();
-                    }}
-                    onKeyDown={e => {
-                      if (e.target !== e.currentTarget) return;
-                      if (renamingId === s.id) return;
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      focusComposerWhenReady();
-                      setDraftChatOpen(false);
-                      void actions.selectChatSession(s.id);
-                      textareaRef.current?.focus();
-                    }}
-                    onFocus={() => setHoveredChatId(s.id)}
-                    onBlur={e => {
-                      const nextFocus = e.relatedTarget;
-                      if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
-                        setHoveredChatId(null);
-                      }
-                    }}
-                    onMouseEnter={() => setHoveredChatId(s.id)}
-                    onMouseLeave={() => setHoveredChatId(null)}
-                    style={{
-                      padding: "8px 12px", cursor: "pointer",
-                      background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
-                      borderLeft: activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
-                      transition: "background 0.1s",
-                    }}>
-                    <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
-                      {renamingId === s.id ? (
-                        <input
-                          autoFocus
-                          value={renameValue}
-                          onChange={e => setRenameValue(e.target.value)}
-                          onClick={e => e.stopPropagation()}
-                          onKeyDown={e => {
-                            if (e.key === "Enter") { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }
-                            if (e.key === "Escape") setRenamingId(null);
-                          }}
-                          onBlur={() => { void actions.renameChatSession(s.id, renameValue); setRenamingId(null); }}
-                          style={{ flex: 1, minWidth: 0, height: 18, boxSizing: "border-box", fontSize: 12, background: "var(--bg3)", border: "1px solid var(--teal)", borderRadius: "var(--radius-sm)", color: "var(--t0)", padding: "0 4px", outline: "none", fontFamily: "var(--font-sans)", lineHeight: "16px" }}
-                        />
-                      ) : (
-                        <>
-                          <div style={{ flex: 1, minWidth: 0, fontSize: 12, lineHeight: "18px", color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)", fontWeight: activeSessionID === s.id ? 500 : 400, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                            {s.title || "Untitled"}
-                          </div>
-                          {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
-                            <span
-                              title={formatAbsoluteTime(s.updated_at || s.created_at)}
-                              style={{
-                                color: "var(--t3)",
-                                flexShrink: 0,
-                                fontFamily: "var(--font-mono)",
-                                fontSize: 9,
-                                lineHeight: "18px",
-                              }}
-                            >
-                              {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
-                            </span>
-                          )}
-                          <div style={{ display: "flex", gap: 1, opacity: hoveredChatId === s.id ? 1 : 0, transition: "opacity 0.15s", flexShrink: 0 }}>
-                            <button
-                              className="btn btn-ghost btn-sm"
-                              aria-label={`Rename chat ${s.title || "Untitled"}`}
-                              type="button"
-                              onClick={e => { e.stopPropagation(); setRenamingId(s.id); setRenameValue(s.title || ""); }}
-                              style={{ padding: "1px 3px" }}
-                              title="Rename"
-                            >
-                              <Icon d={Icons.edit} size={10} />
-                            </button>
-                            <button
-                              className="btn btn-ghost btn-sm"
-                              aria-label={`Delete chat ${s.title || "Untitled"}`}
-                              type="button"
-                              onClick={e => { e.stopPropagation(); void actions.deleteChatSession(s.id); }}
-                              style={{ padding: "1px 3px", color: "var(--red)" }}
-                              title="Delete"
-                            >
-                              <Icon d={Icons.trash} size={10} />
-                            </button>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10, color: "var(--t3)", marginTop: 1, fontFamily: "var(--font-mono)" }}>
-                      <span>{s.message_count} msg</span>
-                      {isAgentChat && s.agent_brand && renamingId !== s.id && (
-                        <>
-                          <span style={{ color: "var(--t4)" }}>·</span>
-                          <BrandAvatar
-                            brand={s.agent_brand}
-                            fallback={s.agent_label || s.agent_brand}
-                            title={s.agent_label || s.agent_brand}
-                            boxed={false}
-                            size={13}
-                            style={{ flexShrink: 0 }}
-                          />
-                        </>
-                      )}
-                      {isAgentChat
-                        ? s.status_label && (
-                          <>
-                            <span style={{ color: "var(--t4)" }}>·</span>
-                            <span>{s.status_label}</span>
-                          </>
-                        )
-                        : (
-                          <>
-                            <span style={{ color: "var(--t4)" }}>·</span>
-                            <span>{s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}</span>
-                          </>
-                        )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ))}
-            {!isAgentChat && state.chatSessionsLoadingMore && (
-              <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--t3)", textAlign: "center" }}>Loading chats…</div>
-            )}
-            {!isAgentChat && state.chatSessionsHasMore && !state.chatSessionsLoadingMore && (
-              <div style={{ padding: "8px 12px" }}>
-                <button className="btn btn-ghost btn-sm" onClick={() => void actions.loadMoreChatSessions()} style={{ width: "100%", justifyContent: "center" }} type="button">
-                  {sidebarQuery.trim() ? "Search earlier chats" : "Load earlier chats"}
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
+        <ChatSidebar
+          isAgentChat={isAgentChat}
+          onSelectSession={(sessionID) => {
+            focusComposerWhenReady();
+            setDraftChatOpen(false);
+            void actions.selectChatSession(sessionID);
+            textareaRef.current?.focus();
+          }}
+          onCreateChat={() => {
+            setDraftChatOpen(true);
+            setChatSettingsOpen(false);
+            focusComposerWhenReady();
+            void actions.createChatSession();
+          }}
+        />
       )}
 
       {/* Chats main */}
@@ -933,7 +709,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
           />
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              {activeTitle || (sessions.length === 0 ? "New chat" : "Select a chat")}
+              {activeTitle || ((isAgentChat ? state.agentChatSessions : state.chatSessions).length === 0 ? "New chat" : "Select a chat")}
             </div>
             {activeHeaderSubline && (
               <div
@@ -1036,7 +812,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
         {!chatCanvasActive ? (
           <NoActiveChatState
             agentLabel={chatAgentOption(newChatAgentID, state.agentAdapters).label}
-            hasSessions={sessions.length > 0}
+            hasSessions={(isAgentChat ? state.agentChatSessions : state.chatSessions).length > 0}
           />
         ) : (
           <>
@@ -1828,41 +1604,6 @@ function describeChatSegment(segment: AgentChatSegmentRecord): { kicker: string;
   }
 }
 
-function filterSidebarSessions(sessions: SidebarSession[], query: string): SidebarSession[] {
-  const needle = query.trim().toLowerCase();
-  if (!needle) return sessions;
-  return sessions.filter((session) => {
-    const searchable = [
-      session.title,
-      session.last_provider,
-      session.last_model,
-      session.agent_label,
-      session.status_label,
-    ].filter(Boolean).join(" ").toLowerCase();
-    return searchable.includes(needle);
-  });
-}
-
-function sidebarSessionBrand(session: AgentChatSessionRecord): string | undefined {
-  if (session.runtime_kind === "external_agent" || session.adapter_id) {
-    return session.adapter_id;
-  }
-  if (session.runtime_kind === "agent") {
-    return "hecate";
-  }
-  return session.provider || session.model;
-}
-
-function sidebarSessionAgentLabel(session: AgentChatSessionRecord, adapters: AgentAdapterRecord[]): string | undefined {
-  if (session.runtime_kind === "external_agent" || session.adapter_id) {
-    return chatAgentOption(session.adapter_id || "", adapters).label;
-  }
-  if (session.runtime_kind === "agent") {
-    return "Hecate";
-  }
-  return session.provider || session.model;
-}
-
 function buildActiveChatHeaderSubline({
   isAgentChat,
   isExternalAgentChat,
@@ -1894,20 +1635,6 @@ function buildActiveChatHeaderSubline({
     mode,
     activeSession?.workspace || "",
   ].filter(Boolean).join(" · ");
-}
-
-function sidebarSessionTimeLabel(value?: string): string {
-  if (!value) return "";
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return "";
-  const now = new Date();
-  if (d.toDateString() === now.toDateString()) {
-    return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
-  }
-  const yesterday = new Date(now);
-  yesterday.setDate(now.getDate() - 1);
-  if (d.toDateString() === yesterday.toDateString()) return "yesterday";
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 function pendingHecateTaskApprovals(session: AgentChatSessionRecord | null): HecateTaskApproval[] {
@@ -2170,32 +1897,6 @@ function describeTaskApprovalKind(kind: string): string {
     case "agent_loop_tool_call": return "Agent tool call";
     default:                     return kind.replaceAll("_", " ");
   }
-}
-
-function groupSidebarSessions(sessions: SidebarSession[]): Array<{ label: string; sessions: SidebarSession[] }> {
-  const groups = new Map<string, SidebarSession[]>();
-  for (const session of sessions) {
-    const label = sidebarDateGroup(session.updated_at || session.created_at);
-    const group = groups.get(label) ?? [];
-    group.push(session);
-    groups.set(label, group);
-  }
-  return ["Today", "This week", "Older", "No date"]
-    .map((label) => ({ label, sessions: groups.get(label) ?? [] }))
-    .filter((group) => group.sessions.length > 0);
-}
-
-function sidebarDateGroup(value?: string): string {
-  if (!value) return "No date";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "No date";
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const chatDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const ageDays = Math.floor((today.getTime() - chatDay.getTime()) / 86_400_000);
-  if (ageDays <= 0) return "Today";
-  if (ageDays < 7) return "This week";
-  return "Older";
 }
 
 function ChatErrorPanel({


### PR DESCRIPTION
## Summary

ChatView.tsx is **3429 LOC** with sidebar / composer / transcript / header / modals all inlined. This PR cuts the sidebar out as a first per-concern split.

`ChatSidebar` owns its local state (search query, renaming-id, hover-id, sidebar scroll ref) and reads runtime context directly via `useRuntimeConsoleContext()` (landed in [#123](https://github.com/hecatehq/hecate/pull/123)). Two callbacks coordinate with the parent: `onSelectSession` and `onCreateChat`.

## What moves

**New file `ui/src/features/chats/ChatSidebar.tsx` (335 LOC):**

```tsx
type Props = {
  isAgentChat: boolean;
  onSelectSession: (sessionID: string) => void;
  onCreateChat: () => void;
};

export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Props) {
  const { state, actions } = useRuntimeConsoleContext();
  const [sidebarQuery, setSidebarQuery] = useState("");
  const [renamingId, setRenamingId] = useState<string | null>(null);
  const [renameValue, setRenameValue] = useState("");
  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
  const sidebarScrollRef = useRef<HTMLDivElement>(null);
  // … derives sessions / filteredSessions / groupedSessions / activeSessionID
  // … handleSidebarScroll for load-more pagination
  // … JSX
}
```

State that moved: `sidebarQuery`, `renamingId`, `renameValue`, `hoveredChatId`, `sidebarScrollRef`. Handler moved: `handleSidebarScroll`. Function moved: `focusComposerWhenReady` callsites collapse to the parent's `onSelectSession` / `onCreateChat`.

Helpers + types moved into `ChatSidebar.tsx`:
- `filterSidebarSessions`, `groupSidebarSessions`, `sidebarDateGroup` (sidebar-only)
- `sidebarSessionBrand`, `sidebarSessionAgentLabel`, `sidebarSessionTimeLabel` (also used by ChatView's header / derived state — re-imported)
- `SidebarSession` type

## Callback design

The sidebar doesn't reach across the canvas for the composer ref. Instead the parent passes two coordination callbacks:

```tsx
<ChatSidebar
  isAgentChat={isAgentChat}
  onSelectSession={(sessionID) => {
    focusComposerWhenReady();
    setDraftChatOpen(false);
    void actions.selectChatSession(sessionID);
    textareaRef.current?.focus();
  }}
  onCreateChat={() => {
    setDraftChatOpen(true);
    setChatSettingsOpen(false);
    focusComposerWhenReady();
    void actions.createChatSession();
  }}
/>
```

Readiness gating for new-chat (`newChatAgentReady`) stays inside `ChatSidebar` — it owns the `chatAgentOptionStatus` derivation for `state.newChatAgentID`. `ChatView` no longer computes that.

## Why composer is deferred

The composer's derived-value graph (`composerVisible`, `composerRepair`, `hecateChatModelReady`, `sendDisabled`, `agentBusy`, `queueingMessage`, `selectableModels`, `hecateProviderOptions`, `hecateDisabledProviderReasons`, `selectedCapabilityProvider`, …) is read by ChatView's body for the header, the modals, the transcript empty-state, and the chat-settings panel as well as the composer JSX. Extracting it cleanly needs either a shared derived-state hook or a prop bag larger than fits the stop-condition LOC budget for this PR. Splitting it off here gets the sidebar win shipped while the composer extraction is thought through.

## ChatView diff

```
ChatView.tsx: 3429 → 3130 LOC (-299)
ChatSidebar.tsx: new, 335 LOC
```

What stays in ChatView: the top-level layout, topbar, transcript, header, chat-notice frame, modals (`AgentApprovalModal`, `AddProviderModal`), composer (for now), `ChatSettingsPanel`, derived state for the rest of the canvas, and the callbacks the sidebar invokes.

What ChatView drops:
- 5 `useState` declarations + 1 `useRef` (sidebar-local)
- `sessions` / `filteredSessions` / `groupedSessions` derivations (re-derived inside sidebar)
- `newChatAgentAdapter` / `newChatAgentHealth` / `newChatAgentStatus` / `newChatAgentReady` (sidebar-only readiness check)
- `handleSidebarScroll` function
- `filterSidebarSessions`, `sidebarSessionBrand`, `sidebarSessionAgentLabel`, `sidebarSessionTimeLabel`, `groupSidebarSessions`, `sidebarDateGroup` helper definitions (moved)
- `SidebarSession` type declaration
- ~180 lines of inline sidebar JSX (replaced with `<ChatSidebar />`)
- `chatAgentOptionStatus`, `ChatAgentOptionID`, `formatAbsoluteTime` imports (no longer needed)

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `bun run test:e2e` — 60/60 chromium pass
- [x] Browser preview: sidebar renders the same — New Hecate chat dropdown, search input, empty state. No console errors.

## Why `[skip desktop]`

Pure TS module + JSX move under `ui/src/features/chats/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## What's next

The composer extraction (the bigger sub-PR of this phase), then header / transcript / quick-providers in the following pass.
