### PR TITLE
fix(chat): avoid duplicate model repair errors

### DIFF
--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -58,6 +58,7 @@ export type ChatComposerProps = {
   // Composer gating.
   composerVisible: boolean;
   composerRepair: ChatSetupRepairState | null;
+  suppressChatError?: boolean;
   messageControlsVisible: boolean;
   showClaudeCodeEmptyPreflight: boolean;
   sendDisabled: boolean;
@@ -118,7 +119,7 @@ export function ChatComposer(props: ChatComposerProps) {
   // Pull the slice fields the composer reads. Destructured to keep the
   // rest of the component readable.
   const message = runtime.state.message;
-  const chatError = chat.state.chatError;
+  const rawChatError = chat.state.chatError;
   const chatErrorAction = chat.state.chatErrorAction;
   const chatErrorCode = chat.state.chatErrorCode;
   const chatErrorRequestID = chat.state.chatErrorRequestID;
@@ -140,6 +141,7 @@ export function ChatComposer(props: ChatComposerProps) {
     textareaRef,
     composerVisible,
     composerRepair,
+    suppressChatError = false,
     messageControlsVisible,
     showClaudeCodeEmptyPreflight,
     sendDisabled,
@@ -170,6 +172,7 @@ export function ChatComposer(props: ChatComposerProps) {
     onOpenTask,
     onOpenTrace,
   } = props;
+  const chatError = suppressChatError ? "" : rawChatError;
 
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3751,6 +3751,99 @@ describe("ChatView error display", () => {
     expect(screen.getByText(/Provider returned 500/)).toBeTruthy();
   });
 
+  it("hides model-required errors when the empty repair state already explains the fix", async () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
+      providerScopedModels: [],
+      agentAdapters: [
+        {
+          id: "codex",
+          name: "Codex",
+          kind: "acp",
+          command: "codex-acp",
+          available: true,
+          status: "available",
+          cost_mode: "external",
+        },
+      ],
+      chatError: "Choose a model before starting this chat.",
+      chatErrorCode: "chat.model_required",
+      chatErrorStatus: 400,
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    expect(await screen.findByText("No model provider configured")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
+    expect(screen.queryByText("Model required")).toBeNull();
+    expect(screen.queryByText("400 · chat.model_required")).toBeNull();
+    expect(screen.queryByText("Choose a model before starting this chat.")).toBeNull();
+  });
+
+  it("keeps model-required errors visible while pending tool calls hide the empty repair state", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
+      providerScopedModels: [],
+      agentAdapters: [
+        {
+          id: "codex",
+          name: "Codex",
+          kind: "acp",
+          command: "codex-acp",
+          available: true,
+          status: "available",
+          cost_mode: "external",
+        },
+      ],
+      pendingToolCalls: [{ id: "call_1", name: "lookup", arguments: "{}", result: "" }],
+      chatError: "Choose a model before starting this chat.",
+      chatErrorCode: "chat.model_required",
+      chatErrorStatus: 400,
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    expect(screen.getByText("Model required")).toBeTruthy();
+    expect(screen.getByText("400 · chat.model_required")).toBeTruthy();
+    expect(screen.getByText("Choose a model before starting this chat.")).toBeTruthy();
+    expect(screen.queryByText("No model provider configured")).toBeNull();
+  });
+
+  it("keeps model-required errors visible after the chat already has transcript context", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
+      providerScopedModels: [],
+      activeChatSessionID: "chat_1",
+      activeChatSession: {
+        id: "chat_1",
+        agent_id: "hecate",
+        execution_mode: "hecate_task",
+        title: "Repo work",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        workspace: "/tmp/hecate",
+        status: "completed",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            content: "show status",
+            created_at: "2026-05-03T10:00:00Z",
+          },
+        ],
+      } as any,
+      chatError: "Choose a model before starting this chat.",
+      chatErrorCode: "chat.model_required",
+      chatErrorStatus: 400,
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    expect(screen.getByText("Model required")).toBeTruthy();
+    expect(screen.getByText("400 · chat.model_required")).toBeTruthy();
+    expect(screen.getByText("Choose a model before starting this chat.")).toBeTruthy();
+  });
+
   it("renders operator guidance for stable gateway error codes", () => {
     const openTrace = vi.fn();
     const { state, actions } = setup({

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -449,6 +449,11 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     composerVisible && !emptyStateAlreadyShowsRepair(chatSetupRepair, visibleMessages.length)
       ? composerVisibleRepair(chatSetupRepair)
       : null;
+  const suppressComposerChatError =
+    state.chatErrorCode === "chat.model_required" &&
+    !streaming &&
+    state.pendingToolCalls.length === 0 &&
+    emptyStateAlreadyShowsModelRepair(chatSetupRepair, visibleMessages.length);
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const sendDisabled =
@@ -888,6 +893,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               textareaRef={textareaRef}
               composerVisible={composerVisible}
               composerRepair={composerRepair}
+              suppressChatError={suppressComposerChatError}
               messageControlsVisible={messageControlsVisible}
               showClaudeCodeEmptyPreflight={showClaudeCodeEmptyPreflight}
               sendDisabled={sendDisabled}
@@ -1032,6 +1038,18 @@ function emptyStateAlreadyShowsRepair(
   // owns the capability-write busy/disabled state. Other empty-chat repairs
   // already render the same copy and CTA in ChatEmptyState.
   return repair.action !== "enable_tools";
+}
+
+function emptyStateAlreadyShowsModelRepair(
+  repair: ChatSetupRepairState | null,
+  visibleMessageCount: number,
+): boolean {
+  if (!repair || visibleMessageCount > 0) return false;
+  return (
+    repair.kind === "no_provider" ||
+    repair.kind === "no_routable_model" ||
+    repair.kind === "selected_model_not_ready"
+  );
 }
 
 function isQuickAddableLocalProvider(discovery: LocalProviderDiscoveryRecord): boolean {


### PR DESCRIPTION
## Summary

- suppress the composer-level `chat.model_required` error when an empty chat already shows the matching setup repair state
- keep the same error visible once the transcript has context, where the failure is useful feedback
- add ChatView coverage for both the empty onboarding and transcript-context paths

## Verification

- cd ui && bun run typecheck
- cd ui && bun run test --run src/features/chats/ChatView.test.tsx
- cd ui && bun run test
