### PR TITLE
[codex] Align docs checks and agent guidance

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -6,16 +6,15 @@ alwaysApply: true
 
 # Hecate core rules
 
-Hecate is an open-source AI gateway and agent-task runtime. The Go gateway embeds the React operator UI, mediates OpenAI- and Anthropic-shaped client traffic, runs queued `agent_loop` tasks with policy and approval gates, and emits OpenTelemetry traces for everything it does. Companion entrypoints such as `hecate-acp` handle protocols that need their own process lifecycle.
+Hecate is an open-source local AI runtime console. The main Go runtime runs the local HTTP service, embeds the React operator UI, routes OpenAI- and Anthropic-shaped client traffic to upstream providers, runs Hecate Chat tools-on turns through visible `agent_loop` tasks, supervises external coding-agent adapters from Chats, runs queued `agent_loop` tasks with policy and approval gates, and emits OpenTelemetry traces for everything it does.
 
 The canonical, vendor-neutral instruction layer for this repo lives in [`docs-ai/`](../../docs-ai/README.md). Start there. This file is a thin Cursor adapter listing the top-level non-negotiables.
 
 ## Non-negotiables
 
 - **Architecture rings.** `pkg/types/` → `internal/api/` → `internal/providers/`. Cross-ring imports go inward only. `internal/orchestrator/` sits above providers, called by api.
-- **Storage tier rule.** Every persisted thing mirrors three tiers — memory (default, in-process), sqlite (`modernc.org`, no CGO), postgres (`pgx`).
-- **Auth is path-level.** `/v1/...` accepts tenant API keys; `/admin/...` requires admin bearer; `/v1/tasks/*` accepts both. Don't blur these.
-- **Tenant scoping is automatic.** Every store query gets `WHERE tenant = ?` injected once a request has a tenant principal. Do not bypass via the admin path.
+- **Storage tier rule.** Every persisted thing mirrors two tiers — memory (default, in-process) and sqlite (`modernc.org/sqlite`, no CGO).
+- **Local operator boundary.** Every request is processed as the operator. The runtime binds to `127.0.0.1` by default; bind elsewhere only behind a reverse proxy, firewall, or equivalent access control.
 - **Cost is `int64` micro-USD.** Never `float64`. `1_000_000` = `$1`.
 - **OTel is first-class.** New code paths add spans, not just log lines. Trace IDs surface in `X-Trace-Id`.
 - **The api↔providers parallel-struct rule.** `OpenAIChatMessage` (capital `O`, in `internal/api/`) and `openAIChatMessage` (lowercase `o`, in `internal/providers/`) duplicate the JSON shape on purpose. Mirror fields when adding; do not unify.

--- a/.cursor/rules/10-planning.mdc
+++ b/.cursor/rules/10-planning.mdc
@@ -11,8 +11,8 @@ Substantial changes get a plan before code. Trivial changes (typo fixes, single-
 ## When a plan is required
 
 - Cross-package wire-field changes — the seven-step chain spans `pkg/types/` → `internal/api/` → `internal/providers/`.
-- New persisted things — must mirror memory + sqlite + postgres tiers.
-- New HTTP endpoints (public `/v1/...` or admin `/admin/...`).
+- New persisted things — must mirror memory + sqlite tiers.
+- New HTTP endpoints or changes to the Hecate-native / compatibility API contract.
 - New approval policies or sandbox capabilities.
 - New persistent UI surfaces (inspector, side rail, dashboard block, summary panel) — explicit user approval first.
 - Substantive refactors that cross ring boundaries or touch the api↔providers seam.

--- a/.cursor/rules/20-testing.mdc
+++ b/.cursor/rules/20-testing.mdc
@@ -28,8 +28,8 @@ Race suite is the floor for any change touching `internal/gateway`, `internal/ro
 
 ## Test layer choice (quick guide)
 
-- **Unit** — data transformation, wire-shape passthrough, error classification, tenant scoping, retry/failover, streaming wire shape, agent_loop tool dispatch, MCP tool registration, UI data-to-prop transformation, conditional rendering of critical states.
-- **Integration** — multi-package wiring within the gateway (governor + budget store; router + retention).
+- **Unit** — data transformation, wire-shape passthrough, error classification, retry/failover decisions, streaming wire shape, usage accumulation, agent_loop tool dispatch, MCP tool registration, UI data-to-prop transformation, conditional rendering of critical states.
+- **Integration** — multi-package wiring within the runtime, such as governor + usage store, router + retention, or orchestrator + taskstate.
 - **E2E** — api → orchestrator → providers/sandbox/mcp chain end-to-end; subprocess lifecycle; startup/config semantics; new SSE event sequences operators rely on; public HTTP contract changes.
 
 ## Pointers

--- a/.cursor/rules/30-review.mdc
+++ b/.cursor/rules/30-review.mdc
@@ -12,9 +12,9 @@ For each change, run a pass on each axis. Cite `file:line` for every finding.
 
 1. **Correctness.** Does the change do what it claims? Edge cases handled? Errors classified correctly (`IsClientError`, `IsBudgetExceeded`, `IsRateLimited`, `IsDenied`)?
 2. **Maintainability.** Readable? Comments explain *why*, not *what*? Naming consistent with the surrounding code?
-3. **Architecture fit.** Respects the rings (`pkg/types/` → `internal/api/` → `internal/providers/`, imports inward only)? Mirrors the storage tier rule (memory + sqlite + postgres)? Does it duplicate what should be shared, or share what should be duplicated (api↔providers parallel-struct rule)?
+3. **Architecture fit.** Respects the rings (`pkg/types/` → `internal/api/` → `internal/providers/`, imports inward only)? Mirrors the storage tier rule (memory + sqlite)? Does it duplicate what should be shared, or share what should be duplicated (api↔providers parallel-struct rule)?
 4. **Test coverage.** Tests the seam? The error path? The cross-boundary wire shape? UI data-to-UI transformation and conditional rendering of critical states?
-5. **Security risk.** Auth scoping (`/v1/...` vs `/admin/...`); tenant scoping (no admin-path bypass); sandbox boundary; SSRF guards on `http_request`; secrets in env vs in code.
+5. **Security risk.** Local operator boundary; sandbox boundary; workspace path validation; SSRF guards on `http_request`; secrets in env vs in code.
 6. **Operational risk.** Env-var changes synced to `.env.example` and `docs/<feature>.md`? Schema migrations across storage tiers? Retention worker impact? OTel surface? Log volume?
 7. **Follow-ups.** What's left? What's known-incomplete? What needs a separate change?
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This is the Hecate repo — an open-source AI gateway and agent-task runtime (Go gateway with embedded React UI plus companion integration entrypoints). Shared agent guidance lives in [`docs-ai/`](docs-ai/README.md). This file is a thin Claude-specific adapter; the substance lives there.
+This is the Hecate repo — an open-source local AI runtime console (Go runtime with embedded React UI plus companion integration entrypoints). Shared agent guidance lives in [`docs-ai/`](docs-ai/README.md). This file is a thin Claude-specific adapter; the substance lives there.
 
 ## Start here
 

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ format-check: go-format-check ui-format-check website-format-check docs-format-c
 # Project verification gate. It intentionally runs only non-destructive
 # checks, but it is not cheap: Docker and UI e2e can take a bit.
 # Run the full project verification gate.
-verify: docs-env-check format-check test vet test-race test-docker-smoke ui-lint website-lint ui-test ui-test-e2e build
+verify: docs-check go-format-check ui-format-check website-format-check test vet test-race test-docker-smoke ui-lint website-lint ui-test ui-test-e2e build
 
 # Run desktop-specific verification that requires Rust/Cargo and Tauri deps.
 verify-desktop: tauri-rust-test

--- a/just/docs.just
+++ b/just/docs.just
@@ -9,6 +9,10 @@ docs-format: _ui-deps
 docs-format-check: _ui-deps
 	git ls-files -z '*.md' '*.mdc' | xargs -0 ./ui/node_modules/.bin/oxfmt --check
 
+# Validate Mermaid diagrams embedded in Markdown.
+check-mermaid:
+	bun scripts/check-mermaid.ts
+
 # Catch alpha-risk documentation drift: removed env bootstrap surfaces
 # sneaking back into docs, and release docs going missing.
 # Check docs for removed env-bootstrap surfaces.
@@ -17,8 +21,9 @@ docs-env-check:
 	test -f docs/known-limitations.md
 	! rg -n 'HECATE_POLICY_RULES_JSON|HECATE_PRICEBOOK_JSON|HECATE_PROVIDERS|HECATE_[A-Z0-9_]+_BACKEND|PROVIDER_[A-Z0-9_]+_(PROTOCOL|API_VERSION|TIMEOUT)' README.md docs .env.example internal/config e2e .github
 
-# Run lychee against all markdown and .mdc files to catch broken relative
-# links and dead external URLs. Mirrors the CI Links workflow.
+# Run lychee against tracked markdown and .mdc files to catch broken relative
+# links. Mirrors the hard-fail half of the CI Links workflow; external URL
+# rot is checked separately because network and host failures are flaky.
 # Install lychee via: brew install lychee  OR  cargo install lychee
 # Check markdown links with lychee.
 check-links:
@@ -28,12 +33,34 @@ check-links:
 	  echo "  Cargo:  cargo install lychee"; \
 	  exit 1; \
 	}
-	lychee --no-progress --include-fragments \
+	git ls-files -z '*.md' '*.mdc' | xargs -0 lychee --no-progress --include-fragments \
+	  --scheme file \
 	  --exclude-path .gomodcache \
 	  --exclude-path ui/node_modules \
 	  --exclude-path website/node_modules \
-	  --exclude-path .claude/skills \
-	  './**/*.md' './**/*.mdc'
+	  --exclude-path tauri/node_modules \
+	  --exclude-path .claude/skills
+
+# Check external URLs. Informational locally; CI also runs this as a
+# continue-on-error job so transient host failures do not block PRs.
+check-links-external:
+	command -v lychee >/dev/null 2>&1 || { \
+	  echo "lychee not installed."; \
+	  echo "  macOS:  brew install lychee"; \
+	  echo "  Cargo:  cargo install lychee"; \
+	  exit 1; \
+	}
+	git ls-files -z '*.md' '*.mdc' | xargs -0 lychee --no-progress --include-fragments \
+	  --scheme https \
+	  --scheme http \
+	  --exclude-path .gomodcache \
+	  --exclude-path ui/node_modules \
+	  --exclude-path website/node_modules \
+	  --exclude-path tauri/node_modules \
+	  --exclude-path .claude/skills
+
+# Run all docs-specific verification.
+docs-check: docs-env-check docs-format-check check-mermaid check-links
 
 # One-shot end-to-end screenshot workflow:
 # reset -> build -> start hecate in the background -> wait for /healthz ->

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -37,7 +37,7 @@ ui/src/
 | `bun run dev`        | Vite dev server on `:5173` proxying API to `:8765`                                |
 | `bun run test:e2e`   | Playwright with Vite's API proxy disabled; mock each API route explicitly         |
 
-Claude Code shortcut: `/test-affected` from the repo root when Go packages are touched. For UI work, run `bun run typecheck` and `bun run test` directly.
+Claude Code exposes `/test-affected` from the repo root when Go packages are touched. Other agents should run the equivalent focused `go test` command directly. For UI work, run `bun run typecheck` and `bun run test`.
 
 ## Where to go for depth
 


### PR DESCRIPTION
## Summary

- align Claude and Cursor agent adapters with Hecate's current local runtime console model
- remove stale Cursor guidance around postgres, tenant scoping, and admin auth
- add a `docs-check` Just target that runs docs env drift checks, Markdown formatting, Mermaid validation, and hard-fail lychee checks for tracked relative links
- keep external URL checks as a separate informational `check-links-external` recipe because host/network failures are flaky

## Validation

- `just docs-check`
- `just --dry-run verify`