### PR TITLE
fix(ui): show chat setup guidance before session creation

### DIFF
--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -97,10 +97,28 @@ function chatSessionIsBusy(session: ChatSessionRecord | null): boolean {
 function isExpectedHecateChatSetupError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
   return (
+    error.code === "chat.workspace_required" ||
     error.code === "chat.model_required" ||
     error.code === "model_not_configured" ||
     error.code === "route.no_routable_provider"
   );
+}
+
+function chatWorkspaceRequiredError(): ApiError {
+  return new ApiError(
+    "Choose a workspace before using Hecate Chat tools or External Agent.",
+    400,
+    "chat.workspace_required",
+    {
+      operatorAction: "Choose a workspace, or use Hecate direct model chat.",
+    },
+  );
+}
+
+function chatModelRequiredError(): ApiError {
+  return new ApiError("Choose a model before starting this chat.", 400, "chat.model_required", {
+    operatorAction: "Open Connections or choose a model from the composer.",
+  });
 }
 
 function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null): {
@@ -463,11 +481,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
     try {
       if (!isModelTurn && !turnWorkspace) {
-        setChatError("Choose a workspace path before starting an agent chat.");
+        setChatErrorState(chatWorkspaceRequiredError());
         return;
       }
       if (!isExternalAgent && !turnModel) {
-        setChatError("Choose a model before sending through Hecate.");
+        setChatErrorState(chatModelRequiredError());
         return;
       }
 
@@ -705,7 +723,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       const externalAgentID = requestedAgentID || agentAdapterID;
       const workspace = agentWorkspace.trim();
       if (!workspace) {
-        clearChatErrorState();
+        setChatErrorState(chatWorkspaceRequiredError());
         setActiveChatSessionID("");
         setActiveChatSession(null);
         return;
@@ -752,7 +770,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     });
     const workspace = agentWorkspace.trim();
     if (executionMode === "hecate_task" && !workspace) {
-      clearChatErrorState();
+      setChatErrorState(chatWorkspaceRequiredError());
       setActiveChatSessionID("");
       setActiveChatSession(null);
       return;

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -754,7 +754,7 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
 
-  it("keeps external-agent workspace setup in the chat shell instead of emitting an error", async () => {
+  it("shows workspace guidance when creating an external-agent chat without a workspace", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
     window.localStorage.removeItem("hecate.agentWorkspace");
@@ -782,7 +782,11 @@ describe("useRuntimeConsole", () => {
 
     expect(createCalled).toBe(false);
     expect(result.current.state.activeChatSessionID).toBe("");
-    expect(result.current.state.chatError).toBe("");
+    expect(result.current.state.chatError).toBe(
+      "Choose a workspace before using Hecate Chat tools or External Agent.",
+    );
+    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+    expect(result.current.state.chatErrorStatus).toBe(400);
   });
 
   it("creates a Hecate chat shell when no model is selected", async () => {
@@ -930,7 +934,11 @@ describe("useRuntimeConsole", () => {
     expect(createBody).toBeNull();
     expect(result.current.state.activeChatSessionID).toBe("");
     expect(result.current.state.activeChatSession).toBeNull();
-    expect(result.current.state.chatError).toBe("");
+    expect(result.current.state.chatError).toBe(
+      "Choose a workspace before using Hecate Chat tools or External Agent.",
+    );
+    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+    expect(result.current.state.chatErrorStatus).toBe(400);
   });
 
   it("starts a direct Hecate chat when the selected model explicitly has no tools", async () => {
@@ -992,7 +1000,7 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatError).toBe("");
   });
 
-  it("keeps external-agent workspace setup in the chat shell when no workspace is selected", async () => {
+  it("shows workspace guidance when creating the selected external-agent chat without a workspace", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "codex");
     let createCalled = false;
@@ -1021,8 +1029,58 @@ describe("useRuntimeConsole", () => {
 
     expect(createCalled).toBe(false);
     expect(result.current.state.activeChatSessionID).toBe("");
-    expect(result.current.state.chatError).toBe("");
-    expect(result.current.state.chatErrorCode).toBe("");
+    expect(result.current.state.chatError).toBe(
+      "Choose a workspace before using Hecate Chat tools or External Agent.",
+    );
+    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+    expect(result.current.state.chatErrorStatus).toBe(400);
+  });
+
+  it("shows workspace guidance when creating a tools-on Hecate chat without a workspace", async () => {
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.model", "gpt-4o-mini");
+    window.localStorage.removeItem("hecate.agentWorkspace");
+    let createCalled = false;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/v1/models": () =>
+          jsonResponse({
+            object: "list",
+            data: [
+              {
+                id: "gpt-4o-mini",
+                owned_by: "openai",
+                metadata: {
+                  provider: "openai",
+                  provider_kind: "cloud",
+                  capabilities: { tool_calling: "basic" },
+                },
+              },
+            ],
+          }),
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createCalled = true;
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession({ agentID: "hecate" });
+    });
+
+    expect(createCalled).toBe(false);
+    expect(result.current.state.activeChatSessionID).toBe("");
+    expect(result.current.state.chatError).toBe(
+      "Choose a workspace before using Hecate Chat tools or External Agent.",
+    );
+    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
+    expect(result.current.state.chatErrorStatus).toBe(400);
   });
 
   it("does not create or select a chat when eager external-agent prepare fails", async () => {


### PR DESCRIPTION
## Summary
- convert pre-session missing workspace/model cases into structured chat setup guidance
- avoid creating Hecate/external-agent chat shells when required setup is missing
- cover workspace-required and direct-model fallback behavior in composition tests

## Verification
- cd ui && bun run test -- runtime-console-composition.test.tsx
- cd ui && bun run typecheck
