### PR TITLE
refactor(ui): drop the model-chat transcript placeholder + duplicate spec [skip desktop]

### DIFF
--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -49,8 +49,3 @@ test("maintenance 'Clean up now' fires POST request", async ({ page }) => {
   await page.getByRole("button", { name: /Clean up now/i }).click();
   await expect.poll(() => posted).toBe(true);
 });
-
-test("Usage workspace shows the empty usage state", async ({ page }) => {
-  await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
-  await expect(page.locator("text=No cloud usage recorded yet")).toBeVisible();
-});

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -2,20 +2,8 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { useRuntimeConsoleContext } from "../../app/RuntimeConsoleContext";
 import { formatDurationMs } from "../../lib/format";
-import type { AgentAdapterRecord, ChatActivityRecord, ChatSegmentRecord, ChatTimingRecord, ChatUsageRecord, ConfiguredProviderRecord, ProviderRecord } from "../../types/runtime";
-
-// Placeholder shape kept for the produced_by_call_id lookup in the transcript.
-// The legacy /chat/sessions data path used to populate this map with rich
-// per-call records; agent-chat messages don't, so callers pass an empty map.
-type LegacyProviderCallInfo = {
-  request_id?: string;
-  provider?: string;
-  model?: string;
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  cost_usd?: string;
-};
-import { BrandAvatar, CodeBlock, Icon, Icons } from "../shared/ui";
+import type { ChatActivityRecord, ChatSegmentRecord, ChatTimingRecord, ChatUsageRecord } from "../../types/runtime";
+import { CodeBlock, Icon, Icons } from "../shared/ui";
 import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
 
 import { compactID } from "./ChatComposer";
@@ -55,21 +43,13 @@ export type TranscriptItem =
 
 type Props = {
   // Active chat shape (derived in ChatView and threaded through here).
-  isAgentChat: boolean;
   isHecateAgentChat: boolean;
   activeSessionID: string;
 
-  // Transcript content + provider-call lookup.
+  // Transcript content.
   transcriptItems: TranscriptItem[];
-  callsByID: Map<string, LegacyProviderCallInfo>;
   visibleMessageCount: number;
   streaming: boolean;
-
-  // Streaming-pane branding (read in the model-chat path).
-  selectedAgent?: AgentAdapterRecord;
-  selectedConfiguredProvider?: ConfiguredProviderRecord;
-  selectedRuntimeProvider?: ProviderRecord;
-  hecateChatModelValue: string;
 
   // Pre-rendered empty state. ChatView builds the <ChatEmptyState> with
   // its derived props bag; transcript just slots it in below the
@@ -85,17 +65,11 @@ type Props = {
 };
 
 export function ChatTranscript({
-  isAgentChat,
   isHecateAgentChat,
   activeSessionID,
   transcriptItems,
-  callsByID,
   visibleMessageCount,
   streaming,
-  selectedAgent,
-  selectedConfiguredProvider,
-  selectedRuntimeProvider,
-  hecateChatModelValue,
   emptyState,
   onNavigate,
   onOpenTask,
@@ -156,33 +130,29 @@ export function ChatTranscript({
             return <ChatSegmentDivider key={item.key} segment={item.segment} />;
           }
           const m = item.message;
-          const call = m.produced_by_call_id ? callsByID.get(m.produced_by_call_id) : undefined;
           const role = m.role === "assistant" ? "assistant" : "user";
           const content = typeof m.content === "string" ? m.content : (m.content === null ? "" : JSON.stringify(m.content));
           const time = m.created_at ? new Date(m.created_at).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" }) : "";
           const agentModel = isHecateAgentChat
             ? (m.model || state.activeChatSession?.model || "Hecate Agent")
             : (m.agent_adapter_name || m.agent_adapter_id);
-          const agentRuntime = isAgentChat && role === "assistant"
+          const agentRuntime = role === "assistant"
             ? formatAgentRuntimeMeta(m.run_id, m.duration_ms, m.native_session_id)
             : "";
           const taskID = m.runtime_kind === "agent" ? m.task_id : "";
           const taskRunID = taskID ? m.run_id : "";
-          const traceRequestID = isAgentChat ? m.request_id : call?.request_id;
-          const traceID = isAgentChat ? m.trace_id : undefined;
+          const traceRequestID = m.request_id;
+          const traceID = m.trace_id;
           return (
             <TranscriptMessageRow
               key={item.key}
               id={m.id}
               role={role}
-              model={isAgentChat ? agentModel : call?.model}
-              brand={messageBrand(m, call?.provider, isAgentChat, isHecateAgentChat)}
+              model={agentModel}
+              brand={messageBrand(m, isHecateAgentChat)}
               content={content}
               time={time}
-              promptTokens={call?.prompt_tokens}
-              completionTokens={call?.completion_tokens}
-              costUsd={call?.cost_usd}
-              badge={isAgentChat && role === "assistant" ? (m.agent_status || m.cost_mode) : undefined}
+              badge={role === "assistant" ? (m.agent_status || m.cost_mode) : undefined}
               runtimeMeta={agentRuntime}
               taskLink={isHecateAgentChat && role === "assistant" && taskID
                 ? {
@@ -205,17 +175,17 @@ export function ChatTranscript({
                     },
                   }
                 : undefined}
-              activities={isAgentChat && role === "assistant" ? m.activities : undefined}
-              diffStat={isAgentChat && role === "assistant" ? m.diff_stat : undefined}
-              diff={isAgentChat && role === "assistant" ? m.diff : undefined}
-              agentSessionID={isAgentChat ? state.activeChatSessionID : ""}
+              activities={role === "assistant" ? m.activities : undefined}
+              diffStat={role === "assistant" ? m.diff_stat : undefined}
+              diff={role === "assistant" ? m.diff : undefined}
+              agentSessionID={state.activeChatSessionID}
               onListAgentFiles={actions.listChatMessageFiles}
               onGetAgentFileDiff={actions.getChatMessageFileDiff}
               onRevertAgentFiles={actions.revertChatMessageFiles}
-              rawOutput={isAgentChat && role === "assistant" ? m.raw_output : undefined}
-              agentUsage={isAgentChat && role === "assistant" ? m.usage : undefined}
-              agentTiming={isAgentChat && role === "assistant" ? m.timing : undefined}
-              error={isAgentChat && role === "assistant" ? m.error : undefined}
+              rawOutput={role === "assistant" ? m.raw_output : undefined}
+              agentUsage={role === "assistant" ? m.usage : undefined}
+              agentTiming={role === "assistant" ? m.timing : undefined}
+              error={role === "assistant" ? m.error : undefined}
               setupAction={
                 // Render the "Open Claude Code setup" button only
                 // when the server-side message carries the
@@ -225,7 +195,7 @@ export function ChatTranscript({
                 // time; the token itself is stable contract between
                 // internal/agentadapters/auth_status.go and this UI
                 // handler.
-                isAgentChat && role === "assistant" && m.agent_adapter_id === "claude_code"
+                role === "assistant" && m.agent_adapter_id === "claude_code"
                   && typeof m.error === "string" && m.error.includes("claude_code_auth_required")
                     ? {
                       label: "Open Claude Code setup",
@@ -240,32 +210,6 @@ export function ChatTranscript({
           );
         })}
 
-        {/* Streaming */}
-        {!isAgentChat && streaming && state.streamingContent !== null && (
-          <div style={{ padding: "4px 16px 16px", maxWidth: 820, margin: "0 auto", width: "100%" }}>
-            <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
-              <BrandAvatar
-                brand={isAgentChat ? selectedAgent?.id : (selectedConfiguredProvider?.id || selectedRuntimeProvider?.name || hecateChatModelValue)}
-                fallback={isAgentChat ? selectedAgent?.name : state.model}
-                size={28}
-                style={{ marginTop: 2 }}
-              />
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--teal)" }}>
-                    {isAgentChat ? (selectedAgent?.name || state.agentAdapterID || "agent") : (state.model || "hecate")}
-                  </span>
-                  <span className="badge badge-teal" style={{ animation: "pulse 1s ease-in-out infinite", fontSize: 10 }}>
-                    {isAgentChat ? "running" : "streaming"}
-                  </span>
-                </div>
-                <p style={{ fontSize: 13, color: "var(--t0)", lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
-                  {state.streamingContent}<span className="cursor-blink">▋</span>
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
 
         {/* Pending tool calls */}
         {state.pendingToolCalls.length > 0 && (
@@ -464,14 +408,11 @@ function describeChatSegment(segment: ChatSegmentRecord): { kicker: string; titl
 
 function messageBrand(
   message: VisibleChatMessage,
-  provider: string | undefined,
-  isAgentChat: boolean,
   isHecateAgentChat: boolean,
 ): string | undefined {
-  if (!isAgentChat) return provider || message.model;
   if (message.agent_adapter_id) return message.agent_adapter_id;
   if (message.agent_adapter_name) return message.agent_adapter_name;
-  if (isHecateAgentChat) return provider || message.provider || message.model || "hecate";
+  if (isHecateAgentChat) return message.provider || message.model || "hecate";
   return message.provider || message.model;
 }
 

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -108,10 +108,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const pendingTaskApprovals = isHecateChat
     ? pendingHecateTaskApprovals(state.activeChatSession)
     : [];
-  // Empty for now — agent-chat assistant rows don't carry the
-  // provider-call ID; the lookup map keeps the transcript-row prop
-  // surface unchanged for future use.
-  const callsByID = new Map<string, never>();
   // Hide system messages and any assistant placeholder that is still
   // waiting for content — the streaming-content block below renders
   // the live text instead.
@@ -578,17 +574,11 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
         )}
 
         <ChatTranscript
-          isAgentChat={isAgentChat}
           isHecateAgentChat={isHecateAgentChat}
           activeSessionID={activeSessionID}
           transcriptItems={transcriptItems}
-          callsByID={callsByID}
           visibleMessageCount={visibleMessages.length}
           streaming={streaming}
-          selectedAgent={selectedAgent}
-          selectedConfiguredProvider={selectedConfiguredProvider}
-          selectedRuntimeProvider={selectedRuntimeProvider}
-          hecateChatModelValue={hecateChatModelValue}
           onNavigate={onNavigate}
           onOpenTask={onOpenTask}
           onOpenTrace={onOpenTrace}


### PR DESCRIPTION
## Summary

Two loose ends that surfaced during the model-chat backend removal but were too small to land alongside the deletion. Both deletions, no behavior change.

```
3 files changed, 19 insertions(+), 93 deletions(-)
```

## What changes

`ChatTranscript` still carried two relics from the legacy model-chat data path that lost its callsite when `/chat/sessions` REST went away:

1. **`callsByID: Map<string, LegacyProviderCallInfo>`** — every caller passed an empty map; every `call?.x` consumer evaluated to undefined. The whole `produced_by_call_id` lookup was dead.
2. **`isAgentChat: boolean`** — derived in `ChatView` as `isHecateChat || chatTarget === "external_agent"`, which today always reduces to true (the runtime_kind enum has no "no chat" value). Every `isAgentChat && X` ternary always took the X branch; the `!isAgentChat` streaming pane never rendered.

Removed:
- `LegacyProviderCallInfo` type and the `callsByID` prop on `ChatTranscript`.
- `isAgentChat` prop on `ChatTranscript`; the now-unconditional branches inlined.
- The `!isAgentChat`-only streaming pane (~25 lines of JSX) and its branding/model props (`selectedAgent`, `selectedConfiguredProvider`, `selectedRuntimeProvider`, `hecateChatModelValue`) + the `BrandAvatar` import they used.
- The `messageBrand(message, provider, isAgentChat, isHecateAgentChat)` signature drops both `provider` (always undefined from the dead call lookup) and `isAgentChat` (always true).
- The empty `callsByID = new Map<string, never>()` setup in `ChatView` and the prop pass it fed.

Also drops one duplicate e2e test:
- `ui/e2e/settings.spec.ts` had `"Usage workspace shows the empty usage state"` — this test moved out to `ui/e2e/usage.spec.ts` in [#131](https://github.com/hecatehq/hecate/pull/131); the duplicate stuck around as an unstaged-file mistake.

## What stays

`TranscriptMessageRow`'s `promptTokens` / `completionTokens` / `costUsd` props stay on the component — its own tests still exercise them, and they remain part of the row's public contract if a future caller has the data.

## Test plan

- [x] `cd ui && bun run typecheck` — clean (`tsgo -b`)
- [x] `cd ui && bunx vitest run` — 939 / 939 pass (40 files)
- [x] `cd ui && bun run test:e2e` — 60 / 60 pass (was 61, the duplicate is gone)

## Why `[skip desktop]`

Pure TSX cleanup under `ui/src/features/chats/` + a one-test deletion in `ui/e2e/`. No `tauri/**` or `desktop_force` paths touched.