### PR TITLE
refactor(ui): extract ChatComposer from ChatView [skip desktop]

### DIFF
--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1,0 +1,783 @@
+import { useEffect, useRef, type RefObject, type SyntheticEvent } from "react";
+
+import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
+import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
+import { type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
+import { claudeCodeSetupTokenCommand } from "../../lib/claude-code-setup";
+import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
+import { usePersistedState } from "../../lib/persistedState";
+import type { SelectedModelIssue } from "../../lib/provider-issues";
+import type { AgentAdapterRecord, ModelRecord } from "../../types/runtime";
+import { Icon, Icons, InlineError } from "../shared/ui";
+
+import {
+  ExternalAgentConfigControls,
+  HecateModelConfigControl,
+  HecateProviderConfigControl,
+  LockedHecateModelSnapshot,
+} from "./ChatAgentControls";
+import { ChatNoticeInline } from "./ChatNotice";
+import { ClaudeCodePreflightCard } from "./ClaudeCodeSetup";
+import type { ClaudeCodePreflightState } from "./ClaudeCodeSetup";
+
+type HecateProviderOption = {
+  id: string;
+  name: string;
+  healthy: boolean;
+  kind?: string;
+  configured?: boolean;
+  disabledReason?: string;
+};
+
+export type ChatComposerProps = {
+  // Active chat shape (derived in ChatView and threaded through here).
+  isAgentChat: boolean;
+  isHecateChat: boolean;
+  isExternalAgentChat: boolean;
+  isHecateAgentChat: boolean;
+  activeSessionID: string;
+
+  // Cross-region ref. ChatView owns creation so onSelectSession can
+  // focus the textarea without reaching into composer internals.
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+
+  // Composer gating.
+  composerVisible: boolean;
+  composerRepair: ChatSetupRepairState | null;
+  messageControlsVisible: boolean;
+  showClaudeCodeEmptyPreflight: boolean;
+  sendDisabled: boolean;
+  agentBusy: boolean;
+  queueingMessage: boolean;
+  selectedModelIssue: SelectedModelIssue | null;
+  chatDiagnostic: ReturnType<typeof describeGatewayError>;
+
+  // Hecate-chat config view.
+  hecateAgentModelLocked: boolean;
+  hecateChatProviderValue: string;
+  hecateChatModelValue: string;
+  hecateProviderOptions: HecateProviderOption[];
+  hecateDisabledProviderReasons: Map<string, string>;
+  selectableModels: ModelRecord[];
+
+  // Repair / preflight / capability writes.
+  selectedAgent: AgentAdapterRecord | undefined;
+  selectedAgentHealthLoading: boolean;
+  claudeCodePreflight: ClaudeCodePreflightState | null;
+  selectedCapabilityProvider: string;
+  selectedCapabilityModel: string;
+  capabilitySaving: boolean;
+  enableToolsForSelectedModel: () => Promise<void> | void;
+  chooseWorkspace: () => Promise<void> | void;
+  openClaudeCodeSetup: () => void;
+
+  // Active task tracking + queue.
+  activeHecateTaskID: string;
+  activeHecateRunID: string;
+  // Filtered to the active session — ChatView already does the filter.
+  activeQueuedChatMessages: RuntimeConsoleViewModel["state"]["queuedChatMessages"];
+
+  // User-message history feeds the arrow-key recall, derived in
+  // ChatView from visibleMessages.
+  messageHistory: string[];
+
+  // Threaded from ChatView's own Props.
+  onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings") => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onOpenTrace?: (requestID: string) => void;
+};
+
+export function ChatComposer(props: ChatComposerProps) {
+  const { state, actions } = useRuntimeConsoleContext();
+  const {
+    isAgentChat,
+    isHecateChat,
+    isExternalAgentChat,
+    isHecateAgentChat,
+    activeSessionID,
+    textareaRef,
+    composerVisible,
+    composerRepair,
+    messageControlsVisible,
+    showClaudeCodeEmptyPreflight,
+    sendDisabled,
+    agentBusy,
+    queueingMessage,
+    selectedModelIssue,
+    chatDiagnostic,
+    hecateAgentModelLocked,
+    hecateChatProviderValue,
+    hecateChatModelValue,
+    hecateProviderOptions,
+    hecateDisabledProviderReasons,
+    selectableModels,
+    selectedAgent,
+    selectedAgentHealthLoading,
+    claudeCodePreflight,
+    selectedCapabilityProvider,
+    selectedCapabilityModel,
+    capabilitySaving,
+    enableToolsForSelectedModel,
+    chooseWorkspace,
+    openClaudeCodeSetup,
+    activeHecateTaskID,
+    activeHecateRunID,
+    activeQueuedChatMessages,
+    messageHistory,
+    onNavigate,
+    onOpenTask,
+    onOpenTrace,
+  } = props;
+
+  const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+  const modKey = isMac ? "⌘" : "Ctrl";
+  const [modEnterMode, setModEnterMode] = usePersistedState<boolean>(
+    "hecate.shiftEnterMode",
+    (raw) => raw === "1" ? true : raw === "0" ? false : null,
+    false,
+    { serialize: (v) => v ? "1" : "0" },
+  );
+  const formRef = useRef<HTMLFormElement>(null);
+  const messageHistoryCursorRef = useRef<number | null>(null);
+  const messageHistoryDraftRef = useRef("");
+
+  // Reset history navigation on session change. Scroll-side reset
+  // lives in ChatView since it concerns the transcript surface.
+  useEffect(() => {
+    messageHistoryCursorRef.current = null;
+    messageHistoryDraftRef.current = "";
+  }, [activeSessionID]);
+
+  function setComposerText(value: string, cursorAtEnd = false) {
+    actions.setMessage(value);
+    if (!cursorAtEnd) return;
+    requestAnimationFrame(() => {
+      const node = textareaRef.current;
+      if (!node) return;
+      const end = node.value.length;
+      node.setSelectionRange(end, end);
+    });
+  }
+
+  function handleMessageChange(value: string) {
+    messageHistoryCursorRef.current = null;
+    messageHistoryDraftRef.current = value;
+    actions.setMessage(value);
+  }
+
+  function handleMessageHistoryKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return false;
+    if (messageHistory.length === 0) return false;
+
+    const node = e.currentTarget;
+    const selectionStart = node.selectionStart ?? 0;
+    const selectionEnd = node.selectionEnd ?? 0;
+    const hasSelection = selectionStart !== selectionEnd;
+    const browsing = messageHistoryCursorRef.current !== null;
+    const isEmpty = state.message.length === 0;
+    const singleLine = !state.message.includes("\n");
+    const atStart = selectionStart === 0 && selectionEnd === 0;
+    const atEnd = selectionStart === state.message.length && selectionEnd === state.message.length;
+
+    if (hasSelection) return false;
+
+    if (e.key === "ArrowUp") {
+      // Preserve normal multiline navigation unless the operator is
+      // deliberately at the top of the composer or already browsing.
+      if (!singleLine && !isEmpty && !atStart && !browsing) return false;
+      e.preventDefault();
+      if (!browsing) {
+        messageHistoryDraftRef.current = state.message;
+      }
+      const current = messageHistoryCursorRef.current;
+      const next = current === null ? messageHistory.length - 1 : Math.max(0, current - 1);
+      messageHistoryCursorRef.current = next;
+      setComposerText(messageHistory[next], true);
+      return true;
+    }
+
+    if (!singleLine && !isEmpty && !atEnd && !browsing) return false;
+    e.preventDefault();
+    const current = messageHistoryCursorRef.current;
+    if (current === null) return true;
+    const next = current + 1;
+    if (next >= messageHistory.length) {
+      messageHistoryCursorRef.current = null;
+      setComposerText(messageHistoryDraftRef.current, true);
+      return true;
+    }
+    messageHistoryCursorRef.current = next;
+    setComposerText(messageHistory[next], true);
+    return true;
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (handleMessageHistoryKey(e)) return;
+    if (e.key !== "Enter") return;
+    const modPressed = isMac ? e.metaKey : e.ctrlKey;
+    if (modEnterMode) {
+      // ⌘/Ctrl+Enter sends; plain Enter is a newline (default behaviour)
+      if (modPressed) { e.preventDefault(); formRef.current?.requestSubmit(); }
+    } else {
+      // Enter sends; Shift+Enter or ⌘/Ctrl+Enter inserts a newline
+      if (e.shiftKey || modPressed) return;
+      e.preventDefault();
+      formRef.current?.requestSubmit();
+    }
+  }
+
+  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+    void actions.submitChat(e);
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }
+
+  function toggleModEnterMode() {
+    setModEnterMode(v => !v);
+  }
+
+  if (showClaudeCodeEmptyPreflight) return null;
+  if (!composerVisible && !messageControlsVisible && !state.chatError && !selectedModelIssue) return null;
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit} style={{ borderTop: "1px solid var(--border)", padding: "10px 12px", background: "var(--bg1)", flexShrink: 0 }}>
+      {state.chatError && (
+        <div style={{ marginBottom: 8 }}>
+          <ChatErrorPanel
+            message={state.chatError}
+            provider={state.runtimeHeaders?.provider}
+            code={state.chatErrorCode}
+            action={state.chatErrorAction}
+            requestID={state.chatErrorRequestID}
+            status={state.chatErrorStatus ?? undefined}
+            traceID={state.chatErrorTraceID}
+            onOpenTrace={onOpenTrace}
+            diagnostic={chatDiagnostic}
+          />
+        </div>
+      )}
+      {isHecateChat && selectedModelIssue && (
+        <div style={{ marginBottom: composerVisible ? 8 : 0 }}>
+          <SelectedModelReadinessNotice
+            issue={selectedModelIssue}
+            onOpenProviders={() => onNavigate?.("connections")}
+            onUseSuggestedModel={(model) => {
+              actions.setProviderFilter("auto");
+              actions.setModel(model);
+            }}
+          />
+        </div>
+      )}
+      {composerVisible && (
+      <>
+      {isExternalAgentChat && claudeCodePreflight && !showClaudeCodeEmptyPreflight && (
+        <ClaudeCodePreflightCard
+          state={claudeCodePreflight}
+          loading={selectedAgentHealthLoading}
+          onCopyInstall={() => void actions.copyCommand("npx -y @anthropic-ai/claude-code --version")}
+          onCopySetup={() => void actions.copyCommand(claudeCodeSetupTokenCommand(selectedAgent?.claude_code_cli))}
+          onOpenSetup={openClaudeCodeSetup}
+          onTest={() => void actions.probeAgentAdapter("claude_code")}
+        />
+      )}
+      {composerRepair && (
+        <ChatSetupRepairNotice
+          repair={composerRepair}
+          actionBusy={composerRepair.action === "enable_tools" && capabilitySaving}
+          actionDisabled={composerRepair.action === "enable_tools" && (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving)}
+          actionTitle={composerRepair.action === "enable_tools" && selectedCapabilityProvider
+            ? `Enable tools for ${selectedCapabilityProvider}/${selectedCapabilityModel}`
+            : undefined}
+          onAction={(repair) => {
+            if (repair.action === "choose_workspace") {
+              void chooseWorkspace();
+            } else if (repair.action === "enable_tools") {
+              void enableToolsForSelectedModel();
+            } else if (repair.action === "open_agent_setup") {
+              openClaudeCodeSetup();
+            } else if (repair.action === "open_connections") {
+              onNavigate?.("connections");
+            }
+          }}
+        />
+      )}
+      {activeQueuedChatMessages.length > 0 && (
+        <div
+          aria-label="Queued messages"
+          style={{
+            maxWidth: 820,
+            margin: "0 auto 8px",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--bg2)",
+            padding: "7px 9px",
+            display: "grid",
+            gap: 6,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+            <span style={{ color: "var(--t2)", fontFamily: "var(--font-mono)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              Queued next
+            </span>
+            <span style={{ color: "var(--t3)", fontSize: 11 }}>
+              will send when the active run finishes
+            </span>
+          </div>
+          {activeQueuedChatMessages.map((queued, index) => (
+            <div
+              key={queued.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto minmax(0, 1fr) auto",
+                alignItems: "center",
+                gap: 8,
+                color: "var(--t0)",
+                fontSize: 12,
+              }}
+            >
+              <span style={{ color: "var(--teal)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+                #{index + 1}
+              </span>
+              <textarea
+                aria-label={`Queued message ${index + 1}`}
+                className="queued-chat-message-input"
+                value={queued.content}
+                onChange={(event) => actions.updateQueuedChatMessage(queued.id, event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && !event.shiftKey) event.preventDefault();
+                }}
+                rows={Math.min(4, Math.max(1, queued.content.split("\n").length))}
+                style={{
+                  minWidth: 0,
+                  width: "100%",
+                  resize: "vertical",
+                  borderRadius: "var(--radius-sm)",
+                  color: "var(--t0)",
+                  font: "inherit",
+                  padding: "3px 6px",
+                  outline: "none",
+                }}
+              />
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                aria-label={`Remove queued message ${index + 1}`}
+                onClick={() => actions.removeQueuedChatMessage(queued.id)}
+                style={{ padding: "2px 6px", fontFamily: "var(--font-mono)", fontSize: 10 }}
+              >
+                remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      {messageControlsVisible && (
+        <div
+          aria-label={isExternalAgentChat ? "External agent message controls" : "Hecate message controls"}
+          style={{
+            maxWidth: 820,
+            margin: "0 auto 8px",
+            display: "flex",
+            justifyContent: "flex-start",
+            flexWrap: "wrap",
+            gap: 6,
+          }}
+        >
+          {isExternalAgentChat ? (
+            <ExternalAgentConfigControls
+              session={state.activeAgentChatSession}
+              onChange={actions.setAgentChatConfigOption}
+              placement="composer"
+            />
+          ) : hecateAgentModelLocked ? (
+            <LockedHecateModelSnapshot
+              provider={providerLabelForHecateChat(state, hecateChatProviderValue)}
+              model={hecateChatModelValue}
+            />
+          ) : (
+            <>
+              <HecateProviderConfigControl
+                value={state.providerFilter}
+                onChange={v => actions.setProviderFilter(v as typeof state.providerFilter)}
+                options={hecateProviderOptions}
+              />
+              <HecateModelConfigControl
+                value={state.model}
+                onChange={actions.setModel}
+                models={selectableModels}
+                presets={state.providerPresets}
+                showProvider={false}
+                disabledProviders={hecateDisabledProviderReasons}
+              />
+            </>
+          )}
+        </div>
+      )}
+      <div style={{ maxWidth: 820, margin: "0 auto", position: "relative" }}>
+        <textarea
+          ref={textareaRef}
+          aria-label="Message"
+          value={state.message}
+          onChange={e => handleMessageChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={modEnterMode ? `Message… (${modKey}+Enter to send)` : "Message… (Shift+Enter for newline)"}
+          rows={1}
+          style={{
+            width: "100%", background: "var(--bg3)", border: "1px solid var(--border)",
+            borderRadius: "var(--radius)", color: "var(--t0)", fontFamily: "var(--font-sans)",
+            fontSize: 13, padding: "10px 44px 10px 12px", outline: "none", resize: "none",
+            lineHeight: 1.5, transition: "border-color 0.1s", minHeight: 42, maxHeight: 160, overflowY: "auto",
+          }}
+          onInput={e => {
+            const el = e.target as HTMLTextAreaElement;
+            el.style.height = "auto";
+            el.style.height = Math.min(el.scrollHeight, 160) + "px";
+          }}
+          onFocus={e => (e.target.style.borderColor = "var(--teal)")}
+          onBlur={e => (e.target.style.borderColor = "var(--border)")}
+        />
+        {agentBusy && !queueingMessage ? (
+          <button type="button"
+            className="btn btn-danger"
+            aria-label="Stop current run"
+            disabled={state.agentChatCancelling}
+            title={state.agentChatCancelling ? "Stopping..." : "Stop current run"}
+            onClick={actions.cancelAgentChat}
+            style={{
+              position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
+              width: 28, height: 28, borderRadius: "var(--radius-sm)",
+              padding: 0,
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>
+            <Icon d={Icons.stop} size={13} fill="currentColor" strokeWidth={0} />
+          </button>
+        ) : (
+          <button type="submit"
+            aria-label={queueingMessage ? "Queue message" : "Send message"}
+            disabled={sendDisabled}
+            title={queueingMessage ? "Queue this message after the active run finishes" : "Send message"}
+            style={{
+              position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
+              width: 28, height: 28, borderRadius: "var(--radius-sm)",
+              background: !sendDisabled ? "var(--teal)" : "var(--bg4)",
+              border: "none", cursor: !sendDisabled ? "pointer" : "default",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              transition: "background 0.1s",
+              color: !sendDisabled ? "var(--bg0)" : "var(--t3)",
+            }}>
+            <Icon d={Icons.send} size={14} />
+          </button>
+        )}
+      </div>
+      {agentBusy && (
+        <div style={{ maxWidth: 820, margin: "6px auto 0", color: "var(--amber)", fontFamily: "var(--font-mono)", fontSize: 11, lineHeight: 1.45, display: "flex", alignItems: "center", gap: 8, justifyContent: "space-between", flexWrap: "wrap" }}>
+          <span>
+            {isExternalAgentChat
+              ? "External Agent is still working. New messages will queue until it finishes."
+              : "Hecate Chat is still working on this task. New messages will queue until the active task finishes."}
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+            {onOpenTask && activeHecateTaskID && (
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
+                style={{ fontFamily: "var(--font-mono)", fontSize: 10, padding: "2px 6px", color: "var(--amber)" }}
+              >
+                Open task
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              aria-label={isExternalAgentChat ? "Stop external agent" : "Stop active task"}
+              title={state.agentChatCancelling ? "Stopping..." : isExternalAgentChat ? "Stop external agent" : "Stop active task"}
+              onClick={actions.cancelAgentChat}
+              disabled={state.agentChatCancelling}
+              style={{ fontFamily: "var(--font-mono)", fontSize: 10, padding: "2px 6px", color: "var(--danger)" }}
+            >
+              Stop
+            </button>
+          </span>
+        </div>
+      )}
+      {isAgentChat && state.agentChatCancelling && (
+        <div style={{ maxWidth: 820, margin: "6px auto 0", color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
+          Stopping...
+        </div>
+      )}
+      <div style={{ maxWidth: 820, margin: "3px auto 0", display: "flex", alignItems: "center", gap: 10, justifyContent: "space-between" }}>
+        {isExternalAgentChat ? (
+          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            External agents run as your OS user in the selected workspace — no sandbox
+          </span>
+        ) : isHecateAgentChat ? (
+          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            Hecate Agent runs through task approvals and per-call sandboxing in the selected workspace.
+          </span>
+        ) : <span />}
+        <button type="button" onClick={toggleModEnterMode} style={{
+          fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)",
+          background: "none", border: "none", cursor: "pointer", padding: 0,
+        }}>
+          {modEnterMode ? `${modKey}+↵ to send` : "↵ to send"}
+        </button>
+      </div>
+      </>
+      )}
+    </form>
+  );
+}
+
+export function ChatErrorPanel({
+  message,
+  provider,
+  code,
+  action,
+  requestID,
+  status,
+  traceID,
+  onOpenTrace,
+  diagnostic,
+}: {
+  message: string;
+  provider?: string;
+  code?: string;
+  action?: string;
+  requestID?: string;
+  status?: number;
+  traceID?: string;
+  onOpenTrace?: (requestID: string) => void;
+  diagnostic: ReturnType<typeof describeGatewayError>;
+}) {
+  const label = formatErrorCode(code, status);
+  const recommendedAction = action || diagnostic?.action || "";
+  if (!diagnostic) {
+    return <InlineError message={`${provider ? `[${provider}] ` : ""}${message}`} />;
+  }
+
+  return (
+    <div
+      role="alert"
+      style={{
+        border: "1px solid var(--red-border)",
+        background: "var(--red-bg)",
+        borderRadius: "var(--radius)",
+        padding: "9px 11px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--red)" }}>{diagnostic.title}</span>
+        {label && (
+          <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--red)" }}>
+            {label}
+          </span>
+        )}
+      </div>
+      <div style={{ fontSize: 12, color: "var(--t0)", lineHeight: 1.45 }}>{message}</div>
+      {recommendedAction && (
+        <div style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.45, marginTop: 5 }}>
+          {provider ? `${provider}: ` : ""}{recommendedAction}
+        </div>
+      )}
+      {(requestID || traceID) && (
+        <div style={{ marginTop: 7, display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+          {requestID && (
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+              request <span style={{ color: "var(--t1)" }}>{compactID(requestID, [], 10)}</span>
+            </span>
+          )}
+          {traceID && (
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
+              trace <span style={{ color: "var(--t1)" }}>{compactID(traceID, [], 10)}</span>
+            </span>
+          )}
+          {requestID && onOpenTrace && (
+            <button
+              type="button"
+              onClick={() => onOpenTrace(requestID)}
+              style={{
+                border: "1px solid var(--red-border)",
+                background: "transparent",
+                color: "var(--red)",
+                borderRadius: 999,
+                padding: "2px 8px",
+                fontSize: 10,
+                fontFamily: "var(--font-mono)",
+                cursor: "pointer",
+              }}
+            >
+              Open trace
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ChatSetupRepairNotice({
+  repair,
+  actionBusy = false,
+  actionDisabled = false,
+  actionTitle,
+  onAction,
+}: {
+  repair: ChatSetupRepairState;
+  actionBusy?: boolean;
+  actionDisabled?: boolean;
+  actionTitle?: string;
+  onAction: (repair: ChatSetupRepairState) => void;
+}) {
+  return (
+    <ChatNoticeInline
+      tone={repair.tone}
+      title={repair.title}
+      message={repair.message}
+      action={repair.actionLabel}
+      actionBusy={actionBusy}
+      actionBusyLabel="Saving..."
+      actionDisabled={actionDisabled}
+      actionTitle={actionTitle}
+      onAction={() => onAction(repair)}
+    />
+  );
+}
+
+export function SelectedModelReadinessNotice({
+  issue,
+  compact = false,
+  onOpenProviders,
+  onUseSuggestedModel,
+}: {
+  issue: SelectedModelIssue;
+  compact?: boolean;
+  onOpenProviders?: () => void;
+  onUseSuggestedModel?: (model: string) => void;
+}) {
+  return (
+    <div style={{
+      margin: compact ? "14px auto 0" : "0 auto",
+      maxWidth: compact ? 560 : 820,
+      border: "1px solid rgba(245, 191, 79, 0.32)",
+      borderRadius: "var(--radius)",
+      background: "rgba(245, 191, 79, 0.06)",
+      padding: 12,
+      textAlign: "left",
+    }}>
+      {!compact && (
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: "var(--amber)", marginBottom: 4 }}>
+              {issue.title}
+            </div>
+            <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.5 }}>
+              {issue.message}
+            </div>
+          </div>
+          {onOpenProviders && (
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenProviders} style={{ flexShrink: 0 }}>
+              Open Connections
+            </button>
+          )}
+          {issue.suggestedModel && onUseSuggestedModel && (
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
+              style={{ flexShrink: 0 }}
+            >
+              Use {issue.suggestedModel}
+            </button>
+          )}
+        </div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8, marginTop: 10 }}>
+        {selectedModelNoticeDetails(issue.details, compact).map((detail) => (
+          <InfoChip key={detail.label} label={detail.label} value={detail.value} />
+        ))}
+      </div>
+      {compact ? (
+        <>
+          <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
+            {issue.steps.slice(0, 2).map((step) => <li key={step}>{step}</li>)}
+          </ul>
+          {issue.suggestedModel && onUseSuggestedModel && (
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
+              style={{ marginTop: 10 }}
+            >
+              Use {issue.suggestedModel}
+            </button>
+          )}
+        </>
+      ) : (
+        <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
+          {issue.steps.map((step) => <li key={step}>{step}</li>)}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function selectedModelNoticeDetails(
+  details: SelectedModelIssue["details"],
+  compact: boolean,
+): SelectedModelIssue["details"] {
+  if (!compact) {
+    return details;
+  }
+  const priorityLabels = new Set(["Selected model", "Provider route", "Discovered models", "Health", "Blocked by", "Last error"]);
+  const selected = details.filter((detail) => priorityLabels.has(detail.label));
+  return selected.length > 0 ? selected : details;
+}
+
+function InfoChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg3)", padding: "7px 8px", minWidth: 0 }}>
+      <div style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+        {label}
+      </div>
+      <div title={value} style={{ marginTop: 3, fontSize: 11, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function providerLabelForHecateChat(state: RuntimeConsoleViewModel["state"], providerID: string): string {
+  if (!providerID || providerID === "auto") {
+    return "Select provider";
+  }
+  return state.settingsConfig?.providers.find(provider => provider.id === providerID)?.name
+    || state.providerPresets.find(preset => preset.id === providerID)?.name
+    || state.providers.find(provider => provider.name === providerID)?.name
+    || providerID;
+}
+
+export function repairActionIcon(repair: ChatSetupRepairState) {
+  switch (repair.action) {
+    case "choose_workspace":
+      return Icons.folder;
+    case "open_agent_setup":
+      return Icons.terminal;
+    case "use_suggested_model":
+      return Icons.model;
+    case "open_connections":
+      return Icons.connections;
+    case "enable_tools":
+      return Icons.providers;
+  }
+  return Icons.providers;
+}
+
+export function compactID(id: string, prefixes: string[], length: number): string {
+  const trimmed = id.trim();
+  const withoutPrefix = prefixes.reduce((current, prefix) => (
+    current.startsWith(prefix) ? current.slice(prefix.length) : current
+  ), trimmed);
+  return withoutPrefix.slice(0, length);
+}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import type { ReactNode, SyntheticEvent } from "react";
+import type { ReactNode } from "react";
 import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
-import type { RuntimeConsoleViewModel } from "../../app/useRuntimeConsole";
 import { discoverLocalProviders } from "../../lib/api";
 import { resolveChatSetupRepairState, type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
-import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnostics";
+import { describeGatewayError } from "../../lib/error-diagnostics";
 import { formatDurationMs, formatInteger, formatLocaleTime } from "../../lib/format";
-import { usePersistedState } from "../../lib/persistedState";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import type { AgentAdapterRecord, AgentAdapterSetupCommandStatus, AgentChatActivityRecord, AgentChatSegmentRecord, AgentChatSessionRecord, AgentChatTimingRecord, AgentChatUsageRecord, LocalProviderDiscoveryRecord, ProviderPresetRecord } from "../../types/runtime";
@@ -15,11 +13,12 @@ import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
 import { AgentApprovalAutoModeBanner, AgentApprovalsBanner } from "./AgentApprovalBanner";
 import { AgentApprovalModal } from "./AgentApprovalModal";
 import { AddProviderModal } from "../providers/AddProviderModal";
+import { ChatComposer, SelectedModelReadinessNotice, compactID, repairActionIcon } from "./ChatComposer";
 import { ChatSidebar, sidebarSessionAgentLabel, sidebarSessionBrand } from "./ChatSidebar";
-import { ExternalAgentConfigControls, ExternalAgentSettingsControls, HecateModelConfigControl, HecateProviderConfigControl, LockedHecateModelSnapshot, chatAgentOption } from "./ChatAgentControls";
+import { ExternalAgentSettingsControls, chatAgentOption } from "./ChatAgentControls";
 import { ChatInstructionsPanel } from "./ChatInstructionsPanel";
-import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeInline, ChatNoticeRow } from "./ChatNotice";
-import { AgentSetupHints, ClaudeCodePreflightCard, ClaudeCodeSetupEmptyPanel, claudeCodePreflightState, claudeCodeSetupTokenCommand } from "./ClaudeCodeSetup";
+import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeRow } from "./ChatNotice";
+import { AgentSetupHints, ClaudeCodeSetupEmptyPanel, claudeCodePreflightState } from "./ClaudeCodeSetup";
 import type { ClaudeCodePreflightState } from "./ClaudeCodeSetup";
 
 type Props = {
@@ -97,22 +96,11 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const [capabilitySaving, setCapabilitySaving] = useState(false);
   const [claudeTokenDraft, setClaudeTokenDraft] = useState("");
   const [claudeTokenSaving, setClaudeTokenSaving] = useState(false);
-  const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
-  const modKey = isMac ? "⌘" : "Ctrl";
-  const [modEnterMode, setModEnterMode] = usePersistedState<boolean>(
-    "hecate.shiftEnterMode",
-    (raw) => raw === "1" ? true : raw === "0" ? false : null,
-    false,
-    { serialize: (v) => v ? "1" : "0" },
-  );
-  const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
   const focusComposerAfterNewChatRef = useRef(false);
-  const messageHistoryCursorRef = useRef<number | null>(null);
-  const messageHistoryDraftRef = useRef("");
 
   const activeSessionIsExternal = Boolean(state.activeAgentChatSession?.runtime_kind === "external_agent" || state.activeAgentChatSession?.adapter_id);
   const activeSessionIsHecate = Boolean(state.activeAgentChatSession && !activeSessionIsExternal);
@@ -423,8 +411,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     // Focus is instead applied at the explicit user-driven entry points:
     // the New-session button and the session row onClick handlers.
     userScrolledRef.current = false;
-    messageHistoryCursorRef.current = null;
-    messageHistoryDraftRef.current = "";
     setAtBottom(true);
     bottomRef.current?.scrollIntoView({ behavior: "instant" });
   }, [activeSessionID]);
@@ -489,10 +475,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     navigator.clipboard?.writeText(text).catch(() => {});
     setCopiedMsgId(id);
     setTimeout(() => setCopiedMsgId(null), 2000);
-  }
-
-  function toggleModEnterMode() {
-    setModEnterMode(v => !v);
   }
 
   async function refreshQuickLocalProviders() {
@@ -573,91 +555,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       setRTKOnboardingDismissed(true);
     }
     void actions.setHecateRTKEnabled(enabled);
-  }
-
-  function setComposerText(value: string, cursorAtEnd = false) {
-    actions.setMessage(value);
-    if (!cursorAtEnd) return;
-    requestAnimationFrame(() => {
-      const node = textareaRef.current;
-      if (!node) return;
-      const end = node.value.length;
-      node.setSelectionRange(end, end);
-    });
-  }
-
-  function handleMessageChange(value: string) {
-    messageHistoryCursorRef.current = null;
-    messageHistoryDraftRef.current = value;
-    actions.setMessage(value);
-  }
-
-  function handleMessageHistoryKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return false;
-    if (messageHistory.length === 0) return false;
-
-    const node = e.currentTarget;
-    const selectionStart = node.selectionStart ?? 0;
-    const selectionEnd = node.selectionEnd ?? 0;
-    const hasSelection = selectionStart !== selectionEnd;
-    const browsing = messageHistoryCursorRef.current !== null;
-    const isEmpty = state.message.length === 0;
-    const singleLine = !state.message.includes("\n");
-    const atStart = selectionStart === 0 && selectionEnd === 0;
-    const atEnd = selectionStart === state.message.length && selectionEnd === state.message.length;
-
-    if (hasSelection) return false;
-
-    if (e.key === "ArrowUp") {
-      // Preserve normal multiline navigation unless the operator is
-      // deliberately at the top of the composer or already browsing.
-      if (!singleLine && !isEmpty && !atStart && !browsing) return false;
-      e.preventDefault();
-      if (!browsing) {
-        messageHistoryDraftRef.current = state.message;
-      }
-      const current = messageHistoryCursorRef.current;
-      const next = current === null ? messageHistory.length - 1 : Math.max(0, current - 1);
-      messageHistoryCursorRef.current = next;
-      setComposerText(messageHistory[next], true);
-      return true;
-    }
-
-    if (!singleLine && !isEmpty && !atEnd && !browsing) return false;
-    e.preventDefault();
-    const current = messageHistoryCursorRef.current;
-    if (current === null) return true;
-    const next = current + 1;
-    if (next >= messageHistory.length) {
-      messageHistoryCursorRef.current = null;
-      setComposerText(messageHistoryDraftRef.current, true);
-      return true;
-    }
-    messageHistoryCursorRef.current = next;
-    setComposerText(messageHistory[next], true);
-    return true;
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (handleMessageHistoryKey(e)) return;
-    if (e.key !== "Enter") return;
-    const modPressed = isMac ? e.metaKey : e.ctrlKey;
-    if (modEnterMode) {
-      // ⌘/Ctrl+Enter sends; plain Enter is a newline (default behaviour)
-      if (modPressed) { e.preventDefault(); formRef.current?.requestSubmit(); }
-    } else {
-      // Enter sends; Shift+Enter or ⌘/Ctrl+Enter inserts a newline
-      if (e.shiftKey || modPressed) return;
-      e.preventDefault();
-      formRef.current?.requestSubmit();
-    }
-  }
-
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    void actions.submitChat(e);
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-    }
   }
 
   function focusComposerWhenReady() {
@@ -1086,294 +983,45 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
         )}
         </div>
 
-        {!showClaudeCodeEmptyPreflight && (composerVisible || messageControlsVisible || state.chatError || selectedModelIssue) && (
-        <form ref={formRef} onSubmit={handleSubmit} style={{ borderTop: "1px solid var(--border)", padding: "10px 12px", background: "var(--bg1)", flexShrink: 0 }}>
-          {state.chatError && (
-            <div style={{ marginBottom: 8 }}>
-              <ChatErrorPanel
-                message={state.chatError}
-                provider={state.runtimeHeaders?.provider}
-                code={state.chatErrorCode}
-                action={state.chatErrorAction}
-                requestID={state.chatErrorRequestID}
-                status={state.chatErrorStatus ?? undefined}
-                traceID={state.chatErrorTraceID}
-                onOpenTrace={onOpenTrace}
-                diagnostic={chatDiagnostic}
-              />
-            </div>
-          )}
-          {isHecateChat && selectedModelIssue && (
-            <div style={{ marginBottom: composerVisible ? 8 : 0 }}>
-              <SelectedModelReadinessNotice
-                issue={selectedModelIssue}
-                onOpenProviders={() => onNavigate?.("connections")}
-                onUseSuggestedModel={(model) => {
-                  actions.setProviderFilter("auto");
-                  actions.setModel(model);
-                }}
-              />
-            </div>
-          )}
-          {composerVisible && (
-          <>
-          {isExternalAgentChat && claudeCodePreflight && !showClaudeCodeEmptyPreflight && (
-            <ClaudeCodePreflightCard
-              state={claudeCodePreflight}
-              loading={selectedAgentHealthLoading}
-              onCopyInstall={() => void actions.copyCommand("npx -y @anthropic-ai/claude-code --version")}
-              onCopySetup={() => void actions.copyCommand(claudeCodeSetupTokenCommand(selectedAgent?.claude_code_cli))}
-              onOpenSetup={openClaudeCodeSetup}
-              onTest={() => void actions.probeAgentAdapter("claude_code")}
-            />
-          )}
-          {composerRepair && (
-            <ChatSetupRepairNotice
-              repair={composerRepair}
-              actionBusy={composerRepair.action === "enable_tools" && capabilitySaving}
-              actionDisabled={composerRepair.action === "enable_tools" && (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving)}
-              actionTitle={composerRepair.action === "enable_tools" && selectedCapabilityProvider
-                ? `Enable tools for ${selectedCapabilityProvider}/${selectedCapabilityModel}`
-                : undefined}
-              onAction={(repair) => {
-                if (repair.action === "choose_workspace") {
-                  void chooseWorkspace();
-                } else if (repair.action === "enable_tools") {
-                  void enableToolsForSelectedModel();
-                } else if (repair.action === "open_agent_setup") {
-                  openClaudeCodeSetup();
-                } else if (repair.action === "open_connections") {
-                  onNavigate?.("connections");
-                }
-              }}
-            />
-          )}
-          {activeQueuedChatMessages.length > 0 && (
-            <div
-              aria-label="Queued messages"
-              style={{
-                maxWidth: 820,
-                margin: "0 auto 8px",
-                border: "1px solid var(--border)",
-                borderRadius: "var(--radius-sm)",
-                background: "var(--bg2)",
-                padding: "7px 9px",
-                display: "grid",
-                gap: 6,
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
-                <span style={{ color: "var(--t2)", fontFamily: "var(--font-mono)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.08em" }}>
-                  Queued next
-                </span>
-                <span style={{ color: "var(--t3)", fontSize: 11 }}>
-                  will send when the active run finishes
-                </span>
-              </div>
-              {activeQueuedChatMessages.map((queued, index) => (
-                <div
-                  key={queued.id}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "auto minmax(0, 1fr) auto",
-                    alignItems: "center",
-                    gap: 8,
-                    color: "var(--t0)",
-                    fontSize: 12,
-                  }}
-                >
-                  <span style={{ color: "var(--teal)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                    #{index + 1}
-                  </span>
-                  <textarea
-                    aria-label={`Queued message ${index + 1}`}
-                    className="queued-chat-message-input"
-                    value={queued.content}
-                    onChange={(event) => actions.updateQueuedChatMessage(queued.id, event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" && !event.shiftKey) event.preventDefault();
-                    }}
-                    rows={Math.min(4, Math.max(1, queued.content.split("\n").length))}
-                    style={{
-                      minWidth: 0,
-                      width: "100%",
-                      resize: "vertical",
-                      borderRadius: "var(--radius-sm)",
-                      color: "var(--t0)",
-                      font: "inherit",
-                      padding: "3px 6px",
-                      outline: "none",
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className="btn btn-ghost btn-sm"
-                    aria-label={`Remove queued message ${index + 1}`}
-                    onClick={() => actions.removeQueuedChatMessage(queued.id)}
-                    style={{ padding: "2px 6px", fontFamily: "var(--font-mono)", fontSize: 10 }}
-                  >
-                    remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-          {messageControlsVisible && (
-            <div
-              aria-label={isExternalAgentChat ? "External agent message controls" : "Hecate message controls"}
-              style={{
-                maxWidth: 820,
-                margin: "0 auto 8px",
-                display: "flex",
-                justifyContent: "flex-start",
-                flexWrap: "wrap",
-                gap: 6,
-              }}
-            >
-              {isExternalAgentChat ? (
-                <ExternalAgentConfigControls
-                  session={state.activeAgentChatSession}
-                  onChange={actions.setAgentChatConfigOption}
-                  placement="composer"
-                />
-              ) : hecateAgentModelLocked ? (
-                <LockedHecateModelSnapshot
-                  provider={providerLabelForHecateChat(state, hecateChatProviderValue)}
-                  model={hecateChatModelValue}
-                />
-              ) : (
-                <>
-                  <HecateProviderConfigControl
-                    value={state.providerFilter}
-                    onChange={v => actions.setProviderFilter(v as typeof state.providerFilter)}
-                    options={hecateProviderOptions}
-                  />
-                  <HecateModelConfigControl
-                    value={state.model}
-                    onChange={actions.setModel}
-                    models={selectableModels}
-                    presets={state.providerPresets}
-                    showProvider={false}
-                    disabledProviders={hecateDisabledProviderReasons}
-                  />
-                </>
-              )}
-            </div>
-          )}
-          <div style={{ maxWidth: 820, margin: "0 auto", position: "relative" }}>
-            <textarea
-              ref={textareaRef}
-              aria-label="Message"
-              value={state.message}
-              onChange={e => handleMessageChange(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={modEnterMode ? `Message… (${modKey}+Enter to send)` : "Message… (Shift+Enter for newline)"}
-              rows={1}
-              style={{
-                width: "100%", background: "var(--bg3)", border: "1px solid var(--border)",
-                borderRadius: "var(--radius)", color: "var(--t0)", fontFamily: "var(--font-sans)",
-                fontSize: 13, padding: "10px 44px 10px 12px", outline: "none", resize: "none",
-                lineHeight: 1.5, transition: "border-color 0.1s", minHeight: 42, maxHeight: 160, overflowY: "auto",
-              }}
-              onInput={e => {
-                const el = e.target as HTMLTextAreaElement;
-                el.style.height = "auto";
-                el.style.height = Math.min(el.scrollHeight, 160) + "px";
-              }}
-              onFocus={e => (e.target.style.borderColor = "var(--teal)")}
-              onBlur={e => (e.target.style.borderColor = "var(--border)")}
-            />
-            {agentBusy && !queueingMessage ? (
-              <button type="button"
-                className="btn btn-danger"
-                aria-label="Stop current run"
-                disabled={state.agentChatCancelling}
-                title={state.agentChatCancelling ? "Stopping..." : "Stop current run"}
-                onClick={actions.cancelAgentChat}
-                style={{
-                  position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
-                  width: 28, height: 28, borderRadius: "var(--radius-sm)",
-                  padding: 0,
-                  display: "flex", alignItems: "center", justifyContent: "center",
-                }}>
-                <Icon d={Icons.stop} size={13} fill="currentColor" strokeWidth={0} />
-              </button>
-            ) : (
-              <button type="submit"
-                aria-label={queueingMessage ? "Queue message" : "Send message"}
-                disabled={sendDisabled}
-                title={queueingMessage ? "Queue this message after the active run finishes" : "Send message"}
-                style={{
-                  position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
-                  width: 28, height: 28, borderRadius: "var(--radius-sm)",
-                  background: !sendDisabled ? "var(--teal)" : "var(--bg4)",
-                  border: "none", cursor: !sendDisabled ? "pointer" : "default",
-                  display: "flex", alignItems: "center", justifyContent: "center",
-                  transition: "background 0.1s",
-                  color: !sendDisabled ? "var(--bg0)" : "var(--t3)",
-                }}>
-                <Icon d={Icons.send} size={14} />
-              </button>
-            )}
-          </div>
-          {agentBusy && (
-            <div style={{ maxWidth: 820, margin: "6px auto 0", color: "var(--amber)", fontFamily: "var(--font-mono)", fontSize: 11, lineHeight: 1.45, display: "flex", alignItems: "center", gap: 8, justifyContent: "space-between", flexWrap: "wrap" }}>
-              <span>
-                {isExternalAgentChat
-                  ? "External Agent is still working. New messages will queue until it finishes."
-                  : "Hecate Chat is still working on this task. New messages will queue until the active task finishes."}
-              </span>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-                {onOpenTask && activeHecateTaskID && (
-                  <button
-                    type="button"
-                    className="btn btn-ghost btn-sm"
-                    onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
-                    style={{ fontFamily: "var(--font-mono)", fontSize: 10, padding: "2px 6px", color: "var(--amber)" }}
-                  >
-                    Open task
-                  </button>
-                )}
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm"
-                  aria-label={isExternalAgentChat ? "Stop external agent" : "Stop active task"}
-                  title={state.agentChatCancelling ? "Stopping..." : isExternalAgentChat ? "Stop external agent" : "Stop active task"}
-                  onClick={actions.cancelAgentChat}
-                  disabled={state.agentChatCancelling}
-                  style={{ fontFamily: "var(--font-mono)", fontSize: 10, padding: "2px 6px", color: "var(--danger)" }}
-                >
-                  Stop
-                </button>
-              </span>
-            </div>
-          )}
-          {isAgentChat && state.agentChatCancelling && (
-            <div style={{ maxWidth: 820, margin: "6px auto 0", color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
-              Stopping...
-            </div>
-          )}
-          <div style={{ maxWidth: 820, margin: "3px auto 0", display: "flex", alignItems: "center", gap: 10, justifyContent: "space-between" }}>
-            {isExternalAgentChat ? (
-              <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                External agents run as your OS user in the selected workspace — no sandbox
-              </span>
-            ) : isHecateAgentChat ? (
-              <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                Hecate Agent runs through task approvals and per-call sandboxing in the selected workspace.
-              </span>
-            ) : <span />}
-            <button type="button" onClick={toggleModEnterMode} style={{
-              fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)",
-              background: "none", border: "none", cursor: "pointer", padding: 0,
-            }}>
-              {modEnterMode ? `${modKey}+↵ to send` : "↵ to send"}
-            </button>
-          </div>
-          </>
-          )}
-        </form>
-        )}
+        <ChatComposer
+          isAgentChat={isAgentChat}
+          isHecateChat={isHecateChat}
+          isExternalAgentChat={isExternalAgentChat}
+          isHecateAgentChat={isHecateAgentChat}
+          activeSessionID={activeSessionID}
+          textareaRef={textareaRef}
+          composerVisible={composerVisible}
+          composerRepair={composerRepair}
+          messageControlsVisible={messageControlsVisible}
+          showClaudeCodeEmptyPreflight={showClaudeCodeEmptyPreflight}
+          sendDisabled={sendDisabled}
+          agentBusy={agentBusy}
+          queueingMessage={queueingMessage}
+          selectedModelIssue={selectedModelIssue}
+          chatDiagnostic={chatDiagnostic}
+          hecateAgentModelLocked={hecateAgentModelLocked}
+          hecateChatProviderValue={hecateChatProviderValue}
+          hecateChatModelValue={hecateChatModelValue}
+          hecateProviderOptions={hecateProviderOptions}
+          hecateDisabledProviderReasons={hecateDisabledProviderReasons}
+          selectableModels={selectableModels}
+          selectedAgent={selectedAgent}
+          selectedAgentHealthLoading={selectedAgentHealthLoading}
+          claudeCodePreflight={claudeCodePreflight}
+          selectedCapabilityProvider={selectedCapabilityProvider}
+          selectedCapabilityModel={selectedCapabilityModel}
+          capabilitySaving={capabilitySaving}
+          enableToolsForSelectedModel={enableToolsForSelectedModel}
+          chooseWorkspace={chooseWorkspace}
+          openClaudeCodeSetup={openClaudeCodeSetup}
+          activeHecateTaskID={activeHecateTaskID}
+          activeHecateRunID={activeHecateRunID}
+          activeQueuedChatMessages={activeQueuedChatMessages}
+          messageHistory={messageHistory}
+          onNavigate={onNavigate}
+          onOpenTask={onOpenTask}
+          onOpenTrace={onOpenTrace}
+        />
         </>
         )}
           </div>
@@ -1775,16 +1423,6 @@ function messageBrand(
   return message.provider || message.model;
 }
 
-function providerLabelForHecateChat(state: RuntimeConsoleViewModel["state"], providerID: string): string {
-  if (!providerID || providerID === "auto") {
-    return "Select provider";
-  }
-  return state.settingsConfig?.providers.find(provider => provider.id === providerID)?.name
-    || state.providerPresets.find(preset => preset.id === providerID)?.name
-    || state.providers.find(provider => provider.name === providerID)?.name
-    || providerID;
-}
-
 function HecateTaskApprovalsBanner({
   approvals,
   taskID,
@@ -1897,93 +1535,6 @@ function describeTaskApprovalKind(kind: string): string {
     case "agent_loop_tool_call": return "Agent tool call";
     default:                     return kind.replaceAll("_", " ");
   }
-}
-
-function ChatErrorPanel({
-  message,
-  provider,
-  code,
-  action,
-  requestID,
-  status,
-  traceID,
-  onOpenTrace,
-  diagnostic,
-}: {
-  message: string;
-  provider?: string;
-  code?: string;
-  action?: string;
-  requestID?: string;
-  status?: number;
-  traceID?: string;
-  onOpenTrace?: (requestID: string) => void;
-  diagnostic: ReturnType<typeof describeGatewayError>;
-}) {
-  const label = formatErrorCode(code, status);
-  const recommendedAction = action || diagnostic?.action || "";
-  if (!diagnostic) {
-    return <InlineError message={`${provider ? `[${provider}] ` : ""}${message}`} />;
-  }
-
-  return (
-    <div
-      role="alert"
-      style={{
-        border: "1px solid var(--red-border)",
-        background: "var(--red-bg)",
-        borderRadius: "var(--radius)",
-        padding: "9px 11px",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
-        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--red)" }}>{diagnostic.title}</span>
-        {label && (
-          <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--red)" }}>
-            {label}
-          </span>
-        )}
-      </div>
-      <div style={{ fontSize: 12, color: "var(--t0)", lineHeight: 1.45 }}>{message}</div>
-      {recommendedAction && (
-        <div style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.45, marginTop: 5 }}>
-          {provider ? `${provider}: ` : ""}{recommendedAction}
-        </div>
-      )}
-      {(requestID || traceID) && (
-        <div style={{ marginTop: 7, display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-          {requestID && (
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-              request <span style={{ color: "var(--t1)" }}>{compactID(requestID, [], 10)}</span>
-            </span>
-          )}
-          {traceID && (
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}>
-              trace <span style={{ color: "var(--t1)" }}>{compactID(traceID, [], 10)}</span>
-            </span>
-          )}
-          {requestID && onOpenTrace && (
-            <button
-              type="button"
-              onClick={() => onOpenTrace(requestID)}
-              style={{
-                border: "1px solid var(--red-border)",
-                background: "transparent",
-                color: "var(--red)",
-                borderRadius: 999,
-                padding: "2px 8px",
-                fontSize: 10,
-                fontFamily: "var(--font-mono)",
-                cursor: "pointer",
-              }}
-            >
-              Open trace
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
 }
 
 function ChatEmptyState({
@@ -2232,112 +1783,6 @@ function RTKOnboardingHint({ path, onEnable }: { path: string; onEnable: () => v
   );
 }
 
-function ChatSetupRepairNotice({
-  repair,
-  actionBusy = false,
-  actionDisabled = false,
-  actionTitle,
-  onAction,
-}: {
-  repair: ChatSetupRepairState;
-  actionBusy?: boolean;
-  actionDisabled?: boolean;
-  actionTitle?: string;
-  onAction: (repair: ChatSetupRepairState) => void;
-}) {
-  return (
-    <ChatNoticeInline
-      tone={repair.tone}
-      title={repair.title}
-      message={repair.message}
-      action={repair.actionLabel}
-      actionBusy={actionBusy}
-      actionBusyLabel="Saving..."
-      actionDisabled={actionDisabled}
-      actionTitle={actionTitle}
-      onAction={() => onAction(repair)}
-    />
-  );
-}
-
-function SelectedModelReadinessNotice({
-  issue,
-  compact = false,
-  onOpenProviders,
-  onUseSuggestedModel,
-}: {
-  issue: SelectedModelIssue;
-  compact?: boolean;
-  onOpenProviders?: () => void;
-  onUseSuggestedModel?: (model: string) => void;
-}) {
-  return (
-    <div style={{
-      margin: compact ? "14px auto 0" : "0 auto",
-      maxWidth: compact ? 560 : 820,
-      border: "1px solid rgba(245, 191, 79, 0.32)",
-      borderRadius: "var(--radius)",
-      background: "rgba(245, 191, 79, 0.06)",
-      padding: 12,
-      textAlign: "left",
-    }}>
-      {!compact && (
-        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
-          <div style={{ minWidth: 0 }}>
-            <div style={{ fontSize: 12, fontWeight: 700, color: "var(--amber)", marginBottom: 4 }}>
-              {issue.title}
-            </div>
-            <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.5 }}>
-              {issue.message}
-            </div>
-          </div>
-          {onOpenProviders && (
-            <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenProviders} style={{ flexShrink: 0 }}>
-              Open Connections
-            </button>
-          )}
-          {issue.suggestedModel && onUseSuggestedModel && (
-            <button
-              className="btn btn-primary btn-sm"
-              type="button"
-              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
-              style={{ flexShrink: 0 }}
-            >
-              Use {issue.suggestedModel}
-            </button>
-          )}
-        </div>
-      )}
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8, marginTop: 10 }}>
-        {selectedModelNoticeDetails(issue.details, compact).map((detail) => (
-          <InfoChip key={detail.label} label={detail.label} value={detail.value} />
-        ))}
-      </div>
-      {compact ? (
-        <>
-          <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
-            {issue.steps.slice(0, 2).map((step) => <li key={step}>{step}</li>)}
-          </ul>
-          {issue.suggestedModel && onUseSuggestedModel && (
-            <button
-              className="btn btn-primary btn-sm"
-              type="button"
-              onClick={() => onUseSuggestedModel(issue.suggestedModel!)}
-              style={{ marginTop: 10 }}
-            >
-              Use {issue.suggestedModel}
-            </button>
-          )}
-        </>
-      ) : (
-        <ul style={{ margin: "10px 0 0", paddingLeft: 18, color: "var(--t3)", fontSize: 11, lineHeight: 1.55 }}>
-          {issue.steps.map((step) => <li key={step}>{step}</li>)}
-        </ul>
-      )}
-    </div>
-  );
-}
-
 function composerVisibleRepair(repair: ChatSetupRepairState | null): ChatSetupRepairState | null {
   if (!repair) return null;
   switch (repair.kind) {
@@ -2357,47 +1802,6 @@ function emptyStateAlreadyShowsRepair(repair: ChatSetupRepairState | null, visib
   // owns the capability-write busy/disabled state. Other empty-chat repairs
   // already render the same copy and CTA in ChatEmptyState.
   return repair.action !== "enable_tools";
-}
-
-function repairActionIcon(repair: ChatSetupRepairState) {
-  switch (repair.action) {
-    case "choose_workspace":
-      return Icons.folder;
-    case "open_agent_setup":
-      return Icons.terminal;
-    case "use_suggested_model":
-      return Icons.model;
-    case "open_connections":
-      return Icons.connections;
-    case "enable_tools":
-      return Icons.providers;
-  }
-  return Icons.providers;
-}
-
-function selectedModelNoticeDetails(
-  details: SelectedModelIssue["details"],
-  compact: boolean,
-): SelectedModelIssue["details"] {
-  if (!compact) {
-    return details;
-  }
-  const priorityLabels = new Set(["Selected model", "Provider route", "Discovered models", "Health", "Blocked by", "Last error"]);
-  const selected = details.filter((detail) => priorityLabels.has(detail.label));
-  return selected.length > 0 ? selected : details;
-}
-
-function InfoChip({ label, value }: { label: string; value: string }) {
-  return (
-    <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg3)", padding: "7px 8px", minWidth: 0 }}>
-      <div style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
-        {label}
-      </div>
-      <div title={value} style={{ marginTop: 3, fontSize: 11, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-        {value}
-      </div>
-    </div>
-  );
 }
 
 function QuickLocalProviderAdd({
@@ -3118,13 +2522,5 @@ function CopyCommandRow({ label, command, onCopy }: { label: string; command: st
 
 function shortID(id: string): string {
   return compactID(id, ["task_", "run_", "agent_chat_"], 8);
-}
-
-function compactID(id: string, prefixes: string[], length: number): string {
-  const trimmed = id.trim();
-  const withoutPrefix = prefixes.reduce((current, prefix) => (
-    current.startsWith(prefix) ? current.slice(prefix.length) : current
-  ), trimmed);
-  return withoutPrefix.slice(0, length);
 }
 


### PR DESCRIPTION
## Summary

After the sidebar carve-out in [#124](https://github.com/hecatehq/hecate/pull/124), the next concrete cut is the composer's `<form>` subtree plus its handler graph plus the three inline notice components that only the composer renders. They go together — `handleSubmit` reads `textareaRef`, `handleKeyDown` reads `formRef`, `handleMessageHistoryKey` reads `messageHistory` and the two history refs, and the three notices (`ChatErrorPanel`, `ChatSetupRepairNotice`, `SelectedModelReadinessNotice`) sit at the top of the form before the textarea.

**Stacks on [#124](https://github.com/hecatehq/hecate/pull/124)** (ChatSidebar). Base ref is `refactor/ui-chatview-split`; merge that first.

## What moves

**New file `ui/src/features/chats/ChatComposer.tsx` (783 LOC):**

```tsx
export type ChatComposerProps = {
  isAgentChat: boolean;
  isHecateChat: boolean;
  isExternalAgentChat: boolean;
  isHecateAgentChat: boolean;
  activeSessionID: string;
  textareaRef: RefObject<HTMLTextAreaElement | null>;
  // … 30+ derived values that ChatView already computes for its
  // own header / modals / transcript / empty-state surfaces …
};

export function ChatComposer(props: ChatComposerProps) {
  const { state, actions } = useRuntimeConsoleContext();
  const [modEnterMode, setModEnterMode] = usePersistedState<boolean>(/* hecate.shiftEnterMode */);
  const formRef = useRef<HTMLFormElement>(null);
  const messageHistoryCursorRef = useRef<number | null>(null);
  const messageHistoryDraftRef = useRef("");
  // … handlers + JSX …
}
```

State that moved: `modEnterMode` (persisted), `formRef`, `messageHistoryCursorRef`, `messageHistoryDraftRef`. Handlers that moved: `setComposerText`, `handleMessageChange`, `handleMessageHistoryKey`, `handleKeyDown`, `handleSubmit`, `toggleModEnterMode`. Effect that moved: the history-reset effect on `activeSessionID` change (scroll-side reset stays in ChatView since it concerns the transcript surface).

Components moved (+ helpers): `ChatErrorPanel`, `ChatSetupRepairNotice`, `SelectedModelReadinessNotice` (+ `InfoChip`, `selectedModelNoticeDetails`, `repairActionIcon`).

Helpers moved: `compactID` (the error panel uses it for request/trace IDs — `ChatView` still uses it for `HecateTaskApprovalsBanner` and `formatTaskLinkLabel`, so it's re-imported), `providerLabelForHecateChat` (only used inside the composer's message-controls bar).

## What stays in ChatView

- **All derived-value plumbing** — `composerVisible`, `composerRepair`, `sendDisabled`, `hecateChatModelReady`, `selectableModels`, `hecateProviderOptions`, `selectedAgent`, `claudeCodePreflight`, … The header / modals / transcript / empty-state read most of them too, so a clean move would need a shared derived-state hook. Keep them on the ChatView side and pass the bag down for now.
- **Cross-region coordination** — `textareaRef` (created here so `ChatSidebar.onSelectSession` can focus it), focus effects, transcript scroll state (`scrollRef`, `bottomRef`, `userScrolledRef`, `atBottom`).
- **Composer-form callbacks ChatView owns** — `chooseWorkspace`, `enableToolsForSelectedModel`, `openClaudeCodeSetup`. They cross-cut state/actions ChatView still mediates.

## Why the prop bag is so wide

35 props because the composer reads 30+ derived values that ChatView computes for itself too. Three viable next steps to slim it:

1. **`useChatViewModel()` hook** — co-locates all derived values, both ChatView and ChatComposer call it, each picks what it needs. Cleanest but adds a new abstraction layer (out of scope here).
2. **Move more state into the chat slice** — derive `composerVisible` etc. inside `state/chat.tsx`. Smallest API change but pollutes the slice with view-model concerns.
3. **Keep the bag** — accept the verbosity in exchange for clear, surgical state ownership. Current PR's path.

This PR takes path 3; a follow-up can revisit if the prop bag becomes a friction point.

## ChatView diff

```
ChatView.tsx: 3130 → 2526 LOC (-604)
ChatComposer.tsx: new, 783 LOC
```

Imports retired from ChatView: `SyntheticEvent`, `formatErrorCode`, `usePersistedState`, `ChatNoticeInline`, `ClaudeCodePreflightCard`, `claudeCodeSetupTokenCommand`, `ExternalAgentConfigControls`, `LockedHecateModelSnapshot`, `HecateProviderConfigControl`, `HecateModelConfigControl`, `RuntimeConsoleViewModel` type.

ChatView re-imports from ChatComposer: `ChatComposer`, `SelectedModelReadinessNotice` (`ChatEmptyState`'s compact variant), `compactID` (`HecateTaskApprovalsBanner` + `formatTaskLinkLabel`), `repairActionIcon` (`ChatEmptyState`'s repair CTA).

## Test plan

- [x] `bun run typecheck` — clean (`tsgo -b`)
- [x] `bunx vitest run` — 824/824 pass (38 files, no count delta)
- [x] `bun run test:e2e` — 60/60 chromium pass
- [x] Browser preview: sidebar + topbar unchanged; clicking "New Hecate chat" opens the draft and the empty-state "Choose a workspace" repair shows (composer correctly hidden because no providers configured). No console errors.

## Why `[skip desktop]`

Pure TS module + JSX move under `ui/src/features/chats/`. No `desktop_force` paths touched, so the safety guard ([#115](https://github.com/hecatehq/hecate/pull/115)) honours the skip. Tauri Rust tests still run.

## What's next

Transcript + header + quick-providers extraction. Smaller, more isolated surfaces than the composer was.
