### PR TITLE
feat(acp): advertise terminal setup auth

### DIFF
--- a/cmd/hecate-acp/main.go
+++ b/cmd/hecate-acp/main.go
@@ -73,6 +73,19 @@ func main() {
 		case "--version", "-v", "version":
 			fmt.Println(version.Version)
 			return
+		case "auth":
+			if len(os.Args) > 2 && os.Args[2] == "setup" {
+				cfg, err := configFromEnv()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
+					os.Exit(1)
+				}
+				if err := runAuthSetup(context.Background(), os.Stdout, cfg); err != nil {
+					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
 		}
 	}
 	cfg, err := configFromEnv()
@@ -290,6 +303,42 @@ func gatewayHealthy(baseURL string) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+func runAuthSetup(ctx context.Context, stdout io.Writer, cfg bridgeConfig) error {
+	client, err := newGatewayHTTPClient(cfg)
+	if err != nil {
+		return err
+	}
+	if err := client.Health(ctx); err != nil {
+		fmt.Fprintf(stdout, "Hecate gateway: not reachable at %s\n", cfg.GatewayURL)
+		fmt.Fprintln(stdout, "Start Hecate first, or set HECATE_GATEWAY_URL to the running gateway URL.")
+		return err
+	}
+	fmt.Fprintf(stdout, "Hecate gateway: reachable at %s\n", cfg.GatewayURL)
+
+	models, err := client.ListModels(ctx)
+	if err != nil {
+		fmt.Fprintln(stdout, "Models: could not list models from the gateway.")
+		return err
+	}
+	if len(models) > 0 {
+		fmt.Fprintf(stdout, "Models: %d available\n", len(models))
+		fmt.Fprintln(stdout, "ACP setup is ready.")
+		return nil
+	}
+
+	fmt.Fprintln(stdout, "Models: none available")
+	statuses, statusErr := client.ProviderStatuses(ctx)
+	if statusErr == nil && len(statuses) > 0 {
+		fmt.Fprintln(stdout, "Provider readiness:")
+		for _, status := range statuses {
+			message := firstNonEmpty(status.Readiness.Message, status.RoutingBlockedReason, status.Status)
+			fmt.Fprintf(stdout, "- %s: %s\n", status.Name, message)
+		}
+	}
+	fmt.Fprintln(stdout, "Open the Hecate operator console and configure at least one routable provider/model.")
+	return fmt.Errorf("no Hecate models are available")
+}
+
 func bridgeTracer() oteltrace.Tracer {
 	return otel.Tracer("hecate.acp")
 }
@@ -477,6 +526,51 @@ func (c *gatewayHTTPClient) ListModels(ctx context.Context) ([]string, error) {
 		}
 	}
 	return models, nil
+}
+
+func (c *gatewayHTTPClient) Health(ctx context.Context) error {
+	ctx, span := startGatewaySpan(ctx, http.MethodGet, "/healthz")
+	defer span.End()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/healthz", nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	injectBridgeTraceContext(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	defer resp.Body.Close()
+	recordSpanStatus(span, resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		err := fmt.Errorf("gateway returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		recordSpanError(span, err)
+		return err
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+type providerStatus struct {
+	Name                 string `json:"name"`
+	Status               string `json:"status"`
+	RoutingBlockedReason string `json:"routing_blocked_reason"`
+	Readiness            struct {
+		Message string `json:"message"`
+	} `json:"readiness"`
+}
+
+func (c *gatewayHTTPClient) ProviderStatuses(ctx context.Context) ([]providerStatus, error) {
+	var payload struct {
+		Data []providerStatus `json:"data"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/hecate/v1/providers/status", nil, &payload); err != nil {
+		return nil, err
+	}
+	return payload.Data, nil
 }
 
 func (c *gatewayHTTPClient) CreateAgentLoopTask(ctx context.Context, request acp.CreateTaskRequest) (acp.CreateTaskResult, error) {

--- a/cmd/hecate-acp/main.go
+++ b/cmd/hecate-acp/main.go
@@ -77,23 +77,7 @@ func main() {
 			fmt.Println(version.Version)
 			return
 		case "auth":
-			if len(os.Args) == 3 && os.Args[2] == "setup" {
-				cfg, err := configFromEnv()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
-					os.Exit(1)
-				}
-				if err := runAuthSetup(context.Background(), os.Stdout, cfg); err != nil {
-					if errors.Is(err, errAuthSetupFailed) {
-						os.Exit(1)
-					}
-					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
-					os.Exit(1)
-				}
-				return
-			}
-			fmt.Fprintln(os.Stderr, "usage: hecate-acp auth setup")
-			os.Exit(1)
+			os.Exit(runAuthCommand(context.Background(), os.Args[2:], os.Stdout, os.Stderr))
 		}
 	}
 	cfg, err := configFromEnv()
@@ -311,6 +295,46 @@ func gatewayHealthy(baseURL string) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+func runAuthCommand(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: hecate-acp auth setup")
+		return 1
+	}
+	switch args[0] {
+	case "help", "--help", "-h":
+		fmt.Fprintln(stdout, "usage: hecate-acp auth setup")
+		return 0
+	case "setup":
+		if len(args) > 1 {
+			if len(args) == 2 && (args[1] == "--help" || args[1] == "-h") {
+				fmt.Fprintln(stdout, "usage: hecate-acp auth setup")
+				return 0
+			}
+			fmt.Fprintf(stderr, "hecate-acp: unexpected auth setup argument %q\n", args[1])
+			fmt.Fprintln(stderr, "usage: hecate-acp auth setup")
+			return 1
+		}
+	default:
+		fmt.Fprintf(stderr, "hecate-acp: unknown auth subcommand %q\n", args[0])
+		fmt.Fprintln(stderr, "usage: hecate-acp auth setup")
+		return 1
+	}
+
+	cfg, err := configFromEnv()
+	if err != nil {
+		fmt.Fprintf(stderr, "hecate-acp: %v\n", err)
+		return 1
+	}
+	if err := runAuthSetup(ctx, stdout, cfg); err != nil {
+		if errors.Is(err, errAuthSetupFailed) {
+			return 1
+		}
+		fmt.Fprintf(stderr, "hecate-acp: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
 func runAuthSetup(ctx context.Context, stdout io.Writer, cfg bridgeConfig) error {
 	client, err := newGatewayHTTPClient(cfg)
 	if err != nil {
@@ -326,7 +350,8 @@ func runAuthSetup(ctx context.Context, stdout io.Writer, cfg bridgeConfig) error
 	models, err := client.ListModelDescriptions(ctx)
 	if err != nil {
 		fmt.Fprintln(stdout, "Models: could not list models from the gateway.")
-		return err
+		fmt.Fprintln(stdout, "Open the Hecate operator console or check HECATE_GATEWAY_URL, then retry setup.")
+		return errAuthSetupFailed
 	}
 	if ready := readyModelCount(models); ready > 0 {
 		fmt.Fprintf(stdout, "Models: %d ready\n", ready)

--- a/cmd/hecate-acp/main.go
+++ b/cmd/hecate-acp/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,6 +45,8 @@ const (
 	maxMessageBytes   = 4 << 20
 )
 
+var errAuthSetupFailed = errors.New("auth setup failed")
+
 type bridgeConfig struct {
 	GatewayURL    string
 	AgentName     string
@@ -74,18 +77,23 @@ func main() {
 			fmt.Println(version.Version)
 			return
 		case "auth":
-			if len(os.Args) > 2 && os.Args[2] == "setup" {
+			if len(os.Args) == 3 && os.Args[2] == "setup" {
 				cfg, err := configFromEnv()
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
 					os.Exit(1)
 				}
 				if err := runAuthSetup(context.Background(), os.Stdout, cfg); err != nil {
+					if errors.Is(err, errAuthSetupFailed) {
+						os.Exit(1)
+					}
 					fmt.Fprintf(os.Stderr, "hecate-acp: %v\n", err)
 					os.Exit(1)
 				}
 				return
 			}
+			fmt.Fprintln(os.Stderr, "usage: hecate-acp auth setup")
+			os.Exit(1)
 		}
 	}
 	cfg, err := configFromEnv()
@@ -311,22 +319,26 @@ func runAuthSetup(ctx context.Context, stdout io.Writer, cfg bridgeConfig) error
 	if err := client.Health(ctx); err != nil {
 		fmt.Fprintf(stdout, "Hecate gateway: not reachable at %s\n", cfg.GatewayURL)
 		fmt.Fprintln(stdout, "Start Hecate first, or set HECATE_GATEWAY_URL to the running gateway URL.")
-		return err
+		return errAuthSetupFailed
 	}
 	fmt.Fprintf(stdout, "Hecate gateway: reachable at %s\n", cfg.GatewayURL)
 
-	models, err := client.ListModels(ctx)
+	models, err := client.ListModelDescriptions(ctx)
 	if err != nil {
 		fmt.Fprintln(stdout, "Models: could not list models from the gateway.")
 		return err
 	}
-	if len(models) > 0 {
-		fmt.Fprintf(stdout, "Models: %d available\n", len(models))
+	if ready := readyModelCount(models); ready > 0 {
+		fmt.Fprintf(stdout, "Models: %d ready\n", ready)
 		fmt.Fprintln(stdout, "ACP setup is ready.")
 		return nil
 	}
 
-	fmt.Fprintln(stdout, "Models: none available")
+	if len(models) == 0 {
+		fmt.Fprintln(stdout, "Models: none available")
+	} else {
+		fmt.Fprintf(stdout, "Models: %d listed, none ready for routing\n", len(models))
+	}
 	statuses, statusErr := client.ProviderStatuses(ctx)
 	if statusErr == nil && len(statuses) > 0 {
 		fmt.Fprintln(stdout, "Provider readiness:")
@@ -336,7 +348,17 @@ func runAuthSetup(ctx context.Context, stdout io.Writer, cfg bridgeConfig) error
 		}
 	}
 	fmt.Fprintln(stdout, "Open the Hecate operator console and configure at least one routable provider/model.")
-	return fmt.Errorf("no Hecate models are available")
+	return errAuthSetupFailed
+}
+
+func readyModelCount(models []modelDescription) int {
+	count := 0
+	for _, model := range models {
+		if model.Metadata.Readiness.Ready && model.Metadata.Readiness.RoutingReady {
+			count++
+		}
+	}
+	return count
 }
 
 func bridgeTracer() oteltrace.Tracer {
@@ -490,6 +512,30 @@ func newGatewayHTTPClient(cfg bridgeConfig) (*gatewayHTTPClient, error) {
 }
 
 func (c *gatewayHTTPClient) ListModels(ctx context.Context) ([]string, error) {
+	descriptions, err := c.ListModelDescriptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	models := make([]string, 0, len(descriptions))
+	for _, item := range descriptions {
+		if strings.TrimSpace(item.ID) != "" {
+			models = append(models, item.ID)
+		}
+	}
+	return models, nil
+}
+
+type modelDescription struct {
+	ID       string `json:"id"`
+	Metadata struct {
+		Readiness struct {
+			Ready        bool `json:"ready"`
+			RoutingReady bool `json:"routing_ready"`
+		} `json:"readiness"`
+	} `json:"metadata"`
+}
+
+func (c *gatewayHTTPClient) ListModelDescriptions(ctx context.Context) ([]modelDescription, error) {
 	ctx, span := startGatewaySpan(ctx, http.MethodGet, "/v1/models")
 	defer span.End()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/models", nil)
@@ -512,20 +558,12 @@ func (c *gatewayHTTPClient) ListModels(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	var payload struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
+		Data []modelDescription `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return nil, err
 	}
-	models := make([]string, 0, len(payload.Data))
-	for _, item := range payload.Data {
-		if strings.TrimSpace(item.ID) != "" {
-			models = append(models, item.ID)
-		}
-	}
-	return models, nil
+	return payload.Data, nil
 }
 
 func (c *gatewayHTTPClient) Health(ctx context.Context) error {

--- a/cmd/hecate-acp/main_test.go
+++ b/cmd/hecate-acp/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -169,7 +170,7 @@ func TestRunAuthSetupReady(t *testing.T) {
 		case "/healthz":
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		case "/v1/models":
-			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama3.1:8b"}]}`))
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama3.1:8b","metadata":{"readiness":{"ready":true,"routing_ready":true}}}]}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -183,6 +184,35 @@ func TestRunAuthSetupReady(t *testing.T) {
 	}
 	output := stdout.String()
 	if !strings.Contains(output, "ACP setup is ready") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunAuthSetupRejectsListedUnreadyModels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/healthz":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/v1/models":
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama3.1:8b","metadata":{"readiness":{"ready":false,"routing_ready":false}}}]}`))
+		case "/hecate/v1/providers/status":
+			_, _ = w.Write([]byte(`{"object":"provider_status","data":[{"name":"ollama","status":"blocked","readiness":{"message":"Provider is disabled."}}]}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAuthSetup(context.Background(), &stdout, bridgeConfig{GatewayURL: srv.URL})
+	if !errors.Is(err, errAuthSetupFailed) {
+		t.Fatalf("runAuthSetup() error = %v, want errAuthSetupFailed", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "1 listed, none ready for routing") || !strings.Contains(output, "Provider is disabled.") {
 		t.Fatalf("output = %q", output)
 	}
 }
@@ -207,8 +237,8 @@ func TestRunAuthSetupExplainsMissingModels(t *testing.T) {
 
 	var stdout bytes.Buffer
 	err := runAuthSetup(context.Background(), &stdout, bridgeConfig{GatewayURL: srv.URL})
-	if err == nil {
-		t.Fatal("runAuthSetup() error = nil, want missing models error")
+	if !errors.Is(err, errAuthSetupFailed) {
+		t.Fatalf("runAuthSetup() error = %v, want errAuthSetupFailed", err)
 	}
 	output := stdout.String()
 	if !strings.Contains(output, "Models: none available") || !strings.Contains(output, "Start Ollama and load a model.") {

--- a/cmd/hecate-acp/main_test.go
+++ b/cmd/hecate-acp/main_test.go
@@ -161,6 +161,64 @@ func TestGatewayHTTPClientProviderStatuses(t *testing.T) {
 	}
 }
 
+func TestRunAuthCommandUsage(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "bare auth",
+			args:       nil,
+			wantCode:   1,
+			wantStderr: "usage: hecate-acp auth setup",
+		},
+		{
+			name:       "auth help",
+			args:       []string{"--help"},
+			wantCode:   0,
+			wantStdout: "usage: hecate-acp auth setup",
+		},
+		{
+			name:       "setup help",
+			args:       []string{"setup", "--help"},
+			wantCode:   0,
+			wantStdout: "usage: hecate-acp auth setup",
+		},
+		{
+			name:       "unknown subcommand",
+			args:       []string{"login"},
+			wantCode:   1,
+			wantStderr: `unknown auth subcommand "login"`,
+		},
+		{
+			name:       "unexpected setup argument",
+			args:       []string{"setup", "--json"},
+			wantCode:   1,
+			wantStderr: `unexpected auth setup argument "--json"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			got := runAuthCommand(context.Background(), tt.args, &stdout, &stderr)
+			if got != tt.wantCode {
+				t.Fatalf("runAuthCommand() = %d, want %d", got, tt.wantCode)
+			}
+			if tt.wantStdout != "" && !strings.Contains(stdout.String(), tt.wantStdout) {
+				t.Fatalf("stdout = %q, want %q", stdout.String(), tt.wantStdout)
+			}
+			if tt.wantStderr != "" && !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tt.wantStderr)
+			}
+		})
+	}
+}
+
 func TestRunAuthSetupReady(t *testing.T) {
 	t.Parallel()
 
@@ -184,6 +242,33 @@ func TestRunAuthSetupReady(t *testing.T) {
 	}
 	output := stdout.String()
 	if !strings.Contains(output, "ACP setup is ready") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunAuthSetupExplainsModelListFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/healthz":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/v1/models":
+			http.Error(w, "model list unavailable", http.StatusServiceUnavailable)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAuthSetup(context.Background(), &stdout, bridgeConfig{GatewayURL: srv.URL})
+	if !errors.Is(err, errAuthSetupFailed) {
+		t.Fatalf("runAuthSetup() error = %v, want errAuthSetupFailed", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Models: could not list models from the gateway.") || !strings.Contains(output, "check HECATE_GATEWAY_URL") {
 		t.Fatalf("output = %q", output)
 	}
 }

--- a/cmd/hecate-acp/main_test.go
+++ b/cmd/hecate-acp/main_test.go
@@ -114,6 +114,108 @@ func TestGatewayHTTPClientListModels(t *testing.T) {
 	}
 }
 
+func TestGatewayHTTPClientHealth(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Fatalf("path = %q, want /healthz", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	client, err := newGatewayHTTPClient(bridgeConfig{GatewayURL: srv.URL})
+	if err != nil {
+		t.Fatalf("newGatewayHTTPClient() error = %v", err)
+	}
+	if err := client.Health(context.Background()); err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+}
+
+func TestGatewayHTTPClientProviderStatuses(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hecate/v1/providers/status" {
+			t.Fatalf("path = %q, want /hecate/v1/providers/status", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"provider_status","data":[{"name":"ollama","status":"blocked","routing_blocked_reason":"no_models","readiness":{"message":"Load at least one model."}}]}`))
+	}))
+	defer srv.Close()
+
+	client, err := newGatewayHTTPClient(bridgeConfig{GatewayURL: srv.URL})
+	if err != nil {
+		t.Fatalf("newGatewayHTTPClient() error = %v", err)
+	}
+	statuses, err := client.ProviderStatuses(context.Background())
+	if err != nil {
+		t.Fatalf("ProviderStatuses() error = %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Name != "ollama" || statuses[0].Readiness.Message != "Load at least one model." {
+		t.Fatalf("statuses = %+v", statuses)
+	}
+}
+
+func TestRunAuthSetupReady(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/healthz":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/v1/models":
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"llama3.1:8b"}]}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAuthSetup(context.Background(), &stdout, bridgeConfig{GatewayURL: srv.URL})
+	if err != nil {
+		t.Fatalf("runAuthSetup() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "ACP setup is ready") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunAuthSetupExplainsMissingModels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/healthz":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/v1/models":
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		case "/hecate/v1/providers/status":
+			_, _ = w.Write([]byte(`{"object":"provider_status","data":[{"name":"ollama","status":"blocked","readiness":{"message":"Start Ollama and load a model."}}]}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAuthSetup(context.Background(), &stdout, bridgeConfig{GatewayURL: srv.URL})
+	if err == nil {
+		t.Fatal("runAuthSetup() error = nil, want missing models error")
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Models: none available") || !strings.Contains(output, "Start Ollama and load a model.") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
 func TestGatewayHTTPClientCreateAgentLoopTask(t *testing.T) {
 	t.Parallel()
 
@@ -339,7 +441,7 @@ func TestRunInitializeOverStdio(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	input := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1","clientCapabilities":{"permissions":{}}}}` + "\n")
+	input := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1","clientCapabilities":{"permissions":{},"auth":{"terminal":true}}}}` + "\n")
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), input, &stdout, &stderr, bridgeConfig{
 		GatewayURL:    srv.URL,
@@ -372,12 +474,20 @@ func TestRunInitializeOverStdio(t *testing.T) {
 		AvailableModels []struct {
 			ID string `json:"id"`
 		} `json:"availableModels"`
+		AuthMethods []struct {
+			ID   string   `json:"id"`
+			Type string   `json:"type"`
+			Args []string `json:"args"`
+		} `json:"authMethods"`
 	}
 	if err := json.Unmarshal(resp.Result, &result); err != nil {
 		t.Fatalf("decode result: %v", err)
 	}
 	if len(result.AvailableModels) != 1 || result.AvailableModels[0].ID != "llama3.1:8b" {
 		t.Fatalf("availableModels = %#v", result.AvailableModels)
+	}
+	if len(result.AuthMethods) != 1 || result.AuthMethods[0].ID != "hecate-setup" || result.AuthMethods[0].Type != "terminal" || strings.Join(result.AuthMethods[0].Args, " ") != "auth setup" {
+		t.Fatalf("authMethods = %#v", result.AuthMethods)
 	}
 }
 

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -97,6 +97,29 @@ Prefer `HECATE_GATEWAY_URL` when a parent process or launcher already knows the
 gateway URL. The runtime file is intentionally only an ephemeral discovery
 fallback for independently launched ACP hosts.
 
+## ACP registry authentication setup
+
+The bridge advertises a terminal auth method named `hecate-setup` when an ACP
+host declares `clientCapabilities.auth.terminal=true` during `initialize`. The
+method runs the same bridge binary with:
+
+```sh
+hecate-acp auth setup
+```
+
+This command does not create a separate Hecate key or ask for provider
+credentials in the editor. It verifies that the local gateway is reachable,
+lists routable models, and prints provider-readiness guidance when no model is
+available. Operators can run it directly while testing a registry install:
+
+```sh
+/absolute/path/to/hecate-acp auth setup
+```
+
+For native-app users, the command discovers the sidecar through
+`hecate.runtime.json` the same way stdio mode does. For Docker, non-default
+ports, or reverse proxies, set `HECATE_GATEWAY_URL` before running it.
+
 ## Gateway launch options
 
 ACP hosts always start `hecate-acp`; they do not start the gateway. Start

--- a/internal/acp/capabilities.go
+++ b/internal/acp/capabilities.go
@@ -15,7 +15,7 @@ type ClientCapabilities struct {
 	FS          *FSCapability         `json:"fs,omitempty"`
 	Terminal    *TerminalCapability   `json:"terminal,omitempty"`
 	Permissions *PermissionCapability `json:"permissions,omitempty"`
-	Auth        *AuthCapabilities     `json:"auth,omitempty"`
+	Auth        *AuthCapability       `json:"auth,omitempty"`
 }
 
 // FSCapability mirrors the ACP spec's fs capability block. Both fields
@@ -35,10 +35,10 @@ type TerminalCapability struct{}
 // editor either supports session/request_permission or it doesn't.
 type PermissionCapability struct{}
 
-// AuthCapabilities advertises which authentication setup helpers the
+// AuthCapability advertises which authentication setup helpers the
 // editor can present. Terminal auth requires an explicit opt-in because
 // it asks the client to launch an interactive terminal command.
-type AuthCapabilities struct {
+type AuthCapability struct {
 	Terminal bool `json:"terminal,omitempty"`
 }
 

--- a/internal/acp/capabilities.go
+++ b/internal/acp/capabilities.go
@@ -15,6 +15,7 @@ type ClientCapabilities struct {
 	FS          *FSCapability         `json:"fs,omitempty"`
 	Terminal    *TerminalCapability   `json:"terminal,omitempty"`
 	Permissions *PermissionCapability `json:"permissions,omitempty"`
+	Auth        *AuthCapabilities     `json:"auth,omitempty"`
 }
 
 // FSCapability mirrors the ACP spec's fs capability block. Both fields
@@ -34,6 +35,13 @@ type TerminalCapability struct{}
 // editor either supports session/request_permission or it doesn't.
 type PermissionCapability struct{}
 
+// AuthCapabilities advertises which authentication setup helpers the
+// editor can present. Terminal auth requires an explicit opt-in because
+// it asks the client to launch an interactive terminal command.
+type AuthCapabilities struct {
+	Terminal bool `json:"terminal,omitempty"`
+}
+
 // ClientInfo is human-readable metadata the editor sends for
 // telemetry / log lines.
 type ClientInfo struct {
@@ -47,6 +55,7 @@ type InitializeResult struct {
 	AgentCaps       AgentCapabilities  `json:"agentCapabilities"`
 	AgentInfo       AgentInfo          `json:"agentInfo"`
 	AvailableModels []ModelDescription `json:"availableModels"`
+	AuthMethods     []AuthMethod       `json:"authMethods,omitempty"`
 }
 
 // AgentCapabilities advertises which ACP surfaces the bridge supports.
@@ -61,6 +70,18 @@ type AgentInfo struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`
 	Description string `json:"description,omitempty"`
+}
+
+// AuthMethod describes one setup path a client can offer before the
+// user starts a session. Hecate currently uses terminal auth to verify
+// that the local gateway is running and has a routable model.
+type AuthMethod struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
 }
 
 // ModelDescription is one entry in the model picker.

--- a/internal/acp/dispatcher.go
+++ b/internal/acp/dispatcher.go
@@ -191,6 +191,15 @@ func (d *Dispatcher) handleInitialize(ctx context.Context, req *Request) *Respon
 		},
 		AvailableModels: descriptions,
 	}
+	if params.ClientCaps.Auth != nil && params.ClientCaps.Auth.Terminal {
+		result.AuthMethods = []AuthMethod{{
+			ID:          "hecate-setup",
+			Name:        "Set up Hecate",
+			Description: "Verify the local Hecate gateway and provider readiness.",
+			Type:        "terminal",
+			Args:        []string{"auth", "setup"},
+		}}
+	}
 	// Commit the negotiated mode only after the rest of initialize
 	// has succeeded — otherwise a downstream failure (gateway
 	// unreachable, etc.) leaves WorkspaceMode() reporting a value

--- a/internal/acp/dispatcher_test.go
+++ b/internal/acp/dispatcher_test.go
@@ -88,7 +88,7 @@ func initParamsWithTerminalAuth(t *testing.T) json.RawMessage {
 	t.Helper()
 	p := InitializeParams{ProtocolVersion: DeclaredProtocolVersion}
 	p.ClientCaps.Permissions = &PermissionCapability{}
-	p.ClientCaps.Auth = &AuthCapabilities{Terminal: true}
+	p.ClientCaps.Auth = &AuthCapability{Terminal: true}
 	raw, err := json.Marshal(p)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)

--- a/internal/acp/dispatcher_test.go
+++ b/internal/acp/dispatcher_test.go
@@ -84,6 +84,18 @@ func initParams(t *testing.T, perms bool) json.RawMessage {
 	return raw
 }
 
+func initParamsWithTerminalAuth(t *testing.T) json.RawMessage {
+	t.Helper()
+	p := InitializeParams{ProtocolVersion: DeclaredProtocolVersion}
+	p.ClientCaps.Permissions = &PermissionCapability{}
+	p.ClientCaps.Auth = &AuthCapabilities{Terminal: true}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
 func TestInitialize_Happy(t *testing.T) {
 	gw := &fakeGateway{models: []string{"claude-sonnet-4-5", "gpt-4o"}}
 	d := NewDispatcher(gw, NewSessionStore(), Config{AgentName: "Hecate", AgentVersion: "v0.42.0", ApprovalRoute: "editor"})
@@ -112,6 +124,54 @@ func TestInitialize_Happy(t *testing.T) {
 	}
 	if !result.AgentCaps.Permissions {
 		t.Error("agentCaps.Permissions = false, want true with ApprovalRoute=editor")
+	}
+}
+
+func TestInitialize_AdvertisesTerminalAuthWhenSupported(t *testing.T) {
+	gw := &fakeGateway{models: []string{"claude-sonnet-4-5"}}
+	d := NewDispatcher(gw, NewSessionStore(), Config{AgentName: "Hecate", AgentVersion: "v0.42.0", ApprovalRoute: "editor"})
+
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  initParamsWithTerminalAuth(t),
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error = %v", resp.Error)
+	}
+	var result InitializeResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.AuthMethods) != 1 {
+		t.Fatalf("authMethods len = %d, want 1", len(result.AuthMethods))
+	}
+	method := result.AuthMethods[0]
+	if method.ID != "hecate-setup" || method.Type != "terminal" || strings.Join(method.Args, " ") != "auth setup" {
+		t.Fatalf("auth method = %+v", method)
+	}
+}
+
+func TestInitialize_OmitsTerminalAuthWhenUnsupported(t *testing.T) {
+	gw := &fakeGateway{models: []string{"claude-sonnet-4-5"}}
+	d := NewDispatcher(gw, NewSessionStore(), Config{AgentName: "Hecate", AgentVersion: "v0.42.0", ApprovalRoute: "editor"})
+
+	resp := d.Handle(context.Background(), &Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      makeID(t, 1),
+		Method:  MethodInitialize,
+		Params:  initParams(t, true),
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error = %v", resp.Error)
+	}
+	var result InitializeResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.AuthMethods) != 0 {
+		t.Fatalf("authMethods = %+v, want omitted", result.AuthMethods)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds ACP auth-method metadata so registry-aware clients can discover Hecate setup support during initialize.

- Adds terminal auth capability parsing and authMethods in the ACP initialize result.
- Advertises a terminal setup method named hecate-setup, using hecate-acp auth setup when the client opts into terminal auth.
- Adds the setup command to verify gateway health, model availability, and provider readiness guidance.
- Documents the registry setup flow in docs/acp.md.

## Validation

- go test ./cmd/hecate-acp ./internal/acp
- go vet ./cmd/hecate-acp ./internal/acp
- git diff --check
- markdown oxfmt check across tracked md/mdc files
