### PR TITLE
fix(chat): keep plain chat available for toolless models

### DIFF
--- a/docs/rfcs/hecate-chat-model-capabilities.md
+++ b/docs/rfcs/hecate-chat-model-capabilities.md
@@ -229,17 +229,23 @@ The operator UI may also keep a local FIFO for prompts typed while the backing
 task is busy. That queue is a UX layer above the API invariant: queued prompts
 are not persisted until the UI submits them after the active task settles.
 
-If tools are explicitly disabled for the selected model, the message endpoint returns:
+If tools are explicitly disabled for the selected model and the client still
+requests `execution_mode="hecate_task"`, the message endpoint returns:
 
 ```text
 422 chat.model_capability_required
 ```
 
-The UI copy is:
+The API copy is:
 
 ```text
-Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Connections.
+Tools are unavailable for this model. Continue with direct model chat or enable tools in Connections.
 ```
+
+The operator UI should normally avoid this server error: when the selected model
+is explicitly `tool_calling="none"`, Hecate Chat keeps the composer sendable and
+starts a direct model segment instead. The UI still shows a repair affordance to
+enable/test tool support in Connections.
 
 ## Workspace Modes
 
@@ -340,28 +346,30 @@ Shows:
 - live run activity from task-run events
 - pending task approvals with Approve / Deny actions
 
-Send is disabled unless a workspace is selected. If the selected model has
-`tool_calling="none"`, the tools-on send path is disabled and the operator can
-either turn tools off for direct model chat or enable tools in Connections.
+Task-backed sends are disabled unless a workspace is selected. If the selected
+model has `tool_calling="none"`, Hecate Chat should keep normal chat available:
+the next send starts a direct model segment, the tools indicator reports that
+tools are unavailable for the selected model, and repair copy points to
+Connections for capability override/probe controls.
 
-When a Hecate Agent task-backed segment is running, provider/model controls are
-locked to that segment's snapshot and the chat composer treats the whole
-session as busy. Operators can turn tools off while waiting, but direct model
-sends are blocked until the backing task finishes, is cancelled, or reaches an
-approval the operator resolves. The busy composer should keep **Open task** and
-**Stop** close to the input so the operator does not need to hunt for the
-canonical Task view. After the active task settles, tools-off sends create
-normal direct model segments; turning tools on again creates a new task-backed
-segment instead of mutating the older task.
+When a task-backed Hecate Chat segment is running, provider/model controls are
+locked to that segment's snapshot and the chat composer treats the whole session
+as busy. Operators can turn tools off while waiting, but direct model sends are
+blocked until the backing task finishes, is cancelled, or reaches an approval
+the operator resolves. The busy composer should keep **Open task** and **Stop**
+close to the input so the operator does not need to hunt for the canonical Task
+view. After the active task settles, tools-off sends create normal direct model
+segments; turning tools on again creates a new task-backed segment instead of
+mutating the older task.
 
 On browser refresh or reconnect, the UI should hydrate from the persisted
 Agent Chat session plus its backing task/run snapshot. Active task-backed
 segments must come back as running, awaiting approval, completed, cancelled, or
 failed without requiring a fresh prompt.
 
-Hecate Agent uses the task runtime, so approvals, artifacts, diff/patch review,
-workspace modes, retry/resume, and OTel should come from Tasks rather than a
-new parallel agent runtime.
+Task-backed Hecate Chat uses the task runtime, so approvals, artifacts,
+diff/patch review, workspace modes, retry/resume, and OTel should come from
+Tasks rather than a new parallel agent runtime.
 
 ### External Agent
 
@@ -379,15 +387,15 @@ Memory and SQLite must persist:
 - Hecate Agent profiles
 - selected `agent_profile_id`
 - `agent_id`
-- Hecate Agent task/run linkage fields on chat sessions
+- task-backed Hecate Chat task/run linkage fields on chat sessions
 - per-message `execution_mode`, `segment_id`, provider/model, capability
   snapshot, and task/run linkage
 - derived API segment metadata from the persisted message snapshots
-- workspace mode snapshot on Hecate Agent sessions
+- workspace mode snapshot on task-backed Hecate Chat sessions
 
 The effective capability record is a snapshot at session creation time. Model
-metadata can change later, but a running Hecate Agent session should keep the
-capability record it was created with for audit/debugging.
+metadata can change later, but a running task-backed Hecate Chat segment should
+keep the capability record it was created with for audit/debugging.
 
 Profile settings and workspace mode should also be snapshotted onto the
 session or backing task. Historical sessions should explain what was actually
@@ -401,16 +409,17 @@ Minimum coverage:
   unknown local default.
 - `/v1/models` includes capability metadata.
 - Override/probe endpoints persist and affect `/v1/models`.
-- Hecate Agent first message creates a visible task/run.
-- Hecate Agent follow-up continues the same task after the latest run is
+- Task-backed Hecate Chat first message creates a visible task/run.
+- Task-backed Hecate Chat follow-up continues the same task after the latest run is
   terminal.
 - Busy backing runs return `409 chat.agent_session_busy`.
-- Explicitly disabled tools return `422 chat.model_capability_required`.
+- Explicit `hecate_task` requests against models with disabled tools return
+  `422 chat.model_capability_required`.
 - Memory/SQLite parity for capability records and new session fields.
-- UI target picker, tools on/off switches, disabled Hecate Agent send state, and
-  task/run links.
-- Hecate Agent run activity projection from task-run SSE into Chats.
-- Hecate Agent task approval banner in Chats, including approve, reject, and a
+- UI target picker, tools on/off switches, tools-unavailable direct fallback,
+  and task/run links.
+- Task-backed Hecate Chat run activity projection from task-run SSE into Chats.
+- Task-backed Hecate Chat task approval banner in Chats, including approve, reject, and a
   link to the backing Task.
 - Busy-state UX and local queued-prompt behavior in Chats.
 - Workspace mode selection and task creation parity.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -58,20 +58,20 @@ Hecate-native JSON errors use one stable envelope:
 
 Common Hecate-native error types:
 
-| Type                                   | Status | Meaning                                                                         |
-| -------------------------------------- | -----: | ------------------------------------------------------------------------------- |
-| `invalid_request`                      |    400 | Request JSON, query parameters, or required fields are invalid.                 |
-| `not_found`                            |    404 | The requested Hecate resource does not exist.                                   |
-| `conflict`                             |    409 | The resource changed state or the requested transition is not valid now.        |
-| `gateway_error`                        |    500 | Hecate failed before it could classify the failure more specifically.           |
-| `rate_limit_exceeded`                  |    429 | The local gateway rate limiter rejected the request.                            |
-| `model_not_configured`                 |    422 | The selected model is stale or not currently reported by the selected provider. |
-| `chat.agent_session_busy`              |    409 | A Hecate Chat task-backed loop is queued, running, or awaiting approval.        |
-| `chat.model_capability_required`       |    422 | Tools are on, but the model is not marked tool-capable.                         |
-| `chat.workspace_required`              |    400 | Task-backed Hecate Chat or External Agent chat needs a workspace path.          |
-| `chat.session_limit_exceeded`          |    422 | The chat turn limit was reached.                                                |
-| `chat.session_duration_limit_exceeded` |    422 | The chat wall-clock limit was reached.                                          |
-| `chat.session_idle_timeout`            |    422 | The chat was idle beyond the configured timeout.                                |
+| Type                                   | Status | Meaning                                                                          |
+| -------------------------------------- | -----: | -------------------------------------------------------------------------------- |
+| `invalid_request`                      |    400 | Request JSON, query parameters, or required fields are invalid.                  |
+| `not_found`                            |    404 | The requested Hecate resource does not exist.                                    |
+| `conflict`                             |    409 | The resource changed state or the requested transition is not valid now.         |
+| `gateway_error`                        |    500 | Hecate failed before it could classify the failure more specifically.            |
+| `rate_limit_exceeded`                  |    429 | The local gateway rate limiter rejected the request.                             |
+| `model_not_configured`                 |    422 | The selected model is stale or not currently reported by the selected provider.  |
+| `chat.agent_session_busy`              |    409 | A Hecate Chat task-backed loop is queued, running, or awaiting approval.         |
+| `chat.model_capability_required`       |    422 | A task-backed Hecate Chat turn was requested, but the model is not tool-capable. |
+| `chat.workspace_required`              |    400 | Task-backed Hecate Chat or External Agent chat needs a workspace path.           |
+| `chat.session_limit_exceeded`          |    422 | The chat turn limit was reached.                                                 |
+| `chat.session_duration_limit_exceeded` |    422 | The chat wall-clock limit was reached.                                           |
+| `chat.session_idle_timeout`            |    422 | The chat was idle beyond the configured timeout.                                 |
 
 OpenAI-compatible and Anthropic-compatible ingress paths keep their protocol
 shape, but gateway-classified failures also include the same
@@ -1487,7 +1487,7 @@ Chat execution errors:
 | `409`  | `chat.session_stopping`          | The session is still cancelling or closing; retry after it settles.                                                                                                                      |
 | `409`  | `chat.session_not_running`       | A stop request was issued when no run was active.                                                                                                                                        |
 | `422`  | `model_not_configured`           | The selected model is not currently reported by the selected provider. Choose a discovered model or refresh/fix provider discovery.                                                      |
-| `422`  | `chat.model_capability_required` | Tools are explicitly disabled for the selected model. Turn tools off for direct model chat or enable tools in Connections.                                                               |
+| `422`  | `chat.model_capability_required` | A task-backed Hecate Chat turn was explicitly requested, but tools are unavailable for the selected model. Continue with direct model chat or enable tools in Connections.               |
 
 Client note: browser/operator clients may queue a prompt locally when they
 receive or predict `chat.agent_session_busy`, but the server still

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -610,7 +610,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		return
 	case chat.ExecutionModeHecateTask:
 		if isExternalChatSession(session) {
-			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Agent turns")
+			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run task-backed Hecate Chat turns")
 			return
 		}
 		h.handleCreateHecateChatMessage(w, r, session, req)

--- a/internal/api/handler_chat_errors.go
+++ b/internal/api/handler_chat_errors.go
@@ -13,7 +13,7 @@ import (
 func writeAgentChatWorkspaceRequired(w http.ResponseWriter, mode string) {
 	WriteErrorDetails(w, http.StatusBadRequest, errCodeWorkspaceRequired, fmt.Sprintf("workspace is required for %s chat", chatExecutionModeLabel(mode)), ErrorDetails{
 		UserMessage:    "Choose a workspace before starting this chat mode.",
-		OperatorAction: "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path.",
+		OperatorAction: "Use the workspace picker in Chats. Task-backed Hecate Chat and External Agent sessions need a real workspace path.",
 	})
 }
 
@@ -138,7 +138,7 @@ func writeHecateAgentBusy(w http.ResponseWriter, session chat.Session, runStatus
 func chatExecutionModeLabel(mode string) string {
 	switch mode {
 	case chat.ExecutionModeHecateTask:
-		return "Hecate Agent"
+		return "task-backed Hecate Chat"
 	case chat.ExecutionModeExternalAgent:
 		return "External Agent"
 	default:

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -51,7 +51,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		caps = resolved
 	}
 	if !modelcaps.ToolCapable(caps) {
-		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are disabled for this model. Turn tools off for direct model chat or enable tools in Connections.", ErrorDetails{
+		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are unavailable for this model. Send as direct model chat or enable tools in Connections.", ErrorDetails{
 			Fields: map[string]any{
 				"provider":     session.Provider,
 				"model":        session.Model,
@@ -136,7 +136,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		CreatedAt:     startedAt,
 		StartedAt:     startedAt,
 		Activities: []chat.Activity{
-			newChatActivity("started", "running", "Starting Hecate Agent", "Creating or continuing the backing task run"),
+			newChatActivity("started", "running", "Starting Hecate Chat tools", "Creating or continuing the backing task run"),
 		},
 	})
 	if err != nil {
@@ -374,7 +374,7 @@ func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session cha
 		now := time.Now().UTC()
 		title := strings.TrimSpace(session.Title)
 		if title == "" {
-			title = "Hecate Agent chat"
+			title = "Hecate Chat"
 		}
 		task := types.Task{
 			ID:                 newTaskID(),
@@ -663,17 +663,17 @@ func humanHecateAgentRunStatus(status string) string {
 func hecateAgentFallbackOutput(status, taskID, runID, errorText string) string {
 	switch status {
 	case "awaiting_approval":
-		return fmt.Sprintf("Hecate Agent is awaiting approval in task `%s`, run `%s`.", taskID, runID)
+		return fmt.Sprintf("Hecate Chat is awaiting approval in task `%s`, run `%s`.", taskID, runID)
 	case "queued", "running":
-		return fmt.Sprintf("Hecate Agent task `%s` is still %s.", taskID, status)
+		return fmt.Sprintf("Hecate Chat task `%s` is still %s.", taskID, status)
 	case "failed":
 		if strings.TrimSpace(errorText) != "" {
 			return errorText
 		}
-		return "Hecate Agent run failed."
+		return "Hecate Chat run failed."
 	case "cancelled":
-		return "Hecate Agent run cancelled."
+		return "Hecate Chat run cancelled."
 	default:
-		return "Hecate Agent run completed."
+		return "Hecate Chat run completed."
 	}
 }

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -32,7 +32,7 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 			CreatedAt: time.Now().UTC(),
 			Choices: []types.ChatChoice{{
 				Index:        0,
-				Message:      types.Message{Role: "assistant", Content: "Hecate Agent final answer."},
+				Message:      types.Message{Role: "assistant", Content: "Hecate Chat final answer."},
 				FinishReason: "stop",
 			}},
 			Usage: types.Usage{PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14},
@@ -70,7 +70,7 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	if first.Data.Status != "completed" {
 		t.Fatalf("first status = %q, want completed", first.Data.Status)
 	}
-	if len(first.Data.Messages) < 2 || !strings.Contains(first.Data.Messages[len(first.Data.Messages)-1].Content, "Hecate Agent final answer") {
+	if len(first.Data.Messages) < 2 || !strings.Contains(first.Data.Messages[len(first.Data.Messages)-1].Content, "Hecate Chat final answer") {
 		t.Fatalf("first transcript = %+v", first.Data.Messages)
 	}
 	assistant := first.Data.Messages[len(first.Data.Messages)-1]
@@ -90,7 +90,7 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 		t.Fatalf("assistant activities missing projected task run result activity: %+v", assistant.Activities)
 	}
 	if assistant.Timing == nil || assistant.Timing.TurnCount == 0 || assistant.Timing.Bottleneck == "" {
-		t.Fatalf("assistant timing = %+v, want persisted Hecate Agent run timing", assistant.Timing)
+		t.Fatalf("assistant timing = %+v, want persisted Hecate Chat run timing", assistant.Timing)
 	}
 
 	taskResponse := mustRequestJSON[TaskResponse](client, http.MethodGet, "/hecate/v1/tasks/"+first.Data.TaskID, "")
@@ -906,7 +906,7 @@ func TestHecateAgentChatRejectsDisabledToolCapability(t *testing.T) {
 	if payload.Error.Type != errCodeModelCapability {
 		t.Fatalf("error type = %q, want %s", payload.Error.Type, errCodeModelCapability)
 	}
-	if !strings.Contains(payload.Error.Message, "Tools are disabled for this model") {
+	if !strings.Contains(payload.Error.Message, "Tools are unavailable for this model") {
 		t.Fatalf("message = %q", payload.Error.Message)
 	}
 }

--- a/internal/api/handler_chat_sse.go
+++ b/internal/api/handler_chat_sse.go
@@ -54,9 +54,9 @@ func agentChatTraceAttrs(session chat.Session, adapter agentadapters.Adapter, ru
 }
 
 // hecateAgentChatTraceAttrs mirrors agentChatTraceAttrs for Hecate-owned
-// agent_loop chats. The backing task/run trace carries the detailed queue,
+// task-backed chats. The backing task/run trace carries the detailed queue,
 // model, tool, approval, and artifact timings; these attrs make the chat
-// wrapper itself visible in the same agent-chat dashboards.
+// wrapper itself visible in the same chat dashboards.
 func hecateAgentChatTraceAttrs(session chat.Session, taskID, runID, messageID string, attrs map[string]any) map[string]any {
 	out := map[string]any{
 		telemetry.AttrHecateChatSessionID:    session.ID,
@@ -65,7 +65,7 @@ func hecateAgentChatTraceAttrs(session chat.Session, taskID, runID, messageID st
 		telemetry.AttrHecateRunID:            runID,
 		telemetry.AttrHecateExecutionKind:    "chat",
 		telemetry.AttrHecateAgentAdapterID:   "hecate",
-		telemetry.AttrHecateAgentAdapterName: "Hecate Agent",
+		telemetry.AttrHecateAgentAdapterName: "Hecate Chat",
 		telemetry.AttrHecateAgentDriverKind:  "hecate",
 		telemetry.AttrHecateWorkspacePath:    session.Workspace,
 		telemetry.AttrGenAIProviderName:      session.Provider,

--- a/internal/api/handler_workspace_dialog.go
+++ b/internal/api/handler_workspace_dialog.go
@@ -40,7 +40,7 @@ func chooseWorkspaceDirectory(ctx context.Context) (string, error) {
 			dialogCtx,
 			"osascript",
 			"-e",
-			`POSIX path of (choose folder with prompt "Choose a workspace for Hecate Agent Chat")`,
+			`POSIX path of (choose folder with prompt "Choose a workspace for Hecate Chat")`,
 		).CombinedOutput()
 		if isWorkspaceDialogCancelled(err, string(out)) {
 			return "", nil

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -192,11 +192,11 @@ func defaultErrorAction(code string) string {
 	case errCodeAgentSessionBusy:
 		return "Open the backing task, resolve the pending approval, or stop the run before sending another message."
 	case errCodeModelCapability:
-		return "Turn tools off for direct model chat, test the model, or enable tool support in Connections."
+		return "Send as direct model chat, test the model, or enable tool support in Connections."
 	case errCodeModelNotConfigured:
 		return "Choose a discovered model, refresh provider status, or open Connections to fix model discovery."
 	case errCodeWorkspaceRequired:
-		return "Use the workspace picker in Chats. Hecate Agent and External Agent sessions need a real workspace path."
+		return "Use the workspace picker in Chats. Task-backed Hecate Chat and External Agent sessions need a real workspace path."
 	case errCodeModelRequired:
 		return "Use the model picker in the chat header, or add a provider that reports at least one model."
 	case errCodeAgentIDInvalid, errCodeExecutionModeInvalid:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -98,7 +98,7 @@ func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 
 func registerHecateTaskRoutes(mux *http.ServeMux, handler *Handler) {
 	// Native task/runtime API: tasks, runs, approvals, events, patches, and
-	// artifacts. This is the canonical execution surface for Hecate Agent.
+	// artifacts. This is the canonical execution surface for task-backed Hecate Chat.
 	mux.HandleFunc("GET /hecate/v1/tasks", handler.HandleTasks)
 	mux.HandleFunc("POST /hecate/v1/tasks", handler.HandleCreateTask)
 	mux.HandleFunc("GET /hecate/v1/tasks/{id}", handler.HandleTask)

--- a/ui/src/app/runtimeConsoleChatHelpers.test.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.test.ts
@@ -60,14 +60,14 @@ describe("humanizeChatError", () => {
   });
 
   it("rewrites common chat runtime failures into operator-actionable copy", () => {
-    expect(humanizeChatError("Hecate Agent is already running for this chat session.")).toBe(
+    expect(humanizeChatError("Hecate Chat is already running for this chat session.")).toBe(
       "Hecate Chat is still working on this task. Open the task, resolve approval, or stop it before sending another message.",
     );
     expect(humanizeChatError("workspace is required")).toBe(
       "Choose a workspace before using Hecate Chat tools or External Agent.",
     );
     expect(humanizeChatError("model does not support tools")).toBe(
-      "This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.",
+      "This model is not marked as tool-capable. Send directly, test it, or enable tools in Connections → Model capabilities.",
     );
     expect(
       humanizeChatError('route request: no provider supports explicit model "gpt-5.4-mini"'),

--- a/ui/src/app/runtimeConsoleChatHelpers.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.ts
@@ -36,7 +36,7 @@ export function humanizeChatError(raw: string): string {
       raw,
     )
   ) {
-    return "This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.";
+    return "This model is not marked as tool-capable. Send directly, test it, or enable tools in Connections → Model capabilities.";
   }
   const explicitModel = raw.match(/no provider supports explicit model ["“]?([^"”]+)["”]?/i);
   if (explicitModel) {

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -45,11 +45,15 @@ import {
   deriveChatSessionTitle,
   renderChatSessionSummary,
 } from "../../runtimeConsoleChatHelpers";
+import { modelSelectionHasNoToolCalling } from "../../../lib/chat-setup-readiness";
 import {
   type ChatExecutionMode,
+  type HecateChatTarget,
   type ChatTarget,
   type QueuedChatMessage,
   chatTargetToExecutionMode,
+  executionModeToChatTarget,
+  normalizeStoredHecateChatTarget,
 } from "../_shared";
 import { useApprovals } from "../approvals";
 import { useChat } from "../chat";
@@ -58,6 +62,7 @@ import { useRuntime } from "../runtime";
 import { useUsage } from "../usage";
 import type { RuntimeHeaders } from "../../../types/runtime";
 import type { ProviderFilter } from "../../../types/provider";
+import type { ModelRecord } from "../../../types/model";
 import type {
   ChatActivityRecord,
   ChatApprovalRecord,
@@ -114,6 +119,27 @@ function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null)
 
 function chatGuardError(message: string, code: string, operatorAction: string): ApiError {
   return new ApiError(message, 400, code, { operatorAction });
+}
+
+function effectiveHecateExecutionMode({
+  requested,
+  models,
+  providerFilter,
+  model,
+}: {
+  requested: ChatExecutionMode;
+  models: ModelRecord[];
+  providerFilter: ProviderFilter;
+  model: string;
+}): ChatExecutionMode {
+  if (requested !== "hecate_task") return requested;
+  return modelSelectionHasNoToolCalling({ models, providerFilter, model })
+    ? "direct_model"
+    : requested;
+}
+
+function hecateTargetForExecutionMode(mode: ChatExecutionMode): HecateChatTarget {
+  return normalizeStoredHecateChatTarget(executionModeToChatTarget(mode)) || "agent";
 }
 
 export { chatSessionIsExternal, chatSessionIsBusy };
@@ -369,8 +395,16 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const content = (queued?.content ?? message).trim();
     if (!content) return;
 
-    const turnExecutionMode =
+    const turnProviderFilter = queued?.provider_filter ?? providerFilter;
+    const turnModel = queued?.model ?? model;
+    const requestedExecutionMode =
       queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
+    const turnExecutionMode = effectiveHecateExecutionMode({
+      requested: requestedExecutionMode,
+      models,
+      providerFilter: turnProviderFilter,
+      model: turnModel,
+    });
     if (!queued && activeChatSessionID && chatSessionIsBusy(activeChatSession)) {
       queueChatMessage(content, turnExecutionMode, activeChatSessionID);
       return;
@@ -381,8 +415,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     setRuntimeHeaders(null);
     const isExternalAgent = turnExecutionMode === "external_agent";
     const isModelTurn = turnExecutionMode === "direct_model";
-    const turnProviderFilter = queued?.provider_filter ?? providerFilter;
-    const turnModel = queued?.model ?? model;
     const turnWorkspace = queued?.workspace ?? agentWorkspace.trim();
     const turnSystemPrompt = queued?.system_prompt ?? systemPrompt;
     const turnAgentID = queued?.agent_id ?? agentAdapterID;
@@ -391,7 +423,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ? "Starting external agent..."
         : isModelTurn
           ? "Waiting for model output..."
-          : "Starting Hecate Agent...",
+          : "Starting Hecate Chat tools...",
     );
     let streamAbort: AbortController | null = null;
     let streamPromise: Promise<void> | null = null;
@@ -439,6 +471,13 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         setActiveChatSessionID(sessionID);
         applyChatSession(created.data);
       }
+      if (!isExternalAgent && sessionID) {
+        setChatTargetBySessionID((current) => {
+          const next = new Map(current);
+          next.set(sessionID, hecateTargetForExecutionMode(turnExecutionMode));
+          return next;
+        });
+      }
 
       const pendingContent = content;
       setMessage("");
@@ -483,7 +522,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
                       ? "External agent is running..."
                       : isModelTurn
                         ? "Model is responding..."
-                        : "Hecate Agent is running..."),
+                        : "Hecate Chat tools are running..."),
                 );
               }
               return;
@@ -646,7 +685,13 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       return;
     }
 
-    const executionMode = chatTargetToExecutionMode(defaultChatTarget);
+    const requestedExecutionMode = chatTargetToExecutionMode(defaultChatTarget);
+    const executionMode = effectiveHecateExecutionMode({
+      requested: requestedExecutionMode,
+      models,
+      providerFilter,
+      model,
+    });
     const workspace = agentWorkspace.trim();
     if (executionMode === "hecate_task" && !workspace) {
       setChatErrorState(
@@ -685,7 +730,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       setActiveChatSessionID(created.data.id);
       setChatTargetBySessionID((current) => {
         const next = new Map(current);
-        next.set(created.data.id, defaultChatTarget);
+        next.set(created.data.id, hecateTargetForExecutionMode(executionMode));
         return next;
       });
       applyChatSession(created.data);

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -359,12 +359,16 @@ export function HecateToolsToggle({
   toolsDisabledForModel: boolean;
   onChange: (enabled: boolean) => void;
 }) {
+  const effectiveEnabled = enabled && !toolsDisabledForModel;
   const toolsOnTitle = toolsDisabledForModel
-    ? "Tools are disabled for this model in Connections. Enable them there or turn tools off for direct model chat."
+    ? "Tools are unavailable for this model. Messages will send as direct model chat unless you enable tool support in Connections."
     : "Use Hecate's task runtime with tools, approvals, artifacts, and telemetry.";
-  const title = enabled
-    ? toolsOnTitle
-    : "Chat directly with the selected model. No task run or tools.";
+  const title =
+    enabled && toolsDisabledForModel
+      ? toolsOnTitle
+      : effectiveEnabled
+        ? toolsOnTitle
+        : "Chat directly with the selected model. No task run or tools.";
   return (
     <div
       role="group"
@@ -394,8 +398,8 @@ export function HecateToolsToggle({
       <button
         type="button"
         className="btn btn-ghost btn-sm"
-        aria-label={enabled ? "tools on" : "tools off"}
-        aria-pressed={enabled}
+        aria-label={effectiveEnabled ? "tools on" : "tools off"}
+        aria-pressed={effectiveEnabled}
         onClick={() => onChange(!enabled)}
         title={title}
         style={{
@@ -405,12 +409,12 @@ export function HecateToolsToggle({
           padding: "3px 9px",
           fontFamily: "var(--font-mono)",
           fontSize: 10,
-          background: enabled ? "var(--teal-bg)" : "var(--bg3)",
-          color: enabled ? (toolsDisabledForModel ? "var(--amber)" : "var(--teal)") : "var(--t1)",
+          background: effectiveEnabled ? "var(--teal-bg)" : "var(--bg3)",
+          color: enabled && toolsDisabledForModel ? "var(--amber)" : "var(--t1)",
           justifyContent: "center",
         }}
       >
-        {enabled ? "on" : "off"}
+        {effectiveEnabled ? "on" : "off"}
       </button>
     </div>
   );
@@ -842,7 +846,7 @@ export function LockedHecateModelSnapshot({
   model: string;
 }) {
   const title =
-    "Provider and model are fixed for this Hecate Agent task. Turn tools off for direct model chat, or start a new chat to use a different tools-enabled model.";
+    "Provider and model are fixed for this task-backed turn. For direct model chat, disable tools, or start a new chat to use a different tools-enabled model.";
   const lockedStyle = {
     ...externalAgentComposerControlStyle,
     color: "var(--t2)",

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -48,7 +48,7 @@ export type ChatComposerProps = {
   isAgentChat: boolean;
   isHecateChat: boolean;
   isExternalAgentChat: boolean;
-  isHecateAgentChat: boolean;
+  hecateTaskToolsAvailable: boolean;
   activeSessionID: string;
 
   // Cross-region ref. ChatView owns creation so onSelectSession can
@@ -135,7 +135,7 @@ export function ChatComposer(props: ChatComposerProps) {
     isAgentChat,
     isHecateChat,
     isExternalAgentChat,
-    isHecateAgentChat,
+    hecateTaskToolsAvailable,
     activeSessionID,
     textareaRef,
     composerVisible,
@@ -690,10 +690,9 @@ export function ChatComposer(props: ChatComposerProps) {
               <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
                 External agents run as your OS user in the selected workspace — no sandbox
               </span>
-            ) : isHecateAgentChat ? (
+            ) : hecateTaskToolsAvailable ? (
               <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                Hecate Agent runs through task approvals and per-call sandboxing in the selected
-                workspace.
+                Tools use task approvals and per-call sandboxing in the selected workspace.
               </span>
             ) : (
               <span />

--- a/ui/src/features/chats/ChatInstructionsPanel.tsx
+++ b/ui/src/features/chats/ChatInstructionsPanel.tsx
@@ -38,7 +38,7 @@ export function ChatInstructionsPanel({
       </div>
       <div style={{ color: "var(--t2)", fontSize: 12, marginBottom: 8, lineHeight: 1.45 }}>
         {isHecateAgentChat
-          ? "This is the system prompt for future Hecate Agent turns. It steers the model, but does not change approval policy, sandboxing, or external-agent settings."
+          ? "This is the system prompt for future tool-backed Hecate Chat turns. It steers the model, but does not change approval policy, sandboxing, or external-agent settings."
           : "This is the system prompt for future direct model turns in this Hecate Chat."}
       </div>
       <textarea

--- a/ui/src/features/chats/ChatSettingsPanel.tsx
+++ b/ui/src/features/chats/ChatSettingsPanel.tsx
@@ -250,6 +250,7 @@ function ChatSettingsToolsRow({
   disabled: boolean;
   onChange: (enabled: boolean) => void;
 }) {
+  const effectiveEnabled = enabled && !disabled;
   return (
     <div
       style={{
@@ -266,33 +267,34 @@ function ChatSettingsToolsRow({
       <div>
         <div style={{ fontSize: 12, fontWeight: 650, color: "var(--t0)" }}>Tools</div>
         <div style={{ marginTop: 3, fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
-          {enabled
+          {effectiveEnabled
             ? "Use Hecate's task runtime, approvals, artifacts, and sandboxed tool calls."
             : "Send the next turn directly to the selected provider/model without local tools."}
         </div>
         {disabled && (
           <div style={{ marginTop: 4, fontSize: 11, color: "var(--amber)", lineHeight: 1.45 }}>
-            This model does not have known tool-calling support.
+            This model does not have known tool-calling support. You can still chat normally.
           </div>
         )}
       </div>
       <button
         className="btn btn-ghost btn-sm"
         type="button"
-        aria-label={`Tools ${enabled ? "on" : "off"}`}
-        aria-pressed={enabled}
+        aria-label={`Tools ${effectiveEnabled ? "on" : "off"}`}
+        aria-pressed={effectiveEnabled}
         disabled={disabled && !enabled}
         onClick={() => onChange(!enabled)}
         style={{
           flexShrink: 0,
           minWidth: 72,
           justifyContent: "center",
-          color: enabled ? "var(--teal)" : "var(--t2)",
-          borderColor: enabled ? "var(--teal-border)" : "var(--border)",
-          background: enabled ? "var(--teal-bg)" : "transparent",
+          color:
+            enabled && disabled ? "var(--amber)" : effectiveEnabled ? "var(--teal)" : "var(--t2)",
+          borderColor: effectiveEnabled ? "var(--teal-border)" : "var(--border)",
+          background: effectiveEnabled ? "var(--teal-bg)" : "transparent",
         }}
       >
-        {enabled ? "on" : "off"}
+        {effectiveEnabled ? "on" : "off"}
       </button>
     </div>
   );

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -167,7 +167,7 @@ export function ChatTranscript({
               })
             : "";
           const agentModel = isHecateAgentChat
-            ? m.model || activeChatSession?.model || "Hecate Agent"
+            ? m.model || activeChatSession?.model || "Hecate Chat"
             : m.agent_name || m.agent_id;
           const agentRuntime =
             role === "assistant"

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -920,7 +920,7 @@ describe("ChatView input", () => {
     expect(setProviderFilter).toHaveBeenCalledWith("ollama");
   });
 
-  it("shows one-click local provider onboarding from Hecate Agent chat", async () => {
+  it("shows one-click local provider onboarding from Hecate Chat", async () => {
     vi.mocked(discoverLocalProviders).mockResolvedValueOnce({
       object: "local_provider_discovery",
       data: [
@@ -1203,7 +1203,7 @@ describe("ChatView input", () => {
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
   });
 
-  it("enables Hecate Agent when tools are not explicitly disabled for the model", async () => {
+  it("enables Hecate Chat tools when tools are not explicitly disabled for the model", async () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       message: "inspect this repo",
@@ -1240,7 +1240,7 @@ describe("ChatView input", () => {
     expect(send.disabled).toBe(false);
   });
 
-  it("keeps provider and model pickers editable after a task-backed Hecate Agent segment completes", () => {
+  it("keeps provider and model pickers editable after a task-backed Hecate Chat segment completes", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       message: "continue",
@@ -1506,7 +1506,7 @@ describe("ChatView input", () => {
     expect(provider.textContent).not.toContain("ollama");
   });
 
-  it("locks provider and model while a task-backed Hecate Agent segment is active", () => {
+  it("locks provider and model while a task-backed Hecate Chat segment is active", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       message: "continue",
@@ -1566,7 +1566,7 @@ describe("ChatView input", () => {
     expect(fixedProvider.disabled).toBe(true);
     expect(fixedModel.disabled).toBe(true);
     expect(screen.queryByText("smollm2:135m")).toBeNull();
-    expect(screen.queryByText(/Tools are disabled for this model/)).toBeNull();
+    expect(screen.queryByText(/Tools are unavailable for this model/)).toBeNull();
     expect(screen.getByRole("button", { name: "Queue message" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Stop active task" })).toBeTruthy();
     expect(screen.getByText(/Hecate Chat is still working on this task/)).toBeTruthy();
@@ -1736,7 +1736,7 @@ describe("ChatView input", () => {
     expect(screen.queryByDisplayValue("not in this chat")).toBeNull();
   });
 
-  it("shows the Hecate Agent sandbox reminder only when tools are enabled", () => {
+  it("shows the tools sandbox reminder only when task-backed tools are available", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       providerScopedModels: [
@@ -1754,20 +1754,17 @@ describe("ChatView input", () => {
     });
     const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    expect(
-      screen.getByText(/Hecate Agent runs through task approvals and per-call sandboxing/),
-    ).toBeTruthy();
+    expect(screen.getByText(/Tools use task approvals and per-call sandboxing/)).toBeTruthy();
 
     rerender(
       withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }),
     );
-    expect(
-      screen.queryByText(/Hecate Agent runs through task approvals and per-call sandboxing/),
-    ).toBeNull();
+    expect(screen.queryByText(/Tools use task approvals and per-call sandboxing/)).toBeNull();
   });
 
-  it("blocks Hecate Agent sends when tools are explicitly disabled for the model", async () => {
+  it("keeps Hecate Chat sendable when tools are explicitly unavailable for the model", async () => {
     const upsertModelCapabilityOverride = vi.fn(async () => true);
+    const submitChat = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
         chatTarget: "agent",
@@ -1793,13 +1790,13 @@ describe("ChatView input", () => {
           },
         ],
       },
-      { upsertModelCapabilityOverride },
+      { submitChat, upsertModelCapabilityOverride },
     );
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    expect(screen.getByText(/Tools are disabled for this model/)).toBeTruthy();
+    expect(screen.getByText(/Tools are unavailable for this model/)).toBeTruthy();
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
-    expect(send.disabled).toBe(true);
+    expect(send.disabled).toBe(false);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Enable tools" }));
@@ -1811,9 +1808,11 @@ describe("ChatView input", () => {
         note: "Tools enabled from Hecate Chat.",
       }),
     );
+    await user.click(send);
+    expect(submitChat).toHaveBeenCalled();
   });
 
-  it("opens the backing task from the Hecate Agent assistant turn, not the header", async () => {
+  it("opens the backing task from the Hecate Chat assistant turn, not the header", async () => {
     const onOpenTask = vi.fn();
     const { state, actions } = setup({
       chatTarget: "agent",
@@ -2021,7 +2020,7 @@ describe("ChatView input", () => {
     expect(screen.getAllByText(/direct model chat/)).toHaveLength(2);
   });
 
-  it("renders projected Hecate Agent task run activity in the transcript", () => {
+  it("renders projected Hecate Chat task run activity in the transcript", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       activeChatSessionID: "chat_1",
@@ -2105,7 +2104,7 @@ describe("ChatView input", () => {
     expect(screen.queryByText("Run completed")).toBeNull();
   });
 
-  it("resolves projected Hecate Agent task approvals from the chat banner", async () => {
+  it("resolves projected Hecate Chat task approvals from the chat banner", async () => {
     const resolveTaskApproval = vi.fn(async () => true);
     const onOpenTask = vi.fn();
     const { state, actions } = setup(
@@ -2174,7 +2173,7 @@ describe("ChatView input", () => {
     });
   });
 
-  it("does not keep stale resolved Hecate Agent task approvals actionable", () => {
+  it("does not keep stale resolved Hecate Chat task approvals actionable", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       activeChatSessionID: "chat_1",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../app/state/coordinators/wired";
 import { discoverLocalProviders } from "../../lib/api";
 import {
+  modelSelectionHasNoToolCalling,
   resolveChatSetupRepairState,
   type ChatSetupRepairState,
 } from "../../lib/chat-setup-readiness";
@@ -358,15 +359,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       ? sidebarSessionAgentLabel(state.activeChatSession, state.agentAdapters)
       : chatAgentOption(newChatAgentID, state.agentAdapters).label
     : selectedProviderName;
-  const activeHeaderSubline = buildActiveChatHeaderSubline({
-    isAgentChat,
-    isExternalAgentChat,
-    isHecateAgentChat,
-    activeSession: state.activeChatSession,
-    selectedAgent,
-    newChatAgentID,
-    adapters: state.agentAdapters,
-  });
   const latestChatUsage = isAgentChat ? findLatestAgentUsage(state.activeChatSession) : null;
   const selectedHecateModelRecord = hecateAgentModelLocked
     ? undefined
@@ -390,7 +382,14 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const selectedModelCapabilities = hecateAgentModelLocked
     ? state.activeChatSession?.capabilities
     : selectedHecateModelRecord?.metadata?.capabilities;
-  const hecateAgentToolsDisabledForModel = selectedModelCapabilities?.tool_calling === "none";
+  const hecateAgentToolsDisabledForModel = hecateAgentModelLocked
+    ? selectedModelCapabilities?.tool_calling === "none"
+    : modelSelectionHasNoToolCalling({
+        models: selectableModels,
+        providerFilter: state.providerFilter,
+        model: state.model,
+      });
+  const hecateTaskToolsAvailable = isHecateAgentChat && !hecateAgentToolsDisabledForModel;
   const selectedCapabilityProvider = hecateAgentModelLocked
     ? ""
     : state.providerFilter !== "auto"
@@ -401,7 +400,17 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     isHecateAgentChat && hecateAgentModelLocked
       ? Boolean(hecateChatModelValue)
       : Boolean(state.model) && !modelRouteUnavailable && !selectedModelIssue;
-  const showHeaderWorkspaceButton = isExternalAgentChat || isHecateAgentChat;
+  const showHeaderWorkspaceButton = isExternalAgentChat || hecateTaskToolsAvailable;
+  const activeHeaderSubline = buildActiveChatHeaderSubline({
+    isAgentChat,
+    isExternalAgentChat,
+    isHecateAgentChat,
+    hecateTaskToolsAvailable,
+    activeSession: state.activeChatSession,
+    selectedAgent,
+    newChatAgentID,
+    adapters: state.agentAdapters,
+  });
   const showClaudeCodeEmptyPreflight =
     isExternalAgentChat &&
     visibleMessages.length === 0 &&
@@ -452,7 +461,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     (!agentBusy && isExternalAgentChat && Boolean(claudeCodePreflight?.blockSend)) ||
     (!agentBusy &&
       isHecateAgentChat &&
-      (!state.agentWorkspace.trim() || !hecateChatModelReady || hecateAgentToolsDisabledForModel));
+      (!hecateChatModelReady ||
+        (!hecateAgentToolsDisabledForModel && !state.agentWorkspace.trim())));
 
   async function enableToolsForSelectedModel() {
     if (!selectedCapabilityProvider || !selectedCapabilityModel || capabilitySaving) {
@@ -873,7 +883,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               isAgentChat={isAgentChat}
               isHecateChat={isHecateChat}
               isExternalAgentChat={isExternalAgentChat}
-              isHecateAgentChat={isHecateAgentChat}
+              hecateTaskToolsAvailable={hecateTaskToolsAvailable}
               activeSessionID={activeSessionID}
               textareaRef={textareaRef}
               composerVisible={composerVisible}
@@ -970,6 +980,7 @@ function buildActiveChatHeaderSubline({
   isAgentChat,
   isExternalAgentChat,
   isHecateAgentChat,
+  hecateTaskToolsAvailable,
   activeSession,
   selectedAgent,
   newChatAgentID,
@@ -978,6 +989,7 @@ function buildActiveChatHeaderSubline({
   isAgentChat: boolean;
   isExternalAgentChat: boolean;
   isHecateAgentChat: boolean;
+  hecateTaskToolsAvailable: boolean;
   activeSession: ChatSessionRecord | null;
   selectedAgent?: AgentAdapterRecord;
   newChatAgentID: string;
@@ -990,7 +1002,11 @@ function buildActiveChatHeaderSubline({
       : `${chatAgentOption(newChatAgentID, adapters).label} · new session`;
     return [base, activeSession?.workspace || ""].filter(Boolean).join(" · ");
   }
-  const mode = isHecateAgentChat ? "Tools on" : "Tools off";
+  const mode = isHecateAgentChat
+    ? hecateTaskToolsAvailable
+      ? "Tools on"
+      : "Tools unavailable"
+    : "Tools off";
   return [mode, activeSession?.workspace || ""].filter(Boolean).join(" · ");
 }
 

--- a/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
+++ b/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
@@ -138,7 +138,7 @@ export function HecateTaskApprovalsBanner({
   const overflow = approvals.length - visible.length;
   return (
     <ChatNoticeFrame
-      aria-label="Pending Hecate Agent task approvals"
+      aria-label="Pending Hecate Chat task approvals"
       testID="hecate-task-approval-banner"
       tone="amber"
     >

--- a/ui/src/features/runs/TaskList.test.tsx
+++ b/ui/src/features/runs/TaskList.test.tsx
@@ -213,7 +213,7 @@ describe("TaskList", () => {
     expect(screen.getByText("agent")).toBeTruthy();
   });
 
-  it("renders Hecate Agent chat origin metadata", () => {
+  it("renders Hecate Chat origin metadata", () => {
     const { render } = setup({
       tasks: [
         makeTask({

--- a/ui/src/features/runs/TaskList.tsx
+++ b/ui/src/features/runs/TaskList.tsx
@@ -168,9 +168,7 @@ export function TaskList({
                   <span
                     className="badge badge-muted"
                     title={
-                      t.origin_id
-                        ? `Created from chat ${t.origin_id}`
-                        : "Created from a Hecate Agent chat"
+                      t.origin_id ? `Created from chat ${t.origin_id}` : "Created from Hecate Chat"
                     }
                     style={{
                       fontSize: 9,

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -347,7 +347,7 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText(/builtin\.agent_loop/)).toBeNull();
   });
 
-  it("summarizes Hecate Agent task internals without duplicate terminal rows", () => {
+  it("summarizes Hecate Chat task internals without duplicate terminal rows", () => {
     const activities: ChatActivityRecord[] = [
       {
         type: "tool_call",
@@ -391,7 +391,7 @@ describe("TranscriptActivityTimeline", () => {
 
   it("renders expanded activity rows in chronological order instead of grouping tools first", () => {
     const activities: ChatActivityRecord[] = [
-      { type: "started", title: "Starting Hecate Agent", status: "running" },
+      { type: "started", title: "Starting Hecate Chat tools", status: "running" },
       {
         type: "task_run",
         title: "Backing task",

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -180,7 +180,7 @@ describe("TranscriptMessageRow", () => {
     expect(screen.queryByText(/reported by adapter/)).toBeNull();
   });
 
-  it("renders the Hecate Agent timing summary when timing is present", () => {
+  it("renders the Hecate Chat timing summary when timing is present", () => {
     const timing: ChatTimingRecord = {
       total_ms: 12_400,
       queue_ms: 120,
@@ -194,7 +194,7 @@ describe("TranscriptMessageRow", () => {
       bottleneck_ms: 8_500,
     };
     render(<TranscriptMessageRow {...baseProps} agentTiming={timing} />);
-    expect(screen.getByLabelText("Hecate Agent timing summary")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hecate Chat timing summary")).toBeInTheDocument();
     expect(screen.getByText(/bottleneck · model 8\.5s/)).toBeInTheDocument();
     expect(screen.getByText(/total 12s/)).toBeInTheDocument();
     expect(screen.getByText(/2 turns · 1 tool/)).toBeInTheDocument();

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -583,7 +583,7 @@ function AgentTiming({ timing }: { timing: ChatTimingRecord }) {
     .join(" · ");
   return (
     <div
-      aria-label="Hecate Agent timing summary"
+      aria-label="Hecate Chat timing summary"
       style={{
         background: "rgba(0, 194, 184, 0.05)",
         border: "1px solid var(--teal-border)",

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -303,7 +303,7 @@ describe("activityDisplay", () => {
 
   it("renders 'Starting agent' for the canonical start-row title", () => {
     expect(
-      activityDisplay(activity({ type: "started", title: "Starting Hecate Agent" })).title,
+      activityDisplay(activity({ type: "started", title: "Starting Hecate Chat tools" })).title,
     ).toBe("Starting agent");
   });
 

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -233,7 +233,7 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
       detail: cleanActivityDetail(activity) || activity.title,
     };
   }
-  if (activity.type === "started" && /^Starting Hecate Agent$/i.test(activity.title.trim())) {
+  if (activity.type === "started" && /^Starting Hecate Chat tools$/i.test(activity.title.trim())) {
     return { title: "Starting agent", detail: cleanActivityDetail(activity) };
   }
   if (activity.type === "cancelled") {

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveChatSetupRepairState } from "./chat-setup-readiness";
+import {
+  modelSelectionHasNoToolCalling,
+  resolveChatSetupRepairState,
+} from "./chat-setup-readiness";
 
 describe("resolveChatSetupRepairState", () => {
   const base = {
@@ -53,7 +56,7 @@ describe("resolveChatSetupRepairState", () => {
     });
   });
 
-  it("blocks Hecate Agent when tools are disabled for the selected model", () => {
+  it("warns when tools are unavailable for the selected model", () => {
     const repair = resolveChatSetupRepairState({
       ...base,
       target: "agent",
@@ -63,11 +66,11 @@ describe("resolveChatSetupRepairState", () => {
     expect(repair).toMatchObject({
       kind: "tools_disabled",
       action: "enable_tools",
-      title: "Tools are disabled for this model",
+      title: "Tools are unavailable for this model",
     });
   });
 
-  it("requires a workspace for task-backed Hecate Agent chats", () => {
+  it("requires a workspace for task-backed Hecate Chat", () => {
     const repair = resolveChatSetupRepairState({
       ...base,
       target: "agent",
@@ -109,5 +112,53 @@ describe("resolveChatSetupRepairState", () => {
       action: "open_agent_setup",
       actionLabel: "Open setup",
     });
+  });
+});
+
+describe("modelSelectionHasNoToolCalling", () => {
+  it("returns true when the explicit provider/model selection has no tool support", () => {
+    expect(
+      modelSelectionHasNoToolCalling({
+        model: "llama3.1:8b",
+        providerFilter: "ollama",
+        models: [
+          {
+            id: "llama3.1:8b",
+            owned_by: "ollama",
+            metadata: {
+              provider: "ollama",
+              capabilities: { tool_calling: "none" },
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps auto provider usable when any matching route supports tools", () => {
+    expect(
+      modelSelectionHasNoToolCalling({
+        model: "shared-model",
+        providerFilter: "auto",
+        models: [
+          {
+            id: "shared-model",
+            owned_by: "provider-a",
+            metadata: {
+              provider: "provider-a",
+              capabilities: { tool_calling: "none" },
+            },
+          },
+          {
+            id: "shared-model",
+            owned_by: "provider-b",
+            metadata: {
+              provider: "provider-b",
+              capabilities: { tool_calling: "basic" },
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
   });
 });

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -1,4 +1,6 @@
 import type { SelectedModelIssue } from "./provider-issues";
+import type { ModelRecord } from "../types/model";
+import type { ProviderFilter } from "../types/provider";
 
 export type ChatSetupTarget = "model" | "agent" | "external_agent";
 
@@ -112,9 +114,9 @@ export function resolveChatSetupRepairState({
   if (target === "agent" && toolsDisabledForModel) {
     return {
       kind: "tools_disabled",
-      title: "Tools are disabled for this model",
+      title: "Tools are unavailable for this model",
       message:
-        "Turn tools off for direct chat, or enable tool-calling for this provider/model in Connections.",
+        "You can still chat normally. Hecate will send this turn directly to the selected model unless you enable tool support in Connections.",
       action: "enable_tools",
       actionLabel: "Enable tools",
       tone: "amber",
@@ -137,4 +139,23 @@ function workspaceRepair(): ChatSetupRepairState {
     actionLabel: "Choose workspace",
     tone: "amber",
   };
+}
+
+export function modelSelectionHasNoToolCalling({
+  models,
+  providerFilter,
+  model,
+}: {
+  models: ModelRecord[];
+  providerFilter: ProviderFilter;
+  model: string;
+}): boolean {
+  if (!model) return false;
+  const matches = models.filter((entry) => {
+    if (entry.id !== model) return false;
+    if (!providerFilter || providerFilter === "auto") return true;
+    return entry.metadata?.provider === providerFilter;
+  });
+  if (matches.length === 0) return false;
+  return matches.every((entry) => entry.metadata?.capabilities?.tool_calling === "none");
 }

--- a/ui/src/lib/error-diagnostics.ts
+++ b/ui/src/lib/error-diagnostics.ts
@@ -44,7 +44,7 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
   },
   "chat.workspace_required": {
     title: "Workspace required",
-    action: "Choose a workspace before using Hecate Agent or External Agent.",
+    action: "Choose a workspace before using Hecate Chat tools or an external agent.",
     tone: "warning",
   },
   "chat.model_required": {
@@ -61,7 +61,7 @@ const diagnostics: Record<string, GatewayErrorDiagnostic> = {
   "chat.model_capability_required": {
     title: "Tools unavailable for this model",
     action:
-      "Turn tools off for direct model chat, test the model, or enable tool support in Connections.",
+      "Continue with direct model chat, test the model, or enable tool support in Connections.",
     tone: "warning",
   },
   "chat.agent_session_busy": {

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -283,7 +283,7 @@ describe("useRuntimeConsole", () => {
               object: "chat_session",
               data: {
                 id: "chat_hecate",
-                title: "Hecate Agent chat",
+                title: "Hecate Chat",
                 agent_id: "hecate",
                 provider: "",
                 model: "gpt-4o-mini",
@@ -398,7 +398,7 @@ describe("useRuntimeConsole", () => {
               object: "chat_session",
               data: {
                 id: "chat_ollama",
-                title: "Hecate Agent chat",
+                title: "Hecate Chat",
                 agent_id: "hecate",
                 provider: "ollama",
                 model: "llama3.1:8b",
@@ -499,6 +499,65 @@ describe("useRuntimeConsole", () => {
       "Choose a workspace before using Hecate Chat tools or External Agent.",
     );
     expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+  });
+
+  it("starts a direct Hecate chat when the selected model explicitly has no tools", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.model", "llama3.1:8b");
+    let createBody: any = null;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/v1/models": () =>
+          jsonResponse({
+            object: "list",
+            data: [
+              {
+                id: "llama3.1:8b",
+                owned_by: "ollama",
+                metadata: {
+                  provider: "ollama",
+                  provider_kind: "local",
+                  capabilities: { tool_calling: "none", streaming: true },
+                },
+              },
+            ],
+          }),
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_direct_tools_unavailable",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: "",
+                model: "llama3.1:8b",
+                status: "idle",
+                messages: [],
+              },
+            });
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession();
+    });
+
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      model: "llama3.1:8b",
+    });
+    expect(createBody).not.toHaveProperty("workspace");
+    expect(result.current.state.activeChatSessionID).toBe("chat_direct_tools_unavailable");
+    expect(result.current.state.chatTarget).toBe("model");
+    expect(result.current.state.chatError).toBe("");
   });
 
   it("surfaces a clear error when external-agent chat has no workspace", async () => {
@@ -3049,14 +3108,14 @@ describe("humanizeChatError", () => {
 
   it("humanizes busy, unroutable model, and upstream provider errors", async () => {
     const { humanizeChatError } = await import("./runtime-console-test-composer");
-    expect(humanizeChatError("Hecate Agent is already running for this chat session.")).toBe(
+    expect(humanizeChatError("Hecate Chat is already running for this chat session.")).toBe(
       "Hecate Chat is still working on this task. Open the task, resolve approval, or stop it before sending another message.",
     );
     expect(humanizeChatError("workspace is required")).toBe(
       "Choose a workspace before using Hecate Chat tools or External Agent.",
     );
     expect(humanizeChatError("tool calling support is unknown")).toBe(
-      "This model is not marked as tool-capable. Turn tools off, test it, or enable tools in Connections → Model capabilities.",
+      "This model is not marked as tool-capable. Send directly, test it, or enable tools in Connections → Model capabilities.",
     );
     expect(
       humanizeChatError('route request: no provider supports explicit model "gpt-5.4-mini"'),


### PR DESCRIPTION
## Summary

- Keep Hecate Chat usable when the selected model explicitly reports `tool_calling: none`; tools show as unavailable, but the turn sends as direct model chat instead of blocking on workspace/tool support.
- Apply the same fallback when creating a new Hecate chat or sending a message from an existing one, while preserving task-backed behavior for unknown or tool-capable models.
- Align remaining live copy and telemetry labels from old `Hecate Agent` wording to `Hecate Chat` / `task-backed Hecate Chat`.
- Update runtime API and model-capabilities RFC notes to describe the explicit `hecate_task` backend error versus the operator UI direct-chat fallback.

## Self-review

- Checked the execution-mode downgrade path: it only applies to Hecate-owned `hecate_task` requests, and only when every matching provider/model route explicitly reports no tool support.
- Confirmed unknown capability records and mixed auto-provider routes still keep tools-on behavior.
- Confirmed external-agent sessions are untouched except for shared terminology/error-copy cleanup.
- No findings left from self-review.

## Verification

- `go test ./internal/api`
- `go vet ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- Markdown format check
- `just docs-env-check`
