### PR TITLE
refactor(api): route every stable error code through the registry [skip desktop]

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -487,13 +487,13 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 			slog.String("event.name", "gateway.models.list.failed"),
 			slog.Any("error", err),
 		)
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 
 	cpState, err := h.settingsState(ctx)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	data := make([]OpenAIModelData, 0, len(result.Models))
@@ -571,7 +571,7 @@ func settingsActor(r *http.Request) string {
 // decodeJSON decodes the request body into v and writes a 400 on failure.
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		WriteError(w, http.StatusBadRequest, "invalid_request", "request body must be valid JSON")
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be valid JSON")
 		return false
 	}
 	return true

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,7 +28,7 @@ const (
 func (h *Handler) HandleChatSessions(w http.ResponseWriter, r *http.Request) {
 	items, err := h.agentChat.List(r.Context())
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	data := make([]ChatSessionSummaryItem, 0, len(items))
@@ -41,8 +40,7 @@ func (h *Handler) HandleChatSessions(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request) {
 	var req CreateChatSessionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid JSON body")
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	runtimeKind := normalizeAgentChatRuntimeKind(req.RuntimeKind, req.AdapterID)
@@ -139,7 +137,7 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	}
 	session, err = h.agentChat.Create(r.Context(), session)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if runtimeKind == "external_agent" {
@@ -166,7 +164,7 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 			_ = h.agentChatRunner.CloseSession(cleanupCtx, session.ID)
 			cleanupCancel()
 			_ = h.agentChat.Delete(context.Background(), session.ID)
-			WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
 	}
@@ -198,11 +196,11 @@ func isValidAgentChatRuntimeKind(runtimeKind string) bool {
 func (h *Handler) HandleChatSession(w http.ResponseWriter, r *http.Request) {
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
@@ -253,11 +251,11 @@ func (h *Handler) HandleChatSessionStream(w http.ResponseWriter, r *http.Request
 	}
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
 	updates, unsubscribe := h.agentChatLive.subscribe(session.ID)
@@ -324,7 +322,7 @@ func (h *Handler) HandleDeleteChatSession(w http.ResponseWriter, r *http.Request
 		_ = h.agentChatRunner.CloseSession(r.Context(), sessionID)
 	}
 	if err := h.agentChat.Delete(r.Context(), sessionID); err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -333,17 +331,17 @@ func (h *Handler) HandleDeleteChatSession(w http.ResponseWriter, r *http.Request
 func (h *Handler) HandleCancelChatSession(w http.ResponseWriter, r *http.Request) {
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
 	if renderAgentChatRuntimeKind(session) == "agent" && h.taskStore != nil && h.taskRunner != nil && session.TaskID != "" && session.LatestRunID != "" {
 		task, found, err := h.taskStore.GetTask(r.Context(), session.TaskID)
 		if err != nil {
-			WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
 		if found {
@@ -374,11 +372,11 @@ func (h *Handler) HandleCancelChatSession(w http.ResponseWriter, r *http.Request
 func (h *Handler) HandleCloseChatSession(w http.ResponseWriter, r *http.Request) {
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
 	cancelCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
@@ -396,7 +394,7 @@ func (h *Handler) HandleCloseChatSession(w http.ResponseWriter, r *http.Request)
 		item.NativeSessionID = ""
 	})
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
@@ -419,8 +417,7 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 		return
 	}
 	var req SetAgentChatConfigOptionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid request body")
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	setReq, err := agentChatConfigOptionSetRequest(sessionID, configID, req.Value)
@@ -466,8 +463,7 @@ func (h *Handler) HandleSetAgentChatSettings(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req SetAgentChatSettingsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid request body")
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if req.RTKEnabled == nil {
@@ -572,16 +568,15 @@ func agentChatConfigOptionSetRequest(sessionID, configID string, rawValue any) (
 func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request) {
 	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, "not_found", "agent chat session not found")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
 	var req CreateChatMessageRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid JSON body")
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	content := strings.TrimSpace(req.Content)
@@ -672,7 +667,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		CreatedAt: time.Now().UTC(),
 	})
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	h.agentChatLive.publishSession(updated)
@@ -701,7 +696,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		},
 	})
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	h.agentChatLive.publishSession(updated)
@@ -871,7 +866,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		message.Activities = append(message.Activities, newChatActivity(status, status, finalChatActivityTitle(status), errorText))
 	})
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	if result.DriverKind != "" || result.NativeSessionID != "" || result.ConfigOptions != nil {
@@ -887,7 +882,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 			}
 		})
 		if err != nil {
-			WriteError(w, http.StatusInternalServerError, "gateway_error", err.Error())
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
 	}

--- a/internal/api/handler_model_capabilities.go
+++ b/internal/api/handler_model_capabilities.go
@@ -41,7 +41,7 @@ func (h *Handler) HandleDeleteModelCapabilityOverride(w http.ResponseWriter, r *
 		return
 	}
 	if err := h.controlPlane.DeleteModelCapabilityOverride(r.Context(), provider, model); err != nil {
-		WriteError(w, http.StatusNotFound, "not_found", err.Error())
+		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -322,7 +322,7 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 			slog.Any("error", err),
 		)
 		if errors.Is(err, orchestrator.ErrAgentLoopMisconfigured) {
-			WriteError(w, http.StatusUnprocessableEntity, "model_not_configured", err.Error())
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, err.Error())
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -86,7 +86,7 @@ func LoggingMiddleware(logger *slog.Logger) middleware {
 func SameOriginMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !sameOriginAllowed(r) {
-			WriteError(w, http.StatusForbidden, "forbidden", "cross-origin browser request rejected")
+			WriteError(w, http.StatusForbidden, errCodeForbidden, "cross-origin browser request rejected")
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -127,7 +127,7 @@ func RecoveryMiddleware(logger *slog.Logger) middleware {
 						slog.String("event.name", "http.server.panic"),
 						slog.String("exception.message", stringifyPanic(recovered)),
 					)
-					WriteError(w, http.StatusInternalServerError, "internal_error", "unexpected server error")
+					WriteError(w, http.StatusInternalServerError, errCodeInternalError, "unexpected server error")
 				}
 			}()
 

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -11,6 +11,7 @@ const (
 	errCodeInvalidRequest          = "invalid_request"
 	errCodeForbidden               = "forbidden"
 	errCodeGatewayError            = "gateway_error"
+	errCodeInternalError           = "internal_error"
 	errCodeUpstreamError           = "upstream_error"
 	errCodeNotFound                = "not_found"
 	errCodeConflict                = "conflict"


### PR DESCRIPTION
## Summary

The error-code constants in `internal/api/response.go` are the **wire contract** for the `error.type` field — operators pin dashboards and alerts on them. ~30 HTTP-handler callsites had drifted back to raw string literals (`"gateway_error"`, `"invalid_request"`, `"not_found"`, `"forbidden"`, `"internal_error"`, `"model_not_configured"`), so a typo in one was a wire bug the type checker couldn't catch.

This routes every callsite through the consts. **No wire-visible `error.type` value changes.**

```
6 files changed, 32 insertions(+), 36 deletions(-)
```

## What changes

- `internal/api/response.go`: add `errCodeInternalError = "internal_error"` (the only stable code that didn't have a const yet — used by the panic-recovery middleware).
- 28 `WriteError(...)` raw-string callsites swept to the matching const across `handler.go`, `handler_chat.go`, `handler_tasks.go`, `handler_model_capabilities.go`, `middleware.go`.
- 4 hand-rolled `json.NewDecoder(r.Body).Decode(&req)` blocks in `handler_chat.go` now use the package-local `decodeJSON` helper (`HandleCreateChatSession`, `HandleSetChatConfigOption`, `HandleSetChatSettings`, `HandleCreateChatMessage`). Unused `encoding/json` import dropped.
- The decoder error message standardizes on the helper's `"request body must be valid JSON"`; the previous `"invalid JSON body"` / `"invalid request body"` strings were not pinned by any test or doc. This shifts operator-facing prose on 4 endpoints' decode-failure path — not a stable contract.

## What stays hand-rolled

Two decoder blocks intentionally not consolidated:

- `handler_admin.go:408-412` — conditional on `r.Body != nil && r.ContentLength != 0` (allows fully empty body)
- `handler_chat_files.go:66` — accepts `io.EOF` (allows empty body)

The shared `decodeJSON` rejects both cases. Either we add a parameterized variant or these stay hand-rolled; this PR picks the latter to keep scope narrow.

## Acceptance

```sh
grep -rnE 'WriteError(Details)?\([^,]+,[^,]+,\s*"[a-z_.]+"' \
  internal/api/ --include='*.go' \
  | grep -v errCode
```
Returns zero hits.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — 1779 / 1779 pass across 36 packages

## Why `[skip desktop]`

No `ui/**` or `tauri/**` changes; pure Go-side cleanup under `internal/api/`.