### PR TITLE
fix(ui): silence Vite proxy noise in e2e

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -309,6 +309,10 @@ Tests use `withRuntimeConsole(ui, fixture)` from `src/test/runtime-console-rende
 
 **Never `bun test`** — it skips testing-library DOM setup and panics with `document[isPrepared]`. Always `bun run test`.
 
+Playwright starts Vite with `VITE_DISABLE_API_PROXY=1`. E2E specs should mock
+every API route they depend on; missing mocks should fail quietly as 404s, not
+fall through to the Vite dev proxy and spam `ECONNREFUSED` for `:8765`.
+
 Oxc config lives at repo root in `.oxlintrc.json` and is shared by the UI and
 website. UI and website lint scripts run `oxlint --type-aware`, backed by the
 `oxlint-tsgolint` package. The config enables the React, JSX accessibility,

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -35,6 +35,7 @@ ui/src/
 | `bun run test`       | Vitest run before committing — never `bun test` (skips testing-library DOM setup) |
 | `bun run test:watch` | Iteration                                                                         |
 | `bun run dev`        | Vite dev server on `:5173` proxying API to `:8765`                                |
+| `bun run test:e2e`   | Playwright with Vite's API proxy disabled; mock each API route explicitly         |
 
 Claude Code shortcut: `/test-affected` from the repo root when Go packages are touched. For UI work, run `bun run typecheck` and `bun run test` directly.
 

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -32,9 +32,10 @@ export default defineConfig({
   webServer: {
     // Playwright owns API mocking. Disable Vite's localhost proxy here so
     // missed mocks fail as quiet 404s instead of noisy ECONNREFUSED proxy logs.
-    command: "VITE_DISABLE_API_PROXY=1 bun run dev",
+    command: "bun run dev",
+    env: { VITE_DISABLE_API_PROXY: "1" },
     url: "http://localhost:5173",
-    reuseExistingServer: true,
+    reuseExistingServer: false,
     timeout: 30_000,
   },
 });

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -30,7 +30,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "bun run dev",
+    // Playwright owns API mocking. Disable Vite's localhost proxy here so
+    // missed mocks fail as quiet 404s instead of noisy ECONNREFUSED proxy logs.
+    command: "VITE_DISABLE_API_PROXY=1 bun run dev",
     url: "http://localhost:5173",
     reuseExistingServer: true,
     timeout: 30_000,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -88,6 +88,7 @@ export default defineConfig(({ mode }) => {
     plugins: [react(), preloadLikelyFirstWorkspace(), preserveDistGitkeep()],
     server: {
       port: 5173,
+      strictPort: apiProxyDisabled,
       proxy: apiProxyDisabled
         ? undefined
         : {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -81,7 +81,7 @@ function preloadLikelyFirstWorkspace(): Plugin {
 const apiProxyTarget = "http://127.0.0.1:8765";
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, ".", "");
+  const env = loadEnv(mode, ".");
   const apiProxyDisabled = env.VITE_DISABLE_API_PROXY === "1";
 
   return {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
 // preserveDistGitkeep emits ui/dist/.gitkeep alongside the build
@@ -78,14 +78,23 @@ function preloadLikelyFirstWorkspace(): Plugin {
   };
 }
 
-export default defineConfig({
-  plugins: [react(), preloadLikelyFirstWorkspace(), preserveDistGitkeep()],
-  server: {
-    port: 5173,
-    proxy: {
-      "/healthz": "http://127.0.0.1:8765",
-      "/hecate": "http://127.0.0.1:8765",
-      "/v1": "http://127.0.0.1:8765",
+const apiProxyTarget = "http://127.0.0.1:8765";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, ".", "");
+  const apiProxyDisabled = env.VITE_DISABLE_API_PROXY === "1";
+
+  return {
+    plugins: [react(), preloadLikelyFirstWorkspace(), preserveDistGitkeep()],
+    server: {
+      port: 5173,
+      proxy: apiProxyDisabled
+        ? undefined
+        : {
+            "/healthz": apiProxyTarget,
+            "/hecate": apiProxyTarget,
+            "/v1": apiProxyTarget,
+          },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

- Disable Vite's Hecate API proxy only for Playwright runs with `VITE_DISABLE_API_PROXY=1`.
- Keep normal `bun run dev` proxy behavior unchanged for local UI iteration against `:8765`.
- Document the e2e route-mocking contract in UI guidance.

## Why

Playwright owns API mocking, but any missed mock currently falls through to Vite's dev proxy and logs noisy `ECONNREFUSED 127.0.0.1:8765` messages because no backend is running for UI e2e. With the proxy disabled in e2e, missed mocks fail quietly as 404s instead of socket-refused spam.

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-format-check`
- `cd ui && bun run test`
- `cd ui && bun run test:e2e e2e/provider-presets-lazy.spec.ts`
