### PR TITLE
docs(rfcs): define project and context memory model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,10 @@ direction, implemented records, and experimental parking-lot ideas.
 | [RFC index](rfcs/README.md) | Catalog of active proposals, accepted alpha direction, implemented records, and experimental ideas. |
 | [Hecate Chat and model capabilities](rfcs/hecate-chat-model-capabilities.md) | Accepted alpha direction for Hecate Chat tools on/off segments, model capability metadata, profiles, and future probes. |
 | [External agent adapters](rfcs/external-agent-adapters.md) | Accepted alpha direction for Codex, Claude Code, Cursor Agent, ACP controls, approvals, readiness, diagnostics, and diff review. |
+| [Projects](rfcs/projects.md) | Active proposal for durable project identity, project-scoped memory, agent profiles, presets, and workspace separation. |
+| [Context assembly and injection boundaries](rfcs/context-assembly-and-injection-boundaries.md) | Active proposal for context packets, trust labels, prompt-injection boundaries, and "what did the model see?" inspection. |
+| [Agent memory](rfcs/agent-memory.md) | Active proposal for durable operator-authored memory that feeds context assembly. |
+| [LLM context window management](rfcs/llm-context-window-management.md) | Active proposal for token estimation, context warnings/caps, and optional fitting policies. |
 | [Terminal / CLI distribution](rfcs/terminal-distribution.md) | Active proposal for a terminal-first install with `hecate`, `hecate-acp`, and a future first-class TUI. |
 | [Event protocol v1](rfcs/event-protocol-v1.md) | Candidate event envelope; implemented for task-run event streams, but payload stability is still in progress. |
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,8 +38,10 @@ Implemented runtime behavior lives in the main docs:
 |---|---|---|
 | [Terminal / CLI distribution](terminal-distribution.md) | Proposed. Release archives already ship `hecate` and `hecate-acp`; the first-class TUI and terminal setup commands do not exist yet. | Decide the command surface and build the first attach-only TUI slice. |
 | [Migration CLI](migration-cli.md) | Proposed. No dedicated migration/rollback CLI exists yet. | Design `hecate migrate` around the current SQLite migration packages. |
-| [Agent memory](agent-memory.md) | Proposed. No durable memory primitive exists yet. | Reconfirm product placement now that Connections and Chat settings exist. |
-| [LLM context window management](llm-context-window-management.md) | Proposed. Hecate still needs better token estimation, context limits, truncation policy, and summarization. | Refresh naming around context limits before implementation. |
+| [Projects](projects.md) | Proposed. Hecate does not yet have durable project identities separate from concrete workspaces. | Introduce `project_id` before project-scoped memory, agent profiles, presets, and richer context assembly. |
+| [Context assembly and injection boundaries](context-assembly-and-injection-boundaries.md) | Proposed. Hecate does not yet persist an inspectable "what did the model see?" context packet. | Implement context-packet snapshots before memory or summarization work. |
+| [Agent memory](agent-memory.md) | Proposed. No durable operator-authored memory primitive exists yet. | Build after context packets so memory inclusion is visible and auditable. |
+| [LLM context window management](llm-context-window-management.md) | Proposed. Hecate still needs token estimation, context warnings/caps, and optional fitting policies. | Use context packets as the estimator input; keep trust decisions in context assembly. |
 | [Import external chat history](import-external-chat-history.md) | Proposed. Import from Claude Code and Codex transcripts is not implemented. | Keep as-is until import work starts. |
 | [Embeddings](embeddings.md) | Proposed. OpenAI-compatible embeddings routing is not implemented. | Refresh provider/capability references before implementation. |
 | [Provider response extensions](provider-response-extensions.md) | Proposed. Vendor-specific response extras are still not preserved end-to-end. | Use when adding Perplexity citations, DeepSeek/xAI reasoning content, or Gemini citation metadata. |

--- a/docs/rfcs/agent-memory.md
+++ b/docs/rfcs/agent-memory.md
@@ -1,428 +1,338 @@
 # Agent Memory
 
 > **Status:** proposed; not implemented.
-> **Current source of truth:** [Chat sessions](../chat-sessions.md) and
-> [Agent runtime](../agent-runtime.md) for today's system-prompt layers.
-> **Next action:** recheck product placement now that Connections and Chat
-> settings exist; do not assume a generic Settings view is the right home.
+> **Current source of truth:** [Chat sessions](../chat-sessions.md),
+> [Agent runtime](../agent-runtime.md), and
+> [Context assembly and injection boundaries](context-assembly-and-injection-boundaries.md)
+> for today's prompt and context behavior.
+> **Next action:** implement context-packet snapshots first, then add a
+> small operator-authored memory store as one source for context assembly.
 
-Operators currently re-establish the same context every chat: their
-role, the codebase paths they care about, conventions they want the
-assistant to follow, the way they want answers shaped. Even within a
-single workspace, every new Hecate Chat or `agent_loop` task run
-starts cold. The system prompt is shared across runs, but it is a
-single global string — operators can't carve it into reusable
-entries scoped to specific situations.
+Operators often repeat the same durable context: coding preferences,
+repository conventions, communication style, recurring paths, and project facts
+that should survive across Hecate Chat sessions, external-agent chats, and
+task-backed runs. Today those facts live either in the global system prompt, in
+workspace docs, in external-agent-specific settings, or in the operator's head.
 
-OpenAI and Anthropic ship vendor-locked memory features. Hecate
-operators can't depend on them and can't take their memory with them
-when they switch providers.
+This RFC defines Hecate memory as **operator-approved durable context**. It is
+not automatic transcript mining, not a vector search system, and not a vendor
+memory feature. Memory entries are visible, scoped, editable, and included in a
+model call only through the context assembly pipeline.
+
+[Projects](projects.md) provide the durable default scope for memory. Agent
+profiles choose which memory sources and scopes a given agent uses. Context
+assembly remains the enforcement layer that decides what enters a specific
+model or adapter call.
+
+## Relationship To Context
+
+Memory is one input to the context pipeline:
+
+```mermaid
+flowchart LR
+    A["Project"] --> B["Agent profile"]
+    B --> C["Memory service"]
+    C --> D["Context assembly"]
+    D --> E["Context window management"]
+    E --> F["Provider or adapter prompt"]
+```
+
+- [Context assembly](context-assembly-and-injection-boundaries.md) decides
+  whether a memory entry is active for a given chat message or task run and
+  labels it as `operator_memory`.
+- [Context window management](llm-context-window-management.md) counts memory
+  tokens and may warn/block if memory plus transcript exceeds the model limit.
+- [Projects](projects.md) provide the default durable scope for memory.
+- Agent profiles select which memory scopes and external memory providers the
+  active agent should use.
+- Memory itself only stores durable entries and scopes. It does not perform
+  retrieval, summarization, or prompt rendering.
 
 ## Goals
 
-In rough priority order:
+1. **Operator-authored persistence.** Entries survive restarts, chats, and task
+   runs.
+2. **Scoped activation.** Entries can apply globally, to a project, to a
+   chat/session, to a runtime surface, or through a named agent profile.
+3. **Full visibility.** Operators can see which memory entries are active before
+   sending and can inspect which entries influenced a completed message/run.
+4. **Provider-neutral behavior.** Memory works the same whether the next call
+   routes to OpenAI, Anthropic, Gemini, a local provider, or another compatible
+   backend.
+5. **Agent-neutral project memory.** Hecate Chat and external-agent chats can
+   both use project memory when their active agent profile opts into it.
+6. **No silent writes.** The model cannot quietly create or edit memory. Any
+   future "remember this" flow must be explicit and operator-approved.
 
-1. **Operator-authored memory entries** survive across chats and
-   across `agent_loop` task runs. An entry written today is in the
-   conversation tomorrow without re-typing it.
-2. **Scoped activation.** An entry can target every chat, only one
-   workspace, only one agent kind (Hecate Agent vs `agent_loop`
-   tasks), or some intersection. Not every entry should fire on
-   every conversation.
-3. **Fully visible.** The operator can see every active memory
-   entry in Connections or Chat settings, and per-chat. No "the assistant
-   remembered something but I can't see what" behavior.
-4. **Provider-agnostic.** Same memory entries work across OpenAI,
-   Anthropic, Gemini, etc. No vendor lock-in.
-5. **Encrypted at rest** when `GATEWAY_CONTROL_PLANE_SECRET_KEY`
-   is set, mirroring how persisted provider API keys are protected.
+## Non-goals
 
-## Non-goals (v1)
+- **Automatic extraction from chats.** No "I noticed this, so I remembered it"
+  behavior in v1.
+- **Semantic recall or vector retrieval.** Exact scope matching first. Embedding
+  search can become a later retrieval RFC.
+- **Owning external-agent private memory.** Codex, Claude Code, and Cursor have
+  their own memory/settings layers. Hecate can provide project memory to an
+  external-agent session through supported prompt/config surfaces, but it should
+  not pretend to read, rewrite, or synchronize the agent's private memory.
+- **Cross-user sharing.** Hecate remains local-first and single-operator shaped.
+- **Replacing workspace docs.** Repository guidance belongs in repo files such
+  as `AGENTS.md`; memory is for operator-owned durable preferences and facts.
 
-- **Auto-extraction from past chats.** The "this looks important,
-  I'll remember it" behavior every vendor's memory feature does is
-  the worst kind of memory: surprising, opaque, and easy to abuse.
-  v1 is operator-authored only. Auto-extraction can be a separate
-  RFC after eval scaffolding exists.
-- **Semantic recall.** Vector DB territory. v1 is exact-match
-  scope rules + plain text, prepended verbatim. Semantic retrieval
-  ("memories relevant to *this question*") is a future RFC.
-- **External-agent integration.** Codex, Claude Code, and Cursor
-  Agent each have their own settings layer outside Hecate's
-  control. We can't inject memory into their conversations without
-  ACP standardizing a memory primitive, which it hasn't. v1 covers
-  Hecate-controlled surfaces only: Hecate Chat (tools-off + Hecate
-  Agent) and `agent_loop` task runs.
-- **Cross-tenant sharing.** Hecate is single-user; shared memory
-  across operators isn't a real use case. If multi-user lands, this
-  RFC's scope model maps cleanly onto per-user partitions.
-- **Memory editing by the LLM.** The LLM never writes to memory.
-  Only the operator does. (Future RFC could add an opt-in
-  "remember this" tool that requires explicit operator approval
-  per write, but not v1.)
+## Memory Entry Model
 
-## Constraints
-
-- **Single-user mode.** All memory entries are owned by the local
-  operator. No principal model.
-- **Local-first.** Entries persist in the same SQLite database as
-  the rest of operator state. No cloud sync.
-- **Operator-controlled.** Every byte of memory the LLM sees is
-  something the operator typed. No background extraction, no
-  auto-import from past conversations in v1.
-- **Provider-neutral.** Memory entries are plain text. Providers
-  receive them as part of the system prompt, not via any vendor's
-  memory API.
-
-## Data model
-
-A memory entry is title + body + scope:
+Sketch:
 
 ```go
-// pkg/types/memory.go (new)
 type MemoryEntry struct {
-    ID        string          // mem_<hex>
-    Title     string          // operator-facing label, ~60 chars
-    Body      string          // the content prepended to system prompt
-    Scope     MemoryScope     // global | workspace | agent_kind | composite
-    ScopeKey  string          // e.g. workspace path; "" for global
-    AgentKind string          // "" | "hecate_chat" | "agent_loop"
-    Enabled   bool            // toggle without delete
-    CreatedAt time.Time
-    UpdatedAt time.Time
+    ID            string
+    Title         string
+    Body          string
+    Scope         MemoryScope
+    ProjectID     string
+    ChatSessionID string
+    AgentProfile  string
+    Surface       string // "" | "hecate_chat" | "external_agent" | "task_run"
+    Enabled       bool
+    Source        string // local | external
+    SourceRef     string // provider/key reference for external memory backends
+    CreatedAt     time.Time
+    UpdatedAt     time.Time
 }
 
 type MemoryScope string
 
 const (
     MemoryScopeGlobal       MemoryScope = "global"
-    MemoryScopeWorkspace    MemoryScope = "workspace"
-    MemoryScopeAgentKind    MemoryScope = "agent_kind"
-    MemoryScopeComposite    MemoryScope = "composite" // workspace + agent_kind
+    MemoryScopeProject      MemoryScope = "project"
+    MemoryScopeChat         MemoryScope = "chat"
+    MemoryScopeAgentProfile MemoryScope = "agent_profile"
+    MemoryScopeSurface      MemoryScope = "surface"
+    MemoryScopeComposite    MemoryScope = "composite"
 )
 ```
 
-Scope semantics, evaluated when preparing a chat or task run:
+Scope semantics:
 
-| Entry scope | Activates when |
+| Scope | Activates when |
 |---|---|
-| `global` | Always, every chat / task run |
-| `workspace` (`scope_key=/path`) | Active workspace path matches `/path` |
-| `agent_kind` (`agent_kind="agent_loop"`) | Current surface matches |
-| `composite` | Both `scope_key` and `agent_kind` match |
+| `global` | Every Hecate-controlled model call. |
+| `project` | Active `project_id` matches. |
+| `chat` | Active chat/session ID matches. |
+| `agent_profile` | Active agent profile opts into the entry or backing source. |
+| `surface` | Runtime surface matches `surface`, such as Hecate Chat or task runs. |
+| `composite` | Project, chat, profile, and/or surface constraints all match. |
 
-`Enabled=false` excludes the entry from injection but preserves it
-for future re-enable. Cheaper than delete-and-recreate when an
-operator wants to A/B with and without a memory.
+Agent profiles can reference a set of memory entries, memory scopes, or
+external memory sources, but they should not become memory themselves. A profile
+is a reusable runtime configuration; memory is durable context. Presets are one
+step earlier: templates that create or update profiles/project defaults. Once a
+preset is applied, the resolved profile settings control memory activation.
+
+## Memory Layers
+
+| Layer | Persistence | Scope | Promotion |
+|---|---|---|---|
+| Global memory | Durable | Whole local Hecate instance | Explicit only |
+| Project memory | Durable | One `project_id` | Explicit save from chat/task |
+| Chat/session memory | Session-local or durable-per-chat | One chat/session | Never auto-promoted |
+| Profile-selected memory | Durable selection rule | One agent profile | References scopes/sources; does not store memory itself |
+| Current context | Per request | One model/agent call | Not memory |
+
+Project memory should be the default durable scope. Chat/session memory is for
+short-lived continuity and notes inside one conversation. If something learned
+in a chat should persist for the project, the operator should explicitly save
+it to project memory.
+
+## External Memory Providers
+
+External memory providers should integrate behind Hecate's memory service, with
+agent profiles as the user-facing control plane.
+
+Responsibilities:
+
+- **Project** owns the default durable memory scope.
+- **Agent profile** selects which memory scopes and external memory providers an
+  agent should use.
+- **Memory service** normalizes local and external entries into Hecate
+  `MemoryEntry` records or read-only `ContextItem` candidates.
+- **Context assembly** applies trust labels, prompt-injection boundaries,
+  context-window eligibility, and audit snapshots.
+- **Adapters/providers** receive only the rendered context Hecate chose to send.
+
+This keeps Hecate in control of visibility and safety while still allowing
+future integrations with external memory systems.
+
+External memory provider rules:
+
+1. External memory reads are optional per agent profile.
+2. External memory writes require explicit operator approval.
+3. External provider output is not trusted more than local operator memory
+   unless the operator marks that source as trusted.
+4. Failed external memory lookups should degrade gracefully and be visible in
+   the context inspector.
+5. External memory providers cannot bypass Hecate approvals, sandboxing, or
+   workspace validation.
+
+## Hecate And External Agents
+
+Hecate Chat can inject project memory directly into the provider prompt because
+Hecate owns that model call.
+
+External agents are different: Codex, Claude Code, and Cursor own their private
+prompt/history internals. Hecate should still let them use project memory, but
+only through explicit surfaces:
+
+- ACP config/session options when an adapter exposes a suitable field.
+- Hecate-authored session preamble or instruction text when the adapter accepts
+  it.
+- Operator-visible context notes in the chat settings/context inspector when no
+  injection surface exists.
+
+The UI should make this distinction visible: "available to Hecate Chat" versus
+"sent to this external agent" versus "stored as project memory but not injected."
 
 ## Storage
 
-New table in `internal/chatstate/sqlite.go` (or a new
-`internal/memory/` package — see open questions):
+Memory should live in a new `internal/memory/` package with memory and SQLite
+backends, following the storage-tier rule. It is logically related to chats but
+not owned by chat sessions.
+
+SQLite sketch:
 
 ```sql
 CREATE TABLE IF NOT EXISTS memory_entries (
-    id          TEXT PRIMARY KEY,
-    title       TEXT NOT NULL,
-    body        BLOB NOT NULL,        -- AES-GCM ciphertext when settings key set
-    scope       TEXT NOT NULL,        -- global|workspace|agent_kind|composite
-    scope_key   TEXT NOT NULL DEFAULT '',
-    agent_kind  TEXT NOT NULL DEFAULT '',
-    enabled     INTEGER NOT NULL DEFAULT 1,
-    created_at  TEXT NOT NULL,
-    updated_at  TEXT NOT NULL
+    id              TEXT PRIMARY KEY,
+    title           TEXT NOT NULL,
+    body            BLOB NOT NULL,
+    scope           TEXT NOT NULL,
+    project_id      TEXT NOT NULL DEFAULT '',
+    chat_session_id TEXT NOT NULL DEFAULT '',
+    agent_profile   TEXT NOT NULL DEFAULT '',
+    surface         TEXT NOT NULL DEFAULT '',
+    source          TEXT NOT NULL DEFAULT 'local',
+    source_ref      TEXT NOT NULL DEFAULT '',
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_memory_scope ON memory_entries (scope, scope_key, agent_kind);
+CREATE INDEX IF NOT EXISTS idx_memory_entries_scope
+    ON memory_entries (scope, project_id, chat_session_id, agent_profile, surface, enabled);
 ```
 
-Encryption: `body` is encrypted with the same `secrets.AESGCMCipher`
-used for stored provider API keys, when `GATEWAY_CONTROL_PLANE_SECRET_KEY`
-is configured. When unset, `body` is stored as plain UTF-8 (matching
-the existing pattern for provider keys).
+When `GATEWAY_CONTROL_PLANE_SECRET_KEY` is set, `body` should be encrypted with
+the same secret-management primitives used for stored provider credentials.
+When the key is unset, store plain UTF-8, matching the current local-dev
+posture.
 
-## API surface
+## API Surface
 
-Five routes on `/hecate/v1/memory`:
-
-```
-GET    /hecate/v1/memory                     # list (paginated)
-POST   /hecate/v1/memory                     # create
-GET    /hecate/v1/memory/{id}                # get one
-PATCH  /hecate/v1/memory/{id}                # update title/body/scope/enabled
-DELETE /hecate/v1/memory/{id}                # delete
-```
-
-Plus one runtime introspection endpoint:
+Hecate-native endpoints:
 
 ```
-GET    /hecate/v1/memory/active?workspace=/path&agent_kind=agent_loop
+GET    /hecate/v1/memory
+POST   /hecate/v1/memory
+GET    /hecate/v1/memory/{id}
+PATCH  /hecate/v1/memory/{id}
+DELETE /hecate/v1/memory/{id}
+GET    /hecate/v1/memory/active?project_id=proj_...&chat_session_id=chat_...&agent_profile=codex&surface=external_agent
 ```
 
-Returns the ordered list of memory entries that *would* be injected
-for a given workspace + agent kind. Used by the per-chat indicator
-in the UI ("3 memory entries active in this chat") so operators
-always know what's in scope.
+`/active` is an introspection endpoint. It returns entries that would become
+`operator_memory` context items for the supplied project, chat, agent profile,
+and surface, but it does not render a prompt and does not apply
+context-window truncation.
 
-Response shape mirrors today's `{object, data}` Hecate-native
-envelope.
+## Context Assembly Integration
 
-## Injection mechanics
+Memory enters a model call through the context packet, not by ad hoc prompt
+string concatenation.
 
-Hecate has two different system-prompt paths today; memory hooks
-into both, but the surrounding layers differ. Stable order in both
-cases: matching entries sorted by `(created_at, id)` ascending —
-deterministic, operator-controllable via timestamps if reordering
-matters.
+For every model-backed chat message, external-agent session, or task run:
 
-Format inside the prompt is consistent across both paths:
+1. Context assembly asks the memory service for scoped active entries and
+   profile-selected external memory candidates.
+2. Each matching entry becomes a `ContextItem` with
+   `trust_level=operator_memory`, `kind=memory`, and `origin=<memory_id>`.
+3. The context packet stores the memory item IDs and snapshots enough title/body
+   content for auditability.
+4. The provider renderer inserts the memory block after system instructions and
+   before workspace guidance.
+5. Context-window management counts the memory tokens with the rest of the
+   packet.
 
-```
-# Memory: <title>
+Recommended rendered block:
+
+```markdown
+## Operator Memory
+
+### <title>
 <body>
 ```
 
-Plain markdown headers separate entries. Most providers respect
-markdown structure in system prompts; the rare ones that don't
-still receive readable context.
+This label is intentional. It tells the model that memory is durable operator
+context, while keeping it distinct from Hecate runtime instructions and
+workspace guidance.
 
-### `agent_loop` task runs (three-layer composition)
+## UI Placement
 
-`internal/api/system_prompt.go`'s `buildSystemPromptResolver`
-builds the resolver that `agent_loop` runs through the
-`orchestrator.SystemPromptResolver` interface. Memory entries
-become a new layer between global and workspace:
+Memory should be visible from two places:
 
-```
-[GATEWAY_TASK_AGENT_SYSTEM_PROMPT]                  ← global
-[matching memory entries, in stable order]         ← new
-[workspace CLAUDE.md / AGENTS.md]                  ← workspace
-[per-task system prompt from Task.SystemPrompt]    ← per-task
-```
+- **Management surface:** likely Connections or a dedicated "Memory" view once
+  the feature is real. The operator can create, edit, disable, delete, and
+  scope entries there.
+- **Chat/Run context inspector:** shows active memory entries for the next call
+  and the memory entries that influenced a completed message/run.
 
-Existing layers are unchanged; memory enters as a fourth
-narrowest-but-broader-than-workspace tier. Hecate Chat segments
-that run tools-on (Hecate Agent) flow through the task runtime
-and pick this path automatically.
+Avoid hiding memory only in a generic Settings page. The operator needs memory
+visibility at the point of use.
 
-### Hecate Chat model-chat segments (session-level prompt)
+## Safety Rules
 
-Tools-off model chat (and any other consumer of `/v1/chat/completions`
-the gateway proxies for an operator session) goes through
-`applySessionSystemPrompt` in `internal/api/handler_chat.go`. That
-function prepends the persisted `ChatSessionRecord.SystemPrompt`
-as a single `system` message at the head of the request's
-`Messages`. There is no workspace layer and no per-task layer here.
+1. Memory writes require explicit operator action.
+2. Imported text, tool output, raw adapter output, and generated summaries
+   cannot become memory without review.
+3. Disabled entries are never included in context packets.
+4. Deleted or edited entries do not rewrite historical context packet snapshots.
+5. Memory cannot override Hecate security policy, approvals, sandboxing, or
+   workspace validation.
+6. Memory entries should have size guardrails. Initial proposal: warn at 5,000
+   characters and block at 20,000 characters per entry unless overridden.
 
-Memory injection on this path: the matching entries are concatenated
-(same `# Memory: <title>` headers) and prepended *before* the
-session system prompt, as a single additional `system` message:
+## Implementation Plan
 
-```
-system: [matching memory entries, in stable order]   ← new
-system: [ChatSessionRecord.SystemPrompt]             ← existing
-user/assistant/...                                   ← conversation
-```
+| PR | Scope |
+|---|---|
+| 1 | `internal/memory/` store interface with memory + SQLite backends and parity tests. |
+| 2 | CRUD and `/active` API endpoints with structured errors and trace IDs. |
+| 3 | Context assembly integration that emits `operator_memory` context items. |
+| 4 | Agent profile memory-source selection for Hecate Chat and external agents. |
+| 5 | UI management surface plus active-memory indicators in Chat and Task Detail. |
+| 6 | Docs, screenshots, and e2e coverage for scoped memory visibility. |
 
-Two `system` messages back-to-back is well-supported by every
-provider Hecate routes to today; the alternative (concatenating
-into one `system` message) is also fine but loses the visual
-boundary in trace inspectors.
+This should land after the first context-packet implementation. Otherwise
+memory will have no durable "what saw this entry?" audit trail.
 
-### Anthropic prompt caching
+## Test Plan
 
-For both paths, when the request goes to Anthropic the memory
-block is wrapped in a `cache_control` marker. Memory changes
-infrequently and is identical across runs that share the same
-scope, so cache hits are high. The marker mechanics for the
-`system` prompt and `tools` catalog already shipped (PR #59) and
-are documented in [`docs/providers.md`](../providers.md#anthropic-prompt-caching);
-this RFC extends them by wrapping the memory block. The
-[LLM context window management RFC](llm-context-window-management.md)'s
-[Cache marker integration](llm-context-window-management.md#cache-marker-integration)
-section anticipates the same hookup.
+- Store parity tests for memory and SQLite.
+- Scope matching unit tests for global, project, chat, agent profile, surface, and composite
+  entries.
+- API tests for CRUD, disabled entries, and `/active`.
+- Context assembly tests proving memory items are labelled `operator_memory`.
+- External memory provider tests proving failures are visible but non-fatal.
+- Prompt-injection regression tests proving untrusted content cannot write or
+  override memory.
+- UI tests for active-memory indicators and management CRUD.
+- E2E test where project-scoped memory appears in one project and not another.
+- E2E test where Hecate Chat and an external-agent chat share the same project
+  memory when their profiles opt in.
 
-When the request goes elsewhere, no markers — the block is just
-text.
+## Open Questions
 
-## UI surface
-
-### Connections / Chat settings surface — Memory
-
-List all memory entries with:
-
-- Title (inline-editable)
-- Body (multiline editor; markdown preview)
-- Scope picker (global / workspace / agent_kind / composite) with
-  appropriate fields revealed
-- Enabled toggle
-- Last updated timestamp
-- Delete (with confirm)
-- New-entry form
-
-Tests should follow the existing settings/connection CRUD patterns.
-
-### Per-chat indicator
-
-In Hecate Chat header (and external-agent chat header — see future
-work), small badge: **"3 memories active"**. Click expands to a
-panel listing the matching entries, each with title + scope. Each
-entry has a "Manage memory" link. No edit-from-chat in v1 (keeps
-the chat surface focused; Connections or Chat settings is the source of truth).
-
-The indicator queries `GET /hecate/v1/memory/active` with the
-current workspace and agent kind so it always reflects what just
-went into the system prompt.
-
-### Task Detail
-
-Task runs that consumed memory entries record their IDs as a span
-attribute (`hecate.task.memory_entries=mem_a,mem_b,mem_c`) and
-expose them as a row in the task run header. Operator can click to
-see the entries that influenced this run, even if they've since
-been edited or deleted (provenance via the IDs preserved in the
-trace).
-
-## End-to-end scope
-
-| Layer | Files | Lines (rough) |
-|---|---|---|
-| Types | `pkg/types/memory.go`, `internal/api/openai.go` (response types) | ~80 |
-| Storage | new `internal/memory/` package (or table in chatstate), memory store + sqlite | ~400 |
-| API handlers | `internal/api/handler_memory.go` + routes | ~250 |
-| Injection | wiring in handler_chat.go + executor_agent_loop.go's prompt composer | ~150 |
-| UI types | `ui/src/types/runtime.ts` | ~30 |
-| UI memory surface | Connections or Chat settings memory component + tests | ~500 |
-| UI per-chat indicator | small component in Hecate Chat header + tests | ~150 |
-| Task Detail provenance row | `ui/src/features/runs/TaskDetail.tsx` change | ~60 |
-| Tests at every layer | provider, storage, handler, injection, UI | ~600 |
-| Docs | new `docs/memory.md`; cross-link from `chat-sessions.md`, `agent-runtime.md`; `known-limitations.md` update | ~150 |
-
-Total: ~2400 lines, ~6 PRs across api/storage/UI.
-
-## Phasing
-
-| PR | Scope | Size |
-|---|---|---|
-| 1 | Types + storage layer (memory store interface, memory/sqlite, no API or UI yet) | ~480 |
-| 2 | API handlers + runtime introspection endpoint | ~280 |
-| 3 | System-prompt injection in Hecate Chat + `agent_loop`; Task Detail provenance trace attribute | ~210 |
-| 4 | UI types + Settings Memory tab CRUD | ~530 |
-| 5 | Per-chat indicator + Task Detail provenance row | ~210 |
-| 6 | Docs + `known-limitations.md` update if applicable | ~150 |
-
-PRs 1–3 give API consumers a working memory primitive without UI.
-PRs 4–5 expose it to the operator. PR 6 documents.
-
-PR 1 is shippable and useful for headless operators / scripted
-workflows even without UI. PR 4 is where most operators see the
-feature.
-
-## Open questions
-
-- **New package or table in chatstate?** Memory is logically a
-  sibling of chats, not a property of them. Probably its own
-  package `internal/memory/` with its own SQLite store, registered
-  in the migration registry alongside the other nine packages.
-  Defaulting to a separate package for separation of concerns.
-- **Scope model: rich enough?** Three predefined scopes
-  (global / workspace / agent_kind) plus composite. Free-form tags
-  on top would let operators do "all backend chats" or "Python
-  projects." Probably v2; v1 covers 80% of the use cases without
-  the freeform-string UX problem.
-- **Memory size limit?** Without a cap, a verbose operator can
-  inflate every system prompt to context-overflow. Initial
-  proposal: soft warn at 5,000 chars per entry, hard cap at
-  20,000. Operator-overridable via a flag. Cross-references
-  context window RFC.
-- **Per-message provenance.** Beyond the trace attribute on task
-  runs, should each chat message record which memory entries
-  influenced it? Useful for "the assistant said something weird,
-  what was in scope?" forensics. Adds a JSON column to message
-  rows; not free. Probably v1.5.
-- **Export / import.** Operators who switch machines want their
-  memory to come along. Plain JSON export of the table is trivial
-  to add; defer until requested.
-- **Memory in external-agent chats.** Codex / Claude Code / Cursor
-  have their own settings/memory layers outside Hecate's control.
-  We can't reach them without an ACP extension that doesn't exist
-  yet. v1 documents this as a known gap; if ACP adds a memory
-  primitive, Hecate's memory entries become a candidate sync
-  source.
-- **Auto-extraction from past chats.** Real product feature with
-  eval requirements (precision/recall on what should be
-  remembered, hallucination guardrails). Out of scope for v1; would
-  be its own RFC after manual memory has shipped and operators
-  have a baseline.
-
-## Risks
-
-1. **Memory inflates context silently.** Adding 5 entries × 2,000
-   chars = 10,000 chars (~2,500 tokens) before the actual
-   conversation starts. Pairs with the context-management RFC: the
-   token estimate there must count memory contributions.
-2. **Operator forgets a memory entry is enabled** and gets
-   surprising answers. Mitigation: per-chat indicator (always-on,
-   click to inspect), and the memory management surface is the canonical source of
-   truth. Disable beats delete.
-3. **Memory drift across providers.** Different providers respect
-   markdown structure in system prompts differently. Most major
-   providers handle headers fine; the rare ones still see plain
-   text. Mitigation: keep the format simple (markdown headers +
-   body); avoid relying on any specific structure.
-4. **Encrypted body breaks operator backup tools.** Operators who
-   `cp .data/hecate.db backup.db` get an encrypted body. Without
-   the settings key the body is unrecoverable. Mitigation: same
-   pattern as provider API keys — operators who set the key are
-   responsible for backing it up. Document explicitly.
-5. **Memory + agent_loop interaction.** Memory is in the system
-   prompt at task-run start; mid-run it can't change. If an
-   operator edits a memory entry mid-run, the change applies to
-   the next run, not this one. Document this; otherwise expect
-   "I changed memory but the task didn't pick it up" reports.
-
-## Acceptance criteria
-
-When this RFC is implemented:
-
-- An operator can create, edit, scope, enable, disable, and delete
-  memory entries from the chosen memory management surface.
-- Memory entries scoped to "global" appear in every Hecate Chat
-  conversation and every `agent_loop` task run.
-- Memory entries scoped to a workspace path appear only when the
-  active workspace matches.
-- Memory entries scoped to an `agent_kind` appear only when the
-  current surface matches.
-- The per-chat indicator shows the number of active memory entries
-  and lets the operator inspect them without leaving the chat.
-- Memory bodies are encrypted at rest when
-  `GATEWAY_CONTROL_PLANE_SECRET_KEY` is set; left as plain UTF-8
-  otherwise.
-- Task runs record the IDs of consumed memory entries as a span
-  attribute, surfaced in Task Detail.
-- An operator's memory works identically against OpenAI, Anthropic,
-  and any other configured provider — provider-neutrality verified
-  by integration tests across at least two providers.
-- The known-limitations doc gains an entry for "memory is
-  operator-authored only; no auto-extraction" so the contract is
-  explicit.
-
-## Cross-reference
-
-The companion RFC, [**LLM context window management**](llm-context-window-management.md),
-handles token estimation, soft thresholds, hard caps, and
-truncation. Anthropic prompt-cache markers for the `system`
-prompt and `tools` catalog shipped separately via PR #59 and
-are documented in [`docs/providers.md`](../providers.md#anthropic-prompt-caching).
-Memory entries inflate context, so:
-
-- The token estimator MUST count memory contributions in its
-  pre-flight estimate.
-- The Anthropic adapter SHOULD wrap the memory block in the same
-  `cache_control: {"type":"ephemeral"}` marker when caching is on,
-  since memory changes infrequently relative to conversation turns.
-  The system-prompt and tools wrappers are already in place; the
-  memory-block wrapper lands with this RFC.
-
-These features are designed to compose cleanly. The cache-marker
-plumbing already exists; the context-window RFC and this one each
-gain their hook on top.
+- What is the first external memory provider worth supporting, if any?
+- Should operators be able to export/import memory as JSON? This is useful for
+  backup and migration; keep it out of the first storage/API PR.
+- Should a future "remember this" command exist? Only if it opens a visible
+  approval/edit flow before persisting anything.
+- Which external-agent adapters support a safe project-memory injection surface
+  today, and which should show memory as operator-side notes only?

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -1,0 +1,300 @@
+# Context Assembly And Injection Boundaries
+
+> **Status:** proposed; not implemented.
+> **Current source of truth:** [Chat sessions](../chat-sessions.md),
+> [Agent runtime](../agent-runtime.md), and [Security](../security.md) for
+> today's prompt, workspace, tool, and approval behavior.
+> **Next action:** implement a small context-packet snapshot for Hecate Chat
+> and task-backed runs before adding durable memory or automatic context
+> summarization.
+
+Hecate is starting to grow several related ideas: projects, chat settings,
+system prompts, task-backed Hecate Chat turns, external-agent transcripts,
+workspace instructions, model capabilities, future memory, external memory
+providers, and future context window management. Without a named assembly layer,
+these concepts blur together and invite two bad outcomes:
+
+- Memory becomes "whatever text we prepend to the prompt."
+- Context-window management becomes responsible for security decisions it
+  should not own.
+
+This RFC introduces a small, explicit context assembly contract. Context
+assembly decides what information is eligible for a model call, how each piece
+is labelled, what trust boundary it crosses, and how the operator can inspect
+the final packet. Context-window management then decides how that packet fits
+inside a model limit. Agent memory becomes one durable input to the packet, not
+the packet itself.
+
+## Relationship To Adjacent RFCs
+
+| Concept | Owns | Does not own |
+|---|---|---|
+| [**Projects**](projects.md) | Durable identity for a codebase/work area: defaults, memory scope, history grouping, trusted context sources. | Concrete sandbox/workspace execution or per-call prompt rendering. |
+| **Context assembly** (this RFC) | Source collection, trust labels, injection boundaries, final context packet snapshot, "what did the model see?" UI. | Token fitting, summarization algorithms, long-term memory CRUD. |
+| [**Agent memory**](agent-memory.md) | Durable operator-approved facts and preferences with scopes. | Deciding whether an entry fits a model window or whether untrusted content should become memory. |
+| [**LLM context window management**](llm-context-window-management.md) | Token estimation, warning/cap thresholds, truncation, summarization, model limit lookup. | Deciding whether a source is trusted, authoritative, or eligible. |
+| **Agent profiles** | Saved runtime configurations: agent/provider/model controls, tools, RTK, approvals, memory-source selection, and system prompt text. | Durable project identity, memory storage, or prompt rendering by itself. |
+| **Presets** | Templates for creating/updating project defaults or agent profiles. | Runtime identity. Once applied, the resolved profile/settings are what matter. |
+| **Prompt-injection defense** | Enforced mostly by context assembly: source labels, authority boundaries, and no silent promotion from untrusted text to instructions. | Perfect detection of malicious text. Hecate should label and bound sources, not pretend it can classify every attack. |
+
+## Goals
+
+1. **Make context visible.** Operators can inspect the context packet used for a
+   chat message or task run: system instructions, workspace guidance, selected
+   files, memory entries, summaries, tool output, and untrusted external text.
+2. **Separate authority from evidence.** System instructions, operator-authored
+   memory, workspace docs, tool output, and imported external text are not
+   equivalent. The prompt renderer must preserve that distinction.
+3. **Create a stable input for token budgeting.** Context-window management
+   receives a resolved packet and can count, trim, or summarize it without
+   re-deciding security policy.
+4. **Support future memory safely.** Durable memory entries can be added to the
+   packet only when scoped and visible. Untrusted text cannot silently become
+   memory.
+5. **Preserve auditability.** A completed model call records enough context
+   metadata to answer "why did the model know that?" after the underlying
+   memory, settings, or files change.
+
+## Non-goals
+
+- **Full semantic retrieval.** Embeddings and vector search can suggest
+  candidate context later, but the first assembly layer is source/provenance
+  plumbing.
+- **Automatic memory extraction.** This RFC explicitly keeps memory writes
+  operator-approved. Auto-extraction needs a separate review and eval story.
+- **Replacing sandbox or approval policy.** Prompt labelling reduces instruction
+  confusion; it does not replace tool sandboxing, approvals, network policy, or
+  workspace validation.
+- **External-agent private context control.** Codex, Claude Code, and Cursor
+  own their internal prompts and history. Hecate can show and label the
+  transcript and raw adapter output it receives, but cannot fully assemble their
+  private model context through ACP today.
+- **Hosted multi-user policy.** Hecate remains local-first and single-operator
+  shaped for this RFC.
+
+## Context Pipeline
+
+The proposed pipeline has five stages:
+
+```mermaid
+flowchart LR
+    A["Source discovery"] --> B["Trust classification"]
+    B --> C["Context packet snapshot"]
+    C --> D["Window management"]
+    D --> E["Provider prompt rendering"]
+```
+
+### 1. Source Discovery
+
+Candidate sources are collected from the active runtime surface:
+
+| Source | Examples |
+|---|---|
+| Chat state | User and assistant messages, direct-model segment history, task-backed segment summaries. |
+| Runtime state | Task/run status, approvals, artifacts, changed files, prior tool output. |
+| Operator settings | System prompt, tools on/off, RTK state, profile/preset choices when they exist. |
+| Project context | `project_id`, project defaults, project instructions, saved project memory, trusted project docs. |
+| Agent profile context | Profile-selected memory sources, adapter/model controls, profile instructions. |
+| Workspace context | Concrete workspace path, `AGENTS.md`, `CLAUDE.md`, selected files, git diff, file tree snippets. |
+| Memory | Future operator-authored memory entries selected by scope. |
+| External memory providers | Future profile-selected memory sources normalized through Hecate memory service. |
+| External imports | Future imported Codex/Claude transcripts, PR comments, issue text, web content, raw adapter output. |
+
+Discovery is allowed to over-collect candidates. Later stages decide inclusion.
+
+### 2. Trust Classification
+
+Every context item gets a trust level before rendering:
+
+| Trust level | Meaning | Examples |
+|---|---|---|
+| `system_instruction` | Highest authority. Hecate-authored runtime instructions and operator-authored system prompt. | Built-in tool rules, explicit chat system prompt. |
+| `operator_memory` | Durable facts or preferences intentionally saved by the operator. | "Use conventional commits", "Prefer Go-first tooling". |
+| `workspace_guidance` | Repository-local guidance. Trusted for this workspace, but still less authoritative than operator/system policy. | `AGENTS.md`, `CLAUDE.md`, repo docs selected by user. |
+| `runtime_state` | Hecate-observed state. Evidence, not instruction. | Run status, approvals, artifact metadata, changed files. |
+| `tool_output` | Output produced by tools. Evidence, not instruction. | `git status`, `go test`, stdout/stderr artifacts. |
+| `generated_summary` | Model-generated compression of older context. Evidence with lossy provenance. | Conversation summary produced by a summarizer. |
+| `external_untrusted` | Text from outside the current operator/runtime trust boundary. Must be quoted/labelled as untrusted. | PR comments, imported chat text, web pages, raw adapter output. |
+
+The renderer must never merge untrusted text into an instruction block. If a
+PR comment says "ignore previous instructions," it remains labelled as external
+evidence, not as a system message.
+
+### 3. Context Packet Snapshot
+
+The assembly output is a `ContextPacket`: a durable, inspectable description of
+what was prepared for a model call.
+
+Sketch:
+
+```go
+type ContextPacket struct {
+    ID          string
+    SessionID   string
+    MessageID   string
+    TaskID      string
+    RunID       string
+    CreatedAt   time.Time
+    ProjectID   string
+    Workspace   string
+    AgentProfile string
+    SourcePreset string
+    Provider    string
+    Model       string
+    RuntimeKind string // direct_model | hecate_agent | external_agent_projection
+    Items       []ContextItem
+}
+
+type ContextItem struct {
+    ID              string
+    Kind            string // system_prompt | memory | workspace_doc | transcript | tool_output | summary | imported_text
+    TrustLevel      string
+    Origin          string // file path, memory id, run event id, import id, etc.
+    Title           string
+    Body            string // optional inline text; large bodies may be referenced
+    BodyRef         string // artifact/file/blob reference when not inlined
+    TokenEstimate   int
+    Included        bool
+    InclusionReason string
+    Redacted        bool
+}
+```
+
+Storage can start as a JSON column on chat messages and task runs, then move to
+`internal/context/` if the shape grows. The important part is that in-memory
+and SQLite storage backends expose the same packet data.
+
+### 4. Window Management
+
+Window management receives only the packet items marked `Included=true`. It can:
+
+- Estimate tokens for the full packet.
+- Warn or block before provider context errors.
+- Drop low-priority items according to policy.
+- Replace older transcript/tool output with generated summaries.
+
+It cannot promote an excluded source, remove trust labels, or rewrite untrusted
+text as an instruction. If it summarizes, the summary becomes a new
+`generated_summary` item that references the items it replaced.
+
+### 5. Provider Prompt Rendering
+
+Prompt rendering converts the packet into provider-specific wire messages.
+
+Recommended rendering order:
+
+1. Hecate runtime instructions.
+2. Operator system prompt / profile instructions.
+3. Project memory and profile-selected memory blocks.
+4. Workspace guidance block.
+5. Runtime state block.
+6. Transcript.
+7. Tool output and external evidence blocks, explicitly labelled.
+
+The exact provider message shape can differ: OpenAI-style `system` messages,
+Anthropic system blocks, or task-runtime prompt layers. The packet order and
+trust labels should remain stable.
+
+## Operator UX
+
+### Chat And Task Views
+
+Each model-backed message/run should expose a quiet "context" action:
+
+- Shows included items grouped by trust level.
+- Shows excluded candidates and why they were excluded when useful.
+- Links large items to artifacts/files instead of dumping huge text inline.
+- Shows token estimates once context-window management exists.
+
+This becomes the answer to "what did the model see?"
+
+### Connections / Settings
+
+Connections remains the right place for provider/model readiness and future
+model capabilities. Chat settings remains the right place for per-chat runtime
+choices. Memory management can live in either Connections, Projects, or a
+dedicated memory surface, but the active memory list must be visible from the
+chat context inspector. Agent profiles should make it clear whether project
+memory is injected into the current agent, visible only as operator notes, or
+disabled.
+
+## API Sketch
+
+Hecate-native endpoints remain under `/hecate/v1`.
+
+```
+GET /hecate/v1/chats/{session_id}/messages/{message_id}/context
+GET /hecate/v1/tasks/{task_id}/runs/{run_id}/context
+```
+
+Both return:
+
+```json
+{
+  "object": "context_packet",
+  "data": {
+    "id": "ctx_...",
+    "session_id": "chat_...",
+    "run_id": "run_...",
+    "items": []
+  }
+}
+```
+
+The initial implementation can omit standalone list/delete endpoints. Context
+packets are audit snapshots owned by their parent message/run.
+
+## Prompt-Injection Rules
+
+1. Untrusted external content is always labelled as untrusted evidence.
+2. Tool output is evidence, not instruction.
+3. Generated summaries are evidence, not instruction.
+4. Memory writes require explicit operator action.
+5. Workspace guidance can guide codebase behavior but cannot override Hecate
+   security policy, approvals, sandboxing, or operator system prompt.
+6. Context packet inspection must show labels that match the actual prompt
+   rendering.
+7. Any future automatic retrieval or import feature must preserve origin and
+   trust labels all the way to the rendered prompt.
+8. External memory provider results enter as labelled memory/context items via
+   the Hecate memory service, never as hidden agent instructions.
+
+## Implementation Plan
+
+| PR | Scope |
+|---|---|
+| 1 | Add `internal/context/` packet types, in-memory assembly for Hecate Chat direct-model and tools-on messages, and context inspector API. |
+| 2 | Persist context packet snapshots in memory and SQLite chat/task stores. |
+| 3 | Add UI context inspector for chat messages and task runs. |
+| 4 | Wire token estimates from the context-window RFC against packet items. |
+| 5 | Add agent-memory selection as a packet source after the memory store exists. |
+
+The first PR is intentionally small: no memory, no summarization, no vector
+retrieval. Just create the audit boundary.
+
+## Test Plan
+
+- Unit tests for trust classification and rendering order.
+- API tests for chat-message and task-run context packet retrieval.
+- SQLite/memory parity tests for packet persistence.
+- UI tests for context inspector grouping and large-item references.
+- Prompt-injection tests where untrusted text tries to override system
+  instructions and remains labelled evidence.
+- Regression test that context-window truncation cannot move
+  `external_untrusted` text into an instruction slot.
+
+## Open Questions
+
+- Should the first packet snapshot store full inline bodies, body references,
+  or both? Recommendation: inline small text, reference artifacts/files for
+  large bodies.
+- Should context packet snapshots be retained forever with chat/task history or
+  pruned by retention? Recommendation: follow the parent chat/task retention
+  policy.
+- Should operators be able to manually pin context items before memory exists?
+  This is useful but may blur into memory. Recommendation: keep pinning out of
+  v1 and implement memory deliberately.
+- Should external-agent runs get a packet? Recommendation: yes, but only as a
+  projection of what Hecate knows: operator prompt, workspace, adapter settings,
+  ACP events, raw adapter output, and artifacts. Do not claim it is the
+  adapter's full internal model context.

--- a/docs/rfcs/llm-context-window-management.md
+++ b/docs/rfcs/llm-context-window-management.md
@@ -1,484 +1,252 @@
 # LLM Context Window Management
 
 > **Status:** proposed; not implemented.
-> **Current source of truth:** [Chat sessions](../chat-sessions.md) and
-> [Agent runtime](../agent-runtime.md) for today's token/usage reporting.
-> **Next action:** refresh naming around context limits before implementation;
-> avoid confusing context-limit policy with removed global budget controls.
+> **Current source of truth:** [Chat sessions](../chat-sessions.md),
+> [Agent runtime](../agent-runtime.md), and
+> [Context assembly and injection boundaries](context-assembly-and-injection-boundaries.md)
+> for today's prompt, transcript, and usage behavior.
+> **Next action:** implement context-packet snapshots first; then add token
+> estimation and warning/cap behavior against those packets.
 
-Today an operator running a long Hecate Chat or an `agent_loop` task
-with `GATEWAY_TASK_AGENT_LOOP_MAX_TURNS=8` (the default) and a few
-`read_file` results will silently exceed the model's context window.
-The gateway hands the whole transcript upstream; the upstream errors
-with a provider-specific `context_length_exceeded` (or worse, a
-generic 4xx); the operator sees a mid-stream failure with no
-preceding warning. Nothing in Hecate counts tokens, sets a threshold,
-or warns ahead of time.
+Long Hecate Chat sessions and task-backed `agent_loop` runs can exceed a
+model's context window. Today that failure usually comes back from the upstream
+provider as a provider-specific 4xx, often after the operator has waited for a
+run to start. Hecate should be able to warn, explain, and eventually compress
+or block before the provider rejects the request.
 
-`GATEWAY_TASK_AGENT_LOOP_MAX_TURNS` is a runaway-loop guard, not a
-context guard — it bounds *iterations*, not *tokens*. An agent doing
-3 huge file reads can exceed 100K tokens in 4 turns; another doing
-50 small command checks stays under 20K. They need orthogonal safety
-nets.
+This RFC owns **fitting already-assembled context into a model window**. It does
+not decide which sources are trusted or eligible. That belongs to
+[context assembly](context-assembly-and-injection-boundaries.md).
 
-This RFC scopes the smallest framework that closes the gap, the
-phased path to ship it, and the open design choices the implementer
-will need to settle.
+## Relationship To Context And Memory
+
+```mermaid
+flowchart LR
+    A["Context assembly"] --> B["Context packet"]
+    B --> C["Token estimation"]
+    C --> D["Warn / cap / trim / summarize"]
+    D --> E["Provider prompt rendering"]
+```
+
+- Context assembly produces an ordered `ContextPacket` with trust labels and
+  inclusion reasons.
+- Agent memory contributes `operator_memory` items to that packet.
+- Context-window management estimates tokens for the included packet items,
+  applies thresholds, and may produce a smaller packet view.
+- It must not change trust labels or promote untrusted content into
+  instructions.
 
 ## Goals
 
-In rough priority order:
-
-1. **Visibility.** Pre-flight token estimate per call surfaced as a
-   trace attribute (`hecate.context.tokens_in`); the projected
-   running total vs. the model limit surfaced as a runtime header
-   (`X-Runtime-Context-Used: projected/model_limit`). No more silent
-   context-overflow failures.
-2. **Soft warning.** Structured warning when the conversation
-   approaches the model's context limit (default 80%). Doesn't
-   block the call; gives operators advance notice.
-3. **Hard cap.** Configurable per-conversation token budget that
-   refuses calls before they hit the upstream limit. Returns a
-   structured error the operator can see, not an opaque upstream
-   4xx.
-4. **Cost-side relief.** Anthropic prompt-cache marker hooks
-   (already shipped via PR #59) wrap memory entries when the
-   agent-memory primitive lands.
-5. **Capability-side relief.** Optional truncation policy when
-   over budget. Default OFF; opt-in via env knob. Whatever policy
-   we ship, operators will report regressions on the use case it
-   mishandles, so the right default is "current behavior preserved
-   unless operator chooses otherwise."
-6. **Future: summarization.** Side-call to a (configurable, often
-   local) model to compress older turns when threshold is hit.
-   Real product feature, not v1; framed here so the policy hook is
-   ready when summarization arrives.
+1. **Visibility.** Show estimated context usage before provider failure:
+   `tokens_in`, `model_limit`, and fraction of the window.
+2. **Friendly failures.** Return a stable Hecate error before an upstream
+   context-length error when the next call is clearly too large.
+3. **Soft warnings.** Warn near the model limit without blocking.
+4. **Optional fitting policy.** Allow explicit opt-in truncation or
+   summarization for long task/chat histories.
+5. **Auditability.** Record which items were kept, dropped, or summarized so
+   the operator can inspect the decision.
 
 ## Non-goals
 
-- **External-agent adapter context management.** Codex, Claude
-  Code, and Cursor Agent each make their own LLM calls outside
-  Hecate's control. We don't see their requests; we can't manage
-  their context. Out of scope by physics, not policy. ACP would
-  need to standardize a context-management primitive first.
-- **Replacing provider-side safety nets.** OpenAI's
-  `max_completion_tokens`, Anthropic's `max_tokens` — these still
-  apply server-side. Hecate's caps complement them; they don't
-  substitute.
-- **Cost vs capability conflation.** This RFC is honest about which
-  problem each piece solves. Caching + summarization fix *cost*.
-  Truncation + hard cap fix *capability*. Visibility serves both.
-- **Per-model fine-grained tokenizers** for non-OpenAI providers.
-  ±5–10% error from a tiktoken-based approximation is acceptable
-  for an 80% threshold. Closing the gap means per-provider exact
-  count_tokens API calls (paid + slow). Not worth it.
-- **Vector-DB-backed semantic compression** ("only include the
-  three most relevant earlier turns"). That's a future RFC if
-  summarization isn't enough.
+- **Source eligibility and prompt-injection boundaries.** Those are owned by
+  context assembly.
+- **External-agent private context management.** Hecate cannot count or trim
+  Codex/Claude Code/Cursor internal model calls through ACP today.
+- **Exact tokenization for every provider.** Approximate estimates are enough
+  for warnings and Hecate-side caps. Exact vendor count APIs can be added later
+  only where they are cheap and useful.
+- **Automatic memory retrieval.** Memory selection happens before this stage.
+- **Cost enforcement.** Hecate records usage for visibility; this RFC is about
+  model capability limits, not spend controls.
 
-## Architecture
+## Token Estimation
 
-Per-conversation token tracking with per-call telemetry emission:
+Initial estimator:
 
-```
-       ┌────────────────────────────────────────────────────┐
-       │ Conversation prepare                               │
-       │                                                    │
-       │   estimate = tokens(messages + system +            │
-       │              tools + memory)                       │
-       │   projected = persisted_running_tokens + estimate  │
-       │   model_limit = lookupModelContextLimit(model)     │
-       │                                                    │
-       │   if projected > 0.95 * model_limit:               │
-       │       ┌──── if truncation enabled ──┐              │
-       │       │  apply policy → re-estimate │              │
-       │       │  → projected = persisted +  │              │
-       │       │    new_estimate             │              │
-       │       └─────────────────────────────┘              │
-       │       ┌──── if still > 0.95 ────────┐              │
-       │       │  if hard_cap enabled:       │              │
-       │       │      refuse → 422           │              │
-       │       └─────────────────────────────┘              │
-       │   if projected > 0.80 * model_limit:               │
-       │       emit structured warning to trace + header    │
-       │                                                    │
-       │   set runtime header: X-Runtime-Context-Used:      │
-       │       projected/model_limit                        │
-       │   set span attr: hecate.context.tokens_in          │
-       │   set span attr: hecate.context.fraction           │
-       │                                                    │
-       │   ──────── after upstream call succeeds ─────────  │
-       │   persisted_running_tokens = projected             │
-       └────────────────────────────────────────────────────┘
-```
+- Uses a shared helper, proposed as `internal/contextwindow/`.
+- Estimates `ContextPacket` items plus tool definitions and provider-specific
+  message framing overhead.
+- Uses `tiktoken-go` or a similarly maintained tokenizer for OpenAI-shaped
+  estimates.
+- Falls back to conservative approximations for providers without a cheap exact
+  count API.
 
-Two values are deliberately distinct: `persisted_running_tokens`
-is the durable per-conversation total carried in the chat-session
-or task-run row; `projected` is `persisted + estimate`, computed
-fresh per call and used for both threshold checks and the runtime
-header. The persisted value updates only on a successful upstream
-response (see "Risks" — failed-and-retried calls must not double-count).
-
-Where the estimate runs:
-- **Hecate Chat / model chat**: in `internal/api/handler_chat.go`'s
-  request preparation, before the provider call dispatches.
-- **`agent_loop` task runs**: in
-  `internal/orchestrator/executor_agent_loop.go`'s per-turn loop,
-  before each upstream call.
-
-Both paths converge on a single estimation helper in (proposed)
-`internal/contextbudget/` so the logic isn't duplicated.
-
-## Tokenizer choice
-
-**Default: `github.com/pkoukk/tiktoken-go`** — the de-facto Go port
-of OpenAI's tiktoken. ~10K stars, actively maintained, used by
-LangChain Go bindings and most Go-based gateways. Tracks upstream
-tokenizer updates (cl100k_base for older OpenAI, o200k_base for the
-GPT-4o family).
-
-For non-OpenAI providers (Anthropic, Gemini, DeepSeek, xAI,
-local), we use the same tiktoken-go encoder with cl100k_base. ±5–10%
-error vs. each vendor's actual tokenizer. That's fine for an 80%
-threshold — the warning still fires within the right ballpark, and
-the hard cap still catches real overflows. The cost of being exact
-(vendor-specific count_tokens API calls per request) outweighs the
-benefit at this layer of accuracy.
-
-### Open: vendor or stay on upstream
-
-`tiktoken-go` is a third-party dependency. Two postures:
-
-- **(a) Direct dependency** (default proposal). Track upstream
-  releases via `go get`. Smallest maintenance burden today.
-- **(b) Vendor a copy** under `internal/contextbudget/tiktoken/`,
-  pin a known-good version. Insulates from upstream churn at the
-  cost of pulling our own copy along when upstream ships fixes.
-- **(c) Write our own**. Reimplement BPE encoding + ship the
-  encoding tables. The encoding tables for cl100k_base and
-  o200k_base are large (~MB each), the BPE algorithm is real but
-  not exotic, and we'd be on the hook for tracking every new
-  OpenAI model with a new tokenizer. ~weeks of work for the
-  marginal control-gain.
-
-**Recommendation:** start with (a). Re-evaluate to (b) only if
-upstream becomes unmaintained or ships a breaking change we can't
-absorb. (c) is over-engineering at our accuracy target.
-
-## Per-conversation tracking, per-call telemetry
-
-Every gateway call to a provider emits two telemetry signals:
-
-- **Span attribute** `hecate.context.tokens_in` (estimated, this
-  call only) and `hecate.context.fraction` (running total /
-  model_limit).
-- **Runtime header** `X-Runtime-Context-Used: NNNN/MMMMM` on the
-  response so SDK consumers can render a context-usage meter without
-  re-estimating client-side. Matches the existing `X-Runtime-*`
-  convention (`X-Runtime-Provider`, `X-Runtime-Model`, etc.).
-
-The running total persists on the conversation:
-
-- For Hecate Chat: tracked on `ChatSessionRecord`; new column
-  `running_context_tokens INTEGER` migrated additively in
-  `internal/chatstate/sqlite.go`.
-- For `agent_loop` task runs: tracked on `TaskRun`; similar
-  additive migration in `internal/taskstate/sqlite.go`.
-
-Hard cap and warn threshold both evaluate against the running
-total, not the per-call estimate.
-
-## Per-model context limits
-
-Hecate doesn't currently know that gpt-4o-mini is 128K and o1 is
-200K. New file `internal/contextbudget/model_limits.go` with a
-hardcoded table:
+The estimator should return:
 
 ```go
-var modelContextLimits = map[string]int{
-    "gpt-4o":         128_000,
-    "gpt-4o-mini":    128_000,
-    "o1":             200_000,
-    "o3-mini":        200_000,
-    "claude-3-5-sonnet-latest": 200_000,
-    "claude-3-5-haiku-latest":  200_000,
-    "claude-3-opus":  200_000,
-    "gemini-1.5-pro": 1_000_000,
-    "gemini-1.5-flash": 1_000_000,
-    "deepseek-chat":  64_000,
-    "deepseek-reasoner": 64_000,
-    // … see implementation
+type ContextEstimate struct {
+    TokensIn        int
+    ModelLimit      int
+    Fraction        float64
+    UnknownLimit    bool
+    Estimator       string
+    PacketID        string
+    IncludedItemIDs []string
 }
 ```
 
-When the model isn't in the table, fall back to a structured
-warning ("`unknown_model_context_limit`") and use a conservative
-default (32K). Operators override the default per-model in the
-model capability registry, which gains an optional
-`context_window_tokens` field. The value can come from a static catalog,
-provider discovery, or an operator override.
+When the model limit is unknown, use the model capability registry if possible,
+then a conservative fallback. The response should include a warning that the
+limit is estimated.
+
+## Model Context Limits
+
+Model limits belong in the shared model capability record, not in a hidden
+budget package.
 
 Lookup precedence:
 
-1. Operator capability override (per-model)
-2. Hardcoded table
-3. Conservative fallback (32K) + structured warning
+1. Operator capability override.
+2. Provider-discovered capability if available.
+3. Static catalog default.
+4. Conservative fallback plus `unknown_model_context_limit` warning.
 
-## Threshold semantics
+The model capability field should be named `max_context_tokens` or
+`context_window_tokens` consistently with existing model capability naming. The
+implementation should pick one and update the API/docs in the same PR.
 
-Three levels:
+## Threshold Behavior
 
-| Level | Default | Trigger | Effect |
-|---|---|---|---|
-| **Soft warn** | 80% of model limit | Running total exceeds | Structured warning in trace + `X-Runtime-Context-Warning` header. Call proceeds. |
-| **Hard cap** | 95% of model limit | Running total + estimated next-call exceeds | Call refused. Returns 422 with structured body: `type=context.budget_exceeded`, includes `tokens_in`, `tokens_limit`, `model`. |
-| **Per-task budget** | unset (0) | Operator-configured `GATEWAY_TASK_AGENT_LOOP_MAX_CONTEXT_TOKENS`. When set, takes precedence over the model-limit-derived cap. | Same 422 shape. |
+Recommended defaults:
 
-The `context.*` prefix is intentional. Hecate's existing `error.type`
-values follow two conventions: plain snake_case for top-level
-gateway errors (`rate_limit_exceeded`, `gateway_error`,
-`invalid_request`) and `<subsystem>.<reason>` for subsystem-scoped
-errors that will plausibly grow siblings — `chat.session_limit_exceeded`,
-`chat.session_duration_limit_exceeded` are the precedent in
-`internal/api/response.go`. Context-window failures will plausibly
-add `context.truncation_failed`, `context.summarization_failed`,
-and similar variants as later phases ship, so the dot-prefixed
-form matches the subsystem-scoped convention rather than treating
-this single error in isolation.
-
-Both percentage thresholds are configurable via env knobs:
-
-```
-GATEWAY_CONTEXT_WARN_THRESHOLD=0.80
-GATEWAY_CONTEXT_HARD_CAP_THRESHOLD=0.95
-```
-
-## Truncation policy (opt-in)
-
-Default OFF. Operators opt in via:
-
-```
-GATEWAY_TASK_AGENT_LOOP_TRUNCATION=drop_oldest
-GATEWAY_TASK_AGENT_LOOP_TRUNCATION_KEEP_RECENT=4
-```
-
-Three policies in scope:
-
-- **`drop_oldest`**: drop oldest user/assistant pairs until under
-  threshold. Preserves system + last `KEEP_RECENT` pairs.
-  Simplest. Loses original context.
-- **`drop_tool_intermediates`**: drop oldest *tool_call /
-  tool_result* messages while keeping user/assistant text intact.
-  Better for QA-style transcripts; breaks if later turns reference
-  earlier tool output.
-- **`summarize_then_drop`**: side-call to a configurable
-  summarization model; replace dropped messages with a single
-  `system` message containing the summary. Most useful, most
-  complex (see next section).
-
-Truncation runs only on `agent_loop` task runs initially; Hecate
-Chat operators get hard-cap or do their own message editing
-client-side. Adding truncation to the chat path is a phase-2
-extension once the policy primitives prove out in tasks.
-
-## Summarization (deferred to a later phase)
-
-Real product feature with eval requirements: precision/recall on
-"did the summary preserve enough?", latency (the side call adds
-~500ms before the main call), cost (paying for summary).
-
-**For local-only deployments, the cost concern goes away** — the
-summarization model can be a local Ollama / LM Studio model; no
-per-token charge. This makes summarization a friction-free default
-for local-first operators.
-
-For cloud deployments, the operator picks a cheap "summarization
-model" (Haiku for Anthropic, gpt-4o-mini for OpenAI, etc.). Knobs:
-
-```
-GATEWAY_TASK_AGENT_LOOP_SUMMARIZATION_MODEL=
-GATEWAY_TASK_AGENT_LOOP_SUMMARIZATION_KEEP_RECENT=4
-GATEWAY_TASK_AGENT_LOOP_SUMMARIZATION_TRIGGER_THRESHOLD=0.75
-```
-
-The summarized form replaces dropped older messages:
-
-```
-system (frozen, untouched)
-system: "Earlier in this conversation: <model-generated summary>"
-user/assistant turn (N-3)
-user/assistant turn (N-2)
-user/assistant turn (N-1)
-user (current)
-```
-
-Phase: ships AFTER the visibility + hard-cap pieces are in
-production. Doesn't block the rest of the framework.
-
-## Memory-aware
-
-The [agent-memory RFC](agent-memory.md) introduces operator-authored
-memory entries injected into the system prompt. Memory entries
-contribute tokens; the budget MUST count them.
-
-Concretely:
-
-- The estimator helper takes the resolved system prompt
-  (post-injection of memory + workspace files + per-task) plus the
-  message list plus tool definitions, and counts the whole thing.
-- Memory entries that are large enough to risk inflating context
-  trigger the same warn/cap mechanics as long conversations.
-- The agent-memory RFC's per-entry size limit (5K soft / 20K hard)
-  exists partly to keep this estimator's ceiling reasonable.
-
-## Cache marker integration
-
-Anthropic prompt-cache markers shipped via PR #59 (system prompt +
-tools entries). Two extensions this RFC anticipates but doesn't
-build:
-
-- **Memory block**: when the agent-memory RFC is implemented, the
-  injection code wraps the memory block in the same
-  `cache_control: {"type": "ephemeral"}` marker. Memory changes
-  infrequently, so cache hits are high.
-- **Conversation prefix**: long stable conversation prefixes (e.g.
-  the system prompt + first 3 user/assistant pairs) are also
-  cacheable. Applying the marker dynamically based on stability is
-  a phase-3 enhancement.
-
-This RFC declares the integration points; the actual changes ride
-in the relevant feature PRs.
-
-## Cost vs capability framing
-
-Two different operator motivations for context-window work:
-
-| Motivation | Failure mode today | Pieces that fix it |
+| Level | Default | Effect |
 |---|---|---|
-| **Cost** | "the conversation succeeds but bills more than expected" | Caching (PR #59), summarization, memory size limits |
-| **Capability** | "the conversation fails mid-call when upstream rejects 200K tokens" | Visibility, hard cap, truncation |
+| Soft warning | 80% of model limit | Add warning to response metadata, trace, and UI. Call proceeds. |
+| Hard cap | 95% of model limit | Refuse before provider call with a structured Hecate error. |
+| Unknown limit | 32K fallback | Warn that the limit is estimated. |
 
-The RFC is honest that neither piece solves both problems. An
-operator who only cares about cost should turn on caching +
-summarization. One who cares about capability should set hard caps.
-Most operators will turn on visibility, hard caps, and
-caching; summarization is opt-in for those willing to accept its
-trade-offs.
+Structured error sketch:
 
-## Phasing
+```json
+{
+  "error": {
+    "type": "context.window_exceeded",
+    "message": "This request is too large for the selected model.",
+    "details": {
+      "tokens_in": 129000,
+      "model_limit": 128000,
+      "model": "example-model",
+      "packet_id": "ctx_..."
+    }
+  }
+}
+```
 
-| PR | Scope | Size |
-|---|---|---|
-| 1 | `internal/contextbudget/` package: tokenizer (tiktoken-go), estimator, model-limit table. Unit-tested in isolation. No wiring. | ~400 |
-| 2 | Per-call telemetry: span attribute + `X-Runtime-Context-Used` runtime header in `handler_chat.go` and `executor_agent_loop.go`. Visibility-only, no caps. | ~250 |
-| 3 | Per-conversation running-total persistence: additive migrations on `chat_sessions` and `task_runs`; running total updated per call. | ~300 |
-| 4 | Soft warn threshold (default 80%) — structured warning in trace, `X-Runtime-Context-Warning` runtime header. Operator-configurable threshold. | ~200 |
-| 5 | Hard cap (default 95% derived; per-task budget knob). Returns 422 with structured `context.budget_exceeded` body. | ~250 |
-| 6 | Truncation policy: `drop_oldest` and `drop_tool_intermediates`. Opt-in via env knob. `agent_loop` only. | ~400 |
-| 7 | Summarization policy. Side-call architecture. Configurable model. Local-model friction-free default for local-only operators. | ~600 |
-| 8 | Docs: drop the relevant `known-limitations.md` entries; add `docs/context-budget.md` operator guide. | ~150 |
+Use a context-specific error family (`context.*`) because future siblings are
+likely: `context.summary_failed`, `context.truncation_failed`,
+`context.unknown_model_limit`.
 
-Total: ~2550 lines, 8 PRs. PRs 1–5 close the visibility +
-capability gap. PR 6 is opt-in policy. PR 7 is the cost-side relief
-(deferrable). PR 8 documents.
+## Fitting Policies
 
-PRs 1–5 alone would close the immediate operator pain. The rest is
-incremental.
+Default behavior should be conservative: warn and cap, but do not silently
+remove context. Operators should opt in to fitting policies.
 
-## Open questions
+### Drop Oldest Transcript
 
-- **Vendor tiktoken-go or stay on upstream.** Recommendation:
-  upstream until proven painful. Re-evaluate per release.
-- **Is `context.fraction` the right name** for the running-total /
-  model-limit ratio? Operators might prefer `context.percent_used`.
-  Bikeshed; defer to implementer taste.
-- **Truncation in Hecate Chat** (not just `agent_loop`). Phase-2
-  extension once the policy primitives prove out. Open: should
-  Hecate Chat get an inline "[earlier messages truncated]" notice
-  in the transcript so operators can see what happened?
-- **Per-message provenance for truncation.** Drop-policy actions
-  could be recorded as a span event ("dropped 12 tool_result
-  messages") so operators can audit. Useful but adds a logging
-  surface; defer to implementer.
-- **Streaming**: token estimation mid-stream is hard. The estimator
-  runs pre-flight, before stream starts; the response stream
-  doesn't refine the estimate (the response side updates the
-  running total once complete). Acceptable for v1; phase-2
-  improvement.
-- **Capability field for context_window_tokens.** Schema/API change to
-  the model capability store. Probably worth doing alongside PR 1 since
-  the model-limit lookup is the new dependency.
-- **What to do when `model` isn't set on a call.** Some clients
-  don't set model in the request when the gateway's default applies.
-  The estimator needs to know which model to look up. Resolve via
-  the same router-decision logic that picks the actual upstream
-  model.
+Drop oldest user/assistant transcript pairs while preserving:
 
-## Risks
+- System instructions.
+- Operator memory.
+- Workspace guidance.
+- Recent transcript turns.
+- Current user request.
 
-1. **Tokenizer drift on non-OpenAI providers.** Anthropic's
-   tokenizer differs from tiktoken; estimates will be ±5–10% off.
-   Mitigation: thresholds are 80%/95%, not 99% — the slop is
-   absorbed by the headroom.
-2. **Hard cap false-positives.** Operator hits the cap mid-task,
-   the run fails, they're confused. Mitigation: structured 422
-   with `tokens_in`, `tokens_limit`, model name; runtime header
-   `X-Runtime-Context-Used`; operator-tunable threshold; documented in
-   `docs/context-budget.md`.
-3. **Truncation breaks user expectations** on the use case the
-   chosen policy mishandles. Mitigation: opt-in default; operators
-   choose. Documentation explicit about each policy's
-   trade-offs.
-4. **Summarization summary loses tool-call context.** If a turn
-   later in the conversation references "the file we read above"
-   and that turn is now in the summary, the model may hallucinate
-   contents. Mitigation: keep tool_call/tool_result pairs intact
-   when possible (`drop_tool_intermediates` is the cleaner
-   variant); summarization is opt-in; eval scaffolding before
-   shipping.
-5. **Capability schema change** for `context_window_tokens` ripples
-   to the model capability store. Mitigation: field is nullable; null
-   means "use the hardcoded fallback"; existing rows don't need
-   migration.
-6. **Per-conversation tracking is wrong on retried calls.** A
-   failed-and-retried call shouldn't double-count tokens.
-   Mitigation: running total updates on success only (or on the
-   final attempt of a retry sequence); failed calls are recorded
-   separately for billing.
+This is simple and predictable, but can lose important early intent.
 
-## Acceptance criteria
+### Drop Tool Intermediates
 
-When this RFC is implemented end-to-end:
+Drop older tool output before dropping user/assistant text. This is useful for
+agentic coding workflows where large stdout/stderr or file reads dominate the
+window, but it can break references to earlier tool results.
 
-- A long Hecate Chat or `agent_loop` task run that approaches the
-  model's context limit produces a structured warning in the trace
-  and an `X-Runtime-Context-Warning` header *before* the upstream
-  errors.
-- A run that would exceed the hard cap is refused with a structured
-  422 (`context.budget_exceeded`) instead of a mid-stream upstream
-  error.
-- An operator can see `hecate.context.tokens_in` and
-  `hecate.context.fraction` on every span and `X-Runtime-Context-Used`
-  on every response.
-- An operator can opt into truncation (`drop_oldest` or
-  `drop_tool_intermediates`) per-deployment via env knob; default
-  remains OFF.
-- An operator running entirely against local models can opt into
-  summarization without per-token cost concerns.
-- Memory entries (when the agent-memory RFC is implemented)
-  contribute to the running token total and trigger warns / caps
-  appropriately.
-- The relevant `known-limitations.md` entries about silent context
-  failures are dropped or rewritten.
+### Summarize Older Context
 
-## Cross-references
+Use a configurable summarization model to replace older transcript/tool output
+with a generated summary item.
 
-- [Agent memory](agent-memory.md) — memory entries inflate context;
-  the estimator MUST count them. Memory size limits in that RFC
-  exist partly to keep this estimator's ceiling reasonable.
-- [Provider response extensions](provider-response-extensions.md) —
-  `Usage.ReasoningTokens` is one piece of context-cost accounting
-  this framework integrates with on the response side.
-- PR #59 (Anthropic prompt cache markers) — already-shipped code
-  that this RFC anticipates extending in phase-3 to cover memory
-  blocks and stable conversation prefixes.
+The generated summary must become a `generated_summary` context item that
+references the item IDs it replaced. It is evidence, not instruction.
+
+## Packet Mutation Rules
+
+Window management may produce a fitted view of the packet, but the original
+packet remains inspectable.
+
+Allowed:
+
+- Mark included items as dropped for size.
+- Add a generated summary item with provenance.
+- Recompute token estimates.
+- Return warnings/caps.
+
+Not allowed:
+
+- Change trust labels.
+- Turn untrusted text into an instruction.
+- Drop Hecate safety instructions.
+- Drop operator system prompt or approval/sandbox policy text.
+- Rewrite memory entries.
+
+## Telemetry And UI
+
+Emit:
+
+- Span attributes:
+  - `hecate.context.packet_id`
+  - `hecate.context.tokens_in`
+  - `hecate.context.model_limit`
+  - `hecate.context.fraction`
+  - `hecate.context.policy`
+- Optional response headers for compatibility clients:
+  - `X-Hecate-Context-Used: <tokens>/<limit>`
+  - `X-Hecate-Context-Warning: <reason>`
+
+UI:
+
+- Chat composer warning near the model picker when the next call is near the
+  limit.
+- Message/run context inspector shows original packet, fitted view, dropped
+  items, summaries, and token estimates.
+- Friendly error with repair actions: switch model, reduce context, summarize,
+  or start a fresh chat.
+
+## Implementation Plan
+
+| PR | Scope |
+|---|---|
+| 1 | Add model context limit field to capability records and provider/model API responses. |
+| 2 | Add token estimator over `ContextPacket` items with unit tests. |
+| 3 | Add soft warning + hard cap for Hecate Chat direct-model and tools-on runs. |
+| 4 | Surface context usage in Chat and Task Detail. |
+| 5 | Add opt-in fitting policy for task-backed Hecate Chat runs. |
+| 6 | Add summarization as a separate, evaluated feature. |
+
+PRs 1-4 are the practical beta target. PRs 5-6 are useful but should not block
+basic context visibility.
+
+## Test Plan
+
+- Unit tests for model-limit lookup precedence.
+- Unit tests for token estimation across system prompt, memory, workspace docs,
+  transcript, and tool output items.
+- API tests for soft warning and hard cap response shapes.
+- Regression tests proving fitting policies preserve trust labels.
+- SQLite/memory parity tests if context estimates are persisted on packets.
+- UI tests for warning, error, and context inspector rendering.
+- E2E test for a synthetic long transcript that produces a friendly Hecate
+  error instead of an upstream provider context error.
+
+## Open Questions
+
+- Should Hecate call provider count-token APIs when available? Recommendation:
+  not in v1; add only if a provider makes it free and low-latency.
+- Should context limits be per chat, per segment, or per run? Recommendation:
+  estimate per model call, display per message/run, and aggregate only for
+  orientation.
+- Should summarization default to local providers when configured?
+  Recommendation: yes, but only after summarization has its own evals.
+- Should operators configure thresholds globally or per model/profile?
+  Recommendation: global defaults first, profile-level overrides later.
+

--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -1,0 +1,260 @@
+# Projects
+
+Status: Proposed
+
+Current source of truth: [Agent runtime](../agent-runtime.md), [Chat sessions](../chat-sessions.md), [Architecture](../architecture.md)
+
+Next action: introduce a durable `project_id` model before project-scoped memory, agent profiles, and richer context assembly.
+
+## Summary
+
+Hecate should distinguish **Projects** from **Workspaces**.
+
+A project is the durable Hecate identity for a codebase or work area. It owns memory scopes, chat/task grouping, default runtime choices, trusted context sources, and future agent-profile defaults. A workspace is a concrete filesystem root used by one chat, task, run, or external-agent session.
+
+Today Hecate often uses a raw workspace path as both identity and runtime location. That works for early local flows, but it becomes confusing once we add durable memory, imported contexts, multiple checkouts of the same repo, temporary task workspaces, editor-owned workspaces, and future assistant layers.
+
+## Problem
+
+`workspace` currently carries too many meanings:
+
+- The directory where a task or agent is allowed to read/write.
+- The UI label for where a chat is happening.
+- The implicit scope for memories or instructions.
+- The thing future agent profiles would likely attach to.
+- Sometimes a source checkout, sometimes a temporary clone, sometimes an in-place working tree.
+
+Raw paths are not stable enough to be the durable identity:
+
+- A repo can move on disk.
+- The same repo can have multiple clones.
+- A task can run in an isolated clone while the user thinks of it as the same project.
+- Native app, web, Docker, and editor-owned ACP workspaces can expose different paths for the same logical work.
+- Future project memory should not silently split because the path changed.
+
+## Terminology
+
+| Term | Meaning |
+|---|---|
+| Project | Durable Hecate object representing a codebase or work area. Identified by `project_id`. Owns defaults, memories, history grouping, and context sources. |
+| Workspace | Concrete filesystem root used for execution. A project can have one or more workspaces over time. |
+| Chat | Conversation attached to an optional project and, when running, a concrete workspace. |
+| Task | Durable runtime object attached to an optional project and a concrete workspace mode. |
+| Run | One execution attempt under a task. Runs never define project identity by themselves. |
+| Agent profile | Reusable agent configuration for Hecate Chat or an external agent: model/adapter controls, tools, memory sources, system instructions, and safety posture. |
+| Preset | Template for creating or updating a project default or agent profile. Presets are not used directly at runtime once applied. |
+| Context packet | A snapshot of what Hecate assembled for a model/agent call, including project and workspace metadata. |
+
+## Goals
+
+- Add stable project identity independent of raw filesystem paths.
+- Make project memory a first-class durable scope.
+- Give Hecate Chat, Tasks, and External Agents a shared grouping model.
+- Keep workspace modes explicit: in-place, isolated clone, temporary workspace, editor-owned workspace.
+- Let project defaults feed new chats and tasks: provider, model, agent profile, tools, command-output compaction, approval posture, workspace mode, and system prompt where applicable.
+- Let context assembly use project-level sources: project instructions, selected docs, saved memories, and trusted files.
+- Let Hecate Chat and external-agent chats share project memory when their active agent profile opts into it.
+- Make UI history clearer: “these chats/tasks belong to this project,” not just “these happened under similar-looking paths.”
+
+## Non-goals
+
+- Hosted multi-tenant project management.
+- Team permissions, sharing, or organization policy.
+- Replacing task workspaces or sandboxing.
+- Automatically cloning or syncing repositories.
+- Importing private memory from external agents.
+- Synchronizing external-agent private memory into Hecate memory.
+- Treating a project as a billing/accounting boundary.
+
+## Data Model
+
+Sketch:
+
+```go
+type Project struct {
+    ID              string // proj_...
+    Name            string
+    Roots           []ProjectRoot
+    DefaultRootID   string
+    RepoURL         string
+    DefaultBranch   string
+    DefaultProvider string
+    DefaultModel    string
+    DefaultAgentProfile string
+    SourcePresetID string
+
+    DefaultToolsEnabled      *bool
+    DefaultWorkspaceMode     string
+    DefaultSystemPrompt      string
+    DefaultCompactToolOutput *bool
+
+    CreatedAt    time.Time
+    UpdatedAt    time.Time
+    LastOpenedAt time.Time
+}
+
+type ProjectRoot struct {
+    ID        string
+    Path      string
+    Kind      string // local, isolated_clone, editor_owned, temporary
+    GitRemote string
+    GitBranch string
+    Active    bool
+}
+```
+
+Rules:
+
+- `project_id` is nullable during migration.
+- Existing chats and tasks without a project remain valid.
+- First implementation may auto-create a path-derived project when a user starts a chat or task from a local workspace.
+- Operators can rename a path-derived project later.
+- Multiple roots can map to one project, but one root should not silently attach to many projects without operator confirmation.
+
+## API Shape
+
+Proposed Hecate-native endpoints:
+
+```text
+GET    /hecate/v1/projects
+POST   /hecate/v1/projects
+GET    /hecate/v1/projects/{project_id}
+PATCH  /hecate/v1/projects/{project_id}
+DELETE /hecate/v1/projects/{project_id}
+GET    /hecate/v1/projects/{project_id}/activity
+```
+
+Chats and tasks should expose project linkage directly:
+
+```json
+{
+  "id": "chat_...",
+  "project_id": "proj_...",
+  "workspace": "/Users/me/dev/hecate",
+  "workspace_mode": "in_place"
+}
+```
+
+Project activity is a convenience aggregation over existing chats, tasks, runs, approvals, and usage. It should not replace those canonical APIs.
+
+## Memory Relationship
+
+Project memory should be the default durable memory scope.
+
+Memory layers:
+
+| Layer | Persistence | Scope | Promotion |
+|---|---|---|---|
+| Global memory | Durable | Whole local Hecate instance | Explicit only |
+| Project memory | Durable | One `project_id` | Explicit save from chat/task |
+| Chat/session memory | Session-local | One chat/session | Never auto-promoted |
+| Current context | Per request | One model/agent call | Not memory |
+
+This keeps short-lived conversation facts out of project memory unless the operator or assistant explicitly saves them.
+
+Agent profiles decide whether project memory is used for a given agent. For
+example, a Hecate Chat profile can inject project memory into the provider
+prompt, while a Claude Code profile can send the same project memory only if the
+ACP adapter exposes a safe instruction/config surface. If no such surface
+exists, Hecate can still show the project memory in the context inspector as
+operator-side notes.
+
+External memory providers should plug in behind the Hecate memory service and
+be selected by agent profile. Projects define the durable scope; profiles define
+which local/external memory sources participate for a specific agent.
+
+## Profiles And Presets
+
+Projects, profiles, and presets have separate jobs:
+
+| Object | Job | Runtime role |
+|---|---|---|
+| Project | Durable identity for a codebase/work area. Owns defaults, history grouping, and project memory. | Active runtime scope. |
+| Agent profile | Saved configuration for an agent in a project or globally: Hecate/Codex/Claude/Cursor, model/adapter controls, tools, approvals, memory sources, system prompt, RTK. | Active runtime configuration. |
+| Preset | Reusable template such as "code review", "implementation", "docs", "safe external agent", or "fast local model". | Applied to create/update a profile or project default; not a live scope. |
+
+In other words: a project can choose a default agent profile, and a profile can
+be created from a preset. After application, Hecate should persist the resolved
+profile/settings. Context packets may record `source_preset_id` for audit, but
+the runtime should not depend on a mutable preset staying unchanged.
+
+## Context Relationship
+
+Context assembly should include both project and workspace metadata:
+
+- `project_id`: stable identity for memory/defaults/history.
+- `workspace`: concrete execution path.
+- `workspace_mode`: in-place, isolated clone, temporary, or editor-owned.
+- `project_context`: saved memories, project instructions, selected docs, and trusted repo guidance.
+- `agent_profile_context`: selected memory sources, profile instructions, and adapter/model controls.
+- `workspace_context`: files, diffs, tool output, and runtime artifacts from the concrete workspace.
+
+This prevents future context systems from confusing “same path today” with “same durable project.”
+
+## UI Shape
+
+Initial UI should stay lightweight:
+
+- Show project identity in Chat settings and Task detail when present.
+- Group chat/task history by project once projects exist.
+- Let “New Hecate chat” inherit project defaults.
+- Let “Use model” and “Use external agent” attach to the same project when started from the same workspace.
+- Let agent profiles expose whether project memory is injected, visible only,
+  or disabled for that agent.
+- Add a project details surface later for defaults, memory, trusted docs, and recent activity.
+
+Avoid turning Projects into a heavy project-management product. This is a runtime identity and context boundary first.
+
+## Storage Plan
+
+Add a new `internal/projects/` package with memory and SQLite stores.
+
+Persist `project_id` on:
+
+- Agent Chat sessions.
+- Chat-completion sessions where a workspace/project is selected.
+- Tasks and runs.
+- Context packets.
+- Memory entries.
+- Future presets/profiles.
+
+SQLite migration should be additive first:
+
+- New `projects` table.
+- New `project_roots` table.
+- Nullable `project_id` columns on existing tables.
+
+Because Hecate has no stable users yet, later cleanup can remove legacy path-derived compatibility once the new model settles.
+
+## Implementation Plan
+
+1. Add project store, API, and UI list/create basics.
+2. Auto-create path-derived projects for local workspaces.
+3. Add `project_id` to chat sessions and tasks.
+4. Thread project identity into context packets.
+5. Add project-scoped memory.
+6. Add agent-profile memory-source selection.
+7. Move relevant defaults from ad hoc chat/task state into project defaults.
+8. Add project activity aggregation.
+9. Update docs, screenshots, and e2e coverage.
+
+## Test Plan
+
+- Unit tests for memory and SQLite project store parity.
+- API tests for CRUD, root attachment, rename, and deletion constraints.
+- Migration tests for adding nullable `project_id` to existing data.
+- Chat tests that new Hecate Chat sessions inherit project defaults.
+- Task tests that task/run records preserve `project_id`.
+- Memory tests that project memory appears only for matching `project_id`.
+- Profile tests proving Hecate Chat and external-agent profiles can opt into the
+  same project memory without sharing private adapter memory.
+- E2E: create project from workspace, start chat, create task-backed turn, refresh, verify chat/task grouping.
+
+## Open Questions
+
+- Should a single filesystem root be allowed in multiple projects?
+- Should project identity be inferred from Git remote by default, or only from explicit user selection?
+- How should project defaults interact with per-chat overrides?
+- Should imported Claude/Codex contexts create projects automatically?
+- Should a project have one preferred workspace mode or separate defaults for Hecate Chat, Tasks, and External Agents?
+- Which agent profiles should opt into project memory by default?


### PR DESCRIPTION
## Summary

- Adds a Projects RFC that separates durable project identity from concrete execution workspaces.
- Reworks Agent Memory around project-scoped memory, chat/session memory, agent-profile-selected memory sources, and external memory provider layering.
- Adds a Context Assembly RFC that defines context packets, trust labels, prompt-injection boundaries, and the inspection surface needed before memory/summarization work.
- Refreshes the LLM context-window RFC and RFC catalogs so Projects, Memory, Context Assembly, and Context Window Management describe one coherent model.

## Design shape

Projects are durable scope. Workspaces are concrete filesystem execution roots. Agent profiles are active runtime configurations. Presets are templates for creating/updating project defaults or profiles; they are not live runtime scope.

External memory providers sit behind Hecate's memory service. Agent profiles select which local/external memory sources are available, and context assembly decides what actually gets injected into Hecate Chat, tasks, or external-agent sessions.

## Verification

- Ran a local changed-doc markdown link and fragment check over the modified RFC/docs files.
