### PR TITLE
fix(ui): clarify chat capability fallback and provider readiness

### DIFF
--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -969,8 +969,8 @@ describe("ProvidersView table renders", () => {
     );
 
     expect(screen.getAllByText(/lmstudio/i).length).toBeGreaterThan(0);
-    expect(screen.getByText("Discovery pending")).toBeTruthy();
-    expect(screen.queryByText(/does not have a current model-discovery result/i)).toBeNull();
+    expect(screen.getAllByText("Not checked").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/has not received a current readiness check/i)).toBeNull();
   });
 
   it("shows provider health diagnostics and last errors", async () => {

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -28,7 +28,7 @@ function resolveHealthBadge(
   rt: ProviderRecord | undefined,
   credentialConfigured: boolean,
 ): { status: string; label: string } {
-  if (!rt) return { status: "disabled", label: "Pending" };
+  if (!rt) return { status: "disabled", label: "Not checked" };
   const status = rt.status;
   if (status === "open" || status === "unhealthy") return { status: "down", label: "Down" };
   if (status === "degraded" || status === "half_open")
@@ -45,7 +45,7 @@ function resolveHealthBadge(
   // save. Once the next probe runs, routing_ready flips to true on its own.
   if (rt.routing_ready === false) {
     if (rt.routing_blocked_reason === "credential_missing" && credentialConfigured) {
-      return { status: "healthy", label: "Pending probe" };
+      return { status: "healthy", label: "Checking" };
     }
     return { status: "degraded", label: describeRoutingBlockedReason(rt.routing_blocked_reason) };
   }
@@ -231,7 +231,7 @@ export function ProvidersView() {
       modelCount > 0
         ? null
         : cp && !rt
-          ? { status: "degraded", label: "Discovery pending" }
+          ? { status: "degraded", label: "Not checked" }
           : { status: "degraded", label: "No models" };
     const protocol = cp?.protocol || preset?.protocol || "—";
     const isSelected = selectedID === id;
@@ -329,9 +329,9 @@ export function ProvidersView() {
           title={
             modelCount === 0
               ? cp && !rt
-                ? "Hecate has not received a current model-discovery result for this configured provider yet."
+                ? "Hecate has not received a current readiness check for this configured provider yet. Start the provider if needed, then refresh Connections."
                 : cp?.kind === "local"
-                  ? "No models discovered yet. Run `ollama pull <model>` (or your provider's equivalent) to populate this list."
+                  ? "No models reported yet. Load a model in the provider app or run `ollama pull <model>` for Ollama, then refresh Connections."
                   : "No models returned by /v1/models. Check the API key is correct and that the provider's account has model access."
               : undefined
           }

--- a/ui/src/lib/provider-readiness.test.ts
+++ b/ui/src/lib/provider-readiness.test.ts
@@ -30,7 +30,7 @@ describe("readinessRecommendation", () => {
     ).toContain("API key");
     expect(
       readinessRecommendation({ name: "models", status: "blocked", reason: "no_models" }),
-    ).toContain("pull or load");
+    ).toContain("load or pull");
   });
 });
 
@@ -88,7 +88,7 @@ describe("providerRepairHint", () => {
     expect(hint.action).toBe("Wait for cooldown.");
   });
 
-  it("explains reachable local providers with no discovered models", () => {
+  it("explains reachable local providers with no reported models", () => {
     const hint = providerRepairHint({
       configuredProvider: {
         id: "ollama",
@@ -106,8 +106,9 @@ describe("providerRepairHint", () => {
       },
     });
 
-    expect(hint.title).toBe("No models discovered");
-    expect(hint.action).toContain("Pull or load");
+    expect(hint.title).toBe("No models reported");
+    expect(hint.message).toContain("not reporting any models");
+    expect(hint.action).toContain("Load or pull");
     expect(hint.actionKind).toBe("refresh_providers");
   });
 
@@ -137,10 +138,10 @@ describe("providerRepairHint", () => {
       },
     });
 
-    expect(hint.title).toBe("No models discovered");
+    expect(hint.title).toBe("No models reported");
   });
 
-  it("treats configured providers without runtime discovery as needing models", () => {
+  it("treats configured providers without runtime status as not checked yet", () => {
     const hint = providerRepairHint({
       configuredProvider: {
         id: "ollama",
@@ -150,8 +151,9 @@ describe("providerRepairHint", () => {
       },
     });
 
-    expect(hint.title).toBe("No models discovered");
-    expect(hint.action).toContain("refresh Connections");
+    expect(hint.title).toBe("Not checked yet");
+    expect(hint.message).toContain("current readiness check");
+    expect(hint.action).toContain("Start Ollama");
   });
 
   it("humanizes routing blocked reasons when readiness details are absent", () => {
@@ -229,7 +231,7 @@ describe("providerFleetRepairHint", () => {
         ],
         statuses,
       )?.title,
-    ).toBe("No models discovered");
+    ).toBe("No models reported");
 
     expect(
       providerFleetRepairHint(
@@ -285,7 +287,7 @@ describe("providerReadinessMeaning", () => {
         modelCount: 1,
         repair: null,
       }).message,
-    ).toContain("Providers exist");
+    ).toContain("none have passed readiness checks");
 
     expect(
       providerReadinessMeaning({
@@ -294,7 +296,7 @@ describe("providerReadinessMeaning", () => {
         blockedCount: 0,
         modelCount: 0,
       }).message,
-    ).toContain("no models");
+    ).toContain("none are reporting models");
 
     expect(
       providerReadinessMeaning({

--- a/ui/src/lib/provider-readiness.ts
+++ b/ui/src/lib/provider-readiness.ts
@@ -42,13 +42,15 @@ export function providerReadinessMeaning({
   }
   if (readyCount === 0) {
     return {
-      message: "Providers exist, but none are ready to route chat requests yet.",
+      message:
+        "Providers are configured, but none have passed readiness checks yet. Refresh Connections after starting local apps or fixing credentials.",
       tone: "amber",
     };
   }
   if (modelCount === 0) {
     return {
-      message: "Providers are reachable, but no models have been discovered yet.",
+      message:
+        "Providers are reachable, but none are reporting models yet. Load or pull a model, then refresh Connections.",
       tone: "amber",
     };
   }
@@ -75,7 +77,7 @@ export function readinessRecommendation(check: ProviderReadinessCheckRecord): st
     case "default_model_only":
       return "Send a test request or refresh discovery to confirm the default model is real.";
     case "no_models":
-      return "Start the provider and pull or load at least one model.";
+      return "Start the provider and load or pull at least one model.";
     case "provider_slow":
       return "Keep it enabled if acceptable, or route to a faster provider.";
     case "provider_rate_limited":
@@ -119,10 +121,10 @@ export function providerRepairHint({
 
   if (configuredProvider && !runtimeProvider) {
     return {
-      title: "No models discovered",
-      message: `${name} is configured, but Hecate does not have a current model-discovery result for it yet.`,
+      title: "Not checked yet",
+      message: `${name} is configured, but Hecate has not received a current readiness check for it yet.`,
       action: isLocal
-        ? "Start the local provider process, pull or load a model, then refresh Connections."
+        ? `Start ${name} if needed, load or pull a model, then refresh Connections.`
         : "Confirm the account has model access, then refresh Connections.",
       actionKind: "refresh_providers",
       providerID: configuredProvider.id,
@@ -180,10 +182,10 @@ export function providerRepairHint({
 
   if (runtimeProvider && modelCount === 0 && runtimeProvider.healthy) {
     return {
-      title: "No models discovered",
-      message: `${name} is reachable, but Hecate has not discovered any models from it yet.`,
+      title: "No models reported",
+      message: `${name} is reachable, but it is not reporting any models yet.`,
       action: isLocal
-        ? "Pull or load a model in the local provider, then refresh Connections."
+        ? `Load or pull a model in ${name}, then refresh Connections.`
         : "Confirm the account has model access, then refresh Connections.",
       actionKind: "refresh_providers",
       providerID: configuredProvider?.id,
@@ -332,7 +334,7 @@ function readinessTitle(check: ProviderReadinessCheckRecord): string {
     case "credential_missing":
       return "Credentials required";
     case "no_models":
-      return "No models discovered";
+      return "No models reported";
     case "discovery_failed":
       return "Discovery failed";
     case "provider_unhealthy":

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -1381,6 +1381,106 @@ describe("useRuntimeConsole", () => {
       });
     });
 
+    it("sends Hecate Chat turns directly when the selected model is not tool-capable", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "agent");
+      window.localStorage.setItem("hecate.chatSessionID", "a1");
+      window.localStorage.setItem("hecate.providerFilter", "ollama");
+      window.localStorage.setItem("hecate.model", "smollm2:135m");
+      let postedBody: any = null;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/v1/models") {
+          return jsonResponse({
+            object: "list",
+            data: [
+              {
+                id: "smollm2:135m",
+                owned_by: "ollama",
+                metadata: {
+                  provider: "ollama",
+                  provider_kind: "local",
+                  capabilities: { tool_calling: "none", streaming: true },
+                },
+              },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/chat/sessions") {
+          return jsonResponse({
+            object: "chat_sessions",
+            data: [
+              {
+                id: "a1",
+                title: "Agent",
+                agent_id: "hecate",
+                status: "completed",
+                provider: "ollama",
+                model: "smollm2:135m",
+                message_count: 0,
+              },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/chat/sessions/a1") {
+          return jsonResponse({
+            object: "chat_session",
+            data: {
+              id: "a1",
+              title: "Agent",
+              agent_id: "hecate",
+              status: "completed",
+              provider: "ollama",
+              model: "smollm2:135m",
+              messages: [],
+              created_at: "2026-04-20T00:00:00Z",
+              updated_at: "2026-04-20T00:00:00Z",
+            },
+          });
+        }
+        if (url === "/hecate/v1/chat/sessions/a1/stream") {
+          return emptyStreamResponse();
+        }
+        if (url === "/hecate/v1/chat/sessions/a1/messages") {
+          postedBody = JSON.parse(String(init?.body ?? "{}"));
+          return jsonResponse({
+            object: "chat_session",
+            data: {
+              id: "a1",
+              title: "Agent",
+              agent_id: "hecate",
+              status: "completed",
+              provider: "ollama",
+              model: "smollm2:135m",
+              messages: [],
+              created_at: "2026-04-20T00:00:00Z",
+              updated_at: "2026-04-20T00:00:01Z",
+            },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderRuntimeConsoleHook();
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      await waitFor(() => expect(result.current.state.model).toBe("smollm2:135m"));
+
+      act(() => {
+        result.current.actions.setMessage("tell a small joke");
+      });
+      await act(async () => {
+        await result.current.actions.submitChat({ preventDefault: vi.fn() } as any);
+      });
+
+      expect(postedBody).toMatchObject({
+        content: "tell a small joke",
+        execution_mode: "direct_model",
+        provider: "ollama",
+        model: "smollm2:135m",
+      });
+      expect(postedBody).not.toHaveProperty("workspace");
+      expect(result.current.state.chatError).toBe("");
+    });
+
     it("queues a prompt while the active agent run is busy and sends it after completion", async () => {
       window.localStorage.setItem("hecate.chatTarget", "agent");
       window.localStorage.setItem("hecate.chatSessionID", "a1");


### PR DESCRIPTION
## Summary

This PR keeps the four chat capability/readiness follow-ups together in one small UI-focused slice:

- clarifies provider readiness states so configured-but-not-checked providers are no longer described as a model-discovery failure
- updates provider table badges from vague pending/discovery language to `Not checked`, `Checking`, and `No models`
- keeps Hecate Chat fallback behavior covered when a selected model reports no tool-calling support: the next turn is sent as `direct_model`, keeps the selected provider/model, and does not require a workspace
- updates provider readiness tests to match the new operator-facing copy

## Why

Operators were seeing LM Studio/Ollama states that looked broken even when Hecate simply had not received a current readiness check yet. At the same time, the tools-unavailable behavior should remain boring: chat still works as plain model chat instead of failing a task-backed run.

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run test src/lib/provider-readiness.test.ts src/features/providers/ProvidersView.test.tsx src/test/runtime-console-composition.test.tsx`
- `cd ui && bun run test`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
