### PR TITLE
refactor(app): extract settings slice; useRuntimeConsole has zero inline state

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -7,6 +7,7 @@ import { ChatProvider } from "./state/chat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
+import { SettingsProvider } from "./state/settings";
 import { UsageProvider } from "./state/usage";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriRuntime } from "../lib/tauri";
@@ -31,9 +32,11 @@ export default function App() {
           <ChatProvider>
             <RetentionProvider>
               <ApprovalsProvider>
-                <RuntimeConsoleContextProvider>
-                  <AppConsole />
-                </RuntimeConsoleContextProvider>
+                <SettingsProvider>
+                  <RuntimeConsoleContextProvider>
+                    <AppConsole />
+                  </RuntimeConsoleContextProvider>
+                </SettingsProvider>
               </ApprovalsProvider>
             </RetentionProvider>
           </ChatProvider>

--- a/ui/src/app/state/settings.tsx
+++ b/ui/src/app/state/settings.tsx
@@ -1,0 +1,113 @@
+// Settings slice: the server-fetched configuration snapshot the
+// settings page renders against, the settings-mutation error string
+// shown next to settings forms, and the transient cross-page notice
+// banner (success / error toast).
+//
+// `notice` is a global UI concern rather than a settings concern —
+// it's set after settings mutations but also after chat actions and
+// other operator-driven events. Lives here because it had no better
+// home and shipping a one-field "notice" slice felt heavier than
+// the seam was worth; if the slice grows a second non-settings
+// concern, split.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+
+import type { ConfiguredStateResponse } from "../../types/runtime";
+
+export type NoticeState = {
+  kind: "success" | "error";
+  message: string;
+};
+
+export type SettingsState = {
+  config: ConfiguredStateResponse["data"] | null;
+  error: string;
+  notice: NoticeState | null;
+};
+
+export type SettingsActions = {
+  setConfig: (value: ConfiguredStateResponse["data"] | null) => void;
+  updateConfig: (
+    updater: (current: ConfiguredStateResponse["data"] | null) => ConfiguredStateResponse["data"] | null,
+  ) => void;
+  setError: (value: string) => void;
+  setNotice: (value: NoticeState | null) => void;
+  dismissNotice: () => void;
+  dismissNoticeIfMatching: (notice: NoticeState) => void;
+};
+
+type SettingsContextValue = {
+  state: SettingsState;
+  actions: SettingsActions;
+};
+
+type Action =
+  | { type: "config/set"; value: ConfiguredStateResponse["data"] | null }
+  | {
+      type: "config/update";
+      updater: (current: ConfiguredStateResponse["data"] | null) => ConfiguredStateResponse["data"] | null;
+    }
+  | { type: "error/set"; value: string }
+  | { type: "notice/set"; value: NoticeState | null }
+  | { type: "notice/dismissIfMatching"; notice: NoticeState };
+
+const initialState: SettingsState = {
+  config: null,
+  error: "",
+  notice: null,
+};
+
+function reducer(state: SettingsState, action: Action): SettingsState {
+  switch (action.type) {
+    case "config/set":    return { ...state, config: action.value };
+    case "config/update": return { ...state, config: action.updater(state.config) };
+    case "error/set":     return { ...state, error: action.value };
+    case "notice/set":    return { ...state, notice: action.value };
+    case "notice/dismissIfMatching":
+      return state.notice === action.notice ? { ...state, notice: null } : state;
+  }
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setConfig = useCallback((value: ConfiguredStateResponse["data"] | null) => {
+    dispatch({ type: "config/set", value });
+  }, []);
+  const updateConfig = useCallback(
+    (updater: (current: ConfiguredStateResponse["data"] | null) => ConfiguredStateResponse["data"] | null) => {
+      dispatch({ type: "config/update", updater });
+    },
+    [],
+  );
+  const setError = useCallback((value: string) => {
+    dispatch({ type: "error/set", value });
+  }, []);
+  const setNotice = useCallback((value: NoticeState | null) => {
+    dispatch({ type: "notice/set", value });
+  }, []);
+  const dismissNotice = useCallback(() => {
+    dispatch({ type: "notice/set", value: null });
+  }, []);
+  const dismissNoticeIfMatching = useCallback((notice: NoticeState) => {
+    dispatch({ type: "notice/dismissIfMatching", notice });
+  }, []);
+
+  const actions = useMemo<SettingsActions>(
+    () => ({ setConfig, updateConfig, setError, setNotice, dismissNotice, dismissNoticeIfMatching }),
+    [setConfig, updateConfig, setError, setNotice, dismissNotice, dismissNoticeIfMatching],
+  );
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export function useSettings(): SettingsContextValue {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) {
+    throw new Error("useSettings must be used inside a <SettingsProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/app/useRuntimeConsole.test.tsx
+++ b/ui/src/app/useRuntimeConsole.test.tsx
@@ -7,6 +7,7 @@ import { ChatProvider } from "./state/chat";
 import { ProvidersAndModelsProvider } from "./state/providersAndModels";
 import { RetentionProvider } from "./state/retention";
 import { RuntimeProvider } from "./state/runtime";
+import { SettingsProvider } from "./state/settings";
 import { UsageProvider } from "./state/usage";
 import { useRuntimeConsole } from "./useRuntimeConsole";
 
@@ -22,7 +23,9 @@ function SliceProviders({ children }: { children: ReactNode }) {
         <ProvidersAndModelsProvider>
           <ChatProvider>
             <RetentionProvider>
-              <ApprovalsProvider>{children}</ApprovalsProvider>
+              <ApprovalsProvider>
+                <SettingsProvider>{children}</SettingsProvider>
+              </ApprovalsProvider>
             </RetentionProvider>
           </ChatProvider>
         </ProvidersAndModelsProvider>

--- a/ui/src/app/useRuntimeConsole.ts
+++ b/ui/src/app/useRuntimeConsole.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type SyntheticEvent } from "react";
+import { useEffect, useMemo, type SyntheticEvent } from "react";
 
 import {
   type ChatTarget,
@@ -57,6 +57,7 @@ import { useChat } from "./state/chat";
 import { useProvidersAndModels } from "./state/providersAndModels";
 import { useRetention } from "./state/retention";
 import { useRuntime } from "./state/runtime";
+import { useSettings, type NoticeState } from "./state/settings";
 import { useUsage } from "./state/usage";
 import type {
   AgentAdapterHealthRecord,
@@ -66,15 +67,9 @@ import type {
   ChatChangedFileRecord,
   ChatSessionRecord,
   ChatResponse,
-  ConfiguredStateResponse,
   ProviderFilter,
   RuntimeHeaders,
 } from "../types/runtime";
-
-type NoticeState = {
-  kind: "success" | "error";
-  message: string;
-};
 
 function chatSessionIsExternal(session: ChatSessionRecord | null): boolean {
   return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);
@@ -261,10 +256,17 @@ export function useRuntimeConsole() {
   // chatGrants,chatGrantsLoading,chatGrantsError}`
   // keys and the actions under their legacy identifiers.
   const approvals = useApprovals();
-  const [settingsConfig, setSettingsConfig] = useState<ConfiguredStateResponse["data"] | null>(null);
 
-  const [settingsError, setSettingsError] = useState("");
-  const [notice, setNotice] = useState<NoticeState | null>(null);
+  // Settings slice: server config snapshot, settings-mutation error,
+  // transient notice banner. Legacy aliases below keep the rest of
+  // the hook body reading identically to its pre-slice form.
+  const settings = useSettings();
+  const settingsConfig = settings.state.config;
+  const settingsError = settings.state.error;
+  const notice = settings.state.notice;
+  const setSettingsError = settings.actions.setError;
+  const setNotice = settings.actions.setNotice;
+  const dismissNotice = settings.actions.dismissNotice;
 
   const chatTarget = activeChatSessionID && activeChatSession
     ? (chatSessionIsExternal(activeChatSession)
@@ -340,10 +342,10 @@ export function useRuntimeConsole() {
       return;
     }
     const timeout = window.setTimeout(() => {
-      setNotice((current) => (current === notice ? null : current));
+      settings.actions.dismissNoticeIfMatching(notice);
     }, 3000);
     return () => window.clearTimeout(timeout);
-  }, [notice]);
+  }, [notice, settings.actions]);
 
   useEffect(() => {
     if (providerFilter !== "auto") {
@@ -490,7 +492,7 @@ export function useRuntimeConsole() {
           setHealth(essentials.health);
           setSessionInfo(essentials.sessionInfo);
           setModels(essentials.models);
-          setSettingsConfig(essentials.settingsConfig);
+          settings.actions.setConfig(essentials.settingsConfig);
         },
       });
 
@@ -507,7 +509,7 @@ export function useRuntimeConsole() {
       setActiveChatSession(snapshot.activeChatSession);
       syncHecateSelectionFromSession(snapshot.activeChatSession);
       setUsageEvents(snapshot.usageEvents);
-      setSettingsConfig(snapshot.settingsConfig);
+      settings.actions.setConfig(snapshot.settingsConfig);
       setAgentAdapterApprovalMode(snapshot.agentAdapterApprovalMode);
       setHecateRTKAvailable(snapshot.rtkAvailable);
       setHecateRTKPath(snapshot.rtkPath);
@@ -940,7 +942,7 @@ export function useRuntimeConsole() {
     const previousProviderFilter = providerFilter;
     const previousModel = model;
 
-    setSettingsConfig(current => current
+    settings.actions.updateConfig(current => current
       ? { ...current, providers: current.providers.filter(provider => provider.id !== id) }
       : current);
     setProviders(current => current.filter(provider => provider.name !== id));
@@ -957,7 +959,7 @@ export function useRuntimeConsole() {
       setNoticeMessage("success", "Provider removed.");
       void loadDashboard();
     } catch (error) {
-      setSettingsConfig(current => {
+      settings.actions.updateConfig(current => {
         if (!removedConfiguredProvider) return current;
         if (!current) return current;
         if (current.providers.some(provider => provider.id === id)) return current;
@@ -1627,7 +1629,7 @@ export function useRuntimeConsole() {
       probeAgentAdapter,
       setAgentAdapterCredential,
       deleteAgentAdapterCredential,
-      dismissNotice: () => setNotice(null),
+      dismissNotice,
     },
   };
 }


### PR DESCRIPTION
## Summary

The three remaining inline \`useState\` calls in \`ui/src/app/useRuntimeConsole.ts\` (\`settingsConfig\`, \`settingsError\`, \`notice\`) move into a new \`settings\` slice at \`ui/src/app/state/settings.tsx\`, joining the existing 6 slices under \`app/state/\`. After this PR, useRuntimeConsole is pure composition — every piece of state lives in a slice; the hook reads/writes via slice actions only.

## What changes

**New** \`ui/src/app/state/settings.tsx\`:
- \`SettingsState\` = \`{ config, error, notice }\`
- \`SettingsActions\` = \`{ setConfig, updateConfig, setError, setNotice, dismissNotice, dismissNoticeIfMatching }\`
- \`SettingsProvider\` + \`useSettings\` hook following the same pattern as the existing slices

**\`ui/src/app/App.tsx\`** — wraps \`<RuntimeConsoleContextProvider>\` with \`<SettingsProvider>\`.

**\`ui/src/app/useRuntimeConsole.ts\`** — drops the 3 inline \`useState\` declarations, the local \`NoticeState\` type definition, and the inline arrow \`dismissNotice\`. Replaces them with a \`const settings = useSettings()\` integration plus the slice's exported \`NoticeState\` type. The auto-dismiss \`useEffect\` now calls \`settings.actions.dismissNoticeIfMatching(notice)\` rather than passing a functional updater to a React setter.

**\`ui/src/app/useRuntimeConsole.test.tsx\`** — \`SliceProviders\` test wrapper gains \`<SettingsProvider>\` so \`renderHook(() => useRuntimeConsole())\` can find the context.

## API additions on the slice

- \`setConfig(value)\` — replace the config snapshot
- \`updateConfig(updater)\` — functional updater form (used by the optimistic-update + rollback paths in \`deleteProvider\`)
- \`setNotice(value)\` — set or clear the banner
- \`dismissNotice()\` — clear unconditionally (used by the bag's \`actions.dismissNotice\`)
- \`dismissNoticeIfMatching(notice)\` — clear only if the slice still holds the captured notice. Used by the 3s auto-dismiss \`useEffect\` so a newer notice that displaced the timed-out one doesn't get wiped by a stale timeout.

## What doesn't change

- \`useRuntimeConsole\`'s external \`{ state, actions }\` surface is byte-identical: \`state.settingsConfig\`, \`state.settingsError\`, \`state.notice\`, \`actions.dismissNotice\` all stay.
- No view-facing prop or context-shape change. Views that read via \`useRuntimeConsoleContext()\` see exactly the same shape.

## Note on slice scope

The \`notice\` field is a cross-cutting concern (transient banner set by many call sites, not just settings) but lives in the settings slice because shipping a one-field "notice" slice felt heavier than the seam was worth. Documented in the slice's doc comment; if it grows a second non-settings concern, split.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bunx vitest run\` — 939 / 939 pass across 40 test files
- \`grep "useState\\ |useReducer" ui/src/app/useRuntimeConsole.ts\` — returns 0 hits

## Why no \`[skip desktop]\`?

Touches \`ui/**\`; the desktop bundle re-builds.