### PR TITLE
docs(security): clarify bootstrap key storage roadmap

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,7 @@ Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser request
 - [Binary install](#binary-install)
 - [Desktop app](#desktop-app)
 - [Resetting state](#resetting-state)
+- [Bootstrap key and backups](#bootstrap-key-and-backups)
 - [Storage backends](#storage-backends)
 - [External-agent startup knobs](#external-agent-startup-knobs)
 - [Rate limiting](#rate-limiting)
@@ -138,6 +139,28 @@ just reset-docker
 ```
 
 For local (non-Docker) development resets, see [`development.md`](development.md#reset-state).
+
+## Bootstrap key and backups
+
+Encrypted local credentials depend on two pieces of state:
+
+- the settings database, usually `hecate.db` when the relevant storage backend
+  is `sqlite`;
+- the bootstrap control-plane key, loaded from
+  `GATEWAY_CONTROL_PLANE_SECRET_KEY`, `GATEWAY_BOOTSTRAP_FILE`, or
+  `hecate.bootstrap.json` in the data directory.
+
+Back up and restore those pieces together when you want provider keys, external
+agent credentials, or encrypted MCP literals to remain usable. Restoring the
+database without the matching bootstrap key leaves encrypted secrets
+undecryptable; restore the old key or re-enter the credentials from the
+operator UI.
+
+Docker's default `/data` volume stores both `/data/hecate.db` and the default
+bootstrap file, so backing up the volume is enough for the default path. If you
+override `GATEWAY_CONTROL_PLANE_SECRET_KEY`, the secret lives in your shell,
+supervisor, container secret, or vault layer instead; back up that source with
+the same care as the database.
 
 ## Storage backends
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -158,9 +158,12 @@ operator UI.
 
 Docker's default `/data` volume stores both `/data/hecate.db` and the default
 bootstrap file, so backing up the volume is enough for the default path. If you
-override `GATEWAY_CONTROL_PLANE_SECRET_KEY`, the secret lives in your shell,
-supervisor, container secret, or vault layer instead; back up that source with
-the same care as the database.
+override `GATEWAY_CONTROL_PLANE_SECRET_KEY`, treat the env var as the source
+that seeds the bootstrap key, not as env-only storage: Hecate persists that key
+to `GATEWAY_BOOTSTRAP_FILE` or the default bootstrap file on startup, overwriting
+any existing bootstrap key, and the bootstrap path must be writable. Back up the
+env/secret-manager value and the bootstrap file with the same care as the
+database; if they diverge, the env value wins on the next startup.
 
 ## Storage backends
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -186,13 +186,17 @@ Values in `env` (stdio) and `headers` (HTTP) are stored in one of three forms. S
 | Form                  | Example            | Behavior                                                                                                                                                   |
 | --------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Process-env reference | `$GITHUB_TOKEN`    | Resolved from Hecate's process environment at subprocess spawn time. The reference is what's stored on the task; the token itself never hits the database. |
-| Encrypted literal     | `enc:<base64>`     | AES-GCM encrypted with `GATEWAY_CONTROL_PLANE_SECRET_KEY`. Decrypted at spawn time.                                                                        |
+| Encrypted literal     | `enc:<base64>`     | AES-GCM encrypted with the startup-resolved control-plane key. Decrypted at spawn time.                                                                    |
 | Bare literal          | `secret-token-xyz` | Stored as-is. Acceptable for non-secret values.                                                                                                            |
 
 Behavior of the API layer:
 
 - **On create**: any value that is NOT a `$VAR_NAME` reference and NOT already `enc:<base64>` gets auto-encrypted to `enc:...` if a settings encryption key is configured, or stored bare if not.
 - **On render** (`GET /hecate/v1/tasks/...`): `$VAR_NAME` values come back verbatim; everything else (encrypted ciphertext, bare literals) is replaced with `[redacted]`. Stored secrets cannot leak through the task API.
+
+The control-plane key comes from `GATEWAY_CONTROL_PLANE_SECRET_KEY` when set,
+or from the bootstrap key file otherwise. See
+[`security.md`](security.md#bootstrap-key-today) for the local storage model.
 
 If a value arrives as `enc:...` and no settings encryption key is configured, the run fails fast at spawn time with a clear error rather than forwarding ciphertext to the subprocess.
 
@@ -253,7 +257,7 @@ Order matters and is enforced by the handler: runner first, cache second. Closin
 | `initialize` handshake fails                                    | Run fails at start. For stdio servers, the error message includes the captured stderr — usually pinpoints missing deps, bad args, or auth failures the upstream prints before exiting. |
 | Tool call returns `isError: true`                               | The agent loop forwards the upstream's error text as a tool message with `is_error: true`. The LLM gets a chance to retry or pick a different tool; the run does NOT fail.             |
 | Transport closed mid-run (subprocess died, HTTP server hung up) | The cache evicts the entry; the call returns a transport error to the loop, which surfaces it as a tool error on the next turn. The next task respawns.                                |
-| `enc:` value arrives without `GATEWAY_CONTROL_PLANE_SECRET_KEY` | Run fails fast at spawn time with a clear error.                                                                                                                                       |
+| `enc:` value cannot be decrypted with the startup-resolved key  | Run fails fast at spawn time with a clear error.                                                                                                                                       |
 
 Bring-up (initialize + tools/list) gets one bounded retry with a 500ms backoff, rebuilding the transport from scratch between attempts. Absorbs ordinary flakiness — slow-booting subprocess, brief network blip, transient 5xx — without hiding real failures: a permanent broken config (missing binary, bad args, auth rejected) fails twice and surfaces the same diagnostic, just delayed by ~500ms. Cancellation aborts the retry promptly rather than waiting out the backoff, so runner shutdown stays responsive.
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -887,7 +887,7 @@ Status codes:
 ### `PUT /hecate/v1/agent-adapters/{id}/credentials`
 
 Stores a local adapter credential. Hecate encrypts the value with the
-configured control-plane secret key and injects it only into the matching
+startup-resolved control-plane key and injects it only into the matching
 adapter subprocess. The first guided setup uses this for Claude Code
 subscription auth: save the token from `claude setup-token` as
 `CLAUDE_CODE_OAUTH_TOKEN`, then run the adapter probe again.

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,26 +53,70 @@ Review broad grants carefully, especially workspace-wide or adapter-wide grants 
 Hecate stores local configuration and operational state on disk.
 
 - Provider credentials and settings are local to the gateway data directory / desktop app data directory.
-- Persisted provider, agent-adapter, and MCP literal credentials are encrypted
-  with a gateway-local AES-GCM control-plane key. By default that bootstrap key
-  is generated on first run, stored as `hecate.bootstrap.json`, and validated on
-  every startup. POSIX platforms create and repair the file with `0600`
-  permissions.
-- If Hecate cannot validate or secure `hecate.bootstrap.json`, startup fails
-  closed. The desktop app startup screen and `gateway.log` include the affected
-  path; fix ownership, ACLs, or POSIX mode bits so the file is private, or unset
-  an invalid `GATEWAY_CONTROL_PLANE_SECRET_KEY` override.
-- On Windows, the file-backed bootstrap path uses Go's cross-platform file-mode
-  APIs and does not rewrite existing DACLs. Treat the OS account and data
-  directory ACL as part of the local operator boundary on Windows.
-- This protects against accidental disclosure from the settings database, but
-  it is not a vault boundary: a process running as the same OS user that can
-  read both the database and bootstrap key can decrypt stored credentials.
 - Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
 - External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own those accounts.
 - If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach the gateway may be able to spend those credentials.
-- Future hardening should move the bootstrap key into the OS keychain where
-  available and preserve file-backed bootstrap for headless/Docker deployments.
+
+### Bootstrap key today
+
+Persisted provider, agent-adapter, and MCP literal credentials are encrypted
+with a gateway-local AES-GCM control-plane key. Hecate resolves that key at
+startup:
+
+1. If `GATEWAY_CONTROL_PLANE_SECRET_KEY` is set, Hecate validates and uses that
+   base64-encoded 32-byte key.
+2. Otherwise Hecate loads `hecate.bootstrap.json` from the data directory, or
+   from `GATEWAY_BOOTSTRAP_FILE` when that path is set.
+3. If no bootstrap file exists, Hecate generates a new key and writes the file.
+
+The file-backed bootstrap path is intentionally local and boring:
+
+- POSIX platforms create the bootstrap file with `0600` permissions and repair
+  broader group/world modes on startup. Stricter owner-only modes such as
+  `0400` are accepted.
+- Windows uses Go's cross-platform file-mode APIs for the file-backed path, but
+  those APIs do not rewrite existing DACLs. Treat the OS account and data
+  directory ACL as part of the local operator boundary on Windows.
+- Docker and headless installs keep using the file-backed path by default. If
+  you mount the data directory or `GATEWAY_BOOTSTRAP_FILE` separately, keep the
+  host-side permissions private to the operator or service account.
+
+If Hecate cannot validate or secure the bootstrap source, startup fails closed.
+The desktop app startup screen and `gateway.log` include the affected path or
+environment override; fix ownership, ACLs, POSIX mode bits, or unset an invalid
+`GATEWAY_CONTROL_PLANE_SECRET_KEY` override before restarting.
+
+This protects against accidental disclosure from the settings database alone,
+but it is not a vault boundary. A process running as the same OS user that can
+read both the database and bootstrap key can decrypt stored credentials.
+
+Back up the settings database and bootstrap key together when you want stored
+credentials to survive a restore. If the bootstrap key is deleted, lost, or
+changed while keeping the old database, existing encrypted credentials cannot be
+decrypted; restore the old key or re-enter the provider, adapter, and MCP
+credentials.
+
+### Key storage roadmap
+
+The file-backed key is good enough for the local operator console today, but
+desktop builds should eventually prefer OS-backed storage:
+
+- macOS: store the bootstrap key in Keychain, scoped to the signed Hecate app
+  or current user, with the file-backed path kept for explicit overrides and
+  non-desktop launches.
+- Windows: store the key in Credential Manager or a DPAPI/CNG-protected secret
+  bound to the current user profile. Do not claim DACL hardening for existing
+  files until Hecate actively manages those ACLs.
+- Linux desktop: use Secret Service/libsecret when a user session service is
+  available, with file-backed bootstrap as the fallback for servers, CI, Docker,
+  and minimal window managers.
+
+The migration should be explicit in metadata: record which key source is in
+use, import an existing file-backed key into the OS key store on first eligible
+desktop launch, keep migration idempotent, and preserve `GATEWAY_BOOTSTRAP_FILE`
+and `GATEWAY_CONTROL_PLANE_SECRET_KEY` as operator-controlled escape hatches.
+Tests should cover missing keychain items, locked or unavailable keychains,
+idempotent migration, fallback behavior, and recovery messaging.
 
 ## Native app and sidecars
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,14 +63,17 @@ Persisted provider, agent-adapter, and MCP literal credentials are encrypted
 with a gateway-local AES-GCM control-plane key. Hecate resolves that key at
 startup:
 
-1. If `GATEWAY_CONTROL_PLANE_SECRET_KEY` is set, Hecate validates and uses that
-   base64-encoded 32-byte key.
+1. If `GATEWAY_CONTROL_PLANE_SECRET_KEY` is set, Hecate validates that
+   base64-encoded 32-byte key, uses it for this run, and persists it to the
+   bootstrap file.
 2. Otherwise Hecate loads `hecate.bootstrap.json` from the data directory, or
    from `GATEWAY_BOOTSTRAP_FILE` when that path is set.
 3. If no bootstrap file exists, Hecate generates a new key and writes the file.
 
 The file-backed bootstrap path is intentionally local and boring:
 
+- An env-provided key is not env-only storage. On startup it overwrites the
+  bootstrap file at the resolved path, and that path must be writable.
 - POSIX platforms create the bootstrap file with `0600` permissions and repair
   broader group/world modes on startup. Stricter owner-only modes such as
   `0400` are accepted.
@@ -93,8 +96,9 @@ read both the database and bootstrap key can decrypt stored credentials.
 Back up the settings database and bootstrap key together when you want stored
 credentials to survive a restore. If the bootstrap key is deleted, lost, or
 changed while keeping the old database, existing encrypted credentials cannot be
-decrypted; restore the old key or re-enter the provider, adapter, and MCP
-credentials.
+decrypted. Changing `GATEWAY_CONTROL_PLANE_SECRET_KEY` has the same effect
+unless encrypted rows are rekeyed at the same time; today the recovery path is
+to restore the old key or re-enter the provider, adapter, and MCP credentials.
 
 ### Key storage roadmap
 


### PR DESCRIPTION
## Summary

- Document the current bootstrap key resolution order and what the file-backed model protects.
- Add backup and restore guidance for encrypted local credentials.
- Clarify MCP and adapter credential docs to reference the startup-resolved control-plane key instead of only the env var.
- Capture the future OS keychain roadmap for desktop while preserving file-backed bootstrap for Docker and headless use.

## Validation

- `/Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check docs/security.md docs/deployment.md docs/mcp.md docs/runtime-api.md`
- `git diff --check`

Docs-only change; no runtime tests run.