### PR TITLE
refactor(providers): centralize protocol dispatch in one table [skip desktop]

### DIFF
--- a/internal/providers/protocol_dispatch.go
+++ b/internal/providers/protocol_dispatch.go
@@ -1,0 +1,60 @@
+package providers
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/hecate/agent-runtime/internal/config"
+)
+
+// protocolDispatch describes one inbound-protocol family the gateway can
+// instantiate. It centralizes the per-protocol facts that callers used
+// to discover via scattered `Protocol == "anthropic"` checks:
+//
+//   - Constructor — how to build a Provider for this protocol.
+//   - SupportsAnthropicCache — whether the gateway-wide Anthropic prompt
+//     cache toggle (config.Providers.AnthropicCacheDisabled) is
+//     meaningful for instances on this protocol. Only the Anthropic
+//     adapter respects the flag today; OpenAI-compatible providers
+//     ignore it because the upstream has no equivalent knob.
+//
+// Add a third protocol by registering one entry below. The two original
+// dispatch sites (buildProviders constructor switch and the cache-marker
+// gating in hydrateMutableProviders) now read from this table instead of
+// inline string compares.
+type protocolDispatch struct {
+	Constructor            func(config.OpenAICompatibleProviderConfig, *slog.Logger) Provider
+	SupportsAnthropicCache bool
+}
+
+// protocolDispatchByName maps the canonical (lowercase, trimmed)
+// protocol value to its dispatch entry. Unknown protocols fall back to
+// the OpenAI-compatible adapter via lookupProtocolDispatch — keeping
+// the same default semantics buildProviders had before the table.
+var protocolDispatchByName = map[string]protocolDispatch{
+	"anthropic": {
+		Constructor: func(cfg config.OpenAICompatibleProviderConfig, logger *slog.Logger) Provider {
+			return NewAnthropicProvider(cfg, logger)
+		},
+		SupportsAnthropicCache: true,
+	},
+	"openai": {
+		Constructor: func(cfg config.OpenAICompatibleProviderConfig, logger *slog.Logger) Provider {
+			return NewOpenAICompatibleProvider(cfg, logger)
+		},
+		SupportsAnthropicCache: false,
+	},
+}
+
+// lookupProtocolDispatch returns the dispatch entry for the given
+// protocol string (case-insensitive, whitespace tolerant). Unknown
+// protocols default to the OpenAI-compatible entry; the boolean
+// signals whether the protocol was explicitly registered (vs. falling
+// through to default).
+func lookupProtocolDispatch(protocol string) (protocolDispatch, bool) {
+	key := strings.ToLower(strings.TrimSpace(protocol))
+	if entry, ok := protocolDispatchByName[key]; ok {
+		return entry, true
+	}
+	return protocolDispatchByName["openai"], false
+}

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -220,15 +220,14 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 			Enabled:      true,
 		}
 		// Apply the gateway-wide Anthropic cache toggle to any
-		// Anthropic-protocol provider, regardless of whether it has
-		// a matching env-derived base config. The flag is global by
+		// provider whose protocol respects it. The flag is global by
 		// design (the AnthropicProvider's caching behavior is the
 		// same conceptual knob whether the operator added the
 		// provider via env or via the Providers tab); inheriting it
 		// only via name-match left CP-only Anthropic providers stuck
 		// at the default. SetGlobalAnthropicCacheDisabled is the
 		// single source of truth.
-		if strings.EqualFold(cfg.Protocol, "anthropic") {
+		if entry, _ := lookupProtocolDispatch(cfg.Protocol); entry.SupportsAnthropicCache {
 			cfg.AnthropicCacheDisabled = m.anthropicCacheDisabled
 		}
 		if builtIn, ok := builtInForControlPlaneProvider(item); ok {
@@ -382,12 +381,8 @@ func buildProviders(configs []config.OpenAICompatibleProviderConfig, logger *slo
 			logger.Warn("skipping provider with empty name")
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(providerCfg.Protocol)) {
-		case "anthropic":
-			items = append(items, NewAnthropicProvider(providerCfg, logger))
-		default:
-			items = append(items, NewOpenAICompatibleProvider(providerCfg, logger))
-		}
+		entry, _ := lookupProtocolDispatch(providerCfg.Protocol)
+		items = append(items, entry.Constructor(providerCfg, logger))
 	}
 	return items
 }


### PR DESCRIPTION
## Summary

Two sites in `internal/providers/runtime_manager.go` branched on the provider protocol via inline string compares:

- **line 231**: gated the gateway-wide `AnthropicCacheDisabled` toggle on `strings.EqualFold(cfg.Protocol, \"anthropic\")`.
- **lines 385-390**: a `switch strings.ToLower(strings.TrimSpace(providerCfg.Protocol))` chose the Provider constructor (Anthropic vs. default OpenAI-compatible).

Adding a third protocol meant editing both — and drift between the constructor switch and the cache-gating check was a latent bug. Move the per-protocol facts to one table.

```
2 files changed, 64 insertions(+), 9 deletions(-)
```

## New: `internal/providers/protocol_dispatch.go`

```go
type protocolDispatch struct {
    Constructor            func(cfg, logger) Provider
    SupportsAnthropicCache bool
}

var protocolDispatchByName = map[string]protocolDispatch{
    "anthropic": { Constructor: ..., SupportsAnthropicCache: true },
    "openai":    { Constructor: ..., SupportsAnthropicCache: false },
}

// Unknown protocols fall back to the OpenAI-compatible entry,
// preserving buildProviders' prior default semantics. The bool
// signals whether the protocol was explicitly registered.
func lookupProtocolDispatch(protocol string) (protocolDispatch, bool)
```

## Edit: `runtime_manager.go`

- `buildProviders`' switch becomes one lookup + `entry.Constructor(...)` call.
- The cache-marker gating becomes `entry.SupportsAnthropicCache`, so it can't drift from the constructor's actual capability.

A third protocol (Google, Bedrock, etc.) now registers one entry in the dispatch map; both sites pick it up automatically.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `go test ./... -race -count=1` — 1779 / 1779 pass across 36 packages

## Why `[skip desktop]`

Pure Go-side refactor under `internal/providers/`. No `ui/**` or `tauri/**` changes.