### PR TITLE
fix(chat): stabilize setup and external launch controls

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -95,6 +95,11 @@ curl -s http://127.0.0.1:8765/hecate/v1/agent-adapters | jq
 
 Discovery reports command availability, tested version range, and lightweight
 auth hints (`auth_status`: `ok`, `unauthenticated`, `billing`, or `unknown`).
+When an ACP bridge or launcher is separate from the coding-agent CLI, Hecate
+reports both versions: `adapter_version` for the bridge and `agent_version` for
+the underlying agent (`codex`, `claude`, `cursor-agent`, `grok`). Managed package
+adapters avoid package-manager execution during passive discovery; their
+`adapter_version` is populated only after an explicit adapter test.
 
 Manual setup stays in the upstream CLIs:
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -737,7 +737,8 @@ GET /hecate/v1/agent-adapters
       "status": "available",
       "path": "/Users/alice/Library/Caches/hecate/agent-adapters/codex-acp",
       "cost_mode": "external",
-      "version": "1.2.3",
+      "adapter_version": "1.2.3",
+      "agent_version": "0.48.0",
       "supported_range": ">=0.1.0",
       "version_outside_range": false,
       "auth_status": "ok"
@@ -799,7 +800,7 @@ GET /hecate/v1/agent-adapters
       "status": "available",
       "path": "/Users/alice/.local/bin/cursor-agent",
       "cost_mode": "external",
-      "version": "0.0.9",
+      "agent_version": "0.0.9",
       "supported_range": ">=0.1.0",
       "version_outside_range": true,
       "auth_status": "unauthenticated",
@@ -824,12 +825,16 @@ GET /hecate/v1/agent-adapters
 }
 ```
 
-`version` is populated by running the binary with `--version` and extracting
-the first semver-shaped token from stdout; it is absent when the adapter is
-missing or when the binary does not print a recognisable version string.
-`version_outside_range` is `true` when both `version` and `supported_range`
-are present and the version does not satisfy the constraint — the Connections UI
-shows an amber "outside tested range" chip in that case.
+`adapter_version` is the ACP bridge/launcher version when Hecate needs a
+separate adapter package or binary to speak ACP. Managed package adapters avoid
+package-manager execution during passive listing; their adapter version is only
+populated after an explicit adapter probe. `agent_version` is the underlying
+coding-agent CLI version, such as `codex`, `claude`, `cursor-agent`, or `grok`.
+Both fields are extracted from `--version` output and omitted when the command is
+missing or does not print a recognisable semver string. `version_outside_range`
+is `true` when the version subject to `supported_range` does not satisfy the
+constraint — the Connections UI shows an amber "outside tested range" chip in
+that case.
 
 `auth_status` is a lightweight dashboard hint, not a full login check. Values:
 `ok`, `unauthenticated`, `billing`, or `unknown`. It is derived from known env

--- a/internal/agentadapters/launch_config.go
+++ b/internal/agentadapters/launch_config.go
@@ -133,6 +133,22 @@ func LaunchConfigOptions(ctx context.Context, status Status) []agentcontrols.Con
 	return options
 }
 
+// IsLaunchConfigOption reports whether configID is owned by Hecate's
+// launch-time adapter wrapper instead of the live ACP session.
+func IsLaunchConfigOption(adapterID, configID string) bool {
+	adapter, ok := BuiltInByID(adapterID)
+	if !ok {
+		return false
+	}
+	configID = strings.TrimSpace(configID)
+	for _, config := range launchSelectConfigs(adapter) {
+		if config.ConfigID == configID {
+			return true
+		}
+	}
+	return false
+}
+
 func launchConfigEnabled(adapter Adapter) bool {
 	return len(launchSelectConfigs(adapter)) > 0
 }

--- a/internal/agentadapters/launch_config.go
+++ b/internal/agentadapters/launch_config.go
@@ -106,6 +106,7 @@ func appendLaunchConfigOptions(ctx context.Context, command string, adapter Adap
 			Name:         config.Name,
 			Description:  strings.TrimSpace(config.Description),
 			Category:     strings.TrimSpace(config.Category),
+			Source:       agentcontrols.ConfigOptionSourceLaunch,
 			Type:         agentcontrols.ConfigOptionTypeSelect,
 			CurrentValue: current,
 			Options:      launchSelectOptions(config, candidates, current),

--- a/internal/agentadapters/launch_config.go
+++ b/internal/agentadapters/launch_config.go
@@ -81,7 +81,7 @@ func appendLaunchConfigOptions(ctx context.Context, command string, adapter Adap
 		if hasLaunchConfigOption(out, config) || !launchHelpSupportsTemplate(help, config.ArgTemplate) {
 			continue
 		}
-		current := selectedLaunchValue(config, selected)
+		current, selectedPresent := selectedLaunchValueWithPresence(config, selected)
 		if current == "" {
 			current = strings.TrimSpace(config.Default)
 		}
@@ -93,6 +93,11 @@ func appendLaunchConfigOptions(ctx context.Context, command string, adapter Adap
 			models := discoverLaunchModels(ctx, command, adapter)
 			if len(models) == 0 {
 				models = cloneLaunchModels(adapter.LaunchModel.FallbackModels)
+			}
+			if !selectedPresent && launchSelectIsUnset(config, current) {
+				if defaultModel := defaultLaunchModel(models); defaultModel != "" {
+					current = defaultModel
+				}
 			}
 			candidates = launchModelsToSelectOptions(models)
 		}
@@ -183,13 +188,18 @@ func selectedLaunchModel(config LaunchModelConfig, options []agentcontrols.Confi
 }
 
 func selectedLaunchValue(config LaunchSelectConfig, options []agentcontrols.ConfigOption) string {
+	value, _ := selectedLaunchValueWithPresence(config, options)
+	return value
+}
+
+func selectedLaunchValueWithPresence(config LaunchSelectConfig, options []agentcontrols.ConfigOption) (string, bool) {
 	configID := strings.TrimSpace(config.ConfigID)
 	for _, option := range options {
 		if option.ID == configID {
-			return strings.TrimSpace(option.CurrentValue)
+			return strings.TrimSpace(option.CurrentValue), true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func launchModelIsUnset(value string) bool {
@@ -338,12 +348,19 @@ func storeLaunchDiscoveryCache(key launchDiscoveryCacheKey, entry launchDiscover
 func parseLaunchModelList(raw string) []LaunchModel {
 	seen := map[string]struct{}{}
 	var models []LaunchModel
+	defaultID := ""
 	inModels := false
 	scanner := bufio.NewScanner(strings.NewReader(raw))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		lower := strings.ToLower(line)
-		if line == "" || strings.HasPrefix(line, "Tip:") || strings.HasPrefix(lower, "default model:") || strings.HasPrefix(lower, "you are logged in") {
+		if strings.HasPrefix(lower, "default model:") {
+			if _, value, ok := strings.Cut(line, ":"); ok {
+				defaultID = strings.TrimSpace(value)
+			}
+			continue
+		}
+		if line == "" || strings.HasPrefix(line, "Tip:") || strings.HasPrefix(lower, "you are logged in") {
 			continue
 		}
 		if strings.TrimSuffix(lower, ":") == "available models" {
@@ -361,7 +378,10 @@ func parseLaunchModelList(raw string) []LaunchModel {
 		}
 		if strings.Contains(line, " - ") {
 			parts := strings.SplitN(line, " - ", 2)
-			models = appendLaunchModel(models, seen, parts[0], parts[1])
+			name := strings.TrimSpace(parts[1])
+			isDefault := strings.Contains(strings.ToLower(name), "(default)")
+			name = strings.TrimSpace(strings.TrimSuffix(name, "(default)"))
+			models = appendLaunchModel(models, seen, parts[0], name, isDefault)
 			continue
 		}
 		fields := strings.Fields(line)
@@ -370,13 +390,21 @@ func parseLaunchModelList(raw string) []LaunchModel {
 		}
 		id := fields[0]
 		name := strings.TrimSpace(strings.TrimPrefix(line, id))
+		isDefault := strings.Contains(strings.ToLower(name), "(default)")
 		name = strings.TrimSpace(strings.TrimSuffix(name, "(default)"))
-		models = appendLaunchModel(models, seen, id, name)
+		models = appendLaunchModel(models, seen, id, name, isDefault)
+	}
+	if defaultID != "" {
+		for i := range models {
+			if models[i].ID == defaultID {
+				models[i].Default = true
+			}
+		}
 	}
 	return models
 }
 
-func appendLaunchModel(models []LaunchModel, seen map[string]struct{}, id, name string) []LaunchModel {
+func appendLaunchModel(models []LaunchModel, seen map[string]struct{}, id, name string, isDefault ...bool) []LaunchModel {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return models
@@ -389,7 +417,20 @@ func appendLaunchModel(models []LaunchModel, seen map[string]struct{}, id, name 
 	if name == "" {
 		name = humanizeModelID(id)
 	}
-	return append(models, LaunchModel{ID: id, Name: name})
+	model := LaunchModel{ID: id, Name: name}
+	for _, value := range isDefault {
+		model.Default = model.Default || value
+	}
+	return append(models, model)
+}
+
+func defaultLaunchModel(models []LaunchModel) string {
+	for _, model := range models {
+		if model.Default && strings.TrimSpace(model.ID) != "" {
+			return strings.TrimSpace(model.ID)
+		}
+	}
+	return ""
 }
 
 func launchModelSelectOptions(models []LaunchModel, current string) []agentcontrols.ConfigSelectOption {

--- a/internal/agentadapters/launch_config.go
+++ b/internal/agentadapters/launch_config.go
@@ -149,6 +149,52 @@ func IsLaunchConfigOption(adapterID, configID string) bool {
 	return false
 }
 
+// LaunchConfigOptionForSet builds the Hecate-owned launch option for a
+// pending config update. It is used when an older persisted chat session has
+// no copy of the launch controls that the current adapter registry exposes.
+func LaunchConfigOptionForSet(adapterID, configID, value string) (agentcontrols.ConfigOption, bool) {
+	adapter, ok := BuiltInByID(adapterID)
+	if !ok {
+		return agentcontrols.ConfigOption{}, false
+	}
+	configID = strings.TrimSpace(configID)
+	value = strings.TrimSpace(value)
+	for _, config := range launchSelectConfigs(adapter) {
+		if config.ConfigID != configID {
+			continue
+		}
+		if value == "" {
+			return agentcontrols.ConfigOption{}, false
+		}
+		if !launchSelectIsUnset(config, value) && !launchConfigValueAllowed(config, value) {
+			return agentcontrols.ConfigOption{}, false
+		}
+		return agentcontrols.ConfigOption{
+			ID:           config.ConfigID,
+			Name:         config.Name,
+			Description:  strings.TrimSpace(config.Description),
+			Category:     strings.TrimSpace(config.Category),
+			Source:       agentcontrols.ConfigOptionSourceLaunch,
+			Type:         agentcontrols.ConfigOptionTypeSelect,
+			CurrentValue: value,
+			Options:      launchSelectOptions(config, config.Options, value),
+		}, true
+	}
+	return agentcontrols.ConfigOption{}, false
+}
+
+func launchConfigValueAllowed(config LaunchSelectConfig, value string) bool {
+	if len(config.Options) == 0 {
+		return true
+	}
+	for _, option := range config.Options {
+		if option.ID == value {
+			return true
+		}
+	}
+	return false
+}
+
 func launchConfigEnabled(adapter Adapter) bool {
 	return len(launchSelectConfigs(adapter)) > 0
 }

--- a/internal/agentadapters/launch_config_test.go
+++ b/internal/agentadapters/launch_config_test.go
@@ -139,7 +139,7 @@ Available models:
   * model-a (default)
   - model-b
 auto - Auto
-model-c - Model C
+model-c - Model C (default)
 Tip: use --model <id>
 `
 	got := parseLaunchModelList(raw)
@@ -154,6 +154,72 @@ Tip: use --model <id>
 	}
 	if got[3].Name != "Model C" {
 		t.Fatalf("cursor-style model name = %q, want Model C", got[3].Name)
+	}
+	if !got[0].Default {
+		t.Fatalf("model[0].Default = false, want true for the CLI default")
+	}
+	if !got[3].Default {
+		t.Fatalf("model[3].Default = false, want true for inline default marker")
+	}
+	for _, i := range []int{1, 2} {
+		if got[i].Default {
+			t.Fatalf("model[%d].Default = true, want false", i)
+		}
+	}
+}
+
+func TestLaunchConfig_SelectsDiscoveredDefaultModel(t *testing.T) {
+	resetLaunchDiscoveryCacheForTest(t)
+	t.Setenv("CODEX_LAUNCH_CONFIG_HELPER", "1")
+	countFile := filepath.Join(t.TempDir(), "count")
+	adapter := Adapter{
+		ID:   "grok_build",
+		Name: "Grok Build",
+		Args: []string{"-test.run=TestLaunchConfigHelperProcess", "--", "agent", countFile},
+		LaunchModel: LaunchModelConfig{
+			ArgTemplate: []string{"--model", "{model}"},
+			ListArgs:    []string{"-test.run=TestLaunchConfigHelperProcess", "--", "models-default", countFile},
+		},
+	}
+
+	got, managed := appendLaunchConfigOptions(context.Background(), os.Args[0], adapter, nil, nil)
+	if _, ok := managed["model"]; !ok {
+		t.Fatalf("managed config ids = %#v, want model", managed)
+	}
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want one model option", got)
+	}
+	if got[0].CurrentValue != "model-a" {
+		t.Fatalf("current model = %q, want discovered default model-a", got[0].CurrentValue)
+	}
+	if len(got[0].Options) != 3 || got[0].Options[1].Value != "model-a" || got[0].Options[2].Value != "model-b" {
+		t.Fatalf("model candidates = %#v, want unset plus discovered models", got[0].Options)
+	}
+}
+
+func TestLaunchConfig_PreservesExplicitUnsetSelection(t *testing.T) {
+	resetLaunchDiscoveryCacheForTest(t)
+	t.Setenv("CODEX_LAUNCH_CONFIG_HELPER", "1")
+	countFile := filepath.Join(t.TempDir(), "count")
+	adapter := Adapter{
+		ID:   "grok_build",
+		Name: "Grok Build",
+		Args: []string{"-test.run=TestLaunchConfigHelperProcess", "--", "agent", countFile},
+		LaunchModel: LaunchModelConfig{
+			ArgTemplate: []string{"--model", "{model}"},
+			ListArgs:    []string{"-test.run=TestLaunchConfigHelperProcess", "--", "models-default", countFile},
+		},
+	}
+
+	got, _ := appendLaunchConfigOptions(context.Background(), os.Args[0], adapter, nil, []agentcontrols.ConfigOption{{
+		ID:           "model",
+		CurrentValue: launchModelUnsetValue,
+	}})
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want one model option", got)
+	}
+	if got[0].CurrentValue != launchModelUnsetValue {
+		t.Fatalf("current model = %q, want explicit unset selection", got[0].CurrentValue)
 	}
 }
 
@@ -216,6 +282,11 @@ func TestLaunchConfigHelperProcess(t *testing.T) {
 	case "models":
 		fmt.Println("Available models:")
 		fmt.Println("model-a - Model A")
+	case "models-default":
+		fmt.Println("Default model: model-a")
+		fmt.Println("Available models:")
+		fmt.Println("* model-a (default)")
+		fmt.Println("- model-b")
 	default:
 		os.Exit(2)
 	}

--- a/internal/agentadapters/launch_config_test.go
+++ b/internal/agentadapters/launch_config_test.go
@@ -27,7 +27,7 @@ func TestLaunchConfig_AppendsGrokModelOptionWithUnsetSelection(t *testing.T) {
 		t.Fatalf("managed config ids = %#v, want reasoning_effort", managed)
 	}
 	option := got[0]
-	if option.ID != "model" || option.Category != "model" || option.CurrentValue != launchModelUnsetValue {
+	if option.ID != "model" || option.Category != "model" || option.Source != agentcontrols.ConfigOptionSourceLaunch || option.CurrentValue != launchModelUnsetValue {
 		t.Fatalf("launch model option = %#v, want model category with unset current", option)
 	}
 	if len(option.Options) != 1 || option.Options[0].Value != launchModelUnsetValue {
@@ -37,7 +37,7 @@ func TestLaunchConfig_AppendsGrokModelOptionWithUnsetSelection(t *testing.T) {
 		t.Fatalf("unset option name = %q, want Pick a model", option.Options[0].Name)
 	}
 	reasoning := got[1]
-	if reasoning.ID != "reasoning_effort" || reasoning.Category != "thought_level" {
+	if reasoning.ID != "reasoning_effort" || reasoning.Category != "thought_level" || reasoning.Source != agentcontrols.ConfigOptionSourceLaunch {
 		t.Fatalf("reasoning option = %#v, want thought_level launch option", reasoning)
 	}
 	if len(reasoning.Options) != 6 || reasoning.Options[0].Name != "Pick reasoning" {

--- a/internal/agentadapters/launch_config_test.go
+++ b/internal/agentadapters/launch_config_test.go
@@ -45,6 +45,39 @@ func TestLaunchConfig_AppendsGrokModelOptionWithUnsetSelection(t *testing.T) {
 	}
 }
 
+func TestLaunchConfig_OptionForSetSeedsMissingModel(t *testing.T) {
+	option, ok := LaunchConfigOptionForSet("grok_build", "model", "grok-latest")
+	if !ok {
+		t.Fatal("LaunchConfigOptionForSet(model) = false, want true")
+	}
+	if option.ID != "model" || option.Source != agentcontrols.ConfigOptionSourceLaunch {
+		t.Fatalf("option identity = %#v, want launch model", option)
+	}
+	if option.CurrentValue != "grok-latest" {
+		t.Fatalf("current value = %q, want requested model", option.CurrentValue)
+	}
+	found := false
+	for _, candidate := range option.Options {
+		found = found || candidate.Value == "grok-latest"
+	}
+	if !found {
+		t.Fatalf("options = %#v, want requested model included", option.Options)
+	}
+}
+
+func TestLaunchConfig_OptionForSetRejectsUnknownStaticOption(t *testing.T) {
+	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "turbo"); ok {
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=turbo) = true, want false")
+	}
+	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "high")
+	if !ok {
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=high) = false, want true")
+	}
+	if option.CurrentValue != "high" {
+		t.Fatalf("current value = %q, want high", option.CurrentValue)
+	}
+}
+
 func TestLaunchConfig_UsesBaseArgsUntilModelSelected(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -56,6 +56,7 @@ type Adapter struct {
 	Command          string
 	Args             []string
 	CandidatePaths   []string
+	AgentVersion     VersionProbe
 	Managed          ManagedLauncher
 	LaunchSuffixArgs []string
 	LaunchModel      LaunchModelConfig
@@ -65,6 +66,12 @@ type Adapter struct {
 	CostMode         string
 	DocsURL          string
 	SupportedRange   string
+}
+
+type VersionProbe struct {
+	Command        string
+	Args           []string
+	CandidatePaths []string
 }
 
 type LaunchModelConfig struct {
@@ -116,7 +123,8 @@ type Status struct {
 	Status              string
 	Path                string
 	Error               string
-	Version             string
+	AdapterVersion      string
+	AgentVersion        string
 	VersionOutsideRange bool
 	AuthStatus          string
 	AuthError           string
@@ -216,6 +224,16 @@ func BuiltIns() []Adapter {
 				"/opt/homebrew/bin/codex-acp",
 				"/usr/local/bin/codex-acp",
 			},
+			AgentVersion: VersionProbe{
+				Command: "codex",
+				Args:    []string{"--version"},
+				CandidatePaths: []string{
+					"${HOME}/.local/bin/codex",
+					"${HOME}/.volta/bin/codex",
+					"/opt/homebrew/bin/codex",
+					"/usr/local/bin/codex",
+				},
+			},
 			Managed: ManagedLauncher{
 				Package: "@zed-industries/codex-acp",
 				Runners: []ManagedRunner{
@@ -236,6 +254,16 @@ func BuiltIns() []Adapter {
 				"${HOME}/.local/bin/claude-agent-acp",
 				"/opt/homebrew/bin/claude-agent-acp",
 				"/usr/local/bin/claude-agent-acp",
+			},
+			AgentVersion: VersionProbe{
+				Command: "claude",
+				Args:    []string{"--version"},
+				CandidatePaths: []string{
+					"${HOME}/.local/bin/claude",
+					"${HOME}/.volta/bin/claude",
+					"/opt/homebrew/bin/claude",
+					"/usr/local/bin/claude",
+				},
 			},
 			Managed: ManagedLauncher{
 				Package: "@agentclientprotocol/claude-agent-acp",
@@ -334,12 +362,24 @@ func ListWithLookup(ctx context.Context, lookup LookupFunc) []Status {
 	items := BuiltIns()
 	out := make([]Status, 0, len(items))
 	for _, item := range items {
-		out = append(out, statusForAdapter(ctx, item, lookup))
+		out = append(out, statusForAdapter(ctx, item, lookup, statusProbeOptions{}))
 	}
 	return out
 }
 
 func StatusForAdapter(ctx context.Context, id string, lookup LookupFunc) (Status, bool) {
+	return statusForAdapterByID(ctx, id, lookup, statusProbeOptions{})
+}
+
+func StatusForAdapterAfterExplicitProbe(ctx context.Context, id string, lookup LookupFunc) (Status, bool) {
+	return statusForAdapterByID(ctx, id, lookup, statusProbeOptions{allowManagedAdapterVersion: true})
+}
+
+type statusProbeOptions struct {
+	allowManagedAdapterVersion bool
+}
+
+func statusForAdapterByID(ctx context.Context, id string, lookup LookupFunc, opts statusProbeOptions) (Status, bool) {
 	if lookup == nil {
 		lookup = exec.LookPath
 	}
@@ -347,12 +387,12 @@ func StatusForAdapter(ctx context.Context, id string, lookup LookupFunc) (Status
 		if item.ID != strings.TrimSpace(id) {
 			continue
 		}
-		return statusForAdapter(ctx, item, lookup), true
+		return statusForAdapter(ctx, item, lookup, opts), true
 	}
 	return Status{}, false
 }
 
-func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Status {
+func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc, opts statusProbeOptions) Status {
 	status := Status{
 		Adapter:    item,
 		Status:     StatusMissing,
@@ -379,20 +419,24 @@ func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Stat
 	status.Available = true
 	status.Status = StatusAvailable
 	status.Path = path
-	if shouldProbeVersionForStatus(item, path, lookup) {
+	if item.Managed.Package != "" && shouldProbeAdapterVersionForStatus(item, path, lookup, opts.allowManagedAdapterVersion) {
 		v := DetectVersion(ctx, path)
-		status.Version = v
-		status.VersionOutsideRange = !satisfiesRange(v, item.SupportedRange)
+		status.AdapterVersion = v
 	}
+	status.AgentVersion = detectAgentVersionForStatus(ctx, item, path, lookup)
+	status.VersionOutsideRange = !satisfiesRange(firstNonEmptyVersion(status.AdapterVersion, status.AgentVersion), item.SupportedRange)
 	status.AuthStatus, status.AuthError = DetectAuthStatus(item)
 	return status
 }
 
-func shouldProbeVersionForStatus(adapter Adapter, path string, lookup LookupFunc) bool {
+func shouldProbeAdapterVersionForStatus(adapter Adapter, path string, lookup LookupFunc, allowManaged bool) bool {
 	if !shouldProbeVersion(path) {
 		return false
 	}
 	if adapter.Managed.Package == "" {
+		return true
+	}
+	if allowManaged {
 		return true
 	}
 	planned, err := plannedManagedLauncher(adapter, lookup)
@@ -400,6 +444,26 @@ func shouldProbeVersionForStatus(adapter Adapter, path string, lookup LookupFunc
 		return true
 	}
 	return filepath.Clean(planned) != filepath.Clean(path)
+}
+
+func detectAgentVersionForStatus(ctx context.Context, adapter Adapter, path string, lookup LookupFunc) string {
+	if adapter.AgentVersion.Command != "" {
+		return DetectVersionProbe(ctx, adapter.AgentVersion, lookup)
+	}
+	if adapter.Managed.Package != "" {
+		return ""
+	}
+	return DetectVersion(ctx, path)
+}
+
+func firstNonEmptyVersion(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func shouldProbeVersion(path string) bool {
@@ -491,7 +555,8 @@ func normalizeAdapterDevOverride(value string) (string, bool) {
 }
 
 func applyAdapterDevOverride(status Status, override string) Status {
-	status.Version = ""
+	status.AdapterVersion = ""
+	status.AgentVersion = ""
 	status.VersionOutsideRange = false
 	status.AuthStatus = AuthStatusUnknown
 	status.AuthError = ""
@@ -542,7 +607,8 @@ func applyAdapterDevOverride(status Status, override string) Status {
 }
 
 func applyAdapterDiscoveryOverride(status Status, override string) Status {
-	status.Version = ""
+	status.AdapterVersion = ""
+	status.AgentVersion = ""
 	status.VersionOutsideRange = false
 	status.AuthStatus = AuthStatusUnknown
 	status.AuthError = ""
@@ -672,7 +738,7 @@ func RefreshManagedLauncher(ctx context.Context, id string, lookup LookupFunc) (
 	if _, err := ensureManagedLauncher(adapter, lookup); err != nil {
 		return Status{}, err
 	}
-	return statusForAdapter(ctx, adapter, lookup), nil
+	return statusForAdapter(ctx, adapter, lookup, statusProbeOptions{}), nil
 }
 
 func GCManagedLaunchers() (int, error) {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -85,6 +85,7 @@ type LaunchModel struct {
 	ID          string
 	Name        string
 	Description string
+	Default     bool
 }
 
 type LaunchSelectConfig struct {

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -3,6 +3,7 @@ package agentadapters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -205,7 +206,7 @@ func TestStatusForAdapterIgnoresInvalidDiscoveryOverride(t *testing.T) {
 		Command: "fake-adapter",
 	}, func(file string) (string, error) {
 		return "", errors.New("not found on PATH")
-	})
+	}, statusProbeOptions{})
 	if status.Available || status.Status != StatusMissing || !strings.Contains(status.Error, "not found") {
 		t.Fatalf("status = %#v, want normal missing lookup", status)
 	}
@@ -325,8 +326,138 @@ func TestShouldProbeVersionForStatusSkipsPlannedManagedLauncher(t *testing.T) {
 		}
 		return "", errors.New("not found on PATH")
 	}
-	if shouldProbeVersionForStatus(adapter, path, lookup) {
-		t.Fatalf("shouldProbeVersionForStatus returned true for planned managed launcher")
+	if shouldProbeAdapterVersionForStatus(adapter, path, lookup, false) {
+		t.Fatalf("shouldProbeAdapterVersionForStatus returned true for planned managed launcher")
+	}
+}
+
+func TestStatusForAdapterDoesNotRunManagedPackageForVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
+	marker := filepath.Join(dir, "runner-called")
+
+	runnerPath := writeGoHelperBinary(t, dir, "fake-npx", fmt.Sprintf(`package main
+
+import "os"
+
+func main() {
+	if err := os.WriteFile(%q, []byte("called"), 0o644); err != nil {
+		panic(err)
+	}
+}
+`, marker))
+	adapter := Adapter{
+		ID:      "managed_test",
+		Name:    "Managed Test",
+		Command: "managed-test-acp",
+		Managed: ManagedLauncher{
+			Package: "@example/managed-test-acp",
+			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
+		},
+		SupportedRange: ">=4.0.0",
+	}
+	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
+		if file == "npx" {
+			return runnerPath, nil
+		}
+		return "", errors.New("not found on PATH")
+	}, statusProbeOptions{})
+	if !status.Available {
+		t.Fatalf("status = %#v, want managed adapter available", status)
+	}
+	if status.AdapterVersion != "" {
+		t.Fatalf("status.AdapterVersion = %q, want passive status to avoid package-manager execution", status.AdapterVersion)
+	}
+	if status.VersionOutsideRange {
+		t.Fatalf("status.VersionOutsideRange = true, want false when version is unknown")
+	}
+	if _, err := os.Stat(status.Path); !os.IsNotExist(err) {
+		t.Fatalf("managed status lookup wrote launcher at %q, stat error = %v", status.Path, err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("passive managed status probe executed package runner, marker stat error = %v", err)
+	}
+}
+
+func TestStatusForAdapterReportsManagedAgentVersionWithoutRunningPackage(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
+	marker := filepath.Join(dir, "runner-called")
+	agent := writeFakeBinary(t, dir, "codex", "codex 9.8.7")
+	runnerPath := writeGoHelperBinary(t, dir, "fake-npx", fmt.Sprintf(`package main
+
+import "os"
+
+func main() {
+	if err := os.WriteFile(%q, []byte("called"), 0o644); err != nil {
+		panic(err)
+	}
+}
+`, marker))
+	adapter := Adapter{
+		ID:      "managed_test",
+		Name:    "Managed Test",
+		Command: "managed-test-acp",
+		AgentVersion: VersionProbe{
+			Command: "codex",
+			Args:    []string{"--version"},
+		},
+		Managed: ManagedLauncher{
+			Package: "@example/managed-test-acp",
+			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
+		},
+		SupportedRange: ">=4.0.0",
+	}
+	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
+		switch file {
+		case "codex":
+			return agent, nil
+		case "npx":
+			return runnerPath, nil
+		default:
+			return "", errors.New("not found on PATH")
+		}
+	}, statusProbeOptions{})
+	if status.AgentVersion != "9.8.7" {
+		t.Fatalf("status.AgentVersion = %q, want 9.8.7", status.AgentVersion)
+	}
+	if status.AdapterVersion != "" {
+		t.Fatalf("status.AdapterVersion = %q, want passive status to avoid package-manager execution", status.AdapterVersion)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("passive managed status probe executed package runner, marker stat error = %v", err)
+	}
+}
+
+func TestStatusForAdapterExplicitProbeAllowsManagedAdapterVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
+
+	adapter := Adapter{
+		ID:      "managed_test",
+		Name:    "Managed Test",
+		Command: "managed-test-acp",
+		Managed: ManagedLauncher{
+			Package: "@example/managed-test-acp",
+			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
+		},
+		SupportedRange: ">=4.0.0",
+	}
+	path := filepath.Join(dir, managedLauncherName(adapter.Command))
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho managed-test-acp 4.5.6\n"), 0o755); err != nil {
+		t.Fatalf("write planned launcher: %v", err)
+	}
+	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
+		if file == "npx" {
+			return "/usr/local/bin/npx", nil
+		}
+		return "", errors.New("not found on PATH")
+	}, statusProbeOptions{allowManagedAdapterVersion: true})
+	if status.AdapterVersion != "4.5.6" {
+		t.Fatalf("status.AdapterVersion = %q, want 4.5.6", status.AdapterVersion)
+	}
+	if status.VersionOutsideRange {
+		t.Fatalf("status.VersionOutsideRange = true, want version in supported range")
 	}
 }
 
@@ -336,10 +467,10 @@ func TestShouldProbeVersionForStatusAllowsDirectBinary(t *testing.T) {
 		t.Fatalf("write executable: %v", err)
 	}
 
-	if !shouldProbeVersionForStatus(Adapter{Command: "codex-acp"}, exe, func(file string) (string, error) {
+	if !shouldProbeAdapterVersionForStatus(Adapter{Command: "codex-acp"}, exe, func(file string) (string, error) {
 		return "", errors.New("not found on PATH")
-	}) {
-		t.Fatalf("shouldProbeVersionForStatus returned false for direct binary")
+	}, false) {
+		t.Fatalf("shouldProbeAdapterVersionForStatus returned false for direct binary")
 	}
 }
 

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -36,10 +36,43 @@ var detectVersionTimeout = 5 * time.Second
 // not reachable, does not respond within detectVersionTimeout, or
 // prints no recognisable version string.
 func DetectVersion(ctx context.Context, path string) string {
+	return detectVersionCommand(ctx, path, "--version")
+}
+
+func DetectVersionProbe(ctx context.Context, probe VersionProbe, lookup LookupFunc) string {
+	path, ok := resolveVersionProbe(probe, lookup)
+	if !ok {
+		return ""
+	}
+	return detectVersionCommand(ctx, path, probe.Args...)
+}
+
+func resolveVersionProbe(probe VersionProbe, lookup LookupFunc) (string, bool) {
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	if strings.TrimSpace(probe.Command) != "" {
+		if path, err := lookup(probe.Command); err == nil {
+			return path, true
+		}
+	}
+	for _, candidate := range probe.CandidatePaths {
+		path := expandPath(candidate)
+		if path == "" {
+			continue
+		}
+		if _, err := exec.LookPath(path); err == nil {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func detectVersionCommand(ctx context.Context, command string, args ...string) string {
 	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, path, "--version")
+	cmd := exec.CommandContext(ctx, command, args...)
 	out, _ := cmd.CombinedOutput()
 	// Some CLI adapters print version text before exiting non-zero, so prefer
 	// any captured semver token before treating the command as unusable.

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -61,8 +61,8 @@ func resolveVersionProbe(probe VersionProbe, lookup LookupFunc) (string, bool) {
 		if path == "" {
 			continue
 		}
-		if _, err := exec.LookPath(path); err == nil {
-			return path, true
+		if resolved, err := lookup(path); err == nil {
+			return resolved, true
 		}
 	}
 	return "", false

--- a/internal/agentadapters/version_test.go
+++ b/internal/agentadapters/version_test.go
@@ -153,6 +153,28 @@ func TestDetectVersionMissingBinaryReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestResolveVersionProbeUsesInjectedLookupForCandidatePaths(t *testing.T) {
+	t.Setenv("HOME", "/tmp/hecate-home")
+	probe := VersionProbe{CandidatePaths: []string{"${HOME}/bin/fake-adapter"}}
+	calledWith := ""
+	got, ok := resolveVersionProbe(probe, func(name string) (string, error) {
+		calledWith = name
+		if name == "/tmp/hecate-home/bin/fake-adapter" {
+			return "/resolved/fake-adapter", nil
+		}
+		return "", exec.ErrNotFound
+	})
+	if !ok {
+		t.Fatal("resolveVersionProbe = false, want candidate lookup success")
+	}
+	if got != "/resolved/fake-adapter" {
+		t.Fatalf("resolved path = %q, want injected lookup result", got)
+	}
+	if calledWith != "/tmp/hecate-home/bin/fake-adapter" {
+		t.Fatalf("lookup called with %q, want expanded candidate path", calledWith)
+	}
+}
+
 func TestDetectVersionTimeoutReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/internal/agentcontrols/config_options.go
+++ b/internal/agentcontrols/config_options.go
@@ -10,6 +10,8 @@ const (
 	ConfigOptionTypeSelect  = "select"
 	ConfigOptionTypeBoolean = "boolean"
 	ConfigOptionTypeUnknown = "unknown"
+
+	ConfigOptionSourceLaunch = "launch"
 )
 
 // ConfigOption is Hecate's stable projection of ACP session config
@@ -21,6 +23,7 @@ type ConfigOption struct {
 	Name         string               `json:"name"`
 	Description  string               `json:"description,omitempty"`
 	Category     string               `json:"category,omitempty"`
+	Source       string               `json:"source,omitempty"`
 	Type         string               `json:"type"`
 	CurrentValue string               `json:"current_value,omitempty"`
 	CurrentBool  *bool                `json:"current_bool,omitempty"`

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -28,12 +28,12 @@ func (h *Handler) HandleAgentAdapterProbe(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "adapter id is required")
 		return
 	}
-	status, ok := agentadapters.StatusForAdapter(ctx, id, nil)
-	if !ok {
+	if _, ok := agentadapters.FindAdapter(id); !ok {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "adapter not found")
 		return
 	}
 	result := h.probeAgentAdapter(ctx, id)
+	status, _ := agentadapters.StatusForAdapterAfterExplicitProbe(ctx, id, nil)
 	item := renderAgentAdapterItem(ctx, status)
 	if !agentadapters.DevOverrideActive(id) {
 		item.AuthStatus, item.AuthError = authStatusFromProbe(result, item.AuthStatus, item.AuthError)
@@ -94,7 +94,8 @@ func renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) Agen
 		Description:         item.Description,
 		CostMode:            item.CostMode,
 		DocsURL:             item.DocsURL,
-		Version:             item.Version,
+		AdapterVersion:      item.AdapterVersion,
+		AgentVersion:        item.AgentVersion,
 		SupportedRange:      item.SupportedRange,
 		VersionOutsideRange: item.VersionOutsideRange,
 		AuthStatus:          item.AuthStatus,

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hecate/agent-runtime/internal/agentadapters"
+	"github.com/hecate/agent-runtime/internal/agentcontrols"
 	"github.com/hecate/agent-runtime/internal/chat"
 	"github.com/hecate/agent-runtime/internal/modelcaps"
 	"github.com/hecate/agent-runtime/internal/requestscope"
@@ -427,6 +428,21 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 	result, err := h.agentChatRunner.SetSessionConfigOption(setCtx, setReq)
 	cancel()
 	if err != nil {
+		if errors.Is(err, agentadapters.ErrSessionNotActive) {
+			configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq)
+			if updateErr == nil {
+				updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
+					item.ConfigOptions = configOptions
+				})
+				if err != nil {
+					WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+					return
+				}
+				h.agentChatLive.publishSession(updated)
+				WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+				return
+			}
+		}
 		writeAgentChatConfigOptionError(w, session, err)
 		return
 	}
@@ -593,6 +609,46 @@ func agentChatConfigOptionSetRequest(sessionID, configID string, rawValue any) (
 	default:
 		return agentadapters.SetSessionConfigOptionRequest{}, fmt.Errorf("value must be a string or boolean")
 	}
+}
+
+func updateStoredAgentChatConfigOption(options []agentcontrols.ConfigOption, req agentadapters.SetSessionConfigOptionRequest) ([]agentcontrols.ConfigOption, error) {
+	out := append([]agentcontrols.ConfigOption(nil), options...)
+	for i := range out {
+		if out[i].ID != req.ConfigID {
+			continue
+		}
+		switch {
+		case req.BoolValue != nil:
+			if out[i].Type != agentcontrols.ConfigOptionTypeBoolean {
+				return nil, fmt.Errorf("config option %q is not boolean", req.ConfigID)
+			}
+			value := *req.BoolValue
+			out[i].CurrentBool = &value
+		default:
+			value := strings.TrimSpace(req.Value)
+			if value == "" {
+				return nil, fmt.Errorf("value is required")
+			}
+			if out[i].Type == agentcontrols.ConfigOptionTypeSelect && !storedConfigOptionAllowsValue(out[i], value) {
+				return nil, fmt.Errorf("value %q is not available for %s", value, out[i].Name)
+			}
+			out[i].CurrentValue = value
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("config option %q not found", req.ConfigID)
+}
+
+func storedConfigOptionAllowsValue(option agentcontrols.ConfigOption, value string) bool {
+	if len(option.Options) == 0 {
+		return true
+	}
+	for _, candidate := range option.Options {
+		if candidate.Value == value {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -430,7 +430,11 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 	if err != nil {
 		allowStoredOption := errors.Is(err, agentadapters.ErrSessionNotActive) ||
 			agentadapters.IsLaunchConfigOption(session.AgentID, setReq.ConfigID)
-		configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq, allowStoredOption)
+		configOptions, updateErr := updateStoredAgentChatConfigOption(
+			seedLaunchConfigOptionForSet(session.ConfigOptions, session.AgentID, setReq),
+			setReq,
+			allowStoredOption,
+		)
 		if updateErr == nil {
 			updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
 				item.ConfigOptions = configOptions
@@ -455,6 +459,30 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 	}
 	h.agentChatLive.publishSession(updated)
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+}
+
+func seedLaunchConfigOptionForSet(options []agentcontrols.ConfigOption, agentID string, req agentadapters.SetSessionConfigOptionRequest) []agentcontrols.ConfigOption {
+	if req.BoolValue != nil {
+		return options
+	}
+	seed, ok := agentadapters.LaunchConfigOptionForSet(agentID, req.ConfigID, req.Value)
+	if !ok {
+		return options
+	}
+	out := append([]agentcontrols.ConfigOption(nil), options...)
+	for i := range out {
+		if out[i].ID != req.ConfigID {
+			continue
+		}
+		if out[i].Source == "" {
+			out[i].Source = agentcontrols.ConfigOptionSourceLaunch
+		}
+		if out[i].Type == agentcontrols.ConfigOptionTypeSelect && !storedConfigOptionAllowsValue(out[i], req.Value) {
+			out[i].Options = seed.Options
+		}
+		return out
+	}
+	return append(out, seed)
 }
 
 func (h *Handler) HandleSetAgentChatSettings(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -428,7 +428,9 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 	result, err := h.agentChatRunner.SetSessionConfigOption(setCtx, setReq)
 	cancel()
 	if err != nil {
-		configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq, errors.Is(err, agentadapters.ErrSessionNotActive))
+		allowStoredOption := errors.Is(err, agentadapters.ErrSessionNotActive) ||
+			agentadapters.IsLaunchConfigOption(session.AgentID, setReq.ConfigID)
+		configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq, allowStoredOption)
 		if updateErr == nil {
 			updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
 				item.ConfigOptions = configOptions

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -428,20 +428,18 @@ func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.
 	result, err := h.agentChatRunner.SetSessionConfigOption(setCtx, setReq)
 	cancel()
 	if err != nil {
-		if errors.Is(err, agentadapters.ErrSessionNotActive) {
-			configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq)
-			if updateErr == nil {
-				updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
-					item.ConfigOptions = configOptions
-				})
-				if err != nil {
-					WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-					return
-				}
-				h.agentChatLive.publishSession(updated)
-				WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+		configOptions, updateErr := updateStoredAgentChatConfigOption(session.ConfigOptions, setReq, errors.Is(err, agentadapters.ErrSessionNotActive))
+		if updateErr == nil {
+			updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
+				item.ConfigOptions = configOptions
+			})
+			if err != nil {
+				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 				return
 			}
+			h.agentChatLive.publishSession(updated)
+			WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+			return
 		}
 		writeAgentChatConfigOptionError(w, session, err)
 		return
@@ -611,11 +609,14 @@ func agentChatConfigOptionSetRequest(sessionID, configID string, rawValue any) (
 	}
 }
 
-func updateStoredAgentChatConfigOption(options []agentcontrols.ConfigOption, req agentadapters.SetSessionConfigOptionRequest) ([]agentcontrols.ConfigOption, error) {
+func updateStoredAgentChatConfigOption(options []agentcontrols.ConfigOption, req agentadapters.SetSessionConfigOptionRequest, allowInactiveAdapterOption bool) ([]agentcontrols.ConfigOption, error) {
 	out := append([]agentcontrols.ConfigOption(nil), options...)
 	for i := range out {
 		if out[i].ID != req.ConfigID {
 			continue
+		}
+		if !allowInactiveAdapterOption && out[i].Source != agentcontrols.ConfigOptionSourceLaunch {
+			return nil, fmt.Errorf("config option %q is not launch-managed", req.ConfigID)
 		}
 		switch {
 		case req.BoolValue != nil:

--- a/internal/api/handler_local_provider_discovery.go
+++ b/internal/api/handler_local_provider_discovery.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -157,13 +158,22 @@ func discoverLocalProviderPairsConcurrently(ctx context.Context, providers []loc
 }
 
 func findLocalProviderCommand(providerID string, lookPath localProviderLookPath) (string, string) {
-	for _, command := range localProviderCommandCandidates(providerID) {
+	candidates := localProviderCommandCandidates(providerID)
+	for _, command := range candidates {
 		path, err := lookPath(command)
 		if err == nil && strings.TrimSpace(path) != "" {
 			return command, path
 		}
 	}
-	candidates := localProviderCommandCandidates(providerID)
+	for _, candidate := range localProviderCommandPathCandidates(providerID) {
+		path, err := lookPath(expandLocalProviderPath(candidate))
+		if err == nil && strings.TrimSpace(path) != "" {
+			if len(candidates) == 0 {
+				return strings.TrimSpace(candidate), path
+			}
+			return candidates[0], path
+		}
+	}
 	if len(candidates) == 0 {
 		return "", ""
 	}
@@ -183,6 +193,57 @@ func localProviderCommandCandidates(providerID string) []string {
 	default:
 		return nil
 	}
+}
+
+func localProviderCommandPathCandidates(providerID string) []string {
+	switch providerID {
+	case "ollama":
+		return []string{
+			"${HOME}/.local/bin/ollama",
+			"/opt/homebrew/bin/ollama",
+			"/usr/local/bin/ollama",
+			"/Applications/Ollama.app/Contents/Resources/ollama",
+		}
+	case "lmstudio":
+		return []string{
+			"${HOME}/.lmstudio/bin/lms",
+			"${HOME}/.local/bin/lms",
+			"${HOME}/.volta/bin/lms",
+			"/opt/homebrew/bin/lms",
+			"/usr/local/bin/lms",
+		}
+	case "llamacpp":
+		return []string{
+			"${HOME}/.local/bin/llama-server",
+			"/opt/homebrew/bin/llama-server",
+			"/usr/local/bin/llama-server",
+		}
+	case "localai":
+		return []string{
+			"${HOME}/.local/bin/local-ai",
+			"${HOME}/.local/bin/localai",
+			"/opt/homebrew/bin/local-ai",
+			"/opt/homebrew/bin/localai",
+			"/usr/local/bin/local-ai",
+			"/usr/local/bin/localai",
+		}
+	default:
+		return nil
+	}
+}
+
+func expandLocalProviderPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		path = strings.ReplaceAll(path, "${HOME}", home)
+		if strings.HasPrefix(path, "~/") {
+			path = home + path[1:]
+		}
+	}
+	return path
 }
 
 func localProviderProbeURL(provider config.BuiltInProvider) string {

--- a/internal/api/handler_local_provider_discovery_test.go
+++ b/internal/api/handler_local_provider_discovery_test.go
@@ -183,6 +183,41 @@ func TestDiscoverLocalProvidersChecksCommandPresence(t *testing.T) {
 	}
 }
 
+func TestDiscoverLocalProvidersFindsLMStudioInNativeAppPath(t *testing.T) {
+	t.Setenv("HOME", "/Users/alice")
+
+	providers := []config.BuiltInProvider{
+		{ID: "lmstudio", Name: "LM Studio", Kind: "local", BaseURL: "http://127.0.0.1:1234/v1"},
+	}
+	rt := &localProviderRoundTrip{
+		err: map[string]error{
+			"http://127.0.0.1:1234/v1/models": errors.New("connection refused"),
+		},
+	}
+	lookPath := func(command string) (string, error) {
+		if command == "/Users/alice/.lmstudio/bin/lms" {
+			return command, nil
+		}
+		return "", errors.New("missing")
+	}
+
+	items := discoverLocalProviders(context.Background(), providers, lookPath, rt)
+
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Command != "lms" {
+		t.Fatalf("command = %q, want lms", item.Command)
+	}
+	if item.CommandPath != "/Users/alice/.lmstudio/bin/lms" {
+		t.Fatalf("command path = %q, want native LM Studio path", item.CommandPath)
+	}
+	if item.Status != "installed" {
+		t.Fatalf("status = %q, want installed", item.Status)
+	}
+}
+
 func TestDiscoverLocalProvidersOllamaInstalledStoppedAndRunning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -557,7 +557,8 @@ type AgentAdapterResponseItem struct {
 	Description         string                              `json:"description,omitempty"`
 	CostMode            string                              `json:"cost_mode,omitempty"`
 	DocsURL             string                              `json:"docs_url,omitempty"`
-	Version             string                              `json:"version,omitempty"`
+	AdapterVersion      string                              `json:"adapter_version,omitempty"`
+	AgentVersion        string                              `json:"agent_version,omitempty"`
 	SupportedRange      string                              `json:"supported_range,omitempty"`
 	VersionOutsideRange bool                                `json:"version_outside_range,omitempty"`
 	AuthStatus          string                              `json:"auth_status,omitempty"`

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2693,7 +2693,6 @@ func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing
 				ID:           "model",
 				Name:         "Model",
 				Category:     "model",
-				Source:       agentcontrols.ConfigOptionSourceLaunch,
 				Type:         agentcontrols.ConfigOptionTypeSelect,
 				CurrentValue: "fast",
 				Options: []agentcontrols.ConfigSelectOption{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1110,8 +1110,14 @@ func TestAgentAdaptersIncludesLaunchConfigOptions(t *testing.T) {
 	if grok.ConfigOptions[0].ID != "model" || grok.ConfigOptions[0].CurrentValue == "" {
 		t.Fatalf("grok model option = %#v, want populated model picker", grok.ConfigOptions[0])
 	}
+	if grok.ConfigOptions[0].Source != agentcontrols.ConfigOptionSourceLaunch {
+		t.Fatalf("grok model option source = %q, want launch", grok.ConfigOptions[0].Source)
+	}
 	if grok.ConfigOptions[1].ID != "reasoning_effort" {
 		t.Fatalf("grok reasoning option = %#v, want reasoning_effort", grok.ConfigOptions[1])
+	}
+	if grok.ConfigOptions[1].Source != agentcontrols.ConfigOptionSourceLaunch {
+		t.Fatalf("grok reasoning option source = %q, want launch", grok.ConfigOptions[1].Source)
 	}
 }
 
@@ -2674,6 +2680,38 @@ func TestAgentChatExternalStoredConfigOptionUpdatesWhenSessionInactive(t *testin
 	updated = decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/auto_approve", `{"value":true}`))
 	if got := updated.Data.ConfigOptions; len(got) != 2 || got[1].CurrentBool == nil || !*got[1].CurrentBool {
 		t.Fatalf("config options after inactive boolean set = %#v, want auto_approve true", got)
+	}
+}
+
+func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	runner := &fakeAgentChatRunner{
+		configOptions: []agentcontrols.ConfigOption{
+			{
+				ID:           "model",
+				Name:         "Model",
+				Category:     "model",
+				Source:       agentcontrols.ConfigOptionSourceLaunch,
+				Type:         agentcontrols.ConfigOptionTypeSelect,
+				CurrentValue: "fast",
+				Options: []agentcontrols.ConfigSelectOption{
+					{Value: "fast", Name: "Fast"},
+					{Value: "smart", Name: "Smart"},
+				},
+			},
+		},
+	}
+	apiHandler.SetAgentChatRunner(runner)
+	handler := NewServer(logger, apiHandler)
+
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"grok_build","workspace":%q}`, dir)))
+	runner.setConfigErr = errors.New("adapter rejected launch option")
+
+	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"smart"}`))
+	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].CurrentValue != "smart" {
+		t.Fatalf("config options after launch set = %#v, want smart", got)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2714,6 +2714,25 @@ func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing
 	}
 }
 
+func TestAgentChatExternalLaunchConfigOptionSeedsMissingStoredOption(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	runner := &fakeAgentChatRunner{setConfigErr: errors.New("adapter rejected launch option")}
+	apiHandler.SetAgentChatRunner(runner)
+	handler := NewServer(logger, apiHandler)
+
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"grok_build","workspace":%q}`, dir)))
+	if len(created.Data.ConfigOptions) != 0 {
+		t.Fatalf("created config options = %#v, want stale session without stored launch options", created.Data.ConfigOptions)
+	}
+
+	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"grok-latest"}`))
+	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].ID != "model" || got[0].CurrentValue != "grok-latest" {
+		t.Fatalf("config options after seeded launch set = %#v, want selected model", got)
+	}
+}
+
 func TestAgentChatExternalConfigOptionAdapterFailure(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2633,6 +2633,50 @@ func TestAgentChatExternalConfigOptionSessionNotActive(t *testing.T) {
 	}
 }
 
+func TestAgentChatExternalStoredConfigOptionUpdatesWhenSessionInactive(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	autoApprove := false
+	runner := &fakeAgentChatRunner{
+		configOptions: []agentcontrols.ConfigOption{
+			{
+				ID:           "model",
+				Name:         "Model",
+				Category:     "model",
+				Type:         agentcontrols.ConfigOptionTypeSelect,
+				CurrentValue: "fast",
+				Options: []agentcontrols.ConfigSelectOption{
+					{Value: "fast", Name: "Fast"},
+					{Value: "smart", Name: "Smart"},
+				},
+			},
+			{
+				ID:          "auto_approve",
+				Name:        "Auto approve",
+				Category:    "mode",
+				Type:        agentcontrols.ConfigOptionTypeBoolean,
+				CurrentBool: &autoApprove,
+			},
+		},
+	}
+	apiHandler.SetAgentChatRunner(runner)
+	handler := NewServer(logger, apiHandler)
+
+	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir)))
+	runner.setConfigErr = fmt.Errorf("%w: %q", agentadapters.ErrSessionNotActive, created.Data.ID)
+
+	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"smart"}`))
+	if got := updated.Data.ConfigOptions; len(got) != 2 || got[0].CurrentValue != "smart" {
+		t.Fatalf("config options after inactive model set = %#v, want smart", got)
+	}
+
+	updated = decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/auto_approve", `{"value":true}`))
+	if got := updated.Data.ConfigOptions; len(got) != 2 || got[1].CurrentBool == nil || !*got[1].CurrentBool {
+		t.Fatalf("config options after inactive boolean set = %#v, want auto_approve true", got)
+	}
+}
+
 func TestAgentChatExternalConfigOptionAdapterFailure(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -2087,7 +2087,6 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
   await expect(page.getByRole("button", { name: "Fixed model: qwen2.5" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Stop active task" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Open task", exact: true })).toBeVisible();
-  await expect(page.getByText(/Hecate Chat is still working on this task/)).toBeVisible();
   await expect(page.getByText("Backing task")).toBeVisible();
 
   await page.locator("textarea").fill("try direct while busy");
@@ -2305,13 +2304,13 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
   await page.waitForSelector(".hecate-activitybar");
 
   await expect(page.getByTestId("hecate-task-approval-banner")).toBeVisible();
-  await expect(page.getByText(/Hecate Chat is still working on this task/)).toBeVisible();
   await expect(
     page
       .getByTestId("hecate-task-approval-banner")
       .getByRole("button", { name: "Open task", exact: true }),
   ).toBeVisible();
-  await expect(page.locator("button[type='submit']")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
+  await expect(page.getByText("Hecate Chat is working. New messages will queue.")).toBeVisible();
 
   await page.getByRole("button", { name: /Approve Agent tool call/i }).click();
   await expect(page.getByTestId("hecate-task-approval-banner")).toBeHidden();

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -20,6 +20,9 @@ const test = baseTest.extend<{ page: Page }>({
 });
 
 test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
   await page.goto("/");
   // Chat is the default workspace
   await page.waitForSelector(".hecate-activitybar");
@@ -289,6 +292,177 @@ test("New chat creates an external-agent session with controls before the first 
   );
 });
 
+test("New Hecate chat asks for workspace before creating a tools-on session", async ({
+  page,
+}) => {
+  let createBody: any = null;
+  await page.route("/hecate/v1/chat/sessions", async (route) => {
+    if (route.request().method() === "POST") {
+      createBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { type: "unexpected", message: "unexpected create" } }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.removeItem("hecate.agentWorkspace");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
+
+  await expect(page.getByText("Choose a workspace")).toBeVisible();
+  await expect(page.locator("textarea")).toHaveCount(0);
+  await expect(page.getByText("Model required")).toHaveCount(0);
+  await expect.poll(() => createBody).toBeNull();
+});
+
+test("New external-agent chat asks for workspace without flashing an inline error", async ({
+  page,
+}) => {
+  let createBody: any = null;
+  await page.route("/hecate/v1/agent-adapters*", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "agent_adapters",
+        data: [
+          {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("/hecate/v1/chat/sessions", async (route) => {
+    if (route.request().method() === "POST") {
+      createBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { type: "unexpected", message: "unexpected create" } }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "codex");
+    window.localStorage.removeItem("hecate.agentWorkspace");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByRole("button", { name: "New Codex chat", exact: true }).click();
+
+  await expect(page.getByText("Choose a workspace")).toBeVisible();
+  await expect(page.locator("textarea")).toHaveCount(0);
+  await expect(page.getByText("Workspace required")).toHaveCount(0);
+  await expect.poll(() => createBody).toBeNull();
+});
+
+test("New external-agent chat with model setup shows controls and composer together", async ({
+  page,
+}) => {
+  let createBody: any = null;
+  await page.route("/hecate/v1/agent-adapters*", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "agent_adapters",
+        data: [
+          {
+            id: "grok_build",
+            name: "Grok Build",
+            kind: "acp",
+            command: "grok",
+            args: ["agent", "stdio"],
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            config_options: [
+              {
+                id: "model",
+                name: "Model",
+                category: "model",
+                type: "select",
+                current_value: "__hecate_no_model_selected__",
+                options: [
+                  { value: "__hecate_no_model_selected__", name: "Pick a model" },
+                  { value: "grok-build-0429", name: "Grok Build 0429" },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("/hecate/v1/chat/sessions", async (route) => {
+    if (route.request().method() === "POST") {
+      createBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "chat_session",
+          data: {
+            id: "grok-build-e2e",
+            title: "Grok Build chat",
+            agent_id: "grok_build",
+            agent_name: "Grok Build",
+            driver_kind: "acp",
+            native_session_id: "native-grok-build-e2e",
+            workspace: "/tmp/hecate-e2e",
+            status: "idle",
+            config_options: createBody.config_options ?? [],
+            messages: [],
+          },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "grok_build");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByRole("button", { name: "New Grok Build chat", exact: true }).click();
+
+  await expect(page.getByRole("button", { name: "Model" })).toContainText("Pick a model");
+  await expect(page.locator("textarea")).toBeVisible();
+  await page.locator("textarea").fill("Build a tiny app");
+  await expect(page.locator("button[type='submit']")).toBeDisabled();
+
+  await page.getByRole("button", { name: "Model" }).click();
+  await page.getByRole("option", { name: "Grok Build 0429" }).click();
+
+  await expect(page.getByRole("button", { name: "Model" })).toContainText("Grok Build 0429");
+  await expect(page.locator("button[type='submit']")).toBeEnabled();
+});
+
 test("New chat falls back to Hecate when the remembered external agent needs setup", async ({
   page,
 }) => {
@@ -461,11 +635,11 @@ test("system prompt editor opens and closes", async ({ page }) => {
   await switchToModel(page);
   const settingsBtn = page.getByRole("button", { name: "Chat settings" });
   await settingsBtn.click();
-  await expect(page.getByText("SYSTEM PROMPT / INSTRUCTIONS", { exact: true })).toBeVisible();
+  await expect(page.getByText("SYSTEM PROMPT / AGENT INSTRUCTIONS", { exact: true })).toBeVisible();
   await expect(page.locator("textarea").nth(1)).toBeVisible();
 
   await settingsBtn.click();
-  await expect(page.getByText("SYSTEM PROMPT / INSTRUCTIONS", { exact: true })).not.toBeVisible();
+  await expect(page.getByText("SYSTEM PROMPT / AGENT INSTRUCTIONS", { exact: true })).not.toBeVisible();
 });
 
 test("Enter-switch toggle is visible in the input toolbar and clickable", async ({ page }) => {
@@ -912,8 +1086,9 @@ test("local provider quick-add makes model chat runnable without detected-provid
   await page.getByRole("button", { name: "Add selected" }).click();
 
   await expect.poll(() => [...createdPresets].sort()).toEqual(["lmstudio", "ollama"]);
-  await page.getByRole("button", { name: "Use model" }).click();
   await expect(page.getByText("Ready when you are")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Message" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /model picker/i })).toContainText("llama3.1:8b");
   await expect(page.getByText("No routable model")).toHaveCount(0);
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
@@ -1552,7 +1727,6 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.providerFilter", "ollama");
     window.localStorage.setItem("hecate.model", "qwen2.5-coder");
-    window.localStorage.removeItem("hecate.agentWorkspace");
   });
   await mockGatewayAPIs(page, {
     settingsConfig: {

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -292,9 +292,7 @@ test("New chat creates an external-agent session with controls before the first 
   );
 });
 
-test("New Hecate chat asks for workspace before creating a tools-on session", async ({
-  page,
-}) => {
+test("New Hecate chat asks for workspace before creating a tools-on session", async ({ page }) => {
   let createBody: any = null;
   await page.route("/hecate/v1/chat/sessions", async (route) => {
     if (route.request().method() === "POST") {
@@ -380,6 +378,7 @@ test("New external-agent chat with model setup shows controls and composer toget
   page,
 }) => {
   let createBody: any = null;
+  let createdSession: any = null;
   await page.route("/hecate/v1/agent-adapters*", async (route) => {
     if (route.request().method() !== "GET") return route.continue();
     await route.fulfill({
@@ -418,29 +417,48 @@ test("New external-agent chat with model setup shows controls and composer toget
   await page.route("/hecate/v1/chat/sessions", async (route) => {
     if (route.request().method() === "POST") {
       createBody = JSON.parse(route.request().postData() ?? "{}");
+      createdSession = {
+        id: "grok-build-e2e",
+        title: "Grok Build chat",
+        agent_id: "grok_build",
+        agent_name: "Grok Build",
+        driver_kind: "acp",
+        native_session_id: "native-grok-build-e2e",
+        workspace: "/tmp/hecate-e2e",
+        status: "idle",
+        config_options: createBody.config_options ?? [],
+        messages: [],
+      };
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
           object: "chat_session",
-          data: {
-            id: "grok-build-e2e",
-            title: "Grok Build chat",
-            agent_id: "grok_build",
-            agent_name: "Grok Build",
-            driver_kind: "acp",
-            native_session_id: "native-grok-build-e2e",
-            workspace: "/tmp/hecate-e2e",
-            status: "idle",
-            config_options: createBody.config_options ?? [],
-            messages: [],
-          },
+          data: createdSession,
         }),
       });
       return;
     }
     await route.fallback();
   });
+  await page.route(
+    "/hecate/v1/chat/sessions/grok-build-e2e/config-options/model",
+    async (route) => {
+      if (route.request().method() !== "POST") return route.fallback();
+      const body = JSON.parse(route.request().postData() ?? "{}");
+      createdSession = {
+        ...createdSession,
+        config_options: (createdSession?.config_options ?? []).map((option: any) =>
+          option.id === "model" ? { ...option, current_value: String(body.value ?? "") } : option,
+        ),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "chat_session", data: createdSession }),
+      });
+    },
+  );
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "grok_build");
@@ -451,6 +469,10 @@ test("New external-agent chat with model setup shows controls and composer toget
 
   await page.getByRole("button", { name: "New Grok Build chat", exact: true }).click();
 
+  await expect.poll(() => createBody?.agent_id).toBe("grok_build");
+  await expect(
+    page.getByRole("button", { name: /Chat Grok Build chat, Grok Build/i }),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: "Model" })).toContainText("Pick a model");
   await expect(page.locator("textarea")).toBeVisible();
   await page.locator("textarea").fill("Build a tiny app");
@@ -639,7 +661,9 @@ test("system prompt editor opens and closes", async ({ page }) => {
   await expect(page.locator("textarea").nth(1)).toBeVisible();
 
   await settingsBtn.click();
-  await expect(page.getByText("SYSTEM PROMPT / AGENT INSTRUCTIONS", { exact: true })).not.toBeVisible();
+  await expect(
+    page.getByText("SYSTEM PROMPT / AGENT INSTRUCTIONS", { exact: true }),
+  ).not.toBeVisible();
 });
 
 test("Enter-switch toggle is visible in the input toolbar and clickable", async ({ page }) => {

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -472,17 +472,25 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       }
 
       let sessionID = queued?.session_id ?? activeChatSessionID;
-      if (sessionID && !activeChatSession) {
-        // The server owns chat persistence. If localStorage points at a
-        // deleted or unavailable session, start clean instead of making the
-        // next prompt fail with a stale 404.
-        sessionID = "";
-        setActiveChatSessionID("");
+      let sessionForSubmit = activeChatSession;
+      if (sessionID && !sessionForSubmit) {
+        try {
+          const payload = await getChatSession(sessionID);
+          sessionForSubmit = payload.data;
+          applyChatSession(payload.data);
+        } catch {
+          // The server owns chat persistence. If localStorage points at a
+          // deleted or unavailable session, start clean instead of making the
+          // next prompt fail with a stale 404.
+          sessionID = "";
+          setActiveChatSessionID("");
+        }
       }
-      if (sessionID && activeChatSession?.agent_id) {
-        const activeExternal = activeChatSession.agent_id !== "hecate";
+      if (sessionID && sessionForSubmit?.agent_id) {
+        const activeExternal = sessionForSubmit.agent_id !== "hecate";
         if (activeExternal !== isExternalAgent) {
           sessionID = "";
+          sessionForSubmit = null;
           setActiveChatSessionID("");
           setActiveChatSession(null);
         }

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -127,10 +127,6 @@ function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null)
   return { provider: session.provider ?? "", model: session.model ?? "" };
 }
 
-function chatGuardError(message: string, code: string, operatorAction: string): ApiError {
-  return new ApiError(message, 400, code, { operatorAction });
-}
-
 function effectiveHecateExecutionMode({
   requested,
   models,
@@ -146,6 +142,19 @@ function effectiveHecateExecutionMode({
   return modelSelectionHasNoToolCalling({ models, providerFilter, model })
     ? "direct_model"
     : requested;
+}
+
+function modelAvailableForProviderFilter(
+  models: ModelRecord[],
+  providerFilter: ProviderFilter,
+  model: string,
+): boolean {
+  if (!model.trim()) return false;
+  return models.some((entry) => {
+    if (entry.id !== model) return false;
+    if (!providerFilter || providerFilter === "auto") return true;
+    return entry.metadata?.provider === providerFilter;
+  });
 }
 
 function hecateTargetForExecutionMode(mode: ChatExecutionMode): HecateChatTarget {
@@ -688,13 +697,9 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       const externalAgentID = requestedAgentID || agentAdapterID;
       const workspace = agentWorkspace.trim();
       if (!workspace) {
-        setChatErrorState(
-          chatGuardError(
-            "Choose a workspace before starting an external-agent chat.",
-            "chat.workspace_required",
-            "Choose a workspace, then start the chat again.",
-          ),
-        );
+        clearChatErrorState();
+        setActiveChatSessionID("");
+        setActiveChatSession(null);
         return;
       }
       setChatLoading(true);
@@ -725,13 +730,25 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
     const requestedChatTarget = requestedAgentID === "hecate" ? "agent" : defaultChatTarget;
     const requestedExecutionMode = chatTargetToExecutionMode(requestedChatTarget);
+    const requestedModel =
+      requestedExecutionMode === "hecate_task" &&
+      model &&
+      !modelAvailableForProviderFilter(models, providerFilter, model)
+        ? ""
+        : model;
     const executionMode = effectiveHecateExecutionMode({
       requested: requestedExecutionMode,
       models,
       providerFilter,
-      model,
+      model: requestedModel,
     });
     const workspace = agentWorkspace.trim();
+    if (executionMode === "hecate_task" && !workspace) {
+      clearChatErrorState();
+      setActiveChatSessionID("");
+      setActiveChatSession(null);
+      return;
+    }
     setChatLoading(true);
     clearChatErrorState();
     try {
@@ -739,7 +756,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ...(createProjectID ? { project_id: createProjectID } : {}),
         agent_id: "hecate",
         provider: providerFilter === "auto" ? "" : providerFilter,
-        model,
+        model: requestedModel,
         ...(executionMode === "hecate_task"
           ? {
               workspace,

--- a/ui/src/app/state/rootEffects.test.tsx
+++ b/ui/src/app/state/rootEffects.test.tsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RootEffects } from "./rootEffects";
+import {
+  createRuntimeConsoleActions,
+  createRuntimeConsoleFixture,
+} from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
+import type { AgentAdapterRecord } from "../../types/agent-adapter";
+
+function adapter(id: string, overrides: Partial<AgentAdapterRecord> = {}): AgentAdapterRecord {
+  return {
+    id,
+    name: id,
+    kind: "acp",
+    command: `${id}-acp`,
+    available: true,
+    status: "available",
+    cost_mode: "external",
+    ...overrides,
+  };
+}
+
+describe("RootEffects", () => {
+  it("probes direct startup agent adapters concurrently", async () => {
+    const pending = new Map<string, () => void>();
+    const probeAgentAdapter = vi.fn(
+      (adapterID: string) =>
+        new Promise<null>((resolve) => {
+          pending.set(adapterID, () => resolve(null));
+        }),
+    );
+    const state = createRuntimeConsoleFixture({
+      agentAdapters: [
+        adapter("codex", { managed: true }),
+        adapter("claude_code", { managed: true }),
+        adapter("cursor_agent"),
+        adapter("grok_build"),
+      ],
+    });
+    const actions = {
+      ...createRuntimeConsoleActions(),
+      probeAgentAdapter,
+      loadDashboard: vi.fn(async () => undefined),
+      loadProjects: vi.fn(async () => undefined),
+    };
+
+    render(withRuntimeConsole(<RootEffects />, { state, actions }));
+
+    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledTimes(2));
+    expect(probeAgentAdapter.mock.calls.map(([id]) => id)).toEqual(["cursor_agent", "grok_build"]);
+    // If the effect awaited each probe serially, only the first call
+    // would exist until its promise resolved. Seeing both pending
+    // promises proves the startup pass is concurrent.
+    expect([...pending.keys()]).toEqual(["cursor_agent", "grok_build"]);
+    for (const resolve of pending.values()) resolve();
+  });
+
+  it("does not run managed adapter probes during quiet startup", async () => {
+    const probeAgentAdapter = vi.fn(async () => null);
+    const state = createRuntimeConsoleFixture({
+      agentAdapters: [
+        adapter("codex", { managed: true, managed_package: "@zed-industries/codex-acp" }),
+        adapter("claude_code", {
+          managed: true,
+          managed_package: "@agentclientprotocol/claude-agent-acp",
+        }),
+      ],
+    });
+    const actions = {
+      ...createRuntimeConsoleActions(),
+      probeAgentAdapter,
+      loadDashboard: vi.fn(async () => undefined),
+      loadProjects: vi.fn(async () => undefined),
+    };
+
+    render(withRuntimeConsole(<RootEffects />, { state, actions }));
+
+    await waitFor(() => expect(actions.loadDashboard).toHaveBeenCalled());
+    expect(probeAgentAdapter).not.toHaveBeenCalled();
+  });
+
+  it("probes adapters that arrive after dashboard load only once", async () => {
+    const probeAgentAdapter = vi.fn(async () => null);
+    const actions = {
+      ...createRuntimeConsoleActions(),
+      probeAgentAdapter,
+      loadDashboard: vi.fn(async () => undefined),
+      loadProjects: vi.fn(async () => undefined),
+    };
+    const initial = createRuntimeConsoleFixture({ agentAdapters: [] });
+    const { rerender } = render(withRuntimeConsole(<RootEffects />, { state: initial, actions }));
+
+    expect(probeAgentAdapter).not.toHaveBeenCalled();
+
+    const next = createRuntimeConsoleFixture({ agentAdapters: [adapter("claude_code")] });
+    rerender(withRuntimeConsole(<RootEffects />, { state: next, actions }));
+
+    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code"));
+    rerender(withRuntimeConsole(<RootEffects />, { state: { ...next }, actions }));
+    expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/app/state/rootEffects.test.tsx
+++ b/ui/src/app/state/rootEffects.test.tsx
@@ -23,14 +23,8 @@ function adapter(id: string, overrides: Partial<AgentAdapterRecord> = {}): Agent
 }
 
 describe("RootEffects", () => {
-  it("probes direct startup agent adapters concurrently", async () => {
-    const pending = new Map<string, () => void>();
-    const probeAgentAdapter = vi.fn(
-      (adapterID: string) =>
-        new Promise<null>((resolve) => {
-          pending.set(adapterID, () => resolve(null));
-        }),
-    );
+  it("does not actively probe agent adapters during quiet startup", async () => {
+    const probeAgentAdapter = vi.fn(async () => null);
     const state = createRuntimeConsoleFixture({
       agentAdapters: [
         adapter("codex", { managed: true }),
@@ -48,40 +42,11 @@ describe("RootEffects", () => {
 
     render(withRuntimeConsole(<RootEffects />, { state, actions }));
 
-    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledTimes(2));
-    expect(probeAgentAdapter.mock.calls.map(([id]) => id)).toEqual(["cursor_agent", "grok_build"]);
-    // If the effect awaited each probe serially, only the first call
-    // would exist until its promise resolved. Seeing both pending
-    // promises proves the startup pass is concurrent.
-    expect([...pending.keys()]).toEqual(["cursor_agent", "grok_build"]);
-    for (const resolve of pending.values()) resolve();
-  });
-
-  it("does not run managed adapter probes during quiet startup", async () => {
-    const probeAgentAdapter = vi.fn(async () => null);
-    const state = createRuntimeConsoleFixture({
-      agentAdapters: [
-        adapter("codex", { managed: true, managed_package: "@zed-industries/codex-acp" }),
-        adapter("claude_code", {
-          managed: true,
-          managed_package: "@agentclientprotocol/claude-agent-acp",
-        }),
-      ],
-    });
-    const actions = {
-      ...createRuntimeConsoleActions(),
-      probeAgentAdapter,
-      loadDashboard: vi.fn(async () => undefined),
-      loadProjects: vi.fn(async () => undefined),
-    };
-
-    render(withRuntimeConsole(<RootEffects />, { state, actions }));
-
     await waitFor(() => expect(actions.loadDashboard).toHaveBeenCalled());
     expect(probeAgentAdapter).not.toHaveBeenCalled();
   });
 
-  it("probes adapters that arrive after dashboard load only once", async () => {
+  it("keeps passive adapter arrivals from starting ACP sessions", async () => {
     const probeAgentAdapter = vi.fn(async () => null);
     const actions = {
       ...createRuntimeConsoleActions(),
@@ -92,13 +57,12 @@ describe("RootEffects", () => {
     const initial = createRuntimeConsoleFixture({ agentAdapters: [] });
     const { rerender } = render(withRuntimeConsole(<RootEffects />, { state: initial, actions }));
 
-    expect(probeAgentAdapter).not.toHaveBeenCalled();
-
-    const next = createRuntimeConsoleFixture({ agentAdapters: [adapter("claude_code")] });
+    const next = createRuntimeConsoleFixture({
+      agentAdapters: [adapter("cursor_agent"), adapter("grok_build")],
+    });
     rerender(withRuntimeConsole(<RootEffects />, { state: next, actions }));
 
-    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code"));
-    rerender(withRuntimeConsole(<RootEffects />, { state: { ...next }, actions }));
-    expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(actions.loadDashboard).toHaveBeenCalled());
+    expect(probeAgentAdapter).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/state/rootEffects.ts
+++ b/ui/src/app/state/rootEffects.ts
@@ -131,11 +131,9 @@ export function RootEffects() {
   const { setChatCancelling, setModel, setProviderFilter, setQueuedChatMessages } = chat.actions;
   const { setHecateRTKEnabled: setHecateRTKEnabledState } = runtime.actions;
   const { models, providers } = providersAndModels.state;
-  const { agentAdapters } = providersAndModels.state;
   const { notice } = settings.state;
   const { dismissNoticeIfMatching } = settings.actions;
   const settingsConfig = settings.state.config;
-  const probedAgentAdapterIDsRef = useRef<Set<string>>(new Set());
 
   // Mount-time dashboard load. The facade ran the same effect; the
   // dashboard coordinator's loadDashboard is stable, so this is a
@@ -145,24 +143,6 @@ export function RootEffects() {
     void projects.actions.loadProjects();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    const adaptersToProbe = agentAdapters.filter((adapter) => {
-      if (!adapter.id || probedAgentAdapterIDsRef.current.has(adapter.id)) return false;
-      if (adapter.managed) return false;
-      probedAgentAdapterIDsRef.current.add(adapter.id);
-      return true;
-    });
-    if (adaptersToProbe.length === 0) return;
-
-    // Probe direct adapters together so the agent picker converges as
-    // soon as the dashboard knows which adapters exist. Managed
-    // adapters can run package managers such as npx, so they only run
-    // after an explicit operator check in Connections.
-    void Promise.allSettled(
-      adaptersToProbe.map((adapter) => providersAndModels.actions.probeAgentAdapter(adapter.id)),
-    );
-  }, [agentAdapters, providersAndModels.actions]);
 
   useEffect(() => {
     if (!chatLoading) {

--- a/ui/src/app/state/rootEffects.ts
+++ b/ui/src/app/state/rootEffects.ts
@@ -131,9 +131,11 @@ export function RootEffects() {
   const { setChatCancelling, setModel, setProviderFilter, setQueuedChatMessages } = chat.actions;
   const { setHecateRTKEnabled: setHecateRTKEnabledState } = runtime.actions;
   const { models, providers } = providersAndModels.state;
+  const { agentAdapters } = providersAndModels.state;
   const { notice } = settings.state;
   const { dismissNoticeIfMatching } = settings.actions;
   const settingsConfig = settings.state.config;
+  const probedAgentAdapterIDsRef = useRef<Set<string>>(new Set());
 
   // Mount-time dashboard load. The facade ran the same effect; the
   // dashboard coordinator's loadDashboard is stable, so this is a
@@ -143,6 +145,24 @@ export function RootEffects() {
     void projects.actions.loadProjects();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const adaptersToProbe = agentAdapters.filter((adapter) => {
+      if (!adapter.id || probedAgentAdapterIDsRef.current.has(adapter.id)) return false;
+      if (adapter.managed) return false;
+      probedAgentAdapterIDsRef.current.add(adapter.id);
+      return true;
+    });
+    if (adaptersToProbe.length === 0) return;
+
+    // Probe direct adapters together so the agent picker converges as
+    // soon as the dashboard knows which adapters exist. Managed
+    // adapters can run package managers such as npx, so they only run
+    // after an explicit operator check in Connections.
+    void Promise.allSettled(
+      adaptersToProbe.map((adapter) => providersAndModels.actions.probeAgentAdapter(adapter.id)),
+    );
+  }, [agentAdapters, providersAndModels.actions]);
 
   useEffect(() => {
     if (!chatLoading) {

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -75,7 +75,7 @@ export type ChatComposerProps = {
 
   // Repair actions.
   chooseWorkspace: () => Promise<void> | void;
-  openClaudeCodeSetup: () => void;
+  openExternalAgentSetup: () => void;
 
   // Active task tracking + queue.
   activeHecateTaskID: string;
@@ -152,7 +152,7 @@ export function ChatComposer(props: ChatComposerProps) {
     selectableModels,
     onHecateModelChange,
     chooseWorkspace,
-    openClaudeCodeSetup,
+    openExternalAgentSetup,
     activeHecateTaskID,
     activeHecateRunID,
     activeQueuedChatMessages,
@@ -187,6 +187,17 @@ export function ChatComposer(props: ChatComposerProps) {
   const composerNoticeVisible = Boolean(
     composerRepair || chatError || (isHecateChat && selectedModelIssue),
   );
+  const activeRunStatusText = agentBusy
+    ? isExternalAgentChat
+      ? "External Agent is working. New messages will queue."
+      : "Hecate Chat is working. New messages will queue."
+    : "";
+  const baselineComposerStatus = isExternalAgentChat
+    ? "External agents run as your OS user in the selected workspace — no sandbox"
+    : hecateTaskToolsAvailable
+      ? "Tools use task approvals and per-call sandboxing in the selected workspace."
+      : "";
+  const composerStatusText = activeRunStatusText || baselineComposerStatus;
 
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";
@@ -497,71 +508,6 @@ export function ChatComposer(props: ChatComposerProps) {
               ))}
             </div>
           )}
-          {agentBusy && (
-            <div
-              aria-label="Active run status"
-              style={{
-                maxWidth: 820,
-                margin: "0 auto 6px",
-                color: "var(--amber)",
-                fontFamily: "var(--font-mono)",
-                fontSize: 11,
-                lineHeight: 1.45,
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                justifyContent: "space-between",
-                flexWrap: "wrap",
-              }}
-            >
-              <span>
-                {isExternalAgentChat
-                  ? "External Agent is still working. New messages will queue until it finishes."
-                  : "Hecate Chat is still working on this task. New messages will queue until the active task finishes."}
-              </span>
-              <span
-                style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}
-              >
-                {onOpenTask && activeHecateTaskID && (
-                  <button
-                    type="button"
-                    className="btn btn-ghost btn-sm"
-                    onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
-                    style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: 10,
-                      padding: "2px 6px",
-                      color: "var(--amber)",
-                    }}
-                  >
-                    Open task
-                  </button>
-                )}
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm"
-                  aria-label={isExternalAgentChat ? "Stop external agent" : "Stop active task"}
-                  title={
-                    chatCancelling
-                      ? "Stopping..."
-                      : isExternalAgentChat
-                        ? "Stop external agent"
-                        : "Stop active task"
-                  }
-                  onClick={chatActions.cancelAgentChat}
-                  disabled={chatCancelling}
-                  style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: 10,
-                    padding: "2px 6px",
-                    color: "var(--danger)",
-                  }}
-                >
-                  Stop
-                </button>
-              </span>
-            </div>
-          )}
           <div style={{ maxWidth: 820, margin: "0 auto", position: "relative" }}>
             <textarea
               ref={textareaRef}
@@ -600,63 +546,37 @@ export function ChatComposer(props: ChatComposerProps) {
               onFocus={(e) => (e.target.style.borderColor = "var(--teal)")}
               onBlur={(e) => (e.target.style.borderColor = "var(--border)")}
             />
-            {agentBusy && !queueingMessage ? (
-              <button
-                type="button"
-                className="btn btn-danger"
-                aria-label="Stop current run"
-                disabled={chatCancelling}
-                title={chatCancelling ? "Stopping..." : "Stop current run"}
-                onClick={chatActions.cancelAgentChat}
-                style={{
-                  position: "absolute",
-                  right: 8,
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  width: 28,
-                  height: 28,
-                  borderRadius: "var(--radius-sm)",
-                  padding: 0,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
-                <Icon d={Icons.stop} size={13} fill="currentColor" strokeWidth={0} />
-              </button>
-            ) : (
-              <button
-                type="submit"
-                aria-label={queueingMessage ? "Queue message" : "Send message"}
-                disabled={sendDisabled}
-                title={
-                  queueingMessage
-                    ? "Queue this message after the active run finishes"
-                    : messageSendBlocked
-                      ? "Complete chat setup before sending"
-                      : "Send message"
-                }
-                style={{
-                  position: "absolute",
-                  right: 8,
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  width: 28,
-                  height: 28,
-                  borderRadius: "var(--radius-sm)",
-                  background: !sendDisabled ? "var(--teal)" : "var(--bg4)",
-                  border: "none",
-                  cursor: !sendDisabled ? "pointer" : "default",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  transition: "background 0.1s",
-                  color: !sendDisabled ? "var(--bg0)" : "var(--t3)",
-                }}
-              >
-                <Icon d={Icons.send} size={14} />
-              </button>
-            )}
+            <button
+              type="submit"
+              aria-label={queueingMessage ? "Queue message" : "Send message"}
+              disabled={sendDisabled}
+              title={
+                queueingMessage
+                  ? "Queue this message after the active run finishes"
+                  : messageSendBlocked
+                    ? "Complete chat setup before sending"
+                    : "Send message"
+              }
+              style={{
+                position: "absolute",
+                right: 8,
+                top: "50%",
+                transform: "translateY(-50%)",
+                width: 28,
+                height: 28,
+                borderRadius: "var(--radius-sm)",
+                background: !sendDisabled ? "var(--teal)" : "var(--bg4)",
+                border: "none",
+                cursor: !sendDisabled ? "pointer" : "default",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "background 0.1s",
+                color: !sendDisabled ? "var(--bg0)" : "var(--t3)",
+              }}
+            >
+              <Icon d={Icons.send} size={14} />
+            </button>
           </div>
           {composerNoticeVisible && (
             <div
@@ -670,7 +590,7 @@ export function ChatComposer(props: ChatComposerProps) {
                     if (repair.action === "choose_workspace") {
                       void chooseWorkspace();
                     } else if (repair.action === "open_agent_setup") {
-                      openClaudeCodeSetup();
+                      openExternalAgentSetup();
                     } else if (repair.action === "open_connections") {
                       onNavigate?.("connections");
                     }
@@ -723,19 +643,69 @@ export function ChatComposer(props: ChatComposerProps) {
               alignItems: "center",
               gap: 10,
               justifyContent: "space-between",
+              minHeight: 22,
             }}
           >
-            {isExternalAgentChat ? (
-              <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                External agents run as your OS user in the selected workspace — no sandbox
+            <span
+              aria-label={agentBusy ? "Active run status" : undefined}
+              style={{
+                minWidth: 0,
+                color: agentBusy ? "var(--amber)" : "var(--t3)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 8,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+                {composerStatusText}
               </span>
-            ) : hecateTaskToolsAvailable ? (
-              <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-                Tools use task approvals and per-call sandboxing in the selected workspace.
-              </span>
-            ) : (
-              <span />
-            )}
+              {agentBusy && onOpenTask && activeHecateTaskID && (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
+                  style={{
+                    flexShrink: 0,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    padding: "2px 6px",
+                    color: "var(--amber)",
+                  }}
+                >
+                  Open task
+                </button>
+              )}
+              {agentBusy && (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  aria-label={isExternalAgentChat ? "Stop external agent" : "Stop active task"}
+                  title={
+                    chatCancelling
+                      ? "Stopping..."
+                      : isExternalAgentChat
+                        ? "Stop external agent"
+                        : "Stop active task"
+                  }
+                  onClick={chatActions.cancelAgentChat}
+                  disabled={chatCancelling}
+                  style={{
+                    flexShrink: 0,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    padding: "2px 6px",
+                    color: "var(--danger)",
+                  }}
+                >
+                  Stop
+                </button>
+              )}
+            </span>
             <button
               type="button"
               onClick={toggleModEnterMode}

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -493,7 +493,8 @@ function agentReadyLabel(adapter: AgentAdapterRecord): string {
   if (adapter.auth_status === "unauthenticated" || adapter.auth_status === "billing") {
     return adapter.auth_error || `Auth status: ${adapter.auth_status}`;
   }
-  if (adapter.version) return `Ready · ${adapter.version}`;
+  if (adapter.agent_version) return `Ready · agent ${adapter.agent_version}`;
+  if (adapter.adapter_version) return `Ready · adapter ${adapter.adapter_version}`;
   return "Ready";
 }
 

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -13,7 +13,6 @@ import type { ProjectRecord } from "../../types/project";
 import { BrandAvatar, ConfirmModal, Icon, Icons } from "../shared/ui";
 
 import { NewChatAgentButton, chatAgentOption, chatAgentOptionStatus } from "./ChatAgentControls";
-import { externalAgentRequiresModelSelection } from "./agentConfigOptions";
 import type { ChatAgentOptionID } from "./ChatAgentControls";
 
 export type SidebarSession = {
@@ -100,12 +99,6 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
       agentID === "hecate" ? undefined : agentAdapters.find((item) => item.id === agentID);
     const health = agentID === "hecate" ? undefined : agentAdapterHealthByID.get(agentID);
     return chatAgentOptionStatus(agentID, adapter, health);
-  }
-
-  function agentNeedsPreSessionSetup(agentID: ChatAgentOptionID) {
-    if (agentID === "hecate") return false;
-    const adapter = agentAdapters.find((item) => item.id === agentID);
-    return externalAgentRequiresModelSelection(adapter?.config_options ?? []);
   }
 
   function startProjectRename(project: ProjectRecord) {
@@ -239,10 +232,6 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
               if (!statusForAgent(agentID).ready) return;
               if (agentID !== newChatAgentID) chatActions.setNewChatAgent(agentID);
               onSelectSession("");
-              if (agentNeedsPreSessionSetup(agentID)) {
-                chat.actions.clearChatErrorState();
-                return;
-              }
               onCreateChat(agentID, projects.activeProjectID);
             }}
           />

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -238,9 +238,9 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
             onCreate={(agentID) => {
               if (!statusForAgent(agentID).ready) return;
               if (agentID !== newChatAgentID) chatActions.setNewChatAgent(agentID);
+              onSelectSession("");
               if (agentNeedsPreSessionSetup(agentID)) {
                 chat.actions.clearChatErrorState();
-                onSelectSession("");
                 return;
               }
               onCreateChat(agentID, projects.activeProjectID);

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -69,7 +69,7 @@ type Props = {
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
-  openClaudeCodeSetup: () => void;
+  openExternalAgentSetup: (adapterID?: string) => void;
 };
 
 export function ChatTranscript({
@@ -82,7 +82,7 @@ export function ChatTranscript({
   onNavigate,
   onOpenTask,
   onOpenTrace,
-  openClaudeCodeSetup,
+  openExternalAgentSetup,
 }: Props) {
   const chat = useChat();
   const chatTarget = useChatTarget();
@@ -224,26 +224,7 @@ export function ChatTranscript({
               agentUsage={role === "assistant" ? m.usage : undefined}
               agentTiming={role === "assistant" ? m.timing : undefined}
               error={role === "assistant" ? m.error : undefined}
-              setupAction={
-                // Render the "Open Claude Code setup" button only
-                // when the server-side message carries the
-                // claude_code_auth_required marker. Pattern-match
-                // (not strict equality) is deliberate — the marker
-                // is part of a paragraph that may be reworded over
-                // time; the token itself is stable contract between
-                // internal/agentadapters/auth_status.go and this UI
-                // handler.
-                role === "assistant" &&
-                m.agent_id === "claude_code" &&
-                typeof m.error === "string" &&
-                m.error.includes("claude_code_auth_required")
-                  ? {
-                      label: "Open Claude Code setup",
-                      title: "Open Connections and scroll to the guided setup card",
-                      onClick: openClaudeCodeSetup,
-                    }
-                  : undefined
-              }
+              setupAction={externalAgentSetupAction(role, m, openExternalAgentSetup)}
               onCopy={copyMsg}
               copied={copiedMsgId === m.id}
             />
@@ -547,6 +528,52 @@ function messageBrand(message: VisibleChatMessage, isHecateAgentChat: boolean): 
   if (message.agent_name) return message.agent_name;
   if (isHecateAgentChat) return message.provider || message.model || "hecate";
   return message.provider || message.model;
+}
+
+function externalAgentSetupAction(
+  role: string,
+  message: VisibleChatMessage,
+  openExternalAgentSetup: (adapterID?: string) => void,
+): { label: string; title: string; onClick: () => void } | undefined {
+  if (role !== "assistant" || !message.agent_id || message.agent_id === "hecate") return undefined;
+  const error = typeof message.error === "string" ? message.error : "";
+  if (!isExternalAgentSetupError(error)) return undefined;
+  const label = message.agent_name || externalAgentDisplayName(message.agent_id);
+  return {
+    label: `Open ${label} setup`,
+    title: `Open Connections and scroll to ${label} setup`,
+    onClick: () => openExternalAgentSetup(message.agent_id),
+  };
+}
+
+function isExternalAgentSetupError(error: string): boolean {
+  const normalized = error.toLowerCase();
+  return (
+    normalized.includes("auth_required") ||
+    normalized.includes("authentication required") ||
+    normalized.includes("unauthenticated") ||
+    normalized.includes("not authenticated") ||
+    normalized.includes("not signed in") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("login required") ||
+    normalized.includes("command not found") ||
+    normalized.includes("not installed")
+  );
+}
+
+function externalAgentDisplayName(agentID: string): string {
+  switch (agentID) {
+    case "claude_code":
+      return "Claude Code";
+    case "codex":
+      return "Codex";
+    case "cursor_agent":
+      return "Cursor";
+    case "grok_build":
+      return "Grok Build";
+    default:
+      return "agent";
+  }
 }
 
 function formatTaskLinkLabel(taskID: string): string {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -181,10 +181,12 @@ describe("ChatView input", () => {
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /New Grok Build chat/i }));
+
     const modelPicker = await screen.findByRole("button", { name: "Model" });
     expect(modelPicker).toHaveTextContent("Pick a model");
 
-    const user = userEvent.setup();
     await user.click(modelPicker);
     await user.click(screen.getByRole("option", { name: /Model A/ }));
 
@@ -199,6 +201,7 @@ describe("ChatView input", () => {
         chatTarget: "external_agent",
         agentAdapterID: "grok_build",
         newChatAgentID: "grok_build",
+        agentWorkspace: "/tmp/hecate",
         activeChatSessionID: "",
         activeChatSession: null,
         agentAdapters: [
@@ -219,7 +222,7 @@ describe("ChatView input", () => {
                 current_value: "__hecate_no_model_selected__",
                 options: [
                   { value: "__hecate_no_model_selected__", name: "Pick a model" },
-                  { value: "grok-build-0429a", name: "Grok Build 0429a" },
+                  { value: "grok-latest", name: "Grok Latest" },
                 ],
               },
             ],
@@ -270,7 +273,7 @@ describe("ChatView input", () => {
               current_value: "__hecate_no_model_selected__",
               options: [
                 { value: "__hecate_no_model_selected__", name: "Pick a model" },
-                { value: "grok-build-0429a", name: "Grok Build 0429a" },
+                { value: "grok-latest", name: "Grok Latest" },
               ],
             },
             {
@@ -292,6 +295,7 @@ describe("ChatView input", () => {
 
     expect(await screen.findByRole("button", { name: "Model" })).toHaveTextContent("Pick a model");
     expect(screen.getByRole("button", { name: "Reasoning" })).toHaveTextContent("Pick reasoning");
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeTruthy();
   });
 
   it("toggles Hecate Chat between direct model chat and tool-backed agent mode", async () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -193,7 +193,7 @@ describe("ChatView input", () => {
     expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Model A");
   });
 
-  it("keeps Grok Build in pre-session setup when the launch model is not selected", async () => {
+  it("creates a Grok Build chat before the launch model is selected", async () => {
     const createChatSession = vi.fn(async () => undefined);
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
@@ -236,9 +236,8 @@ describe("ChatView input", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "New Grok Build chat" }));
 
-    expect(createChatSession).not.toHaveBeenCalled();
+    expect(createChatSession).toHaveBeenCalledWith({ agentID: "grok_build", projectID: "" });
     expect(selectChatSession).toHaveBeenCalledWith("");
-    expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Pick a model");
   });
 
   it("shows Grok Build model controls for an existing session without persisted config options", async () => {
@@ -1936,8 +1935,8 @@ describe("ChatView input", () => {
     expect(screen.getByRole("button", { name: "Queue message" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Stop active task" })).toBeTruthy();
     const activeRunStatus = screen.getByLabelText("Active run status");
-    expect(activeRunStatus).toHaveTextContent(/Hecate Chat is still working on this task/);
-    expectBefore(activeRunStatus, screen.getByLabelText("Message"));
+    expect(activeRunStatus).toHaveTextContent(/Hecate Chat is working/);
+    expectBefore(screen.getByLabelText("Message"), activeRunStatus);
 
     rerender(
       withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }),
@@ -1946,7 +1945,7 @@ describe("ChatView input", () => {
     expect(document.querySelector('[aria-label="Fixed model: qwen2.5-coder"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Model picker: smollm2:135m"]')).toBeNull();
     expect(screen.getByRole("button", { name: "Stop active task" })).toBeTruthy();
-    expect(screen.getByText(/Hecate Chat is still working on this task/)).toBeTruthy();
+    expect(screen.getByText(/Hecate Chat is working/)).toBeTruthy();
   });
 
   it("locks controls to the active task segment even when the session root is direct chat", () => {
@@ -2022,7 +2021,7 @@ describe("ChatView input", () => {
     expect(screen.getByRole("button", { name: "Fixed model: qwen2.5-coder" })).toBeTruthy();
     expect(screen.queryByText("smollm2:135m")).toBeNull();
     expect(screen.getByRole("button", { name: "Stop active task" })).toBeTruthy();
-    expect(screen.getByText(/New messages will queue until the active task finishes/)).toBeTruthy();
+    expect(screen.getByText(/New messages will queue/)).toBeTruthy();
     screen.getByRole("button", { name: "Open task" }).click();
     expect(onOpenTask).toHaveBeenCalledWith("task_hecate_123456", "run_hecate_abcdef");
   });
@@ -3249,6 +3248,9 @@ describe("ChatView external-agent target", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Open setup" }));
     expect(onNavigate).toHaveBeenCalledWith("connections");
+    expect(sessionStorage.getItem("hecate.connectionsFocus")).toBe(
+      "external-agent-auth-setup-claude_code",
+    );
   });
 
   it("shows Claude Code setup repair in empty sessions without a token form", () => {
@@ -4296,8 +4298,31 @@ describe("ChatView session title", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.queryByText("No chat selected")).toBeNull();
-    expect(screen.getByText("New chat")).toBeTruthy();
+    expect(screen.queryByText("New chat")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Chat settings" })).toBeNull();
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
+  });
+
+  it("does not show the session header for an unselected draft chat", async () => {
+    const createChatSession = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        activeChatSessionID: "",
+        activeChatSession: null,
+        message: "",
+      },
+      { createChatSession },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /New Hecate chat/i }));
+
+    expect(createChatSession).toHaveBeenCalled();
+    expect(screen.queryByText("New chat")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Chat settings" })).toBeNull();
+    expect(screen.queryByTitle("Choose workspace folder")).toBeNull();
   });
 
   it("shows the active session's title", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -481,9 +481,11 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       (!hecateChatModelReady ||
         (!hecateAgentToolsDisabledForModel && !state.agentWorkspace.trim())));
 
-  function openAgentSetup() {
+  function openAgentSetup(adapterID = activeAgentAdapterID) {
     try {
-      sessionStorage.setItem("hecate.connectionsFocus", "external-agent-auth-setup");
+      if (adapterID) {
+        sessionStorage.setItem("hecate.connectionsFocus", `external-agent-auth-setup-${adapterID}`);
+      }
     } catch {
       // sessionStorage unavailable — navigation still
       // works, just no auto-scroll to the auth setup card.
@@ -686,27 +688,29 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
           position: "relative",
         }}
       >
-        <ChatHeader
-          sidebarOpen={sidebarOpen}
-          onOpenSidebar={() => setSidebarOpen(true)}
-          brand={activeHeaderBrand}
-          fallback={activeHeaderFallback}
-          title={activeTitle || "New chat"}
-          subline={activeHeaderSubline}
-          sublineHoverTitle={
-            isExternalAgentChat
-              ? formatAgentSessionTitle(state.activeChatSession, selectedAgent)
-              : activeHeaderSubline
-          }
-          isAgentChat={isAgentChat}
-          isExternalAgentChat={isExternalAgentChat}
-          showWorkspaceButton={showHeaderWorkspaceButton}
-          workspacePath={state.agentWorkspace}
-          chatSettingsOpen={chatSettingsOpen}
-          onChooseWorkspace={() => void chooseWorkspace()}
-          onToggleChatSettings={() => setChatSettingsOpen((open) => !open)}
-          activeChatSession={state.activeChatSession}
-        />
+        {selectedChatReady && (
+          <ChatHeader
+            sidebarOpen={sidebarOpen}
+            onOpenSidebar={() => setSidebarOpen(true)}
+            brand={activeHeaderBrand}
+            fallback={activeHeaderFallback}
+            title={activeTitle || "New chat"}
+            subline={activeHeaderSubline}
+            sublineHoverTitle={
+              isExternalAgentChat
+                ? formatAgentSessionTitle(state.activeChatSession, selectedAgent)
+                : activeHeaderSubline
+            }
+            isAgentChat={isAgentChat}
+            isExternalAgentChat={isExternalAgentChat}
+            showWorkspaceButton={showHeaderWorkspaceButton}
+            workspacePath={state.agentWorkspace}
+            chatSettingsOpen={chatSettingsOpen}
+            onChooseWorkspace={() => void chooseWorkspace()}
+            onToggleChatSettings={() => setChatSettingsOpen((open) => !open)}
+            activeChatSession={state.activeChatSession}
+          />
+        )}
 
         <div style={{ flex: 1, display: "flex", minHeight: 0, overflow: "hidden" }}>
           <div
@@ -802,7 +806,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               onNavigate={onNavigate}
               onOpenTask={onOpenTask}
               onOpenTrace={onOpenTrace}
-              openClaudeCodeSetup={openAgentSetup}
+              openExternalAgentSetup={openAgentSetup}
               emptyState={
                 <ChatEmptyState
                   isAgentChat={isAgentChat}
@@ -834,7 +838,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                     actions.setModel(model);
                   }}
                   onChooseWorkspace={() => void chooseWorkspace()}
-                  onOpenAgentSetup={openAgentSetup}
+                  onOpenAgentSetup={() => openAgentSetup()}
                   onQuickAddLocalProviders={quickAddLocalProviders}
                   onRefreshQuickLocalProviders={refreshQuickLocalProviders}
                   onSwitchTarget={actions.setChatTarget}
@@ -873,7 +877,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                 selectableModels={selectableModels}
                 onHecateModelChange={handleHecateModelChange}
                 chooseWorkspace={chooseWorkspace}
-                openClaudeCodeSetup={openAgentSetup}
+                openExternalAgentSetup={openAgentSetup}
                 activeHecateTaskID={activeHecateTaskID}
                 activeHecateRunID={activeHecateRunID}
                 activeQueuedChatMessages={activeQueuedChatMessages}
@@ -884,7 +888,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               />
             )}
           </div>
-          {isAgentChat && chatSettingsOpen && (
+          {selectedChatReady && isAgentChat && chatSettingsOpen && (
             <ChatSettingsPanel
               showHecateControls={isHecateChat}
               toolsEnabled={isHecateAgentChat}

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -135,6 +135,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const [approvalModalID, setApprovalModalID] = useState<string | null>(null);
   const [workspaceEntryOpen, setWorkspaceEntryOpen] = useState(false);
   const [chatSettingsOpen, setChatSettingsOpen] = useState(false);
+  const [draftChatStarted, setDraftChatStarted] = useState(false);
   const [rtkOnboardingDismissed, setRTKOnboardingDismissed] = useState(false);
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [workspacePathValue, setWorkspacePathValue] = useState("");
@@ -407,13 +408,33 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const externalAgentModelRequired = externalAgentRequiresModelSelection(
     externalAgentConfigOptions,
   );
-  const composerVisible = selectedChatReady && isAgentChat;
+  const draftHecateReadyForComposer =
+    isHecateChat &&
+    draftChatStarted &&
+    !selectedChatReady &&
+    hecateChatModelReady &&
+    !selectedModelIssue &&
+    (!hecateTaskToolsAvailable || Boolean(state.agentWorkspace.trim()));
+  const draftExternalAgentReadyForComposer =
+    isExternalAgentChat &&
+    draftChatStarted &&
+    !selectedChatReady &&
+    Boolean(selectedAgent?.available) &&
+    !externalAgentSetupRequired &&
+    Boolean(state.agentWorkspace.trim());
+  const composerVisible =
+    isAgentChat &&
+    (selectedChatReady || draftHecateReadyForComposer || draftExternalAgentReadyForComposer);
   const hecateHasMessageControls =
     isHecateChat &&
     (hecateAgentModelLocked || hasConfiguredProviders || selectableModels.length > 0);
+  const externalMessageControlsVisible =
+    isExternalAgentChat &&
+    externalAgentHasConfigControls &&
+    (selectedChatReady || draftExternalAgentReadyForComposer);
   const messageControlsVisible =
-    (isExternalAgentChat && externalAgentHasConfigControls) ||
-    (selectedChatReady && hecateHasMessageControls);
+    externalMessageControlsVisible ||
+    ((selectedChatReady || draftHecateReadyForComposer) && hecateHasMessageControls);
   const composerShellVisible = selectedChatReady || messageControlsVisible;
   const composerRepair =
     composerVisible && !emptyStateAlreadyShowsRepair(chatSetupRepair, visibleMessages.length)
@@ -423,12 +444,18 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     visibleMessages.length === 0 &&
     (emptyStateAlreadyShowsModelRepair(chatSetupRepair, visibleMessages.length) ||
       (state.chatErrorCode === "model_not_configured" && modelRouteUnavailable));
+  const emptyStateExplainsSetupRepair =
+    emptyStateAlreadyShowsRepair(chatSetupRepair, visibleMessages.length) &&
+    (state.chatErrorCode === "chat.workspace_required" ||
+      state.chatErrorCode === "chat.model_required");
   const suppressComposerChatError =
-    (state.chatErrorCode === "chat.model_required" ||
-      state.chatErrorCode === "model_not_configured") &&
+    (state.chatErrorCode === "model_not_configured" ||
+      emptyStateExplainsSetupRepair ||
+      (state.chatErrorCode === "chat.model_required" &&
+        (emptyStateExplainsModelRoute || externalAgentModelRequired))) &&
     !streaming &&
     state.pendingToolCalls.length === 0 &&
-    emptyStateExplainsModelRoute;
+    (emptyStateExplainsModelRoute || emptyStateExplainsSetupRepair || externalAgentModelRequired);
   const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const messageSendBlocked =
@@ -463,6 +490,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     }
     onNavigate?.("connections");
   }
+
+  useEffect(() => {
+    if (selectedChatReady) setDraftChatStarted(false);
+  }, [selectedChatReady]);
 
   useEffect(() => {
     if (!focusComposerAfterNewChatRef.current || !composerVisible) return;
@@ -582,6 +613,12 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
           createdDiscoveries[0];
         if (preferred?.preset_id) {
           actions.setProviderFilter(preferred.preset_id as ProviderFilter);
+          const preferredModel = preferred.models?.[0];
+          if (preferredModel) {
+            actions.setModel(preferredModel);
+          }
+          setDraftChatStarted(true);
+          focusComposerWhenReady();
         }
       }
       if (firstError) {
@@ -624,12 +661,14 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
         <ChatSidebar
           isAgentChat={isAgentChat}
           onSelectSession={(sessionID) => {
+            setDraftChatStarted(!sessionID);
             focusComposerWhenReady();
             void actions.selectChatSession(sessionID);
             textareaRef.current?.focus();
           }}
           onCreateChat={(agentID, projectID) => {
             setChatSettingsOpen(false);
+            setDraftChatStarted(true);
             focusComposerWhenReady();
             void actions.createChatSession({ agentID, projectID });
           }}

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useApprovals } from "../../app/state/approvals";
 import { useChatActions } from "../../app/state/coordinators/chat";
 import { useAgentAdapterActions } from "../../app/state/coordinators/agentAdapters";
@@ -27,7 +27,7 @@ import type {
   ConfiguredStateResponse,
   ProviderRecord,
 } from "../../types/provider";
-import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
+import { BrandAvatar, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
 
 type Props = {
   onNavigate?: (
@@ -125,13 +125,8 @@ export function ConnectionsPanel({
   const liveAnthropicProvider = findAnthropicProvider(settingsConfig?.providers ?? []);
   const [rememberedAnthropicProvider, setRememberedAnthropicProvider] =
     useState<ConfiguredProviderRecord | null>(liveAnthropicProvider);
-  const probedAdapterIDsRef = useRef<Set<string>>(new Set());
-  const adapterIDsKey = useMemo(
-    () =>
-      agentAdapters
-        .map((adapter) => adapter.id)
-        .sort()
-        .join(","),
+  const adapterFocusTargets = useMemo(
+    () => new Set(agentAdapters.map((adapter) => externalAgentSetupFocusTarget(adapter.id))),
     [agentAdapters],
   );
   const listChatGrants = approvals.actions.loadGrants;
@@ -140,18 +135,6 @@ export function ConnectionsPanel({
   useEffect(() => {
     if (liveAnthropicProvider) setRememberedAnthropicProvider(liveAnthropicProvider);
   }, [liveAnthropicProvider]);
-
-  useEffect(() => {
-    for (const adapter of agentAdapters) {
-      if (probedAdapterIDsRef.current.has(adapter.id)) continue;
-      probedAdapterIDsRef.current.add(adapter.id);
-      void probeAgentAdapter(adapter.id);
-    }
-    // `probeAgentAdapter` is a coordinator action that can be re-created
-    // by parent renders. Probe only when the adapter ID set changes; the
-    // ref prevents duplicate probes for IDs we've already checked.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [adapterIDsKey]);
 
   useEffect(() => {
     void listChatGrants();
@@ -171,10 +154,8 @@ export function ConnectionsPanel({
   // injection class from an unexpected sessionStorage value (which
   // could happen via a stale entry, a third-party extension writing
   // into the same key, or a forward-compat token a newer build set
-  // that this build doesn't know about). Add new targets to the
-  // KNOWN_FOCUS_TARGETS set when more callers wire one in.
+  // that this build doesn't know about).
   useEffect(() => {
-    const KNOWN_FOCUS_TARGETS = new Set(["external-agent-auth-setup"]);
     let focusTarget: string | null = null;
     try {
       const raw =
@@ -184,7 +165,7 @@ export function ConnectionsPanel({
         sessionStorage.removeItem("hecate.connectionsFocus");
         sessionStorage.removeItem("hecate.settingsFocus");
       }
-      if (raw && KNOWN_FOCUS_TARGETS.has(raw)) focusTarget = raw;
+      if (raw && adapterFocusTargets.has(raw)) focusTarget = raw;
     } catch {
       // sessionStorage unavailable — nothing to focus.
     }
@@ -209,7 +190,7 @@ export function ConnectionsPanel({
       window.clearTimeout(startHandle);
       if (removeHandle !== null) window.clearTimeout(removeHandle);
     };
-  }, []);
+  }, [adapterFocusTargets]);
 
   // Adapter status uses the runtime slice for copyCommand because
   // clipboard writes are side-effects, not session mutations.
@@ -632,12 +613,11 @@ function AnthropicProviderKeyCard({
 }
 
 // AdapterStatusSection lists the configured external-agent adapters.
-// The parent tab auto-runs actions.probeAgentAdapter on mount, which
-// spawns each adapter, completes the ACP handshake, and returns a
-// typed health classification. That handshake is also the auth
-// check: auth failures surface as `auth_required`.
-// Probe state is cached on the hook so leaving and returning to the
-// tab doesn't lose the last-known status.
+// Quiet startup probes only touch direct binaries. Managed adapters may
+// invoke a package-manager launcher, so manual checks ask first before
+// spawning the adapter, completing the ACP handshake, and returning a
+// typed health classification. That handshake is also the auth check:
+// auth failures surface as `auth_required`.
 //
 // The section is read-only otherwise: adapter discovery and
 // availability are still owned by the dashboard fan-out's
@@ -656,9 +636,22 @@ function AdapterStatusSection({
   copyCommand: (command: string) => Promise<void>;
   onProbeAdapter: (adapterID: string) => void;
 }) {
+  const [managedProbeConfirm, setManagedProbeConfirm] = useState<AgentAdapterRecord | null>(null);
   if (!agentAdapters || agentAdapters.length === 0) {
     return null;
   }
+  const requestProbe = (adapter: AgentAdapterRecord) => {
+    if (adapter.managed) {
+      setManagedProbeConfirm(adapter);
+      return;
+    }
+    onProbeAdapter(adapter.id);
+  };
+  const confirmManagedProbe = () => {
+    if (!managedProbeConfirm) return;
+    onProbeAdapter(managedProbeConfirm.id);
+    setManagedProbeConfirm(null);
+  };
   return (
     <div style={{ marginBottom: 24 }} data-testid="external-agents-adapters">
       <SectionHeader
@@ -675,10 +668,40 @@ function AdapterStatusSection({
             health={agentAdapterHealthByID.get(adapter.id) ?? null}
             loading={Boolean(agentAdapterHealthLoadingByID.get(adapter.id))}
             onCopyCommand={(command) => void copyCommand(command)}
-            onProbeAdapter={onProbeAdapter}
+            onProbeAdapter={requestProbe}
           />
         ))}
       </div>
+      {managedProbeConfirm && (
+        <ConfirmModal
+          title="Run managed adapter check?"
+          confirmLabel="Run check"
+          onClose={() => setManagedProbeConfirm(null)}
+          onConfirm={confirmManagedProbe}
+          message={
+            <div>
+              <p style={{ marginTop: 0 }}>
+                Hecate will start {managedProbeConfirm.name} to verify readiness and auth. This
+                managed adapter can run its package-manager launcher
+                {managedProbeConfirm.managed_package ? (
+                  <>
+                    {" "}
+                    for{" "}
+                    <code style={{ fontFamily: "var(--font-mono)", color: "var(--t0)" }}>
+                      {managedProbeConfirm.managed_package}
+                    </code>
+                  </>
+                ) : null}
+                .
+              </p>
+              <p style={{ marginBottom: 0, color: "var(--t2)" }}>
+                Continue only if you trust this adapter package. Passive startup checks never run
+                package managers.
+              </p>
+            </div>
+          }
+        />
+      )}
     </div>
   );
 }
@@ -696,7 +719,7 @@ function AdapterStatusRow({
   health: AgentAdapterHealthRecord | null;
   loading: boolean;
   onCopyCommand: (command: string) => void;
-  onProbeAdapter: (adapterID: string) => void;
+  onProbeAdapter: (adapter: AgentAdapterRecord) => void;
 }) {
   // Collapse discovery, probe, and auth into one operator-facing state
   // so adapters don't show as both "missing" and "auth unknown".
@@ -707,7 +730,8 @@ function AdapterStatusRow({
   const localAuthNeedsRepair =
     displayAuthStatus === "unauthenticated" || health?.status === "auth_required";
   const showLocalAuthSetup = Boolean(loginCommand) && !probeVerifiedAuth && localAuthNeedsRepair;
-  const visibleHealthError = health && shouldShowProbeError(health) ? (health.error ?? "") : "";
+  const visibleHealthError =
+    health && shouldShowProbeError(health) ? humanizeProbeError(health.error ?? "") : "";
   const healthPath = health?.path ?? "";
   const state = adapterStatusState(adapter, health, displayAuthStatus, showLocalAuthSetup);
   const detail = adapterStatusDetail(adapter, health, state, visibleHealthError, displayAuthError);
@@ -790,9 +814,14 @@ function AdapterStatusRow({
               command <span style={{ color: "var(--t1)" }}>{adapter.command}</span>
             </span>
           )}
-          {adapter.version && (
+          {adapter.adapter_version && (
             <span>
-              version <span style={{ color: "var(--t1)" }}>{adapter.version}</span>
+              adapter <span style={{ color: "var(--t1)" }}>{adapter.adapter_version}</span>
+            </span>
+          )}
+          {adapter.agent_version && (
+            <span>
+              agent <span style={{ color: "var(--t1)" }}>{adapter.agent_version}</span>
             </span>
           )}
           {showAuthMetadata && (
@@ -850,9 +879,10 @@ function AdapterStatusRow({
         )}
         {showLocalAuthSetup && loginCommand && (
           <AdapterLocalAuthSetup
+            adapterID={adapter.id}
             loginCommand={loginCommand}
             onCopyCommand={onCopyCommand}
-            onTestAgain={() => onProbeAdapter(adapter.id)}
+            onTestAgain={() => onProbeAdapter(adapter)}
             testing={loading}
           />
         )}
@@ -875,11 +905,13 @@ function AdapterStatusRow({
 }
 
 function AdapterLocalAuthSetup({
+  adapterID,
   loginCommand,
   onCopyCommand,
   onTestAgain,
   testing,
 }: {
+  adapterID: string;
   loginCommand: string;
   onCopyCommand: (command: string) => void;
   onTestAgain: () => void;
@@ -889,7 +921,7 @@ function AdapterLocalAuthSetup({
 
   return (
     <div
-      data-testid="external-agent-auth-setup"
+      data-testid={externalAgentSetupFocusTarget(adapterID)}
       style={{
         marginTop: 10,
         padding: 10,
@@ -1093,8 +1125,31 @@ function adapterLoginCommand(adapter: AgentAdapterRecord): string {
       return "claude /login";
     case "cursor_agent":
       return "cursor-agent login";
+    case "grok_build":
+      return "grok login";
     default:
       return "";
+  }
+}
+
+function externalAgentSetupFocusTarget(adapterID: string): string {
+  return `external-agent-auth-setup-${adapterID}`;
+}
+
+function humanizeProbeError(error: string): string {
+  const trimmed = error.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      data?: { error?: unknown };
+    };
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    const detail = typeof parsed.data?.error === "string" ? parsed.data.error : "";
+    if (message && detail) return `${message}: ${detail}`;
+    return detail || message || trimmed;
+  } catch {
+    return trimmed;
   }
 }
 

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -158,14 +158,13 @@ export function ConnectionsPanel({
   useEffect(() => {
     let focusTarget: string | null = null;
     try {
-      const raw =
-        sessionStorage.getItem("hecate.connectionsFocus") ||
-        sessionStorage.getItem("hecate.settingsFocus");
-      if (raw) {
-        sessionStorage.removeItem("hecate.connectionsFocus");
-        sessionStorage.removeItem("hecate.settingsFocus");
+      for (const key of ["hecate.connectionsFocus", "hecate.settingsFocus"]) {
+        const raw = sessionStorage.getItem(key);
+        if (raw && adapterFocusTargets.has(raw)) {
+          focusTarget = raw;
+          break;
+        }
       }
-      if (raw && adapterFocusTargets.has(raw)) focusTarget = raw;
     } catch {
       // sessionStorage unavailable — nothing to focus.
     }
@@ -178,6 +177,12 @@ export function ConnectionsPanel({
     const startHandle = window.setTimeout(() => {
       const card = document.querySelector(`[data-testid="${target}"]`);
       if (!card) return;
+      try {
+        sessionStorage.removeItem("hecate.connectionsFocus");
+        sessionStorage.removeItem("hecate.settingsFocus");
+      } catch {
+        // sessionStorage unavailable — focus still works without clearing.
+      }
       card.scrollIntoView({ behavior: "smooth", block: "center" });
       // Brief highlight so the operator's eye lands on it. Class is
       // toggled rather than inlined so the styling lives in CSS.

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -629,11 +629,9 @@ describe("ProvidersView table renders", () => {
 
   it("renders external-agent readiness and grants in the Connections workspace", async () => {
     const listChatGrants = vi.fn(async () => undefined);
-    const probeAgentAdapter = vi.fn(async () => null);
     const actions = {
       ...createRuntimeConsoleActions(),
       listChatGrants,
-      probeAgentAdapter,
     };
     const state = createRuntimeConsoleFixture({
       session: localSession,
@@ -681,7 +679,6 @@ describe("ProvidersView table renders", () => {
     expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
     expect(screen.getByTestId("external-agents-row-grant-1")).toBeTruthy();
     expect(listChatGrants).toHaveBeenCalled();
-    expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
   });
 
   it("blocks submit when the typed Endpoint URL is already taken", async () => {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -339,9 +339,11 @@ describe("Connections external-agent panel", () => {
     expect(setProviderAPIKey).toHaveBeenNthCalledWith(2, "anthropic", "");
   });
 
-  // Adapter status panel — surfaces auto-probe results when the tab
-  // opens. The section is hidden when no adapters are registered (no
-  // point showing an empty card); otherwise each row renders inline
+  // Adapter status panel — surfaces adapter readiness diagnostics.
+  // Direct binaries can be checked quietly; managed package-launcher
+  // adapters require an explicit confirmation before a manual check.
+  // The section is hidden when no adapters are registered (no point
+  // showing an empty card); otherwise each row renders inline
   // diagnostic copy when a result exists.
   describe("adapter status panel", () => {
     function withAdapter(overrides: Record<string, unknown> = {}) {
@@ -375,24 +377,29 @@ describe("Connections external-agent panel", () => {
       expect(screen.queryByTestId("external-agents-test-codex")).toBeNull();
     });
 
-    it("auto-runs adapter probes when the tab opens", async () => {
-      const probeAgentAdapter = vi.fn(async () => null);
-      const { state, actions } = setup(withAdapter(), { probeAgentAdapter });
+    it("shows adapter and underlying agent versions separately", async () => {
+      const { state, actions } = setup(
+        withAdapter({
+          agentAdapters: [
+            {
+              id: "codex",
+              name: "Codex",
+              kind: "acp",
+              command: "codex-acp",
+              available: true,
+              status: "available",
+              cost_mode: "external",
+              adapter_version: "1.2.3",
+              agent_version: "0.48.0",
+            },
+          ],
+        }),
+      );
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
-      expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
-    });
 
-    it("auto-runs adapter probes when adapters arrive after the tab opens", async () => {
-      const probeAgentAdapter = vi.fn(async () => null);
-      const { state, actions } = setup({ agentAdapters: [] }, { probeAgentAdapter });
-      const { rerender } = render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
-      expect(probeAgentAdapter).not.toHaveBeenCalled();
-
-      const nextState = createRuntimeConsoleFixture(withAdapter());
-      rerender(withRuntimeConsole(<ConnectionsPanel />, { state: nextState, actions }));
-      expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
-      rerender(withRuntimeConsole(<ConnectionsPanel />, { state: { ...nextState }, actions }));
-      expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
+      const row = await screen.findByTestId("external-agents-adapter-codex");
+      expect(row).toHaveTextContent("adapter 1.2.3");
+      expect(row).toHaveTextContent("agent 0.48.0");
     });
 
     it("renders compact local sign-in when the cached probe says auth is missing", async () => {
@@ -569,6 +576,8 @@ describe("Connections external-agent panel", () => {
               name: "Claude Code",
               kind: "acp",
               command: "claude-agent-acp",
+              managed: true,
+              managed_package: "@agentclientprotocol/claude-agent-acp",
               available: true,
               status: "available",
               cost_mode: "external",
@@ -629,6 +638,8 @@ describe("Connections external-agent panel", () => {
               command: "claude-agent-acp",
               available: true,
               status: "available",
+              managed: true,
+              managed_package: "@agentclientprotocol/claude-agent-acp",
               cost_mode: "external",
               auth_status: "unauthenticated",
             },
@@ -654,6 +665,8 @@ describe("Connections external-agent panel", () => {
               command: "claude-agent-acp",
               available: true,
               status: "available",
+              managed: true,
+              managed_package: "@agentclientprotocol/claude-agent-acp",
               cost_mode: "external",
               auth_status: "unauthenticated",
             },
@@ -664,6 +677,12 @@ describe("Connections external-agent panel", () => {
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       await user.click(await screen.findByRole("button", { name: "Test again" }));
+      expect(probeAgentAdapter).not.toHaveBeenCalled();
+      expect(
+        await screen.findByRole("dialog", { name: "Run managed adapter check?" }),
+      ).toBeTruthy();
+      expect(screen.getByText(/@agentclientprotocol\/claude-agent-acp/)).toBeTruthy();
+      await user.click(screen.getByRole("button", { name: "Run check" }));
       expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
     });
   });

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -70,6 +70,20 @@ describe("resolveChatSetupRepairState", () => {
     });
   });
 
+  it("asks for workspace before provider repair when a provider exists", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "agent",
+      workspace: "",
+      modelRouteUnavailable: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "workspace_required",
+      action: "choose_workspace",
+    });
+  });
+
   it("routes unavailable external agents to Connections", () => {
     const repair = resolveChatSetupRepairState({
       ...base,

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -80,6 +80,10 @@ export function resolveChatSetupRepairState({
     return null;
   }
 
+  if (target === "agent" && hasConfiguredProviders && !workspace.trim()) {
+    return workspaceRepair();
+  }
+
   if (modelRouteUnavailable) {
     return {
       kind: hasConfiguredProviders ? "no_routable_model" : "no_provider",

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -473,7 +473,7 @@ describe("useRuntimeConsole", () => {
 
     expect(createBody).toMatchObject({
       agent_id: "hecate",
-      model: "gpt-4o-mini",
+      model: "",
       workspace: "/tmp/hecate",
     });
     expect(createBody).not.toHaveProperty("adapter_id");
@@ -695,7 +695,7 @@ describe("useRuntimeConsole", () => {
 
     expect(createBody).toMatchObject({
       agent_id: "hecate",
-      model: "gpt-4o-mini",
+      model: "",
       workspace: "/tmp/hecate",
       project_id: "proj_1",
     });
@@ -754,6 +754,37 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
 
+  it("keeps external-agent workspace setup in the chat shell instead of emitting an error", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
+    window.localStorage.removeItem("hecate.agentWorkspace");
+    let createCalled = false;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/hecate/v1/agent-adapters": () =>
+          jsonResponse({
+            object: "agent_adapters",
+            data: [{ id: "claude_code", name: "Claude Code", available: true }],
+          }),
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") createCalled = true;
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession({ agentID: "claude_code" });
+    });
+
+    expect(createCalled).toBe(false);
+    expect(result.current.state.activeChatSessionID).toBe("");
+    expect(result.current.state.chatError).toBe("");
+  });
+
   it("creates a Hecate chat shell when no model is selected", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
@@ -802,7 +833,52 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatError).toBe("");
   });
 
-  it("creates a Hecate chat shell when tools are on and no workspace is selected", async () => {
+  it("drops a stale selected model when creating a new Hecate chat shell", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
+    window.localStorage.setItem("hecate.model", "missing-model");
+    let createBody: any = null;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/v1/models": () => jsonResponse({ object: "list", data: [] }),
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_stale_model",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: "",
+                model: "",
+                workspace: "/tmp/hecate",
+                status: "idle",
+                messages: [],
+              },
+            });
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession();
+    });
+
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      model: "",
+    });
+    expect(result.current.state.activeChatSessionID).toBe("chat_stale_model");
+    expect(result.current.state.chatError).toBe("");
+  });
+
+  it("keeps Hecate tools-on setup local when no workspace is selected", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.model", "llama3.1:8b");
     let createBody: any = null;
@@ -851,13 +927,9 @@ describe("useRuntimeConsole", () => {
       await result.current.actions.createChatSession();
     });
 
-    expect(createBody).toMatchObject({
-      agent_id: "hecate",
-      model: "llama3.1:8b",
-      workspace: "",
-    });
-    expect(result.current.state.activeChatSessionID).toBe("chat_no_workspace");
-    expect(result.current.state.activeChatSession?.agent_id).toBe("hecate");
+    expect(createBody).toBeNull();
+    expect(result.current.state.activeChatSessionID).toBe("");
+    expect(result.current.state.activeChatSession).toBeNull();
     expect(result.current.state.chatError).toBe("");
   });
 
@@ -920,7 +992,7 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatError).toBe("");
   });
 
-  it("surfaces a clear error when external-agent chat has no workspace", async () => {
+  it("keeps external-agent workspace setup in the chat shell when no workspace is selected", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "codex");
     let createCalled = false;
@@ -949,10 +1021,8 @@ describe("useRuntimeConsole", () => {
 
     expect(createCalled).toBe(false);
     expect(result.current.state.activeChatSessionID).toBe("");
-    expect(result.current.state.chatError).toBe(
-      "Choose a workspace before using Hecate Chat tools or External Agent.",
-    );
-    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+    expect(result.current.state.chatError).toBe("");
+    expect(result.current.state.chatErrorCode).toBe("");
   });
 
   it("does not create or select a chat when eager external-agent prepare fails", async () => {

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -2010,6 +2010,106 @@ describe("useRuntimeConsole", () => {
       await waitFor(() => expect(result.current.state.queuedChatMessages).toHaveLength(0));
     });
 
+    it("submits into the selected external session after a transient hydrate failure", async () => {
+      window.localStorage.setItem("hecate.chatTarget", "external_agent");
+      window.localStorage.setItem("hecate.agentAdapterID", "codex");
+      window.localStorage.setItem("hecate.chatSessionID", "a1");
+      window.localStorage.setItem("hecate.agentWorkspace", "/workspace");
+
+      let createPostCount = 0;
+      let messagePostCount = 0;
+      let sessionFetchCount = 0;
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/hecate/v1/chat/sessions") {
+          if (init?.method === "POST") {
+            createPostCount += 1;
+            return jsonResponse({ object: "chat_session", data: {} });
+          }
+          return jsonResponse({
+            object: "chat_sessions",
+            data: [
+              {
+                id: "a1",
+                title: "Codex chat",
+                agent_id: "codex",
+                status: "completed",
+                workspace: "/workspace",
+                message_count: 0,
+                created_at: "2026-04-20T00:00:00Z",
+                updated_at: "2026-04-20T00:00:00Z",
+              },
+            ],
+          });
+        }
+        if (url === "/hecate/v1/chat/sessions/a1") {
+          sessionFetchCount += 1;
+          if (sessionFetchCount === 1) {
+            return jsonResponse({ error: { message: "temporary load failure" } }, 500);
+          }
+          return jsonResponse({
+            object: "chat_session",
+            data: {
+              id: "a1",
+              title: "Codex chat",
+              agent_id: "codex",
+              status: "completed",
+              workspace: "/workspace",
+              messages: [],
+              created_at: "2026-04-20T00:00:00Z",
+              updated_at: "2026-04-20T00:00:00Z",
+            },
+          });
+        }
+        if (url === "/hecate/v1/chat/sessions/a1/stream") {
+          return emptyStreamResponse();
+        }
+        if (url === "/hecate/v1/chat/sessions/a1/messages") {
+          messagePostCount += 1;
+          void init;
+          return jsonResponse({
+            object: "chat_session",
+            data: {
+              id: "a1",
+              title: "Codex chat",
+              agent_id: "codex",
+              status: "completed",
+              workspace: "/workspace",
+              messages: [
+                {
+                  id: "u1",
+                  agent_id: "codex",
+                  role: "user",
+                  content: "continue here",
+                  created_at: "2026-04-20T00:00:01Z",
+                },
+              ],
+              created_at: "2026-04-20T00:00:00Z",
+              updated_at: "2026-04-20T00:00:01Z",
+            },
+          });
+        }
+        return defaultBackendMock()(input, init);
+      });
+
+      const { result } = renderRuntimeConsoleHook();
+      await waitFor(() => expect(result.current.state.loading).toBe(false));
+      expect(result.current.state.activeChatSessionID).toBe("a1");
+      expect(result.current.state.activeChatSession).toBeNull();
+
+      act(() => {
+        result.current.actions.setMessage("continue here");
+      });
+      await act(async () => {
+        await result.current.actions.submitChat({ preventDefault: vi.fn() } as any);
+      });
+
+      expect(createPostCount).toBe(0);
+      expect(messagePostCount).toBe(1);
+      expect(result.current.state.activeChatSessionID).toBe("a1");
+      expect(result.current.state.activeChatSession?.agent_id).toBe("codex");
+    });
+
     it("restores queued prompts from local storage and persists edits", async () => {
       window.localStorage.setItem("hecate.chatTarget", "agent");
       window.localStorage.setItem("hecate.chatSessionID", "a1");

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -229,6 +229,7 @@ export type RuntimeConsoleFixtureActions = {
   setProviderName: (id: string, name: string) => Promise<void>;
   setProviderCustomName: (id: string, customName: string) => Promise<void>;
   setActiveProjectID: (id: string) => void;
+  loadProjects: () => Promise<void>;
   selectProject: (id: string) => Promise<void>;
   createProjectFromFolder: () => Promise<ProjectRecord | null>;
   renameProject: (id: string, name: string) => Promise<void>;
@@ -298,6 +299,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setProviderName: async () => undefined,
     setProviderCustomName: async () => undefined,
     setActiveProjectID: () => undefined,
+    loadProjects: async () => undefined,
     selectProject: async () => undefined,
     createProjectFromFolder: async () => null,
     renameProject: async () => undefined,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -187,9 +187,11 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
     },
     providersAndModelsSlice: {
       refreshProviders: actions.refreshProviders,
+      probeAgentAdapter: actions.probeAgentAdapter,
     },
     projectsSlice: {
       setActiveProjectID: actions.setActiveProjectID,
+      loadProjects: actions.loadProjects,
       createProjectFromFolder: actions.createProjectFromFolder,
       selectProject: actions.selectProject,
       renameProject: actions.renameProject,

--- a/ui/src/types/agent-adapter.ts
+++ b/ui/src/types/agent-adapter.ts
@@ -15,7 +15,8 @@ export type AgentAdapterRecord = {
   description?: string;
   cost_mode?: string;
   docs_url?: string;
-  version?: string;
+  adapter_version?: string;
+  agent_version?: string;
   supported_range?: string;
   version_outside_range?: boolean;
   auth_status?: "ok" | "unauthenticated" | "billing" | "unknown" | string;

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -137,6 +137,7 @@ export type ChatConfigOptionRecord = {
   name: string;
   description?: string;
   category?: string;
+  source?: "launch" | (string & {});
   type: "select" | "boolean" | (string & {});
   current_value?: string;
   current_bool?: boolean;


### PR DESCRIPTION
## Summary

- Align Hecate and external-agent new-chat setup so empty/pre-session chats do not show stale headers, fake selected sessions, or a changing composer layout.
- Keep external-agent setup passive: status reads no longer launch package-manager managed adapters or open agent auth pages unexpectedly.
- Make external launch controls reliable for ACP adapters: discover Grok defaults, persist selected model/reasoning controls, recognize adapter-provided launch controls, and reseed stale sessions when an adapter starts reporting new controls.
- Improve adapter readiness details by separating adapter command availability from agent version/auth state, and make native-app local provider discovery match browser/dev behavior for LM Studio.

## Tests

- `go test ./internal/agentadapters ./internal/api`
- `cd ui && bun run test`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just go-format-check`
- `just docs-format-check`
- `git diff --check`

## Notes

- Commit stack kept split by reviewable behavior: setup parity, readiness/probe behavior, Grok defaults, and launch-control persistence/recognition.
- There are unrelated local uncommitted module-path edits in the worktree; they are intentionally not part of this PR.

## Breaking API note

- Intentional alpha breaking change: /hecate/v1/agent-adapters no longer returns the ambiguous version field. The response now exposes adapter_version and agent_version separately so UI and operators can distinguish the ACP adapter wrapper from the underlying agent CLI.