### PR TITLE
fix(security): harden bootstrap key handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,6 +206,22 @@ jobs:
       - name: Test
         run: go test -race -timeout 10m ./...
 
+  test-bootstrap-windows:
+    name: Bootstrap tests (Windows)
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test bootstrap package
+        run: go test ./internal/bootstrap
+
   build-hecate:
     name: Build hecate
     needs: changes
@@ -459,6 +475,7 @@ jobs:
       - test-tauri-rust
       - lint-go
       - test-go
+      - test-bootstrap-windows
       - build-hecate
       - e2e
       - e2e-ollama
@@ -494,6 +511,7 @@ jobs:
       contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
       contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&
       contains(fromJSON('["success","skipped"]'), needs.test-go.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-bootstrap-windows.result) &&
       contains(fromJSON('["success","skipped"]'), needs.build-hecate.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e-ollama.result) &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,10 +191,20 @@ jobs:
         run: go vet ./...
 
   test-go:
-    name: Go tests
+    name: Go tests (${{ matrix.name }})
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux race
+            os: ubuntu-latest
+            command: go test -race -timeout 10m ./...
+          - name: Windows bootstrap
+            os: windows-latest
+            command: go test ./internal/bootstrap
     steps:
       - uses: actions/checkout@v6
 
@@ -204,23 +214,7 @@ jobs:
           cache: true
 
       - name: Test
-        run: go test -race -timeout 10m ./...
-
-  test-bootstrap-windows:
-    name: Bootstrap tests (Windows)
-    needs: changes
-    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Test bootstrap package
-        run: go test ./internal/bootstrap
+        run: ${{ matrix.command }}
 
   build-hecate:
     name: Build hecate
@@ -475,7 +469,6 @@ jobs:
       - test-tauri-rust
       - lint-go
       - test-go
-      - test-bootstrap-windows
       - build-hecate
       - e2e
       - e2e-ollama
@@ -511,7 +504,6 @@ jobs:
       contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
       contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&
       contains(fromJSON('["success","skipped"]'), needs.test-go.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.test-bootstrap-windows.result) &&
       contains(fromJSON('["success","skipped"]'), needs.build-hecate.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e-ollama.result) &&

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -66,7 +66,12 @@ func main() {
 	bootstrapPath := resolveBootstrapPath(cfg.Server.BootstrapFile, cfg.Server.DataDir)
 	boot, err := bootstrap.Resolve(bootstrapPath, cfg.Server.ControlPlaneSecretKey)
 	if err != nil {
-		slog.Error("bootstrap secret init failed", slog.String("path", bootstrapPath), slog.Any("error", err))
+		slog.Error(
+			"bootstrap secret init failed",
+			slog.String("path", bootstrapPath),
+			slog.String("hint", "Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions; fix file ownership or permissions, or unset an invalid GATEWAY_CONTROL_PLANE_SECRET_KEY"),
+			slog.Any("error", err),
+		)
 		os.Exit(1)
 	}
 	cfg.Server.ControlPlaneSecretKey = boot.ControlPlaneSecretKey

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -69,7 +69,7 @@ func main() {
 		slog.Error(
 			"bootstrap secret init failed",
 			slog.String("path", bootstrapPath),
-			slog.String("hint", "Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions; fix file ownership or permissions, or unset an invalid GATEWAY_CONTROL_PLANE_SECRET_KEY"),
+			slog.String("hint", "Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and use private file permissions; fix ownership, ACLs, or POSIX mode bits, or unset an invalid GATEWAY_CONTROL_PLANE_SECRET_KEY"),
 			slog.Any("error", err),
 		)
 		os.Exit(1)

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -47,7 +47,9 @@ What works:
 - Per-platform writable data dir (`~/Library/Application Support/sh.hecate.app/`,
   `%APPDATA%\sh.hecate.app\`, `~/.local/share/sh.hecate.app/`).
 - Sidecar stderr piped to `<data_dir>/gateway.log` (truncated per launch);
-  the startup splash shows failures with the log and data-directory paths.
+  the startup splash shows failures with the log and data-directory paths, and
+  adds a bootstrap-key recovery hint when startup fails before the gateway
+  serves the web UI.
 - Startup splash fonts are vendored for offline startup; their OFL license
   texts live next to the font files under `tauri/splash/fonts/`.
 - Window size and position persistence across launches.

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,8 +55,9 @@ Hecate stores local configuration and operational state on disk.
 - Provider credentials and settings are local to the gateway data directory / desktop app data directory.
 - Persisted provider, agent-adapter, and MCP literal credentials are encrypted
   with a gateway-local AES-GCM control-plane key. By default that bootstrap key
-  is generated on first run, stored as `hecate.bootstrap.json` with `0600`
-  permissions, and validated on every startup.
+  is generated on first run, stored as `hecate.bootstrap.json`, and validated on
+  every startup. POSIX platforms create and repair the file with `0600`
+  permissions.
 - If Hecate cannot validate or secure `hecate.bootstrap.json`, startup fails
   closed. The desktop app startup screen and `gateway.log` include the affected
   path; fix ownership, ACLs, or POSIX mode bits so the file is private, or unset

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,9 +53,18 @@ Review broad grants carefully, especially workspace-wide or adapter-wide grants 
 Hecate stores local configuration and operational state on disk.
 
 - Provider credentials and settings are local to the gateway data directory / desktop app data directory.
+- Persisted provider, agent-adapter, and MCP literal credentials are encrypted
+  with a gateway-local AES-GCM control-plane key. By default that bootstrap key
+  is generated on first run, stored as `hecate.bootstrap.json` with `0600`
+  permissions, and validated on every startup.
+- This protects against accidental disclosure from the settings database, but
+  it is not a vault boundary: a process running as the same OS user that can
+  read both the database and bootstrap key can decrypt stored credentials.
 - Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
 - External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own those accounts.
 - If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach the gateway may be able to spend those credentials.
+- Future hardening should move the bootstrap key into the OS keychain where
+  available and preserve file-backed bootstrap for headless/Docker deployments.
 
 ## Native app and sidecars
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,6 +57,10 @@ Hecate stores local configuration and operational state on disk.
   with a gateway-local AES-GCM control-plane key. By default that bootstrap key
   is generated on first run, stored as `hecate.bootstrap.json` with `0600`
   permissions, and validated on every startup.
+- If Hecate cannot validate or secure `hecate.bootstrap.json`, startup fails
+  closed. The desktop app startup screen and `gateway.log` include the affected
+  path; fix ownership/permissions so the file can be set to `0600`, or unset an
+  invalid `GATEWAY_CONTROL_PLANE_SECRET_KEY` override.
 - This protects against accidental disclosure from the settings database, but
   it is not a vault boundary: a process running as the same OS user that can
   read both the database and bootstrap key can decrypt stored credentials.

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,8 +59,11 @@ Hecate stores local configuration and operational state on disk.
   permissions, and validated on every startup.
 - If Hecate cannot validate or secure `hecate.bootstrap.json`, startup fails
   closed. The desktop app startup screen and `gateway.log` include the affected
-  path; fix ownership/permissions so the file can be set to `0600`, or unset an
-  invalid `GATEWAY_CONTROL_PLANE_SECRET_KEY` override.
+  path; fix ownership, ACLs, or POSIX mode bits so the file is private, or unset
+  an invalid `GATEWAY_CONTROL_PLANE_SECRET_KEY` override.
+- On Windows, the file-backed bootstrap path uses Go's cross-platform file-mode
+  APIs and does not rewrite existing DACLs. Treat the OS account and data
+  directory ACL as part of the local operator boundary on Windows.
 - This protects against accidental disclosure from the settings database, but
   it is not a vault boundary: a process running as the same OS user that can
   read both the database and bootstrap key can decrypt stored credentials.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
+	golang.org/x/sys v0.43.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.50.1
 )
@@ -36,7 +37,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -111,14 +110,10 @@ func secureExistingFile(path string) error {
 	if err != nil {
 		return err
 	}
-	if !modeExposesSharedPermissions(info.Mode().Perm()) {
+	if !bootstrapFileNeedsModeRepair(info.Mode().Perm()) {
 		return nil
 	}
 	return chmodBootstrapFile(path)
-}
-
-func modeExposesSharedPermissions(mode os.FileMode) bool {
-	return mode&0o077 != 0
 }
 
 func replaceBootstrapFile(path string, data []byte) error {
@@ -154,52 +149,6 @@ func replaceBootstrapFile(path string, data []byte) error {
 	}
 	keepTemp = true
 	return chmodBootstrapFile(path)
-}
-
-func replaceFile(tmpPath, path string) error {
-	renameErr := os.Rename(tmpPath, path)
-	if renameErr == nil {
-		return nil
-	}
-	if runtime.GOOS != "windows" {
-		return renameErr
-	}
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return renameErr
-	} else if err != nil {
-		return err
-	}
-
-	backup, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".old-*")
-	if err != nil {
-		return err
-	}
-	backupPath := backup.Name()
-	if err := backup.Close(); err != nil {
-		_ = os.Remove(backupPath)
-		return err
-	}
-	if err := os.Remove(backupPath); err != nil {
-		return err
-	}
-	if err := os.Rename(path, backupPath); err != nil {
-		return err
-	}
-	restoreBackup := true
-	defer func() {
-		if restoreBackup {
-			_ = os.Rename(backupPath, path)
-		} else {
-			_ = os.Remove(backupPath)
-		}
-	}()
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("replace existing bootstrap file after backup: %w", err)
-	}
-	restoreBackup = false
-	return nil
 }
 
 func chmodBootstrapFile(path string) error {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -107,7 +107,7 @@ func save(path string, b Bootstrap) error {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return err
 	}
-	return os.Chmod(path, 0o600)
+	return chmodOwnerOnly(path)
 }
 
 func secureExistingFile(path string) error {
@@ -118,7 +118,14 @@ func secureExistingFile(path string) error {
 	if info.Mode().Perm() == 0o600 {
 		return nil
 	}
-	return os.Chmod(path, 0o600)
+	return chmodOwnerOnly(path)
+}
+
+func chmodOwnerOnly(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("set permissions to 0600 so only the operator can read it: %w", err)
+	}
+	return nil
 }
 
 func randomBase64(n int) (string, error) {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -56,11 +56,16 @@ func Resolve(path, envSecret string) (Bootstrap, error) {
 		b.ControlPlaneSecretKey = key
 		dirty = true
 	}
+	if err := validateControlPlaneSecretKey(b.ControlPlaneSecretKey); err != nil {
+		return Bootstrap{}, err
+	}
 
 	if dirty || envSecret != "" {
 		if err := save(path, b); err != nil {
 			return Bootstrap{}, fmt.Errorf("persist bootstrap file %q: %w", path, err)
 		}
+	} else if err := secureExistingFile(path); err != nil {
+		return Bootstrap{}, fmt.Errorf("secure bootstrap file %q: %w", path, err)
 	}
 
 	return b, nil
@@ -78,6 +83,17 @@ func load(path string) (Bootstrap, error) {
 	return b, nil
 }
 
+func validateControlPlaneSecretKey(key string) error {
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(key))
+	if err != nil {
+		return fmt.Errorf("control-plane secret key must be base64: %w", err)
+	}
+	if len(decoded) != 32 {
+		return fmt.Errorf("control-plane secret key must decode to 32 bytes")
+	}
+	return nil
+}
+
 func save(path string, b Bootstrap) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -89,6 +105,17 @@ func save(path string, b Bootstrap) error {
 	// 0o600 because the file holds the encryption key. Anything more
 	// permissive lets a co-located service decrypt provider credentials.
 	return os.WriteFile(path, data, 0o600)
+}
+
+func secureExistingFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm() == 0o600 {
+		return nil
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func randomBase64(n int) (string, error) {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -104,7 +104,10 @@ func save(path string, b Bootstrap) error {
 	}
 	// 0o600 because the file holds the encryption key. Anything more
 	// permissive lets a co-located service decrypt provider credentials.
-	return os.WriteFile(path, data, 0o600)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func secureExistingFile(path string) error {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -102,6 +102,9 @@ func save(path string, b Bootstrap) error {
 	if err != nil {
 		return err
 	}
+	if err := secureExistingFileForWrite(path); err != nil {
+		return err
+	}
 	// 0o600 because the file holds the encryption key. Anything more
 	// permissive lets a co-located service decrypt provider credentials.
 	if err := os.WriteFile(path, data, 0o600); err != nil {
@@ -115,10 +118,32 @@ func secureExistingFile(path string) error {
 	if err != nil {
 		return err
 	}
-	if info.Mode().Perm() == 0o600 {
+	if !modeExposesSharedPermissions(info.Mode().Perm()) {
 		return nil
 	}
 	return chmodOwnerOnly(path)
+}
+
+func secureExistingFileForWrite(path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	mode := info.Mode().Perm()
+	if mode == 0o600 {
+		return nil
+	}
+	if !modeExposesSharedPermissions(mode) && mode&0o200 != 0 {
+		return nil
+	}
+	return chmodOwnerOnly(path)
+}
+
+func modeExposesSharedPermissions(mode os.FileMode) bool {
+	return mode&0o077 != 0
 }
 
 func chmodOwnerOnly(path string) error {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -102,15 +103,7 @@ func save(path string, b Bootstrap) error {
 	if err != nil {
 		return err
 	}
-	if err := secureExistingFileForWrite(path); err != nil {
-		return err
-	}
-	// 0o600 because the file holds the encryption key. Anything more
-	// permissive lets a co-located service decrypt provider credentials.
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return err
-	}
-	return chmodOwnerOnly(path)
+	return replaceBootstrapFile(path, data)
 }
 
 func secureExistingFile(path string) error {
@@ -121,34 +114,97 @@ func secureExistingFile(path string) error {
 	if !modeExposesSharedPermissions(info.Mode().Perm()) {
 		return nil
 	}
-	return chmodOwnerOnly(path)
-}
-
-func secureExistingFileForWrite(path string) error {
-	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	mode := info.Mode().Perm()
-	if mode == 0o600 {
-		return nil
-	}
-	if !modeExposesSharedPermissions(mode) && mode&0o200 != 0 {
-		return nil
-	}
-	return chmodOwnerOnly(path)
+	return chmodBootstrapFile(path)
 }
 
 func modeExposesSharedPermissions(mode os.FileMode) bool {
 	return mode&0o077 != 0
 }
 
-func chmodOwnerOnly(path string) error {
+func replaceBootstrapFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	keepTemp := false
+	defer func() {
+		if !keepTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// CreateTemp starts with 0600 on POSIX filesystems, but keep the write
+	// path explicit so a future refactor cannot write key material before
+	// setting the intended mode bits.
+	if err := chmodBootstrapFile(tmpPath); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := replaceFile(tmpPath, path); err != nil {
+		return err
+	}
+	keepTemp = true
+	return chmodBootstrapFile(path)
+}
+
+func replaceFile(tmpPath, path string) error {
+	renameErr := os.Rename(tmpPath, path)
+	if renameErr == nil {
+		return nil
+	}
+	if runtime.GOOS != "windows" {
+		return renameErr
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return renameErr
+	} else if err != nil {
+		return err
+	}
+
+	backup, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".old-*")
+	if err != nil {
+		return err
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return err
+	}
+	if err := os.Rename(path, backupPath); err != nil {
+		return err
+	}
+	restoreBackup := true
+	defer func() {
+		if restoreBackup {
+			_ = os.Rename(backupPath, path)
+		} else {
+			_ = os.Remove(backupPath)
+		}
+	}()
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace existing bootstrap file after backup: %w", err)
+	}
+	restoreBackup = false
+	return nil
+}
+
+func chmodBootstrapFile(path string) error {
 	if err := os.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("set permissions to 0600 so only the operator can read it: %w", err)
+		return fmt.Errorf("set bootstrap file permissions to 0600: %w", err)
 	}
 	return nil
 }

--- a/internal/bootstrap/bootstrap_posix_test.go
+++ b/internal/bootstrap/bootstrap_posix_test.go
@@ -1,0 +1,106 @@
+//go:build !windows
+
+package bootstrap
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveGeneratesWithPrivateFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+
+	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertFileMode(t, path, 0o600)
+}
+
+func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	writeBootstrapFixture(t, path, testBootstrapKey(0xef), 0o644)
+
+	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertFileMode(t, path, 0o600)
+}
+
+func TestResolveAcceptsStricterExistingFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	writeBootstrapFixture(t, path, testBootstrapKey(0xef), 0o400)
+
+	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertFileMode(t, path, 0o400)
+}
+
+func TestResolveRepairsLoosePermissionsWhenEnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	writeBootstrapFixture(t, path, testBootstrapKey(0xef), 0o644)
+
+	if _, err := Resolve(path, testBootstrapKey(0xab)); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	assertFileMode(t, path, 0o600)
+}
+
+func TestResolveEnvOverrideReplacesLooseFileInsteadOfRewritingInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	oldSecret := testBootstrapKey(0xef)
+	writeBootstrapFixture(t, path, oldSecret, 0o644)
+
+	oldHandle, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open old file: %v", err)
+	}
+	defer oldHandle.Close()
+
+	newSecret := testBootstrapKey(0xab)
+	if _, err := Resolve(path, newSecret); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	oldHandleRaw, err := io.ReadAll(oldHandle)
+	if err != nil {
+		t.Fatalf("read old handle: %v", err)
+	}
+	var oldHandleDisk Bootstrap
+	if err := json.Unmarshal(oldHandleRaw, &oldHandleDisk); err != nil {
+		t.Fatalf("decode old handle: %v", err)
+	}
+	if oldHandleDisk.ControlPlaneSecretKey != oldSecret {
+		t.Fatalf("old handle secret = %q, want original secret", oldHandleDisk.ControlPlaneSecretKey)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	var replacement Bootstrap
+	if err := json.Unmarshal(raw, &replacement); err != nil {
+		t.Fatalf("decode replacement: %v", err)
+	}
+	if replacement.ControlPlaneSecretKey != newSecret {
+		t.Fatalf("replacement secret = %q, want env override", replacement.ControlPlaneSecretKey)
+	}
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("file mode = %o, want %o", got, want)
+	}
+}

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -251,6 +253,59 @@ func TestResolveRepairsLoosePermissionsWhenEnvOverridesFile(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestResolveEnvOverrideReplacesLooseFileInsteadOfRewritingInPlace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows replace behavior depends on open-handle sharing modes")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	oldSecret := testBootstrapKey(0xef)
+	b := Bootstrap{
+		ControlPlaneSecretKey: oldSecret,
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	oldHandle, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open old file: %v", err)
+	}
+	defer oldHandle.Close()
+
+	newSecret := testBootstrapKey(0xab)
+	if _, err := Resolve(path, newSecret); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	oldHandleRaw, err := io.ReadAll(oldHandle)
+	if err != nil {
+		t.Fatalf("read old handle: %v", err)
+	}
+	var oldHandleDisk Bootstrap
+	if err := json.Unmarshal(oldHandleRaw, &oldHandleDisk); err != nil {
+		t.Fatalf("decode old handle: %v", err)
+	}
+	if oldHandleDisk.ControlPlaneSecretKey != oldSecret {
+		t.Fatalf("old handle secret = %q, want original secret", oldHandleDisk.ControlPlaneSecretKey)
+	}
+
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	var replacement Bootstrap
+	if err := json.Unmarshal(raw, &replacement); err != nil {
+		t.Fatalf("decode replacement: %v", err)
+	}
+	if replacement.ControlPlaneSecretKey != newSecret {
+		t.Fatalf("replacement secret = %q, want env override", replacement.ControlPlaneSecretKey)
 	}
 }
 

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -128,6 +128,16 @@ func TestResolveRejectsInvalidEnvSecret(t *testing.T) {
 	}
 }
 
+func TestResolveRejectsWrongLengthEnvSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+
+	shortKey := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0xab}, 31))
+	if _, err := Resolve(path, shortKey); err == nil {
+		t.Fatal("Resolve() error = nil, want wrong-length env secret error")
+	}
+}
+
 func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hecate.bootstrap.json")
@@ -143,6 +153,32 @@ func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
 	}
 
 	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestResolveRepairsLoosePermissionsWhenEnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	b := Bootstrap{
+		ControlPlaneSecretKey: testBootstrapKey(0xef),
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := Resolve(path, testBootstrapKey(0xab)); err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
 	info, err := os.Stat(path)

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -69,7 +71,7 @@ func TestResolveEnvOverridesFile(t *testing.T) {
 		t.Fatalf("seed Resolve: %v", err)
 	}
 
-	const overrideSecret = "abcdef0123456789abcdef0123456789abcdef0123456789ab=="
+	overrideSecret := testBootstrapKey(0xab)
 	b, err := Resolve(path, overrideSecret)
 	if err != nil {
 		t.Fatalf("Resolve with env override: %v", err)
@@ -115,4 +117,43 @@ func TestResolveRejectsCorruptFile(t *testing.T) {
 	if _, err := Resolve(path, ""); err == nil {
 		t.Error("expected error on corrupt JSON, got nil")
 	}
+}
+
+func TestResolveRejectsInvalidEnvSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+
+	if _, err := Resolve(path, "not-base64"); err == nil {
+		t.Fatal("Resolve() error = nil, want invalid env secret error")
+	}
+}
+
+func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	b := Bootstrap{
+		ControlPlaneSecretKey: testBootstrapKey(0xef),
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func testBootstrapKey(fill byte) string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{fill}, 32))
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -24,14 +22,6 @@ func TestResolveGeneratesAndPersistsOnFirstRun(t *testing.T) {
 	// to exactly 32 bytes.
 	if len(b.ControlPlaneSecretKey) != 44 {
 		t.Errorf("ControlPlaneSecretKey length = %d, want 44 (base64 of 32 bytes)", len(b.ControlPlaneSecretKey))
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
 	}
 
 	raw, err := os.ReadFile(path)
@@ -178,137 +168,20 @@ func TestResolveRejectsWrongLengthPersistedSecret(t *testing.T) {
 	}
 }
 
-func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "hecate.bootstrap.json")
-	b := Bootstrap{
-		ControlPlaneSecretKey: testBootstrapKey(0xef),
-	}
-	raw, err := json.Marshal(b)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
-	if _, err := Resolve(path, ""); err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
-	}
-}
-
-func TestResolveAcceptsStricterExistingFilePermissions(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "hecate.bootstrap.json")
-	b := Bootstrap{
-		ControlPlaneSecretKey: testBootstrapKey(0xef),
-	}
-	raw, err := json.Marshal(b)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	if err := os.WriteFile(path, raw, 0o400); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
-	if _, err := Resolve(path, ""); err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if info.Mode().Perm() != 0o400 {
-		t.Fatalf("file mode = %o, want 0400", info.Mode().Perm())
-	}
-}
-
-func TestResolveRepairsLoosePermissionsWhenEnvOverridesFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "hecate.bootstrap.json")
-	b := Bootstrap{
-		ControlPlaneSecretKey: testBootstrapKey(0xef),
-	}
-	raw, err := json.Marshal(b)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
-	if _, err := Resolve(path, testBootstrapKey(0xab)); err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
-	}
-}
-
-func TestResolveEnvOverrideReplacesLooseFileInsteadOfRewritingInPlace(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows replace behavior depends on open-handle sharing modes")
-	}
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "hecate.bootstrap.json")
-	oldSecret := testBootstrapKey(0xef)
-	b := Bootstrap{
-		ControlPlaneSecretKey: oldSecret,
-	}
-	raw, err := json.Marshal(b)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-	oldHandle, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open old file: %v", err)
-	}
-	defer oldHandle.Close()
-
-	newSecret := testBootstrapKey(0xab)
-	if _, err := Resolve(path, newSecret); err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	oldHandleRaw, err := io.ReadAll(oldHandle)
-	if err != nil {
-		t.Fatalf("read old handle: %v", err)
-	}
-	var oldHandleDisk Bootstrap
-	if err := json.Unmarshal(oldHandleRaw, &oldHandleDisk); err != nil {
-		t.Fatalf("decode old handle: %v", err)
-	}
-	if oldHandleDisk.ControlPlaneSecretKey != oldSecret {
-		t.Fatalf("old handle secret = %q, want original secret", oldHandleDisk.ControlPlaneSecretKey)
-	}
-
-	raw, err = os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read replacement: %v", err)
-	}
-	var replacement Bootstrap
-	if err := json.Unmarshal(raw, &replacement); err != nil {
-		t.Fatalf("decode replacement: %v", err)
-	}
-	if replacement.ControlPlaneSecretKey != newSecret {
-		t.Fatalf("replacement secret = %q, want env override", replacement.ControlPlaneSecretKey)
-	}
-}
-
 func testBootstrapKey(fill byte) string {
 	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{fill}, 32))
+}
+
+func writeBootstrapFixture(t *testing.T, path, key string, mode os.FileMode) {
+	t.Helper()
+	b := Bootstrap{
+		ControlPlaneSecretKey: key,
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, mode); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -138,6 +138,44 @@ func TestResolveRejectsWrongLengthEnvSecret(t *testing.T) {
 	}
 }
 
+func TestResolveRejectsInvalidPersistedSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	b := Bootstrap{
+		ControlPlaneSecretKey: "not-base64",
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := Resolve(path, ""); err == nil {
+		t.Fatal("Resolve() error = nil, want invalid persisted secret error")
+	}
+}
+
+func TestResolveRejectsWrongLengthPersistedSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	b := Bootstrap{
+		ControlPlaneSecretKey: base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0xab}, 31)),
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := Resolve(path, ""); err == nil {
+		t.Fatal("Resolve() error = nil, want wrong-length persisted secret error")
+	}
+}
+
 func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hecate.bootstrap.json")
@@ -161,6 +199,32 @@ func TestResolveRepairsLooseExistingFilePermissions(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("file mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestResolveAcceptsStricterExistingFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	b := Bootstrap{
+		ControlPlaneSecretKey: testBootstrapKey(0xef),
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o400); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := Resolve(path, ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o400 {
+		t.Fatalf("file mode = %o, want 0400", info.Mode().Perm())
 	}
 }
 

--- a/internal/bootstrap/bootstrap_windows_test.go
+++ b/internal/bootstrap/bootstrap_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveWindowsLoadsReadOnlyBootstrapWithoutModeRepair(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	secret := testBootstrapKey(0xef)
+	writeBootstrapFixture(t, path, secret, 0o444)
+	defer func() {
+		_ = os.Chmod(path, 0o600)
+	}()
+
+	b, err := Resolve(path, "")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if b.ControlPlaneSecretKey != secret {
+		t.Fatalf("ControlPlaneSecretKey = %q, want existing secret", b.ControlPlaneSecretKey)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o200 != 0 {
+		t.Fatalf("read-only bootstrap file became writable: mode=%o", info.Mode().Perm())
+	}
+}
+
+func TestResolveWindowsEnvOverrideReplacesBootstrapFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hecate.bootstrap.json")
+	writeBootstrapFixture(t, path, testBootstrapKey(0xef), 0o600)
+
+	override := testBootstrapKey(0xab)
+	b, err := Resolve(path, override)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if b.ControlPlaneSecretKey != override {
+		t.Fatalf("ControlPlaneSecretKey = %q, want override", b.ControlPlaneSecretKey)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement: %v", err)
+	}
+	var disk Bootstrap
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		t.Fatalf("decode replacement: %v", err)
+	}
+	if disk.ControlPlaneSecretKey != override {
+		t.Fatalf("disk ControlPlaneSecretKey = %q, want override", disk.ControlPlaneSecretKey)
+	}
+}

--- a/internal/bootstrap/filemode_posix.go
+++ b/internal/bootstrap/filemode_posix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package bootstrap
+
+import "os"
+
+func bootstrapFileNeedsModeRepair(mode os.FileMode) bool {
+	return mode&0o077 != 0
+}

--- a/internal/bootstrap/filemode_windows.go
+++ b/internal/bootstrap/filemode_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package bootstrap
+
+import "os"
+
+func bootstrapFileNeedsModeRepair(mode os.FileMode) bool {
+	return false
+}

--- a/internal/bootstrap/replace_file_posix.go
+++ b/internal/bootstrap/replace_file_posix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package bootstrap
+
+import "os"
+
+func replaceFile(tmpPath, path string) error {
+	return os.Rename(tmpPath, path)
+}

--- a/internal/bootstrap/replace_file_windows.go
+++ b/internal/bootstrap/replace_file_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package bootstrap
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(tmpPath, path string) error {
+	from, err := windows.UTF16PtrFromString(tmpPath)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		from,
+		to,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/tauri/splash/index.html
+++ b/tauri/splash/index.html
@@ -192,6 +192,10 @@
         gap: 4px;
       }
 
+      .failure-row[hidden] {
+        display: none;
+      }
+
       .failure-label {
         color: rgba(170, 162, 183, 0.82);
         font-size: 10px;

--- a/tauri/splash/index.html
+++ b/tauri/splash/index.html
@@ -307,6 +307,10 @@
             <div class="failure-label">Error</div>
             <div class="failure-value" id="failure-message"></div>
           </div>
+          <div class="failure-row" id="failure-hint-row" hidden>
+            <div class="failure-label">Hint</div>
+            <div class="failure-value" id="failure-hint"></div>
+          </div>
           <div class="failure-row">
             <div class="failure-label">Gateway log</div>
             <div class="failure-value" id="failure-log-path"></div>
@@ -510,8 +514,13 @@
       })();
 
       const renderStartupFailure = (details) => {
+        details = details || {};
         document.getElementById("status").style.display = "none";
         document.getElementById("failure-message").textContent = details.message || "Unknown startup failure.";
+        const hint = details.hint || "";
+        const hintRow = document.getElementById("failure-hint-row");
+        document.getElementById("failure-hint").textContent = hint;
+        hintRow.hidden = hint === "";
         document.getElementById("failure-log-path").textContent = details.logPath || "Not available.";
         document.getElementById("failure-data-dir").textContent = details.dataDir || "Not available.";
         document.getElementById("failure-panel").classList.add("is-visible");

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -103,7 +103,7 @@ fn startup_failure_hint(message: &str) -> Option<&'static str> {
         || lower.contains("control-plane secret key")
     {
         return Some(
-            "Open the data directory, check hecate.bootstrap.json, and fix ownership or permissions so Hecate can secure it as 0600. If GATEWAY_CONTROL_PLANE_SECRET_KEY is set, it must be base64 for exactly 32 bytes.",
+            "Open the data directory, check hecate.bootstrap.json, and fix ownership, ACLs, or POSIX mode bits so the bootstrap key is private. If GATEWAY_CONTROL_PLANE_SECRET_KEY is set, it must be base64 for exactly 32 bytes.",
         );
     }
     None
@@ -424,6 +424,6 @@ mod tests {
         .expect("bootstrap startup failure should include an operator hint");
 
         assert!(hint.contains("hecate.bootstrap.json"));
-        assert!(hint.contains("0600"));
+        assert!(hint.contains("private"));
     }
 }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -97,9 +97,8 @@ fn build_diagnostics_report(app: &tauri::AppHandle) -> String {
 fn startup_failure_hint(message: &str) -> Option<&'static str> {
     let lower = message.to_ascii_lowercase();
     if lower.contains("bootstrap key setup failed")
-        || lower.contains("bootstrap secret init failed")
         || lower.contains("secure bootstrap file")
-        || lower.contains("persist bootstrap file")
+        || lower.contains("set bootstrap file permissions to 0600")
         || lower.contains("control-plane secret key")
     {
         return Some(
@@ -425,5 +424,14 @@ mod tests {
 
         assert!(hint.contains("hecate.bootstrap.json"));
         assert!(hint.contains("private"));
+    }
+
+    #[test]
+    fn test_startup_failure_hint_ignores_generic_persist_failures() {
+        let hint = startup_failure_hint(
+            "gateway exited before becoming healthy. Last gateway log line: bootstrap secret init failed error=\"persist bootstrap file: no space left on device\"",
+        );
+
+        assert_eq!(hint, None);
     }
 }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -39,7 +39,11 @@ const APP_LOG_FILE: &str = "app";
 fn set_update_badge(window: tauri::WebviewWindow, visible: bool) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        let label = if visible { Some("•".to_string()) } else { None };
+        let label = if visible {
+            Some("•".to_string())
+        } else {
+            None
+        };
         window.set_badge_label(label).map_err(|e| e.to_string())
     }
     #[cfg(not(target_os = "macos"))]
@@ -88,6 +92,21 @@ fn build_diagnostics_report(app: &tauri::AppHandle) -> String {
         os = std::env::consts::OS,
         arch = std::env::consts::ARCH,
     )
+}
+
+fn startup_failure_hint(message: &str) -> Option<&'static str> {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("bootstrap key setup failed")
+        || lower.contains("bootstrap secret init failed")
+        || lower.contains("secure bootstrap file")
+        || lower.contains("persist bootstrap file")
+        || lower.contains("control-plane secret key")
+    {
+        return Some(
+            "Open the data directory, check hecate.bootstrap.json, and fix ownership or permissions so Hecate can secure it as 0600. If GATEWAY_CONTROL_PLANE_SECRET_KEY is set, it must be base64 for exactly 32 bytes.",
+        );
+    }
+    None
 }
 
 fn open_path(path: &Path) -> Result<(), String> {
@@ -341,6 +360,7 @@ pub fn run() {
                         log::error!("hecate gateway startup failed: {e}");
                         let payload = serde_json::json!({
                             "message": e,
+                            "hint": startup_failure_hint(&e),
                             "logPath": diagnostics.log_path.display().to_string(),
                             "dataDir": diagnostics.data_dir.display().to_string(),
                         });
@@ -376,7 +396,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{remaining_splash_delay, MIN_SPLASH_DURATION};
+    use super::{remaining_splash_delay, startup_failure_hint, MIN_SPLASH_DURATION};
     use std::time::Duration;
 
     #[test]
@@ -394,5 +414,16 @@ mod tests {
             remaining_splash_delay(MIN_SPLASH_DURATION + Duration::from_millis(1)),
             None,
         );
+    }
+
+    #[test]
+    fn test_startup_failure_hint_recognizes_bootstrap_failures() {
+        let hint = startup_failure_hint(
+            "gateway exited before becoming healthy. Bootstrap key setup failed.",
+        )
+        .expect("bootstrap startup failure should include an operator hint");
+
+        assert!(hint.contains("hecate.bootstrap.json"));
+        assert!(hint.contains("0600"));
     }
 }

--- a/tauri/src-tauri/src/sidecar.rs
+++ b/tauri/src-tauri/src/sidecar.rs
@@ -22,6 +22,7 @@
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use std::{fs::File, io::Read, io::Seek, io::SeekFrom};
 
 use tauri::{AppHandle, Manager};
 
@@ -197,12 +198,19 @@ pub fn remove_gateway_state(path: &std::path::Path) {
 fn gateway_log_tail(path: &Path) -> Option<String> {
     const MAX_TAIL_BYTES: usize = 8192;
 
-    let data = std::fs::read(path).ok()?;
+    let mut file = File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    if len == 0 {
+        return None;
+    }
+    let tail_len = len.min(MAX_TAIL_BYTES as u64);
+    file.seek(SeekFrom::End(-(tail_len as i64))).ok()?;
+    let mut data = Vec::with_capacity(tail_len as usize);
+    file.take(tail_len).read_to_end(&mut data).ok()?;
     if data.is_empty() {
         return None;
     }
-    let start = data.len().saturating_sub(MAX_TAIL_BYTES);
-    let tail = String::from_utf8_lossy(&data[start..]).trim().to_string();
+    let tail = String::from_utf8_lossy(&data).trim().to_string();
     if tail.is_empty() {
         None
     } else {
@@ -219,13 +227,12 @@ fn gateway_log_last_line(log: &str) -> Option<&str> {
 
 fn classify_gateway_log(log: &str) -> Option<&'static str> {
     let lower = log.to_ascii_lowercase();
-    if lower.contains("bootstrap secret init failed")
-        || lower.contains("secure bootstrap file")
-        || lower.contains("persist bootstrap file")
+    if lower.contains("secure bootstrap file")
+        || lower.contains("set bootstrap file permissions to 0600")
         || lower.contains("control-plane secret key")
     {
         return Some(
-            "Bootstrap key setup failed. Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions.",
+            "Bootstrap key setup failed. Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and use private file permissions.",
         );
     }
     None
@@ -240,7 +247,8 @@ fn startup_failure_details(log_path: &Path) -> String {
     if let Some(classification) = classify_gateway_log(&log) {
         details.push_str(classification);
         details.push(' ');
-    } else if let Some(line) = gateway_log_last_line(&log) {
+    }
+    if let Some(line) = gateway_log_last_line(&log) {
         details.push_str("Last gateway log line: ");
         details.push_str(line);
         details.push(' ');
@@ -382,15 +390,48 @@ mod tests {
         let path = temp_path("gateway.log");
         fs::write(
             &path,
-            "time=2026-05-18T00:00:00Z level=ERROR msg=\"bootstrap secret init failed\" path=/tmp/hecate.bootstrap.json hint=\"Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions\" error=\"secure bootstrap file: permission denied\"\n",
+            "time=2026-05-18T00:00:00Z level=ERROR msg=\"bootstrap secret init failed\" path=/tmp/hecate.bootstrap.json hint=\"Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and use private file permissions\" error=\"secure bootstrap file: permission denied\"\n",
         )
         .expect("write gateway log fixture");
 
         let details = startup_failure_details(&path);
 
         assert!(details.contains("Bootstrap key setup failed"));
-        assert!(details.contains("0600 permissions"));
-        assert!(!details.contains("Last gateway log line"));
+        assert!(details.contains("private file permissions"));
+        assert!(details.contains("Last gateway log line"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_sidecar_startup_failure_details_keeps_generic_save_errors_unclassified() {
+        let path = temp_path("gateway.log");
+        fs::write(
+            &path,
+            "time=2026-05-18T00:00:00Z level=ERROR msg=\"bootstrap secret init failed\" path=/tmp/hecate.bootstrap.json error=\"persist bootstrap file: no space left on device\"\n",
+        )
+        .expect("write gateway log fixture");
+
+        let details = startup_failure_details(&path);
+
+        assert!(!details.contains("Bootstrap key setup failed"));
+        assert!(details.contains("Last gateway log line"));
+        assert!(details.contains("no space left on device"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_sidecar_startup_failure_details_reads_bounded_log_tail() {
+        let path = temp_path("large-gateway.log");
+        let mut data = vec![b'a'; 20 * 1024];
+        data.extend_from_slice(b"\nsmall final line\n");
+        fs::write(&path, data).expect("write large gateway log fixture");
+
+        let details = startup_failure_details(&path);
+
+        assert!(details.contains("small final line"));
+        assert!(!details.contains(&"a".repeat(20 * 1024)));
 
         let _ = fs::remove_file(path);
     }

--- a/tauri/src-tauri/src/sidecar.rs
+++ b/tauri/src-tauri/src/sidecar.rs
@@ -20,7 +20,7 @@
 //      for calling child.kill() when the app exits.
 
 use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Manager};
@@ -194,6 +194,61 @@ pub fn remove_gateway_state(path: &std::path::Path) {
     }
 }
 
+fn gateway_log_tail(path: &Path) -> Option<String> {
+    const MAX_TAIL_BYTES: usize = 8192;
+
+    let data = std::fs::read(path).ok()?;
+    if data.is_empty() {
+        return None;
+    }
+    let start = data.len().saturating_sub(MAX_TAIL_BYTES);
+    let tail = String::from_utf8_lossy(&data[start..]).trim().to_string();
+    if tail.is_empty() {
+        None
+    } else {
+        Some(tail)
+    }
+}
+
+fn gateway_log_last_line(log: &str) -> Option<&str> {
+    log.lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+}
+
+fn classify_gateway_log(log: &str) -> Option<&'static str> {
+    let lower = log.to_ascii_lowercase();
+    if lower.contains("bootstrap secret init failed")
+        || lower.contains("secure bootstrap file")
+        || lower.contains("persist bootstrap file")
+        || lower.contains("control-plane secret key")
+    {
+        return Some(
+            "Bootstrap key setup failed. Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions.",
+        );
+    }
+    None
+}
+
+fn startup_failure_details(log_path: &Path) -> String {
+    let Some(log) = gateway_log_tail(log_path) else {
+        return format!("See {log_path:?} for sidecar stderr.");
+    };
+
+    let mut details = String::new();
+    if let Some(classification) = classify_gateway_log(&log) {
+        details.push_str(classification);
+        details.push(' ');
+    } else if let Some(line) = gateway_log_last_line(&log) {
+        details.push_str("Last gateway log line: ");
+        details.push_str(line);
+        details.push(' ');
+    }
+    details.push_str(&format!("See {log_path:?} for sidecar stderr."));
+    details
+}
+
 /// Spawn the hecate binary and block (async) until `/healthz` responds 200
 /// or the deadline expires. Returns the gateway base URL on success.
 pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
@@ -243,9 +298,14 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
             let _ = child.kill();
             let _ = child.wait();
             return Err(format!(
-                "gateway did not become healthy within 30 s (checked {healthz}). \
-                 See {:?} for sidecar stderr.",
-                paths.log_path
+                "gateway did not become healthy within 30 s (checked {healthz}). {}",
+                startup_failure_details(&paths.log_path)
+            ));
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            return Err(format!(
+                "gateway exited before becoming healthy ({status}). {}",
+                startup_failure_details(&paths.log_path)
             ));
         }
         match client.get(&healthz).send().await {
@@ -263,7 +323,10 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{free_port, paths_for_data_dir, resolve_env_binary_path, sidecar_binary_names};
+    use super::{
+        free_port, paths_for_data_dir, resolve_env_binary_path, sidecar_binary_names,
+        startup_failure_details,
+    };
     use std::fs;
     use std::net::TcpListener;
     use std::path::PathBuf;
@@ -312,6 +375,24 @@ mod tests {
         assert_eq!(paths.data_dir, data_dir);
         assert_eq!(paths.log_path, paths.data_dir.join("gateway.log"));
         assert_eq!(paths.state_path, paths.data_dir.join("hecate.runtime.json"));
+    }
+
+    #[test]
+    fn test_sidecar_startup_failure_details_classifies_bootstrap_log() {
+        let path = temp_path("gateway.log");
+        fs::write(
+            &path,
+            "time=2026-05-18T00:00:00Z level=ERROR msg=\"bootstrap secret init failed\" path=/tmp/hecate.bootstrap.json hint=\"Hecate requires hecate.bootstrap.json to contain a valid 32-byte base64 key and be secured with 0600 permissions\" error=\"secure bootstrap file: permission denied\"\n",
+        )
+        .expect("write gateway log fixture");
+
+        let details = startup_failure_details(&path);
+
+        assert!(details.contains("Bootstrap key setup failed"));
+        assert!(details.contains("0600 permissions"));
+        assert!(!details.contains("Last gateway log line"));
+
+        let _ = fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens local bootstrap key handling for the gateway control-plane secret key.

- Validates that the control-plane secret key is base64 and decodes to 32 bytes.
- Repairs existing bootstrap file permissions to 0600 when startup loads a valid file.
- Keeps the existing first-run generation and operator UX unchanged.
- Documents the local threat model and future OS-keychain hardening path in docs/security.md.

## Validation

- go test ./internal/bootstrap ./internal/secrets
- go vet ./internal/bootstrap ./internal/secrets
- git diff --check
- markdown oxfmt check across tracked md/mdc files
