### PR TITLE
fix(release): fail fast when docker snapshot cannot run

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -277,10 +277,19 @@ check-links:
 # Run the full project verification gate.
 verify: docs-env-check format-check test vet test-race test-acp-smoke test-docker-smoke ui-lint website-lint ui-test ui-test-e2e build
 
-# Run verification, then cut a release tag. Optional args pass through to
-# scripts/release.ts, for example: just release vX.Y.Z --skip-snapshot.
+# Validate release-only dependencies without running the full verification
+# gate. Optional args pass through to scripts/release.ts.
+# Check release-only dependencies.
+release-preflight version *args:
+	bun scripts/release.ts {{version}} {{args}} --preflight-only
+
+# Check release-only dependencies, run verification, then cut a release tag.
+# Optional args pass through to scripts/release.ts, for example:
+# just release vX.Y.Z --skip-snapshot.
 # Verify and cut a release tag.
-release version *args: verify
+release version *args:
+	bun scripts/release.ts {{version}} {{args}} --preflight-only
+	just verify
 	bun scripts/release.ts {{version}} {{args}}
 
 # Wipe local dev state back to first-run: stop the gateway on :8765 and delete

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -16,12 +16,14 @@ Before running the release script, verify:
 
 1. **`just verify` exits 0** — full gate: `docs-env-check`, race suite, docker-smoke, UI unit + e2e. See [`../core/verification.md`](../core/verification.md). Mandatory; calling out a skip in release notes is acceptable only when the risk is named.
 2. **`goreleaser` is installed.** `which goreleaser`. Install via `go install github.com/goreleaser/goreleaser/v2@latest` if missing.
+3. **Docker is reachable unless `--skip-snapshot` is intentional.** `just release` runs this check before the expensive verify gate because the Goreleaser snapshot builds local Docker images.
 
 ## Cut the release
 
-Use the release recipe. It runs `just verify`, then delegates to the
-release script, which checks clean worktree, tag uniqueness, goreleaser on
-PATH, fires a snapshot dry-run, then prompts before tagging:
+Use the release recipe. It runs the release script in preflight-only mode,
+then `just verify`, then the full release script. The script checks clean
+worktree, tag uniqueness, goreleaser on PATH, Docker availability for the
+snapshot, fires a snapshot dry-run, then prompts before tagging:
 
 ```bash
 just release vX.Y.Z

--- a/docs/release.md
+++ b/docs/release.md
@@ -137,18 +137,19 @@ matrix is the next opportunity to catch regressions.
 
 ## Cut the release
 
-The canonical entry point is the `just release` recipe, which runs
-`just verify` first and then delegates to `scripts/release.ts`:
+The canonical entry point is the `just release` recipe, which first runs a
+fast release preflight, then `just verify`, then delegates to
+`scripts/release.ts`:
 
 ```bash
 just release vX.Y.Z
 ```
 
-It performs, in order: the full project verification gate,
-clean-worktree check, tag-uniqueness check, goreleaser-on-PATH check,
-goreleaser snapshot dry-run, interactive confirmation prompt, Tauri
-version stamp commit (Cargo.toml, package.json, tauri.conf.json),
-annotated tag, push.
+It performs, in order: clean-worktree check, tag-uniqueness check,
+goreleaser-on-PATH check, Docker-daemon check when the snapshot is enabled,
+the full project verification gate, goreleaser snapshot dry-run, interactive
+confirmation prompt, Tauri version stamp commit (Cargo.toml, package.json,
+tauri.conf.json), annotated tag, push.
 
 Pass `--skip-snapshot` to skip the dry-run when you've already validated
 locally:
@@ -203,6 +204,11 @@ Pre-flight checks before the snapshot run (the script enforces these):
   leak into a follow-up commit and break the next release on `--clean`. The
   `ui/dist/` entry in `.gitignore` does **not** cover repo-root `dist/`.
 - `goreleaser` itself is on PATH (`go install github.com/goreleaser/goreleaser/v2@latest`).
+- Docker is reachable when the snapshot is enabled. The snapshot builds local
+  Docker images, so `just release` fails early if Docker Desktop is stopped or
+  the current Docker context points at a missing socket. If `just verify` has
+  already passed and only the local snapshot is blocked, rerun with
+  `--skip-snapshot`.
 
 ## Post-release docs refresh
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,6 +4,7 @@
 // Usage:
 //   bun scripts/release.ts <version>                 # e.g. v0.1.0-alpha.9
 //   bun scripts/release.ts v0.2.0 --skip-snapshot    # skip goreleaser dry-run
+//   bun scripts/release.ts v0.2.0 --preflight-only   # validate local release deps
 //
 // The script runs pre-flight checks, fires a goreleaser snapshot dry-run so
 // you can inspect the changelog before anything is published, stamps the Tauri
@@ -46,6 +47,15 @@ function fail(msg: string): never {
   process.exit(1);
 }
 
+function commandErrorOutput(error: unknown): string {
+  const maybeError = error as { stderr?: { toString(): string }; stdout?: { toString(): string }; message?: string };
+  const stderr = maybeError.stderr?.toString().trim();
+  if (stderr) return stderr;
+  const stdout = maybeError.stdout?.toString().trim();
+  if (stdout) return stdout;
+  return maybeError.message ?? String(error);
+}
+
 function sep(label: string) {
   console.log(`\n── ${label} ${"─".repeat(Math.max(0, 72 - label.length - 4))}`);
 }
@@ -55,11 +65,18 @@ function sep(label: string) {
 const args = process.argv.slice(2);
 const version = args.find(a => !a.startsWith("--")) ?? "";
 const skipSnapshot = args.includes("--skip-snapshot");
+const preflightOnly = args.includes("--preflight-only");
 
 if (!version) {
-  console.error("usage: bun scripts/release.ts <version> [--skip-snapshot]");
+  console.error("usage: bun scripts/release.ts <version> [--skip-snapshot] [--preflight-only]");
   console.error("       version: vX.Y.Z  or  vX.Y.Z-pre.N  (e.g. v0.1.0-alpha.9)");
   process.exit(1);
+}
+
+const allowedFlags = new Set(["--skip-snapshot", "--preflight-only"]);
+const unknownFlags = args.filter(a => a.startsWith("--") && !allowedFlags.has(a));
+if (unknownFlags.length > 0) {
+  fail(`unknown option${unknownFlags.length === 1 ? "" : "s"}: ${unknownFlags.join(", ")}`);
 }
 
 // ── Validate version format ───────────────────────────────────────────────────
@@ -127,6 +144,33 @@ try {
   console.log(`  bun       : ${run("bun --version", { silent: true })}`);
 } catch {
   fail("bun not found — required for Tauri version stamping.");
+}
+
+// 6. Docker must be reachable when the local snapshot will build images.
+// `just release` runs this preflight before `just verify`, so a stopped
+// Docker Desktop fails in seconds instead of after the full release gate.
+if (!skipSnapshot) {
+  try {
+    const dockerVersion = execFileSync("docker", ["info", "--format", "{{.ServerVersion}}"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    console.log(`  docker    : ${dockerVersion}`);
+  } catch (error) {
+    fail(
+      "Docker is required for the Goreleaser snapshot dry-run, but the Docker daemon is not reachable.\n" +
+      "  Start Docker Desktop and retry, or pass --skip-snapshot only after just verify has already passed.\n" +
+      `  Docker said: ${commandErrorOutput(error)}`,
+    );
+  }
+} else {
+  console.log("  docker    : skipped (--skip-snapshot)");
+}
+
+if (preflightOnly) {
+  console.log("\nRelease preflight passed.");
+  process.exit(0);
 }
 
 // ── Goreleaser snapshot dry-run ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a release preflight mode to `scripts/release.ts`
- make `just release` run that preflight before the expensive verification gate
- fail early with an actionable Docker message when the Goreleaser snapshot would not be able to build local images
- document the updated release flow in user and agent release docs

## Why
The `v0.1.0-alpha.34` release passed the full local verification gate, then failed later when the local Goreleaser snapshot tried to reach an unavailable Docker daemon. This keeps the same safety checks but moves the preventable Docker failure to the front of the workflow.

## Verification
- `just docs-format-check`
- `bun build scripts/release.ts --target=bun --outdir ./dist-release-script-check`
- `just --dry-run release v0.0.0-test.0`
- `just --dry-run release v0.0.0-test.0 --skip-snapshot`
- `just --dry-run release-preflight v0.0.0-test.0`
