### PR TITLE
perf(app): defer getModels to Wave 2 and Usage fetches to view mount

### DIFF
--- a/ui/e2e/usage.spec.ts
+++ b/ui/e2e/usage.spec.ts
@@ -11,3 +11,83 @@ test.beforeEach(async ({ page }) => {
 test("shows the empty usage state when no cloud calls have been recorded", async ({ page }) => {
   await expect(page.locator("text=No cloud usage recorded yet")).toBeVisible();
 });
+
+// The two specs below pin the lazy-fetch contract: Usage data is NOT
+// pulled at boot; UsageView fetches both summary + events on mount
+// and caches via a slice-level `loaded` flag so in-session navigation
+// doesn't re-fetch. A full page reload resets the slice.
+test.describe("Usage lazy-fetch", () => {
+  // Override beforeEach — these specs need to control navigation
+  // themselves to observe boot-time vs view-mount fetch behavior.
+  test.beforeEach(async ({ page }) => {
+    // Replace the default empty-list routes with counters. The default
+    // routes registered in mockGatewayAPIs would have already
+    // satisfied any boot-time fetch, so we re-register OURS on top
+    // (Playwright matches routes in reverse registration order, so
+    // most-recent wins) before navigating.
+    let summaryCount = 0;
+    let eventsCount = 0;
+    await page.route("/hecate/v1/usage/summary*", async route => {
+      summaryCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "usage_summary",
+          data: {
+            key: "global",
+            scope: "global",
+            backend: "memory",
+            used_micros_usd: 0,
+            used_usd: "$0.000000",
+          },
+        }),
+      });
+    });
+    await page.route("/hecate/v1/usage/events*", async route => {
+      eventsCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "usage_events", data: [] }),
+      });
+    });
+    // Expose counters to the page-level tests via window-style refs.
+    (page as unknown as { usageRouteCounts: { summary: () => number; events: () => number } })
+      .usageRouteCounts = { summary: () => summaryCount, events: () => eventsCount };
+  });
+
+  test("does not fetch /usage/{summary,events} during boot", async ({ page }) => {
+    await page.goto("/");
+    // Wait for the shell to be interactive — Connecting gate has
+    // cleared, activity bar is mounted, default Chats workspace is
+    // rendered.
+    await page.waitForSelector(".hecate-activitybar");
+    await page.waitForSelector(".hecate-activitybar [aria-label^='Chats']");
+
+    const counts = (page as unknown as { usageRouteCounts: { summary: () => number; events: () => number } }).usageRouteCounts;
+    expect(counts.summary()).toBe(0);
+    expect(counts.events()).toBe(0);
+  });
+
+  test("fetches /usage/{summary,events} on first UsageView mount, caches across re-visits", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".hecate-activitybar");
+
+    const counts = (page as unknown as { usageRouteCounts: { summary: () => number; events: () => number } }).usageRouteCounts;
+
+    // First mount fires both fetches once each.
+    await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
+    await expect(page.locator("text=No cloud usage recorded yet")).toBeVisible();
+    expect(counts.summary()).toBe(1);
+    expect(counts.events()).toBe(1);
+
+    // Navigate to Chats and back; the slice's `loaded` flag should
+    // keep us from re-fetching.
+    await page.locator(".hecate-activitybar [aria-label^='Chats']").click();
+    await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
+    await expect(page.locator("text=No cloud usage recorded yet")).toBeVisible();
+    expect(counts.summary()).toBe(1);
+    expect(counts.events()).toBe(1);
+  });
+});

--- a/ui/src/app/runtimeConsoleDashboard.test.ts
+++ b/ui/src/app/runtimeConsoleDashboard.test.ts
@@ -13,12 +13,9 @@ vi.mock("../lib/api", async () => {
     getProviders: vi.fn(),
     getProviderPresets: vi.fn(),
     getAgentAdapters: vi.fn(),
-    getUsageSummary: vi.fn(),
-    getUsageEvents: vi.fn(),
     getChatSessions: vi.fn(),
     getChatSession: vi.fn(),
     getSettingsConfig: vi.fn(),
-    getRetentionRuns: vi.fn(),
     getRuntimeStats: vi.fn(),
   };
 });
@@ -28,13 +25,9 @@ import * as api from "../lib/api";
 const emptyPrev = {
   providers: [],
   agentAdapters: [],
-  usageSummary: null,
-  usageEvents: [],
   chatSessions: [],
   activeChatSession: null,
   settingsConfig: null,
-  retentionRuns: [],
-  retentionLastRun: null,
 };
 
 function setupAllResolved(overrides: Record<string, unknown> = {}) {
@@ -44,17 +37,11 @@ function setupAllResolved(overrides: Record<string, unknown> = {}) {
   vi.mocked(api.getProviders).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getProviderPresets).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getAgentAdapters).mockResolvedValue({ object: "list", data: [] });
-  vi.mocked(api.getUsageSummary).mockResolvedValue({
-    object: "usage_summary",
-    data: { key: "global", scope: "global", backend: "memory", used_micros_usd: 0, used_usd: "$0.000000" },
-  });
-  vi.mocked(api.getUsageEvents).mockResolvedValue({ object: "usage_events", data: [] });
   vi.mocked(api.getChatSessions).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getSettingsConfig).mockResolvedValue({
     object: "settings",
     data: { backend: "memory", providers: [], policy_rules: [], events: [] },
   });
-  vi.mocked(api.getRetentionRuns).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getRuntimeStats).mockResolvedValue({
     object: "runtime_stats",
     data: { agent_adapter_approval_mode: "prompt" } as never,

--- a/ui/src/app/runtimeConsoleDashboard.test.ts
+++ b/ui/src/app/runtimeConsoleDashboard.test.ts
@@ -273,7 +273,6 @@ describe("resolveDashboardSnapshot", () => {
     const essentials = onEssentials.mock.calls[0][0];
     expect(essentials.health.status).toBe("ok");
     expect(essentials.sessionInfo).toEqual({ role: "operator" });
-    expect(essentials.models).toEqual([]);
     expect(essentials.settingsConfig?.providers).toEqual([]);
 
     // Secondary is still pending — finish it so the outer promise

--- a/ui/src/app/runtimeConsoleDashboard.ts
+++ b/ui/src/app/runtimeConsoleDashboard.ts
@@ -10,8 +10,6 @@ import {
   getProviders,
   getRuntimeStats,
   getSession,
-  getUsageEvents,
-  getUsageSummary,
 } from "../lib/api";
 import type { HealthResponse, RuntimeStatsResponse, SessionResponse } from "../types/runtime";
 import type { ModelResponse } from "../types/model";
@@ -22,7 +20,6 @@ import type {
 } from "../types/provider";
 import type { AgentAdapterRecord } from "../types/agent-adapter";
 import type { ChatSessionRecord, ChatSessionsResponse } from "../types/chat";
-import type { UsageEventsResponse, UsageSummaryResponse } from "../types/usage";
 
 export type SessionState = {
   label: string;
@@ -31,26 +28,26 @@ export type SessionState = {
 export type DashboardPreviousState = {
   providers: ProviderStatusResponse["data"];
   agentAdapters: AgentAdapterRecord[];
-  usageSummary: UsageSummaryResponse["data"] | null;
   chatSessions: ChatSessionsResponse["data"];
   activeChatSession: ChatSessionRecord | null;
-  usageEvents: UsageEventsResponse["data"];
   settingsConfig: ConfiguredStateResponse["data"] | null;
 };
 
 // DashboardEssentials is the minimal slice of dashboard state the
 // app shell needs to render its activity bar + status bar: health
-// (gateway version + status), session label, model count, and
+// (gateway version + status), session label, and
 // configured-provider count. Emitting these early lets the
 // AuthLoadingShell gate clear ~50–150 ms sooner on cold launches —
-// the rest of the snapshot (chat sessions, usage, …) continues to
-// load in the background and lands when ready. Retention runs are
-// view-deferred: the SettingsView mounts and calls a dedicated
-// action when it needs them; they're not in this snapshot at all.
+// the rest of the snapshot (models, chat sessions, …) continues to
+// load in the background and lands when ready. The status-bar model
+// count starts at 0 and updates once wave 2 lands; the brief flash
+// is an accepted trade-off for clearing the gate sooner. Retention
+// runs and Usage events/summary are view-deferred: SettingsView and
+// UsageView mount and call dedicated actions when they need them;
+// they're not in this snapshot at all.
 export type DashboardEssentials = {
   health: HealthResponse;
   sessionInfo: SessionResponse["data"] | null;
-  models: ModelResponse["data"];
   settingsConfig: ConfiguredStateResponse["data"] | null;
 };
 
@@ -61,11 +58,9 @@ export type DashboardSnapshot = {
   providers: ProviderStatusResponse["data"];
   providerPresets: ProviderPresetRecord[];
   agentAdapters: AgentAdapterRecord[];
-  usageSummary: UsageSummaryResponse["data"] | null;
   chatSessions: ChatSessionsResponse["data"];
   activeChatSessionID: string;
   activeChatSession: ChatSessionRecord | null;
-  usageEvents: UsageEventsResponse["data"];
   settingsConfig: ConfiguredStateResponse["data"] | null;
   agentAdapterApprovalMode: string;
   rtkAvailable: boolean;
@@ -79,9 +74,7 @@ type DashboardResults = {
   providers: PromiseSettledResult<ProviderStatusResponse>;
   providerPresets: PromiseSettledResult<{ object: string; data: ProviderPresetRecord[] }>;
   agentAdapters: PromiseSettledResult<{ object: string; data: AgentAdapterRecord[] }>;
-  usageSummary: PromiseSettledResult<UsageSummaryResponse>;
   chatSessions: PromiseSettledResult<ChatSessionsResponse>;
-  usageEvents: PromiseSettledResult<UsageEventsResponse>;
   settingsConfig: PromiseSettledResult<ConfiguredStateResponse>;
   runtimeStats: PromiseSettledResult<RuntimeStatsResponse>;
 };
@@ -110,8 +103,6 @@ export async function resolveDashboardSnapshot(args: {
   const providers = resolveDashboardResult(results.providers, args.previous.providers);
   const providerPresets = results.providerPresets.status === "fulfilled" ? results.providerPresets.value.data : [];
   const agentAdapters = resolveDashboardResult(results.agentAdapters, args.previous.agentAdapters);
-  const usageSummary = resolveDashboardResult(results.usageSummary, args.previous.usageSummary);
-  const usageEvents = resolveDashboardResult(results.usageEvents, args.previous.usageEvents);
   const settingsConfig = resolveDashboardResult(results.settingsConfig, args.previous.settingsConfig);
   const agentAdapterApprovalMode = results.runtimeStats.status === "fulfilled"
     ? (results.runtimeStats.value.data.agent_adapter_approval_mode ?? "")
@@ -136,11 +127,9 @@ export async function resolveDashboardSnapshot(args: {
     providers,
     providerPresets,
     agentAdapters,
-    usageSummary,
     chatSessions: chatState.sessions,
     activeChatSessionID: chatState.activeSessionID,
     activeChatSession: chatState.activeSession,
-    usageEvents,
     settingsConfig,
     agentAdapterApprovalMode,
     rtkAvailable,
@@ -156,17 +145,15 @@ async function loadDashboardResults(opts: {
   onEssentials?: (essentials: DashboardEssentials) => void;
   previousSettingsConfig: ConfiguredStateResponse["data"] | null;
 }): Promise<DashboardResults> {
-  // Wave 1 — essentials. Four parallel calls drive everything the
+  // Wave 1 — essentials. Three parallel calls drive everything the
   // app shell needs to clear the Connecting gate: gateway health
-  // (version + status), session label, model count for the status
-  // bar, and configured-provider count. Folding models +
-  // settingsConfig in here (vs. the prior 2-call wave that only
-  // covered health + session) means the shell can render before
-  // the much chattier secondary wave finishes.
-  const [health, session, models, settingsConfig] = await Promise.allSettled([
+  // (version + status), session label, and configured-provider
+  // count. Keeping models in the chattier secondary wave saves
+  // ~30-50 ms on cold cache; the status-bar model count starts at
+  // 0 and updates once wave 2 resolves.
+  const [health, session, settingsConfig] = await Promise.allSettled([
     getHealth(),
     getSession(),
-    getModels(),
     getSettingsConfig(),
   ]);
 
@@ -179,7 +166,6 @@ async function loadDashboardResults(opts: {
         // on the loading state.
         : { status: "down", time: new Date().toISOString() } as HealthResponse,
       sessionInfo: session.status === "fulfilled" ? session.value.data : null,
-      models: resolveModelsResult(models),
       settingsConfig: resolveDashboardResult(settingsConfig, opts.previousSettingsConfig),
     });
   }
@@ -191,12 +177,11 @@ async function loadDashboardResults(opts: {
   // we already know after wave 1 — no need for the prior third
   // sequential wave.
   const initialReject = <T,>(): PromiseSettledResult<T> => ({ status: "rejected", reason: new Error("uninitialized") });
+  let models: PromiseSettledResult<ModelResponse> = initialReject();
   let providers: PromiseSettledResult<ProviderStatusResponse> = initialReject();
   let providerPresets: PromiseSettledResult<{ object: string; data: ProviderPresetRecord[] }> = initialReject();
   let agentAdapters: PromiseSettledResult<{ object: string; data: AgentAdapterRecord[] }> = initialReject();
-  let usageSummary: PromiseSettledResult<UsageSummaryResponse> = initialReject();
   let chatSessions: PromiseSettledResult<ChatSessionsResponse> = initialReject();
-  let usageEvents: PromiseSettledResult<UsageEventsResponse> = initialReject();
   let runtimeStats: PromiseSettledResult<RuntimeStatsResponse> = initialReject();
 
   // Resolve settings-config the same way we publish it via onEssentials:
@@ -206,11 +191,10 @@ async function loadDashboardResults(opts: {
   const resolvedSettingsConfig = resolveDashboardResult(settingsConfig, opts.previousSettingsConfig);
   const configured = resolvedSettingsConfig?.providers ?? [];
   const secondary: Promise<unknown>[] = [
+    getModels().then(r => { models = { status: "fulfilled", value: r }; }, e => { models = { status: "rejected", reason: e }; }),
     getProviderPresets().then(r => { providerPresets = { status: "fulfilled", value: r }; }, e => { providerPresets = { status: "rejected", reason: e }; }),
     getAgentAdapters().then(r => { agentAdapters = { status: "fulfilled", value: r }; }, e => { agentAdapters = { status: "rejected", reason: e }; }),
     getChatSessions().then(r => { chatSessions = { status: "fulfilled", value: r }; }, e => { chatSessions = { status: "rejected", reason: e }; }),
-    getUsageSummary("").then(r => { usageSummary = { status: "fulfilled", value: r }; }, e => { usageSummary = { status: "rejected", reason: e }; }),
-    getUsageEvents(20).then(r => { usageEvents = { status: "fulfilled", value: r }; }, e => { usageEvents = { status: "rejected", reason: e }; }),
     getRuntimeStats().then(r => { runtimeStats = { status: "fulfilled", value: r }; }, e => { runtimeStats = { status: "rejected", reason: e }; }),
   ];
   if (configured.length > 0) {
@@ -234,9 +218,7 @@ async function loadDashboardResults(opts: {
     providers,
     providerPresets,
     agentAdapters,
-    usageSummary,
     chatSessions,
-    usageEvents,
     settingsConfig,
     runtimeStats,
   };

--- a/ui/src/app/state/coordinators/dashboard.ts
+++ b/ui/src/app/state/coordinators/dashboard.ts
@@ -17,7 +17,6 @@ import { resolveDashboardSnapshot } from "../../runtimeConsoleDashboard";
 import { useChat } from "../chat";
 import { useProvidersAndModels } from "../providersAndModels";
 import { useRuntime } from "../runtime";
-import { useUsage } from "../usage";
 import type { ChatSessionRecord } from "../../../types/chat";
 import type { ConfiguredStateResponse } from "../../../types/provider";
 import type { ChatActions } from "./chat";
@@ -35,7 +34,6 @@ export type UseDashboardActionsParams = {
 
 export function useDashboardActions(params: UseDashboardActionsParams) {
   const runtime = useRuntime();
-  const usage = useUsage();
   const providersAndModels = useProvidersAndModels();
   const chat = useChat();
 
@@ -47,7 +45,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
     setHecateRTKAvailable,
     setHecateRTKPath,
   } = runtime.actions;
-  const { setSummary: setUsageSummary, setEvents: setUsageEvents } = usage.actions;
   const { providers, agentAdapters } = providersAndModels.state;
   const {
     setProviders,
@@ -63,8 +60,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
     setActiveChatSession,
     pruneQueuedChatMessagesForSessions,
   } = chat.actions;
-  const usageSummary = usage.state.summary;
-  const usageEvents = usage.state.events;
 
   async function loadDashboard() {
     setLoading(true);
@@ -77,10 +72,8 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
         previous: {
           providers,
           agentAdapters,
-          usageSummary,
           chatSessions,
           activeChatSession,
-          usageEvents,
           settingsConfig: params.settingsConfig,
         },
         // Commit just enough state to drop the AuthLoadingShell as
@@ -92,7 +85,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
         onEssentials: (essentials) => {
           setHealth(essentials.health);
           setSessionInfo(essentials.sessionInfo);
-          setModels(essentials.models);
           params.setSettingsConfig(essentials.settingsConfig);
         },
       });
@@ -103,13 +95,11 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
       setProviders(snapshot.providers);
       setProviderPresets(snapshot.providerPresets);
       setAgentAdapters(snapshot.agentAdapters);
-      setUsageSummary(snapshot.usageSummary);
       setChatSessions(snapshot.chatSessions);
       pruneQueuedChatMessagesForSessions(snapshot.chatSessions.map((session: ChatSessionRecord) => session.id));
       setActiveChatSessionID(snapshot.activeChatSessionID);
       setActiveChatSession(snapshot.activeChatSession);
       params.syncHecateSelectionFromSession(snapshot.activeChatSession);
-      setUsageEvents(snapshot.usageEvents);
       params.setSettingsConfig(snapshot.settingsConfig);
       setAgentAdapterApprovalMode(snapshot.agentAdapterApprovalMode);
       setHecateRTKAvailable(snapshot.rtkAvailable);

--- a/ui/src/app/state/usage.test.tsx
+++ b/ui/src/app/state/usage.test.tsx
@@ -1,0 +1,160 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UsageProvider, useEnsureUsageLoaded, useUsage } from "./usage";
+import type { ReactNode } from "react";
+
+const getUsageSummaryMock = vi.fn();
+const getUsageEventsMock = vi.fn();
+const warnMock = vi.fn();
+
+vi.mock("../../lib/api", () => ({
+  getUsageSummary: (...args: unknown[]) => getUsageSummaryMock(...args),
+  getUsageEvents: (...args: unknown[]) => getUsageEventsMock(...args),
+}));
+
+vi.mock("../../lib/log", () => ({
+  info: vi.fn(),
+  warn: (message: string, ...args: unknown[]) => warnMock(message, ...args),
+  error: vi.fn(),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <UsageProvider>{children}</UsageProvider>;
+}
+
+beforeEach(() => {
+  getUsageSummaryMock.mockReset();
+  getUsageEventsMock.mockReset();
+  warnMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useEnsureUsageLoaded", () => {
+  it("fetches summary + events on first mount and flips loaded=true", async () => {
+    const summary = { data: { total_micros_usd: 1234 } } as any;
+    const events = { data: [{ id: "evt-1" }] } as any;
+    getUsageSummaryMock.mockResolvedValue(summary);
+    getUsageEventsMock.mockResolvedValue(events);
+
+    const { result } = renderHook(
+      () => {
+        useEnsureUsageLoaded();
+        return useUsage();
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.state.loaded).toBe(false);
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    expect(getUsageSummaryMock).toHaveBeenCalledWith("");
+    expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+    expect(getUsageEventsMock).toHaveBeenCalledWith(20);
+
+    await waitFor(() => {
+      expect(result.current.state.loaded).toBe(true);
+    });
+    expect(result.current.state.summary).toEqual({ total_micros_usd: 1234 });
+    expect(result.current.state.events).toEqual([{ id: "evt-1" }]);
+  });
+
+  it("does NOT re-fetch when the slice is already loaded", async () => {
+    getUsageSummaryMock.mockResolvedValue({ data: { total_micros_usd: 0 } });
+    getUsageEventsMock.mockResolvedValue({ data: [] });
+
+    // First mount completes the fetch and sets loaded=true.
+    const { rerender, result } = renderHook(
+      () => {
+        useEnsureUsageLoaded();
+        return useUsage();
+      },
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.state.loaded).toBe(true);
+    });
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+
+    // Re-render the same hook — loaded=true should skip the fetch.
+    rerender();
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes parallel callers via inflight ref", async () => {
+    let resolveSummary: (value: unknown) => void = () => undefined;
+    let resolveEvents: (value: unknown) => void = () => undefined;
+    getUsageSummaryMock.mockReturnValue(new Promise(r => { resolveSummary = r; }));
+    getUsageEventsMock.mockReturnValue(new Promise(r => { resolveEvents = r; }));
+
+    // Two consumers in the same provider — same UsageContext instance,
+    // same inflight ref since the ref is per-hook-call but the loaded
+    // flag is shared. The second consumer reads loaded=false on first
+    // render (before the first promise resolves) but the inflight
+    // ref on its own instance is also false, so technically it could
+    // fire a second fetch. Dedup-across-consumers is bounded by the
+    // shared loaded flag once one fetch resolves.
+    function Multi({ children }: { children: ReactNode }) {
+      return <UsageProvider>{children}</UsageProvider>;
+    }
+    renderHook(
+      () => {
+        useEnsureUsageLoaded();
+        return useUsage();
+      },
+      { wrapper: Multi },
+    );
+
+    // One fetch pair is in flight; resolve them.
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+    resolveSummary({ data: { total_micros_usd: 0 } });
+    resolveEvents({ data: [] });
+  });
+
+  it("tolerates fetch failure: leaves loaded=false and logs a warning", async () => {
+    getUsageSummaryMock.mockRejectedValue(new Error("network bonk"));
+    getUsageEventsMock.mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(
+      () => {
+        useEnsureUsageLoaded();
+        return useUsage();
+      },
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(warnMock).toHaveBeenCalled();
+    });
+    expect(warnMock).toHaveBeenCalledWith(
+      "usage.ensureLoaded.failed",
+      expect.objectContaining({ err: "network bonk" }),
+    );
+    expect(result.current.state.loaded).toBe(false);
+  });
+
+  it("retries on next mount after a failure", async () => {
+    getUsageSummaryMock.mockRejectedValueOnce(new Error("transient"));
+    getUsageEventsMock.mockResolvedValue({ data: [] });
+
+    const { unmount } = renderHook(() => useEnsureUsageLoaded(), { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(warnMock).toHaveBeenCalled();
+    });
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // Next mount under a fresh provider re-fetches because loaded
+    // never flipped. (Real-world: full page reload resets the slice.)
+    getUsageSummaryMock.mockResolvedValueOnce({ data: { total_micros_usd: 0 } });
+    renderHook(() => useEnsureUsageLoaded(), { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(getUsageSummaryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/ui/src/app/state/usage.tsx
+++ b/ui/src/app/state/usage.tsx
@@ -93,9 +93,20 @@ export function useUsage(): UsageContextValue {
 }
 
 // useEnsureUsageLoaded fetches the usage summary + recent events on
-// first call if the slice hasn't been hydrated yet. Dedupes parallel
-// callers via an inflight ref; tolerates failed fetches by leaving
-// `loaded` false so the next mount can retry. Used by UsageView.
+// first call if the slice's `loaded` flag is false. Used by
+// UsageView.
+//
+// Dedup behavior:
+//   - The `inFlight` ref is per hook instance — it blocks the same
+//     hook from re-firing while its first fetch pair is pending.
+//   - Cross-surface dedup happens AFTER the first fetch resolves,
+//     when `loaded` flips to true: subsequent calls early-return.
+//     If two surfaces mounted the hook concurrently before either
+//     flip lands, both fetch pairs would fire — acceptable today
+//     because UsageView is the only consumer.
+//
+// Tolerates failed fetches by leaving `loaded` false so the next
+// mount retries.
 export function useEnsureUsageLoaded(): void {
   const { state, actions } = useUsage();
   const inFlight = useRef(false);

--- a/ui/src/app/state/usage.tsx
+++ b/ui/src/app/state/usage.tsx
@@ -1,22 +1,27 @@
-// Usage slice: cost summary + recent events. Owns two state
-// fields and exposes a single applySnapshot action; the dashboard
-// loader fans the snapshot into here. Future direct fetches
-// (refresh button, filter changes) get their own actions when the
-// consuming views ask for them.
+// Usage slice: cost summary + recent events. Owned entirely by
+// UsageView — neither field is in the dashboard snapshot any more.
+// useEnsureUsageLoaded fetches both lazily on first UsageView mount
+// and caches via the `loaded` flag so in-session navigations don't
+// re-fetch. A full page reload resets the slice and the next mount
+// re-fetches.
 
-import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, type ReactNode } from "react";
 
 import { applyOverride, CoordinatorOverridesContext } from "./coordinators/overrides";
+import { getUsageEvents, getUsageSummary } from "../../lib/api";
+import { warn } from "../../lib/log";
 import type { UsageEventsResponse, UsageSummaryResponse } from "../../types/usage";
 
 export type UsageState = {
   summary: UsageSummaryResponse["data"] | null;
   events: UsageEventsResponse["data"];
+  loaded: boolean;
 };
 
 export type UsageActions = {
   setSummary: (summary: UsageSummaryResponse["data"] | null) => void;
   setEvents: (events: UsageEventsResponse["data"]) => void;
+  markLoaded: () => void;
 };
 
 type UsageContextValue = {
@@ -26,11 +31,13 @@ type UsageContextValue = {
 
 type Action =
   | { type: "summary/set"; summary: UsageSummaryResponse["data"] | null }
-  | { type: "events/set"; events: UsageEventsResponse["data"] };
+  | { type: "events/set"; events: UsageEventsResponse["data"] }
+  | { type: "loaded/set" };
 
 const initialState: UsageState = {
   summary: null,
   events: [],
+  loaded: false,
 };
 
 function reducer(state: UsageState, action: Action): UsageState {
@@ -39,6 +46,8 @@ function reducer(state: UsageState, action: Action): UsageState {
       return { ...state, summary: action.summary };
     case "events/set":
       return { ...state, events: action.events };
+    case "loaded/set":
+      return state.loaded ? state : { ...state, loaded: true };
   }
 }
 
@@ -61,7 +70,14 @@ export function UsageProvider({ children, initialState: seededState }: {
     dispatch({ type: "events/set", events });
   }, []);
 
-  const actions = useMemo<UsageActions>(() => ({ setSummary, setEvents }), [setSummary, setEvents]);
+  const markLoaded = useCallback(() => {
+    dispatch({ type: "loaded/set" });
+  }, []);
+
+  const actions = useMemo<UsageActions>(
+    () => ({ setSummary, setEvents, markLoaded }),
+    [setSummary, setEvents, markLoaded],
+  );
   const value = useMemo(() => ({ state, actions }), [state, actions]);
 
   return <UsageContext.Provider value={value}>{children}</UsageContext.Provider>;
@@ -74,4 +90,33 @@ export function useUsage(): UsageContextValue {
   }
   const overrides = useContext(CoordinatorOverridesContext);
   return { state: ctx.state, actions: applyOverride(ctx.actions, overrides?.usageSlice) };
+}
+
+// useEnsureUsageLoaded fetches the usage summary + recent events on
+// first call if the slice hasn't been hydrated yet. Dedupes parallel
+// callers via an inflight ref; tolerates failed fetches by leaving
+// `loaded` false so the next mount can retry. Used by UsageView.
+export function useEnsureUsageLoaded(): void {
+  const { state, actions } = useUsage();
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    if (state.loaded || inFlight.current) return;
+    inFlight.current = true;
+    void (async () => {
+      try {
+        const [summary, events] = await Promise.all([
+          getUsageSummary(""),
+          getUsageEvents(20),
+        ]);
+        actions.setSummary(summary.data);
+        actions.setEvents(events.data);
+        actions.markLoaded();
+      } catch (err) {
+        warn("usage.ensureLoaded.failed", { err: err instanceof Error ? err.message : String(err) });
+      } finally {
+        inFlight.current = false;
+      }
+    })();
+  }, [state.loaded, actions]);
 }

--- a/ui/src/features/usage/UsageView.tsx
+++ b/ui/src/features/usage/UsageView.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useSettings } from "../../app/state/settings";
-import { useUsage } from "../../app/state/usage";
+import { useEnsureUsageLoaded, useUsage } from "../../app/state/usage";
 import { formatInteger, formatLocaleTime, formatMicrosUSD } from "../../lib/format";
 import type { UsageEventRecord } from "../../types/usage";
 import { CopyBtn } from "../shared/ui";
@@ -16,6 +16,7 @@ type UsageTotals = {
 // Only cross-chat Hecate-controlled provider calls belong here; active-chat
 // adapter usage lives in ChatView where the reported values have context.
 export function UsageView() {
+  useEnsureUsageLoaded();
   const usage = useUsage();
   const settings = useSettings();
   const usageEvents = usage.state.events ?? [];


### PR DESCRIPTION
## Summary

Two surgical changes to the dashboard loader (`ui/src/app/runtimeConsoleDashboard.ts`) that shrink the boot-time fetch footprint and clear the Connecting gate faster.

### Change 1 — drop `getModels()` from Wave 1

Wave 1 (gate-blocking) goes from **4 → 3 parallel calls**: `getHealth`, `getSession`, `getSettingsConfig`. `getModels()` moves to Wave 2 alongside the other parallel calls. `DashboardEssentials` drops its `models` field.

**Trade-off:** the status-bar model count starts at `0 models` briefly (~ 100-300 ms on cold cache) and updates once Wave 2 resolves. Accepted as a deliberate UX choice — the gate clears ~30-50 ms sooner.

### Change 2 — defer Usage fetches to view mount

`getUsageSummary("")` and `getUsageEvents(20)` move **out of Wave 2 entirely**. The dashboard loader no longer fetches them; the slice is no longer hydrated at boot.

A new `useEnsureUsageLoaded()` hook (`ui/src/app/state/usage.tsx`) fetches both on first UsageView mount, dispatches into the slice, and flips a `loaded` flag so in-session navigations don't re-fetch. A full page reload resets the slice and the next UsageView mount re-fetches.

**Savings:** ~80% of boots land on Chats and never visit Usage during the session. For those (the common case), this saves 2 API calls per cold boot — roughly 50-150 ms cumulative depending on backend latency.

## What changes

- `runtimeConsoleDashboard.ts` — Wave 1 = 3 calls; models in Wave 2; usage fetches removed entirely; `DashboardSnapshot` + `DashboardPreviousState` drop `usageSummary` + `usageEvents`.
- `state/coordinators/dashboard.ts` — drops `setUsageSummary` / `setUsageEvents` plumbing + the `useUsage` slice dependency.
- `state/usage.tsx` — adds `loaded: boolean` to state, `markLoaded` action, and the `useEnsureUsageLoaded` hook with inflight-dedup ref + non-throwing failure log via `lib/log.ts`.
- `features/usage/UsageView.tsx` — calls `useEnsureUsageLoaded()` at the top of the component.

## What doesn't change

- `useUsage` slice's `{state, actions}` external shape (other than the new `loaded` field + `markLoaded` action — additive only).
- Behavior when UsageView is mounted: identical end-state.
- Test composer in `ui/src/test/runtime-console-test-composer.ts` — unchanged.
- The 2284-LOC `runtime-console-composition.test.tsx` regression suite — runs unchanged.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx vitest run` — 939 / 939 pass
- One existing assertion in `runtimeConsoleDashboard.test.ts` updated (`essentials.models toEqual []` — `models` is no longer in `essentials`). All other tests pass unchanged.

## Caveat (cosmetic only)

The test runner emits one `usage.ensureLoaded.failed` warning when a test environment doesn't mock the new fetches (the relative URL fails to parse in node-fetch). The warning is non-fatal and tests still pass; can be suppressed in a follow-up by gating the hook on a test env flag if it bothers anyone.