### PR TITLE
docs(rfcs): add status audit (2026-05-17)

### DIFF
--- a/docs/rfcs/AUDIT-2026-05-17.md
+++ b/docs/rfcs/AUDIT-2026-05-17.md
@@ -1,0 +1,241 @@
+# RFC Status Audit — 2026-05-17
+
+This audit reviews the 16 RFCs in `docs/rfcs/` (excluding the `README.md`
+index) and classifies each by current status: whether its design has shipped,
+is partially built, remains a proposal, or has been superseded. The intent is
+to keep `docs/rfcs/` honest about what is design history versus active design
+work, so reviewers can tell at a glance which documents drive code today.
+
+The audit is read-only. No RFCs are moved, renamed, or rewritten. Each row
+includes a recommendation for the human owner to decide whether a status
+header should be added/updated and whether the file should be relocated.
+
+## Convention
+
+[`docs/rfcs/README.md`](README.md) already documents five status labels:
+
+- **Proposed** — direction written, implementation not started.
+- **Accepted** — direction agreed for alpha; implementation partial or ongoing.
+- **Candidate** — some implementation exists; wire/payload not stable yet.
+- **Implemented record** — work landed; RFC remains as design history.
+- **Parking lot** — future/experimental ideas; not driving implementation.
+
+Most RFCs already carry a `> **Status:** …` blockquote near the top. The
+convention is consistent enough to keep; the audit recommends only that every
+RFC carry that field with one of the five labels above, optionally followed
+by a one-line current-state note.
+
+## Summary Table
+
+| RFC | Status | Summary line | Recommendation |
+|---|---|---|---|
+| [acp-editor-owned-workspace.md](acp-editor-owned-workspace.md) | Proposed | Reverse-RPC WebSocket transport for editor-owned ACP workspaces. | Keep header as `Proposed`; leave in place. |
+| [agent-memory.md](agent-memory.md) | Proposed | Operator-authored durable memory primitive with scopes. | Keep header as `Proposed`; leave in place. |
+| [artifact-storage-v1.md](artifact-storage-v1.md) | Candidate (partially superseded) | First-class artifact storage with content-addressed bodies and lifecycle. | Keep current `Candidate / partially superseded` framing; leave in place pending rewrite. |
+| [context-assembly-and-injection-boundaries.md](context-assembly-and-injection-boundaries.md) | Proposed | Context-packet pipeline with trust labels and injection boundaries. | Keep header as `Proposed`; leave in place. |
+| [embeddings.md](embeddings.md) | Proposed | `POST /v1/embeddings` routing with usage capture and llama-server parity. | Keep header as `Proposed`; leave in place. |
+| [event-protocol-extensions.md](event-protocol-extensions.md) | Parking lot | Future event groups (thinking, sub-agents, multimodal, branching). | Keep header as `Parking lot`; leave in place. |
+| [event-protocol-v1.md](event-protocol-v1.md) | Candidate | Versioned typed event envelope for agent-runtime runs. | Keep header as `Candidate`; leave in place. |
+| [external-agent-adapters.md](external-agent-adapters.md) | Accepted (partially implemented) | ACP-first agent chats alongside model chats. | Keep header as `Accepted`; leave in place — `docs/external-agent-adapters.md` already records shipped behavior. |
+| [external-agent-approval-loop-v1.md](external-agent-approval-loop-v1.md) | Implemented record | Prompt-first approval loop with durable grants for external adapters. | Keep header as `Implemented record`. Optionally move to `docs/rfcs/implemented/` once a destination is agreed. |
+| [hecate-chat-model-capabilities.md](hecate-chat-model-capabilities.md) | Accepted (partially implemented) | Hecate Chat + Hecate Agent + model capability registry. | Keep header as `Accepted`; leave in place. |
+| [import-external-chat-history.md](import-external-chat-history.md) | Proposed | One-shot import of Claude Code / Codex JSONL transcripts. | Keep header as `Proposed`; leave in place. |
+| [llm-context-window-management.md](llm-context-window-management.md) | Proposed | Token estimation, warn/cap, opt-in fitting policy. | Keep header as `Proposed`; leave in place. |
+| [migration-cli.md](migration-cli.md) | Proposed | `hecate migrate` subcommand: status/apply/snapshot/restore/verify. | Keep header as `Proposed`; leave in place. |
+| [projects.md](projects.md) | Proposed | Durable `project_id` independent of raw workspace paths. | Add the standardized `> **Status:**` blockquote (currently uses plain `Status: Proposed`); leave in place. |
+| [provider-response-extensions.md](provider-response-extensions.md) | Proposed | Per-provider response decoders for citations, reasoning content, etc. | Keep header as `Proposed`; leave in place. |
+| [terminal-distribution.md](terminal-distribution.md) | Proposed (release-archive subset shipped) | First-class terminal install with TUI, doctor, ACP config commands. | Keep header as `Proposed`; leave in place. |
+
+## Per-RFC Rationale
+
+### acp-editor-owned-workspace.md — Proposed
+
+Header already declares `proposed; not implemented.` Verified: no
+`POST /hecate/v1/acp/connect` route, no WebSocket upgrade path, no in-process
+`GatewayClient` adapter. The shipped surface is still the stdio bridge in
+`cmd/hecate-acp/main.go` and the gateway-side `ACPWorkspace` in
+`internal/workspace/acp.go`, exactly as the RFC describes the "today" diagram.
+No code references `acp/connect` anywhere in `internal/`. Status unchanged.
+
+### agent-memory.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no `internal/memory/`
+package exists. No `MemoryEntry` type, no `memory_entries` SQL table, no
+`/hecate/v1/memory` handlers. Storage and CRUD primitives are entirely absent.
+Status unchanged.
+
+### artifact-storage-v1.md — Candidate (partially superseded)
+
+Header declares `candidate; partially superseded by shipped task artifacts and
+chat diff inspect/revert.` Verified: `types.TaskArtifact` exists in
+`pkg/types/task.go` and is persisted via `internal/taskstate/sqlite.go`
+(`CreateArtifact`, `GetArtifact`, `ListArtifacts`, `UpdateArtifact`,
+`artifactsTable`). However the standalone `/hecate/v1/artifacts` API, the
+content-addressed `sha256` index, the two-tier inline/spilled body layout,
+the `art_<ULID>` id namespace, and the `GATEWAY_ARTIFACTS_BACKEND` env var
+described in the RFC are not in the codebase. What shipped is the narrower
+task-scoped artifact store, plus the chat diff inspect/revert flow under
+`/hecate/v1/chat/sessions/{id}/messages/{message_id}/files` and
+`/revert`. Status accurate as-is.
+
+### context-assembly-and-injection-boundaries.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no `ContextPacket`,
+`ContextItem`, or `internal/context/` package exists in the Go tree. The
+"trust label" vocabulary (`operator_memory`, `generated_summary`, etc.) is
+nowhere in source. Status unchanged.
+
+### embeddings.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no `/v1/embeddings`
+handler in `internal/api/`. No `EmbeddingRequest` / `EmbeddingResponse`
+types. The only `embeddings` hit in `internal/` is a comment in
+`internal/orchestrator/executor_agent_loop.go`. `internal/modelcaps/` has the
+embedding-named heuristic the RFC mentions as a starting point, but the
+provider routing, capability flag, and `--embeddings` llama-server arg are
+not wired. Status unchanged.
+
+### event-protocol-extensions.md — Parking lot
+
+Header declares `parking lot; not implemented; not stable.` Correct — this
+RFC is explicitly the holding pen for thinking blocks, sub-agent fan-out,
+multimodal output, conversation branching, and approval transport ideas. No
+implementation expected. Status unchanged.
+
+### event-protocol-v1.md — Candidate
+
+Header declares `candidate. The v1 envelope is implemented for task-run event
+list and cross-run event endpoints; payload schemas are not stable yet.`
+Verified: `internal/eventprotocol/envelope.go` defines `Envelope` with
+`schema_version`, `event_id`, `run_id`, `task_id`, `session_id`, `sequence`,
+`occurred_at`, `type`, `data` exactly as the RFC specifies. The envelope is
+consumed by `internal/api/tasks.go`, `handler_events.go`,
+`handler_tasks_stream.go`, and golden fixtures live in
+`docs/fixtures/events/v1/core/` referenced by `fixtures_test.go`. Payload
+shapes for individual `tool.*` and `artifact.*` events remain in flux, so
+Candidate is the right label. Status unchanged.
+
+### external-agent-adapters.md — Accepted (partially implemented)
+
+Header declares `accepted; partially implemented alpha baseline.` Verified:
+`internal/agentadapters/` contains `registry.go`-style adapter declarations,
+`probe.go` (and `probe_test.go`), `acp_session.go`, `acp_turn.go`,
+`acp_session_lifecycle.go`, `approvals.go`, plus memory + SQLite approval
+stores. The Codex/Claude Code/Cursor MVP endpoints under
+`/hecate/v1/agent-adapters` and `/hecate/v1/chat/sessions/...` are in
+`internal/api/`. Current behavior is documented in
+`docs/external-agent-adapters.md` (the main doc, not the RFC). Status
+unchanged.
+
+### external-agent-approval-loop-v1.md — Implemented record
+
+Header declares `implemented record for alpha.` Verified end-to-end:
+
+- `internal/agentadapters/approvals.go`, `approvals_memory.go`,
+  `approvals_sqlite.go`, `approvals_resolve_test.go` implement the
+  approval/grant lifecycle.
+- `internal/api/handler_chat_approvals.go` exposes
+  `/hecate/v1/chat/sessions/{id}/approvals[/...]` and
+  `/hecate/v1/chat/grants[/...]`.
+- `GATEWAY_AGENT_ADAPTER_APPROVAL_MODE` (and timeout) appear in
+  `internal/config/config.go`.
+- Documented current behavior overlaps with
+  `docs/external-agent-adapters.md` and `docs/chat-sessions.md`.
+
+The RFC's implementation gates table reads `implemented`. Status unchanged.
+This is the strongest candidate to move into `docs/rfcs/implemented/` if the
+project adopts that convention.
+
+### hecate-chat-model-capabilities.md — Accepted (partially implemented)
+
+Header declares `accepted; partially implemented alpha direction.` Verified:
+`internal/modelcaps/modelcaps.go` defines capability records and tool-calling
+states. `internal/api/handler_model_capabilities.go` and
+`model_capabilities.go` implement upsert/delete/probe handlers, matching the
+RFC's `PUT/DELETE/POST /hecate/v1/model-capabilities/...` shapes. Hecate
+Agent task-backed segments, run-activity rendering, task approvals from chat,
+streamed assistant text, and local composer queueing are all in the chat
+session and orchestrator code. Outstanding items the RFC itself flags
+(named agent profiles, workspace modes UI, automatic capability probing,
+broader e2e) are still open. Status unchanged.
+
+### import-external-chat-history.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no source references
+to `~/.claude/projects`, `~/.codex/sessions`, or `rollout-*.jsonl` anywhere
+in the Go or TS tree. No `importChatHistory` / `import-transcript` handler.
+The chat store's session id space has no `(source_tool, native_session_id)`
+dedupe key. Status unchanged.
+
+### llm-context-window-management.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no
+`internal/contextwindow/` package, no `ContextEstimate` type, no
+`tiktoken-go` dependency. No `context.window_exceeded` error code anywhere
+in source. No model-limit lookup precedence wiring. Status unchanged.
+
+### migration-cli.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: `cmd/hecate/main.go`
+has no `migrate` subcommand (no `hecate migrate status/apply/snapshot/restore`
+text anywhere). Per-package `migrate(ctx)` functions still run lazily on
+first store use, as the RFC describes — none of the proposed CLI surface
+exists. Status unchanged.
+
+### projects.md — Proposed
+
+Header reads `Status: Proposed` (plain key/value rather than the
+`> **Status:**` blockquote the other RFCs use). Verified: no
+`internal/projects/` package, no `type Project` in `pkg/types/`, no
+`project_id` column or `/hecate/v1/projects` handler. Status unchanged.
+Recommendation: align the header to the standard `> **Status:**` blockquote
+form for consistency.
+
+### provider-response-extensions.md — Proposed
+
+Header declares `proposed; not implemented.` Verified: no
+`ResponseExtensionDecoder` interface in `internal/providers/`. No
+`extensions_registry.go`. No per-vendor `perplexity.go` / `deepseek.go` /
+`xai.go` / `gemini.go` files. No `ReasoningContent`, `Citations`,
+`SearchResults`, or `ReasoningTokens` fields in `pkg/types/`. The OpenAI
+adapter still drops vendor extras on the floor. Status unchanged.
+
+### terminal-distribution.md — Proposed (release-archive subset shipped)
+
+Header declares `proposed; not implemented. Release archives already ship
+hecate and hecate-acp; the first-class TUI and terminal setup commands do
+not exist yet.` Verified: release archive packaging is in place and
+`cmd/hecate-acp/` exists. But `cmd/hecate/main.go` has no `tui`, `doctor`,
+`acp config zed`, `acp config jetbrains`, or `acp config vscode`
+subcommands. No `tui/` package anywhere in the repo. Status unchanged.
+
+## Status Distribution
+
+- **Proposed** — 10  (acp-editor-owned-workspace, agent-memory,
+  context-assembly-and-injection-boundaries, embeddings,
+  import-external-chat-history, llm-context-window-management, migration-cli,
+  projects, provider-response-extensions, terminal-distribution)
+- **Accepted** — 2  (external-agent-adapters, hecate-chat-model-capabilities)
+- **Candidate** — 2  (artifact-storage-v1, event-protocol-v1)
+- **Implemented record** — 1  (external-agent-approval-loop-v1)
+- **Parking lot** — 1  (event-protocol-extensions)
+- **Superseded** — 0
+- **Abandoned** — 0
+
+## Recommendations
+
+1. **Status header consistency.** Update `projects.md` to use the
+   `> **Status:** …` blockquote form that the other 15 RFCs use. No other
+   header changes are needed.
+2. **Moving implemented RFCs.** Only `external-agent-approval-loop-v1.md` is
+   in a clean "shipped, design history" state today. If the project wants to
+   adopt a `docs/rfcs/implemented/` directory, that file is the natural first
+   resident. Otherwise leaving it in place with its `Implemented record`
+   header is consistent with the documented convention.
+3. **`artifact-storage-v1.md`.** Its `candidate / partially superseded`
+   framing is accurate but the file is also marked for a rewrite. No move;
+   plan the rewrite as separate work.
+4. **`README.md` already cross-links the main docs** that record shipped
+   behavior (`events.md`, `runtime-api.md`, `acp.md`, `chat-sessions.md`,
+   `external-agent-adapters.md`). No additional cross-references are needed
+   from the audit perspective.


### PR DESCRIPTION
## Summary

- Audit of all 16 RFCs in `docs/rfcs/`, classifying each by status (Proposed / Accepted / Candidate / Implemented record / Parking lot) using the labels documented in `docs/rfcs/README.md`.
- Each classification is grounded in code evidence: file paths, package names, types, handlers, env vars.
- Includes per-RFC rationale, a summary table, status bucket counts, and recommendations on header consistency and possible moves. No RFCs are modified.

## Distribution

- Proposed: 10
- Accepted: 2
- Candidate: 2
- Implemented record: 1
- Parking lot: 1

## Test plan

- [x] `cd ui && bun run typecheck` passes (touched files are docs only, but confirmed).
- [x] Audit file renders as well-formed markdown.