### PR TITLE
perf(app): defer getProviderPresets to AddProviderModal / TasksView mount

### DIFF
--- a/ui/e2e/boot-shape.spec.ts
+++ b/ui/e2e/boot-shape.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "./fixtures";
+
+// Pins the exact set of endpoints the UI hits during boot on the
+// default (Chats) workspace. A regression here would flag any change
+// that re-adds a deferred fetch to the dashboard loader OR drops a
+// still-needed one.
+//
+// What's expected at boot today:
+//   Wave 1 (gate-blocking): /healthz, /hecate/v1/whoami, /hecate/v1/settings
+//   Wave 2 (background):    /v1/models, /hecate/v1/agent-adapters,
+//                           /hecate/v1/chat/sessions, /hecate/v1/system/stats,
+//                           /hecate/v1/providers/status (conditional on configured providers)
+//
+// What's expected NOT to fire at boot:
+//   /hecate/v1/usage/summary, /hecate/v1/usage/events  (deferred to UsageView)
+//   /hecate/v1/providers/presets                       (deferred to AddProviderModal / TasksView)
+//   /hecate/v1/retention/*                             (deferred to SettingsView)
+//   /hecate/v1/observability/*                         (deferred to ObservabilityView)
+
+test("default Chats boot fires exactly the expected endpoints, no more", async ({ page }) => {
+  const hits: string[] = [];
+  // Capture every request the page issues; the fixtures' page.route
+  // calls fulfill the responses, but we tap with continue() to keep
+  // both behaviors. Use a request listener instead of additional
+  // route handlers so we don't shadow the fixture routes' fulfillment.
+  page.on("request", req => {
+    const url = new URL(req.url());
+    if (url.pathname === "/healthz"
+      || url.pathname === "/v1/models"
+      || url.pathname.startsWith("/hecate/v1/")) {
+      hits.push(url.pathname);
+    }
+  });
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  await page.waitForSelector(".hecate-activitybar [aria-label^='Chats']");
+  // Give Wave 2 + any settle-down effects a moment to complete.
+  await page.waitForTimeout(500);
+
+  const unique = Array.from(new Set(hits));
+
+  // Endpoints that MUST appear during boot.
+  const expectedAtBoot = [
+    "/healthz",
+    "/hecate/v1/whoami",
+    "/hecate/v1/settings",
+    "/v1/models",
+    "/hecate/v1/agent-adapters",
+    "/hecate/v1/chat/sessions",
+    "/hecate/v1/system/stats",
+  ];
+  for (const expected of expectedAtBoot) {
+    expect(unique).toContain(expected);
+  }
+
+  // Endpoints that MUST NOT appear during boot — these are all
+  // explicitly view-deferred. A hit here means someone regressed
+  // the lazy-fetch contract.
+  const forbiddenAtBoot = [
+    "/hecate/v1/usage/summary",
+    "/hecate/v1/usage/events",
+    "/hecate/v1/providers/presets",
+    "/hecate/v1/retention/runs",
+    "/hecate/v1/retention/subsystems",
+    "/hecate/v1/observability/requests",
+  ];
+  for (const forbidden of forbiddenAtBoot) {
+    expect(unique, `${forbidden} should not be fetched at boot`).not.toContain(forbidden);
+  }
+});

--- a/ui/e2e/provider-presets-lazy.spec.ts
+++ b/ui/e2e/provider-presets-lazy.spec.ts
@@ -46,6 +46,19 @@ test.describe("Provider presets lazy-fetch", () => {
         }),
       });
     });
+    // Stub the Connections-view fetches the default fixture doesn't
+    // cover so navigating there doesn't print Vite proxy ECONNREFUSED.
+    // Probes return a 404 the slice's catch block tolerates — a
+    // synthetic 200 shape would break the success path that reads
+    // payload.data.adapter.id.
+    await page.route(/\/hecate\/v1\/agent-adapters\/[^/]+\/probe$/, route =>
+      route.fulfill({ status: 404, contentType: "application/json",
+        body: JSON.stringify({ error: { code: "not_found", message: "stub" } }) }),
+    );
+    await page.route("/hecate/v1/chat/grants*", route =>
+      route.fulfill({ status: 200, contentType: "application/json",
+        body: JSON.stringify({ object: "list", data: [] }) }),
+    );
 
     await page.goto("/");
     await page.waitForSelector(".hecate-activitybar");

--- a/ui/e2e/provider-presets-lazy.spec.ts
+++ b/ui/e2e/provider-presets-lazy.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "./fixtures";
+
+// Pins the lazy-fetch contract for /hecate/v1/providers/presets:
+// the dashboard loader no longer pulls presets at boot; only the
+// AddProviderModal mount (and TasksView mount) trigger the fetch.
+// A regression here would put presets back in Wave 2 and waste a
+// network round-trip on every cold boot.
+
+test.describe("Provider presets lazy-fetch", () => {
+  test("does not fetch /providers/presets during boot on the default Chats workspace", async ({ page }) => {
+    let count = 0;
+    await page.route("/hecate/v1/providers/presets*", async route => {
+      count += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "list", data: [] }),
+      });
+    });
+
+    await page.goto("/");
+    await page.waitForSelector(".hecate-activitybar");
+    // Default workspace is Chats; assert we landed there.
+    await page.waitForSelector(".hecate-activitybar [aria-label^='Chats']");
+
+    // Give Wave 2 time to settle so any stale boot-time call would
+    // have fired by now.
+    await page.waitForTimeout(300);
+    expect(count).toBe(0);
+  });
+
+  test("fetches /providers/presets when AddProviderModal opens, caches across re-opens", async ({ page }) => {
+    let count = 0;
+    await page.route("/hecate/v1/providers/presets*", async route => {
+      count += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "list",
+          data: [
+            { id: "anthropic", name: "Anthropic", kind: "cloud", protocol: "anthropic", base_url: "https://api.anthropic.com/v1" },
+            { id: "openai", name: "OpenAI", kind: "cloud", protocol: "openai", base_url: "https://api.openai.com/v1" },
+            { id: "ollama", name: "Ollama", kind: "local", protocol: "openai", base_url: "http://127.0.0.1:11434/v1" },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/");
+    await page.waitForSelector(".hecate-activitybar");
+    expect(count).toBe(0);
+
+    // Navigate to Connections, then click "Add provider" to mount
+    // the modal. First mount fires the fetch.
+    await page.locator(".hecate-activitybar [aria-label^='Connections']").click();
+    await page.locator("button", { hasText: "Add provider" }).first().click();
+    // The modal's "Local" tab is selected by default; wait for it.
+    await expect(page.locator("[role=dialog]").locator("text=Local").first()).toBeVisible({ timeout: 5_000 });
+    await expect.poll(() => count, { timeout: 5_000 }).toBe(1);
+
+    // Close the modal, reopen — the slice's providerPresetsLoaded
+    // flag should keep us from re-fetching.
+    await page.keyboard.press("Escape");
+    await page.locator("button", { hasText: "Add provider" }).first().click();
+    await expect(page.locator("[role=dialog]").locator("text=Local").first()).toBeVisible({ timeout: 5_000 });
+    // Give the hook a tick to (not) re-fetch.
+    await page.waitForTimeout(200);
+    expect(count).toBe(1);
+  });
+});

--- a/ui/src/app/runtimeConsoleDashboard.ts
+++ b/ui/src/app/runtimeConsoleDashboard.ts
@@ -6,7 +6,6 @@ import {
   getSettingsConfig,
   getHealth,
   getModels,
-  getProviderPresets,
   getProviders,
   getRuntimeStats,
   getSession,
@@ -15,7 +14,6 @@ import type { HealthResponse, RuntimeStatsResponse, SessionResponse } from "../t
 import type { ModelResponse } from "../types/model";
 import type {
   ConfiguredStateResponse,
-  ProviderPresetRecord,
   ProviderStatusResponse,
 } from "../types/provider";
 import type { AgentAdapterRecord } from "../types/agent-adapter";
@@ -42,9 +40,10 @@ export type DashboardPreviousState = {
 // load in the background and lands when ready. The status-bar model
 // count starts at 0 and updates once wave 2 lands; the brief flash
 // is an accepted trade-off for clearing the gate sooner. Retention
-// runs and Usage events/summary are view-deferred: SettingsView and
-// UsageView mount and call dedicated actions when they need them;
-// they're not in this snapshot at all.
+// runs, Usage events/summary, and provider presets are view-deferred:
+// SettingsView / UsageView / AddProviderModal / TasksView mount and
+// call dedicated actions when they need them; none are in this
+// snapshot.
 export type DashboardEssentials = {
   health: HealthResponse;
   sessionInfo: SessionResponse["data"] | null;
@@ -56,7 +55,6 @@ export type DashboardSnapshot = {
   sessionInfo: SessionResponse["data"] | null;
   models: ModelResponse["data"];
   providers: ProviderStatusResponse["data"];
-  providerPresets: ProviderPresetRecord[];
   agentAdapters: AgentAdapterRecord[];
   chatSessions: ChatSessionsResponse["data"];
   activeChatSessionID: string;
@@ -72,7 +70,6 @@ type DashboardResults = {
   session: PromiseSettledResult<SessionResponse>;
   models: PromiseSettledResult<ModelResponse>;
   providers: PromiseSettledResult<ProviderStatusResponse>;
-  providerPresets: PromiseSettledResult<{ object: string; data: ProviderPresetRecord[] }>;
   agentAdapters: PromiseSettledResult<{ object: string; data: AgentAdapterRecord[] }>;
   chatSessions: PromiseSettledResult<ChatSessionsResponse>;
   settingsConfig: PromiseSettledResult<ConfiguredStateResponse>;
@@ -101,7 +98,6 @@ export async function resolveDashboardSnapshot(args: {
   const sessionInfo = results.session.status === "fulfilled" ? results.session.value.data : null;
   const models = resolveModelsResult(results.models);
   const providers = resolveDashboardResult(results.providers, args.previous.providers);
-  const providerPresets = results.providerPresets.status === "fulfilled" ? results.providerPresets.value.data : [];
   const agentAdapters = resolveDashboardResult(results.agentAdapters, args.previous.agentAdapters);
   const settingsConfig = resolveDashboardResult(results.settingsConfig, args.previous.settingsConfig);
   const agentAdapterApprovalMode = results.runtimeStats.status === "fulfilled"
@@ -125,7 +121,6 @@ export async function resolveDashboardSnapshot(args: {
     sessionInfo,
     models,
     providers,
-    providerPresets,
     agentAdapters,
     chatSessions: chatState.sessions,
     activeChatSessionID: chatState.activeSessionID,
@@ -179,7 +174,6 @@ async function loadDashboardResults(opts: {
   const initialReject = <T,>(): PromiseSettledResult<T> => ({ status: "rejected", reason: new Error("uninitialized") });
   let models: PromiseSettledResult<ModelResponse> = initialReject();
   let providers: PromiseSettledResult<ProviderStatusResponse> = initialReject();
-  let providerPresets: PromiseSettledResult<{ object: string; data: ProviderPresetRecord[] }> = initialReject();
   let agentAdapters: PromiseSettledResult<{ object: string; data: AgentAdapterRecord[] }> = initialReject();
   let chatSessions: PromiseSettledResult<ChatSessionsResponse> = initialReject();
   let runtimeStats: PromiseSettledResult<RuntimeStatsResponse> = initialReject();
@@ -192,7 +186,6 @@ async function loadDashboardResults(opts: {
   const configured = resolvedSettingsConfig?.providers ?? [];
   const secondary: Promise<unknown>[] = [
     getModels().then(r => { models = { status: "fulfilled", value: r }; }, e => { models = { status: "rejected", reason: e }; }),
-    getProviderPresets().then(r => { providerPresets = { status: "fulfilled", value: r }; }, e => { providerPresets = { status: "rejected", reason: e }; }),
     getAgentAdapters().then(r => { agentAdapters = { status: "fulfilled", value: r }; }, e => { agentAdapters = { status: "rejected", reason: e }; }),
     getChatSessions().then(r => { chatSessions = { status: "fulfilled", value: r }; }, e => { chatSessions = { status: "rejected", reason: e }; }),
     getRuntimeStats().then(r => { runtimeStats = { status: "fulfilled", value: r }; }, e => { runtimeStats = { status: "rejected", reason: e }; }),
@@ -216,7 +209,6 @@ async function loadDashboardResults(opts: {
     session,
     models,
     providers,
-    providerPresets,
     agentAdapters,
     chatSessions,
     settingsConfig,

--- a/ui/src/app/state/coordinators/dashboard.ts
+++ b/ui/src/app/state/coordinators/dashboard.ts
@@ -48,7 +48,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
   const { providers, agentAdapters } = providersAndModels.state;
   const {
     setProviders,
-    setProviderPresets,
     setModels,
     setAgentAdapters,
     setAgentAdapterApprovalMode,
@@ -93,7 +92,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
       setSessionInfo(snapshot.sessionInfo);
       setModels(snapshot.models);
       setProviders(snapshot.providers);
-      setProviderPresets(snapshot.providerPresets);
       setAgentAdapters(snapshot.agentAdapters);
       setChatSessions(snapshot.chatSessions);
       pruneQueuedChatMessagesForSessions(snapshot.chatSessions.map((session: ChatSessionRecord) => session.id));

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -1,0 +1,124 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ProvidersAndModelsProvider,
+  useEnsureProviderPresetsLoaded,
+  useProvidersAndModels,
+} from "./providersAndModels";
+import type { ReactNode } from "react";
+
+const getProviderPresetsMock = vi.fn();
+const warnMock = vi.fn();
+
+vi.mock("../../lib/api", () => ({
+  getProviderPresets: (...args: unknown[]) => getProviderPresetsMock(...args),
+  // Stubs for other api symbols the slice imports — unused in these tests.
+  getProviders: vi.fn(),
+  getModels: vi.fn(),
+  probeAgentAdapter: vi.fn(),
+  setAgentAdapterCredential: vi.fn(),
+  deleteAgentAdapterCredential: vi.fn(),
+}));
+
+vi.mock("../../lib/log", () => ({
+  info: vi.fn(),
+  warn: (message: string, ...args: unknown[]) => warnMock(message, ...args),
+  error: vi.fn(),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ProvidersAndModelsProvider>{children}</ProvidersAndModelsProvider>;
+}
+
+beforeEach(() => {
+  getProviderPresetsMock.mockReset();
+  warnMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useEnsureProviderPresetsLoaded", () => {
+  it("fetches presets on first mount and flips providerPresetsLoaded=true", async () => {
+    const presets = { object: "list", data: [{ id: "anthropic", name: "Anthropic", kind: "cloud" }] } as any;
+    getProviderPresetsMock.mockResolvedValue(presets);
+
+    const { result } = renderHook(
+      () => {
+        useEnsureProviderPresetsLoaded();
+        return useProvidersAndModels();
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.state.providerPresetsLoaded).toBe(false);
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(result.current.state.providerPresetsLoaded).toBe(true);
+    });
+    expect(result.current.state.providerPresets).toEqual([
+      { id: "anthropic", name: "Anthropic", kind: "cloud" },
+    ]);
+  });
+
+  it("does NOT re-fetch when presets are already loaded", async () => {
+    getProviderPresetsMock.mockResolvedValue({ object: "list", data: [] });
+
+    const { rerender, result } = renderHook(
+      () => {
+        useEnsureProviderPresetsLoaded();
+        return useProvidersAndModels();
+      },
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.providerPresetsLoaded).toBe(true);
+    });
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates fetch failure: leaves loaded=false and logs a warning", async () => {
+    getProviderPresetsMock.mockRejectedValue(new Error("network bonk"));
+
+    const { result } = renderHook(
+      () => {
+        useEnsureProviderPresetsLoaded();
+        return useProvidersAndModels();
+      },
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(warnMock).toHaveBeenCalled();
+    });
+    expect(warnMock).toHaveBeenCalledWith(
+      "providerPresets.ensureLoaded.failed",
+      expect.objectContaining({ err: "network bonk" }),
+    );
+    expect(result.current.state.providerPresetsLoaded).toBe(false);
+  });
+
+  it("retries on next mount after a failure", async () => {
+    getProviderPresetsMock.mockRejectedValueOnce(new Error("transient"));
+
+    const { unmount } = renderHook(() => useEnsureProviderPresetsLoaded(), { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(warnMock).toHaveBeenCalled();
+    });
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(1);
+    unmount();
+
+    getProviderPresetsMock.mockResolvedValueOnce({ object: "list", data: [] });
+    renderHook(() => useEnsureProviderPresetsLoaded(), { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(getProviderPresetsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -105,6 +105,30 @@ describe("useEnsureProviderPresetsLoaded", () => {
     expect(result.current.state.providerPresetsLoaded).toBe(false);
   });
 
+  it("skips the fetch when called with when=false", async () => {
+    getProviderPresetsMock.mockResolvedValue({ object: "list", data: [] });
+
+    // The when gate exists for always-mounted consumers like
+    // AddProviderModal (mounted with open=false inside ChatView).
+    // Without the gate, the optimization would no-op on Chats boots.
+    const { rerender, result } = renderHook(
+      ({ when }: { when: boolean }) => {
+        useEnsureProviderPresetsLoaded(when);
+        return useProvidersAndModels();
+      },
+      { wrapper: Wrapper, initialProps: { when: false } },
+    );
+
+    // Give the effect a tick to (not) fire.
+    await new Promise(r => setTimeout(r, 10));
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(0);
+    expect(result.current.state.providerPresetsLoaded).toBe(false);
+
+    // Flip the gate to true — now the fetch fires.
+    rerender({ when: true });
+    expect(getProviderPresetsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("retries on next mount after a failure", async () => {
     getProviderPresetsMock.mockRejectedValueOnce(new Error("transient"));
 

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -26,16 +26,18 @@
 // state (settingsConfig, providerFilter, model, settingsError).
 // Moving them now would mean dragging those slices in too.
 
-import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, type ReactNode } from "react";
 
 import { applyOverride, CoordinatorOverridesContext } from "./coordinators/overrides";
 import {
   getProviders,
   getModels,
+  getProviderPresets,
   probeAgentAdapter as probeAgentAdapterRequest,
   setAgentAdapterCredential as setAgentAdapterCredentialRequest,
   deleteAgentAdapterCredential as deleteAgentAdapterCredentialRequest,
 } from "../../lib/api";
+import { warn } from "../../lib/log";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ModelResponse } from "../../types/model";
 import type { ProviderPresetRecord, ProviderStatusResponse } from "../../types/provider";
@@ -43,6 +45,13 @@ import type { ProviderPresetRecord, ProviderStatusResponse } from "../../types/p
 export type ProvidersAndModelsState = {
   providers: ProviderStatusResponse["data"];
   providerPresets: ProviderPresetRecord[];
+  /**
+   * True once getProviderPresets() has resolved. Used by
+   * useEnsureProviderPresetsLoaded to dedupe the lazy fetch.
+   * Presets aren't loaded at boot; they're fetched on first
+   * AddProviderModal mount + TasksView mount.
+   */
+  providerPresetsLoaded: boolean;
   models: ModelResponse["data"];
   agentAdapters: AgentAdapterRecord[];
   agentAdapterApprovalMode: string;
@@ -67,6 +76,7 @@ export type AdapterDeleteCredentialResult =
 export type ProvidersAndModelsActions = {
   setProviders: (next: SetStateAction<ProviderStatusResponse["data"]>) => void;
   setProviderPresets: (next: SetStateAction<ProviderPresetRecord[]>) => void;
+  markProviderPresetsLoaded: () => void;
   setModels: (next: SetStateAction<ModelResponse["data"]>) => void;
   setAgentAdapters: (next: SetStateAction<AgentAdapterRecord[]>) => void;
   setAgentAdapterApprovalMode: (value: string) => void;
@@ -94,6 +104,7 @@ type ProvidersAndModelsContextValue = {
 type Action =
   | { type: "providers/set"; next: SetStateAction<ProviderStatusResponse["data"]> }
   | { type: "providerPresets/set"; next: SetStateAction<ProviderPresetRecord[]> }
+  | { type: "providerPresetsLoaded/mark" }
   | { type: "models/set"; next: SetStateAction<ModelResponse["data"]> }
   | { type: "agentAdapters/set"; next: SetStateAction<AgentAdapterRecord[]> }
   | { type: "agentAdapterApprovalMode/set"; value: string }
@@ -104,6 +115,7 @@ type Action =
 const initialState: ProvidersAndModelsState = {
   providers: [],
   providerPresets: [],
+  providerPresetsLoaded: false,
   models: [],
   agentAdapters: [],
   agentAdapterApprovalMode: "",
@@ -121,6 +133,8 @@ function reducer(state: ProvidersAndModelsState, action: Action): ProvidersAndMo
       return { ...state, providers: resolve(state.providers, action.next) };
     case "providerPresets/set":
       return { ...state, providerPresets: resolve(state.providerPresets, action.next) };
+    case "providerPresetsLoaded/mark":
+      return state.providerPresetsLoaded ? state : { ...state, providerPresetsLoaded: true };
     case "models/set":
       return { ...state, models: resolve(state.models, action.next) };
     case "agentAdapters/set":
@@ -170,6 +184,10 @@ export function ProvidersAndModelsProvider({ children, initialState: seededState
   );
   const setProviderPresets = useCallback(
     (next: SetStateAction<ProviderPresetRecord[]>) => dispatch({ type: "providerPresets/set", next }),
+    [],
+  );
+  const markProviderPresetsLoaded = useCallback(
+    () => dispatch({ type: "providerPresetsLoaded/mark" }),
     [],
   );
   const setModels = useCallback(
@@ -287,6 +305,7 @@ export function ProvidersAndModelsProvider({ children, initialState: seededState
   const actions = useMemo<ProvidersAndModelsActions>(() => ({
     setProviders,
     setProviderPresets,
+    markProviderPresetsLoaded,
     setModels,
     setAgentAdapters,
     setAgentAdapterApprovalMode,
@@ -300,6 +319,7 @@ export function ProvidersAndModelsProvider({ children, initialState: seededState
   }), [
     setProviders,
     setProviderPresets,
+    markProviderPresetsLoaded,
     setModels,
     setAgentAdapters,
     setAgentAdapterApprovalMode,
@@ -324,4 +344,36 @@ export function useProvidersAndModels(): ProvidersAndModelsContextValue {
   }
   const overrides = useContext(CoordinatorOverridesContext);
   return { state: ctx.state, actions: applyOverride(ctx.actions, overrides?.providersAndModelsSlice) };
+}
+
+// useEnsureProviderPresetsLoaded fetches the provider preset
+// catalog on first call if the slice's providerPresetsLoaded flag
+// is false. Used by AddProviderModal and TasksView; the dashboard
+// loader no longer pulls presets at boot. Dedupes parallel callers
+// via an inflight ref; tolerates failures by leaving the loaded
+// flag false so a later mount can retry.
+//
+// The optional `when` gate lets callers that always-mount the
+// component (e.g. <AddProviderModal open={…} /> in ChatView) skip
+// the fetch until the modal actually opens — otherwise the
+// always-mounted modal would defeat the lazy-fetch contract.
+export function useEnsureProviderPresetsLoaded(when: boolean = true): void {
+  const { state, actions } = useProvidersAndModels();
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    if (!when || state.providerPresetsLoaded || inFlight.current) return;
+    inFlight.current = true;
+    void (async () => {
+      try {
+        const res = await getProviderPresets();
+        actions.setProviderPresets(res.data ?? []);
+        actions.markProviderPresetsLoaded();
+      } catch (err) {
+        warn("providerPresets.ensureLoaded.failed", { err: err instanceof Error ? err.message : String(err) });
+      } finally {
+        inFlight.current = false;
+      }
+    })();
+  }, [when, state.providerPresetsLoaded, actions]);
 }

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -349,9 +349,21 @@ export function useProvidersAndModels(): ProvidersAndModelsContextValue {
 // useEnsureProviderPresetsLoaded fetches the provider preset
 // catalog on first call if the slice's providerPresetsLoaded flag
 // is false. Used by AddProviderModal and TasksView; the dashboard
-// loader no longer pulls presets at boot. Dedupes parallel callers
-// via an inflight ref; tolerates failures by leaving the loaded
-// flag false so a later mount can retry.
+// loader no longer pulls presets at boot.
+//
+// Dedup behavior:
+//   - The `inFlight` ref is per hook instance — it blocks the same
+//     hook from re-firing while its first fetch is pending.
+//   - Cross-surface dedup happens AFTER the first fetch resolves,
+//     when `providerPresetsLoaded` flips to true: subsequent calls
+//     (whether from a re-mount of the same surface or a different
+//     surface) early-return on the loaded check. If two surfaces
+//     mount the hook simultaneously before either flip lands, both
+//     fetches would fire — acceptable today (only AddProviderModal
+//     and TasksView call it, and they don't mount concurrently).
+//
+// Tolerates failures by leaving `providerPresetsLoaded` false so a
+// later mount retries.
 //
 // The optional `when` gate lets callers that always-mount the
 // component (e.g. <AddProviderModal open={…} /> in ChatView) skip

--- a/ui/src/app/state/usage.test.tsx
+++ b/ui/src/app/state/usage.test.tsx
@@ -85,33 +85,25 @@ describe("useEnsureUsageLoaded", () => {
     expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
   });
 
-  it("dedupes parallel callers via inflight ref", async () => {
+  it("inflight ref blocks re-firing while the first fetch is pending", async () => {
     let resolveSummary: (value: unknown) => void = () => undefined;
     let resolveEvents: (value: unknown) => void = () => undefined;
     getUsageSummaryMock.mockReturnValue(new Promise(r => { resolveSummary = r; }));
     getUsageEventsMock.mockReturnValue(new Promise(r => { resolveEvents = r; }));
 
-    // Two consumers in the same provider — same UsageContext instance,
-    // same inflight ref since the ref is per-hook-call but the loaded
-    // flag is shared. The second consumer reads loaded=false on first
-    // render (before the first promise resolves) but the inflight
-    // ref on its own instance is also false, so technically it could
-    // fire a second fetch. Dedup-across-consumers is bounded by the
-    // shared loaded flag once one fetch resolves.
-    function Multi({ children }: { children: ReactNode }) {
-      return <UsageProvider>{children}</UsageProvider>;
-    }
-    renderHook(
-      () => {
-        useEnsureUsageLoaded();
-        return useUsage();
-      },
-      { wrapper: Multi },
-    );
-
-    // One fetch pair is in flight; resolve them.
+    // Single hook instance; multiple re-renders while the first
+    // fetch is still pending. The inflight ref must prevent a second
+    // pair of fetches from firing before the first resolves.
+    const { rerender } = renderHook(() => useEnsureUsageLoaded(), { wrapper: Wrapper });
     expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
     expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+
+    rerender();
+    rerender();
+    expect(getUsageSummaryMock).toHaveBeenCalledTimes(1);
+    expect(getUsageEventsMock).toHaveBeenCalledTimes(1);
+
+    // Resolve so the test cleans up cleanly.
     resolveSummary({ data: { total_micros_usd: 0 } });
     resolveEvents({ data: [] });
   });

--- a/ui/src/features/providers/AddProviderModal.tsx
+++ b/ui/src/features/providers/AddProviderModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useProvidersAndModels } from "../../app/state/providersAndModels";
+import { useEnsureProviderPresetsLoaded, useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useSettings } from "../../app/state/settings";
 import { useWiredProviderActions } from "../../app/state/coordinators/wired";
 import { discoverLocalProviders } from "../../lib/api";
@@ -22,6 +22,7 @@ type AddFormState = {
 };
 
 export function AddProviderModal({ open, onClose }: Props) {
+  useEnsureProviderPresetsLoaded(open);
   const settings = useSettings();
   const providersAndModels = useProvidersAndModels();
   const providerActions = useWiredProviderActions();

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ApiError,
-  applyTaskRunPatch, cancelTaskRun, createTask, deleteTask, getModels, getProviderPresets, getProviders,
+  applyTaskRunPatch, cancelTaskRun, createTask, deleteTask, getModels, getProviders,
   getTaskApprovals, getTaskRunArtifacts, getTaskRunEvents,
   getTaskRuns, getTaskRunSteps, getTasks, resolveTaskApproval, revertTaskRunPatch,
   retryTaskRun, retryTaskRunFromTurn, resumeTaskRun, resumeTaskRunRaisingCeiling,
   startTask, streamTaskRun,
 } from "../../lib/api";
+import { useEnsureProviderPresetsLoaded, useProvidersAndModels } from "../../app/state/providersAndModels";
 import type { ModelRecord } from "../../types/model";
-import type { ProviderPresetRecord, ProviderRecord } from "../../types/provider";
+import type { ProviderRecord } from "../../types/provider";
 import type {
   TaskActivityRecord,
   TaskApprovalRecord,
@@ -79,7 +80,8 @@ export function TasksView({
   // changes (enabling/disabling a provider) take effect after the
   // operator opens a new tab or refreshes.
   const [availableProviders, setAvailableProviders] = useState<ProviderRecord[]>([]);
-  const [providerPresets, setProviderPresets] = useState<ProviderPresetRecord[]>([]);
+  useEnsureProviderPresetsLoaded();
+  const providerPresets = useProvidersAndModels().state.providerPresets;
 
   const streamCursorRef = useRef(0);
 
@@ -152,7 +154,6 @@ export function TasksView({
     // names, and a missing model list shows "no models match".
     getModels().then(res => setAvailableModels(res.data ?? [])).catch(() => {});
     getProviders().then(res => setAvailableProviders(res.data ?? [])).catch(() => {});
-    getProviderPresets().then(res => setProviderPresets(res.data ?? [])).catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -47,6 +47,11 @@ function usageInitialState(fixture: RuntimeConsoleFixtureState) {
   return {
     summary: fixture.usageSummary,
     events: fixture.usageEvents,
+    // Tests that mount UsageView via this wrapper pretend the slice
+    // is already hydrated — without this flag, useEnsureUsageLoaded
+    // would fire the (unmocked) fetch on every UsageView render and
+    // spam usage.ensureLoaded.failed warnings into the test output.
+    loaded: true,
   };
 }
 
@@ -54,6 +59,11 @@ function providersAndModelsInitialState(fixture: RuntimeConsoleFixtureState) {
   return {
     providers: fixture.providers,
     providerPresets: fixture.providerPresets,
+    // Same dedup reason as usageInitialState: presets are considered
+    // pre-loaded under the fixture so useEnsureProviderPresetsLoaded
+    // doesn't trigger a fetch on every AddProviderModal / TasksView
+    // mount inside a test render.
+    providerPresetsLoaded: true,
     // Same compat shim as the syncer: legacy tests fill
     // providerScopedModels but leave models empty.
     models: fixture.models.length > 0 ? fixture.models : fixture.providerScopedModels,


### PR DESCRIPTION
## Summary

Provider presets move out of the boot-time dashboard loader. The catalog now loads on first \`AddProviderModal\` open (gated by the modal's \`open\` prop) and on first \`TasksView\` mount. A new \`providerPresetsLoaded\` flag on the providersAndModels slice dedupes across in-session re-opens.

## Savings

- **Default-Chats boots** save one API call. ChatView always-mounts the modal (\`open=false\` initially), but the gated hook skips the fetch until the operator clicks "Add provider".
- **Non-Chats boots** save the fetch entirely until either modal or TasksView mounts.

## Boot fanout shape change

| Wave | Before | After |
|---|---|---|
| Wave 1 (gate-blocking) | 3 parallel calls | 3 parallel calls (unchanged) |
| Wave 2 (background) | 5 parallel + 1 conditional | **4** parallel + 1 conditional |

\`DashboardSnapshot\` loses its \`providerPresets\` field. The dashboard coordinator drops the \`setProviderPresets\` plumbing.

## UI rewires

- **\`AddProviderModal\`** calls \`useEnsureProviderPresetsLoaded(open)\` so the hook only fires when the modal is actually open. Critical: ChatView always-mounts the modal, so without the \`open\` gate the optimization would no-op on Chats boots.
- **\`TasksView\`** drops its bespoke local-state fetch and reads \`providerPresets\` from the slice via \`useEnsureProviderPresetsLoaded()\`. The old \`useState\` + inline \`getProviderPresets()\` are gone.

## Slice contract

- New state field: \`providerPresetsLoaded: boolean\` (initial \`false\`).
- New action: \`markProviderPresetsLoaded()\` (idempotent).
- New hook: \`useEnsureProviderPresetsLoaded(when: boolean = true)\` — optional \`when\` gate for always-mounted consumers.

## Test plan

**4 unit tests** (\`providersAndModels.test.tsx\`) cover the hook contract: fetch on first mount, dedup via loaded flag, \`when=false\` gate, failure tolerance, retry-on-next-mount.

**3 e2e tests** (\`provider-presets-lazy.spec.ts\` × 2 + \`boot-shape.spec.ts\` × 1) pin the boot shape (no \`/providers/presets\` fetch at boot on default Chats; exact set of endpoints fired during boot) and the modal-open contract (fetched on first open, not on re-open).

- [x] \`bun run typecheck\` — clean
- [x] \`bunx vitest run\` — 949 / 949 pass
- [x] \`bun run test:e2e provider-presets-lazy.spec.ts\` — 2 / 2 pass, no Vite proxy noise
- [x] \`bun run test:e2e boot-shape.spec.ts\` — 1 / 1 pass

## What doesn't change

- \`useProvidersAndModels\` external shape (additive only — \`providerPresetsLoaded\` + \`markProviderPresetsLoaded\`).
- Existing UsageView, AddProviderModal, ProvidersView, ConnectionsPanel behavior is identical post-fetch.
- Chat coordinators (\`setChatTarget\`, \`deleteProvider\`, rootEffects auto-default cascade) tolerate empty presets gracefully — \`defaultModelForProvider\` falls back to per-provider model list when no preset is found. First cold boot may pick a slightly less optimal default until the user opens AddProviderModal; acceptable trade-off documented in the slice's doc comment.