### PR TITLE
fix(tauri): log sidecar and adapter lifecycle

### DIFF
--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -126,6 +126,11 @@ The `externalBin: ["binaries/hecate"]` entry in `tauri.conf.json` tells Tauri's 
 ## Process lifecycle
 
 - The hecate child is spawned with `stdin = null` and `stdout = null` so it doesn't fight the Tauri process for the terminal in dev mode; `stderr` is redirected to `<data_dir>/gateway.log` (truncated per launch) so startup failures stay diagnosable instead of vanishing.
+- The native wrapper writes lifecycle breadcrumbs to `app.log`: app startup,
+  sidecar spawn/readiness, navigation, update-check dispatch, badge failures,
+  graceful drain, fallback kill, runtime-state cleanup, and ACP adapter
+  process/session lifecycle. When debugging desktop issues, inspect `app.log`
+  for wrapper behavior and `gateway.log` for gateway stderr.
 - The `Child` handle is stored in `GatewayChild` managed state; the gateway's base URL is stored alongside it in `GatewayBaseURL` so the close-window flow can reach the gateway HTTP surface.
 - The splash remains visible for at least 2 s before navigating to the gateway UI; keep this native-side so fast startups don't create a flash.
 - `tauri-plugin-window-state` restores size and position between launches.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -55,6 +55,10 @@ What works:
   the startup splash shows failures with the log and data-directory paths, and
   adds a bootstrap-key recovery hint when startup fails before the gateway
   serves the web UI.
+- Native app lifecycle breadcrumbs are written to the Tauri `app.log`: app
+  startup, gateway sidecar spawn/readiness/shutdown, update-check dispatch,
+  badge failures, and fallback sidecar termination. Use `gateway.log` for the
+  gateway process stderr and `app.log` for the desktop wrapper lifecycle.
 - Startup splash fonts are vendored for offline startup; their OFL license
   texts live next to the font files under `tauri/splash/fonts/`.
 - Window size and position persistence across launches.

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -29,6 +29,7 @@ type acpSession struct {
 	conn      *acp.ClientSideConnection
 	client    *acpChatClient
 	nativeID  string
+	logger    *slog.Logger
 
 	configMu      sync.Mutex
 	configOptions []agentcontrols.ConfigOption
@@ -46,6 +47,20 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		return nil, false, "", err
 	}
 	args := append([]string(nil), adapter.Args...)
+	sessionLogger := logger
+	if sessionLogger != nil {
+		sessionLogger = sessionLogger.With(
+			slog.String("component", "agent_adapters.acp_session"),
+			slog.String("adapter_id", adapter.ID),
+			slog.String("session_id", sessionID),
+			slog.String("workspace", workspace),
+		)
+		sessionLogger.Info("starting ACP adapter process",
+			slog.String("command", command),
+			slog.Any("args", args),
+			slog.Bool("resume_requested", strings.TrimSpace(previousNativeSessionID) != ""),
+		)
+	}
 	cmd := exec.CommandContext(context.Background(), command, args...)
 	configureCommandProcessGroup(cmd)
 	cmd.Dir = workspace
@@ -66,6 +81,9 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	if err := cmd.Start(); err != nil {
 		return nil, false, "", fmt.Errorf("start ACP adapter %q: %w", adapter.ID, err)
 	}
+	if sessionLogger != nil {
+		sessionLogger.Info("ACP adapter process started", slog.Int("pid", cmd.Process.Pid))
+	}
 
 	client := &acpChatClient{
 		sessionID:   sessionID,
@@ -80,6 +98,9 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	}
 	initCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
+	if sessionLogger != nil {
+		sessionLogger.Info("initializing ACP adapter")
+	}
 	initResp, err := conn.Initialize(initCtx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		ClientInfo: &acp.Implementation{
@@ -95,8 +116,16 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		},
 	})
 	if err != nil {
+		if sessionLogger != nil {
+			sessionLogger.Warn("ACP adapter initialize failed", slog.Any("error", err))
+		}
 		terminateProcess(cmd)
 		return nil, false, "", fmt.Errorf("initialize ACP adapter %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
+	}
+	if sessionLogger != nil {
+		sessionLogger.Info("ACP adapter initialized",
+			slog.Bool("load_session_supported", initResp.AgentCapabilities.LoadSession),
+		)
 	}
 
 	nativeID := ""
@@ -105,6 +134,9 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	var configOptions []agentcontrols.ConfigOption
 	previousNativeSessionID = strings.TrimSpace(previousNativeSessionID)
 	if previousNativeSessionID != "" && initResp.AgentCapabilities.LoadSession {
+		if sessionLogger != nil {
+			sessionLogger.Info("loading previous ACP session", slog.String("native_session_id", previousNativeSessionID))
+		}
 		loadCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 		loaded, loadErr := conn.LoadSession(loadCtx, acp.LoadSessionRequest{
 			SessionId:  acp.SessionId(previousNativeSessionID),
@@ -116,11 +148,26 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 			nativeID = previousNativeSessionID
 			resumed = true
 			configOptions = agentcontrols.FromACPOptions(loaded.ConfigOptions)
+			if sessionLogger != nil {
+				sessionLogger.Info("previous ACP session loaded",
+					slog.String("native_session_id", nativeID),
+					slog.Int("config_options", len(configOptions)),
+				)
+			}
 		} else {
 			recovery = fmt.Sprintf("could not restore ACP session %s: %v", previousNativeSessionID, loadErr)
+			if sessionLogger != nil {
+				sessionLogger.Warn("previous ACP session load failed",
+					slog.String("native_session_id", previousNativeSessionID),
+					slog.Any("error", loadErr),
+				)
+			}
 		}
 	}
 	if nativeID == "" {
+		if sessionLogger != nil {
+			sessionLogger.Info("creating ACP session")
+		}
 		newCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 		created, err := conn.NewSession(newCtx, acp.NewSessionRequest{
 			Cwd:        workspace,
@@ -128,11 +175,20 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		})
 		cancel()
 		if err != nil {
+			if sessionLogger != nil {
+				sessionLogger.Warn("ACP session creation failed", slog.Any("error", err))
+			}
 			terminateProcess(cmd)
 			return nil, false, "", fmt.Errorf("create ACP session for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 		}
 		nativeID = string(created.SessionId)
 		configOptions = agentcontrols.FromACPOptions(created.ConfigOptions)
+		if sessionLogger != nil {
+			sessionLogger.Info("ACP session created",
+				slog.String("native_session_id", nativeID),
+				slog.Int("config_options", len(configOptions)),
+			)
+		}
 	}
 	return &acpSession{
 		adapter:       adapter,
@@ -141,6 +197,7 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		conn:          conn,
 		client:        client,
 		nativeID:      nativeID,
+		logger:        sessionLogger,
 		configOptions: configOptions,
 	}, resumed, recovery, nil
 }
@@ -274,16 +331,33 @@ func (s *acpSession) Close(ctx context.Context) error {
 	if s == nil {
 		return nil
 	}
+	if s.logger != nil {
+		pid := 0
+		if s.cmd != nil && s.cmd.Process != nil {
+			pid = s.cmd.Process.Pid
+		}
+		s.logger.Info("closing ACP adapter session",
+			slog.String("native_session_id", s.nativeID),
+			slog.Int("pid", pid),
+		)
+	}
 	cancelCtx, cancel := context.WithTimeout(ctx, acpShutdownCancelTimeout)
-	_ = s.cancelActiveTurn(cancelCtx)
+	if err := s.cancelActiveTurn(cancelCtx); err != nil && s.logger != nil {
+		s.logger.Warn("cancel active ACP turn during close failed", slog.Any("error", err))
+	}
 	cancel()
 	if s.conn != nil && s.nativeID != "" {
 		closeCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
-		_, _ = s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)})
+		if _, err := s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)}); err != nil && s.logger != nil {
+			s.logger.Warn("close ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+		}
 		cancel()
 	}
 	if s.cmd != nil {
 		terminateProcess(s.cmd)
+		if s.logger != nil {
+			s.logger.Info("ACP adapter process terminated", slog.String("native_session_id", s.nativeID))
+		}
 	}
 	return nil
 }

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -94,7 +94,12 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	}
 	conn := acp.NewClientSideConnection(client, stdin, stdout)
 	if logger != nil {
-		conn.SetLogger(logger.With("component", "agent_adapters.acp", "adapter_id", adapter.ID))
+		conn.SetLogger(logger.With(
+			slog.String("component", "agent_adapters.acp"),
+			slog.String("adapter_id", adapter.ID),
+			slog.String("session_id", sessionID),
+			slog.String("workspace", workspace),
+		))
 	}
 	initCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -40,19 +40,23 @@ const APP_LOG_FILE: &str = "app";
 #[tauri::command]
 fn set_update_badge(window: tauri::WebviewWindow, visible: bool) -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    {
+    let result = {
         let label = if visible {
             Some("•".to_string())
         } else {
             None
         };
         window.set_badge_label(label).map_err(|e| e.to_string())
-    }
+    };
     #[cfg(not(target_os = "macos"))]
-    {
+    let result = {
         let count = if visible { Some(1i64) } else { None };
         window.set_badge_count(count).map_err(|e| e.to_string())
+    };
+    if let Err(ref err) = result {
+        log::warn!("set update badge failed visible={visible}: {err}");
     }
+    result
 }
 
 const MIN_SPLASH_DURATION: Duration = Duration::from_secs(2);
@@ -283,20 +287,28 @@ async fn fetch_running_runs(base_url: &str) -> u64 {
         .build()
     {
         Ok(c) => c,
-        Err(_) => return 0,
+        Err(e) => {
+            log::warn!("fetch_running_runs: build HTTP client failed: {e}");
+            return 0;
+        }
     };
     let url = format!("{}/hecate/v1/system/stats", base_url.trim_end_matches('/'));
     let response = match client.get(&url).send().await {
         Ok(r) => r,
         Err(e) => {
-            log::debug!("fetch_running_runs: GET {url} failed: {e}");
+            log::warn!("fetch_running_runs: GET {url} failed: {e}");
             return 0;
         }
     };
+    let status = response.status();
+    if !status.is_success() {
+        log::warn!("fetch_running_runs: GET {url} returned {status}");
+        return 0;
+    }
     let text = match response.text().await {
         Ok(s) => s,
         Err(e) => {
-            log::debug!("fetch_running_runs: read body failed: {e}");
+            log::warn!("fetch_running_runs: read body from {url} failed: {e}");
             return 0;
         }
     };
@@ -340,7 +352,9 @@ async fn drain_gateway(base_url: &str) -> Result<(), String> {
             Err(_) => return Ok(()), // gateway is gone
         }
     }
-    Err(format!("gateway did not exit within {HECATE_DRAIN_DEADLINE:?}"))
+    Err(format!(
+        "gateway did not exit within {HECATE_DRAIN_DEADLINE:?}"
+    ))
 }
 
 /// Shows a native blocking-by-callback confirmation dialog asking the
@@ -377,23 +391,35 @@ async fn confirm_quit_with_running_tasks(app: &AppHandle, running: u64) -> bool 
 /// otherwise re-prompt.
 fn handle_quit_request(app: AppHandle) {
     if QUIT_IN_PROGRESS.swap(true, Ordering::SeqCst) {
+        log::info!("quit request ignored because graceful shutdown is already in progress");
         return;
     }
     tauri::async_runtime::spawn(async move {
         let base_url = app.try_state::<GatewayBaseURL>().and_then(|s| s.snapshot());
+        log::info!(
+            "quit requested app_pid={} gateway_ready={}",
+            std::process::id(),
+            base_url.is_some()
+        );
         if let Some(ref base) = base_url {
             let running = fetch_running_runs(base).await;
+            log::info!("gateway running task count before quit running_runs={running}");
             if running > 0 {
                 let confirmed = confirm_quit_with_running_tasks(&app, running).await;
                 if !confirmed {
+                    log::info!("quit cancelled by operator; keeping gateway running");
                     QUIT_IN_PROGRESS.store(false, Ordering::SeqCst);
                     return;
                 }
+                log::info!("operator confirmed quit with running tasks; draining gateway");
             }
-            if let Err(e) = drain_gateway(base).await {
-                // Non-fatal: RunEvent::Exit's child.kill() is the
-                // fallback. Log so operators have a breadcrumb.
-                log::warn!("graceful gateway drain failed, falling back to child.kill(): {e}");
+            match drain_gateway(base).await {
+                Ok(()) => log::info!("gateway drain completed before app exit"),
+                Err(e) => {
+                    // Non-fatal: RunEvent::Exit's child.kill() is the
+                    // fallback. Log so operators have a breadcrumb.
+                    log::warn!("graceful gateway drain failed, falling back to child.kill(): {e}");
+                }
             }
         } else {
             log::debug!("quit requested before gateway base URL was ready; exiting without drain");
@@ -454,10 +480,18 @@ pub fn run() {
                 // banner state machine). Emit an event the webview can
                 // hook into; the React side handles the rest.
                 if let Some(win) = app.get_webview_window("main") {
-                    let _ = win.show();
-                    let _ = win.set_focus();
+                    if let Err(e) = win.show() {
+                        log::warn!("show main window for update check failed: {e}");
+                    }
+                    if let Err(e) = win.set_focus() {
+                        log::warn!("focus main window for update check failed: {e}");
+                    }
+                } else {
+                    log::warn!("check-for-updates requested but main window was not found");
                 }
-                let _ = app.emit("hecate:check-for-updates", ());
+                if let Err(e) = app.emit("hecate:check-for-updates", ()) {
+                    log::warn!("emit hecate:check-for-updates failed: {e}");
+                }
             }
             "open-app-log" => {
                 // tauri-plugin-log writes to
@@ -468,11 +502,15 @@ pub fn run() {
                     Ok(dir) => {
                         let log_path = dir.join(format!("{APP_LOG_FILE}.log"));
                         if !log_path.exists() {
-                            let _ = std::fs::create_dir_all(&dir);
-                            let _ = std::fs::write(
+                            if let Err(e) = std::fs::create_dir_all(&dir) {
+                                log::warn!("create app log dir {} failed: {e}", dir.display());
+                            }
+                            if let Err(e) = std::fs::write(
                                 &log_path,
                                 "App log has not accumulated any entries yet.\n",
-                            );
+                            ) {
+                                log::warn!("write app log placeholder {} failed: {e}", log_path.display());
+                            }
                         }
                         if let Err(e) = open_path(&log_path) {
                             log::warn!("open app log failed: {e}");
@@ -484,10 +522,15 @@ pub fn run() {
             "open-gateway-log" => {
                 if let Some(paths) = app.try_state::<GatewayDiagnostics>() {
                     if !paths.log_path.exists() {
-                        let _ = std::fs::write(
+                        if let Err(e) = std::fs::write(
                             &paths.log_path,
                             "Gateway log has not been created yet.\n",
-                        );
+                        ) {
+                            log::warn!(
+                                "write gateway log placeholder {} failed: {e}",
+                                paths.log_path.display()
+                            );
+                        }
                     }
                     if let Err(e) = open_path(&paths.log_path) {
                         log::warn!("open gateway log failed: {e}");
@@ -521,6 +564,13 @@ pub fn run() {
 
             let diagnostics = sidecar::diagnostic_paths(app.handle())
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            log::info!(
+                "hecate desktop starting version={} app_pid={} data_dir={} gateway_log={}",
+                env!("CARGO_PKG_VERSION"),
+                std::process::id(),
+                diagnostics.data_dir.display(),
+                diagnostics.log_path.display()
+            );
 
             // The main window is created by tauri.conf.json and starts on the
             // splash page (frontendDist). Grab a handle to it so we can
@@ -563,6 +613,9 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 match sidecar::spawn_and_wait(&app_handle).await {
                     Ok(handle) => {
+                        let sidecar_pid = handle.child.id();
+                        let sidecar_port = handle.port;
+                        let base_url = handle.base_url.clone();
                         // Store the child so the exit handler can kill it.
                         if let Some(state) = app_handle.try_state::<GatewayChild>() {
                             if let Ok(mut slot) = state.0.lock() {
@@ -580,9 +633,15 @@ pub fn run() {
                             tokio::time::sleep(delay).await;
                         }
                         // Navigate to the gateway UI.
-                        let url = tauri::Url::parse(&handle.base_url)
+                        let url = tauri::Url::parse(&base_url)
                             .expect("gateway base_url is always valid");
-                        log::info!("navigating to gateway {}", handle.base_url);
+                        log::info!(
+                            "navigating to gateway base_url={} port={} app_pid={} sidecar_pid={}",
+                            base_url,
+                            sidecar_port,
+                            std::process::id(),
+                            sidecar_pid
+                        );
                         if let Err(e) = win.navigate(url) {
                             log::error!("navigate to gateway failed: {e}");
                         }
@@ -598,8 +657,12 @@ pub fn run() {
                         let script = format!(
                             "window.__hecateStartupFailureDetails = {payload}; window.__hecateStartupFailed && window.__hecateStartupFailed(window.__hecateStartupFailureDetails);"
                         );
-                        let _ = win.eval(script);
-                        let _ = win.set_title("Hecate — startup failed");
+                        if let Err(eval_err) = win.eval(script) {
+                            log::warn!("show startup failure details in splash failed: {eval_err}");
+                        }
+                        if let Err(title_err) = win.set_title("Hecate — startup failed") {
+                            log::warn!("set startup failure window title failed: {title_err}");
+                        }
                     }
                 }
             });
@@ -619,6 +682,7 @@ pub fn run() {
             // doesn't get bypassed and the app doesn't close mid-dialog).
             RunEvent::ExitRequested { api, .. } => {
                 if INTENTIONAL_EXIT.load(Ordering::SeqCst) {
+                    log::info!("intentional app exit requested; allowing process shutdown");
                     return;
                 }
                 api.prevent_exit();
@@ -633,6 +697,8 @@ pub fn run() {
                 if let Some(state) = app_handle.try_state::<GatewayChild>() {
                     if let Ok(mut slot) = state.0.lock() {
                         if let Some(mut child) = slot.take() {
+                            let sidecar_pid = child.id();
+                            log::info!("app exiting; waiting for gateway sidecar pid={} to stop", sidecar_pid);
                             let deadline = Instant::now() + Duration::from_secs(2);
                             let mut exited = false;
                             while Instant::now() < deadline {
@@ -644,16 +710,37 @@ pub fn run() {
                                     Ok(None) => {
                                         std::thread::sleep(Duration::from_millis(100));
                                     }
-                                    Err(_) => break,
+                                    Err(e) => {
+                                        log::warn!(
+                                            "poll gateway sidecar exit status failed pid={}: {e}",
+                                            sidecar_pid
+                                        );
+                                        break;
+                                    }
                                 }
                             }
                             if !exited {
-                                let _ = child.kill();
+                                log::warn!(
+                                    "gateway sidecar still running at app exit; killing pid={}",
+                                    sidecar_pid
+                                );
+                                if let Err(e) = child.kill() {
+                                    log::warn!("kill gateway sidecar failed pid={}: {e}", sidecar_pid);
+                                }
+                            } else {
+                                log::info!(
+                                    "gateway sidecar exited before fallback kill pid={}",
+                                    sidecar_pid
+                                );
                             }
                         }
                     }
                 }
                 if let Some(paths) = app_handle.try_state::<GatewayDiagnostics>() {
+                    log::info!(
+                        "removing gateway runtime state path={}",
+                        paths.state_path.display()
+                    );
                     sidecar::remove_gateway_state(&paths.state_path);
                 }
             }

--- a/tauri/src-tauri/src/sidecar.rs
+++ b/tauri/src-tauri/src/sidecar.rs
@@ -265,6 +265,13 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
     let port = free_port()?;
     let addr = format!("127.0.0.1:{port}");
     let base_url = format!("http://{addr}");
+    log::info!(
+        "starting gateway sidecar bin={} addr={} data_dir={} gateway_log={}",
+        bin.display(),
+        addr,
+        paths.data_dir.display(),
+        paths.log_path.display()
+    );
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(2))
         .build()
@@ -297,12 +304,25 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
         .stderr(std::process::Stdio::from(stderr_log))
         .spawn()
         .map_err(|e| format!("failed to spawn {bin:?}: {e}"))?;
+    let child_pid = child.id();
+    log::info!(
+        "gateway sidecar spawned pid={} base_url={}",
+        child_pid,
+        base_url
+    );
 
     // Poll /healthz. Hard deadline: 30 s.
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(30);
     let healthz = format!("{base_url}/healthz");
     loop {
         if Instant::now() >= deadline {
+            log::warn!(
+                "gateway sidecar health check timed out pid={} base_url={} startup_ms={}",
+                child_pid,
+                base_url,
+                started.elapsed().as_millis()
+            );
             let _ = child.kill();
             let _ = child.wait();
             return Err(format!(
@@ -311,6 +331,12 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
             ));
         }
         if let Ok(Some(status)) = child.try_wait() {
+            log::warn!(
+                "gateway sidecar exited before healthy pid={} status={} startup_ms={}",
+                child_pid,
+                status,
+                started.elapsed().as_millis()
+            );
             return Err(format!(
                 "gateway exited before becoming healthy ({status}). {}",
                 startup_failure_details(&paths.log_path)
@@ -318,6 +344,12 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
         }
         match client.get(&healthz).send().await {
             Ok(resp) if resp.status().is_success() => {
+                log::info!(
+                    "gateway sidecar healthy pid={} base_url={} startup_ms={}",
+                    child_pid,
+                    base_url,
+                    started.elapsed().as_millis()
+                );
                 return Ok(GatewayHandle {
                     base_url,
                     port,


### PR DESCRIPTION
## Summary

- add native desktop breadcrumbs for app startup, gateway sidecar spawn/readiness, navigation, quit/drain, fallback kill, runtime-state cleanup, update badge failures, and manual update-check dispatch failures
- add ACP adapter lifecycle logs for external-agent process start, initialize, session load/create, close/cancel failures, and termination
- document that app.log covers the Tauri wrapper lifecycle while gateway.log covers gateway stderr

## Verification

- go test ./internal/agentadapters
- cd tauri/src-tauri && cargo test
- just docs-format-check