### PR TITLE
refactor(chat): simplify chat execution model

### DIFF
--- a/docs-ai/core/verification.md
+++ b/docs-ai/core/verification.md
@@ -2,6 +2,22 @@
 
 How "done" is determined. Treat the floors as floors, not nice-to-haves.
 
+## Pre-PR rule
+
+Do not file a PR until the verification for every touched implementation
+surface has passed locally:
+
+- Touch `ui/`, `website/`, `.ts`, `.tsx`, `.js`, `.jsx`, CSS, Vitest, or
+  Playwright files: run the UI checks listed below.
+- Touch Go files, Go modules, backend config, or e2e helpers: run the Go
+  checks listed below.
+- Touch both frontend and backend surfaces: run both ladders.
+
+Docs-only and agent-guidance-only changes do not require TypeScript or Go
+tests, but still need the relevant docs checks when formatting, links, or
+screenshots are affected. If a required check cannot run, say why before
+filing the PR and call out the residual risk.
+
 ## Backend verification ladder
 
 | Step          | Command                                                        | When                                                                         |

--- a/docs-ai/core/workflow.md
+++ b/docs-ai/core/workflow.md
@@ -17,7 +17,7 @@ The default operating loop, when to stop and plan, and how to propose commits.
 3. **Plan before non-trivial changes.** See "When to stop and propose a plan first" below. Substantial backend changes (new wire fields, cross-package ripple, new endpoints) and substantial UI changes (new persistent surfaces, new interaction patterns) require a written plan first. Format: [`../tasks/planning.md`](../tasks/planning.md).
 4. **Implement in coherent steps.** Minimal, scoped changes. Avoid drive-by edits that bloat the diff.
 5. **Update docs and diagrams.** For every `.md` file touched (or whose subject matter changed), check whether any Mermaid diagrams in that file — and in directly related docs (e.g. `architecture.md` when changing the task runtime) — still accurately reflect the change. Update stale diagrams in the same commit as the code change, not as a follow-up.
-6. **Verify.** Run the relevant ladder from [`verification.md`](verification.md). State exactly what was run.
+6. **Verify.** Run the relevant ladder from [`verification.md`](verification.md). Before filing a PR, this is mandatory by touched surface: TypeScript/UI changes require the UI checks and Go changes require the Go checks. If a PR touches both, run both. State exactly what was run.
 7. **Summarize.** What changed, what risks remain, what the operator should know — including manual smoke steps if any.
 
 ## When to ask clarifying questions

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -78,23 +78,24 @@ The seven-step chain spans `pkg/types/` → `internal/api/` → `internal/provid
 
 ### Change Agent Chat / ACP adapter behavior
 
-Agent Chat has three runtime kinds:
+Agent Chat separates session ownership from turn execution:
 
-1. `model`: the chat session calls the gateway/router directly and stores
-   direct user/assistant messages. No task is created.
-2. `agent`: the chat session points at one visible `agent_loop` task-backed
-   segment.
-   The first prompt creates the task; follow-ups continue the latest terminal
-   run through the task runtime while the immediately previous segment was also
-   Hecate Agent. Re-enabling tools after a direct model segment creates a new
-   task-backed segment in the same transcript. While a task-backed segment is
-   queued, running, or awaiting approval, the entire Hecate Chat session is
-   busy: direct model turns are rejected too, so one transcript cannot race a
-   live task loop against a separate model call. The browser UI may queue a
-   prompt locally while busy, but the backend contract remains one active
-   task-backed turn per session.
-3. `external_agent`: the chat session points at one supervised adapter session
-   such as Codex, Claude Code, or Cursor Agent.
+1. `agent_id="hecate"` owns built-in Hecate Chat sessions. Each turn chooses
+   `execution_mode="direct_model"` for a plain gateway/router call or
+   `execution_mode="hecate_task"` for task-backed tools.
+2. `agent_id` values such as `codex`, `claude_code`, or `cursor_agent` own
+   External Agent sessions. Their turns use `execution_mode="external_agent"`
+   and point at one supervised adapter session.
+
+For Hecate-owned task turns, the first prompt creates the task; follow-ups
+continue the latest terminal run through the task runtime while the immediately
+previous segment was also task-backed. Re-enabling tools after a direct model
+segment creates a new task-backed segment in the same transcript. While a
+task-backed segment is queued, running, or awaiting approval, the entire Hecate
+Chat session is busy: direct model turns are rejected too, so one transcript
+cannot race a live task loop against a separate model call. The browser UI may
+queue a prompt locally while busy, but the backend contract remains one active
+task-backed turn per session.
 
 External Agent has two live/persistence layers:
 
@@ -176,4 +177,8 @@ For errors that should surface before a run is created (bad config, missing requ
 
 ## Done criteria
 
-See [`../../core/verification.md`](../../core/verification.md). Race suite is the floor for runtime/backend work, not a nice-to-have.
+See [`../../core/verification.md`](../../core/verification.md). Before filing a
+PR that touches Go/backend files, run the relevant Go checks: targeted or broad
+`go vet`, affected `go test` packages, and the race suite for runtime paths. If
+UI/TypeScript files changed too, run the UI ladder as well. Race suite is the
+floor for runtime/backend work, not a nice-to-have.

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -48,6 +48,11 @@ Before adding or changing UI, find the closest existing precedent and reuse it u
 - If a screen already has an empty, loading, repair, or onboarding precedent, extend that component/copy path instead of adding a second parallel state.
 - When making Hecate Chat and External Agent behavior more similar, preserve their real runtime differences: Hecate owns task-backed tools; external agents own ACP-native sessions.
 - Add role/name-based tests for shared controls and view-level tests for every state that previously regressed. E2E should cover cross-view navigation, onboarding, and setup/repair flows when a bug came from app composition.
+- Before filing a PR that touches UI/TypeScript, run the UI verification ladder:
+  `cd ui && bun run typecheck`, `bun run lint`, `bun run format:check`, and
+  `bun run test`. Add targeted Playwright coverage when the change is a
+  workflow, routing, onboarding, or regression fix. If Go files changed too,
+  run the backend ladder as well.
 
 ## UX priorities
 

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -85,7 +85,7 @@ Hecate Agent turns. Those records can point at a runtime when tools are enabled,
 but they can also store direct model segments:
 
 - **Model** segments call the gateway/router directly and store user/assistant
-  messages with `runtime_kind="model"`. They do not create Tasks.
+  messages with `execution_mode="direct_model"`. They do not create Tasks.
 - **Hecate Agent** sessions map one chat session to one visible
   `agent_loop` task-backed segment. The first tool-enabled prompt creates the
   task; follow-up prompts continue the latest terminal run when the previous

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -141,7 +141,7 @@ type ContextPacket struct {
     SourcePreset string
     Provider    string
     Model       string
-    RuntimeKind string // direct_model | hecate_agent | external_agent_projection
+    ExecutionMode string // direct_model | hecate_task | external_agent
     Items       []ContextItem
 }
 

--- a/docs/rfcs/hecate-chat-model-capabilities.md
+++ b/docs/rfcs/hecate-chat-model-capabilities.md
@@ -63,7 +63,7 @@ The staged implementation keeps runtime boundaries explicit. Once a Hecate
 Agent chat has a backing task, its provider/model picker renders the session
 snapshot read-only while tools are enabled. Turning tools off uses the normal
 direct model chat path and the current draft provider/model selection. Agent
-chat messages now carry their own `runtime_kind`, `segment_id`, provider/model
+chat messages now carry their own `execution_mode`, `segment_id`, provider/model
 snapshot, capability snapshot, and task/run linkage so a single transcript can
 explain mixed direct-model and task-backed stretches without relying on the
 current header state. Re-enabling tools after direct-model turns creates a new
@@ -138,10 +138,12 @@ overwrite an explicit operator override.
 
 ## Hecate Agent Sessions
 
-Agent Chat sessions gain a `runtime_kind`:
+Agent Chat sessions use a stable `agent_id` for ownership, while each message
+records the execution mode that produced that turn:
 
 ```ts
-type ChatRuntimeKind = "model" | "agent" | "external_agent";
+type ChatAgentID = "hecate" | "codex" | "claude_code" | "cursor_agent" | string;
+type ChatExecutionMode = "direct_model" | "hecate_task" | "external_agent";
 ```
 
 Hecate Chat sessions also store:
@@ -155,15 +157,14 @@ Hecate Chat sessions also store:
 - `workspace`
 - `workspace_branch`
 
-Each message carries its own runtime snapshot: `runtime_kind`, `segment_id`,
+Each message carries its own runtime snapshot: `execution_mode`, `segment_id`,
 provider/model, capabilities, workspace, and optional task/run linkage. The
 session response also exposes derived segment metadata so the UI can render
 clear transcript boundaries when a chat moves from direct model turns to
 Hecate Agent tool-backed turns and back again.
 
-External Agent sessions keep their adapter fields. Existing sessions without
-`runtime_kind` default to `external_agent` when `adapter_id` is present and
-`model` otherwise.
+External Agent sessions store their adapter id in `agent_id`. Hecate Chat
+sessions use `agent_id="hecate"`.
 
 ### Agent profiles
 
@@ -192,7 +193,7 @@ creation time. Profile edits should not silently rewrite historical sessions.
 
 ### First prompt
 
-For `runtime_kind="agent"` the first user message:
+For `execution_mode="hecate_task"` the first user message:
 
 1. Validates that tools are not explicitly disabled for the selected model
    (`tool_calling!="none"`). Unknown models are allowed by default for now;
@@ -371,9 +372,9 @@ Memory and SQLite must persist:
 - automatic probe results
 - Hecate Agent profiles
 - selected `agent_profile_id`
-- `runtime_kind`
+- `agent_id`
 - Hecate Agent task/run linkage fields on chat sessions
-- per-message `runtime_kind`, `segment_id`, provider/model, capability
+- per-message `execution_mode`, `segment_id`, provider/model, capability
   snapshot, and task/run linkage
 - derived API segment metadata from the persisted message snapshots
 - workspace mode snapshot on Hecate Agent sessions
@@ -433,8 +434,8 @@ Done in the core bridge:
 - streamed assistant text from the backing task updates the chat transcript
   before the run reaches a terminal state when the provider route supports SSE
 - direct model turns and Hecate Agent turns share one Agent Chat transcript
-  using `runtime_kind="model"` / `runtime_kind="agent"` message
-  snapshots
+  using `execution_mode="direct_model"` / `execution_mode="hecate_task"`
+  message snapshots
 - turning tools back on after a direct model segment creates a new task-backed
   segment in the same transcript
 - Hecate Chat queues prompts locally while the active task-backed segment is

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1150,6 +1150,10 @@ Creates an Agent Chat session. `agent_id` chooses the session owner:
 - Any registered external-agent id, such as `codex`, `claude_code`, or
   `cursor_agent`, creates an External Agent chat and requires `workspace`.
 
+Hecate Chat sessions require `model` when they are created. `provider` is
+optional; omit it to let Hecate route across configured providers that expose
+the selected model.
+
 For Hecate Chat sessions, `rtk_enabled` records the chat's command-output
 compaction preference. It is only applied when a future turn runs through the
 task-backed `hecate_task` execution mode; direct model turns never execute

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1033,23 +1033,20 @@ Status codes:
 Lists Agent Chat sessions. Agent Chat uses the same backend selection as model
 chat history: memory by default, SQLite when
 `GATEWAY_CHAT_SESSIONS_BACKEND=sqlite`. It is the alpha transcript surface for
-Hecate Chat and External Agent sessions:
+Hecate Chat and External Agent sessions. A session has a stable `agent_id`
+that chooses the chat owner:
 
-- `runtime_kind="model"` — Hecate Chat sends the turn directly through the
-  gateway/router to the selected provider/model. No task is created and no
-  tools run, but the turn is stored in the same transcript as later Hecate
-  Agent turns.
-- `runtime_kind="agent"` — Hecate creates and continues a visible
-  `agent_loop` task with Hecate tools, task approvals, artifacts, and OTel.
-  The chat transcript projects backing task-run activity and can resolve
-  pending task approvals through the existing task approval endpoint.
-  Agent sessions may opt into RTK command-output compaction with
-  `rtk_enabled=true`; shell and git tool calls then launch as
-  `rtk sh -lc <command>` while keeping Hecate approvals, policy validation,
-  sandboxing, limits, and timeouts in place.
-- `runtime_kind="external_agent"` — Codex, Claude Code, Cursor Agent, or
-  another adapter owns the native session while Hecate supervises lifecycle,
-  transcript, diagnostics, and external-agent approvals.
+- `agent_id="hecate"` — Hecate owns the chat. Individual turns choose
+  `execution_mode="direct_model"` for normal provider/model chat or
+  `execution_mode="hecate_task"` for a visible `agent_loop` task with Hecate
+  tools, task approvals, artifacts, and OTel. Hecate Chat sessions may opt into
+  RTK command-output compaction with `rtk_enabled=true`; shell and git tool
+  calls then launch as `rtk sh -lc <command>` while keeping Hecate approvals,
+  policy validation, sandboxing, limits, and timeouts in place.
+- `agent_id="codex"`, `"claude_code"`, `"cursor_agent"`, or another
+  registered adapter id — the external adapter owns the native session while
+  Hecate supervises lifecycle, transcript, diagnostics, and external-agent
+  approvals. Turns use `execution_mode="external_agent"`.
 
 `GATEWAY_CHAT_SESSIONS_BACKEND=sqlite` is the single selector for the entire
 chat state bundle: sessions, messages, **and** the operator-facing
@@ -1120,7 +1117,7 @@ GET /hecate/v1/chat/sessions
     {
       "id": "chat_...",
       "title": "Hecate Chat",
-      "runtime_kind": "model",
+      "agent_id": "hecate",
       "provider": "ollama",
       "model": "qwen2.5-coder",
       "capabilities": {
@@ -1145,25 +1142,25 @@ GET /hecate/v1/chat/sessions
 
 ### `POST /hecate/v1/chat/sessions`
 
-Creates an Agent Chat session. `runtime_kind` chooses the execution target:
+Creates an Agent Chat session. `agent_id` chooses the session owner:
 
-- `model` requires `model`. `provider` is optional; when omitted, Hecate uses
-  the normal routing path for the requested model. `workspace` is optional
-  because no local tools run.
-- `agent` requires `provider`, `model`, and `workspace`.
-- `external_agent` requires `adapter_id` and `workspace`.
+- `hecate` (default) creates a Hecate Chat. It can later run
+  `execution_mode="direct_model"` turns or `execution_mode="hecate_task"`
+  turns.
+- Any registered external-agent id, such as `codex`, `claude_code`, or
+  `cursor_agent`, creates an External Agent chat and requires `workspace`.
 
-For Hecate Chat sessions (`runtime_kind="model"` or `"agent"`),
-`rtk_enabled` records the chat's command-output compaction preference. It is
-only applied when a future turn runs through the task-backed `agent` runtime;
-direct model turns never execute local commands.
+For Hecate Chat sessions, `rtk_enabled` records the chat's command-output
+compaction preference. It is only applied when a future turn runs through the
+task-backed `hecate_task` execution mode; direct model turns never execute
+local commands.
 
 When `workspace` is provided, it must be an operator-controlled local
 directory. Hecate validates and canonicalizes the path before a tool-backed or
 external-agent run starts, so later runs use the resolved directory instead of
 failing only after execution starts.
 
-For `runtime_kind="external_agent"`, session creation also starts or restores
+For external-agent `agent_id` values, session creation also starts or restores
 the native ACP session immediately. That lets clients render adapter-owned
 `config_options` before the first prompt. If the adapter binary is missing,
 unauthenticated, or fails its ACP handshake, session creation fails and Hecate
@@ -1172,7 +1169,7 @@ removes the empty chat record.
 ```json
 POST /hecate/v1/chat/sessions
 {
-  "runtime_kind": "model",
+  "agent_id": "hecate",
   "provider": "ollama",
   "model": "qwen2.5-coder",
   "title": "Hecate Chat"
@@ -1184,7 +1181,7 @@ POST /hecate/v1/chat/sessions
   "data": {
     "id": "chat_...",
     "title": "Hecate Chat",
-    "runtime_kind": "model",
+    "agent_id": "hecate",
     "provider": "ollama",
     "model": "qwen2.5-coder",
     "capabilities": {
@@ -1207,7 +1204,7 @@ Returns the full session transcript, including user messages and assistant
 messages produced by the backing runtime. Hecate Agent sessions include
 `task_id`, `latest_run_id`, `provider`, `model`, and the capability snapshot
 used when the session was created. Individual chat messages also carry a
-runtime snapshot: `runtime_kind`, `segment_id`, optional `task_id`, optional
+runtime snapshot: `execution_mode`, `segment_id`, optional `task_id`, optional
 `run_id`, provider/model, and capabilities. Frontends should prefer those
 message-level fields when rendering historical turns because the session header
 can change as the operator switches tools on/off. If tools are re-enabled after
@@ -1218,7 +1215,7 @@ The response also includes a derived `segments` array. Messages remain the
 durable source of truth; segments are a render helper that groups contiguous
 turns with the same `segment_id` so clients can show transcript boundaries such
 as "tools off with smollm2" → "tools on with qwen2.5-coder". Each segment
-contains its `runtime_kind`, provider/model snapshot, optional `task_id`,
+contains its `execution_mode`, provider/model snapshot, optional `task_id`,
 latest run id, status, message count, and first/last timestamps.
 
 External Agent sessions may also include `config_options`, a normalized
@@ -1232,7 +1229,7 @@ must handle missing or custom categories.
 ### `PATCH /hecate/v1/chat/sessions/{id}`
 
 Renames an Agent Chat session. This is shared by Hecate Chat
-(`runtime_kind="model"` / `"agent"`) and External Agent sessions. The title is
+(`agent_id="hecate"`) and External Agent sessions. The title is
 metadata only; it does not change the prompt history, workspace, provider/model,
 or ACP native session.
 
@@ -1248,7 +1245,7 @@ PATCH /hecate/v1/chat/sessions/chat_...
   "data": {
     "id": "chat_...",
     "title": "Review release notes",
-    "runtime_kind": "agent",
+    "agent_id": "hecate",
     "status": "completed",
     "messages": []
   }
@@ -1277,8 +1274,7 @@ after the session has been restored.
 ### `PATCH /hecate/v1/chat/sessions/{id}/settings`
 
 Updates Hecate-owned chat settings for future turns. This endpoint currently
-accepts `rtk_enabled` for `runtime_kind="model"` and `runtime_kind="agent"`
-sessions. External Agent sessions reject it with
+accepts `rtk_enabled` for `agent_id="hecate"` sessions. External Agent sessions reject it with
 `chat.runtime_mismatch` because Codex, Claude Code, Cursor, and other ACP
 adapters own their own command execution.
 
@@ -1297,7 +1293,7 @@ PATCH /hecate/v1/chat/sessions/chat_.../settings
   "object": "chat_session",
   "data": {
     "id": "chat_...",
-    "runtime_kind": "agent",
+    "agent_id": "hecate",
     "rtk_enabled": true
   }
 }
@@ -1310,9 +1306,9 @@ the user message and assistant output.
 
 `POST` also accepts per-turn overrides:
 
-- `runtime_kind` — `model`, `agent`, or `external_agent`. Hecate Chat
-  sessions may switch between `model` and `agent`; External Agent
-  sessions cannot switch into Hecate Chat runtimes.
+- `execution_mode` — `direct_model`, `hecate_task`, or `external_agent`.
+  Hecate Chat sessions may switch between `direct_model` and `hecate_task`;
+  External Agent sessions always use `external_agent`.
 - `provider` / `model` — used for direct model turns and new Hecate Agent
   task-backed segments. Existing Hecate Agent task segments continue with their
   saved model snapshot until the operator turns tools off or starts a new
@@ -1321,10 +1317,10 @@ the user message and assistant output.
 - `workspace` — required when starting a Hecate Agent turn on a session that
   does not already have a workspace.
 
-For `runtime_kind="model"`, Hecate calls the normal gateway path and stores the
-user/assistant messages without creating a Task. For
-`runtime_kind="external_agent"`, Hecate sends the prompt to the session's
-native ACP session. For `runtime_kind="agent"`, the first tool-enabled
+For `execution_mode="direct_model"`, Hecate calls the normal gateway path and
+stores the user/assistant messages without creating a Task. For
+`execution_mode="external_agent"`, Hecate sends the prompt to the session's
+native ACP session. For `execution_mode="hecate_task"`, the first tool-enabled
 prompt creates a visible `agent_loop` task and starts it; follow-up prompts
 continue the latest terminal run when the immediately previous segment was also
 Hecate Agent. If the previous segment was direct model chat, Hecate starts a
@@ -1333,7 +1329,7 @@ fresh task-backed segment in the same transcript.
 Only one task-backed segment can be active in a Hecate Chat session at a time.
 If the latest backing task is queued, running, or awaiting approval, **all** new
 turns on that chat are rejected with `409 chat.agent_session_busy`,
-including direct `runtime_kind="model"` turns. Operators should wait for the
+including direct `execution_mode="direct_model"` turns. Operators should wait for the
 task to finish, resolve the pending approval, or cancel/stop the active run
 before sending another prompt. The operator UI layers a local composer queue on
 top of that API contract: prompts submitted while a run is busy are held in a
@@ -1393,8 +1389,8 @@ POST /hecate/v1/chat/sessions/chat_.../messages
         "role": "assistant",
         "content": "...",
         "raw_output": "...",
-        "adapter_id": "codex",
-        "adapter_name": "Codex",
+        "agent_id": "codex",
+        "agent_name": "Codex",
         "driver_kind": "acp",
         "native_session_id": "session_...",
         "status": "completed",
@@ -1478,7 +1474,8 @@ Hecate Agent-specific errors:
 | ------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `400`  | `chat.workspace_required`        | Hecate Agent and External Agent sessions need a selected workspace path before the first turn.                                                                                           |
 | `400`  | `chat.model_required`            | Hecate Chat needs an explicit selected model before direct model or Hecate Agent turns.                                                                                                  |
-| `400`  | `chat.runtime_kind_invalid`      | The requested chat runtime is not one of `model`, `agent`, or `external_agent`.                                                                                                          |
+| `400`  | `chat.agent_id_invalid`          | The requested session owner is not `hecate` and does not match a registered external-agent adapter.                                                                                      |
+| `400`  | `chat.execution_mode_invalid`    | The requested turn execution mode is not one of `direct_model`, `hecate_task`, or `external_agent`.                                                                                      |
 | `400`  | `chat.runtime_mismatch`          | The request tried to run a turn through a runtime that does not match the existing session type.                                                                                         |
 | `400`  | `chat.adapter_not_found`         | The selected external-agent adapter is not registered.                                                                                                                                   |
 | `409`  | `chat.agent_session_busy`        | The backing task run is queued, running, or awaiting approval. Resolve/cancel the active run before sending another prompt, even for direct model turns in the same Hecate Chat session. |

--- a/e2e/approval_reconcile_test.go
+++ b/e2e/approval_reconcile_test.go
@@ -226,12 +226,11 @@ func injectChatSession(t *testing.T, dbPath string) string {
 	sessionID := "chat_e2e_" + fmt.Sprintf("%d", now.UnixNano())
 	_, err = db.Exec(
 		`INSERT INTO hecate_chat_sessions (
-			id, title, runtime_kind, adapter_id, driver_kind, native_session_id, workspace, workspace_branch,
+			id, title, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
 			status, task_id, latest_run_id, provider, model, capabilities, config_options, turns_used, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sessionID,
 		"reconcile smoke",
-		"external_agent",
 		"codex",
 		"acp",
 		"native_e2e",

--- a/internal/agentadapters/version_test.go
+++ b/internal/agentadapters/version_test.go
@@ -124,14 +124,21 @@ func writeGoHelperBinary(t *testing.T, dir, name, source string) string {
 func TestDetectVersionParsesOutputFromNonZeroExit(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
-		t.Skip("skip shell script test on Windows")
+		t.Skip("skip helper binary exit-code test on Windows")
 	}
 	dir := t.TempDir()
-	path := filepath.Join(dir, "nonzero-adapter")
-	content := "#!/bin/sh\necho adapter 3.4.5\nexit 1\n"
-	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
-		t.Fatalf("write nonzero script: %v", err)
-	}
+	path := writeGoHelperBinary(t, dir, "nonzero-adapter", `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("adapter 3.4.5")
+	os.Exit(1)
+}
+`)
 	got := DetectVersion(context.Background(), path)
 	if got != "3.4.5" {
 		t.Fatalf("DetectVersion = %q, want 3.4.5 from non-zero output", got)

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -43,15 +43,16 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	runtimeKind := normalizeAgentChatRuntimeKind(req.RuntimeKind, req.AdapterID)
-	if !isValidAgentChatRuntimeKind(runtimeKind) {
-		writeAgentChatRuntimeKindInvalid(w)
+	agentID := normalizeChatAgentID(req.AgentID)
+	if !h.isValidChatAgentID(agentID) {
+		writeChatAgentIDInvalid(w)
 		return
 	}
+	isExternalAgent := agentID != chat.DefaultAgentID
 	workspace := strings.TrimSpace(req.Workspace)
-	if runtimeKind != "model" {
+	if isExternalAgent {
 		if workspace == "" {
-			writeAgentChatWorkspaceRequired(w, runtimeKind)
+			writeAgentChatWorkspaceRequired(w, chat.ExecutionModeExternalAgent)
 			return
 		}
 		var err error
@@ -71,19 +72,19 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	session := chat.Session{
 		ID:              newChatID("chat"),
 		Title:           title,
-		RuntimeKind:     runtimeKind,
+		AgentID:         agentID,
 		Workspace:       workspace,
 		WorkspaceBranch: workspaceBranch,
 		RTKEnabled:      req.RTKEnabled,
 	}
 	var err error
 	var externalAdapter agentadapters.Adapter
-	switch runtimeKind {
-	case "model":
+	switch {
+	case agentID == chat.DefaultAgentID:
 		provider := strings.TrimSpace(req.Provider)
 		model := strings.TrimSpace(req.Model)
 		if model == "" {
-			writeAgentChatModelRequired(w, "model")
+			writeAgentChatModelRequired(w, chat.ExecutionModeDirectModel)
 			return
 		}
 		caps, err := h.resolveModelCapabilities(r.Context(), provider, model)
@@ -97,10 +98,10 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 		session.Provider = provider
 		session.Model = model
 		session.Capabilities = caps
-	case "external_agent":
-		adapter, ok := agentadapters.BuiltInByID(strings.TrimSpace(req.AdapterID))
+	default:
+		adapter, ok := agentadapters.BuiltInByID(agentID)
 		if !ok {
-			writeAgentChatAdapterNotFound(w, req.AdapterID)
+			writeAgentChatAdapterNotFound(w, agentID)
 			return
 		}
 		if h.agentChatRunner == nil {
@@ -111,40 +112,18 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 		if session.Title == "" {
 			session.Title = adapter.Name + " chat"
 		}
-		session.AdapterID = adapter.ID
 		session.DriverKind = agentadapters.DriverKindACP
-	case "agent":
-		provider := strings.TrimSpace(req.Provider)
-		model := strings.TrimSpace(req.Model)
-		if model == "" {
-			writeAgentChatModelRequired(w, "agent")
-			return
-		}
-		caps, err := h.resolveModelCapabilities(r.Context(), provider, model)
-		if err != nil {
-			writeAgentChatModelResolutionError(w, err)
-			return
-		}
-		if session.Title == "" {
-			session.Title = "Hecate Agent chat"
-		}
-		session.Provider = provider
-		session.Model = model
-		session.Capabilities = caps
-	default:
-		writeAgentChatRuntimeKindInvalid(w)
-		return
 	}
 	session, err = h.agentChat.Create(r.Context(), session)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if runtimeKind == "external_agent" {
+	if isExternalAgent {
 		prepareCtx, cancel := context.WithTimeout(r.Context(), agentChatPrepareTimeout)
 		result, prepareErr := h.agentChatRunner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
 			SessionID:               session.ID,
-			AdapterID:               session.AdapterID,
+			AdapterID:               session.AgentID,
 			Workspace:               session.Workspace,
 			PreviousNativeSessionID: session.NativeSessionID,
 		})
@@ -171,26 +150,19 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
 }
 
-func normalizeAgentChatRuntimeKind(runtimeKind, adapterID string) string {
-	runtimeKind = strings.TrimSpace(runtimeKind)
-	switch runtimeKind {
-	case "":
-		if strings.TrimSpace(adapterID) != "" {
-			return "external_agent"
-		}
-		return "model"
-	default:
-		return runtimeKind
+func normalizeChatAgentID(agentID string) string {
+	if agentID = strings.TrimSpace(agentID); agentID != "" {
+		return agentID
 	}
+	return chat.DefaultAgentID
 }
 
-func isValidAgentChatRuntimeKind(runtimeKind string) bool {
-	switch runtimeKind {
-	case "model", "agent", "external_agent":
+func (h *Handler) isValidChatAgentID(agentID string) bool {
+	if agentID == chat.DefaultAgentID {
 		return true
-	default:
-		return false
 	}
+	_, ok := agentadapters.BuiltInByID(agentID)
+	return ok
 }
 
 func (h *Handler) HandleChatSession(w http.ResponseWriter, r *http.Request) {
@@ -338,7 +310,7 @@ func (h *Handler) HandleCancelChatSession(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
-	if renderAgentChatRuntimeKind(session) == "agent" && h.taskStore != nil && h.taskRunner != nil && session.TaskID != "" && session.LatestRunID != "" {
+	if isHecateChatSession(session) && h.taskStore != nil && h.taskRunner != nil && session.TaskID != "" && session.LatestRunID != "" {
 		task, found, err := h.taskStore.GetTask(r.Context(), session.TaskID)
 		if err != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -412,7 +384,7 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
-	if renderAgentChatRuntimeKind(session) != "external_agent" {
+	if !isExternalChatSession(session) {
 		WriteError(w, http.StatusConflict, errCodeRuntimeMismatch, "agent chat config options are only available for external-agent sessions")
 		return
 	}
@@ -458,7 +430,7 @@ func (h *Handler) HandleSetAgentChatSettings(w http.ResponseWriter, r *http.Requ
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
-	if renderAgentChatRuntimeKind(session) == "external_agent" {
+	if isExternalChatSession(session) {
 		WriteError(w, http.StatusConflict, errCodeRuntimeMismatch, "Hecate Chat settings are not available for external-agent sessions")
 		return
 	}
@@ -529,7 +501,7 @@ func writeAgentChatConfigOptionError(w http.ResponseWriter, session chat.Session
 			OperatorAction: "Try again, or restart the adapter if it stays stuck.",
 		})
 	default:
-		WriteErrorDetails(w, http.StatusBadGateway, errCodeAgentAdapterUnavailable, agentadapters.NormalizeError(agentChatAdapterName(session.AdapterID), err), ErrorDetails{
+		WriteErrorDetails(w, http.StatusBadGateway, errCodeAgentAdapterUnavailable, agentadapters.NormalizeError(agentChatAdapterName(session.AgentID), err), ErrorDetails{
 			UserMessage:    "The external agent could not change that control.",
 			OperatorAction: "Check the adapter status, then retry the control change.",
 		})
@@ -542,6 +514,14 @@ func agentChatAdapterName(adapterID string) string {
 		return "Agent adapter"
 	}
 	return adapter.Name
+}
+
+func isExternalChatSession(session chat.Session) bool {
+	return session.AgentID != "" && session.AgentID != chat.DefaultAgentID
+}
+
+func isHecateChatSession(session chat.Session) bool {
+	return !isExternalChatSession(session)
 }
 
 func agentChatConfigOptionSetRequest(sessionID, configID string, rawValue any) (agentadapters.SetSessionConfigOptionRequest, error) {
@@ -616,31 +596,31 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		})
 		return
 	}
-	turnRuntimeKind := normalizeAgentChatTurnRuntimeKind(req.RuntimeKind, session)
-	switch turnRuntimeKind {
-	case "model":
+	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session)
+	switch executionMode {
+	case chat.ExecutionModeDirectModel:
 		h.handleCreateModelChatMessage(w, r, session, req)
 		return
-	case "agent":
-		if renderAgentChatRuntimeKind(session) == "external_agent" {
+	case chat.ExecutionModeHecateTask:
+		if isExternalChatSession(session) {
 			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Agent turns")
 			return
 		}
 		h.handleCreateHecateChatMessage(w, r, session, req)
 		return
-	case "external_agent":
-		if renderAgentChatRuntimeKind(session) != "external_agent" {
+	case chat.ExecutionModeExternalAgent:
+		if !isExternalChatSession(session) {
 			writeAgentChatRuntimeMismatch(w, "Hecate Chat sessions cannot run external-agent turns")
 			return
 		}
 	default:
-		writeAgentChatRuntimeKindInvalid(w)
+		writeChatExecutionModeInvalid(w)
 		return
 	}
 
-	adapter, ok := agentadapters.BuiltInByID(session.AdapterID)
+	adapter, ok := agentadapters.BuiltInByID(session.AgentID)
 	if !ok {
-		writeAgentChatAdapterNotFound(w, session.AdapterID)
+		writeAgentChatAdapterNotFound(w, session.AgentID)
 		return
 	}
 	assistantID := newChatID("msg")
@@ -661,10 +641,11 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:        newChatID("msg"),
-		Role:      "user",
-		Content:   content,
-		CreatedAt: time.Now().UTC(),
+		ID:            newChatID("msg"),
+		ExecutionMode: chat.ExecutionModeExternalAgent,
+		Role:          "user",
+		Content:       content,
+		CreatedAt:     time.Now().UTC(),
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -676,21 +657,22 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		telemetry.AttrHecateRunStatus: "running",
 	}))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:          assistantID,
-		RunID:       runID,
-		RequestID:   RequestIDFromContext(r.Context()),
-		TraceID:     trace.TraceID,
-		SpanID:      trace.RootSpanID(),
-		Role:        "assistant",
-		Content:     "",
-		AdapterID:   adapter.ID,
-		AdapterName: adapter.Name,
-		DriverKind:  agentadapters.DriverKindACP,
-		Status:      "running",
-		CostMode:    adapter.CostMode,
-		Workspace:   session.Workspace,
-		CreatedAt:   time.Now().UTC(),
-		StartedAt:   startedAt,
+		ID:            assistantID,
+		ExecutionMode: chat.ExecutionModeExternalAgent,
+		RunID:         runID,
+		RequestID:     RequestIDFromContext(r.Context()),
+		TraceID:       trace.TraceID,
+		SpanID:        trace.RootSpanID(),
+		Role:          "assistant",
+		Content:       "",
+		AgentID:       adapter.ID,
+		AgentName:     adapter.Name,
+		DriverKind:    agentadapters.DriverKindACP,
+		Status:        "running",
+		CostMode:      adapter.CostMode,
+		Workspace:     session.Workspace,
+		CreatedAt:     time.Now().UTC(),
+		StartedAt:     startedAt,
 		Activities: []chat.Activity{
 			newChatActivity("running", "running", "Running", "Waiting for ACP output"),
 		},
@@ -899,12 +881,15 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
 }
 
-func normalizeAgentChatTurnRuntimeKind(runtimeKind string, session chat.Session) string {
-	runtimeKind = strings.TrimSpace(runtimeKind)
-	if runtimeKind != "" {
-		return runtimeKind
+func normalizeChatExecutionMode(mode string, session chat.Session) string {
+	mode = strings.TrimSpace(mode)
+	if mode != "" {
+		return mode
 	}
-	return renderAgentChatRuntimeKind(session)
+	if isExternalChatSession(session) {
+		return chat.ExecutionModeExternalAgent
+	}
+	return chat.ExecutionModeDirectModel
 }
 
 func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
@@ -948,15 +933,15 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 
 	segmentID := modelSegmentID(session, provider, model)
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:           newChatID("msg"),
-		RuntimeKind:  "model",
-		SegmentID:    segmentID,
-		Provider:     provider,
-		Model:        model,
-		Capabilities: caps,
-		Role:         "user",
-		Content:      content,
-		CreatedAt:    startedAt,
+		ID:            newChatID("msg"),
+		ExecutionMode: chat.ExecutionModeDirectModel,
+		SegmentID:     segmentID,
+		Provider:      provider,
+		Model:         model,
+		Capabilities:  caps,
+		Role:          "user",
+		Content:       content,
+		CreatedAt:     startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -965,21 +950,21 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 	h.agentChatLive.publishSession(updated)
 
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:           assistantID,
-		RuntimeKind:  "model",
-		SegmentID:    segmentID,
-		RunID:        runID,
-		RequestID:    RequestIDFromContext(r.Context()),
-		Provider:     provider,
-		Model:        model,
-		Capabilities: caps,
-		Role:         "assistant",
-		Content:      "",
-		Status:       "running",
-		CostMode:     "hecate",
-		Workspace:    session.Workspace,
-		CreatedAt:    startedAt,
-		StartedAt:    startedAt,
+		ID:            assistantID,
+		ExecutionMode: chat.ExecutionModeDirectModel,
+		SegmentID:     segmentID,
+		RunID:         runID,
+		RequestID:     RequestIDFromContext(r.Context()),
+		Provider:      provider,
+		Model:         model,
+		Capabilities:  caps,
+		Role:          "assistant",
+		Content:       "",
+		Status:        "running",
+		CostMode:      "hecate",
+		Workspace:     session.Workspace,
+		CreatedAt:     startedAt,
+		StartedAt:     startedAt,
 		Activities: []chat.Activity{
 			newChatActivity("model_request", "running", "Model request", "Waiting for provider response"),
 		},
@@ -1045,7 +1030,6 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if inc, incErr := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
-		item.RuntimeKind = "model"
 		item.Provider = provider
 		item.Model = model
 		item.Capabilities = caps
@@ -1086,7 +1070,7 @@ func agentChatModelHistory(session chat.Session, systemPrompt, content string) [
 func modelSegmentID(session chat.Session, provider, model string) string {
 	for i := len(session.Messages) - 1; i >= 0; i-- {
 		message := session.Messages[i]
-		if message.RuntimeKind != "model" {
+		if message.ExecutionMode != chat.ExecutionModeDirectModel {
 			break
 		}
 		if message.Provider == provider && message.Model == model && message.SegmentID != "" {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -62,9 +62,12 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 			return
 		}
 	} else if workspace != "" {
-		if resolved, err := agentadapters.ValidateWorkspace(workspace); err == nil {
-			workspace = resolved
+		resolved, err := agentadapters.ValidateWorkspace(workspace)
+		if err != nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
 		}
+		workspace = resolved
 	}
 	workspaceBranch := workspaceGitBranch(workspace)
 	title := strings.TrimSpace(req.Title)

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -602,6 +602,10 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session)
 	switch executionMode {
 	case chat.ExecutionModeDirectModel:
+		if isExternalChatSession(session) {
+			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run direct model turns")
+			return
+		}
 		h.handleCreateModelChatMessage(w, r, session, req)
 		return
 	case chat.ExecutionModeHecateTask:

--- a/internal/api/handler_chat_approvals_test.go
+++ b/internal/api/handler_chat_approvals_test.go
@@ -66,7 +66,7 @@ func (f *approvalsHTTPFixture) seedSession(t *testing.T, id string) {
 	if _, err := f.chatMgmt.Create(context.Background(), chat.Session{
 		ID:        id,
 		Title:     "test session",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: "/tmp/w",
 	}); err != nil {
 		t.Fatalf("seed session: %v", err)

--- a/internal/api/handler_chat_errors.go
+++ b/internal/api/handler_chat_errors.go
@@ -10,15 +10,15 @@ import (
 	"github.com/hecate/agent-runtime/internal/gateway"
 )
 
-func writeAgentChatWorkspaceRequired(w http.ResponseWriter, runtimeKind string) {
-	WriteErrorDetails(w, http.StatusBadRequest, errCodeWorkspaceRequired, fmt.Sprintf("workspace is required for %s chat", agentChatRuntimeLabel(runtimeKind)), ErrorDetails{
+func writeAgentChatWorkspaceRequired(w http.ResponseWriter, mode string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeWorkspaceRequired, fmt.Sprintf("workspace is required for %s chat", chatExecutionModeLabel(mode)), ErrorDetails{
 		UserMessage:    "Choose a workspace before starting this chat mode.",
 		OperatorAction: "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path.",
 	})
 }
 
-func writeAgentChatModelRequired(w http.ResponseWriter, runtimeKind string) {
-	WriteErrorDetails(w, http.StatusBadRequest, errCodeModelRequired, fmt.Sprintf("model is required for %s chat", agentChatRuntimeLabel(runtimeKind)), ErrorDetails{
+func writeAgentChatModelRequired(w http.ResponseWriter, mode string) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeModelRequired, fmt.Sprintf("model is required for %s chat", chatExecutionModeLabel(mode)), ErrorDetails{
 		UserMessage:    "Choose a model before sending this message.",
 		OperatorAction: "Use the model picker in the chat header, or add a provider that reports at least one model.",
 	})
@@ -83,10 +83,17 @@ func modelReadinessErrorDetails(readiness gateway.ProviderModelReadiness) ErrorD
 	return details
 }
 
-func writeAgentChatRuntimeKindInvalid(w http.ResponseWriter) {
-	WriteErrorDetails(w, http.StatusBadRequest, errCodeRuntimeKindInvalid, "runtime_kind must be model, agent, or external_agent", ErrorDetails{
+func writeChatAgentIDInvalid(w http.ResponseWriter) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeAgentIDInvalid, "agent_id must be hecate or a configured external agent id", ErrorDetails{
+		UserMessage:    "This chat agent is not supported by the current API.",
+		OperatorAction: "Use hecate, codex, claude_code, or cursor_agent.",
+	})
+}
+
+func writeChatExecutionModeInvalid(w http.ResponseWriter) {
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeExecutionModeInvalid, "execution_mode must be direct_model, hecate_task, or external_agent", ErrorDetails{
 		UserMessage:    "This chat mode is not supported by the current API.",
-		OperatorAction: "Use one of: model, agent, or external_agent.",
+		OperatorAction: "Use one of: direct_model, hecate_task, or external_agent.",
 	})
 }
 
@@ -128,11 +135,11 @@ func writeHecateAgentBusy(w http.ResponseWriter, session chat.Session, runStatus
 	})
 }
 
-func agentChatRuntimeLabel(runtimeKind string) string {
-	switch runtimeKind {
-	case "agent":
+func chatExecutionModeLabel(mode string) string {
+	switch mode {
+	case chat.ExecutionModeHecateTask:
 		return "Hecate Agent"
-	case "external_agent":
+	case chat.ExecutionModeExternalAgent:
 		return "External Agent"
 	default:
 		return "model"

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -21,7 +21,6 @@ const hecateAgentPollInterval = 250 * time.Millisecond
 
 func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
 	content := strings.TrimSpace(req.Content)
-	session.RuntimeKind = "agent"
 	if workspace := strings.TrimSpace(req.Workspace); workspace != "" {
 		resolved, err := agentadapters.ValidateWorkspace(workspace)
 		if err != nil {
@@ -32,7 +31,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		session.WorkspaceBranch = workspaceGitBranch(resolved)
 	}
 	if strings.TrimSpace(session.Workspace) == "" {
-		writeAgentChatWorkspaceRequired(w, "agent")
+		writeAgentChatWorkspaceRequired(w, chat.ExecutionModeHecateTask)
 		return
 	}
 	if provider := strings.TrimSpace(req.Provider); provider != "" {
@@ -101,16 +100,16 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	}
 	messageSnapshot := hecateAgentMessageSnapshot(messageSnapshotSession, caps, segmentID)
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:           userID,
-		RuntimeKind:  messageSnapshot.RuntimeKind,
-		SegmentID:    messageSnapshot.SegmentID,
-		TaskID:       messageSnapshot.TaskID,
-		Provider:     messageSnapshot.Provider,
-		Model:        messageSnapshot.Model,
-		Capabilities: messageSnapshot.Capabilities,
-		Role:         "user",
-		Content:      content,
-		CreatedAt:    startedAt,
+		ID:            userID,
+		ExecutionMode: messageSnapshot.ExecutionMode,
+		SegmentID:     messageSnapshot.SegmentID,
+		TaskID:        messageSnapshot.TaskID,
+		Provider:      messageSnapshot.Provider,
+		Model:         messageSnapshot.Model,
+		Capabilities:  messageSnapshot.Capabilities,
+		Role:          "user",
+		Content:       content,
+		CreatedAt:     startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -119,23 +118,23 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	h.agentChatLive.publishSession(updated)
 
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:           assistantID,
-		RuntimeKind:  messageSnapshot.RuntimeKind,
-		SegmentID:    messageSnapshot.SegmentID,
-		TaskID:       messageSnapshot.TaskID,
-		RequestID:    RequestIDFromContext(r.Context()),
-		TraceID:      trace.TraceID,
-		SpanID:       trace.RootSpanID(),
-		Provider:     messageSnapshot.Provider,
-		Model:        messageSnapshot.Model,
-		Capabilities: messageSnapshot.Capabilities,
-		Role:         "assistant",
-		Content:      "",
-		Status:       "running",
-		CostMode:     "hecate",
-		Workspace:    session.Workspace,
-		CreatedAt:    startedAt,
-		StartedAt:    startedAt,
+		ID:            assistantID,
+		ExecutionMode: messageSnapshot.ExecutionMode,
+		SegmentID:     messageSnapshot.SegmentID,
+		TaskID:        messageSnapshot.TaskID,
+		RequestID:     RequestIDFromContext(r.Context()),
+		TraceID:       trace.TraceID,
+		SpanID:        trace.RootSpanID(),
+		Provider:      messageSnapshot.Provider,
+		Model:         messageSnapshot.Model,
+		Capabilities:  messageSnapshot.Capabilities,
+		Role:          "assistant",
+		Content:       "",
+		Status:        "running",
+		CostMode:      "hecate",
+		Workspace:     session.Workspace,
+		CreatedAt:     startedAt,
+		StartedAt:     startedAt,
 		Activities: []chat.Activity{
 			newChatActivity("started", "running", "Starting Hecate Agent", "Creating or continuing the backing task run"),
 		},
@@ -171,14 +170,13 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	segmentID = "task:" + task.ID
 	messageSnapshot = hecateAgentMessageSnapshot(chat.Session{
 		ID:           session.ID,
-		RuntimeKind:  session.RuntimeKind,
 		TaskID:       task.ID,
 		Provider:     session.Provider,
 		Model:        session.Model,
 		Capabilities: caps,
 	}, caps, segmentID)
 	if userUpdated, userUpdateErr := h.agentChat.UpdateMessage(r.Context(), session.ID, userID, func(message *chat.Message) {
-		message.RuntimeKind = messageSnapshot.RuntimeKind
+		message.ExecutionMode = messageSnapshot.ExecutionMode
 		message.SegmentID = messageSnapshot.SegmentID
 		message.TaskID = messageSnapshot.TaskID
 		message.Provider = messageSnapshot.Provider
@@ -188,7 +186,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		h.agentChatLive.publishSession(userUpdated)
 	}
 	updated, err = h.agentChat.UpdateMessage(r.Context(), session.ID, assistantID, func(message *chat.Message) {
-		message.RuntimeKind = messageSnapshot.RuntimeKind
+		message.ExecutionMode = messageSnapshot.ExecutionMode
 		message.SegmentID = messageSnapshot.SegmentID
 		message.TaskID = messageSnapshot.TaskID
 		message.RunID = run.ID
@@ -204,7 +202,6 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		h.agentChatLive.publishSession(updated)
 	}
 	updated, err = h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
-		item.RuntimeKind = "agent"
 		item.TaskID = task.ID
 		item.LatestRunID = run.ID
 		item.Provider = session.Provider
@@ -323,17 +320,13 @@ func hecateAgentSegmentID(session chat.Session) string {
 }
 
 func hecateAgentMessageSnapshot(session chat.Session, caps types.ModelCapabilities, segmentID string) chat.Message {
-	runtimeKind := session.RuntimeKind
-	if runtimeKind == "" {
-		runtimeKind = "agent"
-	}
 	return chat.Message{
-		RuntimeKind:  runtimeKind,
-		SegmentID:    segmentID,
-		TaskID:       session.TaskID,
-		Provider:     session.Provider,
-		Model:        session.Model,
-		Capabilities: caps,
+		ExecutionMode: chat.ExecutionModeHecateTask,
+		SegmentID:     segmentID,
+		TaskID:        session.TaskID,
+		Provider:      session.Provider,
+		Model:         session.Model,
+		Capabilities:  caps,
 	}
 }
 
@@ -359,7 +352,7 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		if strings.TrimSpace(message.Content) == "" && message.Role == "assistant" {
 			continue
 		}
-		if message.RuntimeKind != "agent" {
+		if message.ExecutionMode != chat.ExecutionModeHecateTask {
 			return true
 		}
 		if provider != "" && strings.TrimSpace(message.Provider) != "" && strings.TrimSpace(message.Provider) != provider {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -920,6 +920,47 @@ func TestHecateChatRejectsUnknownExecutionMode(t *testing.T) {
 	}
 }
 
+func TestExternalAgentChatRejectsDirectModelExecutionMode(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-external-direct-rejected",
+			Model:     "gpt-4o-mini",
+			CreatedAt: time.Now().UTC(),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "should not be appended"},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{nativeSessionID: "native_codex_direct_rejected"})
+	handler := NewServer(logger, apiHandler)
+	client := newTaskTestClient(t, handler)
+	workspace := t.TempDir()
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, workspace))
+	recorder := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
+	payload := decodeRecorder[struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}](t, recorder)
+	if payload.Error.Type != errCodeRuntimeMismatch {
+		t.Fatalf("error type = %q, want %s", payload.Error.Type, errCodeRuntimeMismatch)
+	}
+	if !strings.Contains(payload.Error.Message, "external agent sessions cannot run direct model turns") {
+		t.Fatalf("error message = %q", payload.Error.Message)
+	}
+}
+
 func TestHecateAgentChatRejectsBusyBackingRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -150,6 +150,32 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	}
 }
 
+func TestHecateAgentChatCreateDefaultsTitle(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-hecate-agent-title",
+			Model:     "gpt-4o-mini",
+			CreatedAt: time.Now().UTC(),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "ready"},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	handler := NewServer(logger, apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini"}`)
+	if session.Data.Title != "Hecate Chat" {
+		t.Fatalf("title = %q, want Hecate Chat", session.Data.Title)
+	}
+}
+
 func findTaskRunItem(items []TaskRunItem, id string) TaskRunItem {
 	for _, item := range items {
 		if item.ID == id {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -44,9 +44,9 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	workspace := t.TempDir()
 
 	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
-		fmt.Sprintf(`{"runtime_kind":"agent","title":"Refactor chat","workspace":%q,"provider":"openai","model":"gpt-4o-mini","rtk_enabled":true}`, workspace))
-	if session.Data.RuntimeKind != "agent" {
-		t.Fatalf("runtime_kind = %q, want agent", session.Data.RuntimeKind)
+		fmt.Sprintf(`{"agent_id":"hecate","title":"Refactor chat","workspace":%q,"provider":"openai","model":"gpt-4o-mini","rtk_enabled":true}`, workspace))
+	if session.Data.AgentID != chat.DefaultAgentID {
+		t.Fatalf("agent_id = %q, want hecate", session.Data.AgentID)
 	}
 	if !session.Data.RTKEnabled {
 		t.Fatal("rtk_enabled = false, want true")
@@ -56,7 +56,7 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	}
 
 	first := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"content":"inspect the repo","system_prompt":"Prefer small, reviewable diffs."}`)
+		`{"execution_mode":"hecate_task","content":"inspect the repo","system_prompt":"Prefer small, reviewable diffs."}`)
 	if first.Data.TaskID == "" || first.Data.LatestRunID == "" {
 		t.Fatalf("first response missing task/run linkage: %+v", first.Data)
 	}
@@ -74,8 +74,8 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 		t.Fatalf("first transcript = %+v", first.Data.Messages)
 	}
 	assistant := first.Data.Messages[len(first.Data.Messages)-1]
-	if assistant.RuntimeKind != "agent" || assistant.TaskID != first.Data.TaskID || assistant.SegmentID != "task:"+first.Data.TaskID {
-		t.Fatalf("assistant message runtime snapshot = runtime %q segment %q task %q", assistant.RuntimeKind, assistant.SegmentID, assistant.TaskID)
+	if assistant.ExecutionMode != chat.ExecutionModeHecateTask || assistant.TaskID != first.Data.TaskID || assistant.SegmentID != "task:"+first.Data.TaskID {
+		t.Fatalf("assistant message execution snapshot = mode %q segment %q task %q", assistant.ExecutionMode, assistant.SegmentID, assistant.TaskID)
 	}
 	if assistant.Provider != "openai" || assistant.Model != "gpt-4o-mini" || assistant.Capabilities.ToolCalling != modelcaps.ToolCallingParallel {
 		t.Fatalf("assistant message model snapshot = provider %q model %q caps %+v", assistant.Provider, assistant.Model, assistant.Capabilities)
@@ -117,7 +117,7 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	}
 
 	second := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"content":"continue from there"}`)
+		`{"execution_mode":"hecate_task","content":"continue from there"}`)
 	if second.Data.TaskID != first.Data.TaskID {
 		t.Fatalf("second task_id = %q, want same task %q", second.Data.TaskID, first.Data.TaskID)
 	}
@@ -244,7 +244,7 @@ func TestHecateAgentChatPublishesLiveAssistantContent(t *testing.T) {
 	session, err := chatStore.Create(ctx, chat.Session{
 		ID:          "chat_live",
 		Title:       "Live chat",
-		RuntimeKind: "agent",
+		AgentID:     chat.DefaultAgentID,
 		TaskID:      task.ID,
 		LatestRunID: run.ID,
 		Provider:    "openai",
@@ -257,16 +257,16 @@ func TestHecateAgentChatPublishesLiveAssistantContent(t *testing.T) {
 		t.Fatalf("Create session: %v", err)
 	}
 	if _, err := chatStore.AppendMessage(ctx, session.ID, chat.Message{
-		ID:          "msg_assistant",
-		RuntimeKind: "agent",
-		SegmentID:   "task:" + task.ID,
-		TaskID:      task.ID,
-		RunID:       run.ID,
-		Role:        "assistant",
-		Status:      "running",
-		Content:     "",
-		CreatedAt:   now,
-		StartedAt:   now,
+		ID:            "msg_assistant",
+		ExecutionMode: chat.ExecutionModeHecateTask,
+		SegmentID:     "task:" + task.ID,
+		TaskID:        task.ID,
+		RunID:         run.ID,
+		Role:          "assistant",
+		Status:        "running",
+		Content:       "",
+		CreatedAt:     now,
+		StartedAt:     now,
 	}); err != nil {
 		t.Fatalf("AppendMessage: %v", err)
 	}
@@ -370,63 +370,63 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	workspace := t.TempDir()
 
 	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
-		`{"runtime_kind":"model","title":"Mixed chat","provider":"openai","model":"gpt-4o-mini"}`)
-	if session.Data.RuntimeKind != "model" || session.Data.TaskID != "" {
-		t.Fatalf("created session = runtime %q task %q, want model/no task", session.Data.RuntimeKind, session.Data.TaskID)
+		`{"agent_id":"hecate","title":"Mixed chat","provider":"openai","model":"gpt-4o-mini"}`)
+	if session.Data.AgentID != chat.DefaultAgentID || session.Data.TaskID != "" {
+		t.Fatalf("created session = agent %q task %q, want hecate/no task", session.Data.AgentID, session.Data.TaskID)
 	}
 
 	modelTurn := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"runtime_kind":"model","provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
+		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
 	if len(modelTurn.Data.Messages) != 2 {
 		t.Fatalf("model messages = %d, want 2", len(modelTurn.Data.Messages))
 	}
 	modelAssistant := modelTurn.Data.Messages[1]
-	if modelAssistant.RuntimeKind != "model" || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
-		t.Fatalf("model assistant snapshot = runtime %q task %q model %q", modelAssistant.RuntimeKind, modelAssistant.TaskID, modelAssistant.Model)
+	if modelAssistant.ExecutionMode != chat.ExecutionModeDirectModel || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
+		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
 	if !strings.Contains(modelAssistant.Content, "Segment answer") {
 		t.Fatalf("model assistant content = %q", modelAssistant.Content)
 	}
 
 	toolsTurn := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		fmt.Sprintf(`{"runtime_kind":"agent","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"use tools"}`, workspace))
+		fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"use tools"}`, workspace))
 	if toolsTurn.Data.TaskID == "" || toolsTurn.Data.LatestRunID == "" {
 		t.Fatalf("tools turn missing task/run: %+v", toolsTurn.Data)
 	}
 	firstTaskID := toolsTurn.Data.TaskID
 	toolsAssistant := toolsTurn.Data.Messages[len(toolsTurn.Data.Messages)-1]
-	if toolsAssistant.RuntimeKind != "agent" || toolsAssistant.TaskID != firstTaskID || toolsAssistant.SegmentID != "task:"+firstTaskID {
-		t.Fatalf("tools assistant snapshot = runtime %q task %q segment %q", toolsAssistant.RuntimeKind, toolsAssistant.TaskID, toolsAssistant.SegmentID)
+	if toolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || toolsAssistant.TaskID != firstTaskID || toolsAssistant.SegmentID != "task:"+firstTaskID {
+		t.Fatalf("tools assistant snapshot = execution_mode %q task %q segment %q", toolsAssistant.ExecutionMode, toolsAssistant.TaskID, toolsAssistant.SegmentID)
 	}
 
 	secondModel := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"runtime_kind":"model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
+		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
 	if secondModel.Data.TaskID != firstTaskID {
 		t.Fatalf("model segment should preserve latest task pointer, got %q want %q", secondModel.Data.TaskID, firstTaskID)
 	}
 	secondModelAssistant := secondModel.Data.Messages[len(secondModel.Data.Messages)-1]
-	if secondModelAssistant.RuntimeKind != "model" || secondModelAssistant.TaskID != "" {
-		t.Fatalf("second model assistant snapshot = runtime %q task %q", secondModelAssistant.RuntimeKind, secondModelAssistant.TaskID)
+	if secondModelAssistant.ExecutionMode != chat.ExecutionModeDirectModel || secondModelAssistant.TaskID != "" {
+		t.Fatalf("second model assistant snapshot = execution_mode %q task %q", secondModelAssistant.ExecutionMode, secondModelAssistant.TaskID)
 	}
 
 	secondTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		fmt.Sprintf(`{"runtime_kind":"agent","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"tools again"}`, workspace))
+		fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"tools again"}`, workspace))
 	if secondTools.Data.TaskID == "" || secondTools.Data.TaskID == firstTaskID {
 		t.Fatalf("tools re-entry task_id = %q, want new task distinct from %q", secondTools.Data.TaskID, firstTaskID)
 	}
 	secondToolsAssistant := secondTools.Data.Messages[len(secondTools.Data.Messages)-1]
-	if secondToolsAssistant.RuntimeKind != "agent" || secondToolsAssistant.TaskID != secondTools.Data.TaskID || secondToolsAssistant.SegmentID != "task:"+secondTools.Data.TaskID {
-		t.Fatalf("second tools assistant snapshot = runtime %q task %q segment %q", secondToolsAssistant.RuntimeKind, secondToolsAssistant.TaskID, secondToolsAssistant.SegmentID)
+	if secondToolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondToolsAssistant.TaskID != secondTools.Data.TaskID || secondToolsAssistant.SegmentID != "task:"+secondTools.Data.TaskID {
+		t.Fatalf("second tools assistant snapshot = execution_mode %q task %q segment %q", secondToolsAssistant.ExecutionMode, secondToolsAssistant.TaskID, secondToolsAssistant.SegmentID)
 	}
 
 	changedModelTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		fmt.Sprintf(`{"runtime_kind":"agent","provider":"openai","model":"gpt-4o-mini-2024-07-18","workspace":%q,"content":"use a different model with tools"}`, workspace))
+		fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini-2024-07-18","workspace":%q,"content":"use a different model with tools"}`, workspace))
 	if changedModelTools.Data.TaskID == "" || changedModelTools.Data.TaskID == secondTools.Data.TaskID {
 		t.Fatalf("model-change task_id = %q, want new task distinct from %q", changedModelTools.Data.TaskID, secondTools.Data.TaskID)
 	}
 	changedModelAssistant := changedModelTools.Data.Messages[len(changedModelTools.Data.Messages)-1]
-	if changedModelAssistant.RuntimeKind != "agent" || changedModelAssistant.TaskID != changedModelTools.Data.TaskID || changedModelAssistant.Model != "gpt-4o-mini-2024-07-18" {
-		t.Fatalf("model-change assistant snapshot = runtime %q task %q model %q", changedModelAssistant.RuntimeKind, changedModelAssistant.TaskID, changedModelAssistant.Model)
+	if changedModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || changedModelAssistant.TaskID != changedModelTools.Data.TaskID || changedModelAssistant.Model != "gpt-4o-mini-2024-07-18" {
+		t.Fatalf("model-change assistant snapshot = execution_mode %q task %q model %q", changedModelAssistant.ExecutionMode, changedModelAssistant.TaskID, changedModelAssistant.Model)
 	}
 	changedTask := mustRequestJSON[TaskResponse](client, http.MethodGet, "/hecate/v1/tasks/"+changedModelTools.Data.TaskID, "")
 	if changedTask.Data.RequestedModel != "gpt-4o-mini-2024-07-18" {
@@ -437,10 +437,16 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if len(segments) != 5 {
 		t.Fatalf("segments = %d, want 5: %+v", len(segments), segments)
 	}
-	wantKinds := []string{"model", "agent", "model", "agent", "agent"}
-	for i, want := range wantKinds {
-		if segments[i].RuntimeKind != want {
-			t.Fatalf("segment %d runtime_kind = %q, want %q: %+v", i, segments[i].RuntimeKind, want, segments)
+	wantModes := []string{
+		chat.ExecutionModeDirectModel,
+		chat.ExecutionModeHecateTask,
+		chat.ExecutionModeDirectModel,
+		chat.ExecutionModeHecateTask,
+		chat.ExecutionModeHecateTask,
+	}
+	for i, want := range wantModes {
+		if segments[i].ExecutionMode != want {
+			t.Fatalf("segment %d execution_mode = %q, want %q: %+v", i, segments[i].ExecutionMode, want, segments)
 		}
 		if segments[i].MessageCount != 2 {
 			t.Fatalf("segment %d message_count = %d, want 2: %+v", i, segments[i].MessageCount, segments)
@@ -479,15 +485,15 @@ func TestHecateAgentNewSegmentLivePlaceholderDoesNotBorrowPreviousTask(t *testin
 	workspace := t.TempDir()
 
 	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
-		`{"runtime_kind":"model","title":"Mixed chat","provider":"openai","model":"gpt-4o-mini"}`)
+		`{"agent_id":"hecate","title":"Mixed chat","provider":"openai","model":"gpt-4o-mini"}`)
 	firstTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		fmt.Sprintf(`{"runtime_kind":"agent","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"use tools"}`, workspace))
+		fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"use tools"}`, workspace))
 	firstTaskID := firstTools.Data.TaskID
 	if firstTaskID == "" {
 		t.Fatalf("first tools turn task_id is empty: %+v", firstTools.Data)
 	}
 	secondModel := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"runtime_kind":"model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
+		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
 	if secondModel.Data.TaskID != firstTaskID {
 		t.Fatalf("direct model segment should preserve latest task pointer on the session, got %q want %q", secondModel.Data.TaskID, firstTaskID)
 	}
@@ -502,7 +508,7 @@ func TestHecateAgentNewSegmentLivePlaceholderDoesNotBorrowPreviousTask(t *testin
 	done := make(chan requestResult, 1)
 	go func() {
 		recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-			fmt.Sprintf(`{"runtime_kind":"agent","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"tools again"}`, workspace))
+			fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini","workspace":%q,"content":"tools again"}`, workspace))
 		payload, _ := tryDecodeRecorder[ChatSessionResponse](recorder)
 		done <- requestResult{status: recorder.Code, body: recorder.Body.String(), response: payload}
 	}()
@@ -846,13 +852,13 @@ func TestHecateAgentChatRejectsDisabledToolCapability(t *testing.T) {
 	workspace := t.TempDir()
 
 	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
-		fmt.Sprintf(`{"runtime_kind":"agent","workspace":%q,"provider":"ollama","model":"llama3.1:8b"}`, workspace))
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"provider":"ollama","model":"llama3.1:8b"}`, workspace))
 	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingNone {
 		t.Fatalf("session capabilities = %+v, want none", session.Data.Capabilities)
 	}
 
 	recorder := client.mustRequestStatus(http.StatusUnprocessableEntity, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"content":"use tools"}`)
+		`{"execution_mode":"hecate_task","content":"use tools"}`)
 	var payload struct {
 		Error struct {
 			Type         string                  `json:"type"`
@@ -876,6 +882,41 @@ func TestHecateAgentChatRejectsDisabledToolCapability(t *testing.T) {
 	}
 	if !strings.Contains(payload.Error.Message, "Tools are disabled for this model") {
 		t.Fatalf("message = %q", payload.Error.Message)
+	}
+}
+
+func TestHecateChatRejectsUnknownExecutionMode(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		capabilities: providers.Capabilities{
+			Name:         "openai",
+			Kind:         providers.KindCloud,
+			DefaultModel: "gpt-4o-mini",
+			Models:       []string{"gpt-4o-mini"},
+		},
+	}
+	handler := newTestHTTPHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini"}`)
+	recorder := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"legacy_kind","content":"hello"}`)
+	payload := decodeRecorder[struct {
+		Error struct {
+			Type           string `json:"type"`
+			UserMessage    string `json:"user_message"`
+			OperatorAction string `json:"operator_action"`
+		} `json:"error"`
+	}](t, recorder)
+	if payload.Error.Type != errCodeExecutionModeInvalid {
+		t.Fatalf("error type = %q, want %s", payload.Error.Type, errCodeExecutionModeInvalid)
+	}
+	if payload.Error.UserMessage == "" || payload.Error.OperatorAction == "" {
+		t.Fatalf("error missing operator metadata: %+v", payload.Error)
 	}
 }
 
@@ -912,7 +953,7 @@ func TestHecateAgentChatRejectsBusyBackingRun(t *testing.T) {
 	session, err := apiHandler.agentChat.Create(ctx, chat.Session{
 		ID:              "chat_busy",
 		Title:           "Busy",
-		RuntimeKind:     "agent",
+		AgentID:         chat.DefaultAgentID,
 		Workspace:       t.TempDir(),
 		TaskID:          task.ID,
 		LatestRunID:     run.ID,
@@ -996,7 +1037,7 @@ func TestHecateChatRejectsDirectModelTurnWhileBackingRunBusy(t *testing.T) {
 	session, err := apiHandler.agentChat.Create(ctx, chat.Session{
 		ID:           "chat_busy_model_turn",
 		Title:        "Mixed busy",
-		RuntimeKind:  "model",
+		AgentID:      chat.DefaultAgentID,
 		Workspace:    t.TempDir(),
 		TaskID:       task.ID,
 		LatestRunID:  run.ID,
@@ -1009,7 +1050,7 @@ func TestHecateChatRejectsDirectModelTurnWhileBackingRunBusy(t *testing.T) {
 	}
 
 	recorder := client.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/chat/sessions/"+session.ID+"/messages",
-		`{"runtime_kind":"model","content":"answer directly","model":"gpt-4o-mini"}`)
+		`{"execution_mode":"direct_model","content":"answer directly","model":"gpt-4o-mini"}`)
 	payload := decodeRecorder[struct {
 		Error struct {
 			Type        string `json:"type"`

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -34,8 +34,7 @@ func renderChatSessionSummary(session chat.Session) ChatSessionSummaryItem {
 	return ChatSessionSummaryItem{
 		ID:              session.ID,
 		Title:           session.Title,
-		RuntimeKind:     renderAgentChatRuntimeKind(session),
-		AdapterID:       session.AdapterID,
+		AgentID:         renderChatAgentID(session),
 		DriverKind:      session.DriverKind,
 		NativeSessionID: session.NativeSessionID,
 		TaskID:          session.TaskID,
@@ -58,7 +57,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 	for _, message := range session.Messages {
 		messages = append(messages, ChatMessageItem{
 			ID:              message.ID,
-			RuntimeKind:     message.RuntimeKind,
+			ExecutionMode:   message.ExecutionMode,
 			SegmentID:       message.SegmentID,
 			TaskID:          message.TaskID,
 			RunID:           message.RunID,
@@ -68,8 +67,8 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 			Role:            message.Role,
 			Content:         message.Content,
 			RawOutput:       message.RawOutput,
-			AdapterID:       message.AdapterID,
-			AdapterName:     message.AdapterName,
+			AgentID:         message.AgentID,
+			AgentName:       message.AgentName,
 			DriverKind:      message.DriverKind,
 			NativeSessionID: message.NativeSessionID,
 			Status:          message.Status,
@@ -94,8 +93,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 	return ChatSessionItem{
 		ID:                   session.ID,
 		Title:                session.Title,
-		RuntimeKind:          renderAgentChatRuntimeKind(session),
-		AdapterID:            session.AdapterID,
+		AgentID:              renderChatAgentID(session),
 		DriverKind:           session.DriverKind,
 		NativeSessionID:      session.NativeSessionID,
 		TaskID:               session.TaskID,
@@ -143,19 +141,19 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 			positions[segmentID] = idx
 			builders = append(builders, agentChatSegmentBuilder{
 				item: ChatSegmentItem{
-					ID:          segmentID,
-					RuntimeKind: firstNonEmpty(message.RuntimeKind, renderAgentChatRuntimeKind(session)),
-					Provider:    firstNonEmpty(message.Provider, session.Provider),
-					Model:       firstNonEmpty(message.Model, session.Model),
-					TaskID:      message.TaskID,
-					Workspace:   firstNonEmpty(message.Workspace, session.Workspace),
+					ID:            segmentID,
+					ExecutionMode: firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session)),
+					Provider:      firstNonEmpty(message.Provider, session.Provider),
+					Model:         firstNonEmpty(message.Model, session.Model),
+					TaskID:        message.TaskID,
+					Workspace:     firstNonEmpty(message.Workspace, session.Workspace),
 				},
 			})
 		}
 		builder := &builders[idx]
 		builder.item.MessageCount++
-		if builder.item.RuntimeKind == "" {
-			builder.item.RuntimeKind = firstNonEmpty(message.RuntimeKind, renderAgentChatRuntimeKind(session))
+		if builder.item.ExecutionMode == "" {
+			builder.item.ExecutionMode = firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
 		}
 		if builder.item.Provider == "" {
 			builder.item.Provider = message.Provider
@@ -223,14 +221,21 @@ func agentChatMessageSegmentTime(message chat.Message) time.Time {
 	}
 }
 
-func renderAgentChatRuntimeKind(session chat.Session) string {
-	if session.RuntimeKind != "" {
-		return session.RuntimeKind
+func renderChatAgentID(session chat.Session) string {
+	if session.AgentID != "" {
+		return session.AgentID
 	}
-	if session.AdapterID != "" {
-		return "external_agent"
+	return chat.DefaultAgentID
+}
+
+func defaultMessageExecutionModeForRender(session chat.Session) string {
+	if session.AgentID != "" && session.AgentID != chat.DefaultAgentID {
+		return chat.ExecutionModeExternalAgent
 	}
-	return "agent"
+	if session.TaskID != "" {
+		return chat.ExecutionModeHecateTask
+	}
+	return chat.ExecutionModeDirectModel
 }
 
 func agentChatUsageFromResult(usage agentadapters.Usage) chat.Usage {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -577,22 +577,21 @@ type AgentAdapterCredentialResponseItem struct {
 }
 
 type CreateChatSessionRequest struct {
-	Title       string `json:"title,omitempty"`
-	RuntimeKind string `json:"runtime_kind,omitempty"`
-	AdapterID   string `json:"adapter_id,omitempty"`
-	Provider    string `json:"provider,omitempty"`
-	Model       string `json:"model,omitempty"`
-	Workspace   string `json:"workspace"`
-	RTKEnabled  bool   `json:"rtk_enabled,omitempty"`
+	Title      string `json:"title,omitempty"`
+	AgentID    string `json:"agent_id,omitempty"`
+	Provider   string `json:"provider,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Workspace  string `json:"workspace"`
+	RTKEnabled bool   `json:"rtk_enabled,omitempty"`
 }
 
 type CreateChatMessageRequest struct {
-	Content      string `json:"content"`
-	RuntimeKind  string `json:"runtime_kind,omitempty"`
-	Provider     string `json:"provider,omitempty"`
-	Model        string `json:"model,omitempty"`
-	SystemPrompt string `json:"system_prompt,omitempty"`
-	Workspace    string `json:"workspace,omitempty"`
+	Content       string `json:"content"`
+	ExecutionMode string `json:"execution_mode,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
+	SystemPrompt  string `json:"system_prompt,omitempty"`
+	Workspace     string `json:"workspace,omitempty"`
 }
 
 type UpdateChatSessionRequest struct {
@@ -610,8 +609,7 @@ type SetAgentChatSettingsRequest struct {
 type ChatSessionSummaryItem struct {
 	ID              string                  `json:"id"`
 	Title           string                  `json:"title"`
-	RuntimeKind     string                  `json:"runtime_kind"`
-	AdapterID       string                  `json:"adapter_id,omitempty"`
+	AgentID         string                  `json:"agent_id"`
 	DriverKind      string                  `json:"driver_kind,omitempty"`
 	NativeSessionID string                  `json:"native_session_id,omitempty"`
 	TaskID          string                  `json:"task_id,omitempty"`
@@ -631,8 +629,7 @@ type ChatSessionSummaryItem struct {
 type ChatSessionItem struct {
 	ID                   string                       `json:"id"`
 	Title                string                       `json:"title"`
-	RuntimeKind          string                       `json:"runtime_kind"`
-	AdapterID            string                       `json:"adapter_id,omitempty"`
+	AgentID              string                       `json:"agent_id"`
 	DriverKind           string                       `json:"driver_kind,omitempty"`
 	NativeSessionID      string                       `json:"native_session_id,omitempty"`
 	TaskID               string                       `json:"task_id,omitempty"`
@@ -657,22 +654,22 @@ type ChatSessionItem struct {
 }
 
 type ChatSegmentItem struct {
-	ID           string `json:"id"`
-	RuntimeKind  string `json:"runtime_kind"`
-	Provider     string `json:"provider,omitempty"`
-	Model        string `json:"model,omitempty"`
-	TaskID       string `json:"task_id,omitempty"`
-	LatestRunID  string `json:"latest_run_id,omitempty"`
-	Workspace    string `json:"workspace,omitempty"`
-	Status       string `json:"status,omitempty"`
-	MessageCount int    `json:"message_count"`
-	StartedAt    string `json:"started_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
+	ID            string `json:"id"`
+	ExecutionMode string `json:"execution_mode"`
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
+	TaskID        string `json:"task_id,omitempty"`
+	LatestRunID   string `json:"latest_run_id,omitempty"`
+	Workspace     string `json:"workspace,omitempty"`
+	Status        string `json:"status,omitempty"`
+	MessageCount  int    `json:"message_count"`
+	StartedAt     string `json:"started_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
 }
 
 type ChatMessageItem struct {
 	ID              string                  `json:"id"`
-	RuntimeKind     string                  `json:"runtime_kind,omitempty"`
+	ExecutionMode   string                  `json:"execution_mode,omitempty"`
 	SegmentID       string                  `json:"segment_id,omitempty"`
 	TaskID          string                  `json:"task_id,omitempty"`
 	RunID           string                  `json:"run_id,omitempty"`
@@ -682,8 +679,8 @@ type ChatMessageItem struct {
 	Role            string                  `json:"role"`
 	Content         string                  `json:"content"`
 	RawOutput       string                  `json:"raw_output,omitempty"`
-	AdapterID       string                  `json:"adapter_id,omitempty"`
-	AdapterName     string                  `json:"adapter_name,omitempty"`
+	AgentID         string                  `json:"agent_id,omitempty"`
+	AgentName       string                  `json:"agent_name,omitempty"`
 	DriverKind      string                  `json:"driver_kind,omitempty"`
 	NativeSessionID string                  `json:"native_session_id,omitempty"`
 	Status          string                  `json:"status,omitempty"`

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -200,7 +200,7 @@ func defaultErrorAction(code string) string {
 	case errCodeModelRequired:
 		return "Use the model picker in the chat header, or add a provider that reports at least one model."
 	case errCodeAgentIDInvalid, errCodeExecutionModeInvalid:
-		return "Use one of: model, agent, or external_agent."
+		return "Use agent_id hecate or a registered external agent id. For execution_mode, use direct_model, hecate_task, or external_agent."
 	case errCodeRuntimeMismatch:
 		return "Start a new chat or switch back to the runtime that created this session."
 	case errCodeAgentAdapterNotFound:

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -24,7 +24,8 @@ const (
 	errCodeModelNotConfigured      = "model_not_configured"
 	errCodeWorkspaceRequired       = "chat.workspace_required"
 	errCodeModelRequired           = "chat.model_required"
-	errCodeRuntimeKindInvalid      = "chat.runtime_kind_invalid"
+	errCodeAgentIDInvalid          = "chat.agent_id_invalid"
+	errCodeExecutionModeInvalid    = "chat.execution_mode_invalid"
 	errCodeRuntimeMismatch         = "chat.runtime_mismatch"
 	errCodeAgentAdapterNotFound    = "chat.adapter_not_found"
 	errCodeAgentAdapterUnavailable = "chat.adapter_unavailable"
@@ -150,7 +151,7 @@ func defaultErrorUserMessage(code string) string {
 		return "Choose a workspace before starting this chat mode."
 	case errCodeModelRequired:
 		return "Choose a model before sending this message."
-	case errCodeRuntimeKindInvalid:
+	case errCodeAgentIDInvalid, errCodeExecutionModeInvalid:
 		return "This chat mode is not supported by the current API."
 	case errCodeRuntimeMismatch:
 		return "This message belongs to a different chat runtime."
@@ -198,7 +199,7 @@ func defaultErrorAction(code string) string {
 		return "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path."
 	case errCodeModelRequired:
 		return "Use the model picker in the chat header, or add a provider that reports at least one model."
-	case errCodeRuntimeKindInvalid:
+	case errCodeAgentIDInvalid, errCodeExecutionModeInvalid:
 		return "Use one of: model, agent, or external_agent."
 	case errCodeRuntimeMismatch:
 		return "Start a new chat or switch back to the runtime that created this session."

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1122,9 +1122,9 @@ func TestAgentChatRunsExternalAdapter(t *testing.T) {
 	})
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q,"title":"Codex test"}`, dir))
-	if created.Data.AdapterID != "codex" {
-		t.Fatalf("adapter_id = %q, want codex", created.Data.AdapterID)
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q,"title":"Codex test"}`, dir))
+	if created.Data.AgentID != "codex" {
+		t.Fatalf("adapter_id = %q, want codex", created.Data.AgentID)
 	}
 	if got := created.Data.WorkspaceBranch; got != "" && got != "main" {
 		t.Fatalf("workspace_branch = %q, want empty or main", got)
@@ -1142,7 +1142,7 @@ func TestAgentChatRunsExternalAdapter(t *testing.T) {
 		t.Fatalf("message count = %d, want 2: %#v", len(updated.Data.Messages), updated.Data.Messages)
 	}
 	assistant := updated.Data.Messages[1]
-	if assistant.Role != "assistant" || assistant.AdapterID != "codex" || assistant.Status != "completed" {
+	if assistant.Role != "assistant" || assistant.AgentID != "codex" || assistant.Status != "completed" {
 		t.Fatalf("assistant message = %#v", assistant)
 	}
 	if assistant.DriverKind != "acp" || assistant.NativeSessionID != "native_codex_1" {
@@ -1260,7 +1260,7 @@ func TestUpdateChatSessionRenamesSession(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q,"title":"Original"}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q,"title":"Original"}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPatch, "/hecate/v1/chat/sessions/"+created.Data.ID, `{"title":"Renamed chat"}`)
 	if updated.Data.Title != "Renamed chat" {
 		t.Fatalf("title = %q, want Renamed chat", updated.Data.Title)
@@ -1293,7 +1293,7 @@ func TestAgentChatOmitsStartedActivityWhenNativeSessionReused(t *testing.T) {
 	})
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
 	assistant := updated.Data.Messages[1]
 	if agentChatActivitiesContain(assistant.Activities, "started") {
@@ -1315,7 +1315,7 @@ func TestAgentChatMergesAdapterActivityUpdates(t *testing.T) {
 	})
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
 	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
 
@@ -1350,7 +1350,7 @@ func TestAgentChatFinalOutputReplacesStreamedNarration(t *testing.T) {
 	})
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"show diff"}`)
 	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
 	if assistant.Content != "There is no current diff." {
@@ -1372,7 +1372,7 @@ func TestAgentChatPassesPersistedNativeSessionForResume(t *testing.T) {
 	firstHandler.SetAgentChatStore(store)
 	firstHandler.SetAgentChatRunner(firstRunner)
 	firstClient := newAPITestClient(t, NewServer(logger, firstHandler))
-	created := mustRequestJSON[ChatSessionResponse](firstClient, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](firstClient, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	_ = mustRequestJSON[ChatSessionResponse](firstClient, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"first"}`)
 
 	secondRunner := &fakeAgentChatRunner{
@@ -1413,7 +1413,7 @@ func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
 	})
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if _, err := store.UpdateSession(context.Background(), created.Data.ID, func(item *chat.Session) {
 		item.NativeSessionID = "native_stale"
 	}); err != nil {
@@ -1439,7 +1439,7 @@ func TestAgentChatTagsAdapterJSONRPCBillingError(t *testing.T) {
 	})
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"claude_code","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"claude_code","workspace":%q}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
 	assistant := updated.Data.Messages[1]
 	if assistant.Status != "failed" {
@@ -1479,7 +1479,7 @@ diff --git a/src/app.go b/src/app.go
 	if _, err := store.Create(context.Background(), chat.Session{
 		ID:        sessionID,
 		Title:     "Diff",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: t.TempDir(),
 		Status:    "completed",
 		Messages: []chat.Message{
@@ -1528,7 +1528,7 @@ diff --git a/src/app.go b/src/app.go
 	if _, err := store.Create(context.Background(), chat.Session{
 		ID:        sessionID,
 		Title:     "Diff",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: t.TempDir(),
 		Status:    "completed",
 		Messages:  []chat.Message{{ID: messageID, Role: "assistant", Status: "completed", Diff: diff}},
@@ -1589,7 +1589,7 @@ func TestRevertChatMessageFilesRestoresSelectedPaths(t *testing.T) {
 	if _, err := store.Create(context.Background(), chat.Session{
 		ID:        sessionID,
 		Title:     "Revert",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: workspace,
 		Status:    "completed",
 		Messages:  []chat.Message{{ID: messageID, Role: "assistant", Status: "completed", Diff: diff, DiffStat: diffStat}},
@@ -1639,7 +1639,7 @@ func TestRevertChatMessageFilesRequiresGitWorkspace(t *testing.T) {
 	if _, err := store.Create(context.Background(), chat.Session{
 		ID:        sessionID,
 		Title:     "Revert",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: t.TempDir(),
 		Status:    "completed",
 		Messages:  []chat.Message{{ID: messageID, Role: "assistant", Status: "completed", DiffStat: "README.md | 1 +"}},
@@ -1681,7 +1681,7 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
 	client := newAPITestClient(t, handler)
 
-	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions", `{"adapter_id":"codex","workspace":"/path/that/does/not/exist"}`)
+	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions", `{"agent_id":"codex","workspace":"/path/that/does/not/exist"}`)
 	if !strings.Contains(rec.Body.String(), "not accessible") {
 		t.Fatalf("body = %s, want not accessible error", rec.Body.String())
 	}
@@ -1700,27 +1700,21 @@ func TestAgentChatCreateUsesStableErrorContracts(t *testing.T) {
 	}{
 		{
 			name:       "workspace required for external agent",
-			body:       `{"runtime_kind":"external_agent","adapter_id":"codex"}`,
+			body:       `{"agent_id":"codex"}`,
 			statusCode: http.StatusBadRequest,
 			wantType:   errCodeWorkspaceRequired,
 		},
 		{
-			name:       "model required for model chat",
-			body:       `{"runtime_kind":"model"}`,
+			name:       "model required for hecate chat",
+			body:       `{"agent_id":"hecate"}`,
 			statusCode: http.StatusBadRequest,
 			wantType:   errCodeModelRequired,
 		},
 		{
-			name:       "adapter not found",
-			body:       fmt.Sprintf(`{"runtime_kind":"external_agent","adapter_id":"missing","workspace":%q}`, t.TempDir()),
+			name:       "agent id invalid",
+			body:       fmt.Sprintf(`{"agent_id":"missing","workspace":%q}`, t.TempDir()),
 			statusCode: http.StatusBadRequest,
-			wantType:   errCodeAgentAdapterNotFound,
-		},
-		{
-			name:       "runtime kind invalid",
-			body:       `{"runtime_kind":"bogus"}`,
-			statusCode: http.StatusBadRequest,
-			wantType:   errCodeRuntimeKindInvalid,
+			wantType:   errCodeAgentIDInvalid,
 		},
 	}
 
@@ -1837,7 +1831,7 @@ func TestAgentChatStoreAttachReconcilesInterruptedRun(t *testing.T) {
 	created, err := store.Create(ctx, chat.Session{
 		ID:        "chat_restart",
 		Title:     "Restart",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: t.TempDir(),
 		Status:    "running",
 	})
@@ -1882,7 +1876,7 @@ func TestAgentChatTurnLimitReturns422(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	sessionID := created.Data.ID
 
 	// Two turns should succeed and increment TurnsUsed.
@@ -1921,7 +1915,7 @@ func TestAgentChatTurnsUsedIncrementsAndIsReturned(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	sessionID := created.Data.ID
 
 	for turn := 1; turn <= 3; turn++ {
@@ -1942,7 +1936,7 @@ func TestAgentChatNoLimitWhenMaxTurnsIsZero(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	sessionID := created.Data.ID
 
 	for i := 0; i < 5; i++ {
@@ -1965,7 +1959,7 @@ func TestAgentChatDurationLimitReturns422(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	client := newAPITestClient(t, handler)
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	oldStartedAt := time.Now().UTC().Add(-2 * time.Hour)
 	if _, err := apiHandler.agentChat.UpdateSession(context.Background(), created.Data.ID, func(item *chat.Session) {
 		item.CreatedAt = oldStartedAt
@@ -2003,7 +1997,7 @@ func TestAgentChatSnapshotIncludesDurationAndIdleLimits(t *testing.T) {
 	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{output: "ok"})
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if created.Data.MaxTurnsPerSession != 10 {
 		t.Fatalf("max_turns_per_session = %d, want 10", created.Data.MaxTurnsPerSession)
 	}
@@ -2026,7 +2020,7 @@ func TestAgentChatIdleLimitReturns422(t *testing.T) {
 	session, err := store.Create(context.Background(), chat.Session{
 		ID:        "chat_idle_limit",
 		Title:     "Idle limit",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: workspace,
 		Status:    "completed",
 		CreatedAt: old,
@@ -2067,7 +2061,7 @@ func TestAgentChatIdleSweepCancelsStaleSession(t *testing.T) {
 	session, err := store.Create(context.Background(), chat.Session{
 		ID:        "chat_idle",
 		Title:     "Idle chat",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: workspace,
 		Status:    "completed",
 		CreatedAt: old,
@@ -2125,7 +2119,7 @@ func TestAgentChatCreateExternalSessionCleansUpPreparedSessionOnPersistFailure(t
 	apiHandler.SetAgentChatRunner(runner)
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	rec := client.mustRequestStatus(http.StatusInternalServerError, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	rec := client.mustRequestStatus(http.StatusInternalServerError, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if !strings.Contains(rec.Body.String(), "update failed") {
 		t.Fatalf("response body = %s, want update error", rec.Body.String())
 	}
@@ -2333,7 +2327,7 @@ func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 	apiHandler.SetAgentChatRunner(runner)
 	handler := NewServer(logger, apiHandler)
 
-	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir)))
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir)))
 	if len(runner.prepareRequests) != 1 {
 		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
 	}
@@ -2377,7 +2371,7 @@ func TestAgentChatExternalConfigOptionSessionNotActive(t *testing.T) {
 	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{setConfigErr: fmt.Errorf("%w: %q", agentadapters.ErrSessionNotActive, "chat_1")})
 	handler := NewServer(logger, apiHandler)
 
-	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir)))
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir)))
 	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"fast"}`)
 	if recorder.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body: %s", recorder.Code, recorder.Body.String())
@@ -2402,7 +2396,7 @@ func TestAgentChatExternalConfigOptionAdapterFailure(t *testing.T) {
 	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{setConfigErr: errors.New("adapter rejected option")})
 	handler := NewServer(logger, apiHandler)
 
-	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir)))
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir)))
 	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"fast"}`)
 	if recorder.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502; body: %s", recorder.Code, recorder.Body.String())
@@ -2426,13 +2420,12 @@ func TestAgentChatExternalConfigOptionMissingRunner(t *testing.T) {
 	store := chat.NewMemoryStore()
 	now := time.Now().UTC()
 	session, err := store.Create(context.Background(), chat.Session{
-		ID:          "chat_missing_runner",
-		RuntimeKind: "external_agent",
-		AdapterID:   "codex",
-		Workspace:   dir,
-		Status:      "idle",
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:        "chat_missing_runner",
+		AgentID:   "codex",
+		Workspace: dir,
+		Status:    "idle",
+		CreatedAt: now,
+		UpdatedAt: now,
 	})
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -2472,7 +2465,7 @@ func TestAgentChatExternalCreateCleansUpWhenPrepareFails(t *testing.T) {
 	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{prepareErr: errors.New("adapter handshake failed")})
 	handler := NewServer(logger, apiHandler)
 
-	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if recorder.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502; body: %s", recorder.Code, recorder.Body.String())
 	}
@@ -2505,7 +2498,7 @@ func TestAgentChatExternalCreateMissingRunner(t *testing.T) {
 	apiHandler.agentChatRunner = nil
 	handler := NewServer(logger, apiHandler)
 
-	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if recorder.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500; body: %s", recorder.Code, recorder.Body.String())
 	}
@@ -2542,7 +2535,7 @@ func TestAgentChatExternalCreatePrepareTimeout(t *testing.T) {
 	handler := NewServer(logger, apiHandler)
 	started := time.Now()
 
-	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	if recorder.Code != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want 504; body: %s", recorder.Code, recorder.Body.String())
 	}
@@ -2579,7 +2572,7 @@ func TestChatStreamsExternalAdapterOutput(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	streamReq, err := http.NewRequest(http.MethodGet, server.URL+"/hecate/v1/chat/sessions/"+created.Data.ID+"/stream", nil)
 	if err != nil {
 		t.Fatalf("new stream request: %v", err)
@@ -2650,7 +2643,7 @@ func TestAgentChatCancelsExternalAdapter(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	done := make(chan ChatSessionResponse, 1)
 	go func() {
 		done <- requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"please wait"}`)
@@ -2695,7 +2688,7 @@ func TestAgentChatDeleteCancelsRunBeforeDeletingSession(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	done := make(chan ChatSessionResponse, 1)
 	go func() {
 		done <- requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"please wait"}`)
@@ -2745,7 +2738,7 @@ func TestAgentChatCloseKeepsHistoryAndClosesNativeSession(t *testing.T) {
 	apiHandler.SetAgentChatRunner(runner)
 	client := newAPITestClient(t, NewServer(logger, apiHandler))
 
-	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"adapter_id":"codex","workspace":%q}`, dir))
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
 	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
 	if len(updated.Data.Messages) != 2 {
 		t.Fatalf("messages = %d, want 2", len(updated.Data.Messages))

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1681,9 +1681,26 @@ func TestAgentChatCreateRejectsInvalidWorkspace(t *testing.T) {
 	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
 	client := newAPITestClient(t, handler)
 
-	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions", `{"agent_id":"codex","workspace":"/path/that/does/not/exist"}`)
-	if !strings.Contains(rec.Body.String(), "not accessible") {
-		t.Fatalf("body = %s, want not accessible error", rec.Body.String())
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "external agent",
+			body: `{"agent_id":"codex","workspace":"/path/that/does/not/exist"}`,
+		},
+		{
+			name: "hecate chat",
+			body: `{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini","workspace":"/path/that/does/not/exist"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions", tt.body)
+			if !strings.Contains(rec.Body.String(), "not accessible") {
+				t.Fatalf("body = %s, want not accessible error", rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -56,14 +56,13 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		ctx,
 		fmt.Sprintf(
 			`INSERT INTO %s (
-				id, title, runtime_kind, adapter_id, driver_kind, native_session_id, workspace, workspace_branch,
+				id, title, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
 				status, task_id, latest_run_id, provider, model, capabilities, config_options, rtk_enabled, turns_used, created_at, updated_at
 			 )
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 			   title = excluded.title,
-			   runtime_kind = excluded.runtime_kind,
-			   adapter_id = excluded.adapter_id,
+			   agent_id = excluded.agent_id,
 			   driver_kind = excluded.driver_kind,
 			   native_session_id = excluded.native_session_id,
 			   workspace = excluded.workspace,
@@ -81,8 +80,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		),
 		session.ID,
 		session.Title,
-		normalizeRuntimeKind(session),
-		session.AdapterID,
+		normalizeAgentID(session),
 		session.DriverKind,
 		session.NativeSessionID,
 		session.Workspace,
@@ -120,12 +118,12 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 	rows, err := s.client.DB().QueryContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT s.id, s.title, s.runtime_kind, s.adapter_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
+			`SELECT s.id, s.title, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
 			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at,
 			        COUNT(m.id) AS message_count
 			 FROM %s AS s
 			 LEFT JOIN %s AS m ON m.session_id = s.id
-			 GROUP BY s.id, s.title, s.runtime_kind, s.adapter_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
+			 GROUP BY s.id, s.title, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
 			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at
 			 ORDER BY s.updated_at DESC, s.created_at DESC`,
 			s.sessionsTable,
@@ -146,8 +144,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		if err := rows.Scan(
 			&session.ID,
 			&session.Title,
-			&session.RuntimeKind,
-			&session.AdapterID,
+			&session.AgentID,
 			&session.DriverKind,
 			&session.NativeSessionID,
 			&session.Workspace,
@@ -169,8 +166,8 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		}
 		session.Capabilities = unmarshalModelCapabilities(capabilities)
 		session.ConfigOptions = unmarshalConfigOptions(configOptions)
-		if session.RuntimeKind == "" {
-			session.RuntimeKind = defaultRuntimeKind(session)
+		if session.AgentID == "" {
+			session.AgentID = DefaultAgentID
 		}
 		if messageCount > 0 {
 			session.Messages = make([]Message, messageCount)
@@ -207,14 +204,13 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, update func(
 		ctx,
 		fmt.Sprintf(
 			`UPDATE %s SET
-			   title = ?, runtime_kind = ?, adapter_id = ?, driver_kind = ?, native_session_id = ?, workspace = ?, workspace_branch = ?,
+			   title = ?, agent_id = ?, driver_kind = ?, native_session_id = ?, workspace = ?, workspace_branch = ?,
 			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, rtk_enabled = ?, turns_used = ?, updated_at = ?
 			 WHERE id = ?`,
 			s.sessionsTable,
 		),
 		session.Title,
-		normalizeRuntimeKind(session),
-		session.AdapterID,
+		normalizeAgentID(session),
 		session.DriverKind,
 		session.NativeSessionID,
 		session.Workspace,
@@ -269,8 +265,8 @@ func (s *SQLiteStore) AppendMessage(ctx context.Context, sessionID string, messa
 		ctx,
 		fmt.Sprintf(
 			`INSERT INTO %s (
-				id, session_id, sequence, runtime_kind, segment_id, task_id, run_id, request_id, trace_id, span_id,
-				role, content, raw_output, adapter_id, adapter_name, driver_kind, native_session_id, status, exit_code,
+				id, session_id, sequence, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id,
+				role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code,
 				cost_mode, provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at,
 				error, activities, usage, timing
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -279,7 +275,7 @@ func (s *SQLiteStore) AppendMessage(ctx context.Context, sessionID string, messa
 		message.ID,
 		sessionID,
 		nextSeq,
-		message.RuntimeKind,
+		message.ExecutionMode,
 		message.SegmentID,
 		message.TaskID,
 		message.RunID,
@@ -289,8 +285,8 @@ func (s *SQLiteStore) AppendMessage(ctx context.Context, sessionID string, messa
 		message.Role,
 		message.Content,
 		message.RawOutput,
-		message.AdapterID,
-		message.AdapterName,
+		message.AgentID,
+		message.AgentName,
 		message.DriverKind,
 		message.NativeSessionID,
 		message.Status,
@@ -338,14 +334,14 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, messa
 		ctx,
 		fmt.Sprintf(
 			`UPDATE %s SET
-			   runtime_kind = ?, segment_id = ?, task_id = ?, run_id = ?, request_id = ?, trace_id = ?, span_id = ?, role = ?, content = ?, raw_output = ?, adapter_id = ?, adapter_name = ?,
+			   execution_mode = ?, segment_id = ?, task_id = ?, run_id = ?, request_id = ?, trace_id = ?, span_id = ?, role = ?, content = ?, raw_output = ?, agent_id = ?, agent_name = ?,
 			   driver_kind = ?, native_session_id = ?, status = ?, exit_code = ?,
 			   cost_mode = ?, provider = ?, model = ?, capabilities = ?, workspace = ?, diff_stat = ?, diff = ?, created_at = ?,
 			   started_at = ?, completed_at = ?, error = ?, activities = ?, usage = ?, timing = ?
 			 WHERE id = ? AND session_id = ?`,
 			s.messagesTable,
 		),
-		message.RuntimeKind,
+		message.ExecutionMode,
 		message.SegmentID,
 		message.TaskID,
 		message.RunID,
@@ -355,8 +351,8 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, messa
 		message.Role,
 		message.Content,
 		message.RawOutput,
-		message.AdapterID,
-		message.AdapterName,
+		message.AgentID,
+		message.AgentName,
 		message.DriverKind,
 		message.NativeSessionID,
 		message.Status,
@@ -396,8 +392,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 			`CREATE TABLE IF NOT EXISTS %s (
 				id TEXT PRIMARY KEY,
 				title TEXT NOT NULL,
-				runtime_kind TEXT NOT NULL DEFAULT 'external_agent',
-				adapter_id TEXT NOT NULL,
+				agent_id TEXT NOT NULL DEFAULT 'hecate',
 				driver_kind TEXT NOT NULL DEFAULT '',
 				native_session_id TEXT NOT NULL DEFAULT '',
 				workspace TEXT NOT NULL,
@@ -426,14 +421,14 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 				id TEXT PRIMARY KEY,
 				session_id TEXT NOT NULL REFERENCES %s (id) ON DELETE CASCADE,
 				sequence INTEGER NOT NULL,
-				runtime_kind TEXT NOT NULL DEFAULT '',
+				execution_mode TEXT NOT NULL DEFAULT '',
 				segment_id TEXT NOT NULL DEFAULT '',
 				task_id TEXT NOT NULL DEFAULT '',
 				role TEXT NOT NULL,
 				content TEXT NOT NULL,
 				raw_output TEXT NOT NULL DEFAULT '',
-				adapter_id TEXT NOT NULL,
-				adapter_name TEXT NOT NULL,
+				agent_id TEXT NOT NULL,
+				agent_name TEXT NOT NULL,
 				driver_kind TEXT NOT NULL DEFAULT '',
 				native_session_id TEXT NOT NULL DEFAULT '',
 				status TEXT NOT NULL,
@@ -480,7 +475,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		name       string
 		definition string
 	}{
-		{name: "runtime_kind", definition: "TEXT NOT NULL DEFAULT 'external_agent'"},
+		{name: "agent_id", definition: "TEXT NOT NULL DEFAULT 'hecate'"},
 		{name: "task_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "latest_run_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "provider", definition: "TEXT NOT NULL DEFAULT ''"},
@@ -498,7 +493,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		definition string
 	}{
 		{name: "run_id", definition: "TEXT NOT NULL DEFAULT ''"},
-		{name: "runtime_kind", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "execution_mode", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "segment_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "task_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "request_id", definition: "TEXT NOT NULL DEFAULT ''"},
@@ -546,7 +541,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	err := s.client.DB().QueryRowContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT id, title, runtime_kind, adapter_id, driver_kind, native_session_id, workspace, workspace_branch,
+			`SELECT id, title, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
 			        status, task_id, latest_run_id, provider, model, capabilities, config_options, rtk_enabled, turns_used, created_at, updated_at
 			 FROM %s WHERE id = ?`,
 			s.sessionsTable,
@@ -555,8 +550,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	).Scan(
 		&session.ID,
 		&session.Title,
-		&session.RuntimeKind,
-		&session.AdapterID,
+		&session.AgentID,
 		&session.DriverKind,
 		&session.NativeSessionID,
 		&session.Workspace,
@@ -579,8 +573,8 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 		}
 		return Session{}, fmt.Errorf("read sqlite agent chat session: %w", err)
 	}
-	if session.RuntimeKind == "" {
-		session.RuntimeKind = defaultRuntimeKind(session)
+	if session.AgentID == "" {
+		session.AgentID = DefaultAgentID
 	}
 	session.Capabilities = unmarshalModelCapabilities(capabilities)
 	session.ConfigOptions = unmarshalConfigOptions(configOptions)
@@ -599,7 +593,7 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 	rows, err := s.client.DB().QueryContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT id, runtime_kind, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, adapter_id, adapter_name, driver_kind, native_session_id, status, exit_code, cost_mode,
+			`SELECT id, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
 			        provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at, error, activities, usage, timing
 			 FROM %s
 			 WHERE session_id = ?
@@ -623,7 +617,7 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 		var capabilities string
 		if err := rows.Scan(
 			&message.ID,
-			&message.RuntimeKind,
+			&message.ExecutionMode,
 			&message.SegmentID,
 			&message.TaskID,
 			&message.RunID,
@@ -633,8 +627,8 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 			&message.Role,
 			&message.Content,
 			&message.RawOutput,
-			&message.AdapterID,
-			&message.AdapterName,
+			&message.AgentID,
+			&message.AgentName,
 			&message.DriverKind,
 			&message.NativeSessionID,
 			&message.Status,
@@ -747,7 +741,7 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 	err := tx.QueryRowContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT id, runtime_kind, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, adapter_id, adapter_name, driver_kind, native_session_id, status, exit_code, cost_mode,
+			`SELECT id, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
 			        provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at, error, activities, usage, timing
 			 FROM %s
 			 WHERE id = ? AND session_id = ?`,
@@ -757,7 +751,7 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 		sessionID,
 	).Scan(
 		&message.ID,
-		&message.RuntimeKind,
+		&message.ExecutionMode,
 		&message.SegmentID,
 		&message.TaskID,
 		&message.RunID,
@@ -767,8 +761,8 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 		&message.Role,
 		&message.Content,
 		&message.RawOutput,
-		&message.AdapterID,
-		&message.AdapterName,
+		&message.AgentID,
+		&message.AgentName,
 		&message.DriverKind,
 		&message.NativeSessionID,
 		&message.Status,
@@ -883,11 +877,11 @@ func unmarshalTiming(raw string) Timing {
 	return timing
 }
 
-func normalizeRuntimeKind(session Session) string {
-	if session.RuntimeKind != "" {
-		return session.RuntimeKind
+func normalizeAgentID(session Session) string {
+	if strings.TrimSpace(session.AgentID) != "" {
+		return strings.TrimSpace(session.AgentID)
 	}
-	return defaultRuntimeKind(session)
+	return DefaultAgentID
 }
 
 func marshalModelCapabilities(capabilities types.ModelCapabilities) string {

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -51,7 +51,7 @@ func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {
 	if _, err := store.Create(context.Background(), Session{
 		ID:              "chat_1",
 		Title:           "Persist me",
-		AdapterID:       "cursor_agent",
+		AgentID:         "cursor_agent",
 		Workspace:       "/tmp/hecate",
 		WorkspaceBranch: "feature/sqlite",
 	}); err != nil {
@@ -84,7 +84,7 @@ func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Get after reopen: ok=%v err=%v", ok, err)
 	}
-	if got.AdapterID != "cursor_agent" || got.WorkspaceBranch != "feature/sqlite" || got.Messages[0].Content != "hello" {
+	if got.AgentID != "cursor_agent" || got.WorkspaceBranch != "feature/sqlite" || got.Messages[0].Content != "hello" {
 		t.Fatalf("reopened session mismatch: %+v", got)
 	}
 }

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -15,8 +15,7 @@ import (
 type Session struct {
 	ID              string
 	Title           string
-	RuntimeKind     string
-	AdapterID       string
+	AgentID         string
 	DriverKind      string
 	NativeSessionID string
 	Workspace       string
@@ -42,7 +41,7 @@ type Session struct {
 
 type Message struct {
 	ID              string
-	RuntimeKind     string
+	ExecutionMode   string
 	SegmentID       string
 	TaskID          string
 	RunID           string
@@ -52,8 +51,8 @@ type Message struct {
 	Role            string
 	Content         string
 	RawOutput       string
-	AdapterID       string
-	AdapterName     string
+	AgentID         string
+	AgentName       string
 	DriverKind      string
 	NativeSessionID string
 	Status          string
@@ -240,8 +239,8 @@ func (s *MemoryStore) Create(_ context.Context, session Session) (Session, error
 		session.Status = "idle"
 	}
 	session.Messages = append([]Message(nil), session.Messages...)
-	if session.RuntimeKind == "" {
-		session.RuntimeKind = defaultRuntimeKind(session)
+	if session.AgentID == "" {
+		session.AgentID = DefaultAgentID
 	}
 	s.sessions[session.ID] = session
 	return cloneSession(session), nil
@@ -360,12 +359,22 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 	return out
 }
 
+const (
+	DefaultAgentID             = "hecate"
+	ExecutionModeDirectModel   = "direct_model"
+	ExecutionModeHecateTask    = "hecate_task"
+	ExecutionModeExternalAgent = "external_agent"
+)
+
 func hydrateMessageRuntimeFromSession(message *Message, session Session) {
-	if message.RuntimeKind == "" {
-		message.RuntimeKind = normalizeMessageRuntimeKind(session)
+	if message.ExecutionMode == "" {
+		message.ExecutionMode = defaultMessageExecutionMode(session)
 	}
-	if message.TaskID == "" && message.RuntimeKind != "model" && shouldHydrateMessageTaskID(message) {
+	if message.TaskID == "" && message.ExecutionMode == ExecutionModeHecateTask && shouldHydrateMessageTaskID(message) {
 		message.TaskID = session.TaskID
+	}
+	if message.AgentID == "" {
+		message.AgentID = session.AgentID
 	}
 	if message.Provider == "" {
 		message.Provider = session.Provider
@@ -395,16 +404,12 @@ func shouldHydrateMessageTaskID(message *Message) bool {
 	return strings.HasPrefix(strings.TrimSpace(message.SegmentID), "task:")
 }
 
-func normalizeMessageRuntimeKind(session Session) string {
-	if session.RuntimeKind != "" {
-		return session.RuntimeKind
+func defaultMessageExecutionMode(session Session) string {
+	if session.AgentID != "" && session.AgentID != DefaultAgentID {
+		return ExecutionModeExternalAgent
 	}
-	return defaultRuntimeKind(session)
-}
-
-func defaultRuntimeKind(session Session) string {
-	if session.AdapterID != "" {
-		return "external_agent"
+	if session.TaskID != "" {
+		return ExecutionModeHecateTask
 	}
-	return "agent"
+	return ExecutionModeDirectModel
 }

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -24,7 +24,7 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	created, err := store.Create(ctx, Session{
 		ID:              "chat_1",
 		Title:           "Review diff",
-		RuntimeKind:     "agent",
+		AgentID:         DefaultAgentID,
 		TaskID:          "task_chat_1",
 		LatestRunID:     "run_chat_1",
 		Provider:        "openai",
@@ -42,42 +42,42 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	if created.WorkspaceBranch != "main" {
 		t.Fatalf("created workspace branch = %q, want main", created.WorkspaceBranch)
 	}
-	if created.RuntimeKind != "agent" || created.TaskID != "task_chat_1" || created.LatestRunID != "run_chat_1" {
-		t.Fatalf("created linkage = runtime %q task %q run %q", created.RuntimeKind, created.TaskID, created.LatestRunID)
+	if created.AgentID != DefaultAgentID || created.TaskID != "task_chat_1" || created.LatestRunID != "run_chat_1" {
+		t.Fatalf("created linkage = agent %q task %q run %q", created.AgentID, created.TaskID, created.LatestRunID)
 	}
 	if created.Provider != "openai" || created.Model != "gpt-4o-mini" || created.Capabilities.ToolCalling != "basic" {
 		t.Fatalf("created model snapshot = provider %q model %q caps %+v", created.Provider, created.Model, created.Capabilities)
 	}
 
 	if _, err := store.AppendMessage(ctx, created.ID, Message{
-		ID:          "msg_user",
-		SegmentID:   "task:task_chat_1",
-		RuntimeKind: "agent",
-		TaskID:      "task_chat_1",
-		Provider:    "openai",
-		Model:       "gpt-4o-mini",
-		Role:        "user",
-		Content:     "review this",
+		ID:            "msg_user",
+		ExecutionMode: ExecutionModeHecateTask,
+		SegmentID:     "task:task_chat_1",
+		TaskID:        "task_chat_1",
+		Provider:      "openai",
+		Model:         "gpt-4o-mini",
+		Role:          "user",
+		Content:       "review this",
 	}); err != nil {
 		t.Fatalf("AppendMessage(user): %v", err)
 	}
 	startedAt := time.Now().UTC().Add(-2 * time.Second)
 	if _, err := store.AppendMessage(ctx, created.ID, Message{
-		ID:           "msg_assistant",
-		RuntimeKind:  "agent",
-		SegmentID:    "task:task_chat_1",
-		TaskID:       "task_chat_1",
-		RunID:        "agent_run_1",
-		Provider:     "openai",
-		Model:        "gpt-4o-mini",
-		Capabilities: types.ModelCapabilities{ToolCalling: "basic", Streaming: true, Source: "operator_override"},
-		Role:         "assistant",
-		Content:      "running",
-		AdapterID:    "codex",
-		AdapterName:  "Codex",
-		Status:       "running",
-		CostMode:     "external",
-		Workspace:    "/tmp/hecate",
+		ID:            "msg_assistant",
+		ExecutionMode: ExecutionModeHecateTask,
+		SegmentID:     "task:task_chat_1",
+		TaskID:        "task_chat_1",
+		RunID:         "agent_run_1",
+		Provider:      "openai",
+		Model:         "gpt-4o-mini",
+		Capabilities:  types.ModelCapabilities{ToolCalling: "basic", Streaming: true, Source: "operator_override"},
+		Role:          "assistant",
+		Content:       "running",
+		AgentID:       DefaultAgentID,
+		AgentName:     "Hecate",
+		Status:        "running",
+		CostMode:      "hecate",
+		Workspace:     "/tmp/hecate",
 	}); err != nil {
 		t.Fatalf("AppendMessage(assistant): %v", err)
 	}
@@ -138,8 +138,8 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	if got.WorkspaceBranch != "main" {
 		t.Fatalf("persisted workspace branch = %q, want main", got.WorkspaceBranch)
 	}
-	if got.RuntimeKind != "agent" || got.TaskID != "task_chat_1" || got.LatestRunID != "run_chat_1" {
-		t.Fatalf("persisted linkage = runtime %q task %q run %q", got.RuntimeKind, got.TaskID, got.LatestRunID)
+	if got.AgentID != DefaultAgentID || got.TaskID != "task_chat_1" || got.LatestRunID != "run_chat_1" {
+		t.Fatalf("persisted linkage = agent %q task %q run %q", got.AgentID, got.TaskID, got.LatestRunID)
 	}
 	if got.Provider != "openai" || got.Model != "gpt-4o-mini" || got.Capabilities.ToolCalling != "basic" || got.Capabilities.Source != "operator_override" {
 		t.Fatalf("persisted model snapshot = provider %q model %q caps %+v", got.Provider, got.Model, got.Capabilities)
@@ -153,8 +153,8 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	if got.Messages[1].Timing.Bottleneck != "model" || got.Messages[1].Timing.ModelMS != 900 || got.Messages[1].Timing.TurnCount != 1 {
 		t.Fatalf("persisted timing = %+v, want model bottleneck", got.Messages[1].Timing)
 	}
-	if got.Messages[1].RuntimeKind != "agent" || got.Messages[1].SegmentID != "task:task_chat_1" || got.Messages[1].TaskID != "task_chat_1" {
-		t.Fatalf("persisted message runtime = runtime %q segment %q task %q", got.Messages[1].RuntimeKind, got.Messages[1].SegmentID, got.Messages[1].TaskID)
+	if got.Messages[1].ExecutionMode != ExecutionModeHecateTask || got.Messages[1].SegmentID != "task:task_chat_1" || got.Messages[1].TaskID != "task_chat_1" {
+		t.Fatalf("persisted message execution = mode %q segment %q task %q", got.Messages[1].ExecutionMode, got.Messages[1].SegmentID, got.Messages[1].TaskID)
 	}
 	if got.Messages[1].Provider != "openai" || got.Messages[1].Model != "gpt-4o-mini" || got.Messages[1].Capabilities.ToolCalling != "basic" {
 		t.Fatalf("persisted message model snapshot = provider %q model %q caps %+v", got.Messages[1].Provider, got.Messages[1].Model, got.Messages[1].Capabilities)
@@ -167,7 +167,7 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	if len(list) != 1 || list[0].ID != created.ID {
 		t.Fatalf("List = %+v, want created session", list)
 	}
-	if list[0].WorkspaceBranch != "main" || len(list[0].Messages) != 2 || list[0].RuntimeKind != "agent" || list[0].TaskID != "task_chat_1" {
+	if list[0].WorkspaceBranch != "main" || len(list[0].Messages) != 2 || list[0].AgentID != DefaultAgentID || list[0].TaskID != "task_chat_1" {
 		t.Fatalf("List summary = %+v, want cached branch and message count", list[0])
 	}
 
@@ -187,9 +187,8 @@ func runStoreDeepCopiesConfigOptions(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()
 	created, err := store.Create(ctx, Session{
-		ID:          "chat_config_options",
-		RuntimeKind: "external_agent",
-		AdapterID:   "codex",
+		ID:      "chat_config_options",
+		AgentID: "codex",
 		ConfigOptions: []agentcontrols.ConfigOption{
 			{
 				ID:           "model",
@@ -245,7 +244,7 @@ func runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t *testing.T, store St
 	ctx := context.Background()
 	created, err := store.Create(ctx, Session{
 		ID:          "chat_1",
-		RuntimeKind: "agent",
+		AgentID:     DefaultAgentID,
 		TaskID:      "task_previous",
 		LatestRunID: "run_previous",
 		Provider:    "openai",
@@ -256,11 +255,11 @@ func runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t *testing.T, store St
 	}
 
 	updated, err := store.AppendMessage(ctx, created.ID, Message{
-		ID:          "msg_new_segment",
-		RuntimeKind: "agent",
-		SegmentID:   "segment_pending_new_task",
-		Role:        "user",
-		Content:     "tools again",
+		ID:            "msg_new_segment",
+		ExecutionMode: ExecutionModeHecateTask,
+		SegmentID:     "segment_pending_new_task",
+		Role:          "user",
+		Content:       "tools again",
 	})
 	if err != nil {
 		t.Fatalf("AppendMessage: %v", err)
@@ -270,11 +269,11 @@ func runStoreDoesNotHydrateTaskIDForAnonymousAgentSegment(t *testing.T, store St
 	}
 
 	updated, err = store.AppendMessage(ctx, created.ID, Message{
-		ID:          "msg_existing_task",
-		RuntimeKind: "agent",
-		SegmentID:   "task:task_previous",
-		Role:        "assistant",
-		Content:     "continuing previous task",
+		ID:            "msg_existing_task",
+		ExecutionMode: ExecutionModeHecateTask,
+		SegmentID:     "task:task_previous",
+		Role:          "assistant",
+		Content:       "continuing previous task",
 	})
 	if err != nil {
 		t.Fatalf("AppendMessage(existing task): %v", err)
@@ -290,7 +289,7 @@ func runStoreReconcileInterruptedRuns(t *testing.T, store Store) {
 	created, err := store.Create(ctx, Session{
 		ID:        "chat_interrupted",
 		Title:     "Interrupted",
-		AdapterID: "codex",
+		AgentID:   "codex",
 		Workspace: "/tmp/hecate",
 	})
 	if err != nil {
@@ -305,16 +304,17 @@ func runStoreReconcileInterruptedRuns(t *testing.T, store Store) {
 		t.Fatalf("AppendMessage(user): %v", err)
 	}
 	if _, err := store.AppendMessage(ctx, created.ID, Message{
-		ID:          "msg_assistant",
-		RunID:       "agent_run_interrupted",
-		Role:        "assistant",
-		Content:     "partial answer",
-		AdapterID:   "codex",
-		AdapterName: "Codex",
-		Status:      "running",
-		CostMode:    "external",
-		Workspace:   "/tmp/hecate",
-		StartedAt:   time.Now().UTC().Add(-time.Minute),
+		ID:            "msg_assistant",
+		ExecutionMode: ExecutionModeExternalAgent,
+		RunID:         "agent_run_interrupted",
+		Role:          "assistant",
+		Content:       "partial answer",
+		AgentID:       "codex",
+		AgentName:     "Codex",
+		Status:        "running",
+		CostMode:      "external",
+		Workspace:     "/tmp/hecate",
+		StartedAt:     time.Now().UTC().Add(-time.Minute),
 		Activities: []Activity{
 			{Type: "running", Status: "running", Title: "Running"},
 		},

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1045,8 +1045,8 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     const body = await route.request().postDataJSON();
     submittedTurns.push(body);
     const turn = submittedTurns.length;
-    const runtimeKind = body.execution_mode || "direct_model";
-    const isHecateAgent = runtimeKind === "hecate_task";
+    const executionMode = body.execution_mode || "direct_model";
+    const isHecateAgent = executionMode === "hecate_task";
     const agentTurn = submittedTurns.filter((t) => t.execution_mode === "hecate_task").length;
     const taskID = isHecateAgent ? `task-tools-${agentTurn}` : "";
     const runID = isHecateAgent ? `run-tools-${agentTurn}` : "";
@@ -1060,7 +1060,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     messages.push(
       {
         id: `msg-user-${turn}`,
-        execution_mode: runtimeKind,
+        execution_mode: executionMode,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         provider: body.provider || "",
@@ -1071,7 +1071,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       },
       {
         id: `msg-assistant-${turn}`,
-        execution_mode: runtimeKind,
+        execution_mode: executionMode,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         run_id: isHecateAgent ? runID : undefined,
@@ -1125,7 +1125,6 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
 
     session = {
       ...session,
-      execution_mode: runtimeKind,
       provider: body.provider || "",
       model: body.model,
       capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -1200,7 +1199,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     window.localStorage.setItem("hecate.chatSessionID", "chat-busy-e2e");
     window.localStorage.setItem(
       "hecate.chatTargetBySessionID",
-      JSON.stringify({ "chat-busy-e2e": "direct_model" }),
+      JSON.stringify({ "chat-busy-e2e": "model" }),
     );
     window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
   });

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -111,7 +111,7 @@ test("Hecate composer provider and model controls match shared chat dropdowns", 
   await expect(providerBtn).toContainText("Anthropic");
 
   const modelBtn = page.getByRole("button", { name: /model picker/i });
-  await expect(modelBtn).toContainText("model");
+  await expect(modelBtn).toContainText("claude-sonnet-4-6");
   await modelBtn.click();
 
   const menu = page.locator(".dropdown-menu");
@@ -151,7 +151,7 @@ test("New chat keeps an unsent draft on the active empty chat", async ({ page })
   await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
   // The current empty chat is still the target, so an unsent draft is
   // preserved rather than discarded.
-  await expect(page.getByRole("button", { name: "Chat Hecate chat, anthropic" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Chat Hecate chat/ })).toBeVisible();
   await expect(page.locator("textarea")).toHaveValue("some prior message");
 });
 
@@ -214,9 +214,8 @@ test("New chat creates an external-agent session with controls before the first 
         data: {
           id: "agent-chat-codex-e2e",
           title: "Codex chat",
-          runtime_kind: "external_agent",
-          adapter_id: "codex",
-          adapter_name: "Codex",
+          agent_id: "codex",
+          agent_name: "Codex",
           driver_kind: "acp",
           native_session_id: "native-codex-e2e",
           workspace: "/tmp/hecate-e2e",
@@ -253,8 +252,7 @@ test("New chat creates an external-agent session with controls before the first 
   await expect
     .poll(() => createBody)
     .toMatchObject({
-      runtime_kind: "external_agent",
-      adapter_id: "codex",
+      agent_id: "codex",
       workspace: "/tmp/hecate-e2e",
     });
   await expect(page.getByRole("button", { name: "Model" })).toContainText("Fast");
@@ -282,8 +280,7 @@ test("sidebar rename works for agent-chat sessions", async ({ page }) => {
           {
             id: "rename-chat-e2e",
             title,
-            runtime_kind: "external_agent",
-            adapter_id: "codex",
+            agent_id: "codex",
             workspace: "/tmp/hecate-e2e",
             status: "idle",
             message_count: 0,
@@ -307,8 +304,7 @@ test("sidebar rename works for agent-chat sessions", async ({ page }) => {
         data: {
           id: "rename-chat-e2e",
           title,
-          runtime_kind: "external_agent",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp/hecate-e2e",
           status: "idle",
           messages: [],
@@ -414,7 +410,7 @@ test("chat error renders inline with the humanized message", async ({ page }) =>
         data: {
           id: "chat_err_e2e",
           title: "x",
-          runtime_kind: "model",
+          agent_id: "hecate",
           status: "created",
           provider: "anthropic",
           model: "claude-sonnet-4-6",
@@ -457,7 +453,7 @@ test("agent chat renders indented fenced code blocks as code", async ({ page }) 
   const session = {
     id: "markdown-fence-e2e",
     title: "Markdown fence",
-    runtime_kind: "agent",
+    agent_id: "hecate",
     provider: "ollama",
     model: "qwen2.5-coder",
     workspace: "/tmp/e2e",
@@ -532,7 +528,7 @@ test("agent chat previews failed tool stdout and stderr in Advanced details", as
   const session = {
     id: "failed-tool-output-e2e",
     title: "Failed tool",
-    runtime_kind: "agent",
+    agent_id: "hecate",
     provider: "ollama",
     model: "qwen2.5-coder",
     workspace: "/tmp/e2e",
@@ -548,7 +544,7 @@ test("agent chat previews failed tool stdout and stderr in Advanced details", as
       {
         id: "m-agent",
         role: "assistant",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         content: "The command failed while inspecting git state.",
         provider: "ollama",
         model: "qwen2.5-coder",
@@ -750,7 +746,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
       const session = {
         id: "chat-hecate-e2e",
         title: body.title || "show diff",
-        runtime_kind: "agent",
+        agent_id: "hecate",
         provider: body.provider || "",
         model: body.model || "qwen2.5",
         capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -801,7 +797,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
       messages: [
         {
           id: "msg-user-e2e",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           segment_id: "task:task-hecate-e2e",
           task_id: "task-hecate-e2e",
           role: "user",
@@ -810,7 +806,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
         },
         {
           id: "msg-assistant-e2e",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           segment_id: "task:task-hecate-e2e",
           task_id: "task-hecate-e2e",
           run_id: "run-hecate-e2e",
@@ -855,7 +851,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
   await page.getByRole("button", { name: "Add selected" }).click();
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
   await expect(page.getByText("2 configured")).toBeVisible();
-  await page.getByRole("button", { name: /Chat show diff, Hecate/ }).click();
+  await page.getByRole("button", { name: /Chat show diff/ }).click();
 
   await page.getByRole("button", { name: /model picker/i }).click();
   await page.locator(".dropdown-menu").locator("text=qwen2.5").first().click();
@@ -869,7 +865,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
   await expect
     .poll(() => messagePayload)
     .toMatchObject({
-      runtime_kind: "agent",
+      execution_mode: "hecate_task",
       model: "qwen2.5",
       workspace: "/tmp/hecate-e2e-workspace",
     });
@@ -987,7 +983,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       session = {
         id: "chat-tools-switch-e2e",
         title: body.title || "tools switch",
-        runtime_kind: body.runtime_kind,
+        agent_id: body.agent_id || "hecate",
         provider: body.provider || "",
         model: body.model || "qwen2.5",
         capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -1049,9 +1045,9 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     const body = await route.request().postDataJSON();
     submittedTurns.push(body);
     const turn = submittedTurns.length;
-    const runtimeKind = body.runtime_kind || "model";
-    const isHecateAgent = runtimeKind === "agent";
-    const agentTurn = submittedTurns.filter((t) => t.runtime_kind === "agent").length;
+    const runtimeKind = body.execution_mode || "direct_model";
+    const isHecateAgent = runtimeKind === "hecate_task";
+    const agentTurn = submittedTurns.filter((t) => t.execution_mode === "hecate_task").length;
     const taskID = isHecateAgent ? `task-tools-${agentTurn}` : "";
     const runID = isHecateAgent ? `run-tools-${agentTurn}` : "";
     const firstTaskNeedsApproval = isHecateAgent && agentTurn === 1 && !taskApprovalResolved;
@@ -1064,7 +1060,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     messages.push(
       {
         id: `msg-user-${turn}`,
-        runtime_kind: runtimeKind,
+        execution_mode: runtimeKind,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         provider: body.provider || "",
@@ -1075,7 +1071,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       },
       {
         id: `msg-assistant-${turn}`,
-        runtime_kind: runtimeKind,
+        execution_mode: runtimeKind,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         run_id: isHecateAgent ? runID : undefined,
@@ -1129,7 +1125,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
 
     session = {
       ...session,
-      runtime_kind: runtimeKind,
+      execution_mode: runtimeKind,
       provider: body.provider || "",
       model: body.model,
       capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -1179,13 +1175,13 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
   await expect(page.getByLabel("Tools off segment using qwen2.5")).toHaveCount(1);
 
   expect(createSessionCount).toBe(1);
-  expect(submittedTurns.map((turn) => turn.runtime_kind)).toEqual(["agent", "model", "agent"]);
+  expect(submittedTurns.map((turn) => turn.execution_mode)).toEqual(["hecate_task", "direct_model", "hecate_task"]);
   expect(submittedTurns.map((turn) => turn.content)).toEqual([
     "first with tools",
     "direct model turn",
     "tools again",
   ]);
-  expect(submittedTurns.filter((turn) => turn.runtime_kind === "agent")).toEqual([
+  expect(submittedTurns.filter((turn) => turn.execution_mode === "hecate_task")).toEqual([
     expect.objectContaining({ model: "qwen2.5", workspace: "/tmp/hecate-e2e-workspace" }),
     expect.objectContaining({ model: "qwen2.5", workspace: "/tmp/hecate-e2e-workspace" }),
   ]);
@@ -1200,7 +1196,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     window.localStorage.setItem("hecate.chatSessionID", "chat-busy-e2e");
     window.localStorage.setItem(
       "hecate.chatTargetBySessionID",
-      JSON.stringify({ "chat-busy-e2e": "model" }),
+      JSON.stringify({ "chat-busy-e2e": "direct_model" }),
     );
     window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
   });
@@ -1227,7 +1223,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
   const session = {
     id: "chat-busy-e2e",
     title: "busy tools turn",
-    runtime_kind: "model",
+    agent_id: "hecate",
     provider: "lmstudio",
     model: "qwen2.5",
     capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -1239,7 +1235,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     segments: [
       {
         id: "model:first",
-        runtime_kind: "model",
+        execution_mode: "direct_model",
         provider: "lmstudio",
         model: "qwen2.5",
         status: "completed",
@@ -1247,7 +1243,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
       },
       {
         id: "task:task-busy-e2e",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         provider: "lmstudio",
         model: "qwen2.5",
         task_id: "task-busy-e2e",
@@ -1259,7 +1255,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     messages: [
       {
         id: "msg-user",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         segment_id: "task:task-busy-e2e",
         task_id: "task-busy-e2e",
         role: "user",
@@ -1268,7 +1264,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
       },
       {
         id: "msg-assistant",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         segment_id: "task:task-busy-e2e",
         task_id: "task-busy-e2e",
         run_id: "run-busy-e2e",
@@ -1347,10 +1343,10 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
 
-  await expect(page.getByText("Tools off · /tmp/hecate-e2e-workspace")).toBeVisible();
+  await expect(page.getByText("Tools on · /tmp/hecate-e2e-workspace")).toBeVisible();
   await expect(page.getByRole("button", { name: "Fixed model: qwen2.5" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Stop active task" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Open task" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Open task", exact: true })).toBeVisible();
   await expect(page.getByText(/Hecate Chat is still working on this task/)).toBeVisible();
   await expect(page.getByText("Backing task")).toBeVisible();
 
@@ -1397,7 +1393,7 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
   const pendingSession = {
     id: "chat-approval-refresh-e2e",
     title: "approval refresh",
-    runtime_kind: "agent",
+    agent_id: "hecate",
     provider: "lmstudio",
     model: "qwen2.5",
     capabilities: { tool_calling: "basic", streaming: true, source: "operator_override" },
@@ -1409,7 +1405,7 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
     segments: [
       {
         id: "task:task-approval-refresh-e2e",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         provider: "lmstudio",
         model: "qwen2.5",
         task_id: "task-approval-refresh-e2e",
@@ -1421,7 +1417,7 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
     messages: [
       {
         id: "msg-user-approval",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         segment_id: "task:task-approval-refresh-e2e",
         task_id: "task-approval-refresh-e2e",
         role: "user",
@@ -1430,7 +1426,7 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
       },
       {
         id: "msg-assistant-approval",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         segment_id: "task:task-approval-refresh-e2e",
         task_id: "task-approval-refresh-e2e",
         run_id: "run-approval-refresh-e2e",
@@ -1747,6 +1743,7 @@ test("selected-model readiness can switch to the backend-suggested fallback mode
     window.localStorage.setItem("hecate.chatTarget", "model");
     window.localStorage.setItem("hecate.providerFilter", "anthropic");
     window.localStorage.setItem("hecate.model", "claude-sonnet-4-6");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
   });
 
   await page.goto("/");
@@ -1787,8 +1784,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
           {
             id: "a-e2e-1",
             title: "E2E approval test",
-            runtime_kind: "external_agent",
-            adapter_id: "codex",
+            agent_id: "codex",
             status: "running",
             message_count: 0,
           },
@@ -1821,7 +1817,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
           {
             id: "ap-e2e-1",
             session_id: "a-e2e-1",
-            adapter_id: "codex",
+            agent_id: "codex",
             tool_kind: "fs",
             tool_name: "write_file",
             status: "pending",
@@ -1844,7 +1840,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
         data: {
           id: "ap-e2e-1",
           session_id: "a-e2e-1",
-          adapter_id: "codex",
+          agent_id: "codex",
           tool_kind: "fs",
           tool_name: "write_file",
           status: "pending",
@@ -1869,7 +1865,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
         data: {
           id: "ap-e2e-1",
           session_id: "a-e2e-1",
-          adapter_id: "codex",
+          agent_id: "codex",
           tool_kind: "fs",
           status: "resolved",
           acp_options: [],
@@ -1896,8 +1892,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
         data: {
           id: "a-e2e-1",
           title: "E2E approval test",
-          runtime_kind: "external_agent",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp/e2e",
           status: "running",
           messages: [],
@@ -1949,8 +1944,7 @@ test("agent changed-files review inspects and reverts a captured file", async ({
           {
             id: "a-diff-1",
             title: "Diff review",
-            runtime_kind: "external_agent",
-            adapter_id: "codex",
+            agent_id: "codex",
             status: "completed",
             message_count: 2,
           },
@@ -1964,8 +1958,7 @@ test("agent changed-files review inspects and reverts a captured file", async ({
     data: {
       id: "a-diff-1",
       title: "Diff review",
-      runtime_kind: "external_agent",
-      adapter_id: "codex",
+      agent_id: "codex",
       workspace: "/tmp/e2e",
       status: "completed",
       messages: [
@@ -1974,8 +1967,8 @@ test("agent changed-files review inspects and reverts a captured file", async ({
           id: "m-agent",
           role: "assistant",
           content: "Updated the docs.",
-          adapter_id: "codex",
-          adapter_name: "Codex",
+          agent_id: "codex",
+          agent_name: "Codex",
           status: "completed",
           diff_stat:
             "README.md | 3 ++-\ndocs/runtime-api.md | 4 ++++\n2 files changed, 6 insertions(+), 1 deletion(-)",
@@ -2120,7 +2113,7 @@ async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture
                 ? { ...adapter, auth_status: "ok", auth_error: undefined }
                 : adapter,
             health: {
-              adapter_id: "claude_code",
+              agent_id: "claude_code",
               status,
               stage:
                 status === "ready"
@@ -2152,9 +2145,8 @@ async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture
   const session = {
     id: "claude-code-onboarding-e2e",
     title: "Claude Code chat",
-    runtime_kind: "external_agent",
-    adapter_id: "claude_code",
-    adapter_name: "Claude Code",
+    agent_id: "claude_code",
+    agent_name: "Claude Code",
     driver_kind: "acp",
     native_session_id: "native-claude-code-e2e",
     workspace: "/tmp/hecate-e2e",
@@ -2358,7 +2350,7 @@ test("Claude Code valid token save clears onboarding and enables chat", async ({
       body: JSON.stringify({
         object: "agent_adapter_credential",
         data: {
-          adapter_id: "claude_code",
+          agent_id: "claude_code",
           name: "CLAUDE_CODE_OAUTH_TOKEN",
           configured: true,
           preview: "sk-v...7890",
@@ -2394,7 +2386,7 @@ test("Claude Code valid token save clears onboarding and enables chat", async ({
           data: {
             adapter,
             health: {
-              adapter_id: "claude_code",
+              agent_id: "claude_code",
               status: "ready",
               stage: "ready",
               path: "/usr/local/bin/claude-agent-acp",
@@ -2418,9 +2410,8 @@ test("Claude Code valid token save clears onboarding and enables chat", async ({
   const session = {
     id: "claude-code-token-e2e",
     title: "Claude Code chat",
-    runtime_kind: "external_agent",
-    adapter_id: "claude_code",
-    adapter_name: "Claude Code",
+    agent_id: "claude_code",
+    agent_name: "Claude Code",
     driver_kind: "acp",
     native_session_id: "native-claude-token-e2e",
     workspace: "/tmp/hecate-e2e",

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1821,7 +1821,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
           {
             id: "ap-e2e-1",
             session_id: "a-e2e-1",
-            agent_id: "codex",
+            adapter_id: "codex",
             tool_kind: "fs",
             tool_name: "write_file",
             status: "pending",
@@ -1844,7 +1844,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
         data: {
           id: "ap-e2e-1",
           session_id: "a-e2e-1",
-          agent_id: "codex",
+          adapter_id: "codex",
           tool_kind: "fs",
           tool_name: "write_file",
           status: "pending",
@@ -1869,7 +1869,7 @@ test("agent approval banner: review, allow, banner clears", async ({ page }) => 
         data: {
           id: "ap-e2e-1",
           session_id: "a-e2e-1",
-          agent_id: "codex",
+          adapter_id: "codex",
           tool_kind: "fs",
           status: "resolved",
           acp_options: [],
@@ -2117,7 +2117,7 @@ async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture
                 ? { ...adapter, auth_status: "ok", auth_error: undefined }
                 : adapter,
             health: {
-              agent_id: "claude_code",
+              adapter_id: "claude_code",
               status,
               stage:
                 status === "ready"
@@ -2354,7 +2354,7 @@ test("Claude Code valid token save clears onboarding and enables chat", async ({
       body: JSON.stringify({
         object: "agent_adapter_credential",
         data: {
-          agent_id: "claude_code",
+          adapter_id: "claude_code",
           name: "CLAUDE_CODE_OAUTH_TOKEN",
           configured: true,
           preview: "sk-v...7890",
@@ -2390,7 +2390,7 @@ test("Claude Code valid token save clears onboarding and enables chat", async ({
           data: {
             adapter,
             health: {
-              agent_id: "claude_code",
+              adapter_id: "claude_code",
               status: "ready",
               stage: "ready",
               path: "/usr/local/bin/claude-agent-acp",

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1175,7 +1175,11 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
   await expect(page.getByLabel("Tools off segment using qwen2.5")).toHaveCount(1);
 
   expect(createSessionCount).toBe(1);
-  expect(submittedTurns.map((turn) => turn.execution_mode)).toEqual(["hecate_task", "direct_model", "hecate_task"]);
+  expect(submittedTurns.map((turn) => turn.execution_mode)).toEqual([
+    "hecate_task",
+    "direct_model",
+    "hecate_task",
+  ]);
   expect(submittedTurns.map((turn) => turn.content)).toEqual([
     "first with tools",
     "direct model turn",

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -473,7 +473,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       const content = String(body.content || "");
       const runtimeKind =
         body.execution_mode ||
-        (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
+        (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "direct_model");
       session.messages.push(
         {
           id: `agent-msg-user-${chatSequence}`,

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -371,10 +371,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       if (method === "POST") {
         const body = JSON.parse(request.postData() || "{}");
         const isExternalAgentID = Boolean(body.agent_id && body.agent_id !== "hecate");
-        const runtimeKind =
-          body.execution_mode || (isExternalAgentID ? "external_agent" : "hecate_task");
         const adapter = MOCK_AGENT_ADAPTERS.find((item) => item.id === body.agent_id);
-        const isExternal = runtimeKind === "external_agent";
+        const isExternal = isExternalAgentID;
         const session = {
           id: `chat-e2e-${chatSequence++}`,
           title:
@@ -471,23 +469,23 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
     if (parts[1] === "messages" && method === "POST" && parts.length === 2) {
       const body = JSON.parse(request.postData() || "{}");
       const content = String(body.content || "");
-      const runtimeKind =
+      const executionMode =
         body.execution_mode ||
         (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "direct_model");
       session.messages.push(
         {
           id: `agent-msg-user-${chatSequence}`,
-          execution_mode: runtimeKind,
+          execution_mode: executionMode,
           role: "user",
           content,
           created_at: now(),
         },
         {
           id: `agent-msg-assistant-${chatSequence}`,
-          execution_mode: runtimeKind,
+          execution_mode: executionMode,
           role: "assistant",
           content:
-            runtimeKind === "direct_model"
+            executionMode === "direct_model"
               ? `Direct response to: ${content}`
               : `Agent response to: ${content}`,
           status: "completed",
@@ -495,10 +493,12 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           model: body.model || session.model,
           workspace: session.workspace,
           run_id:
-            runtimeKind === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
+            executionMode === "direct_model"
+              ? `model_run_${chatSequence}`
+              : `run_${chatSequence}`,
           request_id: `req_${chatSequence}`,
           trace_id: `trace_${chatSequence}`,
-          cost_mode: runtimeKind === "external_agent" ? "external" : "hecate",
+          cost_mode: executionMode === "external_agent" ? "external" : "hecate",
           created_at: now(),
         },
       );

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -493,9 +493,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           model: body.model || session.model,
           workspace: session.workspace,
           run_id:
-            executionMode === "direct_model"
-              ? `model_run_${chatSequence}`
-              : `run_${chatSequence}`,
+            executionMode === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
           request_id: `req_${chatSequence}`,
           trace_id: `trace_${chatSequence}`,
           cost_mode: executionMode === "external_agent" ? "external" : "hecate",

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -370,17 +370,17 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       }
       if (method === "POST") {
         const body = JSON.parse(request.postData() || "{}");
-        const runtimeKind = body.runtime_kind || (body.adapter_id ? "external_agent" : "agent");
-        const adapter = MOCK_AGENT_ADAPTERS.find((item) => item.id === body.adapter_id);
+        const isExternalAgentID = Boolean(body.agent_id && body.agent_id !== "hecate");
+        const runtimeKind = body.execution_mode || (isExternalAgentID ? "external_agent" : "hecate_task");
+        const adapter = MOCK_AGENT_ADAPTERS.find((item) => item.id === body.agent_id);
         const isExternal = runtimeKind === "external_agent";
         const session = {
           id: `chat-e2e-${chatSequence++}`,
           title:
             body.title ||
             (isExternal ? `${adapter?.name || "External agent"} chat` : "Hecate chat"),
-          runtime_kind: runtimeKind,
-          adapter_id: body.adapter_id || "",
-          adapter_name: adapter?.name || "",
+          agent_id: body.agent_id || "hecate",
+          agent_name: adapter?.name || "",
           driver_kind: isExternal ? "acp" : "",
           native_session_id: isExternal ? `native-${chatSequence}` : "",
           provider: body.provider || "auto",
@@ -470,28 +470,29 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
     if (parts[1] === "messages" && method === "POST" && parts.length === 2) {
       const body = JSON.parse(request.postData() || "{}");
       const content = String(body.content || "");
-      const runtimeKind = body.runtime_kind || session.runtime_kind || "agent";
+      const runtimeKind =
+        body.execution_mode || (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
       session.messages.push(
         {
           id: `agent-msg-user-${chatSequence}`,
-          runtime_kind: runtimeKind,
+          execution_mode: runtimeKind,
           role: "user",
           content,
           created_at: now(),
         },
         {
           id: `agent-msg-assistant-${chatSequence}`,
-          runtime_kind: runtimeKind,
+          execution_mode: runtimeKind,
           role: "assistant",
           content:
-            runtimeKind === "model"
+            runtimeKind === "direct_model"
               ? `Direct response to: ${content}`
               : `Agent response to: ${content}`,
           status: "completed",
           provider: body.provider || session.provider,
           model: body.model || session.model,
           workspace: session.workspace,
-          run_id: runtimeKind === "model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
+          run_id: runtimeKind === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
           request_id: `req_${chatSequence}`,
           trace_id: `trace_${chatSequence}`,
           cost_mode: runtimeKind === "external_agent" ? "external" : "hecate",
@@ -499,7 +500,6 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
         },
       );
       chatSequence += 1;
-      session.runtime_kind = runtimeKind;
       session.provider = body.provider || session.provider;
       session.model = body.model || session.model;
       session.status = "completed";

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -371,7 +371,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       if (method === "POST") {
         const body = JSON.parse(request.postData() || "{}");
         const isExternalAgentID = Boolean(body.agent_id && body.agent_id !== "hecate");
-        const runtimeKind = body.execution_mode || (isExternalAgentID ? "external_agent" : "hecate_task");
+        const runtimeKind =
+          body.execution_mode || (isExternalAgentID ? "external_agent" : "hecate_task");
         const adapter = MOCK_AGENT_ADAPTERS.find((item) => item.id === body.agent_id);
         const isExternal = runtimeKind === "external_agent";
         const session = {
@@ -471,7 +472,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       const body = JSON.parse(request.postData() || "{}");
       const content = String(body.content || "");
       const runtimeKind =
-        body.execution_mode || (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
+        body.execution_mode ||
+        (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
       session.messages.push(
         {
           id: `agent-msg-user-${chatSequence}`,
@@ -492,7 +494,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           provider: body.provider || session.provider,
           model: body.model || session.model,
           workspace: session.workspace,
-          run_id: runtimeKind === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
+          run_id:
+            runtimeKind === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
           request_id: `req_${chatSequence}`,
           trace_id: `trace_${chatSequence}`,
           cost_mode: runtimeKind === "external_agent" ? "external" : "hecate",

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -180,7 +180,7 @@ describe("ConsoleShell navigation", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Active Cursor work",
-        adapter_id: "cursor_agent",
+        agent_id: "cursor_agent",
         workspace: "/Users/alice/dev/hecate",
         workspace_branch: "main",
         status: "completed",
@@ -206,7 +206,7 @@ describe("ConsoleShell navigation", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Codex work",
-        adapter_id: "codex",
+        agent_id: "codex",
         workspace: "/Users/alice/dev/hecate",
         workspace_branch: "main",
         status: "completed",

--- a/ui/src/app/runtimeConsoleChatHelpers.test.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.test.ts
@@ -289,7 +289,7 @@ describe("renderChatSessionSummary", () => {
     const session: ChatSessionRecord = {
       id: "ac1",
       title: "agent t",
-      adapter_id: "codex",
+      agent_id: "codex",
       driver_kind: "acp",
       native_session_id: "n1",
       workspace: "/repo",
@@ -302,7 +302,7 @@ describe("renderChatSessionSummary", () => {
     };
     const out = renderChatSessionSummary(session);
     expect(out.message_count).toBe(2);
-    expect(out.adapter_id).toBe("codex");
+    expect(out.agent_id).toBe("codex");
     expect(out.workspace_branch).toBe("main");
     expect(out.status).toBe("running");
   });

--- a/ui/src/app/runtimeConsoleChatHelpers.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.ts
@@ -221,8 +221,7 @@ export function renderChatSessionSummary(
   return {
     id: session.id,
     title: session.title,
-    runtime_kind: session.runtime_kind,
-    adapter_id: session.adapter_id,
+    agent_id: session.agent_id,
     driver_kind: session.driver_kind,
     native_session_id: session.native_session_id,
     task_id: session.task_id,

--- a/ui/src/app/runtimeConsoleDashboard.test.ts
+++ b/ui/src/app/runtimeConsoleDashboard.test.ts
@@ -135,7 +135,7 @@ describe("resolveDashboardSnapshot", () => {
         {
           id: "ac1",
           title: "old",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/repo",
           status: "running",
           message_count: 0,
@@ -162,7 +162,7 @@ describe("resolveDashboardSnapshot", () => {
         {
           id: "ac1",
           title: "current",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/repo",
           status: "running",
           message_count: 0,
@@ -175,7 +175,7 @@ describe("resolveDashboardSnapshot", () => {
       activeChatSession: {
         id: "ac1",
         title: "stale",
-        adapter_id: "codex",
+        agent_id: "codex",
         workspace: "/repo",
         status: "running",
       },

--- a/ui/src/app/state/_shared.test.ts
+++ b/ui/src/app/state/_shared.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { parseQueuedChatMessageList } from "./_shared";
+
+describe("parseQueuedChatMessageList", () => {
+  it("keeps valid queued chat messages", () => {
+    expect(
+      parseQueuedChatMessageList([
+        {
+          id: "queued-1",
+          session_id: "chat-1",
+          content: "continue",
+          execution_mode: "direct_model",
+          provider_filter: "auto",
+          model: "gpt-4o-mini",
+          workspace: "/tmp/hecate",
+          system_prompt: "Be concise.",
+          agent_id: "hecate",
+          created_at: "2026-05-18T10:00:00.000Z",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "queued-1",
+        session_id: "chat-1",
+        content: "continue",
+        execution_mode: "direct_model",
+        provider_filter: "auto",
+        model: "gpt-4o-mini",
+        workspace: "/tmp/hecate",
+        system_prompt: "Be concise.",
+        agent_id: "hecate",
+        created_at: "2026-05-18T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("drops queued chat messages without a supported execution mode", () => {
+    expect(
+      parseQueuedChatMessageList([
+        {
+          id: "legacy-queued-model",
+          session_id: "chat-1",
+          content: "legacy direct turn",
+          runtime_kind: "model",
+        },
+        {
+          id: "queued-tools",
+          session_id: "chat-1",
+          content: "valid tools turn",
+          execution_mode: "hecate_task",
+        },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        id: "queued-tools",
+        execution_mode: "hecate_task",
+      }),
+    ]);
+  });
+});

--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -62,7 +62,7 @@ export function chatTargetToExecutionMode(target: ChatTarget): ChatExecutionMode
   }
 }
 
-export function executionModeToChatTarget(mode: string): ChatTarget {
+export function executionModeToChatTarget(mode: string): ChatTarget | "" {
   switch (mode) {
     case "direct_model":
       return "model";
@@ -71,7 +71,7 @@ export function executionModeToChatTarget(mode: string): ChatTarget {
     case "external_agent":
       return "external_agent";
     default:
-      return "agent";
+      return "";
   }
 }
 

--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -18,17 +18,18 @@ import type { ProviderFilter } from "../../types/provider";
 
 export type ChatTarget = "model" | "agent" | "external_agent";
 export type HecateChatTarget = "model" | "agent";
+export type ChatExecutionMode = "direct_model" | "hecate_task" | "external_agent";
 
 export type QueuedChatMessage = {
   id: string;
   session_id: string;
   content: string;
-  runtime_kind: ChatTarget;
+  execution_mode: ChatExecutionMode;
   provider_filter: ProviderFilter;
   model: string;
   workspace: string;
   system_prompt: string;
-  adapter_id: string;
+  agent_id: string;
   created_at: string;
 };
 
@@ -36,16 +37,39 @@ export const queuedChatMessagesStorageKey = "hecate.queuedChatMessages";
 
 // Coercive normalizer — drops unknown values onto the safe default
 // rather than rejecting them. Used by code paths where the wider
-// type system has already vouched for the input (e.g. an
-// `ChatSessionRecord.runtime_kind` field straight off the
-// wire). For localStorage reads use the strict
-// `parseStoredChatTarget` below so corrupt keys get wiped.
+// type system has already vouched for the input. For localStorage
+// reads use the strict `parseStoredChatTarget` below so corrupt keys
+// get wiped.
 export function normalizeStoredChatTarget(value: string): ChatTarget {
   switch (value) {
     case "model":
     case "agent":
     case "external_agent":
       return value;
+    default:
+      return "agent";
+  }
+}
+
+export function chatTargetToExecutionMode(target: ChatTarget): ChatExecutionMode {
+  switch (target) {
+    case "model":
+      return "direct_model";
+    case "agent":
+      return "hecate_task";
+    case "external_agent":
+      return "external_agent";
+  }
+}
+
+export function executionModeToChatTarget(mode: string): ChatTarget {
+  switch (mode) {
+    case "direct_model":
+      return "model";
+    case "hecate_task":
+      return "agent";
+    case "external_agent":
+      return "external_agent";
     default:
       return "agent";
   }
@@ -94,9 +118,12 @@ export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[]
         id,
         session_id: sessionID,
         content,
-        runtime_kind: normalizeStoredChatTarget(
-          typeof item.runtime_kind === "string" ? item.runtime_kind : "",
-        ),
+        execution_mode:
+          item.execution_mode === "direct_model" ||
+          item.execution_mode === "hecate_task" ||
+          item.execution_mode === "external_agent"
+            ? item.execution_mode
+            : "hecate_task",
         provider_filter:
           typeof item.provider_filter === "string"
             ? (item.provider_filter as ProviderFilter)
@@ -104,7 +131,7 @@ export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[]
         model: typeof item.model === "string" ? item.model : "",
         workspace: typeof item.workspace === "string" ? item.workspace : "",
         system_prompt: typeof item.system_prompt === "string" ? item.system_prompt : "",
-        adapter_id: typeof item.adapter_id === "string" ? item.adapter_id : "",
+        agent_id: typeof item.agent_id === "string" ? item.agent_id : "",
         created_at:
           typeof item.created_at === "string" ? item.created_at : new Date().toISOString(),
       },

--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -113,17 +113,19 @@ export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[]
     const sessionID = typeof item.session_id === "string" ? item.session_id : "";
     const content = typeof item.content === "string" ? item.content : "";
     if (!id || !sessionID || !content.trim()) return [];
+    const executionMode =
+      item.execution_mode === "direct_model" ||
+      item.execution_mode === "hecate_task" ||
+      item.execution_mode === "external_agent"
+        ? item.execution_mode
+        : "";
+    if (!executionMode) return [];
     return [
       {
         id,
         session_id: sessionID,
         content,
-        execution_mode:
-          item.execution_mode === "direct_model" ||
-          item.execution_mode === "hecate_task" ||
-          item.execution_mode === "external_agent"
-            ? item.execution_mode
-            : "hecate_task",
+        execution_mode: executionMode,
         provider_filter:
           typeof item.provider_filter === "string"
             ? (item.provider_filter as ProviderFilter)

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -327,7 +327,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       model,
       workspace: agentWorkspace.trim(),
       system_prompt: systemPrompt,
-      agent_id: agentAdapterID,
+      agent_id: executionMode === "external_agent" ? agentAdapterID : "hecate",
       created_at: new Date().toISOString(),
     };
   }

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -369,7 +369,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const content = (queued?.content ?? message).trim();
     if (!content) return;
 
-    const turnExecutionMode = queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
+    const turnExecutionMode =
+      queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
     if (!queued && activeChatSessionID && chatSessionIsBusy(activeChatSession)) {
       queueChatMessage(content, turnExecutionMode, activeChatSessionID);
       return;

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -683,6 +683,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
           : {}),
       });
       setActiveChatSessionID(created.data.id);
+      setChatTargetBySessionID((current) => {
+        const next = new Map(current);
+        next.set(created.data.id, defaultChatTarget);
+        return next;
+      });
       applyChatSession(created.data);
     } catch (error) {
       setChatErrorState(error, "failed to create Hecate chat");

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -45,7 +45,12 @@ import {
   deriveChatSessionTitle,
   renderChatSessionSummary,
 } from "../../runtimeConsoleChatHelpers";
-import { type ChatTarget, type QueuedChatMessage } from "../_shared";
+import {
+  type ChatExecutionMode,
+  type ChatTarget,
+  type QueuedChatMessage,
+  chatTargetToExecutionMode,
+} from "../_shared";
 import { useApprovals } from "../approvals";
 import { useChat } from "../chat";
 import { useProvidersAndModels } from "../providersAndModels";
@@ -69,7 +74,7 @@ export type UseChatActionsParams = {
 };
 
 function chatSessionIsExternal(session: ChatSessionRecord | null): boolean {
-  return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);
+  return Boolean(session?.agent_id && session.agent_id !== "hecate");
 }
 
 function chatSessionIsBusy(session: ChatSessionRecord | null): boolean {
@@ -92,14 +97,14 @@ function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null)
   }
   const segments = [...(session.segments ?? [])].reverse();
   const segment = segments.find(
-    (item) => item.runtime_kind === "agent" || item.runtime_kind === "model",
+    (item) => item.execution_mode === "hecate_task" || item.execution_mode === "direct_model",
   );
   if (segment?.provider || segment?.model) {
     return { provider: segment.provider ?? "", model: segment.model ?? "" };
   }
   const messages = [...(session.messages ?? [])].reverse();
   const message = messages.find(
-    (item) => item.runtime_kind === "agent" || item.runtime_kind === "model",
+    (item) => item.execution_mode === "hecate_task" || item.execution_mode === "direct_model",
   );
   if (message?.provider || message?.model) {
     return { provider: message.provider ?? "", model: message.model ?? "" };
@@ -310,27 +315,27 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
   function buildQueuedChatMessage(
     content: string,
-    runtimeKind: ChatTarget,
+    executionMode: ChatExecutionMode,
     sessionID: string,
   ): QueuedChatMessage {
     return {
       id: `queued-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       session_id: sessionID,
       content,
-      runtime_kind: runtimeKind,
+      execution_mode: executionMode,
       provider_filter: providerFilter,
       model,
       workspace: agentWorkspace.trim(),
       system_prompt: systemPrompt,
-      adapter_id: agentAdapterID,
+      agent_id: agentAdapterID,
       created_at: new Date().toISOString(),
     };
   }
 
-  function queueChatMessage(content: string, runtimeKind: ChatTarget, sessionID: string) {
+  function queueChatMessage(content: string, executionMode: ChatExecutionMode, sessionID: string) {
     setQueuedChatMessages((current) => [
       ...current,
-      buildQueuedChatMessage(content, runtimeKind, sessionID),
+      buildQueuedChatMessage(content, executionMode, sessionID),
     ]);
     setMessage("");
   }
@@ -364,28 +369,22 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const content = (queued?.content ?? message).trim();
     if (!content) return;
 
-    const turnRuntimeKind =
-      queued?.runtime_kind ??
-      (params.chatTarget === "external_agent"
-        ? "external_agent"
-        : params.chatTarget === "agent"
-          ? "agent"
-          : "model");
+    const turnExecutionMode = queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
     if (!queued && activeChatSessionID && chatSessionIsBusy(activeChatSession)) {
-      queueChatMessage(content, turnRuntimeKind, activeChatSessionID);
+      queueChatMessage(content, turnExecutionMode, activeChatSessionID);
       return;
     }
 
     setChatLoading(true);
     clearChatErrorState();
     setRuntimeHeaders(null);
-    const isExternalAgent = turnRuntimeKind === "external_agent";
-    const isModelTurn = turnRuntimeKind === "model";
+    const isExternalAgent = turnExecutionMode === "external_agent";
+    const isModelTurn = turnExecutionMode === "direct_model";
     const turnProviderFilter = queued?.provider_filter ?? providerFilter;
     const turnModel = queued?.model ?? model;
     const turnWorkspace = queued?.workspace ?? agentWorkspace.trim();
     const turnSystemPrompt = queued?.system_prompt ?? systemPrompt;
-    const turnAdapterID = queued?.adapter_id ?? agentAdapterID;
+    const turnAgentID = queued?.agent_id ?? agentAdapterID;
     setStreamingContent(
       isExternalAgent
         ? "Starting external agent..."
@@ -414,8 +413,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         sessionID = "";
         setActiveChatSessionID("");
       }
-      if (sessionID && activeChatSession?.runtime_kind) {
-        const activeExternal = activeChatSession.runtime_kind === "external_agent";
+      if (sessionID && activeChatSession?.agent_id) {
+        const activeExternal = activeChatSession.agent_id !== "hecate";
         if (activeExternal !== isExternalAgent) {
           sessionID = "";
           setActiveChatSessionID("");
@@ -425,13 +424,13 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       if (!sessionID) {
         const created = await createChatSessionRequest({
           title: deriveChatSessionTitle(content),
-          runtime_kind: turnRuntimeKind,
-          ...(isExternalAgent
-            ? { adapter_id: turnAdapterID }
-            : {
+          agent_id: isExternalAgent ? turnAgentID : "hecate",
+          ...(!isExternalAgent
+            ? {
                 provider: turnProviderFilter === "auto" ? "" : turnProviderFilter,
                 model: turnModel,
-              }),
+              }
+            : {}),
           ...(!isModelTurn ? { workspace: turnWorkspace } : {}),
           ...(!isExternalAgent ? { rtk_enabled: hecateRTKEnabled } : {}),
         });
@@ -450,7 +449,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
                 ...(prev.messages ?? []),
                 {
                   id: `pending-agent-user-${Date.now()}`,
-                  runtime_kind: turnRuntimeKind,
+                  execution_mode: turnExecutionMode,
                   provider: !isExternalAgent
                     ? turnProviderFilter === "auto"
                       ? ""
@@ -508,12 +507,12 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       });
       const updated = await createChatMessageRequest(sessionID, {
         content: pendingContent,
-        runtime_kind: turnRuntimeKind,
+        execution_mode: turnExecutionMode,
         ...(!isExternalAgent
           ? { provider: turnProviderFilter === "auto" ? "" : turnProviderFilter, model: turnModel }
           : {}),
         ...(!isExternalAgent ? { system_prompt: turnSystemPrompt } : {}),
-        ...(turnRuntimeKind === "agent" ? { workspace: turnWorkspace } : {}),
+        ...(turnExecutionMode === "hecate_task" ? { workspace: turnWorkspace } : {}),
       });
       applyChatSession(updated.data);
     } catch (submitError) {
@@ -629,8 +628,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         const adapter = agentAdapters.find((item) => item.id === agentAdapterID);
         const created = await createChatSessionRequest({
           title: adapter ? `${adapter.name} chat` : "External agent chat",
-          runtime_kind: "external_agent",
-          adapter_id: agentAdapterID,
+          agent_id: agentAdapterID,
           workspace,
         });
         setActiveChatSessionID(created.data.id);
@@ -647,9 +645,9 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       return;
     }
 
-    const runtimeKind = defaultChatTarget === "model" ? "model" : "agent";
+    const executionMode = chatTargetToExecutionMode(defaultChatTarget);
     const workspace = agentWorkspace.trim();
-    if (runtimeKind === "agent" && !workspace) {
+    if (executionMode === "hecate_task" && !workspace) {
       setChatErrorState(
         chatGuardError(
           "Choose a workspace before starting a Hecate chat with tools.",
@@ -673,10 +671,10 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     clearChatErrorState();
     try {
       const created = await createChatSessionRequest({
-        runtime_kind: runtimeKind,
+        agent_id: "hecate",
         provider: providerFilter === "auto" ? "" : providerFilter,
         model,
-        ...(runtimeKind === "agent"
+        ...(executionMode === "hecate_task"
           ? {
               workspace,
               rtk_enabled: hecateRTKEnabled,
@@ -705,8 +703,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     try {
       const payload = await getChatSession(id);
       setActiveChatSession(payload.data);
-      if (payload.data.adapter_id) {
-        setAgentAdapterID(payload.data.adapter_id);
+      if (payload.data.agent_id && payload.data.agent_id !== "hecate") {
+        setAgentAdapterID(payload.data.agent_id);
       }
       const selection = deriveHecateChatSelectionFromSession(payload.data);
       if (selection.provider) {

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -14,27 +14,34 @@ import { CoordinatorOverridesContext } from "./coordinators/overrides";
 import { useProvidersAndModels } from "./providersAndModels";
 import { useRuntime } from "./runtime";
 import { deriveSessionState, type SessionState } from "../runtimeConsoleDashboard";
-import { type ChatTarget, type HecateChatTarget, normalizeStoredHecateChatTarget } from "./_shared";
+import {
+  type ChatTarget,
+  type HecateChatTarget,
+  executionModeToChatTarget,
+  normalizeStoredHecateChatTarget,
+} from "./_shared";
 import type { ChatSessionRecord } from "../../types/chat";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderRecord } from "../../types/provider";
 
 function chatSessionIsExternal(session: ChatSessionRecord | null): boolean {
-  return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);
+  return Boolean(session?.agent_id && session.agent_id !== "hecate");
 }
 
 function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): HecateChatTarget {
   if (!session) return "agent";
   const messages = session.messages ?? [];
   for (let i = messages.length - 1; i >= 0; i--) {
-    const target = normalizeStoredHecateChatTarget(messages[i]?.runtime_kind ?? "");
+    const target = normalizeStoredHecateChatTarget(
+      executionModeToChatTarget(messages[i]?.execution_mode ?? ""),
+    );
     if (target) return target;
   }
-  return normalizeStoredHecateChatTarget(session.runtime_kind ?? "") || "agent";
+  return "agent";
 }
 
 // chatTarget gates several views' route/copy decisions. The active
-// agent-chat session forces a target via its runtime_kind / adapter_id
+// agent-chat session forces a target via its agent_id
 // shape; the per-session map override (used by Hecate Chat to flip
 // between agent and direct model) and the default target take effect
 // only when nothing in the session pins the target.

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -40,6 +40,21 @@ function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): H
   return "agent";
 }
 
+function hecateTaskStatusIsActive(status?: string): boolean {
+  return status === "queued" || status === "running" || status === "awaiting_approval";
+}
+
+function sessionHasActiveHecateTaskSegment(session: ChatSessionRecord | null): boolean {
+  if (!session) return false;
+  if (session.task_id && hecateTaskStatusIsActive(session.status)) return true;
+  return (session.segments ?? []).some(
+    (segment) =>
+      segment.execution_mode === "hecate_task" &&
+      Boolean(segment.task_id) &&
+      hecateTaskStatusIsActive(segment.status),
+  );
+}
+
 // chatTarget gates several views' route/copy decisions. The active
 // agent-chat session forces a target via its agent_id
 // shape; the per-session map override (used by Hecate Chat to flip
@@ -54,6 +69,7 @@ export function useChatTarget(): ChatTarget {
   if (overrides?.derivedChatTarget) return overrides.derivedChatTarget;
   if (state.activeChatSessionID && state.activeChatSession) {
     if (chatSessionIsExternal(state.activeChatSession)) return "external_agent";
+    if (sessionHasActiveHecateTaskSegment(state.activeChatSession)) return "agent";
     return (
       state.chatTargetBySessionID.get(state.activeChatSessionID) ??
       deriveHecateChatTargetFromSession(state.activeChatSession)

--- a/ui/src/app/state/rootEffects.ts
+++ b/ui/src/app/state/rootEffects.ts
@@ -30,10 +30,8 @@ import { useDashboardActions } from "./coordinators/dashboard";
 import { useSettingsActions } from "./coordinators/settings";
 import type { ConfiguredStateResponse } from "../../types/provider";
 
-function chatSessionIsExternal(
-  session: { runtime_kind?: string; adapter_id?: string } | null,
-): boolean {
-  return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);
+function chatSessionIsExternal(session: { agent_id?: string } | null): boolean {
+  return Boolean(session?.agent_id && session.agent_id !== "hecate");
 }
 
 function chatSessionIsBusy(

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -421,13 +421,14 @@ export function ExternalAgentConfigControls({
   onChange,
   placement = "header",
 }: {
-  session: { id?: string; runtime_kind?: string; config_options?: ChatConfigOptionRecord[] } | null;
+  session: { id?: string; agent_id?: string; config_options?: ChatConfigOptionRecord[] } | null;
   onChange: (sessionID: string, configID: string, value: string | boolean) => Promise<boolean>;
   placement?: "header" | "composer";
 }) {
   if (
     !session?.id ||
-    session.runtime_kind !== "external_agent" ||
+    !session.agent_id ||
+    session.agent_id === "hecate" ||
     !session.config_options?.length
   ) {
     return null;
@@ -466,12 +467,13 @@ export function ExternalAgentSettingsControls({
   session,
   onChange,
 }: {
-  session: { id?: string; runtime_kind?: string; config_options?: ChatConfigOptionRecord[] } | null;
+  session: { id?: string; agent_id?: string; config_options?: ChatConfigOptionRecord[] } | null;
   onChange: (sessionID: string, configID: string, value: string | boolean) => Promise<boolean>;
 }) {
   if (
     !session?.id ||
-    session.runtime_kind !== "external_agent" ||
+    !session.agent_id ||
+    session.agent_id === "hecate" ||
     !session.config_options?.length
   ) {
     return null;

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -62,8 +62,8 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
     title: s.title,
     message_count: s.message_count,
     provider_call_count: 0,
-    last_provider: s.runtime_kind === "external_agent" || s.adapter_id ? s.adapter_id : s.provider,
-    last_model: s.runtime_kind === "external_agent" || s.adapter_id ? s.status : s.model,
+    last_provider: s.agent_id && s.agent_id !== "hecate" ? s.agent_id : s.provider,
+    last_model: s.agent_id && s.agent_id !== "hecate" ? s.status : s.model,
     agent_brand: sidebarSessionBrand(s),
     agent_label: sidebarSessionAgentLabel(s, agentAdapters),
     status_label: s.status,
@@ -386,10 +386,10 @@ export function filterSidebarSessions(sessions: SidebarSession[], query: string)
 }
 
 export function sidebarSessionBrand(session: ChatSessionRecord): string | undefined {
-  if (session.runtime_kind === "external_agent" || session.adapter_id) {
-    return session.adapter_id;
+  if (session.agent_id && session.agent_id !== "hecate") {
+    return session.agent_id;
   }
-  if (session.runtime_kind === "agent") {
+  if (session.agent_id === "hecate") {
     return "hecate";
   }
   return session.provider || session.model;
@@ -399,10 +399,10 @@ export function sidebarSessionAgentLabel(
   session: ChatSessionRecord,
   adapters: AgentAdapterRecord[],
 ): string | undefined {
-  if (session.runtime_kind === "external_agent" || session.adapter_id) {
-    return chatAgentOption(session.adapter_id || "", adapters).label;
+  if (session.agent_id && session.agent_id !== "hecate") {
+    return chatAgentOption(session.agent_id || "", adapters).label;
   }
-  if (session.runtime_kind === "agent") {
+  if (session.agent_id === "hecate") {
     return "Hecate";
   }
   return session.provider || session.model;

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -18,7 +18,7 @@ import { compactID } from "./ChatComposer";
 
 export type VisibleChatMessage = {
   id: string;
-  runtime_kind?: string;
+  execution_mode?: string;
   segment_id?: string;
   task_id?: string;
   run_id?: string;
@@ -29,8 +29,8 @@ export type VisibleChatMessage = {
   content: string | null;
   created_at?: string;
   produced_by_call_id?: string;
-  agent_adapter_id?: string;
-  agent_adapter_name?: string;
+  agent_id?: string;
+  agent_name?: string;
   agent_status?: string;
   cost_mode?: string;
   provider?: string;
@@ -168,12 +168,12 @@ export function ChatTranscript({
             : "";
           const agentModel = isHecateAgentChat
             ? m.model || activeChatSession?.model || "Hecate Agent"
-            : m.agent_adapter_name || m.agent_adapter_id;
+            : m.agent_name || m.agent_id;
           const agentRuntime =
             role === "assistant"
               ? formatAgentRuntimeMeta(m.run_id, m.duration_ms, m.native_session_id)
               : "";
-          const taskID = m.runtime_kind === "agent" ? m.task_id : "";
+          const taskID = m.execution_mode === "hecate_task" ? m.task_id : "";
           const taskRunID = taskID ? m.run_id : "";
           const traceRequestID = m.request_id;
           const traceID = m.trace_id;
@@ -234,7 +234,7 @@ export function ChatTranscript({
                 // internal/agentadapters/auth_status.go and this UI
                 // handler.
                 role === "assistant" &&
-                m.agent_adapter_id === "claude_code" &&
+                m.agent_id === "claude_code" &&
                 typeof m.error === "string" &&
                 m.error.includes("claude_code_auth_required")
                   ? {
@@ -394,7 +394,7 @@ function fallbackSegmentID(message: VisibleChatMessage): string {
 function segmentFromMessage(message: VisibleChatMessage, segmentID: string): ChatSegmentRecord {
   return {
     id: segmentID,
-    runtime_kind: message.runtime_kind || "model",
+    execution_mode: message.execution_mode || "direct_model",
     provider: message.provider,
     model: message.model,
     task_id: message.task_id,
@@ -500,8 +500,8 @@ function describeChatSegment(segment: ChatSegmentRecord): {
 } {
   const model = segment.model || "selected model";
   const provider = segment.provider && segment.provider !== "auto" ? segment.provider : "";
-  switch (segment.runtime_kind) {
-    case "agent": {
+  switch (segment.execution_mode) {
+    case "hecate_task": {
       const meta = [
         provider,
         segment.task_id ? formatTaskLinkLabel(segment.task_id) : "",
@@ -543,8 +543,8 @@ function describeChatSegment(segment: ChatSegmentRecord): {
 }
 
 function messageBrand(message: VisibleChatMessage, isHecateAgentChat: boolean): string | undefined {
-  if (message.agent_adapter_id) return message.agent_adapter_id;
-  if (message.agent_adapter_name) return message.agent_adapter_name;
+  if (message.agent_id) return message.agent_id;
+  if (message.agent_name) return message.agent_name;
   if (isHecateAgentChat) return message.provider || message.model || "hecate";
   return message.provider || message.model;
 }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -103,7 +103,7 @@ describe("ChatView input", () => {
         activeChatSessionID: "chat_1",
         activeChatSession: {
           id: "chat_1",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           title: "Repo work",
           provider: "openai",
           model: "gpt-4o-mini",
@@ -163,7 +163,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_hecate",
       activeChatSession: {
         id: "chat_hecate",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         provider: "ollama",
@@ -193,7 +193,7 @@ describe("ChatView input", () => {
         activeChatSessionID: "chat_1",
         activeChatSession: {
           id: "chat_1",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           title: "Repo work",
           task_id: "task_hecate_123456",
           provider: "ollama",
@@ -313,9 +313,8 @@ describe("ChatView input", () => {
         activeChatSessionID: "a1",
         activeChatSession: {
           id: "a1",
-          runtime_kind: "external_agent",
+          agent_id: "codex",
           title: "Codex work",
-          adapter_id: "codex",
           workspace: "/Users/alice/dev/hecate",
           status: "idle",
           config_options: [
@@ -503,7 +502,7 @@ describe("ChatView input", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Existing chat",
-        runtime_kind: "model",
+        execution_mode: "direct_model",
         status: "completed",
         provider: "ollama",
         model: "llama3.1:8b",
@@ -512,7 +511,7 @@ describe("ChatView input", () => {
             id: "m1",
             role: "user",
             content: "hi",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             created_at: "2026-04-20T00:00:00Z",
           },
         ],
@@ -1309,7 +1308,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         latest_run_id: "run_hecate_abcdef",
@@ -1403,7 +1402,7 @@ describe("ChatView input", () => {
         activeChatSessionID: "chat_1",
         activeChatSession: {
           id: "chat_1",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           title: "Repo work",
           task_id: "task_hecate_123456",
           latest_run_id: "run_hecate_abcdef",
@@ -1487,7 +1486,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         provider: "local-ollama",
         model: "qwen2.5-coder",
@@ -1541,7 +1540,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         latest_run_id: "run_hecate_abcdef",
@@ -1617,7 +1616,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "model",
+        execution_mode: "direct_model",
         title: "Mixed chat",
         provider: "ollama",
         model: "smollm2:135m",
@@ -1626,7 +1625,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -1634,7 +1633,7 @@ describe("ChatView input", () => {
           },
           {
             id: "task:task_hecate_123456",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider: "ollama",
             model: "qwen2.5-coder",
             task_id: "task_hecate_123456",
@@ -1669,12 +1668,12 @@ describe("ChatView input", () => {
             id: "queued_1",
             session_id: "chat_1",
             content: "run tests after this",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider_filter: "ollama",
             model: "qwen2.5-coder",
             workspace: "/workspace",
             system_prompt: "",
-            adapter_id: "codex",
+            agent_id: "hecate",
             created_at: "2026-04-20T00:00:00Z",
           },
         ],
@@ -1704,24 +1703,24 @@ describe("ChatView input", () => {
           id: "queued_active",
           session_id: "chat_active",
           content: "send this here",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           provider_filter: "ollama",
           model: "qwen2.5-coder",
           workspace: "/workspace",
           system_prompt: "",
-          adapter_id: "codex",
+          agent_id: "codex",
           created_at: "2026-04-20T00:00:00Z",
         },
         {
           id: "queued_other",
           session_id: "chat_other",
           content: "not in this chat",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           provider_filter: "ollama",
           model: "qwen2.5-coder",
           workspace: "/workspace",
           system_prompt: "",
-          adapter_id: "codex",
+          agent_id: "codex",
           created_at: "2026-04-20T00:00:00Z",
         },
       ],
@@ -1818,7 +1817,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         latest_run_id: "run_hecate_abcdef",
@@ -1829,7 +1828,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             segment_id: "task:task_hecate_123456",
             task_id: "task_hecate_123456",
             role: "user",
@@ -1838,7 +1837,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             segment_id: "task:task_hecate_123456",
             task_id: "task_hecate_123456",
             run_id: "run_hecate_abcdef",
@@ -1867,7 +1866,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "model",
+        execution_mode: "direct_model",
         title: "Mixed chat",
         task_id: "task_latest",
         latest_run_id: "run_latest",
@@ -1878,7 +1877,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:direct",
             role: "user",
             content: "tell a joke",
@@ -1886,7 +1885,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:direct",
             run_id: "model_run_1",
             trace_id: "trace_1",
@@ -1912,7 +1911,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Mixed chat",
         task_id: "task_second",
         latest_run_id: "run_second",
@@ -1923,7 +1922,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -1931,7 +1930,7 @@ describe("ChatView input", () => {
           },
           {
             id: "task:task_first",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider: "ollama",
             model: "qwen2.5-coder",
             task_id: "task_first",
@@ -1941,7 +1940,7 @@ describe("ChatView input", () => {
           },
           {
             id: "model:second",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -1951,7 +1950,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:first",
             role: "user",
             content: "answer directly",
@@ -1959,7 +1958,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:first",
             role: "assistant",
             content: "Direct answer.",
@@ -1969,7 +1968,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m3",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             segment_id: "task:task_first",
             task_id: "task_first",
             role: "user",
@@ -1978,7 +1977,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m4",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             segment_id: "task:task_first",
             task_id: "task_first",
             run_id: "run_first",
@@ -1990,7 +1989,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m5",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:second",
             role: "user",
             content: "back to direct",
@@ -1998,7 +1997,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m6",
-            runtime_kind: "model",
+            execution_mode: "direct_model",
             segment_id: "model:second",
             role: "assistant",
             content: "Direct again.",
@@ -2025,7 +2024,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         latest_run_id: "run_hecate_abcdef",
@@ -2112,7 +2111,7 @@ describe("ChatView input", () => {
         activeChatSessionID: "chat_1",
         activeChatSession: {
           id: "chat_1",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           title: "Repo work",
           task_id: "task_hecate_123456",
           latest_run_id: "run_hecate_abcdef",
@@ -2178,7 +2177,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         task_id: "task_hecate_123456",
         latest_run_id: "run_hecate_abcdef",
@@ -2422,7 +2421,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "s1",
           title: "Budget check",
-          runtime_kind: "model",
+          execution_mode: "direct_model",
           status: "completed",
           provider: "anthropic",
           message_count: 4,
@@ -2431,7 +2430,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "s2",
           title: "Draft release notes",
-          runtime_kind: "model",
+          execution_mode: "direct_model",
           status: "completed",
           provider: "openai",
           message_count: 2,
@@ -2453,7 +2452,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "a1",
           title: "Codex refactor",
-          adapter_id: "codex",
+          agent_id: "hecate",
           status: "completed",
           message_count: 4,
           updated_at: daysAgo(0),
@@ -2461,7 +2460,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "a2",
           title: "Cursor repro",
-          adapter_id: "cursor_agent",
+          agent_id: "cursor_agent",
           status: "failed",
           message_count: 2,
           updated_at: daysAgo(0),
@@ -2484,7 +2483,7 @@ describe("ChatView chats sidebar", () => {
           {
             id: "a1",
             title: "Codex refactor",
-            adapter_id: "codex",
+            agent_id: "codex",
             status: "completed",
             message_count: 4,
             updated_at: daysAgo(0),
@@ -2622,7 +2621,7 @@ describe("ChatView external-agent target", () => {
           {
             id: "a1",
             title: "Codex work",
-            adapter_id: "codex",
+            agent_id: "codex",
             workspace: "/tmp/hecate",
             status: "completed",
             message_count: 2,
@@ -2632,8 +2631,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Codex work",
-          adapter_id: "codex",
-          runtime_kind: "external_agent",
+          agent_id: "codex",
           workspace: "/tmp/hecate",
           status: "completed",
           config_options: [
@@ -2666,8 +2664,8 @@ describe("ChatView external-agent target", () => {
               role: "assistant",
               content: "Looks good.",
               raw_output: `{"sessionId":"native_codex_1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Looks good."}}}`,
-              adapter_id: "codex",
-              adapter_name: "Codex",
+              agent_id: "codex",
+              agent_name: "Codex",
               driver_kind: "acp",
               native_session_id: "native_codex_1",
               status: "completed",
@@ -2873,8 +2871,8 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Claude work",
-        adapter_id: "claude_code",
-        adapter_name: "Claude Code",
+        agent_id: "claude_code",
+        agent_name: "Claude Code",
         workspace: "/tmp/hecate",
         messages: [],
         status: "idle",
@@ -3040,7 +3038,7 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "a1",
         title: "Running work",
-        adapter_id: "codex",
+        agent_id: "codex",
         driver_kind: "acp",
         workspace: "/tmp/hecate",
         status: "running",
@@ -3050,8 +3048,8 @@ describe("ChatView external-agent target", () => {
             id: "m2",
             role: "assistant",
             content: "",
-            adapter_id: "codex",
-            adapter_name: "Codex",
+            agent_id: "codex",
+            agent_name: "Codex",
             status: "running",
             created_at: "2026-05-03T10:00:01Z",
             activities: [
@@ -3091,7 +3089,7 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "a1",
         title: "Inspect diff",
-        adapter_id: "codex",
+        agent_id: "codex",
         driver_kind: "acp",
         workspace: "/tmp/hecate",
         status: "running",
@@ -3102,8 +3100,8 @@ describe("ChatView external-agent target", () => {
             role: "assistant",
             content:
               "I’ll check the current worktree diff and summarize the changed files plus the important hunks.",
-            adapter_id: "codex",
-            adapter_name: "Codex",
+            agent_id: "codex",
+            agent_name: "Codex",
             status: "running",
             created_at: "2026-05-03T10:00:01Z",
             activities: [
@@ -3154,7 +3152,7 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "a1",
         title: "Usage check",
-        adapter_id: "codex",
+        agent_id: "codex",
         driver_kind: "acp",
         workspace: "/tmp/hecate",
         status: "completed",
@@ -3164,8 +3162,8 @@ describe("ChatView external-agent target", () => {
             id: "m2",
             role: "assistant",
             content: "Done.",
-            adapter_id: "codex",
-            adapter_name: "Codex",
+            agent_id: "codex",
+            agent_name: "Codex",
             status: "completed",
             created_at: "2026-05-03T10:00:01Z",
             usage: {
@@ -3198,7 +3196,7 @@ describe("ChatView external-agent target", () => {
       activeChatSessionID: "h1",
       activeChatSession: {
         id: "h1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Hecate work",
         provider: "ollama",
         model: "qwen2.5-coder",
@@ -3256,7 +3254,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Review files",
-          adapter_id: "codex",
+          agent_id: "hecate",
           workspace: "/tmp/hecate",
           status: "completed",
           messages: [
@@ -3265,8 +3263,8 @@ describe("ChatView external-agent target", () => {
               id: "m2",
               role: "assistant",
               content: "Updated the docs.",
-              adapter_id: "codex",
-              adapter_name: "Codex",
+              agent_id: "codex",
+              agent_name: "Codex",
               status: "completed",
               diff_stat:
                 "README.md | 3 ++-\ndocs/runtime-api.md | 4 ++++\n2 files changed, 6 insertions(+), 1 deletion(-)",
@@ -3317,7 +3315,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Review files",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp/hecate",
           status: "completed",
           messages: [
@@ -3326,8 +3324,8 @@ describe("ChatView external-agent target", () => {
               id: "m2",
               role: "assistant",
               content: "Updated the docs.",
-              adapter_id: "codex",
-              adapter_name: "Codex",
+              agent_id: "codex",
+              agent_name: "Codex",
               status: "completed",
               diff_stat: "README.md | 3 ++-\n1 file changed, 2 insertions(+), 1 deletion(-)",
               diff: "diff --git a/README.md b/README.md\n+new line",
@@ -3372,7 +3370,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Review files",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp/hecate",
           status: "completed",
           messages: [
@@ -3380,8 +3378,8 @@ describe("ChatView external-agent target", () => {
               id: "m2",
               role: "assistant",
               content: "Updated the docs.",
-              adapter_id: "codex",
-              adapter_name: "Codex",
+              agent_id: "codex",
+              agent_name: "Codex",
               status: "completed",
               diff_stat: "README.md | 3 ++-\n1 file changed, 2 insertions(+), 1 deletion(-)",
               diff: "diff --git a/README.md b/README.md\n+new line",
@@ -3423,7 +3421,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Review all",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp/hecate",
           status: "completed",
           messages: [
@@ -3432,8 +3430,8 @@ describe("ChatView external-agent target", () => {
               id: "m2",
               role: "assistant",
               content: "Updated the docs.",
-              adapter_id: "codex",
-              adapter_name: "Codex",
+              agent_id: "codex",
+              agent_name: "Codex",
               status: "completed",
               diff_stat: "README.md | 3 ++-\n1 file changed, 2 insertions(+), 1 deletion(-)",
               diff: "diff --git a/README.md b/README.md",
@@ -3479,7 +3477,7 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "a1",
         title: "Stopping work",
-        adapter_id: "codex",
+        agent_id: "codex",
         driver_kind: "acp",
         workspace: "/tmp/hecate",
         status: "running",
@@ -3513,7 +3511,7 @@ describe("ChatView external-agent target", () => {
       activeChatSession: {
         id: "a1",
         title: "Failed work",
-        adapter_id: "claude_code",
+        agent_id: "claude_code",
         driver_kind: "acp",
         workspace: "/tmp/hecate",
         status: "failed",
@@ -3525,8 +3523,8 @@ describe("ChatView external-agent target", () => {
             content: "Claude Code usage limit: credit balance is too low",
             raw_output: `{"code":-32603,"message":"Internal error: Credit balance is too low"}`,
             error: "Claude Code usage limit: credit balance is too low",
-            adapter_id: "claude_code",
-            adapter_name: "Claude Code",
+            agent_id: "claude_code",
+            agent_name: "Claude Code",
             status: "failed",
             created_at: "2026-05-03T10:00:01Z",
             activities: [
@@ -3850,7 +3848,7 @@ describe("ChatView session title", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         title: "Repo work",
         provider: "ollama",
         model: "qwen2.5-coder",
@@ -4045,7 +4043,7 @@ describe("ChatView agent approvals", () => {
         activeChatSession: {
           id: sessionID,
           title: "S1",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp",
           status: "running",
         } as any,
@@ -4054,7 +4052,7 @@ describe("ChatView agent approvals", () => {
           {
             id: sessionID,
             title: "S1",
-            adapter_id: "codex",
+            agent_id: "codex",
             status: "running",
             message_count: 0,
           } as any,
@@ -4084,7 +4082,7 @@ describe("ChatView agent approvals", () => {
           {
             approval_id: "ap-external",
             session_id: sessionID,
-            adapter_id: "codex",
+            agent_id: "codex",
             tool_kind: "fs",
             tool_name: "write_file",
             created_at: "2026-04-21T10:00:00Z",
@@ -4101,7 +4099,7 @@ describe("ChatView agent approvals", () => {
         activeChatSession: {
           id: sessionID,
           title: "Codex",
-          adapter_id: "codex",
+          agent_id: "codex",
           workspace: "/tmp",
           status: "running",
         } as any,
@@ -4110,7 +4108,7 @@ describe("ChatView agent approvals", () => {
           {
             id: sessionID,
             title: "Codex",
-            adapter_id: "codex",
+            agent_id: "codex",
             status: "running",
             message_count: 0,
           } as any,
@@ -4131,7 +4129,7 @@ describe("ChatView agent approvals", () => {
         activeChatSession: {
           id: "hecate-session",
           title: "Hecate",
-          runtime_kind: "agent",
+          execution_mode: "hecate_task",
           workspace: "/tmp",
           status: "completed",
         } as any,

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2452,7 +2452,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "a1",
           title: "Codex refactor",
-          agent_id: "hecate",
+          agent_id: "codex",
           status: "completed",
           message_count: 4,
           updated_at: daysAgo(0),
@@ -3254,7 +3254,7 @@ describe("ChatView external-agent target", () => {
         activeChatSession: {
           id: "a1",
           title: "Review files",
-          agent_id: "hecate",
+          agent_id: "codex",
           workspace: "/tmp/hecate",
           status: "completed",
           messages: [
@@ -4082,7 +4082,7 @@ describe("ChatView agent approvals", () => {
           {
             approval_id: "ap-external",
             session_id: sessionID,
-            agent_id: "codex",
+            adapter_id: "codex",
             tool_kind: "fs",
             tool_name: "write_file",
             created_at: "2026-04-21T10:00:00Z",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -160,8 +160,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const focusComposerAfterNewChatRef = useRef(false);
 
   const activeSessionIsExternal = Boolean(
-    state.activeChatSession?.runtime_kind === "external_agent" ||
-    state.activeChatSession?.adapter_id,
+    state.activeChatSession?.agent_id && state.activeChatSession.agent_id !== "hecate",
   );
   const activeSessionIsHecate = Boolean(state.activeChatSession && !activeSessionIsExternal);
   const isHecateChat =
@@ -187,7 +186,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const messages: VisibleChatMessage[] = (state.activeChatSession?.messages ?? []).map(
     (m, index) => ({
       id: m.id || `agent-message-${index}`,
-      runtime_kind: m.runtime_kind,
+      execution_mode: m.execution_mode,
       segment_id: m.segment_id,
       task_id: m.task_id,
       run_id: m.run_id,
@@ -197,8 +196,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       role: m.role,
       content: m.content,
       created_at: m.created_at,
-      agent_adapter_id: m.adapter_id,
-      agent_adapter_name: m.adapter_name,
+      agent_id: m.agent_id,
+      agent_name: m.agent_name,
       agent_status: m.status,
       cost_mode: m.cost_mode,
       provider: m.provider,
@@ -236,7 +235,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     state.chatErrorCode,
     state.chatErrorStatus ?? undefined,
   );
-  const activeAgentAdapterID = state.activeChatSession?.adapter_id || state.agentAdapterID;
+  const activeAgentAdapterID =
+    state.activeChatSession?.agent_id && state.activeChatSession.agent_id !== "hecate"
+      ? state.activeChatSession.agent_id
+      : state.agentAdapterID;
   const selectedAgent = state.agentAdapters.find((adapter) => adapter.id === activeAgentAdapterID);
   const selectedAgentHealth = activeAgentAdapterID
     ? (state.agentAdapterHealthByID.get(activeAgentAdapterID) ?? null)
@@ -1030,7 +1032,9 @@ function formatAgentSessionLabel(
 ): string {
   const agentName =
     adapter?.name ||
-    (session?.adapter_id ? chatAgentOption(session.adapter_id, []).label : "External agent");
+    (session?.agent_id && session.agent_id !== "hecate"
+      ? chatAgentOption(session.agent_id, []).label
+      : "External agent");
   if (!session) {
     return adapter?.available ? `${agentName} · New session` : `${agentName} · Not ready`;
   }

--- a/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
+++ b/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
@@ -76,7 +76,7 @@ export function activeTaskBackedHecateSegment(
   const segments = [...(session?.segments ?? [])].reverse();
   const activeSegment = segments.find(
     (segment) =>
-      segment.runtime_kind === "agent" &&
+      segment.execution_mode === "hecate_task" &&
       Boolean(segment.task_id) &&
       hecateAgentSessionIsActive(segment.status),
   );
@@ -86,7 +86,7 @@ export function activeTaskBackedHecateSegment(
   if (session?.task_id && hecateAgentSessionIsActive(session.status)) {
     return {
       id: `task:${session.task_id}`,
-      runtime_kind: "agent",
+      execution_mode: "hecate_task",
       provider: session.provider,
       model: session.model,
       task_id: session.task_id,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -141,8 +141,7 @@ export type RetentionRunPayload = {
 
 export type CreateChatSessionPayload = {
   title?: string;
-  runtime_kind?: "external_agent" | "agent" | "model";
-  adapter_id?: string;
+  agent_id?: string;
   provider?: string;
   model?: string;
   workspace?: string;
@@ -151,7 +150,7 @@ export type CreateChatSessionPayload = {
 
 export type CreateChatMessagePayload = {
   content: string;
-  runtime_kind?: "external_agent" | "agent" | "model";
+  execution_mode?: "external_agent" | "hecate_task" | "direct_model";
   provider?: string;
   model?: string;
   system_prompt?: string;

--- a/ui/src/lib/error-diagnostics.ts
+++ b/ui/src/lib/error-diagnostics.ts
@@ -75,9 +75,14 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
     action: "Start a new chat or switch back to the runtime that created this session.",
     tone: "warning",
   },
-  "chat.runtime_kind_invalid": {
-    title: "Unsupported chat runtime",
-    action: "Use one of the supported chat modes: model, agent, or external_agent.",
+  "chat.agent_id_invalid": {
+    title: "Unsupported agent",
+    action: "Choose Hecate or a configured external agent from the chat sidebar.",
+    tone: "warning",
+  },
+  "chat.execution_mode_invalid": {
+    title: "Unsupported chat mode",
+    action: "Use direct model chat, Hecate tools, or an external agent.",
     tone: "warning",
   },
   "chat.adapter_not_found": {

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -192,8 +192,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "chat_1",
                 title: "Claude Code chat",
-                runtime_kind: "external_agent",
-                adapter_id: "claude_code",
+                agent_id: "claude_code",
                 driver_kind: "acp",
                 native_session_id: "native_1",
                 workspace: "/tmp/hecate-project",
@@ -218,8 +217,7 @@ describe("useRuntimeConsole", () => {
     });
 
     expect(createBody).toMatchObject({
-      runtime_kind: "external_agent",
-      adapter_id: "claude_code",
+      agent_id: "claude_code",
       workspace: "/tmp/hecate-project",
     });
     expect(result.current.state.activeChatSessionID).toBe("chat_1");
@@ -243,7 +241,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "chat_hecate",
                 title: "Hecate Agent chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 provider: "",
                 model: "gpt-4o-mini",
                 workspace: "/tmp/hecate",
@@ -258,8 +256,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Codex chat",
-                runtime_kind: "external_agent",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp/hecate",
                 status: "idle",
                 message_count: 0,
@@ -273,8 +270,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Codex chat",
-              runtime_kind: "external_agent",
-              adapter_id: "codex",
+              agent_id: "codex",
               workspace: "/tmp/hecate",
               status: "idle",
               messages: [],
@@ -293,13 +289,13 @@ describe("useRuntimeConsole", () => {
     });
 
     expect(createBody).toMatchObject({
-      runtime_kind: "agent",
+      agent_id: "hecate",
       model: "gpt-4o-mini",
       workspace: "/tmp/hecate",
     });
     expect(createBody).not.toHaveProperty("adapter_id");
     expect(result.current.state.activeChatSessionID).toBe("chat_hecate");
-    expect(result.current.state.activeChatSession?.runtime_kind).toBe("agent");
+    expect(result.current.state.activeChatSession?.agent_id).toBe("hecate");
   });
 
   it("creates a Hecate chat session from the default model when no model is preselected", async () => {
@@ -360,7 +356,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "chat_ollama",
                 title: "Hecate Agent chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 provider: "ollama",
                 model: "llama3.1:8b",
                 workspace: "/tmp/hecate",
@@ -383,7 +379,7 @@ describe("useRuntimeConsole", () => {
     });
 
     expect(createBody).toMatchObject({
-      runtime_kind: "agent",
+      agent_id: "hecate",
       provider: "ollama",
       model: "llama3.1:8b",
       workspace: "/tmp/hecate",
@@ -554,7 +550,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Hecate",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 rtk_enabled: false,
@@ -568,7 +564,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Hecate",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               rtk_enabled: false,
@@ -584,7 +580,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Hecate",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               rtk_enabled: true,
@@ -623,7 +619,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Still exists",
-                adapter_id: "codex",
+                agent_id: "codex",
                 status: "running",
                 message_count: 2,
               },
@@ -1112,7 +1108,7 @@ describe("useRuntimeConsole", () => {
         "/hecate/v1/chat/sessions": () => {
           const data = sessions.map((s) => ({
             ...s,
-            runtime_kind: "model",
+            agent_id: "hecate",
             status: "completed",
             message_count: 0,
             created_at: "2026-04-20T00:00:00Z",
@@ -1133,19 +1129,19 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "sess_42",
                 title: "Existing",
-                runtime_kind: "model",
+                agent_id: "hecate",
                 status: "completed",
                 messages: [
                   {
                     id: "msg_u",
-                    runtime_kind: "model",
+                    agent_id: "hecate",
                     role: "user",
                     content: "hi",
                     created_at: "2026-04-20T00:00:00Z",
                   },
                   {
                     id: "msg_a",
-                    runtime_kind: "model",
+                    agent_id: "hecate",
                     role: "assistant",
                     content: "hello",
                     status: "completed",
@@ -1190,7 +1186,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Agent",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 provider: "openai",
@@ -1206,7 +1202,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Agent",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               provider: "openai",
@@ -1227,7 +1223,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Agent",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               provider: "openai",
@@ -1235,14 +1231,14 @@ describe("useRuntimeConsole", () => {
               messages: [
                 {
                   id: "u1",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   role: "user",
                   content: "inspect the repo",
                   created_at: "2026-04-20T00:00:01Z",
                 },
                 {
                   id: "a1",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   role: "assistant",
                   content: "done",
                   status: "completed",
@@ -1273,7 +1269,7 @@ describe("useRuntimeConsole", () => {
 
       expect(postedBody).toMatchObject({
         content: "inspect the repo",
-        runtime_kind: "agent",
+        execution_mode: "hecate_task",
         system_prompt: "Prefer small, reviewable diffs.",
         workspace: "/workspace",
       });
@@ -1294,7 +1290,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Agent",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: sessionStatus,
                 workspace: "/workspace",
                 provider: "openai",
@@ -1310,7 +1306,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Agent",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: sessionStatus,
               workspace: "/workspace",
               provider: "openai",
@@ -1332,7 +1328,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Agent",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               provider: "openai",
@@ -1340,7 +1336,7 @@ describe("useRuntimeConsole", () => {
               messages: [
                 {
                   id: "u1",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   role: "user",
                   content: "after this",
                   created_at: "2026-04-20T00:00:01Z",
@@ -1392,12 +1388,12 @@ describe("useRuntimeConsole", () => {
             id: "queued_restore",
             session_id: "a1",
             content: "keep this after refresh",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider_filter: "auto",
             model: "ministral-3:latest",
             workspace: "/workspace",
             system_prompt: "",
-            adapter_id: "codex",
+            agent_id: "hecate",
             created_at: "2026-04-20T00:00:01Z",
           },
         ]),
@@ -1411,7 +1407,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "a1",
                   title: "Agent",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   status: "running",
                   workspace: "/workspace",
                   message_count: 0,
@@ -1424,7 +1420,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "Agent",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "running",
                 workspace: "/workspace",
                 messages: [],
@@ -1461,12 +1457,12 @@ describe("useRuntimeConsole", () => {
             id: "queued_restore",
             session_id: "a1",
             content: "keep this after refresh",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider_filter: "auto",
             model: "ministral-3:latest",
             workspace: "/workspace",
             system_prompt: "",
-            adapter_id: "codex",
+            agent_id: "hecate",
             created_at: "2026-04-20T00:00:01Z",
           },
         ]),
@@ -1487,7 +1483,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "a1",
                   title: "Agent",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   status: "running",
                   workspace: "/workspace",
                   message_count: 0,
@@ -1500,7 +1496,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "Agent",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "running",
                 workspace: "/workspace",
                 messages: [],
@@ -1536,24 +1532,24 @@ describe("useRuntimeConsole", () => {
             id: "queued_keep",
             session_id: "a1",
             content: "keep",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider_filter: "auto",
             model: "ministral-3:latest",
             workspace: "/workspace",
             system_prompt: "",
-            adapter_id: "codex",
+            agent_id: "hecate",
             created_at: "2026-04-20T00:00:01Z",
           },
           {
             id: "queued_drop",
             session_id: "missing",
             content: "drop",
-            runtime_kind: "agent",
+            execution_mode: "hecate_task",
             provider_filter: "auto",
             model: "ministral-3:latest",
             workspace: "/workspace",
             system_prompt: "",
-            adapter_id: "codex",
+            agent_id: "hecate",
             created_at: "2026-04-20T00:00:02Z",
           },
         ]),
@@ -1567,7 +1563,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "a1",
                   title: "Agent",
-                  runtime_kind: "agent",
+                  agent_id: "hecate",
                   status: "running",
                   workspace: "/workspace",
                   message_count: 0,
@@ -1609,7 +1605,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Busy chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "running",
                 workspace: "/workspace",
                 message_count: 0,
@@ -1617,7 +1613,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a2",
                 title: "Idle chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 message_count: 0,
@@ -1631,7 +1627,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a1",
               title: "Busy chat",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "running",
               workspace: "/workspace",
               messages: [],
@@ -1647,7 +1643,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "a2",
               title: "Idle chat",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "completed",
               workspace: "/workspace",
               messages: [],
@@ -1710,7 +1706,7 @@ describe("useRuntimeConsole", () => {
         data: {
           id,
           title: id,
-          runtime_kind: "agent",
+          agent_id: "hecate",
           status,
           workspace: "/workspace",
           provider: "openai",
@@ -1730,7 +1726,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a1",
                 title: "Idle chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 message_count: 0,
@@ -1738,7 +1734,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "a2",
                 title: "Busy chat",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "running",
                 workspace: "/workspace",
                 message_count: 0,
@@ -1814,7 +1810,7 @@ describe("useRuntimeConsole", () => {
         data: {
           id,
           title: id,
-          runtime_kind: "agent",
+          agent_id: "hecate",
           status: "completed",
           workspace: "/workspace",
           provider: "openai",
@@ -1889,7 +1885,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "mixed_chat",
                 title: "Mixed",
-                runtime_kind: "model",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 provider: "ollama",
@@ -1897,7 +1893,7 @@ describe("useRuntimeConsole", () => {
                 segments: [
                   {
                     id: "model:first",
-                    runtime_kind: "model",
+                    execution_mode: "direct_model",
                     provider: "ollama",
                     model: "smollm2:135m",
                     status: "completed",
@@ -1905,7 +1901,7 @@ describe("useRuntimeConsole", () => {
                   },
                   {
                     id: "task:task_tools",
-                    runtime_kind: "agent",
+                    execution_mode: "hecate_task",
                     provider: "ollama",
                     model: "qwen2.5-coder",
                     task_id: "task_tools",
@@ -1998,7 +1994,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "sess_a",
                 title: "Keep",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "completed",
                 workspace: "/workspace",
                 message_count: 0,
@@ -2006,7 +2002,7 @@ describe("useRuntimeConsole", () => {
               {
                 id: "sess_b",
                 title: "Delete me",
-                runtime_kind: "agent",
+                agent_id: "hecate",
                 status: "running",
                 workspace: "/workspace",
                 message_count: 0,
@@ -2024,7 +2020,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "sess_b",
               title: "Delete me",
-              runtime_kind: "agent",
+              agent_id: "hecate",
               status: "running",
               workspace: "/workspace",
               messages: [],
@@ -2067,8 +2063,7 @@ describe("useRuntimeConsole", () => {
             data: {
               id: "agent_a",
               title: "Renamed agent chat",
-              runtime_kind: "external_agent",
-              adapter_id: "codex",
+              agent_id: "codex",
               workspace: "/tmp/workspace",
               status: "idle",
               messages: [],
@@ -2085,8 +2080,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "agent_a",
                   title: "Old agent title",
-                  runtime_kind: "external_agent",
-                  adapter_id: "codex",
+                  agent_id: "codex",
                   workspace: "/tmp/workspace",
                   status: "idle",
                   message_count: 0,
@@ -2101,8 +2095,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "agent_a",
                 title: "Old agent title",
-                runtime_kind: "external_agent",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp/workspace",
                 status: "idle",
                 messages: [],
@@ -2147,8 +2140,7 @@ describe("useRuntimeConsole", () => {
       const seededSession = {
         id: "a1",
         title: "Repo work",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         task_id: "task_42",
         latest_run_id: "run_99",
@@ -2245,8 +2237,7 @@ describe("useRuntimeConsole", () => {
       const seededSession = {
         id: "a1",
         title: "Repo work",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         task_id: "task_42",
         latest_run_id: "run_99",
@@ -2339,8 +2330,7 @@ describe("useRuntimeConsole", () => {
       const seededSession = {
         id: "a1",
         title: "Repo work",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         task_id: "task_42",
         latest_run_id: "run_99",
@@ -2442,8 +2432,7 @@ describe("useRuntimeConsole", () => {
       const seededSession = {
         id: "a1",
         title: "Repo work",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         task_id: "task_42",
         latest_run_id: "run_99",
@@ -2539,8 +2528,7 @@ describe("useRuntimeConsole", () => {
       const sessionA = {
         id: "a1",
         title: "A",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         task_id: "task_42",
         latest_run_id: "run_99",
@@ -2574,8 +2562,7 @@ describe("useRuntimeConsole", () => {
       const sessionB = {
         id: "a2",
         title: "B",
-        runtime_kind: "agent",
-        adapter_id: "hecate",
+        agent_id: "hecate",
         workspace: "/workspace",
         status: "completed",
         message_count: 0,
@@ -2686,7 +2673,7 @@ describe("useRuntimeConsole", () => {
             jsonResponse({
               object: "chat_sessions",
               data: [
-                { id: "a1", title: "S1", adapter_id: "codex", status: "running", message_count: 0 },
+                { id: "a1", title: "S1", agent_id: "codex", status: "running", message_count: 0 },
               ],
             }),
           "/hecate/v1/chat/sessions/a1": () =>
@@ -2695,7 +2682,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "S1",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2740,7 +2727,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "A",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2751,7 +2738,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "b1",
                 title: "B",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2811,7 +2798,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "A",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2822,7 +2809,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "b1",
                 title: "B",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2902,7 +2889,7 @@ describe("useRuntimeConsole", () => {
               data: {
                 id: "a1",
                 title: "S1",
-                adapter_id: "codex",
+                agent_id: "codex",
                 workspace: "/tmp",
                 status: "running",
               },
@@ -2955,7 +2942,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "g1",
                   scope: "session",
-                  adapter_id: "codex",
+                  agent_id: "codex",
                   tool_kind: "fs",
                   decision: "approve",
                   granted_by: "operator",
@@ -2964,7 +2951,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "g2",
                   scope: "workspace_tool",
-                  adapter_id: "codex",
+                  agent_id: "codex",
                   tool_kind: "exec",
                   decision: "approve",
                   granted_by: "operator",

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -172,6 +172,49 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatTarget).toBe("model");
   });
 
+  it("keeps a newly created tools-off Hecate chat in direct model mode", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.model", "gpt-4o-mini");
+    let createBody: any = null;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_direct",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: "",
+                model: "gpt-4o-mini",
+                status: "idle",
+                messages: [],
+              },
+            });
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession();
+    });
+
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      model: "gpt-4o-mini",
+    });
+    expect(createBody).not.toHaveProperty("workspace");
+    expect(result.current.state.activeChatSessionID).toBe("chat_direct");
+    expect(result.current.state.chatTarget).toBe("model");
+  });
+
   it("creates an external-agent session from the selected agent and workspace", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
@@ -2942,7 +2985,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "g1",
                   scope: "session",
-                  agent_id: "codex",
+                  adapter_id: "codex",
                   tool_kind: "fs",
                   decision: "approve",
                   granted_by: "operator",
@@ -2951,7 +2994,7 @@ describe("useRuntimeConsole", () => {
                 {
                   id: "g2",
                   scope: "workspace_tool",
-                  agent_id: "codex",
+                  adapter_id: "codex",
                   tool_kind: "exec",
                   decision: "approve",
                   granted_by: "operator",

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -1410,6 +1410,7 @@ describe("useRuntimeConsole", () => {
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
       expect(result.current.state.queuedChatMessages[0].session_id).toBe("a1");
       expect(result.current.state.queuedChatMessages[0].content).toBe("after this");
+      expect(result.current.state.queuedChatMessages[0].agent_id).toBe("hecate");
 
       sessionStatus = "completed";
       await act(async () => {

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -330,12 +330,12 @@ function FixtureSyncer({ state }: { state: RuntimeConsoleFixtureState }) {
     chatActionsRef.current.setChatError(state.chatError);
     chatActionsRef.current.setModelFilter(state.modelFilter);
     chatActionsRef.current.setProviderFilter(state.providerFilter);
-    // Legacy fixture compat: the old viewmodel exposed `chatTarget`
-    // as a derived field while the chat slice owns defaultChatTarget +
+    // Fixture compat: tests still provide `chatTarget` as a derived
+    // field while the chat slice owns defaultChatTarget +
     // chatTargetBySessionID. The derivation rule is:
     //   - if active session is external_agent → "external_agent"
     //   - else if active session has a per-session override → that
-    //   - else session.runtime_kind (or message tail)
+    //   - else the message execution-mode tail
     //   - else defaultChatTarget
     // Tests pin the *derived* field. We map it back: when there's an
     // active session and the test wants "model" or "agent", set the

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef } from "react";
 import {
   type ChatTarget,
   type HecateChatTarget,
+  executionModeToChatTarget,
   normalizeStoredHecateChatTarget,
 } from "../app/state/_shared";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
@@ -41,7 +42,7 @@ import type { ChatSessionRecord } from "../types/chat";
 import type { ConfiguredStateResponse } from "../types/provider";
 
 function chatSessionIsExternal(session: ChatSessionRecord | null): boolean {
-  return Boolean(session?.runtime_kind === "external_agent" || session?.adapter_id);
+  return Boolean(session?.agent_id && session.agent_id !== "hecate");
 }
 
 function chatSessionIsBusy(session: ChatSessionRecord | null): boolean {
@@ -59,10 +60,12 @@ function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): H
   if (!session) return "agent";
   const messages = session.messages ?? [];
   for (let i = messages.length - 1; i >= 0; i--) {
-    const target = normalizeStoredHecateChatTarget(messages[i]?.runtime_kind ?? "");
+    const target = normalizeStoredHecateChatTarget(
+      executionModeToChatTarget(messages[i]?.execution_mode ?? ""),
+    );
     if (target) return target;
   }
-  return normalizeStoredHecateChatTarget(session.runtime_kind ?? "") || "agent";
+  return "agent";
 }
 
 export { humanizeChatError };

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -56,6 +56,21 @@ function chatSessionIsBusy(session: ChatSessionRecord | null): boolean {
   );
 }
 
+function hecateTaskStatusIsActive(status?: string): boolean {
+  return status === "queued" || status === "running" || status === "awaiting_approval";
+}
+
+function sessionHasActiveHecateTaskSegment(session: ChatSessionRecord | null): boolean {
+  if (!session) return false;
+  if (session.task_id && hecateTaskStatusIsActive(session.status)) return true;
+  return (session.segments ?? []).some(
+    (segment) =>
+      segment.execution_mode === "hecate_task" &&
+      Boolean(segment.task_id) &&
+      hecateTaskStatusIsActive(segment.status),
+  );
+}
+
 function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): HecateChatTarget {
   if (!session) return "agent";
   const messages = session.messages ?? [];
@@ -196,8 +211,10 @@ export function useRuntimeConsole() {
     activeChatSessionID && activeChatSession
       ? chatSessionIsExternal(activeChatSession)
         ? "external_agent"
-        : (chatTargetBySessionID.get(activeChatSessionID) ??
-          deriveHecateChatTargetFromSession(activeChatSession))
+        : sessionHasActiveHecateTaskSegment(activeChatSession)
+          ? "agent"
+          : (chatTargetBySessionID.get(activeChatSessionID) ??
+            deriveHecateChatTargetFromSession(activeChatSession))
       : defaultChatTarget;
 
   // Forward-dependency ref. The cycle is dashboard.loadDashboard

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -21,8 +21,7 @@ export type PersistedContentBlock = {
 export type ChatSessionSummaryRecord = {
   id: string;
   title: string;
-  runtime_kind?: "external_agent" | "agent" | "model" | string;
-  adapter_id?: string;
+  agent_id?: string;
   driver_kind?: string;
   native_session_id?: string;
   task_id?: string;
@@ -41,7 +40,7 @@ export type ChatSessionSummaryRecord = {
 
 export type ChatMessageRecord = {
   id: string;
-  runtime_kind?: "external_agent" | "agent" | "model" | string;
+  execution_mode?: "external_agent" | "hecate_task" | "direct_model" | string;
   segment_id?: string;
   task_id?: string;
   run_id?: string;
@@ -51,8 +50,8 @@ export type ChatMessageRecord = {
   role: "user" | "assistant";
   content: string;
   raw_output?: string;
-  adapter_id?: string;
-  adapter_name?: string;
+  agent_id?: string;
+  agent_name?: string;
   driver_kind?: string;
   native_session_id?: string;
   status?: string;
@@ -76,7 +75,7 @@ export type ChatMessageRecord = {
 
 export type ChatSegmentRecord = {
   id: string;
-  runtime_kind: "external_agent" | "agent" | "model" | string;
+  execution_mode: "external_agent" | "hecate_task" | "direct_model" | string;
   provider?: string;
   model?: string;
   task_id?: string;
@@ -146,8 +145,7 @@ export type ChatConfigOptionRecord = {
 export type ChatSessionRecord = {
   id: string;
   title: string;
-  runtime_kind?: "external_agent" | "agent" | "model" | string;
-  adapter_id?: string;
+  agent_id?: string;
   driver_kind?: string;
   native_session_id?: string;
   task_id?: string;


### PR DESCRIPTION
## Summary

Simplifies the chat execution model by removing the old session-level `runtime_kind` split and replacing it with two clearer concepts:

- `agent_id` owns the chat session (`hecate`, `codex`, `claude_code`, `cursor_agent`, ...).
- `execution_mode` describes each turn/message (`direct_model`, `hecate_task`, `external_agent`).

This lets Hecate Chat keep one session while mixing direct model turns and task-backed tool turns, and keeps External Agent sessions owned by their adapter id without pretending that the whole session is a runtime kind.

## What changed

- Updated chat memory/SQLite stores, API request/response types, renderers, and validation errors to use `agent_id` + per-message `execution_mode`.
- Removed compatibility shims for `runtime_kind`; this is an alpha breaking change by design.
- Updated UI state, Chat view projections, transcript rendering, error diagnostics, E2E fixtures, and tests to use the new model.
- Preserved adapter terminology only where it still describes ACP adapter resources: health, credentials, approvals, and adapter-specific endpoints.
- Updated runtime API docs and RFCs to describe session ownership and turn execution separately.

## Verification

- `go test ./internal/chat ./internal/api`
- `go vet ./internal/chat ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `cd ui && bun run test:e2e chat.spec.ts`
