### PR TITLE
fix(chat): reattach external ACP sessions on load

### DIFF
--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -126,6 +126,16 @@ each message records the execution mode that produced it:
 - **External Agent** sessions map one chat session to one supervised adapter
   session such as Codex, Claude Code, or Cursor Agent.
 
+External Agent sessions persist Hecate's operator-facing shell plus the
+adapter-owned native session handle. Listing chat sessions does not start or
+reattach adapters. Opening a single External Agent session, or subscribing to
+its stream, attempts to load the stored ACP session handle so Hecate can refresh
+adapter controls before the next prompt. If the adapter cannot restore that
+native session, the transcript still opens from Hecate's store; the next send or
+adapter setup action can start a fresh native session and keep the shell intact.
+Opening a chat never silently replaces the stored native session handle with a
+fresh adapter session.
+
 The chat session API shape used by the operator UI is in
 [`runtime-api.md`](runtime-api.md#get-hecatev1chatsessions), and external
 adapter behavior is in [`external-agent-adapters.md`](external-agent-adapters.md).

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -223,7 +223,7 @@ func (h *Handler) loadExternalChatSession(ctx context.Context, session chat.Sess
 	}
 	if !result.SessionResumed {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
-		if result.SessionStarted || (result.NativeSessionID != "" && result.NativeSessionID != session.NativeSessionID) {
+		if result.SessionStarted {
 			_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
 		}
 		closeCancel()

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -221,9 +221,11 @@ func (h *Handler) loadExternalChatSession(ctx context.Context, session chat.Sess
 		}
 		return session
 	}
-	if result.SessionRecovery != "" && !result.SessionResumed {
+	if !result.SessionResumed {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
-		_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
+		if result.SessionStarted || result.NativeSessionID != "" && result.NativeSessionID != session.NativeSessionID {
+			_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
+		}
 		closeCancel()
 		if h.logger != nil {
 			h.logger.WarnContext(ctx, "chat.external_session.load_recovered_fresh_session",

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -189,7 +189,71 @@ func (h *Handler) HandleChatSession(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
+	session = h.loadExternalChatSession(r.Context(), session)
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
+}
+
+func (h *Handler) loadExternalChatSession(ctx context.Context, session chat.Session) chat.Session {
+	if !isExternalChatSession(session) || session.NativeSessionID == "" || session.Workspace == "" || h.agentChatRunner == nil {
+		return session
+	}
+	adapter, ok := agentadapters.BuiltInByID(session.AgentID)
+	if !ok {
+		return session
+	}
+	prepareCtx, cancel := context.WithTimeout(ctx, agentChatPrepareTimeout)
+	result, err := h.agentChatRunner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
+		SessionID:               session.ID,
+		AdapterID:               session.AgentID,
+		Workspace:               session.Workspace,
+		PreviousNativeSessionID: session.NativeSessionID,
+	})
+	cancel()
+	if err != nil {
+		if h.logger != nil {
+			h.logger.WarnContext(ctx, "chat.external_session.load_failed",
+				"session_id", session.ID,
+				"agent_id", session.AgentID,
+				"adapter_name", adapter.Name,
+				"native_session_id", session.NativeSessionID,
+				"error", err,
+			)
+		}
+		return session
+	}
+	if result.SessionRecovery != "" && !result.SessionResumed {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
+		_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
+		closeCancel()
+		if h.logger != nil {
+			h.logger.WarnContext(ctx, "chat.external_session.load_recovered_fresh_session",
+				"session_id", session.ID,
+				"agent_id", session.AgentID,
+				"adapter_name", adapter.Name,
+				"native_session_id", session.NativeSessionID,
+				"fresh_native_session_id", result.NativeSessionID,
+				"recovery", result.SessionRecovery,
+			)
+		}
+		return session
+	}
+	updated, err := h.agentChat.UpdateSession(ctx, session.ID, func(item *chat.Session) {
+		item.DriverKind = result.DriverKind
+		item.NativeSessionID = result.NativeSessionID
+		item.ConfigOptions = result.ConfigOptions
+	})
+	if err != nil {
+		if h.logger != nil {
+			h.logger.WarnContext(ctx, "chat.external_session.load_persist_failed",
+				"session_id", session.ID,
+				"agent_id", session.AgentID,
+				"native_session_id", result.NativeSessionID,
+				"error", err,
+			)
+		}
+		return session
+	}
+	return updated
 }
 
 func (h *Handler) HandleUpdateChatSession(w http.ResponseWriter, r *http.Request) {
@@ -244,6 +308,7 @@ func (h *Handler) HandleChatSessionStream(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
 		return
 	}
+	session = h.loadExternalChatSession(r.Context(), session)
 	updates, unsubscribe := h.agentChatLive.subscribe(session.ID)
 	defer unsubscribe()
 

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -224,16 +224,36 @@ func (h *Handler) loadExternalChatSession(ctx context.Context, session chat.Sess
 	if !result.SessionResumed {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
 		if result.SessionStarted {
-			_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
+			if err := h.agentChatRunner.CloseSession(closeCtx, session.ID); err != nil && h.logger != nil {
+				h.logger.WarnContext(ctx, "chat.external_session.load_fallback_close_failed",
+					"session_id", session.ID,
+					"agent_id", session.AgentID,
+					"adapter_name", adapter.Name,
+					"native_session_id", session.NativeSessionID,
+					"fallback_native_session_id", result.NativeSessionID,
+					"session_started", result.SessionStarted,
+					"session_resumed", result.SessionResumed,
+					"recovery", result.SessionRecovery,
+					"error", err,
+				)
+			}
 		}
 		closeCancel()
 		if h.logger != nil {
-			h.logger.WarnContext(ctx, "chat.external_session.load_recovered_fresh_session",
+			eventName := "chat.external_session.load_returned_unresumed_session"
+			nativeSessionKey := "returned_native_session_id"
+			if result.SessionStarted {
+				eventName = "chat.external_session.load_started_fallback_session"
+				nativeSessionKey = "fallback_native_session_id"
+			}
+			h.logger.WarnContext(ctx, eventName,
 				"session_id", session.ID,
 				"agent_id", session.AgentID,
 				"adapter_name", adapter.Name,
 				"native_session_id", session.NativeSessionID,
-				"fresh_native_session_id", result.NativeSessionID,
+				nativeSessionKey, result.NativeSessionID,
+				"session_started", result.SessionStarted,
+				"session_resumed", result.SessionResumed,
 				"recovery", result.SessionRecovery,
 			)
 		}

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -223,7 +223,7 @@ func (h *Handler) loadExternalChatSession(ctx context.Context, session chat.Sess
 	}
 	if !result.SessionResumed {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
-		if result.SessionStarted || result.NativeSessionID != "" && result.NativeSessionID != session.NativeSessionID {
+		if result.SessionStarted || (result.NativeSessionID != "" && result.NativeSessionID != session.NativeSessionID) {
 			_ = h.agentChatRunner.CloseSession(closeCtx, session.ID)
 		}
 		closeCancel()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1682,6 +1682,48 @@ func TestAgentChatLoadDoesNotPersistFreshSessionWhenLoadUnsupported(t *testing.T
 	}
 }
 
+func TestAgentChatLoadDoesNotCloseActiveSessionWhenNotStarted(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_load_active_elsewhere",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_stored",
+		Workspace:       dir,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_active",
+		sessionStarted:  false,
+		sessionResumed:  false,
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	got := mustRequestJSON[ChatSessionResponse](client, http.MethodGet, "/hecate/v1/chat/sessions/"+created.ID, "")
+	if got.Data.NativeSessionID != "native_stored" || got.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("loaded session metadata = kind %q native %q, want stored shell", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want read path not to close an active session it did not start", runner.closedSessions)
+	}
+	persisted, ok, err := store.Get(context.Background(), created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get persisted: ok=%v err=%v", ok, err)
+	}
+	if persisted.NativeSessionID != "native_stored" {
+		t.Fatalf("persisted native session = %q, want native_stored", persisted.NativeSessionID)
+	}
+}
+
 func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1539,6 +1539,56 @@ func TestAgentChatLoadDoesNotPersistFreshSessionAfterStaleNativeSession(t *testi
 	}
 }
 
+func TestAgentChatLoadDoesNotPersistFreshSessionWhenLoadUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	storedBool := false
+	freshBool := true
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_load_unsupported",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_existing",
+		Workspace:       dir,
+		ConfigOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &storedBool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_fresh",
+		sessionStarted:  true,
+		configOptions:   []agentcontrols.ConfigOption{{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &freshBool}},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	got := mustRequestJSON[ChatSessionResponse](client, http.MethodGet, "/hecate/v1/chat/sessions/"+created.ID, "")
+	if got.Data.NativeSessionID != "native_existing" || got.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("loaded session metadata = kind %q native %q, want stored shell", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+	if len(got.Data.ConfigOptions) != 1 || got.Data.ConfigOptions[0].CurrentBool == nil || *got.Data.ConfigOptions[0].CurrentBool {
+		t.Fatalf("config options = %#v, want stored controls when ACP load starts fresh", got.Data.ConfigOptions)
+	}
+	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.ID {
+		t.Fatalf("closed sessions = %#v, want fresh read-time ACP session closed", runner.closedSessions)
+	}
+	persisted, ok, err := store.Get(context.Background(), created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get persisted: ok=%v err=%v", ok, err)
+	}
+	if persisted.NativeSessionID != "native_existing" {
+		t.Fatalf("persisted native session = %q, want native_existing", persisted.NativeSessionID)
+	}
+}
+
 func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1453,6 +1453,99 @@ func TestAgentChatLoadsExternalNativeSessionOnRead(t *testing.T) {
 	}
 }
 
+func TestAgentChatStreamLoadsExternalNativeSessionOnSubscribe(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	oldBool := false
+	newBool := true
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_stream_load",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_existing",
+		Workspace:       dir,
+		ConfigOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &oldBool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_existing",
+		sessionResumed:  true,
+		configOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &newBool},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	server := httptest.NewServer(NewServer(logger, apiHandler))
+	t.Cleanup(server.Close)
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamReq, err := http.NewRequestWithContext(streamCtx, http.MethodGet, server.URL+"/hecate/v1/chat/sessions/"+created.ID+"/stream", nil)
+	if err != nil {
+		t.Fatalf("new stream request: %v", err)
+	}
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	defer streamResp.Body.Close()
+	if streamResp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200", streamResp.StatusCode)
+	}
+
+	events := readSSEEvents(t, streamResp.Body)
+	var snapshot ChatSessionResponse
+	timeout := time.After(3 * time.Second)
+	gotSnapshot := false
+	for !gotSnapshot {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("stream closed before initial snapshot")
+			}
+			if event.Event != "snapshot" {
+				continue
+			}
+			if err := json.Unmarshal([]byte(event.Data), &snapshot); err != nil {
+				t.Fatalf("decode stream snapshot: %v", err)
+			}
+			cancel()
+			gotSnapshot = true
+		case <-timeout:
+			t.Fatal("timed out waiting for stream snapshot")
+		}
+	}
+
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
+	}
+	if req := runner.prepareRequests[0]; req.PreviousNativeSessionID != "native_existing" || req.AdapterID != "codex" {
+		t.Fatalf("prepare request = %+v, want existing native codex session", req)
+	}
+	if snapshot.Data.NativeSessionID != "native_existing" || snapshot.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("stream snapshot metadata = kind %q native %q", snapshot.Data.DriverKind, snapshot.Data.NativeSessionID)
+	}
+	if len(snapshot.Data.ConfigOptions) != 1 || snapshot.Data.ConfigOptions[0].CurrentBool == nil || !*snapshot.Data.ConfigOptions[0].CurrentBool {
+		t.Fatalf("stream snapshot config options = %#v, want refreshed ACP controls", snapshot.Data.ConfigOptions)
+	}
+	persisted, ok, err := store.Get(context.Background(), created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get persisted: ok=%v err=%v", ok, err)
+	}
+	if len(persisted.ConfigOptions) != 1 || persisted.ConfigOptions[0].CurrentBool == nil || !*persisted.ConfigOptions[0].CurrentBool {
+		t.Fatalf("persisted config options = %#v, want refreshed ACP controls", persisted.ConfigOptions)
+	}
+}
+
 func TestAgentChatLoadKeepsStoredExternalSessionWhenACPUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1584,7 +1584,8 @@ func TestAgentChatLoadKeepsStoredExternalSessionWhenACPUnavailable(t *testing.T)
 func TestAgentChatLoadDoesNotPersistFreshSessionAfterStaleNativeSession(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()
-	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
 	storedBool := false
 	freshBool := true
 
@@ -1607,6 +1608,7 @@ func TestAgentChatLoadDoesNotPersistFreshSessionAfterStaleNativeSession(t *testi
 		sessionStarted:  true,
 		sessionRecovery: "could not restore ACP session native_stale: not found",
 		configOptions:   []agentcontrols.ConfigOption{{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &freshBool}},
+		closeErr:        errors.New("close failed"),
 	}
 	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
 	apiHandler.SetAgentChatStore(store)
@@ -1622,6 +1624,16 @@ func TestAgentChatLoadDoesNotPersistFreshSessionAfterStaleNativeSession(t *testi
 	}
 	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.ID {
 		t.Fatalf("closed sessions = %#v, want fresh read-time ACP session closed", runner.closedSessions)
+	}
+	for _, want := range []string{
+		"chat.external_session.load_fallback_close_failed",
+		"chat.external_session.load_started_fallback_session",
+		"fallback_native_session_id",
+		"session_started",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs missing %q:\n%s", want, logs.String())
+		}
 	}
 	persisted, ok, err := store.Get(context.Background(), created.ID)
 	if err != nil || !ok {
@@ -1685,7 +1697,8 @@ func TestAgentChatLoadDoesNotPersistFreshSessionWhenLoadUnsupported(t *testing.T
 func TestAgentChatLoadDoesNotCloseActiveSessionWhenNotStarted(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()
-	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
 
 	created, err := store.Create(context.Background(), chat.Session{
 		ID:              "chat_external_load_active_elsewhere",
@@ -1714,6 +1727,18 @@ func TestAgentChatLoadDoesNotCloseActiveSessionWhenNotStarted(t *testing.T) {
 	}
 	if len(runner.closedSessions) != 0 {
 		t.Fatalf("closed sessions = %#v, want read path not to close an active session it did not start", runner.closedSessions)
+	}
+	for _, want := range []string{
+		"chat.external_session.load_returned_unresumed_session",
+		"returned_native_session_id",
+		"session_started",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs missing %q:\n%s", want, logs.String())
+		}
+	}
+	if strings.Contains(logs.String(), "fresh_native_session_id") || strings.Contains(logs.String(), "fallback_native_session_id") {
+		t.Fatalf("logs should not describe an unstarted session as fresh/fallback:\n%s", logs.String())
 	}
 	persisted, ok, err := store.Get(context.Background(), created.ID)
 	if err != nil || !ok {
@@ -2537,6 +2562,7 @@ type fakeAgentChatRunner struct {
 	prepareDeadline    time.Time
 	prepareHasDeadline bool
 	closedSessions     []string
+	closeErr           error
 	configOptions      []agentcontrols.ConfigOption
 }
 
@@ -2657,7 +2683,7 @@ func (r *fakeAgentChatRunner) SetSessionConfigOption(_ context.Context, req agen
 
 func (r *fakeAgentChatRunner) CloseSession(_ context.Context, sessionID string) error {
 	r.closedSessions = append(r.closedSessions, sessionID)
-	return nil
+	return r.closeErr
 }
 
 func (r *fakeAgentChatRunner) Shutdown(context.Context) error { return nil }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1398,6 +1398,147 @@ func TestAgentChatPassesPersistedNativeSessionForResume(t *testing.T) {
 	}
 }
 
+func TestAgentChatLoadsExternalNativeSessionOnRead(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	oldBool := false
+	newBool := true
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_load",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_existing",
+		Workspace:       dir,
+		ConfigOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &oldBool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_existing",
+		sessionResumed:  true,
+		configOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &newBool},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	got := mustRequestJSON[ChatSessionResponse](client, http.MethodGet, "/hecate/v1/chat/sessions/"+created.ID, "")
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
+	}
+	if req := runner.prepareRequests[0]; req.PreviousNativeSessionID != "native_existing" || req.AdapterID != "codex" {
+		t.Fatalf("prepare request = %+v, want existing native codex session", req)
+	}
+	if got.Data.NativeSessionID != "native_existing" || got.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("loaded session metadata = kind %q native %q", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+	if len(got.Data.ConfigOptions) != 1 || got.Data.ConfigOptions[0].CurrentBool == nil || !*got.Data.ConfigOptions[0].CurrentBool {
+		t.Fatalf("config options = %#v, want refreshed ACP controls", got.Data.ConfigOptions)
+	}
+	persisted, ok, err := store.Get(context.Background(), created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get persisted: ok=%v err=%v", ok, err)
+	}
+	if len(persisted.ConfigOptions) != 1 || persisted.ConfigOptions[0].CurrentBool == nil || !*persisted.ConfigOptions[0].CurrentBool {
+		t.Fatalf("persisted config options = %#v, want refreshed ACP controls", persisted.ConfigOptions)
+	}
+}
+
+func TestAgentChatLoadKeepsStoredExternalSessionWhenACPUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	storedBool := false
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_load_unavailable",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_existing",
+		Workspace:       dir,
+		ConfigOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &storedBool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{prepareErr: errors.New("adapter unavailable")}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	got := mustRequestJSON[ChatSessionResponse](client, http.MethodGet, "/hecate/v1/chat/sessions/"+created.ID, "")
+	if got.Data.NativeSessionID != "native_existing" || got.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("loaded session metadata = kind %q native %q, want stored shell", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+	if len(got.Data.ConfigOptions) != 1 || got.Data.ConfigOptions[0].CurrentBool == nil || *got.Data.ConfigOptions[0].CurrentBool {
+		t.Fatalf("config options = %#v, want stored controls when ACP load fails", got.Data.ConfigOptions)
+	}
+}
+
+func TestAgentChatLoadDoesNotPersistFreshSessionAfterStaleNativeSession(t *testing.T) {
+	dir := t.TempDir()
+	store := chat.NewMemoryStore()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	storedBool := false
+	freshBool := true
+
+	created, err := store.Create(context.Background(), chat.Session{
+		ID:              "chat_external_load_stale",
+		Title:           "Codex",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_stale",
+		Workspace:       dir,
+		ConfigOptions: []agentcontrols.ConfigOption{
+			{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &storedBool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_fresh",
+		sessionStarted:  true,
+		sessionRecovery: "could not restore ACP session native_stale: not found",
+		configOptions:   []agentcontrols.ConfigOption{{ID: "auto_approve", Name: "Auto approve", Type: agentcontrols.ConfigOptionTypeBoolean, CurrentBool: &freshBool}},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatStore(store)
+	apiHandler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, NewServer(logger, apiHandler))
+
+	got := mustRequestJSON[ChatSessionResponse](client, http.MethodGet, "/hecate/v1/chat/sessions/"+created.ID, "")
+	if got.Data.NativeSessionID != "native_stale" || got.Data.DriverKind != agentadapters.DriverKindACP {
+		t.Fatalf("loaded session metadata = kind %q native %q, want stored stale shell", got.Data.DriverKind, got.Data.NativeSessionID)
+	}
+	if len(got.Data.ConfigOptions) != 1 || got.Data.ConfigOptions[0].CurrentBool == nil || *got.Data.ConfigOptions[0].CurrentBool {
+		t.Fatalf("config options = %#v, want stored controls when read-time load starts fresh", got.Data.ConfigOptions)
+	}
+	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.ID {
+		t.Fatalf("closed sessions = %#v, want fresh read-time ACP session closed", runner.closedSessions)
+	}
+	persisted, ok, err := store.Get(context.Background(), created.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get persisted: ok=%v err=%v", ok, err)
+	}
+	if persisted.NativeSessionID != "native_stale" {
+		t.Fatalf("persisted native session = %q, want native_stale", persisted.NativeSessionID)
+	}
+}
+
 func TestAgentChatShowsFreshSessionRecoveryActivity(t *testing.T) {
 	dir := t.TempDir()
 	store := chat.NewMemoryStore()


### PR DESCRIPTION
## Summary

- Reattach persisted External Agent ACP sessions when a single chat is opened or streamed.
- Refresh adapter config controls after a successful ACP `loadSession` restore.
- Keep the stored Hecate chat shell unchanged if read-time ACP loading cannot restore the native session or falls back to a fresh native session.
- Document the shell-vs-native-session ownership contract for External Agent chats.

## Why

Hecate stores the operator-facing chat shell, while Codex/Claude Code/Cursor own their native ACP session continuity. Before this change, opening an existing External Agent chat restored the transcript from Hecate but did not reattach the ACP session until the next prompt. That meant adapter controls could be stale or unavailable after restart even though the native session id was persisted.

This PR makes opening a specific External Agent chat best-effort reattach the native session, without letting a read operation silently replace adapter history. If ACP cannot restore the stored native session, the transcript still opens and the next real send/setup path can start fresh with visible recovery activity.

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/chat ./internal/agentadapters`
- `just docs-format-check`
- `git diff --check`
