### PR TITLE
docs: clarify hecate runtime wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ When in doubt: read [`docs-ai/core/project-context.md`](docs-ai/core/project-con
 ## Codebase map
 
 ```
-cmd/hecate/            hecate binary entry: gateway, embedded UI, MCP subcommand
+cmd/hecate/            main runtime entry: gateway service, embedded UI, MCP subcommand
 cmd/hecate-acp/         ACP stdio bridge for editor agent panels
 
 pkg/types/              public types (ChatRequest, Message, ContentBlock, ...)

--- a/Justfile
+++ b/Justfile
@@ -20,7 +20,7 @@ _website-deps:
 # Build a single self-contained `hecate` binary with the UI bundle embedded.
 # The UI is built first so //go:embed picks up the real assets; without this
 # step the binary still runs but serves the "UI not built" fallback page.
-# Build the embedded-UI gateway binary.
+# Build the embedded-UI runtime binary.
 build: ui-build _go-cache
 	GOCACHE="$PWD/{{gocache}}" go build -o hecate ./cmd/hecate
 
@@ -81,7 +81,7 @@ run *args: _go-cache
 # stale process is still listening, so a forgotten Ctrl-C never blocks a
 # restart. It also sources .env so configured providers are available,
 # matching the `just dev` workflow.
-# Serve the pre-built gateway binary. Optional arg: --reset.
+# Serve the pre-built runtime binary. Optional arg: --reset.
 serve *args:
 	needs_reset=0; \
 	for arg in {{args}}; do \

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Chats can be renamed from the sidebar. The title is just operator-facing metadat
 
 ## Architecture
 
-The gateway is one local Go process with the React operator UI embedded. `hecate-acp` is a separate stdio bridge for editor ACP hosts.
+The main `hecate` process runs the local gateway service and embeds the React operator UI. `hecate-acp` is a separate stdio bridge for editor ACP hosts.
 
 ```mermaid
 flowchart LR

--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -1,11 +1,11 @@
 # Project context
 
-Hecate is an open-source AI gateway and agent-task runtime. The Go gateway embeds the React operator UI, mediates OpenAI- and Anthropic-shaped client traffic to upstream LLM providers, runs Hecate Chat tools-on turns through visible `agent_loop` tasks, supervises external coding-agent adapters from Chats, runs queued `agent_loop` tasks with policy and approval gates, and emits OpenTelemetry traces for everything it does. Companion entrypoints such as `hecate-acp` handle protocols that need their own process lifecycle. Hecate is gateway-local, deny-by-default, runtime-aware, and storage-tiered (memory / sqlite). Every endpoint, config knob, and error message exists to answer five operator questions: what did the gateway just decide, why, what did it cost, what happens on the next failure, and where is the trace.
+Hecate is an open-source AI gateway and agent-task runtime. The main Go runtime runs the local gateway service, embeds the React operator UI, mediates OpenAI- and Anthropic-shaped client traffic to upstream LLM providers, runs Hecate Chat tools-on turns through visible `agent_loop` tasks, supervises external coding-agent adapters from Chats, runs queued `agent_loop` tasks with policy and approval gates, and emits OpenTelemetry traces for everything it does. Companion entrypoints such as `hecate-acp` handle protocols that need their own process lifecycle. Hecate is gateway-local, deny-by-default, runtime-aware, and storage-tiered (memory / sqlite). Every endpoint, config knob, and error message exists to answer five operator questions: what did the gateway just decide, why, what did it cost, what happens on the next failure, and where is the trace.
 
 ## Repository layout
 
 ```
-cmd/hecate/               hecate binary entry: gateway, embedded UI, MCP subcommand
+cmd/hecate/               main runtime entry: gateway service, embedded UI, MCP subcommand
 cmd/hecate-acp/            ACP stdio bridge for editor agent panels
 
 pkg/types/                 public types (ChatRequest, Message, ContentBlock, ...)

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -18,14 +18,14 @@ Operator-facing companion: [`../../../docs/desktop-app.md`](../../../docs/deskto
 
 ## Architecture in one paragraph
 
-The Tauri app is a thin chrome-frame around the Hecate gateway. On launch the Rust layer allocates a free loopback port, spawns the `hecate` binary as a companion process (not a Tauri shell-plugin sidecar — see gotchas), polls `/healthz` until the gateway is healthy, then navigates the webview to `http://127.0.0.1:{port}/`. The gateway serves its own embedded React UI. No second frontend build, no API bridge, no Vite dev server required.
+The Tauri app is a thin chrome-frame around the main Hecate runtime running in gateway mode. On launch the Rust layer allocates a free loopback port, spawns the `hecate` binary as a companion process (not a Tauri shell-plugin sidecar — see gotchas), polls `/healthz` until the gateway is healthy, then navigates the webview to `http://127.0.0.1:{port}/`. The gateway serves its own embedded React UI. No second frontend build, no API bridge, no Vite dev server required.
 
 ### Why we keep `//go:embed` instead of `frontendDist`
 
 Most Tauri apps point `tauri.conf.json` → `frontendDist: "../ui/dist"` and let the webview load UI files directly from the bundled app. We don't, on purpose:
 
 - **Same-origin loopback surface.** The webview loads from `http://127.0.0.1:{port}/` and the API is at `http://127.0.0.1:{port}/v1/...`. Same origin means no CORS dance and no Tauri IPC bridge. Splitting UI (`tauri://localhost`) from API (`127.0.0.1:{port}`) breaks that property and requires a meaningful security refactor to restore.
-- **Hecate-sidecar property.** The same `hecate` binary ships through Docker, the goreleaser tarballs, *and* the Tauri sidecar. The embed makes that work without conditional builds or runtime path resolution. Reading `ui/dist` from disk inside a bundled `.app` would require a working-dir-independent resolver and a new "UI files missing" failure mode.
+- **Hecate-sidecar property.** The same `hecate` runtime binary ships through Docker, the goreleaser tarballs, *and* the Tauri sidecar. The embed makes that work without conditional builds or runtime path resolution. Reading `ui/dist` from disk inside a bundled `.app` would require a working-dir-independent resolver and a new "UI files missing" failure mode.
 - **Bundle-size cost is small.** Embedding adds ~13 MB to the binary, which means a `.dmg` of ~25 MB instead of ~12 MB. Desktop apps routinely ship at 100+ MB; this isn't a real constraint.
 
 If the gateway and UI ever decouple (gateway as pure API + separate static-server for UI), revisit this. Until then, keep the embed.
@@ -91,7 +91,7 @@ Three responsibilities:
 - Windows: `%APPDATA%\sh.hecate.app\`
 - Linux: `~/.local/share/sh.hecate.app/`
 
-**`spawn_and_wait(app)`** — spawns the hecate binary (via `std::process::Command`, not tokio — see gotchas), polls `/healthz` every 250 ms, returns `GatewayHandle { base_url, port, child }` on success.
+**`spawn_and_wait(app)`** — spawns the `hecate` runtime (via `std::process::Command`, not tokio — see gotchas), polls `/healthz` every 250 ms, returns `GatewayHandle { base_url, port, child }` on success.
 
 ### `lib.rs`
 
@@ -280,7 +280,7 @@ block in `test.yml`'s `tauri-desktop` job.
 ### Pipeline footguns
 
 - **`tauri-action`'s auto-install is unreliable with `projectPath` set.** It silently skips `bun install` in `tauri/`, leaving `node_modules/.bin/tauri` missing — `bun run tauri build` then fails with "tauri: command not found". Always run `cd tauri && bun install --frozen-lockfile` ourselves before the action.
-- **`build.rs` validates `externalBin` paths at build-script run time.** Any step that compiles the Rust crate (`cargo check`, `cargo build`, `tauri build`) needs the sidecar staged at `binaries/hecate-{triple}[.exe]` first. Run `just tauri-sidecar <target>` before any Rust compile; it builds and stages the versioned sidecars in one step. Plain `just build` leaves the gateway version as `dev`; release/native bundles need the versioned sidecar path so `/healthz` and the UI status bar match the Tauri app version.
+- **`build.rs` validates `externalBin` paths at build-script run time.** Any step that compiles the Rust crate (`cargo check`, `cargo build`, `tauri build`) needs the sidecar staged at `binaries/hecate-{triple}[.exe]` first. Run `just tauri-sidecar <target>` before any Rust compile; it builds and stages the versioned sidecars in one step. Plain `just build` leaves the runtime version as `dev`; release/native bundles need the versioned sidecar path so `/healthz` and the UI status bar match the Tauri app version.
 - **Just + Git Bash on Windows runners.** Set `defaults.run.shell: bash` job-wide. Default Windows shell is PowerShell; the Justfile shell recipes and our `cp`/`if` blocks only work in bash. On Windows runners, `bash` resolves to Git Bash.
 - **Go sidecar names differ by host and bundle target.** `just tauri-sidecar <target>` reads `go env GOEXE`, then stages `hecate$GOEXE` and `hecate-acp$GOEXE` to `binaries/<name>-<target>$GOEXE`. A missing source fails at `cp`, which usually means the versioned sidecar build failed earlier in the recipe.
 - **`just tauri-build-sidecars` runs `just ui-build` which checks for `ui/node_modules/@vitejs/plugin-react`.** That's the canary file. CI must run `just ui-install` before building Tauri sidecars. Goreleaser handles the normal gateway build via its `before:` hook (`bun install --cwd ui --frozen-lockfile`); the Tauri matrix does it explicitly.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,7 +39,7 @@ If a `docker run` (or `docker compose up`) errors with `bind: address already in
 
 ## Binary install
 
-The release workflow publishes static, single-file binaries for `linux+darwin × amd64+arm64` to GitHub Releases. Skip Docker if you'd rather run the gateway directly:
+The release workflow publishes static, single-file binaries for `linux+darwin × amd64+arm64` to GitHub Releases. Skip Docker if you'd rather run Hecate directly from the terminal:
 
 ```bash
 # pick the right tarball for your OS / arch
@@ -48,7 +48,7 @@ tar -xzf hecate_0.1.0-alpha.31_linux_amd64.tar.gz
 ./hecate
 ```
 
-The gateway embeds the React operator UI, listens on `127.0.0.1:8765` by default, and stores state under `GATEWAY_DATA_DIR` (default `.data/`). No additional runtime dependencies — the binaries are statically linked and CGO-free.
+The `hecate` binary starts the gateway service, embeds the React operator UI, listens on `127.0.0.1:8765` by default, and stores state under `GATEWAY_DATA_DIR` (default `.data/`). No additional runtime dependencies — the binaries are statically linked and CGO-free.
 
 To pin the data directory to a known location:
 
@@ -82,7 +82,7 @@ A third install path for personal use on a laptop. Same release, different artif
 | Linux x86_64 | `Hecate_X.Y.Z_amd64.deb`, `Hecate_X.Y.Z_amd64.AppImage` |
 | Windows x86_64 | `Hecate_X.Y.Z_x64_en-US.msi` |
 
-The bundle is a Tauri 2.x chrome around the same `hecate` binary used in Docker and the tarballs. On launch the app spawns Hecate as a sidecar on a free loopback port, polls `/healthz`, then loads the embedded UI directly.
+The bundle is a Tauri 2.x chrome around the same `hecate` runtime binary used in Docker and the tarballs. On launch the app spawns it as a gateway sidecar on a free loopback port, polls `/healthz`, then loads the embedded UI directly.
 
 State lives in the platform data dir, not next to the binary:
 
@@ -109,9 +109,9 @@ Full state, footguns, and roadmap: [`desktop-app.md`](desktop-app.md).
 ## External-agent startup knobs
 
 Web, Docker, tarball, and native-app launches use the same gateway env vars for
-Agent Chat. The native app spawns the bundled gateway sidecar with these env
-vars inherited from the app process; Docker reads them from `.env` / compose;
-bare binaries read the shell environment.
+Agent Chat. The native app spawns the bundled `hecate` runtime in gateway mode
+with these env vars inherited from the app process; Docker reads them from
+`.env` / compose; bare binaries read the shell environment.
 
 | Env var | Default | Applies to |
 |---|---|---|

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,10 +1,10 @@
 # Desktop app
 
 Hecate ships a native desktop app (`tauri/`) alongside the binary tarball and
-Docker image. It's a thin Tauri 2.x chrome around the same `hecate` binary
-used everywhere else: on launch, the Rust layer spawns Hecate as a
-companion process on a free loopback port, polls `/healthz`, then navigates a
-webview to `http://127.0.0.1:{port}/` where the gateway serves its embedded UI.
+Docker image. It's a thin Tauri 2.x chrome around the same `hecate` runtime
+binary used everywhere else: on launch, the Rust layer spawns it in gateway
+mode on a free loopback port, polls `/healthz`, then navigates a webview to
+`http://127.0.0.1:{port}/` where the gateway serves its embedded UI.
 
 The desktop app bundles both `hecate` and `hecate-acp`. ACP clients still
 launch `hecate-acp` themselves over stdio, but the gateway writes
@@ -130,7 +130,7 @@ The desktop app bundles the `hecate` and `hecate-acp` binaries. Agent tool calls
 subprocess directly from the gateway with env sanitisation, output cap,
 and wall-clock timeout applied inline (Layer 1). On macOS the call is
 additionally wrapped by `sandbox-exec` (Layer 2) for filesystem and
-network confinement; the binary ships on every macOS install so this
+network confinement; `sandbox-exec` ships on every macOS install so this
 is automatic.
 
 See [`docs/sandbox.md`](sandbox.md) for the layer model and policy

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,7 @@ The Tauri desktop app's local build (`just tauri-dev`) lives in
 
 ## Toolchain
 
-Required for the gateway + embedded UI:
+Required for the main runtime + embedded UI:
 
 - **Go** — pinned via `go.mod`; `just build` runs `go build`.
 - **Bun** — pinned via `ui/package.json` and `website/package.json`
@@ -35,7 +35,7 @@ Required only for the native desktop app:
 
 Optional:
 
-- **Docker** — only required for the docker-smoke test job and container workflows; not needed for the gateway itself.
+- **Docker** — only required for the docker-smoke test job and container workflows; not needed for the local runtime itself.
 - **RTK** — optional local helper used by Hecate Chat's per-chat “compact command output” setting. It is off by default; when the `rtk` command is present in the gateway `PATH`, the UI offers an opt-in hint. Hecate still applies policy validation, env sanitisation, output caps, timeouts, and the OS sandbox wrapper.
 
 Install examples:
@@ -67,7 +67,7 @@ for the UI or website. The committed lockfiles are `ui/bun.lock` and
 `website/bun.lock`, the install command is `bun install`, and all scripts run
 through `bun run ...`.
 
-The `hecate` binary embeds the React UI via `//go:embed ui/dist`. There's no separate UI deployment.
+The `hecate` runtime embeds the React UI via `//go:embed ui/dist`. There's no separate UI deployment.
 
 ## Local build
 
@@ -152,7 +152,7 @@ just verify            # full gate: docs/env check, Go, Docker, UI, build
 just release vX.Y.Z    # verify, then run the release script
 ```
 
-The race detector is the strongest correctness check (and the slowest); CI runs it on every push. `test-acp-smoke` starts a fake OpenAI-compatible upstream, the real `hecate` gateway, and the real `cmd/hecate-acp` stdio bridge, then verifies model discovery, same-task continuation, SSE updates, and editor approval round-trip behavior. The Go e2e suite also includes binary-level Agent Chat approval smokes for SQLite startup reconcile and durable grant persistence; run them with `go test -tags e2e -run 'TestApproval' ./e2e` when touching approval storage or cmd/hecate startup wiring. `test-docker-smoke` requires Docker but doesn't need any other infrastructure — it spins up its own compose project to avoid colliding with a developer's running stack. `test-tauri-smoke` builds only the packaged macOS `.app`, waits for the sidecar gateway to answer `/healthz`, quits Hecate, and confirms the sidecar exits; `test-tauri-acp-smoke` additionally runs the bundled `hecate-acp` without `HECATE_GATEWAY_URL` and verifies native runtime discovery through `hecate.runtime.json`. Both native smokes are opt-in because they open a real GUI window.
+The race detector is the strongest correctness check (and the slowest); CI runs it on every push. `test-acp-smoke` starts a fake OpenAI-compatible upstream, the real `hecate` runtime in gateway mode, and the real `cmd/hecate-acp` stdio bridge, then verifies model discovery, same-task continuation, SSE updates, and editor approval round-trip behavior. The Go e2e suite also includes binary-level Agent Chat approval smokes for SQLite startup reconcile and durable grant persistence; run them with `go test -tags e2e -run 'TestApproval' ./e2e` when touching approval storage or cmd/hecate startup wiring. `test-docker-smoke` requires Docker but doesn't need any other infrastructure — it spins up its own compose project to avoid colliding with a developer's running stack. `test-tauri-smoke` builds only the packaged macOS `.app`, waits for the sidecar gateway to answer `/healthz`, quits Hecate, and confirms the sidecar exits; `test-tauri-acp-smoke` additionally runs the bundled `hecate-acp` without `HECATE_GATEWAY_URL` and verifies native runtime discovery through `hecate.runtime.json`. Both native smokes are opt-in because they open a real GUI window.
 
 Before cutting a public tag, run `just verify` and follow the checklist in [Release](release.md).
 
@@ -201,7 +201,7 @@ Recognized markers: `[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, `[act
 Top-level entry points:
 
 ```
-cmd/hecate/            # hecate entry point (gateway, embedded UI, `mcp-server` subcommand)
+cmd/hecate/            # main runtime entry point (gateway service, embedded UI, `mcp-server` subcommand)
 cmd/hecate-acp/         # ACP stdio bridge for editor agent panels
 ui/                     # React app (Vite + Bun); src/ is the source, dist/ is the embed target
 website/                # Astro homepage for hecate.sh

--- a/docs/rfcs/acp-editor-owned-workspace.md
+++ b/docs/rfcs/acp-editor-owned-workspace.md
@@ -13,7 +13,7 @@
 
 ## The problem
 
-The orchestrator runs in the `hecate` gateway process. The ACP
+The orchestrator runs in the main `hecate` process. The ACP
 dispatcher runs in the `hecate-acp` bridge process — spawned by the
 editor over stdio, talking HTTP REST to the gateway for forward calls
 (`POST /hecate/v1/tasks/...`). When `HECATE_WORKSPACE_MODE` resolves to

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,9 +59,9 @@ Hecate stores local configuration and operational state on disk.
 
 ## Native app and sidecars
 
-The desktop app is a Tauri shell that bundles two Hecate binaries: the
-`hecate` gateway it runs as its primary sidecar, and `hecate-acp` for
-editor Agent Client Protocol (ACP) integrations.
+The desktop app is a Tauri shell that bundles two Hecate executables: the main
+`hecate` runtime, which it launches in gateway mode as its primary sidecar, and
+`hecate-acp` for editor Agent Client Protocol (ACP) integrations.
 
 - The app launches `hecate` as a sidecar on a free loopback port.
 - The app bundle also ships `hecate-acp` so editors that drive Hecate

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the Astro homepage for [hecate.sh](https://hecate.sh).
 It is separate from the embedded operator UI in `../ui`: `website/` builds the
-public site, while `ui/` is bundled into the `hecate` gateway binary.
+public site, while `ui/` is bundled into the `hecate` runtime binary.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Clarify that `hecate` is the main runtime/CLI executable, not only the gateway binary.
- Keep `gateway` terminology for the actual HTTP/routing service mode.
- Update README, deployment/development/desktop/security docs, agent guidance, Tauri guidance, and one ACP RFC sentence before the terminal distribution RFC lands.

## Verification

- `git diff --check`

## Notes

The terminal distribution RFC draft is intentionally not included here; this PR is only the terminology cleanup that makes that RFC easier to read.
