### PR TITLE
refactor(retention): collapse Pruner adapters into one interface [skip desktop]

### DIFF
--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -546,13 +546,12 @@ func pruneableProviderHistory(store providers.HealthHistoryStore) retention.Prun
 	return pruner
 }
 
-// approvalRetentionPruner exposes the ChatApprovalPruner surface
-// when the configured approval store implements it. Memory and SQLite
-// both do; tests that swap in a stub may not — returning nil is
-// harmless because the retention worker skips subsystems with a nil
-// pruner.
-func approvalRetentionPruner(store agentadapters.ApprovalStore) retention.ChatApprovalPruner {
-	pruner, _ := store.(retention.ChatApprovalPruner)
+// approvalRetentionPruner exposes the Pruner surface when the
+// configured approval store implements it. Memory and SQLite both do;
+// tests that swap in a stub may not — returning nil is harmless
+// because the retention worker skips subsystems with a nil pruner.
+func approvalRetentionPruner(store agentadapters.ApprovalStore) retention.Pruner {
+	pruner, _ := store.(retention.Pruner)
 	return pruner
 }
 

--- a/internal/agentadapters/approvals.go
+++ b/internal/agentadapters/approvals.go
@@ -216,6 +216,29 @@ type ApprovalRetentionStore interface {
 	// this at startup before serving requests. Returns rows
 	// reconciled.
 	ReconcilePending(ctx context.Context, now time.Time) (int64, error)
+
+	// Prune implements retention.Pruner — one call that runs both
+	// the resolved-approval sweep (subject to maxAge / maxCount)
+	// and the expired-grant sweep (grants honor only ExpiresAt;
+	// maxAge / maxCount don't apply). Returns the sum so operators
+	// see total rows removed by this subsystem in one number.
+	// Captures `now := time.Now().UTC()` internally; the
+	// per-deletion `now`-tolerant methods stay on the interface for
+	// tests and ad-hoc callers.
+	Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
+}
+
+func pruneApprovalsAndGrants(ctx context.Context, store ApprovalRetentionStore, maxAge time.Duration, maxCount int) (int, error) {
+	now := time.Now().UTC()
+	approvals, err := store.PruneApprovals(ctx, now, maxAge, maxCount)
+	if err != nil {
+		return int(approvals), err
+	}
+	grants, err := store.PruneExpiredGrants(ctx, now)
+	if err != nil {
+		return int(approvals + grants), err
+	}
+	return int(approvals + grants), nil
 }
 
 // ErrApprovalNotFound is returned by ApprovalStore.GetApproval and

--- a/internal/agentadapters/approvals_memory.go
+++ b/internal/agentadapters/approvals_memory.go
@@ -261,6 +261,12 @@ func (s *MemoryApprovalStore) PruneExpiredGrants(_ context.Context, now time.Tim
 	return deleted, nil
 }
 
+// Prune implements retention.Pruner. See ApprovalRetentionStore.Prune
+// for the contract.
+func (s *MemoryApprovalStore) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
+	return pruneApprovalsAndGrants(ctx, s, maxAge, maxCount)
+}
+
 // ReconcilePending sweeps pending rows and marks them timed_out
 // with path=startup_reconcile. The memory backend never has rows
 // surviving a restart in practice (the map is process-local), but

--- a/internal/agentadapters/approvals_sqlite.go
+++ b/internal/agentadapters/approvals_sqlite.go
@@ -356,6 +356,12 @@ func (s *SQLiteApprovalStore) DeleteGrant(ctx context.Context, id string) error 
 	return nil
 }
 
+// Prune implements retention.Pruner. See ApprovalRetentionStore.Prune
+// for the contract.
+func (s *SQLiteApprovalStore) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
+	return pruneApprovalsAndGrants(ctx, s, maxAge, maxCount)
+}
+
 // PruneExpiredGrants removes grants whose ExpiresAt is in the past.
 // Returns the number deleted. Called by the retention worker. Live
 // grants (no expiry, or expiry in the future) are never touched.

--- a/internal/controlplane/helpers_test.go
+++ b/internal/controlplane/helpers_test.go
@@ -126,7 +126,7 @@ func TestNewAuditEventPopulatesFieldsAndTimestamp(t *testing.T) {
 	}
 }
 
-func TestPruneAuditEventsByMaxAge(t *testing.T) {
+func TestPruneByMaxAge(t *testing.T) {
 	now := time.Now()
 	state := &State{
 		Events: []AuditEvent{
@@ -150,7 +150,7 @@ func TestPruneAuditEventsByMaxAge(t *testing.T) {
 	}
 }
 
-func TestPruneAuditEventsByMaxCount(t *testing.T) {
+func TestPruneByMaxCount(t *testing.T) {
 	now := time.Now()
 	state := &State{
 		Events: []AuditEvent{
@@ -173,7 +173,7 @@ func TestPruneAuditEventsByMaxCount(t *testing.T) {
 	}
 }
 
-func TestPruneAuditEventsHandlesNilState(t *testing.T) {
+func TestPruneHandlesNilState(t *testing.T) {
 	if got := pruneAuditEvents(nil, time.Hour, 10); got != 0 {
 		t.Errorf("pruneAuditEvents(nil) = %d, want 0", got)
 	}

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -98,7 +98,7 @@ type Store interface {
 	UpsertModelCapabilityOverride(ctx context.Context, record ModelCapabilityRecord) (ModelCapabilityRecord, error)
 	DeleteModelCapabilityOverride(ctx context.Context, provider, model string) error
 	UpsertModelCapabilityProbe(ctx context.Context, record ModelCapabilityRecord) (ModelCapabilityRecord, error)
-	PruneAuditEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
+	Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
 }
 
 type actorContextKey struct{}

--- a/internal/controlplane/store_memory.go
+++ b/internal/controlplane/store_memory.go
@@ -114,7 +114,7 @@ func (s *MemoryStore) UpsertModelCapabilityProbe(ctx context.Context, record Mod
 	return applyModelCapabilityProbe(ctx, &s.data, record)
 }
 
-func (s *MemoryStore) PruneAuditEvents(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *MemoryStore) Prune(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return pruneAuditEvents(&s.data, maxAge, maxCount), nil

--- a/internal/controlplane/store_memory_test.go
+++ b/internal/controlplane/store_memory_test.go
@@ -64,7 +64,7 @@ func TestMemoryStore_ModelCapabilityLifecycle(t *testing.T) {
 	runStoreModelCapabilityLifecycle(t, NewMemoryStore())
 }
 
-func TestMemoryStore_PruneAuditEvents(t *testing.T) {
+func TestMemoryStore_Prune(t *testing.T) {
 	t.Parallel()
 	store := NewMemoryStore()
 	ctx := context.Background()
@@ -83,7 +83,7 @@ func TestMemoryStore_PruneAuditEvents(t *testing.T) {
 	}
 
 	// Prune to keep only most recent 1.
-	deleted, err := store.PruneAuditEvents(ctx, 0, 1)
+	deleted, err := store.Prune(ctx, 0, 1)
 	if err != nil {
 		t.Fatalf("Prune: %v", err)
 	}

--- a/internal/controlplane/store_sqlite.go
+++ b/internal/controlplane/store_sqlite.go
@@ -257,7 +257,7 @@ func (s *SQLiteStore) UpsertModelCapabilityProbe(ctx context.Context, record Mod
 	return record, nil
 }
 
-func (s *SQLiteStore) PruneAuditEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *SQLiteStore) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/governor/usage.go
+++ b/internal/governor/usage.go
@@ -50,7 +50,7 @@ type UsageEventStore interface {
 	AppendEvent(ctx context.Context, event UsageHistoryEvent) error
 	ListEvents(ctx context.Context, key string, limit int) ([]UsageHistoryEvent, error)
 	ListRecentEvents(ctx context.Context, limit int) ([]UsageHistoryEvent, error)
-	PruneEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
+	Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
 }
 
 type UsageRepository interface {
@@ -139,7 +139,7 @@ func (s *MemoryUsageStore) ListRecentEvents(_ context.Context, limit int) ([]Usa
 	return append([]UsageHistoryEvent(nil), all[:limit]...), nil
 }
 
-func (s *MemoryUsageStore) PruneEvents(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *MemoryUsageStore) Prune(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/governor/usage_sqlite.go
+++ b/internal/governor/usage_sqlite.go
@@ -251,7 +251,7 @@ func (s *SQLiteUsageStore) ListRecentEvents(ctx context.Context, limit int) ([]U
 	return events, nil
 }
 
-func (s *SQLiteUsageStore) PruneEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *SQLiteUsageStore) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	deleted := int64(0)
 
 	if maxAge > 0 {

--- a/internal/governor/usage_sqlite_test.go
+++ b/internal/governor/usage_sqlite_test.go
@@ -173,7 +173,7 @@ func TestSQLiteUsageStore_AppendEventEmptyKeyNoOp(t *testing.T) {
 	}
 }
 
-func TestSQLiteUsageStore_PruneEvents(t *testing.T) {
+func TestSQLiteUsageStore_Prune(t *testing.T) {
 	t.Parallel()
 	store := newSQLiteUsageTestStore(t)
 	ctx := context.Background()
@@ -187,9 +187,9 @@ func TestSQLiteUsageStore_PruneEvents(t *testing.T) {
 		t.Fatalf("AppendEvent(fresh): %v", err)
 	}
 
-	deleted, err := store.PruneEvents(ctx, 30*time.Minute, 0)
+	deleted, err := store.Prune(ctx, 30*time.Minute, 0)
 	if err != nil {
-		t.Fatalf("PruneEvents by age: %v", err)
+		t.Fatalf("Prune by age: %v", err)
 	}
 	if deleted != 1 {
 		t.Fatalf("age deleted = %d, want 1", deleted)
@@ -206,9 +206,9 @@ func TestSQLiteUsageStore_PruneEvents(t *testing.T) {
 		}
 	}
 
-	deleted, err = store.PruneEvents(ctx, 0, 3)
+	deleted, err = store.Prune(ctx, 0, 3)
 	if err != nil {
-		t.Fatalf("PruneEvents by count: %v", err)
+		t.Fatalf("Prune by count: %v", err)
 	}
 	if deleted != 8 {
 		t.Fatalf("count deleted = %d, want 8", deleted)

--- a/internal/governor/usage_test.go
+++ b/internal/governor/usage_test.go
@@ -94,7 +94,7 @@ func TestMemoryUsageStore_AppendAndListEvents(t *testing.T) {
 	}
 }
 
-func TestMemoryUsageStore_PruneEvents(t *testing.T) {
+func TestMemoryUsageStore_Prune(t *testing.T) {
 	t.Parallel()
 	store := NewMemoryUsageStore()
 	ctx := context.Background()
@@ -103,9 +103,9 @@ func TestMemoryUsageStore_PruneEvents(t *testing.T) {
 	fresh := time.Now()
 	_ = store.AppendEvent(ctx, UsageHistoryEvent{Key: "k", OccurredAt: old})
 	_ = store.AppendEvent(ctx, UsageHistoryEvent{Key: "k", OccurredAt: fresh})
-	deleted, err := store.PruneEvents(ctx, 30*time.Minute, 0)
+	deleted, err := store.Prune(ctx, 30*time.Minute, 0)
 	if err != nil {
-		t.Fatalf("PruneEvents by age: %v", err)
+		t.Fatalf("Prune by age: %v", err)
 	}
 	if deleted != 1 {
 		t.Fatalf("age deleted = %d, want 1", deleted)
@@ -114,9 +114,9 @@ func TestMemoryUsageStore_PruneEvents(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		_ = store.AppendEvent(ctx, UsageHistoryEvent{Key: "k", OccurredAt: time.Now().Add(time.Duration(i) * time.Second)})
 	}
-	deleted, err = store.PruneEvents(ctx, 0, 3)
+	deleted, err = store.Prune(ctx, 0, 3)
 	if err != nil {
-		t.Fatalf("PruneEvents by count: %v", err)
+		t.Fatalf("Prune by count: %v", err)
 	}
 	if deleted != 8 {
 		t.Fatalf("count deleted = %d, want 8", deleted)

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -26,75 +26,14 @@ const (
 	SubsystemChatApprovals = "chat_approvals"
 )
 
-// Pruner prunes old or excess records from a subsystem store.
+// Pruner prunes old or excess records from a subsystem store. Each
+// subsystem store implements this directly; the retention worker
+// holds a flat []Pruner keyed by subsystem name, without per-store
+// adapter shims. The approval store handles the (now, approvals +
+// grants) pair internally via the helper in internal/agentadapters
+// — see ApprovalRetentionStore.Prune for the contract.
 type Pruner interface {
 	Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
-}
-
-// UsageEventPruner is implemented by usage stores that support event pruning.
-type UsageEventPruner interface {
-	PruneEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
-}
-
-// AuditEventPruner is implemented by control-plane stores that support audit pruning.
-type AuditEventPruner interface {
-	PruneAuditEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
-}
-
-// TurnEventPruner is implemented by task-state stores that support
-// pruning `turn.completed` rows from the run-events table.
-// Other event types are not touched.
-type TurnEventPruner interface {
-	PruneTurnEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
-}
-
-// ChatApprovalPruner is implemented by approval stores that
-// support pruning resolved external-adapter approvals + expired
-// grants. Pending rows are never pruned. Grants ignore maxAge /
-// maxCount; only their own ExpiresAt drives deletion.
-type ChatApprovalPruner interface {
-	PruneApprovals(ctx context.Context, now time.Time, maxAge time.Duration, maxCount int) (int64, error)
-	PruneExpiredGrants(ctx context.Context, now time.Time) (int64, error)
-}
-
-type usagePrunerAdapter struct{ p UsageEventPruner }
-
-func (a usagePrunerAdapter) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
-	return a.p.PruneEvents(ctx, maxAge, maxCount)
-}
-
-type auditPrunerAdapter struct{ p AuditEventPruner }
-
-func (a auditPrunerAdapter) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
-	return a.p.PruneAuditEvents(ctx, maxAge, maxCount)
-}
-
-type turnEventPrunerAdapter struct{ p TurnEventPruner }
-
-func (a turnEventPrunerAdapter) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
-	return a.p.PruneTurnEvents(ctx, maxAge, maxCount)
-}
-
-// agentChatApprovalPrunerAdapter wraps an ChatApprovalPruner so
-// the retention worker can call Prune(maxAge, maxCount) uniformly.
-// One pass deletes resolved approvals (subject to maxAge / maxCount)
-// then deletes expired grants (independent of maxAge / maxCount —
-// grants honor only their own ExpiresAt, never the retention window).
-// Both deletion counts are summed in the returned `deleted` total so
-// operators see total rows removed by this subsystem in one number.
-type agentChatApprovalPrunerAdapter struct{ p ChatApprovalPruner }
-
-func (a agentChatApprovalPrunerAdapter) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
-	now := time.Now().UTC()
-	approvals, err := a.p.PruneApprovals(ctx, now, maxAge, maxCount)
-	if err != nil {
-		return int(approvals), err
-	}
-	grants, err := a.p.PruneExpiredGrants(ctx, now)
-	if err != nil {
-		return int(approvals + grants), err
-	}
-	return int(approvals + grants), nil
 }
 
 type subsystemEntry struct {
@@ -139,40 +78,24 @@ func NewManager(
 	cfg config.RetentionConfig,
 	tracer profiler.Tracer,
 	traces Pruner,
-	usage UsageEventPruner,
-	audit AuditEventPruner,
+	usage Pruner,
+	audit Pruner,
 	providerHistory Pruner,
-	turnEvents TurnEventPruner,
-	approvals ChatApprovalPruner,
+	turnEvents Pruner,
+	approvals Pruner,
 	history HistoryStore,
 ) *Manager {
-	var usagePruner Pruner
-	if usage != nil {
-		usagePruner = usagePrunerAdapter{usage}
-	}
-	var auditPruner Pruner
-	if audit != nil {
-		auditPruner = auditPrunerAdapter{audit}
-	}
-	var turnEventsPruner Pruner
-	if turnEvents != nil {
-		turnEventsPruner = turnEventPrunerAdapter{turnEvents}
-	}
-	var approvalsPruner Pruner
-	if approvals != nil {
-		approvalsPruner = agentChatApprovalPrunerAdapter{approvals}
-	}
 	return &Manager{
 		logger: logger,
 		cfg:    cfg,
 		tracer: tracer,
 		subsystems: []subsystemEntry{
 			{SubsystemTraces, cfg.TraceSnapshots, traces},
-			{SubsystemUsageEvents, cfg.UsageEvents, usagePruner},
-			{SubsystemAuditEvents, cfg.AuditEvents, auditPruner},
+			{SubsystemUsageEvents, cfg.UsageEvents, usage},
+			{SubsystemAuditEvents, cfg.AuditEvents, audit},
 			{SubsystemProviderHistory, cfg.ProviderHistory, providerHistory},
-			{SubsystemTurnEvents, cfg.TurnEvents, turnEventsPruner},
-			{SubsystemChatApprovals, cfg.ChatApprovals, approvalsPruner},
+			{SubsystemTurnEvents, cfg.TurnEvents, turnEvents},
+			{SubsystemChatApprovals, cfg.ChatApprovals, approvals},
 		},
 		history: history,
 	}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -13,19 +13,19 @@ import (
 
 type fakeUsagePruner struct{ deleted int }
 
-func (f fakeUsagePruner) PruneEvents(context.Context, time.Duration, int) (int, error) {
+func (f fakeUsagePruner) Prune(context.Context, time.Duration, int) (int, error) {
 	return f.deleted, nil
 }
 
 type fakeAuditPruner struct{ deleted int }
 
-func (f fakeAuditPruner) PruneAuditEvents(context.Context, time.Duration, int) (int, error) {
+func (f fakeAuditPruner) Prune(context.Context, time.Duration, int) (int, error) {
 	return f.deleted, nil
 }
 
 type fakeTurnEventPruner struct{ deleted int }
 
-func (f fakeTurnEventPruner) PruneTurnEvents(context.Context, time.Duration, int) (int, error) {
+func (f fakeTurnEventPruner) Prune(context.Context, time.Duration, int) (int, error) {
 	return f.deleted, nil
 }
 

--- a/internal/retention/turn_events_integration_test.go
+++ b/internal/retention/turn_events_integration_test.go
@@ -136,7 +136,7 @@ func TestManagerSweepsRealTurnEventsButSparesOtherTypes(t *testing.T) {
 // TestManagerCountCapDoesNotAffectNonTurnEvents pins down the
 // count-cap branch's scope: even when MaxCount is exceeded by
 // non-turn events present in the same store, only turn events
-// should be pruned. The PruneTurnEvents implementations take the
+// should be pruned. The Prune implementations take the
 // count over turn.completed rows specifically — but a
 // regression that counted across all event types would silently
 // delete operator-visible run.* events, which is the worst kind

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -502,7 +502,7 @@ func (s *MemoryStore) ListEvents(_ context.Context, filter EventFilter) ([]types
 	return result, nil
 }
 
-// PruneTurnEvents removes `turn.completed` rows older than
+// Prune removes `turn.completed` rows older than
 // maxAge or, if maxCount > 0, beyond the most recent maxCount rows
 // (counted globally across all runs). Returns the number of rows
 // removed. Other event types are preserved.
@@ -510,7 +510,7 @@ func (s *MemoryStore) ListEvents(_ context.Context, filter EventFilter) ([]types
 // Both bounds are evaluated additively — i.e. a row is dropped if it
 // fails *either* the age check (when maxAge > 0) or the count check
 // (when maxCount > 0). With both zero, this is a no-op.
-func (s *MemoryStore) PruneTurnEvents(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *MemoryStore) Prune(_ context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/taskstate/prune_turn_events_test.go
+++ b/internal/taskstate/prune_turn_events_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
-// TestPruneTurnEvents_AgeAndCount exercises the retention sweep
+// TestPrune_AgeAndCount exercises the retention sweep
 // against every Store implementation that ships in this binary
 // (memory + sqlite). Each backend should:
 //
@@ -19,7 +19,7 @@ import (
 //
 // The age path is verified by injecting a stale CreatedAt directly;
 // the count path uses real append order.
-func TestPruneTurnEvents_AgeAndCount(t *testing.T) {
+func TestPrune_AgeAndCount(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -70,9 +70,9 @@ func TestPruneTurnEvents_AgeAndCount(t *testing.T) {
 			}
 
 			// Sweep with 1h cutoff (no count cap).
-			n, err := store.PruneTurnEvents(ctx, time.Hour, 0)
+			n, err := store.Prune(ctx, time.Hour, 0)
 			if err != nil {
-				t.Fatalf("PruneTurnEvents(age): %v", err)
+				t.Fatalf("Prune(age): %v", err)
 			}
 			if n != 1 {
 				t.Fatalf("age sweep deleted = %d, want 1", n)
@@ -121,9 +121,9 @@ func TestPruneTurnEvents_AgeAndCount(t *testing.T) {
 				}
 			}
 
-			n, err = store.PruneTurnEvents(ctx, 0, 2)
+			n, err = store.Prune(ctx, 0, 2)
 			if err != nil {
-				t.Fatalf("PruneTurnEvents(count): %v", err)
+				t.Fatalf("Prune(count): %v", err)
 			}
 			if n != 3 {
 				t.Fatalf("count sweep deleted = %d, want 3", n)
@@ -143,10 +143,10 @@ func TestPruneTurnEvents_AgeAndCount(t *testing.T) {
 	}
 }
 
-// TestPruneTurnEvents_NoOpWithZeroBounds confirms the sweep is a
+// TestPrune_NoOpWithZeroBounds confirms the sweep is a
 // genuine no-op when both maxAge and maxCount are zero — the worker
 // uses zero to disable a particular bound.
-func TestPruneTurnEvents_NoOpWithZeroBounds(t *testing.T) {
+func TestPrune_NoOpWithZeroBounds(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -171,9 +171,9 @@ func TestPruneTurnEvents_NoOpWithZeroBounds(t *testing.T) {
 					t.Fatalf("append: %v", err)
 				}
 			}
-			n, err := store.PruneTurnEvents(ctx, 0, 0)
+			n, err := store.Prune(ctx, 0, 0)
 			if err != nil {
-				t.Fatalf("PruneTurnEvents(0, 0): %v", err)
+				t.Fatalf("Prune(0, 0): %v", err)
 			}
 			if n != 0 {
 				t.Fatalf("deleted = %d, want 0 (both bounds disabled)", n)

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -693,10 +693,10 @@ func (s *SQLiteStore) ListEvents(ctx context.Context, filter EventFilter) ([]typ
 	return items, rows.Err()
 }
 
-// PruneTurnEvents drops `turn.completed` rows older than maxAge
+// Prune drops `turn.completed` rows older than maxAge
 // or, when maxCount > 0, beyond the most recent maxCount rows
 // (ordered by sequence DESC). Other event types are preserved.
-func (s *SQLiteStore) PruneTurnEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
+func (s *SQLiteStore) Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error) {
 	deleted := int64(0)
 
 	if maxAge > 0 {

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -86,10 +86,10 @@ type Store interface {
 	// — passing an empty slice means "no task constraint" (admin).
 	ListEvents(ctx context.Context, filter EventFilter) ([]types.TaskRunEvent, error)
 
-	// PruneTurnEvents deletes `turn.completed` rows that are
+	// Prune deletes `turn.completed` rows that are
 	// older than maxAge or, if maxCount > 0, beyond the most recent
 	// maxCount rows (ordered by sequence DESC). Run-level events
 	// (run.started, run.finished, approval.*) are never touched. The
 	// retention worker calls this on its scheduled tick.
-	PruneTurnEvents(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
+	Prune(ctx context.Context, maxAge time.Duration, maxCount int) (int, error)
 }


### PR DESCRIPTION
## Summary

`retention.go` defined four bespoke per-subsystem interfaces (`UsageEventPruner`, `AuditEventPruner`, `TurnEventPruner`, `ChatApprovalPruner`) plus four adapter types that translated each into the common `Pruner.Prune(ctx, maxAge, maxCount)` shape. The indirection bought nothing — three of the four interfaces only existed because the impl method had a descriptive name (`PruneEvents` / `PruneAuditEvents` / `PruneTurnEvents`) instead of plain `Prune`. The fourth (`ChatApprovalPruner`) was meaningfully different: it takes `now time.Time` and does two deletions (approvals + grants) that the adapter then summed.

Rename the impls and move the special-case logic to the approval store; the adapter zoo goes away.

```
19 files changed, 82 insertions(+), 125 deletions(-)
```

## What changes

- **Each store impl renames its bespoke method to `Prune`:**
  - `governor.UsageStore.PruneEvents` → `Prune`
  - `controlplane.Store.PruneAuditEvents` → `Prune`
  - `taskstate.Store.PruneTurnEvents` → `Prune`
  - Test files renamed in lock-step.

- **`agentadapters.ApprovalRetentionStore` gets a new `Prune` method** that internalizes `now := time.Now().UTC()` and sums the two sub-deletions (`PruneApprovals` + `PruneExpiredGrants`). The per-deletion methods stay on the interface for tests and ad-hoc callers. Memory + SQLite impls both add the new `Prune` method via a shared `pruneApprovalsAndGrants` helper.

- **`retention.go` drops the four interface types + four adapter shims.** `NewManager`'s signature loses the four typed parameters; every subsystem now takes `Pruner` directly.

- **`cmd/hecate/main.go`'s `approvalRetentionPruner` helper** returns `retention.Pruner` instead of `retention.ChatApprovalPruner`.

## What doesn't change

- The wire surface (event names, error codes, retention history shape) is unchanged.
- Operators see no difference.
- The flow "subsystem registers a `Pruner` under a name" stays — adding a new subsystem is still constructor parameter + `RetentionConfig` field + `Pruner` impl, just without the per-store adapter type.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `go test ./... -race -count=1` — 1779 / 1779 pass across 36 packages

## Note on Phase 7a (OTel HTTP entry spans)

The plan bundled this with the retention adapter collapse. Splitting them: this PR is just (b). The OTel `http.server.request` decorator is a follow-up — it's additive to `middleware.go` and `internal/telemetry/contract_test.go`, no overlap with this PR's storage-package surface.

## Why `[skip desktop]`

Pure Go-side refactor across `internal/agentadapters/`, `internal/controlplane/`, `internal/governor/`, `internal/retention/`, `internal/taskstate/`, `cmd/hecate/`. No `ui/**` or `tauri/**` changes.