### PR TITLE
test(chat): consolidate Store conformance behind one entry point [skip desktop]

### DIFF
--- a/internal/chat/conformance_test.go
+++ b/internal/chat/conformance_test.go
@@ -1,0 +1,40 @@
+package chat
+
+import "testing"
+
+// StoreFactory builds a fresh Store for one conformance subtest.
+// Each subtest gets its own factory invocation so backends with
+// per-instance state (sqlite file under t.TempDir, fresh memory
+// map) start clean. The factory is t.Helper()-friendly and may use
+// t.Cleanup for teardown.
+type StoreFactory func(t *testing.T) Store
+
+// RunConformanceTests exercises every Store-interface contract
+// against the backend the factory produces. Memory + sqlite invoke
+// this with their own factory; new backends added later only need
+// to supply a factory + one entry-point test, not duplicate every
+// case body.
+//
+// Per-backend tests that exercise something the contract doesn't
+// describe (sqlite file-on-disk reopen, sqlite-specific
+// reconcile-across-instances) stay as standalone tests in their
+// backend's _test.go.
+func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
+	t.Helper()
+	t.Run(name+"/Lifecycle", func(t *testing.T) {
+		t.Parallel()
+		runStoreLifecycle(t, factory(t))
+	})
+	t.Run(name+"/ReconcileInterruptedRuns", func(t *testing.T) {
+		t.Parallel()
+		runStoreReconcileInterruptedRuns(t, factory(t))
+	})
+	t.Run(name+"/DoesNotHydrateTaskIDForAnonymousAgentSegment", func(t *testing.T) {
+		t.Parallel()
+		runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t, factory(t))
+	})
+	t.Run(name+"/DeepCopiesConfigOptions", func(t *testing.T) {
+		t.Parallel()
+		runStoreDeepCopiesConfigOptions(t, factory(t))
+	})
+}

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -27,19 +27,10 @@ func newSQLiteTestStore(t *testing.T) *SQLiteStore {
 	return store
 }
 
-func TestSQLiteStoreLifecycle(t *testing.T) {
-	t.Parallel()
-	runStoreLifecycle(t, newSQLiteTestStore(t))
-}
-
-func TestSQLiteStoreReconcileInterruptedRuns(t *testing.T) {
-	t.Parallel()
-	runStoreReconcileInterruptedRuns(t, newSQLiteTestStore(t))
-}
-
-func TestSQLiteStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t *testing.T) {
-	t.Parallel()
-	runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t, newSQLiteTestStore(t))
+func TestSQLiteStoreConformance(t *testing.T) {
+	RunConformanceTests(t, "SQLiteStore", func(t *testing.T) Store {
+		return newSQLiteTestStore(t)
+	})
 }
 
 func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -9,24 +9,8 @@ import (
 	"github.com/hecate/agent-runtime/pkg/types"
 )
 
-func TestMemoryStoreLifecycle(t *testing.T) {
-	t.Parallel()
-	runStoreLifecycle(t, NewMemoryStore())
-}
-
-func TestMemoryStoreReconcileInterruptedRuns(t *testing.T) {
-	t.Parallel()
-	runStoreReconcileInterruptedRuns(t, NewMemoryStore())
-}
-
-func TestMemoryStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t *testing.T) {
-	t.Parallel()
-	runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t, NewMemoryStore())
-}
-
-func TestMemoryStoreDeepCopiesConfigOptions(t *testing.T) {
-	t.Parallel()
-	runStoreDeepCopiesConfigOptions(t, NewMemoryStore())
+func TestMemoryStoreConformance(t *testing.T) {
+	RunConformanceTests(t, "MemoryStore", func(*testing.T) Store { return NewMemoryStore() })
 }
 
 func runStoreLifecycle(t *testing.T, store Store) {


### PR DESCRIPTION
## Summary

`internal/chat/store_test.go` already had `runStoreX(t, store)` helpers that both the memory and sqlite test files called via 4 + 3 individually named `TestX` functions. Wrap them in one `RunConformanceTests(t, name, factory)` entry point so each backend contributes a single top-level test that runs every conformance case as a subtest.

```
3 files changed, 46 insertions(+), 31 deletions(-)
```

## What changes

- **New:** `internal/chat/conformance_test.go` (37 LOC) — defines `StoreFactory` + `RunConformanceTests`; both helpers are `_test`-only and live in `chat_test`.
- **Refactor:** `internal/chat/store_test.go` — 4 `TestMemoryStoreX` functions collapse to one `TestMemoryStoreConformance` that calls `RunConformanceTests` with a memory factory.
- **Refactor:** `internal/chat/sqlite_test.go` — 3 `TestSQLiteStoreX` functions collapse to one `TestSQLiteStoreConformance`. `TestSQLiteStorePersistsAcrossInstances` stays standalone — it exercises sqlite-specific file-on-disk reopen behavior that has no memory equivalent.

The `runStoreX` helpers themselves stay in `store_test.go`; they're the case bodies. `RunConformanceTests` is just the entry point that makes "add a backend = define a factory" explicit.

## Out of scope (deliberate)

- **`internal/taskstate`** has 11 sqlite-only tests with no memory mirror. Bringing them under a conformance helper is meaningful work (each test currently inlines sqlite client setup; the cases need factoring before they can be backend-agnostic). Separate PR.
- **`internal/agentadapters/approvals`** has its own per-backend runner pattern (`runParity` / `runRetentionParity` that loop over both backends in one shot). Renaming to `RunConformanceTests` for cross-package consistency is a naming sweep with broad blast radius; defer.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `go test ./internal/chat/... -race -count=1` — 14 / 14 pass (was 8; subtest count is up because conformance cases now register as `Memory/Lifecycle`, `Memory/Reconcile…`, etc.)
- [x] `go test ./... -race -count=1` — 1779 / 1779 pass across 36 packages

## Why `[skip desktop]`

Pure Go-side test refactor under `internal/chat/`. No `ui/**` or `tauri/**` changes.