### PR TITLE
fix(telemetry): default trace body capture to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ Download the current alpha from [hecate.sh](https://hecate.sh) or from the
 versioned GitHub Release assets below:
 
 <!-- desktop-release-links:start -->
-| Platform | Bundle |
-|---|---|
-| macOS (Apple Silicon) | [Hecate_0.1.0-alpha.32_aarch64.dmg](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_aarch64.dmg) |
-| Linux x86_64 | [Hecate_0.1.0-alpha.32_amd64.deb](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_amd64.deb) or [Hecate_0.1.0-alpha.32_amd64.AppImage](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_amd64.AppImage) |
-| Windows x86_64 | [Hecate_0.1.0-alpha.32_x64_en-US.msi](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_x64_en-US.msi) |
+
+| Platform              | Bundle                                                                                                                                                                                                                                                                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| macOS (Apple Silicon) | [Hecate_0.1.0-alpha.32_aarch64.dmg](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_aarch64.dmg)                                                                                                                                                  |
+| Linux x86_64          | [Hecate_0.1.0-alpha.32_amd64.deb](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_amd64.deb) or [Hecate_0.1.0-alpha.32_amd64.AppImage](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_amd64.AppImage) |
+| Windows x86_64        | [Hecate_0.1.0-alpha.32_x64_en-US.msi](https://github.com/hecatehq/hecate/releases/download/v0.1.0-alpha.32/Hecate_0.1.0-alpha.32_x64_en-US.msi)                                                                                                                                              |
+
 <!-- desktop-release-links:end -->
 
 Open the bundle and launch Hecate. The app starts the gateway sidecar, waits for it to become healthy, and opens the embedded operator UI automatically. State lives in the platform data dir (`~/Library/Application Support/sh.hecate.app/` on macOS, `%APPDATA%\sh.hecate.app\` on Windows, `~/.local/share/sh.hecate.app/` on Linux).

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -537,6 +537,7 @@ func buildGatewayDependencies(
 		Metrics:           metrics,
 		Retention:         retentionManager,
 		TraceBodyCapture:  cfg.Server.TraceBodyCapture,
+		TraceBodyMode:     cfg.Server.TraceBodyMode,
 		TraceBodyMaxBytes: cfg.Server.TraceBodyMaxBytes,
 	}
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -343,7 +343,9 @@ By default, `GATEWAY_TRACE_BODY_MODE=metadata` records only message shape:
 roles, content byte counts, content-block counts, tool-call counts, model, and
 finish reasons. It does not record prompt or response text. This is the
 recommended mode for routine local debugging because it preserves request shape
-without storing operator data in traces.
+without storing operator data in traces. Metadata capture is capped to the
+first 128 request messages or response choices and sets a `truncated` attribute
+when the event omits additional entries.
 
 `GATEWAY_TRACE_BODY_MODE=redacted_text` records size-capped text snapshots after
 heuristic secret redaction. This mode is for short-lived debugging in trusted

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -165,6 +165,7 @@ Behavior to know:
 Trace body capture is configured separately from OTLP export:
 
 - `GATEWAY_TRACE_BODIES`
+- `GATEWAY_TRACE_BODY_MODE`
 - `GATEWAY_TRACE_BODY_MAX_BYTES`
 
 ## Trace Context Propagation
@@ -333,12 +334,22 @@ Provider execution also emits attempt-level metrics. These are intentionally
 separate from finalized chat metrics: retries and failed attempts are visible
 even when a later provider recovers the request.
 
-When `GATEWAY_TRACE_BODIES=true`, the gateway also records redacted, size-capped trace events named:
+When `GATEWAY_TRACE_BODIES=true`, the gateway also records trace events named:
 
 - `request.body.captured`
 - `response.body.captured`
 
-These events contain truncated message or choice snapshots and are intended for local debugging and carefully controlled observability setups, not blanket production payload capture.
+By default, `GATEWAY_TRACE_BODY_MODE=metadata` records only message shape:
+roles, content byte counts, content-block counts, tool-call counts, model, and
+finish reasons. It does not record prompt or response text. This is the
+recommended mode for routine local debugging because it preserves request shape
+without storing operator data in traces.
+
+`GATEWAY_TRACE_BODY_MODE=redacted_text` records size-capped text snapshots after
+heuristic secret redaction. This mode is for short-lived debugging in trusted
+local or tightly controlled observability setups. Redaction is best effort; it
+is not a data-loss-prevention boundary. `GATEWAY_TRACE_BODY_MAX_BYTES` only
+applies in `redacted_text` mode.
 
 ### Orchestrator Spans
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,10 +150,14 @@ type ServerConfig struct {
 	// Set via GATEWAY_CHAT_IDLE_TIMEOUT.
 	ChatIdleTimeout time.Duration
 
-	// TraceBodyCapture enables recording (redacted) request and response bodies
-	// in the distributed trace.  Off by default; enable via GATEWAY_TRACE_BODIES=true.
+	// TraceBodyCapture enables recording request and response body diagnostics
+	// in the distributed trace. Off by default; enable via GATEWAY_TRACE_BODIES=true.
 	TraceBodyCapture bool
+	// TraceBodyMode controls whether body diagnostics contain metadata only
+	// (default) or redacted text snapshots. Set via GATEWAY_TRACE_BODY_MODE.
+	TraceBodyMode string
 	// TraceBodyMaxBytes caps each captured body at this many bytes (default 4096).
+	// Only applies when TraceBodyMode is "redacted_text".
 	TraceBodyMaxBytes int
 
 	// RateLimit controls per-API-key request throttling.
@@ -377,6 +381,7 @@ func LoadFromEnv() Config {
 			ChatIdleTimeout:                getEnvDuration("GATEWAY_CHAT_IDLE_TIMEOUT", 0),
 			TaskMaxConcurrentPerTenant:     getEnvInt("GATEWAY_TASK_MAX_CONCURRENT_PER_TENANT", 0),
 			TraceBodyCapture:               getEnvBool("GATEWAY_TRACE_BODIES", false),
+			TraceBodyMode:                  getEnv("GATEWAY_TRACE_BODY_MODE", "metadata"),
 			TraceBodyMaxBytes:              getEnvInt("GATEWAY_TRACE_BODY_MAX_BYTES", 4096),
 			RateLimit: RateLimitConfig{
 				Enabled:           getEnvBool("GATEWAY_RATE_LIMIT_ENABLED", false),
@@ -564,6 +569,11 @@ func (c Config) Validate() error {
 	case "", "trace_based", "tracebased", "sampled", "always_on", "alwayson", "always_off", "alwaysoff":
 	default:
 		errs = append(errs, fmt.Errorf("GATEWAY_OTEL_METRICS_EXEMPLAR_FILTER must be one of trace_based, always_on, or always_off"))
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Server.TraceBodyMode)) {
+	case "", "metadata", "redacted_text":
+	default:
+		errs = append(errs, fmt.Errorf("GATEWAY_TRACE_BODY_MODE must be one of metadata or redacted_text"))
 	}
 
 	return errors.Join(errs...)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,23 @@ func TestLoadFromEnvUsesCurrentOpenAIDefaultModel(t *testing.T) {
 		t.Fatalf("default model = %q, want gpt-5.4-mini", cfg.Router.DefaultModel)
 	}
 }
+
+func TestLoadFromEnvTraceBodyModeDefaultsToMetadata(t *testing.T) {
+	cfg := LoadFromEnv()
+	if cfg.Server.TraceBodyMode != "metadata" {
+		t.Fatalf("TraceBodyMode = %q, want metadata", cfg.Server.TraceBodyMode)
+	}
+}
+
+func TestLoadFromEnvTraceBodyModeOverride(t *testing.T) {
+	t.Setenv("GATEWAY_TRACE_BODY_MODE", "redacted_text")
+
+	cfg := LoadFromEnv()
+	if cfg.Server.TraceBodyMode != "redacted_text" {
+		t.Fatalf("TraceBodyMode = %q, want redacted_text", cfg.Server.TraceBodyMode)
+	}
+}
+
 func TestLoadFromEnvOTelSharedDefaults(t *testing.T) {
 	t.Setenv("GATEWAY_OTEL_ENDPOINT", "http://collector:4318")
 	t.Setenv("GATEWAY_OTEL_HEADERS", "x-api-key=secret,tenant=local")
@@ -138,6 +155,19 @@ func TestValidateRejectsInvalidOTelMetricsExemplarFilter(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "GATEWAY_OTEL_METRICS_EXEMPLAR_FILTER") {
 		t.Fatalf("Validate() error = %q, want GATEWAY_OTEL_METRICS_EXEMPLAR_FILTER", err)
+	}
+}
+
+func TestValidateRejectsInvalidTraceBodyMode(t *testing.T) {
+	t.Setenv("GATEWAY_TRACE_BODY_MODE", "raw")
+	cfg := LoadFromEnv()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid trace body mode error")
+	}
+	if !strings.Contains(err.Error(), "GATEWAY_TRACE_BODY_MODE") {
+		t.Fatalf("Validate() error = %q, want GATEWAY_TRACE_BODY_MODE", err)
 	}
 }
 

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -38,8 +39,9 @@ type Dependencies struct {
 	Tracer          profiler.Tracer
 	Metrics         *telemetry.Metrics
 	Retention       *retention.Manager
-	// TraceBodyCapture enables recording (redacted) message bodies in traces.
+	// TraceBodyCapture enables recording message body diagnostics in traces.
 	TraceBodyCapture  bool
+	TraceBodyMode     string
 	TraceBodyMaxBytes int
 }
 
@@ -63,7 +65,13 @@ type Service struct {
 	providers         providers.Registry
 	traceBodyCapture  bool
 	traceBodyMaxBytes int
+	traceBodyMode     string
 }
+
+const (
+	traceBodyModeMetadata     = "metadata"
+	traceBodyModeRedactedText = "redacted_text"
+)
 
 type ChatResult struct {
 	Response *types.ChatResponse
@@ -175,6 +183,7 @@ func NewService(deps Dependencies) *Service {
 	if traceBodyMaxBytes <= 0 {
 		traceBodyMaxBytes = 4096
 	}
+	traceBodyMode := normalizeTraceBodyMode(deps.TraceBodyMode)
 
 	return &Service{
 		finalizer:         finalizer,
@@ -190,6 +199,7 @@ func NewService(deps Dependencies) *Service {
 		providers:         deps.Providers,
 		traceBodyCapture:  deps.TraceBodyCapture,
 		traceBodyMaxBytes: traceBodyMaxBytes,
+		traceBodyMode:     traceBodyMode,
 	}
 }
 
@@ -684,30 +694,30 @@ func validate(req types.ChatRequest) error {
 	return nil
 }
 
-// captureRequestBody records a redacted, size-capped snapshot of the request
+// captureRequestBody records a safe-by-default diagnostic snapshot of request
 // messages into the distributed trace when GATEWAY_TRACE_BODIES=true.
 func (s *Service) captureRequestBody(trace *profiler.Trace, req types.ChatRequest) {
-	type capturedMsg struct {
-		Role    string `json:"role"`
-		Content string `json:"content,omitempty"`
-		Blocks  int    `json:"blocks,omitempty"`
+	type capturedMessage struct {
+		Role         string `json:"role"`
+		Content      string `json:"content,omitempty"`
+		ContentBytes int    `json:"content_bytes,omitempty"`
+		Blocks       int    `json:"blocks,omitempty"`
+		ToolCalls    int    `json:"tool_calls,omitempty"`
 	}
-	msgs := make([]capturedMsg, 0, len(req.Messages))
+	msgs := make([]capturedMessage, 0, len(req.Messages))
 	remaining := s.traceBodyMaxBytes
 	for _, m := range req.Messages {
-		content := redactSensitiveText(m.Content)
-		if len(content) > remaining {
-			content = content[:remaining] + "…[truncated]"
-			remaining = 0
-		} else {
-			remaining -= len(content)
+		item := capturedMessage{
+			Role:         m.Role,
+			ContentBytes: len(m.Content),
+			Blocks:       len(m.ContentBlocks),
+			ToolCalls:    len(m.ToolCalls),
 		}
-		msgs = append(msgs, capturedMsg{
-			Role:    m.Role,
-			Content: content,
-			Blocks:  len(m.ContentBlocks),
-		})
-		if remaining <= 0 {
+		if s.traceBodyMode == traceBodyModeRedactedText {
+			item.Content, remaining = redactedTraceContent(m.Content, remaining)
+		}
+		msgs = append(msgs, item)
+		if s.traceBodyMode == traceBodyModeRedactedText && remaining <= 0 {
 			break
 		}
 	}
@@ -715,11 +725,12 @@ func (s *Service) captureRequestBody(trace *profiler.Trace, req types.ChatReques
 	trace.Record("request.body.captured", map[string]any{
 		"messages": string(b),
 		"model":    req.Model,
+		"mode":     s.traceBodyMode,
 	})
 }
 
-// captureResponseBody records a redacted, size-capped snapshot of the response
-// into the distributed trace when GATEWAY_TRACE_BODIES=true.
+// captureResponseBody records a safe-by-default diagnostic snapshot of the
+// response into the distributed trace when GATEWAY_TRACE_BODIES=true.
 func (s *Service) captureResponseBody(trace *profiler.Trace, resp *types.ChatResponse) {
 	if resp == nil || len(resp.Choices) == 0 {
 		return
@@ -727,26 +738,24 @@ func (s *Service) captureResponseBody(trace *profiler.Trace, resp *types.ChatRes
 	type capturedChoice struct {
 		Role         string `json:"role"`
 		Content      string `json:"content,omitempty"`
+		ContentBytes int    `json:"content_bytes,omitempty"`
 		FinishReason string `json:"finish_reason,omitempty"`
 		ToolCalls    int    `json:"tool_calls,omitempty"`
 	}
 	choices := make([]capturedChoice, 0, len(resp.Choices))
 	remaining := s.traceBodyMaxBytes
 	for _, c := range resp.Choices {
-		content := redactSensitiveText(c.Message.Content)
-		if len(content) > remaining {
-			content = content[:remaining] + "…[truncated]"
-			remaining = 0
-		} else {
-			remaining -= len(content)
-		}
-		choices = append(choices, capturedChoice{
+		item := capturedChoice{
 			Role:         c.Message.Role,
-			Content:      content,
+			ContentBytes: len(c.Message.Content),
 			FinishReason: c.FinishReason,
 			ToolCalls:    len(c.Message.ToolCalls),
-		})
-		if remaining <= 0 {
+		}
+		if s.traceBodyMode == traceBodyModeRedactedText {
+			item.Content, remaining = redactedTraceContent(c.Message.Content, remaining)
+		}
+		choices = append(choices, item)
+		if s.traceBodyMode == traceBodyModeRedactedText && remaining <= 0 {
 			break
 		}
 	}
@@ -754,7 +763,28 @@ func (s *Service) captureResponseBody(trace *profiler.Trace, resp *types.ChatRes
 	trace.Record("response.body.captured", map[string]any{
 		"choices": string(b),
 		"model":   resp.Model,
+		"mode":    s.traceBodyMode,
 	})
+}
+
+func normalizeTraceBodyMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case traceBodyModeRedactedText:
+		return traceBodyModeRedactedText
+	default:
+		return traceBodyModeMetadata
+	}
+}
+
+func redactedTraceContent(content string, remaining int) (string, int) {
+	content = redactSensitiveText(content)
+	if remaining <= 0 {
+		return "…[truncated]", 0
+	}
+	if len(content) > remaining {
+		return content[:remaining] + "…[truncated]", 0
+	}
+	return content, remaining - len(content)
 }
 
 // redactSensitiveText masks patterns that look like secrets in captured bodies.
@@ -762,5 +792,23 @@ func redactSensitiveText(s string) string {
 	// Simple heuristic: mask anything that looks like "key": "sk-..." or
 	// "authorization": "Bearer ..." — exact fields are already stripped at
 	// the HTTP layer; this is a belt-and-suspenders pass over message content.
-	return s
+	out := authorizationHeaderPattern.ReplaceAllString(s, "${1}[redacted]")
+	out = bearerTokenPattern.ReplaceAllString(out, "${1}[redacted]")
+	out = secretAssignmentPattern.ReplaceAllString(out, "${1}[redacted]")
+	out = secretJSONFieldPattern.ReplaceAllString(out, "${1}[redacted]${3}")
+	out = providerSecretPattern.ReplaceAllString(out, "[redacted]")
+	return out
 }
+
+var (
+	authorizationHeaderPattern = regexp.MustCompile(`(?i)(\bAuthorization\s*:\s*)(?:Bearer\s+)?[A-Za-z0-9._~+/=-]{12,}`)
+	bearerTokenPattern         = regexp.MustCompile(`(?i)(\bBearer\s+)[A-Za-z0-9._~+/=-]{12,}`)
+	// Environment and dotenv-style assignments commonly show up in prompts
+	// when an operator pastes setup snippets. Keep the variable name visible
+	// so traces remain useful without retaining the secret value.
+	secretAssignmentPattern = regexp.MustCompile(`(?i)\b((?:OPENAI|ANTHROPIC|CLAUDE|CODEX|CURSOR|GITHUB|GITLAB|NPM|AWS|GOOGLE|AZURE|HECATE)?_?(?:API[_-]?KEY|AUTH[_-]?TOKEN|ACCESS[_-]?TOKEN|SECRET(?:_KEY)?|TOKEN|PASSWORD)\s*=\s*)[^\s"']+`)
+	secretJSONFieldPattern  = regexp.MustCompile(`(?i)(["']?(?:api[_-]?key|auth[_-]?token|access[_-]?token|secret(?:[_-]?key)?|token|password|authorization)["']?\s*:\s*["']?)([^"',}\s]+)(["']?)`)
+	// Provider setup tokens are often pasted as prose, not just as field
+	// values. Match long sk-* values while leaving short words untouched.
+	providerSecretPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9][A-Za-z0-9._-]{16,}\b`)
+)

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -71,6 +71,7 @@ type Service struct {
 const (
 	traceBodyModeMetadata     = "metadata"
 	traceBodyModeRedactedText = "redacted_text"
+	traceBodyMaxItems         = 128
 )
 
 type ChatResult struct {
@@ -704,9 +705,11 @@ func (s *Service) captureRequestBody(trace *profiler.Trace, req types.ChatReques
 		Blocks       int    `json:"blocks,omitempty"`
 		ToolCalls    int    `json:"tool_calls,omitempty"`
 	}
-	msgs := make([]capturedMessage, 0, len(req.Messages))
+	messageCount := len(req.Messages)
+	captureCount := min(messageCount, traceBodyMaxItems)
+	msgs := make([]capturedMessage, 0, captureCount)
 	remaining := s.traceBodyMaxBytes
-	for _, m := range req.Messages {
+	for _, m := range req.Messages[:captureCount] {
 		item := capturedMessage{
 			Role:         m.Role,
 			ContentBytes: len(m.Content),
@@ -723,9 +726,12 @@ func (s *Service) captureRequestBody(trace *profiler.Trace, req types.ChatReques
 	}
 	b, _ := json.Marshal(msgs)
 	trace.Record("request.body.captured", map[string]any{
-		"messages": string(b),
-		"model":    req.Model,
-		"mode":     s.traceBodyMode,
+		"messages":          string(b),
+		"message_count":     messageCount,
+		"messages_captured": len(msgs),
+		"truncated":         len(msgs) < messageCount || (s.traceBodyMode == traceBodyModeRedactedText && remaining <= 0),
+		"model":             req.Model,
+		"mode":              s.traceBodyMode,
 	})
 }
 
@@ -742,9 +748,11 @@ func (s *Service) captureResponseBody(trace *profiler.Trace, resp *types.ChatRes
 		FinishReason string `json:"finish_reason,omitempty"`
 		ToolCalls    int    `json:"tool_calls,omitempty"`
 	}
-	choices := make([]capturedChoice, 0, len(resp.Choices))
+	choiceCount := len(resp.Choices)
+	captureCount := min(choiceCount, traceBodyMaxItems)
+	choices := make([]capturedChoice, 0, captureCount)
 	remaining := s.traceBodyMaxBytes
-	for _, c := range resp.Choices {
+	for _, c := range resp.Choices[:captureCount] {
 		item := capturedChoice{
 			Role:         c.Message.Role,
 			ContentBytes: len(c.Message.Content),
@@ -761,9 +769,12 @@ func (s *Service) captureResponseBody(trace *profiler.Trace, resp *types.ChatRes
 	}
 	b, _ := json.Marshal(choices)
 	trace.Record("response.body.captured", map[string]any{
-		"choices": string(b),
-		"model":   resp.Model,
-		"mode":    s.traceBodyMode,
+		"choices":          string(b),
+		"choice_count":     choiceCount,
+		"choices_captured": len(choices),
+		"truncated":        len(choices) < choiceCount || (s.traceBodyMode == traceBodyModeRedactedText && remaining <= 0),
+		"model":            resp.Model,
+		"mode":             s.traceBodyMode,
 	})
 }
 

--- a/internal/gateway/service_redaction_test.go
+++ b/internal/gateway/service_redaction_test.go
@@ -138,3 +138,81 @@ func TestCaptureResponseBodyRedactedTextModeMasksContent(t *testing.T) {
 		t.Fatalf("redacted_text mode missing redacted content: %s", rawChoices)
 	}
 }
+
+func TestCaptureRequestBodyMetadataModeCapsMessageCount(t *testing.T) {
+	t.Parallel()
+
+	trace := profiler.NewTrace("req-1", nil)
+	service := &Service{
+		traceBodyMode:     traceBodyModeMetadata,
+		traceBodyMaxBytes: 4096,
+	}
+	messages := make([]types.Message, traceBodyMaxItems+2)
+	for i := range messages {
+		messages[i] = types.Message{Role: "user", Content: "hello"}
+	}
+	service.captureRequestBody(trace, types.ChatRequest{
+		Model:    "gpt-test",
+		Messages: messages,
+	})
+
+	attrs := trace.Events()[0].Attributes
+	if attrs["message_count"] != traceBodyMaxItems+2 {
+		t.Fatalf("message_count = %v, want %d", attrs["message_count"], traceBodyMaxItems+2)
+	}
+	if attrs["messages_captured"] != traceBodyMaxItems {
+		t.Fatalf("messages_captured = %v, want %d", attrs["messages_captured"], traceBodyMaxItems)
+	}
+	if attrs["truncated"] != true {
+		t.Fatalf("truncated = %v, want true", attrs["truncated"])
+	}
+	rawMessages := attrs["messages"].(string)
+	var captured []struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal([]byte(rawMessages), &captured); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(captured) != traceBodyMaxItems {
+		t.Fatalf("captured len = %d, want %d", len(captured), traceBodyMaxItems)
+	}
+}
+
+func TestCaptureResponseBodyMetadataModeCapsChoiceCount(t *testing.T) {
+	t.Parallel()
+
+	trace := profiler.NewTrace("req-1", nil)
+	service := &Service{
+		traceBodyMode:     traceBodyModeMetadata,
+		traceBodyMaxBytes: 4096,
+	}
+	choices := make([]types.ChatChoice, traceBodyMaxItems+2)
+	for i := range choices {
+		choices[i] = types.ChatChoice{Message: types.Message{Role: "assistant", Content: "hello"}}
+	}
+	service.captureResponseBody(trace, &types.ChatResponse{
+		Model:   "gpt-test",
+		Choices: choices,
+	})
+
+	attrs := trace.Events()[0].Attributes
+	if attrs["choice_count"] != traceBodyMaxItems+2 {
+		t.Fatalf("choice_count = %v, want %d", attrs["choice_count"], traceBodyMaxItems+2)
+	}
+	if attrs["choices_captured"] != traceBodyMaxItems {
+		t.Fatalf("choices_captured = %v, want %d", attrs["choices_captured"], traceBodyMaxItems)
+	}
+	if attrs["truncated"] != true {
+		t.Fatalf("truncated = %v, want true", attrs["truncated"])
+	}
+	rawChoices := attrs["choices"].(string)
+	var captured []struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal([]byte(rawChoices), &captured); err != nil {
+		t.Fatalf("decode choices: %v", err)
+	}
+	if len(captured) != traceBodyMaxItems {
+		t.Fatalf("captured len = %d, want %d", len(captured), traceBodyMaxItems)
+	}
+}

--- a/internal/gateway/service_redaction_test.go
+++ b/internal/gateway/service_redaction_test.go
@@ -1,0 +1,140 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hecate/agent-runtime/internal/profiler"
+	"github.com/hecate/agent-runtime/pkg/types"
+)
+
+func TestRedactSensitiveTextMasksCommonSecrets(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`Authorization: Bearer sk-valid-token-secret-1234567890`,
+		`{"api_key":"sk-json-secret-1234567890","password":"correct-horse-battery-staple"}`,
+		`OPENAI_API_KEY=sk-env-secret-1234567890`,
+		`CLAUDE_CODE_OAUTH_TOKEN=sk-claude-secret-1234567890`,
+		`plain token sk-prose-secret-1234567890`,
+	}, "\n")
+
+	got := redactSensitiveText(input)
+	for _, leaked := range []string{
+		"sk-valid-token-secret-1234567890",
+		"sk-json-secret-1234567890",
+		"correct-horse-battery-staple",
+		"sk-env-secret-1234567890",
+		"sk-claude-secret-1234567890",
+		"sk-prose-secret-1234567890",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("redacted output leaked %q:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{
+		`Authorization: [redacted]`,
+		`"api_key":"[redacted]"`,
+		`"password":"[redacted]"`,
+		`OPENAI_API_KEY=[redacted]`,
+		`CLAUDE_CODE_OAUTH_TOKEN=[redacted]`,
+		`plain token [redacted]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRedactSensitiveTextLeavesOrdinaryContent(t *testing.T) {
+	t.Parallel()
+
+	input := "The user asked for a token budget and passwordless login docs."
+	if got := redactSensitiveText(input); got != input {
+		t.Fatalf("redactSensitiveText() = %q, want %q", got, input)
+	}
+}
+
+func TestCaptureRequestBodyMetadataModeDoesNotRecordContent(t *testing.T) {
+	t.Parallel()
+
+	trace := profiler.NewTrace("req-1", nil)
+	service := &Service{
+		traceBodyMode:     traceBodyModeMetadata,
+		traceBodyMaxBytes: 4096,
+	}
+	service.captureRequestBody(trace, types.ChatRequest{
+		Model: "gpt-test",
+		Messages: []types.Message{
+			{
+				Role:    "user",
+				Content: "secret prompt sk-request-secret-1234567890",
+				ToolCalls: []types.ToolCall{
+					{ID: "call-1"},
+				},
+			},
+		},
+	})
+
+	attrs := trace.Events()[0].Attributes
+	if attrs["mode"] != traceBodyModeMetadata {
+		t.Fatalf("mode = %v, want %q", attrs["mode"], traceBodyModeMetadata)
+	}
+	rawMessages, ok := attrs["messages"].(string)
+	if !ok {
+		t.Fatalf("messages attr = %#v, want string", attrs["messages"])
+	}
+	if strings.Contains(rawMessages, "secret prompt") || strings.Contains(rawMessages, "sk-request-secret") {
+		t.Fatalf("metadata mode leaked content: %s", rawMessages)
+	}
+	var messages []struct {
+		Role         string `json:"role"`
+		Content      string `json:"content,omitempty"`
+		ContentBytes int    `json:"content_bytes,omitempty"`
+		ToolCalls    int    `json:"tool_calls,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(rawMessages), &messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].Role != "user" || messages[0].Content != "" || messages[0].ContentBytes == 0 || messages[0].ToolCalls != 1 {
+		t.Fatalf("messages = %#v, want metadata without content", messages)
+	}
+}
+
+func TestCaptureResponseBodyRedactedTextModeMasksContent(t *testing.T) {
+	t.Parallel()
+
+	trace := profiler.NewTrace("req-1", nil)
+	service := &Service{
+		traceBodyMode:     traceBodyModeRedactedText,
+		traceBodyMaxBytes: 4096,
+	}
+	service.captureResponseBody(trace, &types.ChatResponse{
+		Model: "gpt-test",
+		Choices: []types.ChatChoice{
+			{
+				Message: types.Message{
+					Role:    "assistant",
+					Content: "use OPENAI_API_KEY=sk-response-secret-1234567890",
+				},
+				FinishReason: "stop",
+			},
+		},
+	})
+
+	attrs := trace.Events()[0].Attributes
+	if attrs["mode"] != traceBodyModeRedactedText {
+		t.Fatalf("mode = %v, want %q", attrs["mode"], traceBodyModeRedactedText)
+	}
+	rawChoices, ok := attrs["choices"].(string)
+	if !ok {
+		t.Fatalf("choices attr = %#v, want string", attrs["choices"])
+	}
+	if strings.Contains(rawChoices, "sk-response-secret") {
+		t.Fatalf("redacted_text mode leaked secret: %s", rawChoices)
+	}
+	if !strings.Contains(rawChoices, "OPENAI_API_KEY=[redacted]") {
+		t.Fatalf("redacted_text mode missing redacted content: %s", rawChoices)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GATEWAY_TRACE_BODY_MODE` with a safe `metadata` default when `GATEWAY_TRACE_BODIES=true`.
- Stop recording prompt/response text by default; metadata mode records message shape only.
- Keep explicit `redacted_text` mode for short-lived diagnostics, with heuristic secret masking and byte caps.
- Document the mode split and add config/gateway coverage.

## Why

Trace body capture previously relied on redaction for safety, but redaction is inherently best-effort. The safer default is to minimize captured data and require an explicit opt-in before storing text snapshots.

## Validation

- `go test ./cmd/hecate ./internal/config ./internal/gateway`
- `git diff --cached --check`
