### PR TITLE
build(tauri): strip debug symbols from sidecar Go binary (-10 MB per bundle)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -374,9 +374,9 @@ tauri-build-sidecars: ui-build _go-cache
 	if [ -z "$version" ]; then \
 	  echo "could not resolve Tauri sidecar version" && exit 1; \
 	fi; \
-	ldflags="-X github.com/hecatehq/hecate/internal/version.Version=$version"; \
+	ldflags="-s -w -X github.com/hecatehq/hecate/internal/version.Version=$version"; \
 	echo "building Tauri sidecars at version $version"; \
-	GOCACHE="$PWD/{{gocache}}" go build -ldflags "$ldflags" -o "hecate$goexe" ./cmd/hecate
+	GOCACHE="$PWD/{{gocache}}" go build -trimpath -ldflags "$ldflags" -o "hecate$goexe" ./cmd/hecate
 
 # Build hecate and stage it as a Tauri sidecar. Pass an explicit
 # target triple in CI matrix builds; local builds auto-detect the host triple.


### PR DESCRIPTION
## Summary

The `tauri-build-sidecars` recipe was only setting the version `-X` ldflag — no `-s -w` and no `-trimpath`. Every Tauri bundle (local AND CI matrix) shipped the unstripped 32.7 MB Go binary instead of the 22.7 MB release-build, even though [`.goreleaser.yaml`](.goreleaser.yaml#L26-L29) and [`Dockerfile.release`](Dockerfile.release) have been stripping all along.

One-line fix: add `-s -w` to the ldflags string and `-trimpath` to the `go build` invocation, matching what goreleaser and the Dockerfile already do.

## Measured impact

On the staged sidecar at `tauri/src-tauri/binaries/hecate-aarch64-apple-darwin`:

| | Before | After | Delta |
|---|---|---|---|
| Size | 32.7 MB | **22.7 MB** | **-10.0 MB (-30.6%)** |

Propagates through every Tauri bundle artifact:

- `.app` on disk
- `.dmg` compressed download
- `.deb` / `.AppImage` / `.msi` (same Go binary inside each)

## Verification

- [x] Sidecar rebuilt; size went from 32.7 MB → 22.7 MB.
- [x] `hecate --version` still returns the embedded version string (`0.1.0-alpha.32`) — `-s -w` doesn't break `-X` ldflag.
- [x] One-line diff, no API/behavior change.

## Test plan

- [ ] CI Tauri bundle matrix produces bundles ~10 MB smaller per platform.
- [ ] `just tauri-dev` still launches the app and the gateway sidecar comes up healthy.