### PR TITLE
feat(runtime): add workspace-bound process and git runners

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -31,11 +31,12 @@ Hecate supports isolated generated workspaces and opt-in in-place workspaces.
 - In isolated mode, when the task source is a Git repository, Hecate clones it with `git clone --no-hardlinks -- <source> <workspace>`.
 - In isolated mode, when the task source is a plain directory, Hecate copies it into the generated workspace.
 - Generated workspace paths reject traversal and existing symlink components before Hecate creates files.
+- Hecate-mediated workspace file operations use the shared WorkspaceFS resolver. This covers native `agent_loop` file/search tools, sandboxed file writes, generated workspace setup, and ACP adapter read/write callbacks. It does not sandbox external-agent subprocess internals.
 - Operator-selected source directories are canonicalized. Symlinked source repos/folders are allowed by design, because operators may intentionally select them.
 - `workspace_mode=in_place` skips clone/copy and runs tools directly in the selected source directory. Treat it as destructive.
 - Adding or selecting a workspace in the UI does not clone it. Clone/copy happens only when a native task run provisions an isolated workspace.
 
-Git is used for workspace setup and change review, not as a security boundary. Hecate also uses Git status/diff information to show branch state, changed files, and revertable workspace changes.
+Git is used for workspace setup and change review, not as a security boundary. Hecate also uses Git status/diff information to show branch state, changed files, and revertable workspace changes. Hecate-owned Git calls go through the shared GitRunner seam, which validates the workspace directory and runs Git with a sanitized environment; external-agent subprocesses can still run their own Git commands internally.
 
 ## Approvals
 

--- a/internal/agentadapters/acp_chat_client.go
+++ b/internal/agentadapters/acp_chat_client.go
@@ -3,7 +3,6 @@ package agentadapters
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 
 	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 )
 
 type acpChatClient struct {
@@ -91,11 +91,11 @@ func (c *acpChatClient) RequestPermission(ctx context.Context, params acp.Reques
 }
 
 func (c *acpChatClient) ReadTextFile(_ context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
-	path, err := c.workspacePath(params.Path)
+	fsys, path, err := c.workspaceFS(params.Path)
 	if err != nil {
 		return acp.ReadTextFileResponse{}, err
 	}
-	data, err := os.ReadFile(path)
+	data, _, err := fsys.ReadFile(path)
 	if err != nil {
 		return acp.ReadTextFileResponse{}, err
 	}
@@ -116,14 +116,11 @@ func (c *acpChatClient) ReadTextFile(_ context.Context, params acp.ReadTextFileR
 }
 
 func (c *acpChatClient) WriteTextFile(_ context.Context, params acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
-	path, err := c.workspacePath(params.Path)
+	fsys, path, err := c.workspaceFS(params.Path)
 	if err != nil {
 		return acp.WriteTextFileResponse{}, err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return acp.WriteTextFileResponse{}, err
-	}
-	if err := os.WriteFile(path, []byte(params.Content), 0o644); err != nil {
+	if _, err := fsys.WriteFile(path, []byte(params.Content), 0o644); err != nil {
 		return acp.WriteTextFileResponse{}, err
 	}
 	return acp.WriteTextFileResponse{}, nil
@@ -154,21 +151,32 @@ func (c *acpChatClient) WaitForTerminalExit(ctx context.Context, _ acp.WaitForTe
 	return acp.WaitForTerminalExitResponse{}, terminalRPCUnsupported("terminal/wait")
 }
 
-func (c *acpChatClient) workspacePath(path string) (string, error) {
+func (c *acpChatClient) workspaceFS(path string) (*workspacefs.FS, string, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return "", fmt.Errorf("path is required")
+		return nil, "", fmt.Errorf("path is required")
 	}
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(c.workspace, path)
-	}
-	clean := filepath.Clean(path)
-	rel, err := filepath.Rel(c.workspace, clean)
+	fsys, err := workspacefs.New(c.workspace)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path %q escapes workspace", path)
+	if filepath.IsAbs(path) {
+		root := fsys.Root()
+		clean := filepath.Clean(path)
+		rel, err := filepath.Rel(root, clean)
+		if err != nil {
+			return nil, "", err
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, "", fmt.Errorf("path %q escapes workspace", path)
+		}
+		if _, err := fsys.Resolve(rel); err != nil {
+			return nil, "", err
+		}
+		return fsys, rel, nil
 	}
-	return clean, nil
+	if _, err := fsys.Resolve(path); err != nil {
+		return nil, "", err
+	}
+	return fsys, path, nil
 }

--- a/internal/agentadapters/acp_terminal_rpc_test.go
+++ b/internal/agentadapters/acp_terminal_rpc_test.go
@@ -3,6 +3,8 @@ package agentadapters
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -139,6 +141,61 @@ func TestAcpChatClientTerminalRPCsTolerateNilMetrics(t *testing.T) {
 		t.Fatal("CreateTerminal: want error, got nil")
 	} else if !errors.Is(err, ErrTerminalRPCUnsupported) {
 		t.Fatalf("CreateTerminal: errors.Is(err, ErrTerminalRPCUnsupported) = false; err = %v", err)
+	}
+}
+
+func TestAcpChatClientReadTextFileRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	client := &acpChatClient{
+		sessionID: "chat_test",
+		adapterID: "codex",
+		workspace: workspace,
+	}
+
+	_, err := client.ReadTextFile(context.Background(), acp.ReadTextFileRequest{Path: "linked/secret.txt"})
+	if err == nil {
+		t.Fatal("ReadTextFile() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("ReadTextFile() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestAcpChatClientWriteTextFileRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	client := &acpChatClient{
+		sessionID: "chat_test",
+		adapterID: "codex",
+		workspace: workspace,
+	}
+
+	_, err := client.WriteTextFile(context.Background(), acp.WriteTextFileRequest{
+		Path:    "linked/escape.txt",
+		Content: "nope",
+	})
+	if err == nil {
+		t.Fatal("WriteTextFile() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("WriteTextFile() error = %v, want symlink rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "escape.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat error = %v, want not exist", statErr)
 	}
 }
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentcontrols"
+	"github.com/hecatehq/hecate/internal/gitrunner"
 )
 
 const (
@@ -974,26 +974,7 @@ func sanitizedEnvForAdapter(adapterID string, env []string) []string {
 }
 
 func captureGitDiff(ctx context.Context, workspace string, maxBytes int64) (string, string) {
-	diffCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if strings.TrimSpace(runGitCapture(diffCtx, workspace, 1024, "rev-parse", "--is-inside-work-tree")) != "true" {
-		return "", ""
-	}
-	return runGitCapture(diffCtx, workspace, maxBytes, "diff", "--stat"), runGitCapture(diffCtx, workspace, maxBytes, "diff", "--no-ext-diff", "--binary")
-}
-
-func runGitCapture(ctx context.Context, workspace string, maxBytes int64, args ...string) string {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = workspace
-	cmd.Env = sanitizedEnv(os.Environ())
-	var out limitedBuffer
-	out.limit = maxBytes
-	cmd.Stdout = &out
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(out.String())
+	return gitrunner.NewLocalRunner().Diff(ctx, workspace, maxBytes)
 }
 
 type limitedBuffer struct {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/requestscope"
 	"github.com/hecatehq/hecate/internal/telemetry"
@@ -1258,24 +1258,7 @@ func workspaceGitBranch(workspace string) string {
 	if workspace == "" {
 		return ""
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	out, err := exec.CommandContext(ctx, "git", "-C", workspace, "branch", "--show-current").Output()
-	if err == nil {
-		if branch := strings.TrimSpace(string(out)); branch != "" {
-			return branch
-		}
-	}
-	out, err = exec.CommandContext(ctx, "git", "-C", workspace, "rev-parse", "--short", "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	commit := strings.TrimSpace(string(out))
-	if commit == "" {
-		return ""
-	}
-	return "detached@" + commit
+	return gitrunner.NewLocalRunner().CurrentRef(context.Background(), workspace)
 }
 
 func newChatID(prefix string) string {

--- a/internal/api/handler_chat_files.go
+++ b/internal/api/handler_chat_files.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/gitrunner"
 )
 
 func (h *Handler) HandleChatMessageFiles(w http.ResponseWriter, r *http.Request) {
@@ -180,8 +180,7 @@ func normalizeRevertPaths(paths []string) []string {
 }
 
 func ensureGitWorkspace(ctx context.Context, workspace string) error {
-	out, err := runGit(ctx, workspace, "rev-parse", "--is-inside-work-tree")
-	if err != nil || strings.TrimSpace(out) != "true" {
+	if !gitrunner.NewLocalRunner().IsWorkTree(ctx, workspace) {
 		return errors.New("agent chat revert requires a git workspace")
 	}
 	return nil
@@ -191,9 +190,21 @@ func runGit(ctx context.Context, workspace string, args ...string) (string, erro
 	if strings.TrimSpace(workspace) == "" {
 		return "", errors.New("workspace is required")
 	}
-	cmdArgs := append([]string{"-C", workspace}, args...)
-	out, err := exec.CommandContext(ctx, "git", cmdArgs...).CombinedOutput()
-	return string(out), err
+	result, err := gitrunner.NewLocalRunner().Run(ctx, workspace, args...)
+	return combinedProcessOutput(result), err
+}
+
+func combinedProcessOutput(result gitrunner.Result) string {
+	out := strings.TrimSpace(result.Stdout)
+	errText := strings.TrimSpace(result.Stderr)
+	switch {
+	case out != "" && errText != "":
+		return out + "\n" + errText
+	case out != "":
+		return out
+	default:
+		return errText
+	}
 }
 
 func renderChatChangedFile(file chat.ChangedFile) ChatChangedFileItem {

--- a/internal/api/handler_tasks_patches.go
+++ b/internal/api/handler_tasks_patches.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -168,17 +169,18 @@ func (h *Handler) HandleRevertTaskRunPatch(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "patch artifact path is empty")
 		return
 	}
-	if !pathWithinRoot(artifact.Path, run.WorkspacePath) {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "patch artifact path is outside the run workspace")
+	fsys, rel, err := patchWorkspaceTarget(run.WorkspacePath, artifact.Path)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
 	if beforeExisted {
-		if err := os.WriteFile(artifact.Path, []byte(before), 0o644); err != nil {
+		if _, err := fsys.WriteFile(rel, []byte(before), 0o644); err != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
 	} else {
-		if err := os.Remove(artifact.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if _, err := fsys.Remove(rel); err != nil && !errors.Is(err, os.ErrNotExist) {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
@@ -234,15 +236,16 @@ func (h *Handler) HandleApplyTaskRunPatch(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "patch artifact path is empty")
 		return
 	}
-	if !pathWithinRoot(artifact.Path, run.WorkspacePath) {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "patch artifact path is outside the run workspace")
+	fsys, rel, err := patchWorkspaceTarget(run.WorkspacePath, artifact.Path)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
-	if err := verifyPatchApplyPrecondition(artifact.Path, before, beforeExisted); err != nil {
+	if err := verifyPatchApplyPrecondition(fsys, rel, before, beforeExisted); err != nil {
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
 		return
 	}
-	if err := os.WriteFile(artifact.Path, []byte(after), 0o644); err != nil {
+	if _, err := fsys.WriteFile(rel, []byte(after), 0o644); err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -297,8 +300,8 @@ func (h *Handler) loadTaskRunPatch(ctx context.Context, w http.ResponseWriter, r
 	}
 	return run, artifact, true
 }
-func verifyPatchApplyPrecondition(path, before string, beforeExisted bool) error {
-	current, err := os.ReadFile(path)
+func verifyPatchApplyPrecondition(fsys *workspacefs.FS, rel, before string, beforeExisted bool) error {
+	current, _, err := fsys.ReadFile(rel)
 	if beforeExisted {
 		if err != nil {
 			return fmt.Errorf("patch target changed before apply: %w", err)
@@ -317,8 +320,25 @@ func verifyPatchApplyPrecondition(path, before string, beforeExisted bool) error
 	return fmt.Errorf("patch target cannot be checked before apply: %w", err)
 }
 
-func pathWithinRoot(path, root string) bool {
-	path = filepath.Clean(path)
-	root = filepath.Clean(root)
-	return path == root || strings.HasPrefix(path, root+string(filepath.Separator))
+func patchWorkspaceTarget(root, path string) (*workspacefs.FS, string, error) {
+	root = strings.TrimSpace(root)
+	path = strings.TrimSpace(path)
+	if root == "" {
+		return nil, "", fmt.Errorf("patch artifact workspace is empty")
+	}
+	fsys, err := workspacefs.New(root)
+	if err != nil {
+		return nil, "", err
+	}
+	rel := path
+	if filepath.IsAbs(path) {
+		rel, err = filepath.Rel(fsys.Root(), filepath.Clean(path))
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	if _, err := fsys.Resolve(rel); err != nil {
+		return nil, "", fmt.Errorf("patch artifact path is outside the run workspace")
+	}
+	return fsys, rel, nil
 }

--- a/internal/api/handler_tasks_patches_test.go
+++ b/internal/api/handler_tasks_patches_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPatchWorkspaceTarget_AllowsAbsolutePathInsideWorkspace(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "nested", "file.txt")
+
+	fsys, rel, err := patchWorkspaceTarget(workspace, target)
+	if err != nil {
+		t.Fatalf("patchWorkspaceTarget: %v", err)
+	}
+	if rel != filepath.Join("nested", "file.txt") {
+		t.Fatalf("rel = %q, want nested/file.txt", rel)
+	}
+	if _, err := fsys.WriteFile(rel, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("WriteFile through resolved target: %v", err)
+	}
+}
+
+func TestPatchWorkspaceTarget_RejectsAbsolutePathOutsideWorkspace(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "escape.txt")
+
+	_, _, err := patchWorkspaceTarget(workspace, outside)
+	if err == nil || !strings.Contains(err.Error(), "outside the run workspace") {
+		t.Fatalf("error = %v, want outside workspace rejection", err)
+	}
+}
+
+func TestPatchWorkspaceTarget_RejectsSymlinkComponentEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires elevated privileges on Windows")
+	}
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(workspace, "linked")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join("linked", "escape.txt"),
+		filepath.Join(workspace, "linked", "escape.txt"),
+	} {
+		_, _, err := patchWorkspaceTarget(workspace, path)
+		if err == nil || !strings.Contains(err.Error(), "outside the run workspace") {
+			t.Fatalf("path %q error = %v, want outside workspace rejection", path, err)
+		}
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hecatehq/hecate/internal/retention"
 	"github.com/hecatehq/hecate/internal/router"
 	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -5503,26 +5504,31 @@ func TestPatchContentExtractsBeforeAndAfter(t *testing.T) {
 func TestVerifyPatchApplyPreconditionRejectsDrift(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "main.go")
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	fsys, err := workspacefs.New(root)
+	if err != nil {
+		t.Fatalf("New workspacefs: %v", err)
+	}
 	if err := os.WriteFile(path, []byte("changed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := verifyPatchApplyPrecondition(path, "original\n", true); err == nil {
+	if err := verifyPatchApplyPrecondition(fsys, "main.go", "original\n", true); err == nil {
 		t.Fatal("verifyPatchApplyPrecondition() error = nil, want conflict")
 	}
 	if err := os.WriteFile(path, []byte("original\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := verifyPatchApplyPrecondition(path, "original\n", true); err != nil {
+	if err := verifyPatchApplyPrecondition(fsys, "main.go", "original\n", true); err != nil {
 		t.Fatalf("verifyPatchApplyPrecondition() error = %v", err)
 	}
-	if err := verifyPatchApplyPrecondition(path, "", false); err == nil {
+	if err := verifyPatchApplyPrecondition(fsys, "main.go", "", false); err == nil {
 		t.Fatal("verifyPatchApplyPrecondition(new file) error = nil for existing file, want conflict")
 	}
 	if err := os.Remove(path); err != nil {
 		t.Fatal(err)
 	}
-	if err := verifyPatchApplyPrecondition(path, "", false); err != nil {
+	if err := verifyPatchApplyPrecondition(fsys, "main.go", "", false); err != nil {
 		t.Fatalf("verifyPatchApplyPrecondition(new file) error = %v", err)
 	}
 }

--- a/internal/api/system_prompt.go
+++ b/internal/api/system_prompt.go
@@ -2,11 +2,10 @@ package api
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 )
 
 // agentWorkspacePromptFiles are the file names the agent loop honors
@@ -56,18 +55,19 @@ func buildSystemPromptResolver(globalDefault string) orchestrator.SystemPromptRe
 // empty when no file is present, the path is empty, or the file is
 // too short to be meaningful.
 //
-// Path safety isn't a concern here — we're reading files inside the
-// workspace the runner provisioned; an attacker who can write a
-// CLAUDE.md inside the workspace can already do worse via the agent's
-// tools. The cap is purely about token cost / prompt sanity.
+// The read still goes through WorkspaceFS so prompt discovery follows the
+// same workspace-boundary behavior as other Hecate-mediated file reads.
 func loadWorkspaceSystemPrompt(workspacePath string) string {
 	workspacePath = strings.TrimSpace(workspacePath)
 	if workspacePath == "" {
 		return ""
 	}
+	fsys, err := workspacefs.New(workspacePath)
+	if err != nil {
+		return ""
+	}
 	for _, name := range agentWorkspacePromptFiles {
-		path := filepath.Join(workspacePath, name)
-		raw, err := os.ReadFile(path)
+		raw, _, err := fsys.ReadFile(name)
 		if err != nil {
 			continue
 		}

--- a/internal/gitrunner/gitrunner.go
+++ b/internal/gitrunner/gitrunner.go
@@ -1,0 +1,203 @@
+package gitrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/processrunner"
+)
+
+const command = "git"
+
+type Result = processrunner.Result
+
+type Runner interface {
+	Run(ctx context.Context, workspace string, args ...string) (Result, error)
+	CurrentRef(ctx context.Context, workspace string) string
+	IsWorkTree(ctx context.Context, workspace string) bool
+	Diff(ctx context.Context, workspace string, maxBytes int64) (string, string)
+	Restore(ctx context.Context, workspace string, paths []string) (Result, error)
+	Clone(ctx context.Context, sourcePath, workspacePath string) (Result, error)
+}
+
+type LocalRunner struct {
+	Process processrunner.Runner
+	Env     []string
+}
+
+func NewLocalRunner() *LocalRunner {
+	return &LocalRunner{Process: processrunner.NewLocalRunner()}
+}
+
+func (r *LocalRunner) Run(ctx context.Context, workspace string, args ...string) (Result, error) {
+	workspace, err := cleanWorkspace(workspace)
+	if err != nil {
+		return Result{ExitCode: -1}, err
+	}
+	return r.run(ctx, processrunner.Request{
+		Command: command,
+		Args:    args,
+		Dir:     workspace,
+		Env:     r.env(),
+	})
+}
+
+func (r *LocalRunner) CurrentRef(ctx context.Context, workspace string) string {
+	refCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	result, err := r.Run(refCtx, workspace, "branch", "--show-current")
+	if err == nil {
+		if branch := strings.TrimSpace(result.Stdout); branch != "" {
+			return branch
+		}
+	}
+	result, err = r.Run(refCtx, workspace, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return ""
+	}
+	commit := strings.TrimSpace(result.Stdout)
+	if commit == "" {
+		return ""
+	}
+	return "detached@" + commit
+}
+
+func (r *LocalRunner) IsWorkTree(ctx context.Context, workspace string) bool {
+	result, err := r.Run(ctx, workspace, "rev-parse", "--is-inside-work-tree")
+	return err == nil && strings.TrimSpace(result.Stdout) == "true"
+}
+
+func (r *LocalRunner) Diff(ctx context.Context, workspace string, maxBytes int64) (string, string) {
+	diffCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if !r.IsWorkTree(diffCtx, workspace) {
+		return "", ""
+	}
+	stat, _ := r.RunLimited(diffCtx, workspace, maxBytes, "diff", "--stat")
+	diff, _ := r.RunLimited(diffCtx, workspace, maxBytes, "diff", "--no-ext-diff", "--binary")
+	return strings.TrimSpace(stat.Stdout), strings.TrimSpace(diff.Stdout)
+}
+
+func (r *LocalRunner) Restore(ctx context.Context, workspace string, paths []string) (Result, error) {
+	cleanedPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path != "" {
+			cleanedPaths = append(cleanedPaths, path)
+		}
+	}
+	if len(cleanedPaths) == 0 {
+		return Result{ExitCode: -1}, errors.New("at least one path is required")
+	}
+	args := append([]string{"restore", "--"}, cleanedPaths...)
+	return r.Run(ctx, workspace, args...)
+}
+
+func (r *LocalRunner) Clone(ctx context.Context, sourcePath, workspacePath string) (Result, error) {
+	sourcePath = strings.TrimSpace(sourcePath)
+	workspacePath = strings.TrimSpace(workspacePath)
+	if sourcePath == "" {
+		return Result{ExitCode: -1}, errors.New("git clone source path is required")
+	}
+	if workspacePath == "" {
+		return Result{ExitCode: -1}, errors.New("git clone workspace path is required")
+	}
+	workspacePath = filepath.Clean(workspacePath)
+	if abs, err := filepath.Abs(workspacePath); err == nil {
+		workspacePath = abs
+	}
+	if err := os.MkdirAll(filepath.Dir(workspacePath), 0o755); err != nil {
+		return Result{ExitCode: -1}, err
+	}
+	return r.run(ctx, processrunner.Request{
+		Command: command,
+		Args:    []string{"clone", "--quiet", "--no-hardlinks", "--", sourcePath, workspacePath},
+		Env:     r.env(),
+	})
+}
+
+func (r *LocalRunner) RunLimited(ctx context.Context, workspace string, maxBytes int64, args ...string) (Result, error) {
+	workspace, err := cleanWorkspace(workspace)
+	if err != nil {
+		return Result{ExitCode: -1}, err
+	}
+	return r.run(ctx, processrunner.Request{
+		Command:        command,
+		Args:           args,
+		Dir:            workspace,
+		Env:            r.env(),
+		MaxStdoutBytes: maxBytes,
+		MaxStderrBytes: maxBytes,
+	})
+}
+
+func (r *LocalRunner) run(ctx context.Context, req processrunner.Request) (Result, error) {
+	process := r.Process
+	if process == nil {
+		process = processrunner.NewLocalRunner()
+	}
+	return process.Run(ctx, req)
+}
+
+func (r *LocalRunner) env() []string {
+	if r.Env != nil {
+		return r.Env
+	}
+	return SanitizedEnv(os.Environ())
+}
+
+func cleanWorkspace(workspace string) (string, error) {
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		return "", errors.New("workspace is required")
+	}
+	workspace = filepath.Clean(workspace)
+	if abs, err := filepath.Abs(workspace); err == nil {
+		workspace = abs
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return "", fmt.Errorf("workspace %q is not accessible: %w", workspace, err)
+	}
+	defer root.Close()
+	info, err := root.Stat(".")
+	if err != nil {
+		return "", fmt.Errorf("workspace %q is not accessible: %w", workspace, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace %q is not a directory", workspace)
+	}
+	return workspace, nil
+}
+
+func SanitizedEnv(env []string) []string {
+	allowedPrefixes := []string{
+		"PATH=",
+		"HOME=",
+		"TMPDIR=",
+		"TEMP=",
+		"TMP=",
+		"LANG=",
+		"LC_",
+		"TERM=",
+		"USER=",
+		"LOGNAME=",
+		"XDG_",
+		"VOLTA_",
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		for _, prefix := range allowedPrefixes {
+			if strings.HasPrefix(entry, prefix) {
+				out = append(out, entry)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/gitrunner/gitrunner_test.go
+++ b/internal/gitrunner/gitrunner_test.go
@@ -1,0 +1,140 @@
+package gitrunner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/processrunner"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	requireGit(t)
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-b", "main").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "add", ".").Run(); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "initial").Run(); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	return dir
+}
+
+func TestLocalRunner_CurrentRef(t *testing.T) {
+	dir := initRepo(t)
+	runner := NewLocalRunner()
+
+	if got := runner.CurrentRef(context.Background(), dir); got != "main" {
+		t.Fatalf("CurrentRef = %q, want main", got)
+	}
+}
+
+func TestLocalRunner_DiffCapturesStatAndPatch(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runner := NewLocalRunner()
+
+	stat, diff := runner.Diff(context.Background(), dir, 64*1024)
+
+	if !strings.Contains(stat, "README.md") {
+		t.Fatalf("stat = %q, want README.md", stat)
+	}
+	if !strings.Contains(diff, "+world") {
+		t.Fatalf("diff = %q, want added line", diff)
+	}
+}
+
+func TestLocalRunner_Restore(t *testing.T) {
+	dir := initRepo(t)
+	path := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(path, []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runner := NewLocalRunner()
+
+	if _, err := runner.Restore(context.Background(), dir, []string{"README.md"}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if got := string(data); got != "hello\n" {
+		t.Fatalf("file = %q, want original", got)
+	}
+}
+
+func TestLocalRunner_RestoreUsesPathspecSeparator(t *testing.T) {
+	dir := t.TempDir()
+	process := &recordingProcessRunner{}
+	runner := &LocalRunner{Process: process}
+
+	if _, err := runner.Restore(context.Background(), dir, []string{"README.md", "docs/guide.md"}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	got := strings.Join(process.request.Args, "\x00")
+	want := strings.Join([]string{"restore", "--", "README.md", "docs/guide.md"}, "\x00")
+	if got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func TestLocalRunner_RestoreRejectsEmptyPathList(t *testing.T) {
+	runner := NewLocalRunner()
+
+	_, err := runner.Restore(context.Background(), t.TempDir(), []string{" ", ""})
+
+	if err == nil || !strings.Contains(err.Error(), "at least one path is required") {
+		t.Fatalf("error = %v, want path required", err)
+	}
+}
+
+func TestSanitizedEnvDropsProviderSecrets(t *testing.T) {
+	env := SanitizedEnv([]string{
+		"PATH=/bin",
+		"OPENAI_API_KEY=secret",
+		"PROVIDER_XAI_API_KEY=secret",
+		"HOME=/tmp/home",
+	})
+
+	got := strings.Join(env, "\n")
+	if strings.Contains(got, "secret") {
+		t.Fatalf("sanitized env leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "PATH=/bin") || !strings.Contains(got, "HOME=/tmp/home") {
+		t.Fatalf("sanitized env = %q, want PATH and HOME", got)
+	}
+}
+
+type recordingProcessRunner struct {
+	request processrunner.Request
+}
+
+func (r *recordingProcessRunner) Run(_ context.Context, req processrunner.Request) (processrunner.Result, error) {
+	r.request = req
+	return processrunner.Result{}, nil
+}
+
+func (r *recordingProcessRunner) RunStreaming(ctx context.Context, req processrunner.Request, _ func(processrunner.Chunk)) (processrunner.Result, error) {
+	return r.Run(ctx, req)
+}

--- a/internal/orchestrator/executor.go
+++ b/internal/orchestrator/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hecatehq/hecate/internal/sandbox"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/internal/workspace"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -314,7 +315,7 @@ func (e *FileExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*Execut
 	if err != nil {
 		return fileFailure(spec, operation, spec.Task.FilePath, err.Error(), fileErrorKind(err)), nil
 	}
-	afterContent, err := os.ReadFile(fileResult.Path)
+	afterContent, err := readFileWithWorkspacePolicy(request, fileResult.Path)
 	if err != nil {
 		return fileFailure(spec, operation, spec.Task.FilePath, err.Error(), fileErrorKind(err)), nil
 	}
@@ -713,7 +714,7 @@ func fileContentBeforeWrite(request sandbox.FileRequest) (content string, exists
 	if err != nil {
 		return "", false, "", err
 	}
-	raw, err := os.ReadFile(resolvedPath)
+	raw, err := readFileWithWorkspacePolicy(request, resolvedPath)
 	if err == nil {
 		return string(raw), true, resolvedPath, nil
 	}
@@ -721,6 +722,27 @@ func fileContentBeforeWrite(request sandbox.FileRequest) (content string, exists
 		return "", false, resolvedPath, nil
 	}
 	return "", false, resolvedPath, err
+}
+
+func readFileWithWorkspacePolicy(request sandbox.FileRequest, path string) ([]byte, error) {
+	allowedRoot := strings.TrimSpace(request.Policy.AllowedRoot)
+	if allowedRoot == "" {
+		return os.ReadFile(path)
+	}
+	root, err := filepath.Abs(allowedRoot)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, err
+	}
+	fsys, err := workspacefs.New(root)
+	if err != nil {
+		return nil, err
+	}
+	raw, _, err := fsys.ReadFile(rel)
+	return raw, err
 }
 
 func newPatchArtifact(spec ExecutionSpec, stepID, operation, displayPath, artifactPath, before, after string, beforeExists bool, createdAt time.Time) types.TaskArtifact {

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -9,16 +9,15 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/hecatehq/hecate/internal/sandbox"
+	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -1058,10 +1057,7 @@ const (
 	listDirEntryCap         = 500
 )
 
-// resolveWorkspacePath joins relPath onto the run's workspace root and
-// rejects the result if it escapes. Returns the absolute path (safe
-// to read) or an error message suitable for the tool result.
-func resolveWorkspacePath(spec ExecutionSpec, relPath string) (string, string) {
+func workspaceFileSystem(spec ExecutionSpec) (*workspacefs.FS, string) {
 	root := strings.TrimSpace(spec.Task.WorkingDirectory)
 	if root == "" {
 		// No workspace configured — operate from current dir as a
@@ -1069,20 +1065,38 @@ func resolveWorkspacePath(spec ExecutionSpec, relPath string) (string, string) {
 		// this to the run's WorkspacePath before dispatching.
 		root, _ = os.Getwd()
 	}
+	fsys, err := workspacefs.New(root)
+	if err != nil {
+		return nil, err.Error()
+	}
+	return fsys, ""
+}
+
+func workspaceFSPath(spec ExecutionSpec, relPath string) (*workspacefs.FS, string, string, string) {
 	rel := strings.TrimSpace(relPath)
 	if rel == "" || rel == "." {
-		return root, ""
+		rel = "."
 	}
-	// Reject absolute paths outright — agent must operate inside the
-	// workspace. Path-traversal via `..` is caught below by the prefix
-	// check on the cleaned absolute path.
-	if filepath.IsAbs(rel) {
-		return "", fmt.Sprintf("path must be relative to the workspace, got absolute: %q", rel)
+	fsys, errMsg := workspaceFileSystem(spec)
+	if errMsg != "" {
+		return nil, "", "", errMsg
 	}
-	abs := filepath.Clean(filepath.Join(root, rel))
-	rootClean := filepath.Clean(root)
-	if abs != rootClean && !strings.HasPrefix(abs, rootClean+string(filepath.Separator)) {
-		return "", fmt.Sprintf("path %q escapes the workspace root", rel)
+	abs, err := fsys.Resolve(rel)
+	if err != nil {
+		if filepath.IsAbs(rel) {
+			return nil, "", "", fmt.Sprintf("path must be relative to the workspace, got absolute: %q", rel)
+		}
+		return nil, "", "", err.Error()
+	}
+	return fsys, rel, abs, ""
+}
+
+// resolveWorkspacePath joins relPath onto the run's workspace root using the
+// same symlink-aware resolver as sandboxed file writes.
+func resolveWorkspacePath(spec ExecutionSpec, relPath string) (string, string) {
+	_, _, abs, errMsg := workspaceFSPath(spec, relPath)
+	if errMsg != "" {
+		return "", errMsg
 	}
 	return abs, ""
 }
@@ -1094,11 +1108,11 @@ func prepareFileEditTask(spec ExecutionSpec, args fileEditArgs) (types.Task, str
 	if args.OldText == "" {
 		return types.Task{}, "", "", "", "file_edit: old_text is required"
 	}
-	abs, errMsg := resolveWorkspacePath(spec, args.Path)
+	fsys, rel, abs, errMsg := workspaceFSPath(spec, args.Path)
 	if errMsg != "" {
 		return types.Task{}, "", "", "", errMsg
 	}
-	info, err := os.Stat(abs)
+	info, _, err := fsys.Stat(rel)
 	if err != nil {
 		return types.Task{}, "", "", "", fmt.Sprintf("file_edit: %v", err)
 	}
@@ -1108,7 +1122,7 @@ func prepareFileEditTask(spec ExecutionSpec, args fileEditArgs) (types.Task, str
 	if info.Size() > fileEditHardCapBytes {
 		return types.Task{}, "", "", "", fmt.Sprintf("file_edit: %q is too large (%d bytes > %d)", args.Path, info.Size(), fileEditHardCapBytes)
 	}
-	raw, err := os.ReadFile(abs)
+	raw, _, err := fsys.ReadFile(rel)
 	if err != nil {
 		return types.Task{}, "", "", "", fmt.Sprintf("file_edit: %v", err)
 	}
@@ -1210,10 +1224,6 @@ func applyPatchTool(spec ExecutionSpec, args applyPatchArgs, stepIndex int, star
 	}
 
 	prepared := make([]preparedPatchOperation, 0, len(ops))
-	root, rootErr := workspaceRoot(spec)
-	if rootErr != "" {
-		return "apply_patch: " + rootErr, nil, nil, nil
-	}
 	for _, op := range ops {
 		if errMsg := validatePatchOperationPath(op); errMsg != "" {
 			return errMsg, nil, nil, nil
@@ -1221,19 +1231,23 @@ func applyPatchTool(spec ExecutionSpec, args applyPatchArgs, stepIndex int, star
 		if args.Propose && op.Kind == "delete" {
 			return "apply_patch: propose=true does not support delete sections because proposed-patch apply currently writes after-content rather than removing files", nil, nil, nil
 		}
-		abs, err := safeJoinWithinRoot(root, strings.TrimSpace(op.Path))
-		if err != nil {
-			return fmt.Sprintf("apply_patch: %v", err), nil, nil, nil
+		fsys, rel, abs, errMsg := workspaceFSPath(spec, op.Path)
+		if errMsg != "" {
+			return "apply_patch: " + errMsg, nil, nil, nil
 		}
-		before, after, beforeExists, errMsg := preparePatchOperation(abs, op)
+		before, after, beforeExists, errMsg := preparePatchOperation(fsys, rel, op)
 		if errMsg != "" {
 			return errMsg, nil, nil, nil
 		}
-		prepared = append(prepared, preparedPatchOperation{op: op, absPath: abs, before: before, after: after, beforeExists: beforeExists})
+		prepared = append(prepared, preparedPatchOperation{op: op, relPath: rel, absPath: abs, before: before, after: after, beforeExists: beforeExists})
 	}
 	if !args.Propose {
 		for _, item := range prepared {
-			if err := writePatchOperation(item.absPath, item.after, item.op.Kind); err != nil {
+			fsys, _, _, errMsg := workspaceFSPath(spec, item.relPath)
+			if errMsg != "" {
+				return "apply_patch: " + errMsg, nil, nil, nil
+			}
+			if err := writePatchOperation(fsys, item.relPath, item.after, item.op.Kind); err != nil {
 				return fmt.Sprintf("apply_patch: %v", err), nil, nil, nil
 			}
 		}
@@ -1269,7 +1283,7 @@ func applyPatchTool(spec ExecutionSpec, args applyPatchArgs, stepIndex int, star
 // tool result text. Bounded by max_bytes; binary files are reported
 // rather than dumped (to avoid pushing garbage into the conversation).
 func readFileTool(spec ExecutionSpec, args readFileArgs, stepIndex int, startedAt time.Time, toolName string) (string, *types.TaskStep, []types.TaskArtifact, error) {
-	abs, errMsg := resolveWorkspacePath(spec, args.Path)
+	fsys, rel, _, errMsg := workspaceFSPath(spec, args.Path)
 	if errMsg != "" {
 		return errMsg, nil, nil, nil
 	}
@@ -1281,7 +1295,7 @@ func readFileTool(spec ExecutionSpec, args readFileArgs, stepIndex int, startedA
 		maxBytes = readFileHardCapBytes
 	}
 
-	info, err := os.Stat(abs)
+	info, _, err := fsys.Stat(rel)
 	if err != nil {
 		return fmt.Sprintf("read_file: %v", err), nil, nil, nil
 	}
@@ -1289,7 +1303,7 @@ func readFileTool(spec ExecutionSpec, args readFileArgs, stepIndex int, startedA
 		return fmt.Sprintf("read_file: %q is a directory; use list_dir instead", args.Path), nil, nil, nil
 	}
 
-	displayContent, lineRange, n, truncated, errMsg := readWorkspaceFileContent(abs, args.Path, info.Size(), maxBytes, args.StartLine, args.EndLine)
+	displayContent, lineRange, n, truncated, errMsg := readWorkspaceFileContent(fsys, rel, args.Path, info.Size(), maxBytes, args.StartLine, args.EndLine)
 	if errMsg != "" {
 		return "read_file: " + errMsg, nil, nil, nil
 	}
@@ -1334,33 +1348,34 @@ func grepTool(spec ExecutionSpec, args grepArgs, stepIndex int, startedAt time.T
 	if maxMatches > grepHardCapMatches {
 		maxMatches = grepHardCapMatches
 	}
-	root, errMsg := resolveWorkspacePath(spec, args.Path)
+	fsys, rootRel, _, errMsg := workspaceFSPath(spec, args.Path)
 	if errMsg != "" {
 		return "grep: " + errMsg, nil, nil, nil
 	}
-	workspaceRoot, rootErr := workspaceRoot(spec)
-	if rootErr != "" {
-		return "grep: " + rootErr, nil, nil, nil
-	}
 
 	var matches []grepMatch
-	err = walkSearchFiles(root, func(path string, info os.FileInfo) error {
+	err = fsys.WalkDir(rootRel, func(_ string, rel string, entry workspacefs.DirEntry) error {
 		if len(matches) >= maxMatches {
 			return filepath.SkipAll
 		}
-		rel, _ := filepath.Rel(workspaceRoot, path)
-		rel = filepath.ToSlash(rel)
-		if args.Include != "" && !globPatternMatches(args.Include, rel) && !globPatternMatches(args.Include, filepath.Base(rel)) {
+		if shouldSkipSearchDir(entry) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir {
 			return nil
 		}
-		fileMatches, err := grepFile(path, rel, re, maxMatches-len(matches))
+		displayRel := filepath.ToSlash(rel)
+		if args.Include != "" && !globPatternMatches(args.Include, displayRel) && !globPatternMatches(args.Include, filepath.Base(displayRel)) {
+			return nil
+		}
+		fileMatches, err := grepFile(fsys, rel, displayRel, re, maxMatches-len(matches))
 		if err != nil {
 			return nil
 		}
 		matches = append(matches, fileMatches...)
 		return nil
 	})
-	if err != nil {
+	if err != nil && err != filepath.SkipAll {
 		return fmt.Sprintf("grep: %v", err), nil, nil, nil
 	}
 	var b strings.Builder
@@ -1394,40 +1409,32 @@ func globTool(spec ExecutionSpec, args globArgs, stepIndex int, startedAt time.T
 	if maxMatches > globHardCapMatches {
 		maxMatches = globHardCapMatches
 	}
-	root, errMsg := resolveWorkspacePath(spec, args.Path)
+	fsys, rootRel, _, errMsg := workspaceFSPath(spec, args.Path)
 	if errMsg != "" {
 		return "glob: " + errMsg, nil, nil, nil
 	}
-	workspaceRoot, rootErr := workspaceRoot(spec)
-	if rootErr != "" {
-		return "glob: " + rootErr, nil, nil, nil
-	}
 	var matches []string
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
+	err := fsys.WalkDir(rootRel, func(_ string, rel string, entry workspacefs.DirEntry) error {
 		if shouldSkipSearchDir(entry) {
 			return filepath.SkipDir
 		}
-		rel, _ := filepath.Rel(workspaceRoot, path)
-		rel = filepath.ToSlash(rel)
-		if rel == "." {
+		displayRel := filepath.ToSlash(rel)
+		if displayRel == "." {
 			return nil
 		}
-		if globPatternMatches(args.Pattern, rel) || globPatternMatches(args.Pattern, filepath.Base(rel)) {
+		if globPatternMatches(args.Pattern, displayRel) || globPatternMatches(args.Pattern, filepath.Base(displayRel)) {
 			suffix := ""
-			if entry.IsDir() {
+			if entry.IsDir {
 				suffix = "/"
 			}
-			matches = append(matches, rel+suffix)
+			matches = append(matches, displayRel+suffix)
 			if len(matches) >= maxMatches {
 				return filepath.SkipAll
 			}
 		}
 		return nil
 	})
-	if err != nil {
+	if err != nil && err != filepath.SkipAll {
 		return fmt.Sprintf("glob: %v", err), nil, nil, nil
 	}
 	sort.Strings(matches)
@@ -1508,24 +1515,24 @@ func artifactReadTool(spec ExecutionSpec, args artifactReadArgs, stepIndex int, 
 // with kind (file/dir/link) and size. Capped at listDirEntryCap so
 // huge directories don't bloat the conversation.
 func listDirTool(spec ExecutionSpec, args listDirArgs, stepIndex int, startedAt time.Time, toolName string) (string, *types.TaskStep, []types.TaskArtifact, error) {
-	abs, errMsg := resolveWorkspacePath(spec, args.Path)
+	fsys, rel, _, errMsg := workspaceFSPath(spec, args.Path)
 	if errMsg != "" {
 		return errMsg, nil, nil, nil
 	}
-	info, err := os.Stat(abs)
+	info, _, err := fsys.Stat(rel)
 	if err != nil {
 		return fmt.Sprintf("list_dir: %v", err), nil, nil, nil
 	}
 	if !info.IsDir() {
 		return fmt.Sprintf("list_dir: %q is not a directory", args.Path), nil, nil, nil
 	}
-	entries, err := os.ReadDir(abs)
+	entries, _, err := fsys.ReadDir(rel)
 	if err != nil {
 		return fmt.Sprintf("list_dir: %v", err), nil, nil, nil
 	}
 	// Sort for deterministic output — saves token churn across
 	// equivalent calls in different turns.
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
 
 	relPath := args.Path
 	if relPath == "" {
@@ -1544,15 +1551,15 @@ func listDirTool(spec ExecutionSpec, args listDirArgs, stepIndex int, startedAt 
 		}
 		kind := "file"
 		size := int64(0)
-		if entry.IsDir() {
+		if entry.IsDir {
 			kind = "dir"
-		} else if entry.Type()&os.ModeSymlink != 0 {
+		} else if entry.Type&os.ModeSymlink != 0 {
 			kind = "link"
 		}
-		if fi, err := entry.Info(); err == nil && !fi.IsDir() {
-			size = fi.Size()
+		if !entry.IsDir {
+			size = entry.Size
 		}
-		fmt.Fprintf(&b, "%-4s %10d  %s\n", kind, size, entry.Name())
+		fmt.Fprintf(&b, "%-4s %10d  %s\n", kind, size, entry.Name)
 		emitted++
 	}
 
@@ -1640,16 +1647,15 @@ func gitDiffTool(ctx context.Context, spec ExecutionSpec, args gitDiffArgs, step
 func runGitReadCommand(ctx context.Context, root string, maxBytes int, args ...string) (string, bool, error) {
 	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(cmdCtx, "git", append([]string{"-C", root, "--no-pager"}, args...)...)
-	cmd.Env = sandbox.SanitizedEnv()
-	output := &limitedCommandBuffer{limit: maxBytes}
-	cmd.Stdout = output
-	cmd.Stderr = output
-	err := cmd.Run()
+	gitArgs := append([]string{"--no-pager"}, args...)
+	result, err := gitrunner.NewLocalRunner().RunLimited(cmdCtx, root, int64(maxBytes), gitArgs...)
 	if cmdCtx.Err() == context.DeadlineExceeded {
 		return "", false, fmt.Errorf("git command timed out")
 	}
-	out := output.String()
+	out := result.Stdout
+	if strings.TrimSpace(result.Stderr) != "" {
+		out += result.Stderr
+	}
 	if err != nil {
 		text := strings.TrimSpace(out)
 		if text != "" {
@@ -1657,51 +1663,11 @@ func runGitReadCommand(ctx context.Context, root string, maxBytes int, args ...s
 		}
 		return "", false, err
 	}
-	return out, output.Truncated(), nil
+	return out, result.StdoutTruncated || result.StderrTruncated, nil
 }
 
-type limitedCommandBuffer struct {
-	mu        sync.Mutex
-	limit     int
-	buf       []byte
-	truncated bool
-}
-
-func (b *limitedCommandBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.limit <= 0 {
-		b.truncated = true
-		return len(p), nil
-	}
-	remaining := b.limit - len(b.buf)
-	if remaining <= 0 {
-		b.truncated = true
-		return len(p), nil
-	}
-	if len(p) > remaining {
-		b.buf = append(b.buf, p[:remaining]...)
-		b.truncated = true
-		return len(p), nil
-	}
-	b.buf = append(b.buf, p...)
-	return len(p), nil
-}
-
-func (b *limitedCommandBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return string(b.buf)
-}
-
-func (b *limitedCommandBuffer) Truncated() bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.truncated
-}
-
-func readWorkspaceFileContent(abs, displayPath string, fileSize int64, maxBytes, startLine, endLine int) (string, string, int, bool, string) {
-	f, err := os.Open(abs)
+func readWorkspaceFileContent(fsys *workspacefs.FS, rel, displayPath string, fileSize int64, maxBytes, startLine, endLine int) (string, string, int, bool, string) {
+	f, _, err := fsys.Open(rel)
 	if err != nil {
 		return "", "", 0, false, err.Error()
 	}
@@ -1857,6 +1823,7 @@ type patchOperation struct {
 
 type preparedPatchOperation struct {
 	op           patchOperation
+	relPath      string
 	absPath      string
 	before       string
 	after        string
@@ -1897,37 +1864,11 @@ func workspaceRoot(spec ExecutionSpec) (string, string) {
 	return root, ""
 }
 
-func walkSearchFiles(root string, visit func(path string, info os.FileInfo) error) error {
-	info, err := os.Stat(root)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return visit(root, info)
-	}
-	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if shouldSkipSearchDir(entry) {
-			return filepath.SkipDir
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return nil
-		}
-		return visit(path, info)
-	})
-}
-
-func shouldSkipSearchDir(entry os.DirEntry) bool {
-	if entry == nil || !entry.IsDir() {
+func shouldSkipSearchDir(entry workspacefs.DirEntry) bool {
+	if !entry.IsDir {
 		return false
 	}
-	switch entry.Name() {
+	switch entry.Name {
 	case ".git", "node_modules", ".gocache", "dist", "build":
 		return true
 	default:
@@ -1935,12 +1876,12 @@ func shouldSkipSearchDir(entry os.DirEntry) bool {
 	}
 }
 
-func grepFile(path, rel string, re *regexp.Regexp, remaining int) ([]grepMatch, error) {
-	info, err := os.Stat(path)
+func grepFile(fsys *workspacefs.FS, rel, displayRel string, re *regexp.Regexp, remaining int) ([]grepMatch, error) {
+	info, _, err := fsys.Stat(rel)
 	if err != nil || info.IsDir() || info.Size() > grepFileHardCapBytes {
 		return nil, err
 	}
-	raw, err := os.ReadFile(path)
+	raw, _, err := fsys.ReadFile(rel)
 	if err != nil {
 		return nil, err
 	}
@@ -1957,7 +1898,7 @@ func grepFile(path, rel string, re *regexp.Regexp, remaining int) ([]grepMatch, 
 	matches := make([]grepMatch, 0)
 	for i, line := range lines {
 		if re.MatchString(line) {
-			matches = append(matches, grepMatch{Path: rel, Line: i + 1, Text: line})
+			matches = append(matches, grepMatch{Path: displayRel, Line: i + 1, Text: line})
 			if len(matches) >= remaining {
 				break
 			}
@@ -2058,8 +1999,8 @@ func validatePatchOperationPath(op patchOperation) string {
 	return ""
 }
 
-func readPatchTargetFile(abs, path string) ([]byte, string) {
-	info, err := os.Stat(abs)
+func readPatchTargetFile(fsys *workspacefs.FS, rel, path string) ([]byte, string) {
+	info, _, err := fsys.Stat(rel)
 	if err != nil {
 		return nil, fmt.Sprintf("apply_patch: %v", err)
 	}
@@ -2069,30 +2010,30 @@ func readPatchTargetFile(abs, path string) ([]byte, string) {
 	if info.Size() > fileEditHardCapBytes {
 		return nil, fmt.Sprintf("apply_patch: %q is too large (%d bytes > %d)", path, info.Size(), fileEditHardCapBytes)
 	}
-	raw, err := os.ReadFile(abs)
+	raw, _, err := fsys.ReadFile(rel)
 	if err != nil {
 		return nil, fmt.Sprintf("apply_patch: %v", err)
 	}
 	return raw, ""
 }
 
-func preparePatchOperation(abs string, op patchOperation) (before, after string, beforeExists bool, errMsg string) {
+func preparePatchOperation(fsys *workspacefs.FS, rel string, op patchOperation) (before, after string, beforeExists bool, errMsg string) {
 	switch op.Kind {
 	case "add":
-		if _, err := os.Stat(abs); err == nil {
+		if _, _, err := fsys.Stat(rel); err == nil {
 			return "", "", false, fmt.Sprintf("apply_patch: %q already exists", op.Path)
 		} else if !os.IsNotExist(err) {
 			return "", "", false, fmt.Sprintf("apply_patch: %v", err)
 		}
 		return "", patchAddedContent(op.Lines), false, ""
 	case "delete":
-		raw, errMsg := readPatchTargetFile(abs, op.Path)
+		raw, errMsg := readPatchTargetFile(fsys, rel, op.Path)
 		if errMsg != "" {
 			return "", "", false, errMsg
 		}
 		return string(raw), "", true, ""
 	case "update":
-		raw, errMsg := readPatchTargetFile(abs, op.Path)
+		raw, errMsg := readPatchTargetFile(fsys, rel, op.Path)
 		if errMsg != "" {
 			return "", "", false, errMsg
 		}
@@ -2164,15 +2105,14 @@ func applyPatchUpdate(current string, patchLines []string) (string, string) {
 	return strings.Join(out, ""), ""
 }
 
-func writePatchOperation(abs, after, kind string) error {
+func writePatchOperation(fsys *workspacefs.FS, rel, after, kind string) error {
 	switch kind {
 	case "delete":
-		return os.Remove(abs)
+		_, err := fsys.Remove(rel)
+		return err
 	default:
-		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-			return err
-		}
-		return os.WriteFile(abs, []byte(after), 0o644)
+		_, err := fsys.WriteFile(rel, []byte(after), 0o644)
+		return err
 	}
 }
 

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -1652,10 +1652,7 @@ func runGitReadCommand(ctx context.Context, root string, maxBytes int, args ...s
 	if cmdCtx.Err() == context.DeadlineExceeded {
 		return "", false, fmt.Errorf("git command timed out")
 	}
-	out := result.Stdout
-	if strings.TrimSpace(result.Stderr) != "" {
-		out += result.Stderr
-	}
+	out := combineGitReadOutput(result.Stdout, result.Stderr)
 	if err != nil {
 		text := strings.TrimSpace(out)
 		if text != "" {
@@ -1664,6 +1661,19 @@ func runGitReadCommand(ctx context.Context, root string, maxBytes int, args ...s
 		return "", false, err
 	}
 	return out, result.StdoutTruncated || result.StderrTruncated, nil
+}
+
+func combineGitReadOutput(stdout, stderr string) string {
+	if strings.TrimSpace(stderr) == "" {
+		return stdout
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return stderr
+	}
+	if strings.HasSuffix(stdout, "\n") {
+		return stdout + stderr
+	}
+	return stdout + "\n" + stderr
 }
 
 func readWorkspaceFileContent(fsys *workspacefs.FS, rel, displayPath string, fileSize int64, maxBytes, startLine, endLine int) (string, string, int, bool, string) {

--- a/internal/orchestrator/executor_agent_loop_test.go
+++ b/internal/orchestrator/executor_agent_loop_test.go
@@ -1115,6 +1115,47 @@ func TestRunGitReadCommandUsesSanitizedEnvironment(t *testing.T) {
 	}
 }
 
+func TestCombineGitReadOutputSeparatesStdoutAndStderr(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "stdout without trailing newline",
+			stdout: "stdout",
+			stderr: "stderr",
+			want:   "stdout\nstderr",
+		},
+		{
+			name:   "stdout with trailing newline",
+			stdout: "stdout\n",
+			stderr: "stderr",
+			want:   "stdout\nstderr",
+		},
+		{
+			name:   "stderr only",
+			stdout: "",
+			stderr: "stderr",
+			want:   "stderr",
+		},
+		{
+			name:   "blank stderr ignored",
+			stdout: "stdout",
+			stderr: " \n",
+			want:   "stdout",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := combineGitReadOutput(tc.stdout, tc.stderr); got != tc.want {
+				t.Fatalf("combineGitReadOutput() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAgentLoop_GitDiffToolDisablesTextconv(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/orchestrator/executor_agent_loop_test.go
+++ b/internal/orchestrator/executor_agent_loop_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/workspace"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -645,12 +646,55 @@ func TestAgentLoop_ReadFileRejectsTraversal(t *testing.T) {
 	secondReq := llm.lastReqs[1]
 	hasEscape := false
 	for _, m := range secondReq.Messages {
-		if m.Role == "tool" && strings.Contains(m.Content, "escapes the workspace root") {
+		if m.Role == "tool" && (strings.Contains(m.Content, "escapes the workspace root") || strings.Contains(m.Content, "unsafe relative workspace path")) {
 			hasEscape = true
 		}
 	}
 	if !hasEscape {
 		t.Errorf("traversal not rejected with workspace-escape error: %+v", secondReq.Messages)
+	}
+}
+
+func TestAgentLoop_ReadFileRejectsSymlinkComponent(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	llm := &scriptedLLM{
+		responses: []*types.ChatResponse{
+			makeChatResp(makeAssistantMsg("", types.ToolCall{
+				ID: "c1", Type: "function",
+				Function: types.ToolCallFunction{Name: "read_file", Arguments: `{"path":"linked/secret.txt"}`},
+			})),
+			makeChatResp(makeAssistantMsg("Denied.")),
+		},
+	}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 8, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	spec.Task.WorkingDirectory = dir
+	res, err := loop.Execute(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Status != "completed" {
+		t.Fatalf("Status = %q, want completed", res.Status)
+	}
+	var toolResult string
+	for _, m := range llm.lastReqs[1].Messages {
+		if m.Role == "tool" && m.ToolCallID == "c1" {
+			toolResult = m.Content
+		}
+	}
+	if !strings.Contains(toolResult, "symlink component") {
+		t.Fatalf("tool result = %q, want symlink rejection", toolResult)
+	}
+	if strings.Contains(toolResult, "secret") {
+		t.Fatalf("tool result leaked outside file content: %q", toolResult)
 	}
 }
 
@@ -2020,13 +2064,16 @@ func TestAgentLoop_ValidatePatchOperationPathRejectsEmptyPath(t *testing.T) {
 
 func TestAgentLoop_PreparePatchOperationRejectsLargeTargets(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "large.txt")
-	if err := os.WriteFile(path, []byte(strings.Repeat("x", fileEditHardCapBytes+1)), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "large.txt"), []byte(strings.Repeat("x", fileEditHardCapBytes+1)), 0o644); err != nil {
 		t.Fatal(err)
+	}
+	fsys, err := workspacefs.New(dir)
+	if err != nil {
+		t.Fatalf("New workspacefs: %v", err)
 	}
 	for _, kind := range []string{"delete", "update"} {
 		t.Run(kind, func(t *testing.T) {
-			_, _, _, errMsg := preparePatchOperation(path, patchOperation{
+			_, _, _, errMsg := preparePatchOperation(fsys, "large.txt", patchOperation{
 				Kind: kind,
 				Path: "large.txt",
 				Lines: []string{

--- a/internal/orchestrator/runner_io.go
+++ b/internal/orchestrator/runner_io.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
@@ -21,20 +21,21 @@ func (r *Runner) gitSummaryArtifact(ctx context.Context, task types.Task, run ty
 	}
 	gitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	if output, err := exec.CommandContext(gitCtx, "git", "-C", workspace, "rev-parse", "--is-inside-work-tree").CombinedOutput(); err != nil || strings.TrimSpace(string(output)) != "true" {
+	git := gitrunner.NewLocalRunner()
+	if !git.IsWorkTree(gitCtx, workspace) {
 		return types.TaskArtifact{}, false
 	}
-	statusOut, err := exec.CommandContext(gitCtx, "git", "-C", workspace, "status", "--porcelain=v1").CombinedOutput()
+	statusOut, err := git.Run(gitCtx, workspace, "status", "--porcelain=v1")
 	if err != nil {
 		return types.TaskArtifact{}, false
 	}
-	changes := parseGitPorcelainStatus(string(statusOut))
+	changes := parseGitPorcelainStatus(statusOut.Stdout)
 	if len(changes) == 0 {
 		return types.TaskArtifact{}, false
 	}
 	diffStat := ""
-	if diffStatOut, err := exec.CommandContext(gitCtx, "git", "-C", workspace, "diff", "--stat", "HEAD", "--").CombinedOutput(); err == nil {
-		diffStat = strings.TrimSpace(string(diffStatOut))
+	if diffStatOut, err := git.Run(gitCtx, workspace, "diff", "--stat", "HEAD", "--"); err == nil {
+		diffStat = strings.TrimSpace(diffStatOut.Stdout)
 	}
 	payload := gitSummaryArtifactPayload{
 		WorkspacePath: workspace,

--- a/internal/orchestrator/workspace.go
+++ b/internal/orchestrator/workspace.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/hecatehq/hecate/internal/gitrunner"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -107,8 +108,19 @@ func provisionGitWorkspace(ctx context.Context, sourcePath, workspacePath string
 	if err := ensureWorkspaceParent(workspacePath); err != nil {
 		return err
 	}
-	if output, err := exec.CommandContext(ctx, "git", "clone", "--quiet", "--no-hardlinks", "--", sourcePath, workspacePath).CombinedOutput(); err != nil {
-		return fmt.Errorf("clone workspace: %w: %s", err, string(output))
+	result, err := gitrunner.NewLocalRunner().Clone(ctx, sourcePath, workspacePath)
+	if err != nil {
+		output := strings.TrimSpace(result.Stdout)
+		if stderr := strings.TrimSpace(result.Stderr); stderr != "" {
+			if output != "" {
+				output += "\n"
+			}
+			output += stderr
+		}
+		if output != "" {
+			return fmt.Errorf("clone workspace: %w: %s", err, output)
+		}
+		return fmt.Errorf("clone workspace: %w", err)
 	}
 	return nil
 }
@@ -235,49 +247,11 @@ func workspacePathSegment(field, value string) (string, error) {
 }
 
 func safeJoinWithinRoot(root, relativePath string) (string, error) {
-	if !filepath.IsLocal(relativePath) {
-		return "", fmt.Errorf("unsafe relative workspace path %q", relativePath)
-	}
-	root = filepath.Clean(root)
-	target := filepath.Clean(filepath.Join(root, relativePath))
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return "", err
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("workspace path escapes root: %q", relativePath)
-	}
-	if err := rejectExistingSymlinkComponents(root, rel); err != nil {
-		return "", err
-	}
-	return target, nil
+	return workspacefs.SafeJoin(root, relativePath)
 }
 
 func rejectExistingSymlinkComponents(root, relativePath string) error {
-	rootDir, err := os.OpenRoot(root)
-	if err != nil {
-		return err
-	}
-	defer rootDir.Close()
-
-	current := "."
-	for _, segment := range strings.Split(relativePath, string(os.PathSeparator)) {
-		if segment == "" || segment == "." {
-			continue
-		}
-		current = filepath.Join(current, segment)
-		info, err := rootDir.Lstat(current)
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("workspace path uses symlink component %q", filepath.Join(root, current))
-		}
-	}
-	return nil
+	return workspacefs.RejectExistingSymlinkComponents(root, relativePath)
 }
 
 func copyFile(sourcePath, destinationPath string, mode fs.FileMode) error {

--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -1,0 +1,161 @@
+package processrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Request describes one local process invocation owned by Hecate.
+type Request struct {
+	Command        string
+	Args           []string
+	Dir            string
+	Env            []string
+	Timeout        time.Duration
+	MaxStdoutBytes int64
+	MaxStderrBytes int64
+}
+
+// Result is the captured result of a local process invocation.
+type Result struct {
+	Stdout          string
+	Stderr          string
+	ExitCode        int
+	StdoutTruncated bool
+	StderrTruncated bool
+}
+
+// Chunk is one streamed process-output chunk.
+type Chunk struct {
+	Stream string
+	Text   string
+}
+
+// Runner is the process seam for Hecate-owned subprocesses. Long-lived ACP
+// adapter sessions still manage their own lifecycle; this seam is for bounded,
+// command-style invocations such as git probes and workspace setup.
+type Runner interface {
+	Run(ctx context.Context, req Request) (Result, error)
+	RunStreaming(ctx context.Context, req Request, onChunk func(Chunk)) (Result, error)
+}
+
+type LocalRunner struct{}
+
+func NewLocalRunner() *LocalRunner {
+	return &LocalRunner{}
+}
+
+func (r *LocalRunner) Run(ctx context.Context, req Request) (Result, error) {
+	return r.RunStreaming(ctx, req, nil)
+}
+
+func (r *LocalRunner) RunStreaming(ctx context.Context, req Request, onChunk func(Chunk)) (Result, error) {
+	command := strings.TrimSpace(req.Command)
+	if command == "" {
+		return Result{ExitCode: -1}, fmt.Errorf("process command is required")
+	}
+	runCtx := ctx
+	var cancel context.CancelFunc
+	if req.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(runCtx, command, req.Args...)
+	if strings.TrimSpace(req.Dir) != "" {
+		cmd.Dir = req.Dir
+	}
+	if req.Env != nil {
+		cmd.Env = req.Env
+	}
+
+	var stdout limitedBuffer
+	var stderr limitedBuffer
+	stdout.limit = req.MaxStdoutBytes
+	stderr.limit = req.MaxStderrBytes
+	stdout.stream = "stdout"
+	stderr.stream = "stderr"
+	stdout.onChunk = onChunk
+	stderr.onChunk = onChunk
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := Result{
+		Stdout:          stdout.String(),
+		Stderr:          stderr.String(),
+		ExitCode:        0,
+		StdoutTruncated: stdout.Truncated(),
+		StderrTruncated: stderr.Truncated(),
+	}
+	if err == nil {
+		return result, nil
+	}
+	if errors.Is(runCtx.Err(), context.Canceled) {
+		result.ExitCode = -1
+		return result, context.Canceled
+	}
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result.ExitCode = -1
+		return result, runCtx.Err()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitCode()
+		return result, err
+	}
+	result.ExitCode = -1
+	return result, err
+}
+
+type limitedBuffer struct {
+	buf       strings.Builder
+	mu        sync.Mutex
+	limit     int64
+	truncated bool
+	stream    string
+	onChunk   func(Chunk)
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	text := string(p)
+	if b.onChunk != nil && text != "" {
+		b.onChunk(Chunk{Stream: b.stream, Text: text})
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limit <= 0 {
+		_, _ = b.buf.Write(p)
+		return len(p), nil
+	}
+	remaining := b.limit - int64(b.buf.Len())
+	if remaining <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if int64(len(p)) > remaining {
+		b.truncated = true
+		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *limitedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}

--- a/internal/processrunner/processrunner_test.go
+++ b/internal/processrunner/processrunner_test.go
@@ -1,0 +1,119 @@
+package processrunner
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLocalRunner_RunCapturesOutputAndExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture uses sh")
+	}
+	runner := NewLocalRunner()
+
+	result, err := runner.Run(context.Background(), Request{
+		Command: "sh",
+		Args:    []string{"-c", "printf stdout; printf stderr >&2; exit 7"},
+	})
+
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T, want *exec.ExitError", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7", result.ExitCode)
+	}
+	if result.Stdout != "stdout" {
+		t.Fatalf("Stdout = %q, want stdout", result.Stdout)
+	}
+	if result.Stderr != "stderr" {
+		t.Fatalf("Stderr = %q, want stderr", result.Stderr)
+	}
+}
+
+func TestLocalRunner_RunTruncatesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture uses sh")
+	}
+	runner := NewLocalRunner()
+
+	result, err := runner.Run(context.Background(), Request{
+		Command:        "sh",
+		Args:           []string{"-c", "printf abcdef; printf ghijkl >&2"},
+		MaxStdoutBytes: 3,
+		MaxStderrBytes: 2,
+	})
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Stdout != "abc" || !result.StdoutTruncated {
+		t.Fatalf("stdout = %q truncated=%v, want abc true", result.Stdout, result.StdoutTruncated)
+	}
+	if result.Stderr != "gh" || !result.StderrTruncated {
+		t.Fatalf("stderr = %q truncated=%v, want gh true", result.Stderr, result.StderrTruncated)
+	}
+}
+
+func TestLocalRunner_RunRejectsBlankCommand(t *testing.T) {
+	runner := NewLocalRunner()
+
+	_, err := runner.Run(context.Background(), Request{Command: "   "})
+
+	if err == nil || !strings.Contains(err.Error(), "command is required") {
+		t.Fatalf("error = %v, want command required", err)
+	}
+}
+
+func TestLocalRunner_RunStreamingEmitsOutputChunks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture uses sh")
+	}
+	runner := NewLocalRunner()
+
+	var mu sync.Mutex
+	var chunks []Chunk
+	result, err := runner.RunStreaming(context.Background(), Request{
+		Command: "sh",
+		Args:    []string{"-c", "printf stdout; printf stderr >&2"},
+	}, func(chunk Chunk) {
+		mu.Lock()
+		defer mu.Unlock()
+		chunks = append(chunks, chunk)
+	})
+
+	if err != nil {
+		t.Fatalf("RunStreaming: %v", err)
+	}
+	if result.Stdout != "stdout" {
+		t.Fatalf("Stdout = %q, want stdout", result.Stdout)
+	}
+	if result.Stderr != "stderr" {
+		t.Fatalf("Stderr = %q, want stderr", result.Stderr)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one streamed chunk")
+	}
+	var sawStdout, sawStderr bool
+	for _, chunk := range chunks {
+		switch chunk.Stream {
+		case "stdout":
+			sawStdout = sawStdout || strings.Contains(chunk.Text, "stdout")
+		case "stderr":
+			sawStderr = sawStderr || strings.Contains(chunk.Text, "stderr")
+		}
+	}
+	if !sawStdout || !sawStderr {
+		t.Fatalf("chunks = %+v, want stdout and stderr chunks", chunks)
+	}
+}

--- a/internal/sandbox/exec.go
+++ b/internal/sandbox/exec.go
@@ -1,8 +1,6 @@
 package sandbox
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,7 +12,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/hecatehq/hecate/internal/processrunner"
+	"github.com/hecatehq/hecate/internal/workspacefs"
 )
 
 // ResourceLimits caps resources consumed by the shell subprocess and the
@@ -25,7 +27,7 @@ import (
 // CPUQuota=, LimitNOFILE=, MemoryMax=, or container --cpus / --memory
 // flags). See docs/sandbox.md for the layer model.
 type ResourceLimits struct {
-	// MaxOutputBytes caps the combined stdout+stderr that drainProcessOutput
+	// MaxOutputBytes caps the combined stdout+stderr that outputCollector
 	// will buffer. When the cap is reached the command is cancelled and
 	// an OutputLimitExceededError is returned. 0 means no cap.
 	MaxOutputBytes int64
@@ -152,10 +154,12 @@ func IsPolicyDenied(err error) bool {
 	return errors.As(err, &policyErr)
 }
 
-type LocalExecutor struct{}
+type LocalExecutor struct {
+	processes processrunner.Runner
+}
 
 func NewLocalExecutor() *LocalExecutor {
-	return &LocalExecutor{}
+	return &LocalExecutor{processes: processrunner.NewLocalRunner()}
 }
 
 func (e *LocalExecutor) Run(ctx context.Context, command Command) (Result, error) {
@@ -177,7 +181,7 @@ func (e *LocalExecutor) RunStreaming(ctx context.Context, command Command, onChu
 		command.Limits.MaxOutputBytes = defaultLimits().MaxOutputBytes
 	}
 
-	// Always derive a cancel-able context so drainProcessOutput can kill
+	// Always derive a cancel-able context so the output collector can kill
 	// the child process when the output-size cap is hit.
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -187,74 +191,34 @@ func (e *LocalExecutor) RunStreaming(ctx context.Context, command Command, onChu
 		defer timeoutCancel()
 	}
 
-	cmd := commandExec(runCtx, command)
-	if workingDirectory != "" {
-		cmd.Dir = workingDirectory
-	}
-	// Sanitised environment — gateway secrets stay out of scope. See
-	// sanitisedEnv() for the allowlist and the reasoning.
-	cmd.Env = sanitisedEnv()
-
 	// Layer 2 — wrap the argv with bwrap (Linux) or sandbox-exec (macOS)
 	// when one is available. No-op on Windows / Linux without bwrap.
-	// Must run before cmd.Start().
-	applyWrapper(cmd, workingDirectory, command.Policy.Network)
+	argv := ShellArgv(command)
+	argv = wrappedArgv(argv, workingDirectory, command.Policy.Network)
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return Result{ExitCode: -1}, err
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return Result{ExitCode: -1}, err
-	}
-	if err := cmd.Start(); err != nil {
-		return Result{ExitCode: -1}, err
-	}
-
-	streamEvents := make(chan outputEvent, 8)
-	go streamPipe(stdoutPipe, "stdout", streamEvents)
-	go streamPipe(stderrPipe, "stderr", streamEvents)
-
-	// Watchdog: close the pipe read-ends whenever runCtx ends so that
-	// streamPipe goroutines unblock even when orphan grandchildren of sh
-	// keep the write-end open. This covers the context-timeout and
-	// external-cancel paths. cancelWithPipes (below) handles the same
-	// problem for the synchronous output-cap path — both may fire; the
-	// second Close() on each pipe is a harmless os.ErrClosed.
-	go func() {
-		<-runCtx.Done()
-		_ = stdoutPipe.Close()
-		_ = stderrPipe.Close()
-	}()
-
-	// cancelWithPipes kills the child process AND closes the pipe read-ends
-	// synchronously so drainProcessOutput can return immediately when the
-	// output-size cap is hit (without waiting for the watchdog to be
-	// scheduled). The watchdog above provides the same guarantee for the
-	// timeout / external-cancel paths.
-	cancelWithPipes := func() {
-		cancel()
-		_ = stdoutPipe.Close()
-		_ = stderrPipe.Close()
+	collector := newOutputCollector(command.Limits.MaxOutputBytes, cancel, onChunk)
+	processResult, err := e.processRunner().RunStreaming(runCtx, processrunner.Request{
+		Command:        argv[0],
+		Args:           argv[1:],
+		Dir:            workingDirectory,
+		MaxStdoutBytes: command.Limits.MaxOutputBytes,
+		MaxStderrBytes: command.Limits.MaxOutputBytes,
+		// Sanitised environment — gateway secrets stay out of scope. See
+		// sanitisedEnv() for the allowlist and the reasoning.
+		Env: sanitisedEnv(),
+	}, collector.handleProcessChunk)
+	if limitErr := collector.err(); limitErr != nil {
+		result := collector.result()
+		result.ExitCode = -1
+		return result, limitErr
 	}
 
-	// drainProcessOutput calls cancelWithPipes() if the output cap is
-	// exceeded so the drain loop always terminates cleanly.
-	readErr := drainProcessOutput(streamEvents, &stdout, &stderr, onChunk, command.Limits.MaxOutputBytes, cancelWithPipes)
-	if readErr != nil {
-		_ = cmd.Wait()
-		return Result{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: -1}, readErr
+	result := collector.result()
+	if result.Stdout == "" && result.Stderr == "" {
+		result.Stdout = processResult.Stdout
+		result.Stderr = processResult.Stderr
 	}
-
-	err = cmd.Wait()
-	result := Result{
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		ExitCode: 0,
-	}
+	result.ExitCode = processResult.ExitCode
 	if err == nil {
 		return result, nil
 	}
@@ -288,9 +252,11 @@ func ShellArgv(command Command) []string {
 	return argv
 }
 
-func commandExec(ctx context.Context, command Command) *exec.Cmd {
-	args := ShellArgv(command)
-	return exec.CommandContext(ctx, args[0], args[1:]...)
+func (e *LocalExecutor) processRunner() processrunner.Runner {
+	if e != nil && e.processes != nil {
+		return e.processes
+	}
+	return processrunner.NewLocalRunner()
 }
 
 func (e *LocalExecutor) WriteFile(_ context.Context, request FileRequest) (FileResult, error) {
@@ -308,6 +274,32 @@ func writeFile(request FileRequest, appendMode bool) (FileResult, error) {
 	targetPath, err := ResolvePath(request.WorkingDirectory, request.Path, request.Policy)
 	if err != nil {
 		return FileResult{}, err
+	}
+	if allowedRoot := strings.TrimSpace(request.Policy.AllowedRoot); allowedRoot != "" {
+		root, err := filepath.Abs(allowedRoot)
+		if err != nil {
+			return FileResult{}, err
+		}
+		rel, err := filepath.Rel(root, targetPath)
+		if err != nil {
+			return FileResult{}, err
+		}
+		fsys, err := workspacefs.New(root)
+		if err != nil {
+			return FileResult{}, err
+		}
+		if !appendMode {
+			path, err := fsys.WriteFile(rel, []byte(request.Content), 0o644)
+			if err != nil {
+				return FileResult{}, err
+			}
+			return FileResult{Path: path, BytesWritten: len(request.Content)}, nil
+		}
+		path, err := fsys.AppendFile(rel, []byte(request.Content), 0o644)
+		if err != nil {
+			return FileResult{}, err
+		}
+		return FileResult{Path: path, BytesWritten: len(request.Content)}, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		return FileResult{}, err
@@ -329,87 +321,77 @@ func writeFile(request FileRequest, appendMode bool) (FileResult, error) {
 	return FileResult{Path: targetPath, BytesWritten: len(request.Content)}, nil
 }
 
-type outputEvent struct {
-	chunk OutputChunk
-	err   error
-	done  bool
+type outputCollector struct {
+	mu       sync.Mutex
+	stdout   strings.Builder
+	stderr   strings.Builder
+	maxBytes int64
+	written  int64
+	limitErr error
+	cancel   context.CancelFunc
+	onChunk  func(OutputChunk)
 }
 
-func streamPipe(pipe io.ReadCloser, streamName string, events chan<- outputEvent) {
-	defer pipe.Close()
+func newOutputCollector(maxBytes int64, cancel context.CancelFunc, onChunk func(OutputChunk)) *outputCollector {
+	return &outputCollector{maxBytes: maxBytes, cancel: cancel, onChunk: onChunk}
+}
 
-	reader := bufio.NewReader(pipe)
-	buffer := make([]byte, 4096)
-	for {
-		n, err := reader.Read(buffer)
-		if n > 0 {
-			events <- outputEvent{
-				chunk: OutputChunk{Stream: streamName, Text: string(buffer[:n])},
-			}
-		}
-		if err == nil {
-			continue
-		}
-		if errors.Is(err, io.EOF) {
-			events <- outputEvent{done: true}
-			return
-		}
-		if errors.Is(err, os.ErrClosed) {
-			events <- outputEvent{done: true}
-			return
-		}
-		events <- outputEvent{done: true, err: err}
+func (c *outputCollector) handleProcessChunk(chunk processrunner.Chunk) {
+	text := chunk.Text
+	if text == "" {
 		return
 	}
-}
 
-// drainProcessOutput reads output events from the streaming goroutines until
-// both stdout and stderr report done. cancelCmd is called when the output cap
-// is exceeded — it cancels the exec.CommandContext that owns the child process,
-// causing the pipes to close and the drain loop to terminate without leaving
-// goroutines blocked.
-func drainProcessOutput(events <-chan outputEvent, stdout, stderr *bytes.Buffer, onChunk func(OutputChunk), maxBytes int64, cancelCmd context.CancelFunc) error {
-	var (
-		readErr          error
-		totalBytes       int64
-		completedStreams int
-	)
-	for completedStreams < 2 {
-		event := <-events
-		if event.done {
-			completedStreams++
-			if event.err != nil && readErr == nil {
-				readErr = event.err
+	cancel := false
+	c.mu.Lock()
+	if c.limitErr != nil {
+		c.mu.Unlock()
+		return
+	}
+	if c.maxBytes > 0 {
+		remaining := c.maxBytes - c.written
+		if remaining <= 0 {
+			c.limitErr = &OutputLimitExceededError{Limit: c.maxBytes}
+			cancel = true
+			c.mu.Unlock()
+			if cancel && c.cancel != nil {
+				c.cancel()
 			}
-			continue
+			return
 		}
-		// If we already have an error (e.g. output cap hit), keep draining
-		// events without accumulating them so the pipe goroutines can finish.
-		if readErr != nil {
-			continue
-		}
-
-		n := int64(len(event.chunk.Text))
-		if maxBytes > 0 {
-			totalBytes += n
-			if totalBytes > maxBytes {
-				readErr = &OutputLimitExceededError{Limit: maxBytes}
-				cancelCmd() // kill the child; pipes close → goroutines send done events
-				continue
-			}
-		}
-
-		switch event.chunk.Stream {
-		case "stdout":
-			stdout.WriteString(event.chunk.Text)
-		case "stderr":
-			stderr.WriteString(event.chunk.Text)
-		}
-		if onChunk != nil {
-			onChunk(event.chunk)
+		if int64(len(text)) > remaining {
+			text = text[:remaining]
+			c.limitErr = &OutputLimitExceededError{Limit: c.maxBytes}
+			cancel = true
 		}
 	}
-	return readErr
+	c.written += int64(len(text))
+	switch chunk.Stream {
+	case "stderr":
+		_, _ = c.stderr.WriteString(text)
+	default:
+		_, _ = c.stdout.WriteString(text)
+	}
+	c.mu.Unlock()
+
+	if c.onChunk != nil && text != "" {
+		c.onChunk(OutputChunk{Stream: chunk.Stream, Text: text})
+	}
+	if cancel && c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *outputCollector) result() Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return Result{Stdout: c.stdout.String(), Stderr: c.stderr.String()}
+}
+
+func (c *outputCollector) err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.limitErr
 }
 
 func ResolvePath(workingDirectory, targetPath string, policy Policy) (string, error) {
@@ -436,6 +418,25 @@ func ResolvePath(workingDirectory, targetPath string, policy Policy) (string, er
 		return "", err
 	}
 
+	allowedRoot := strings.TrimSpace(policy.AllowedRoot)
+	if allowedRoot == "" {
+		return resolvedPath, nil
+	}
+	root, err := filepath.Abs(allowedRoot)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, resolvedPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", &PolicyError{Reason: fmt.Sprintf("path %q escapes allowed root %q", resolvedPath, root)}
+	}
+	resolvedPath, err = workspacefs.SafeJoin(root, rel)
+	if err != nil {
+		return "", &PolicyError{Reason: err.Error()}
+	}
 	if err := ensureWithinAllowedRoot(resolvedPath, policy); err != nil {
 		return "", err
 	}
@@ -452,6 +453,24 @@ func resolveWorkingDirectory(workingDirectory string, policy Policy) (string, er
 	resolvedDirectory, err := filepath.Abs(workingDirectory)
 	if err != nil {
 		return "", err
+	}
+	allowedRoot := strings.TrimSpace(policy.AllowedRoot)
+	if allowedRoot != "" {
+		root, err := filepath.Abs(allowedRoot)
+		if err != nil {
+			return "", err
+		}
+		rel, err := filepath.Rel(root, resolvedDirectory)
+		if err != nil {
+			return "", err
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", &PolicyError{Reason: fmt.Sprintf("path %q escapes allowed root %q", resolvedDirectory, root)}
+		}
+		resolvedDirectory, err = workspacefs.SafeJoin(root, rel)
+		if err != nil {
+			return "", &PolicyError{Reason: err.Error()}
+		}
 	}
 	if err := ensureWithinAllowedRoot(resolvedDirectory, policy); err != nil {
 		return "", err

--- a/internal/sandbox/exec_test.go
+++ b/internal/sandbox/exec_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hecatehq/hecate/internal/processrunner"
 )
 
 func TestLocalExecutorSeparatesStdoutAndStderr(t *testing.T) {
@@ -63,6 +65,72 @@ func TestLocalExecutorUsesRTKWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestLocalExecutorStreamsThroughProcessRunner(t *testing.T) {
+	t.Parallel()
+	reset := SetWrapperForTesting(WrapperNone)
+	defer reset()
+
+	workspace := t.TempDir()
+	process := &recordingProcessRunner{
+		result: processrunner.Result{Stdout: "streamed", ExitCode: 0},
+		chunks: []processrunner.Chunk{{Stream: "stdout", Text: "streamed"}},
+	}
+	exec := &LocalExecutor{processes: process}
+
+	var chunks []OutputChunk
+	result, err := exec.RunStreaming(context.Background(), Command{
+		Command:          `printf streamed`,
+		WorkingDirectory: workspace,
+		Timeout:          time.Second,
+		Limits:           ResourceLimits{MaxOutputBytes: 10},
+	}, func(chunk OutputChunk) {
+		chunks = append(chunks, chunk)
+	})
+
+	if err != nil {
+		t.Fatalf("RunStreaming() error = %v", err)
+	}
+	if result.Stdout != "streamed" {
+		t.Fatalf("stdout = %q, want streamed", result.Stdout)
+	}
+	if process.req.Command != "sh" {
+		t.Fatalf("process command = %q, want sh", process.req.Command)
+	}
+	if got := strings.Join(process.req.Args, "\x00"); got != "-lc\x00printf streamed" {
+		t.Fatalf("process args = %q, want shell argv", got)
+	}
+	if process.req.Dir != workspace {
+		t.Fatalf("process dir = %q, want %q", process.req.Dir, workspace)
+	}
+	if process.req.MaxStdoutBytes != 10 || process.req.MaxStderrBytes != 10 {
+		t.Fatalf("process caps = stdout %d stderr %d, want 10/10", process.req.MaxStdoutBytes, process.req.MaxStderrBytes)
+	}
+	if len(chunks) != 1 || chunks[0].Text != "streamed" {
+		t.Fatalf("chunks = %+v, want streamed chunk", chunks)
+	}
+}
+
+func TestLocalExecutorOutputLimitCancelsThroughProcessRunner(t *testing.T) {
+	t.Parallel()
+
+	exec := NewLocalExecutor()
+	result, err := exec.Run(context.Background(), Command{
+		Command: `printf abcdef`,
+		Timeout: time.Second,
+		Limits:  ResourceLimits{MaxOutputBytes: 3},
+	})
+
+	if !IsOutputLimitExceeded(err) {
+		t.Fatalf("Run() error = %v, want output limit exceeded", err)
+	}
+	if result.Stdout != "abc" {
+		t.Fatalf("stdout = %q, want capped abc", result.Stdout)
+	}
+	if result.ExitCode != -1 {
+		t.Fatalf("exit_code = %d, want -1", result.ExitCode)
+	}
+}
+
 func TestShellArgvUsesRTKOnlyWhenEnabled(t *testing.T) {
 	got := strings.Join(ShellArgv(Command{Command: "go test ./...", RTKEnabled: true}), "\x00")
 	want := strings.Join([]string{"rtk", "sh", "-lc", "go test ./..."}, "\x00")
@@ -74,6 +142,26 @@ func TestShellArgvUsesRTKOnlyWhenEnabled(t *testing.T) {
 	if got != want {
 		t.Fatalf("plain argv = %q, want %q", got, want)
 	}
+}
+
+type recordingProcessRunner struct {
+	req    processrunner.Request
+	result processrunner.Result
+	chunks []processrunner.Chunk
+}
+
+func (r *recordingProcessRunner) Run(ctx context.Context, req processrunner.Request) (processrunner.Result, error) {
+	return r.RunStreaming(ctx, req, nil)
+}
+
+func (r *recordingProcessRunner) RunStreaming(_ context.Context, req processrunner.Request, onChunk func(processrunner.Chunk)) (processrunner.Result, error) {
+	r.req = req
+	for _, chunk := range r.chunks {
+		if onChunk != nil {
+			onChunk(chunk)
+		}
+	}
+	return r.result, nil
 }
 
 func TestRTKAvailableReportsPathPresence(t *testing.T) {
@@ -383,5 +471,53 @@ func TestLocalExecutorWritesFile(t *testing.T) {
 	}
 	if result.Path == "" {
 		t.Fatal("result path is empty")
+	}
+}
+
+func TestLocalExecutorWriteFileRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	exec := NewLocalExecutor()
+	_, err := exec.WriteFile(context.Background(), FileRequest{
+		WorkingDirectory: root,
+		Path:             "linked/escape.txt",
+		Content:          "nope",
+		Policy:           Policy{AllowedRoot: root},
+	})
+	if !IsPolicyDenied(err) {
+		t.Fatalf("WriteFile() error = %v, want policy denial", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "escape.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestLocalExecutorAppendFileRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	exec := NewLocalExecutor()
+	_, err := exec.AppendFile(context.Background(), FileRequest{
+		WorkingDirectory: root,
+		Path:             "linked/escape.txt",
+		Content:          "nope",
+		Policy:           Policy{AllowedRoot: root},
+	})
+	if !IsPolicyDenied(err) {
+		t.Fatalf("AppendFile() error = %v, want policy denial", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "escape.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat error = %v, want not exist", statErr)
 	}
 }

--- a/internal/sandbox/wrapper.go
+++ b/internal/sandbox/wrapper.go
@@ -166,17 +166,50 @@ func probeWrapper(ctx context.Context) (WrapperKind, string) {
 // network alone and lets the policy validation upstream decide which
 // hosts the command can reach (best-effort, string-match).
 func applyWrapper(cmd *exec.Cmd, workspace string, network bool) {
+	argv := wrappedArgv(cmd.Args, workspace, network)
+	if len(argv) == 0 {
+		return
+	}
+	if equalStringSlices(argv, cmd.Args) {
+		return
+	}
+	cmd.Path = argv[0]
+	cmd.Args = argv
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func wrappedArgv(argv []string, workspace string, network bool) []string {
 	switch DetectWrapper(context.Background()) {
 	case WrapperBwrap:
-		applyBwrap(cmd, workspace, network)
+		return bwrapArgv(argv, workspace, network)
 	case WrapperSandboxExec:
-		applySandboxExec(cmd, network)
+		return sandboxExecArgv(argv, network)
 	default:
-		// WrapperNone — leave cmd unchanged.
+		return argv
 	}
 }
 
 func applyBwrap(cmd *exec.Cmd, workspace string, network bool) {
+	argv := bwrapArgv(cmd.Args, workspace, network)
+	if len(argv) == 0 {
+		return
+	}
+	cmd.Path = argv[0]
+	cmd.Args = argv
+}
+
+func bwrapArgv(argv []string, workspace string, network bool) []string {
 	args := []string{
 		"--ro-bind", "/", "/",
 		// Procfs and devfs need explicit mounts; bwrap does NOT bind
@@ -200,13 +233,25 @@ func applyBwrap(cmd *exec.Cmd, workspace string, network bool) {
 		args = append(args, "--unshare-net")
 	}
 	// Append the original argv (sh -lc <command>).
-	args = append(args, cmd.Args...)
+	args = append(args, argv...)
 
-	cmd.Path = WrapperPath()
-	cmd.Args = args
+	path := WrapperPath()
+	if path == "" {
+		path = bwrapPath
+	}
+	return append([]string{path}, args...)
 }
 
 func applySandboxExec(cmd *exec.Cmd, network bool) {
+	argv := sandboxExecArgv(cmd.Args, network)
+	if len(argv) == 0 {
+		return
+	}
+	cmd.Path = argv[0]
+	cmd.Args = argv
+}
+
+func sandboxExecArgv(argv []string, network bool) []string {
 	// v1: network-only profile. File-write confinement to the workspace
 	// is roadmap work — Seatbelt SBPL needs careful tuning to allow
 	// macOS frameworks (Mach IPC, sysctl reads, /private/var/folders
@@ -216,12 +261,10 @@ func applySandboxExec(cmd *exec.Cmd, network bool) {
 		// so the LLM-supplied policy + host allowlist stay the only check.
 		// (We don't emit a no-op profile because that adds a fork+exec
 		// cost for nothing.)
-		return
+		return argv
 	}
 	const profile = `(version 1)(deny network*)(allow default)`
-	args := append([]string{sandboxExecBinary, "-p", profile}, cmd.Args...)
-	cmd.Path = sandboxExecBinary
-	cmd.Args = args
+	return append([]string{sandboxExecBinary, "-p", profile}, argv...)
 }
 
 // WrapperHealthInfo is the shape served on /healthz under

--- a/internal/workspacefs/workspacefs.go
+++ b/internal/workspacefs/workspacefs.go
@@ -1,0 +1,333 @@
+package workspacefs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FS is the canonical path resolver for Hecate-controlled workspace file
+// operations. It rejects traversal and existing symlink components so callers
+// do not each need to reimplement workspace-boundary checks.
+type FS struct {
+	root string
+}
+
+type DirEntry struct {
+	Name  string
+	Type  fs.FileMode
+	IsDir bool
+	Size  int64
+}
+
+func New(root string) (*FS, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("workspace root is required")
+	}
+	root = filepath.Clean(root)
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return &FS{root: root}, nil
+}
+
+func (fsys *FS) Root() string {
+	if fsys == nil {
+		return ""
+	}
+	return fsys.root
+}
+
+func (fsys *FS) Resolve(relativePath string) (string, error) {
+	if fsys == nil {
+		return "", fmt.Errorf("workspace filesystem is not configured")
+	}
+	return SafeJoin(fsys.root, relativePath)
+}
+
+func (fsys *FS) ReadFile(relativePath string) ([]byte, string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return nil, "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rootDir.Close()
+	data, err := rootDir.ReadFile(rel)
+	return data, path, err
+}
+
+func (fsys *FS) Stat(relativePath string) (fs.FileInfo, string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return nil, "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rootDir.Close()
+	info, err := rootDir.Stat(rel)
+	return info, path, err
+}
+
+func (fsys *FS) Open(relativePath string) (*os.File, string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return nil, "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rootDir.Close()
+	file, err := rootDir.Open(rel)
+	return file, path, err
+}
+
+func (fsys *FS) ReadDir(relativePath string) ([]DirEntry, string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return nil, "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rootDir.Close()
+	entries, err := readDirFromRoot(rootDir, rel)
+	if err != nil {
+		return nil, "", err
+	}
+	result := make([]DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, dirEntryFromDirEntry(entry))
+	}
+	return result, path, nil
+}
+
+func (fsys *FS) WriteFile(relativePath string, data []byte, mode fs.FileMode) (string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return "", err
+	}
+	defer rootDir.Close()
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := rootDir.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+	if err := rootDir.WriteFile(rel, data, mode); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (fsys *FS) AppendFile(relativePath string, data []byte, mode fs.FileMode) (string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return "", err
+	}
+	defer rootDir.Close()
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := rootDir.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+	handle, err := rootDir.OpenFile(rel, os.O_CREATE|os.O_WRONLY|os.O_APPEND, mode)
+	if err != nil {
+		return "", err
+	}
+	defer handle.Close()
+	_, err = handle.Write(data)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (fsys *FS) Remove(relativePath string) (string, error) {
+	path, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return "", err
+	}
+	rootDir, rel, err := fsys.openRootRelative(path)
+	if err != nil {
+		return "", err
+	}
+	defer rootDir.Close()
+	if err := rootDir.Remove(rel); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (fsys *FS) WalkDir(relativePath string, visit func(absPath, relPath string, entry DirEntry) error) error {
+	if visit == nil {
+		return nil
+	}
+	startPath, err := fsys.Resolve(relativePath)
+	if err != nil {
+		return err
+	}
+	rootDir, startRel, err := fsys.openRootRelative(startPath)
+	if err != nil {
+		return err
+	}
+	defer rootDir.Close()
+	return fsys.walkRootDir(rootDir, startRel, visit)
+}
+
+// SafeJoin resolves relativePath beneath root and rejects path traversal and
+// existing symlink components. It intentionally does not require the final path
+// to exist so callers can use it for both reads and writes.
+func SafeJoin(root, relativePath string) (string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", fmt.Errorf("workspace root is required")
+	}
+	if !filepath.IsLocal(relativePath) {
+		return "", fmt.Errorf("unsafe relative workspace path %q", relativePath)
+	}
+	root = filepath.Clean(root)
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	target := filepath.Clean(filepath.Join(root, relativePath))
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("workspace path escapes root: %q", relativePath)
+	}
+	if err := RejectExistingSymlinkComponents(root, rel); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func dirEntryFromDirEntry(entry fs.DirEntry) DirEntry {
+	result := DirEntry{Name: entry.Name(), Type: entry.Type(), IsDir: entry.IsDir()}
+	if info, err := entry.Info(); err == nil {
+		result.Size = info.Size()
+		result.Type = info.Mode().Type()
+		result.IsDir = info.IsDir()
+	}
+	return result
+}
+
+func dirEntryFromFileInfo(name string, info fs.FileInfo) DirEntry {
+	return DirEntry{Name: name, Type: info.Mode().Type(), IsDir: info.IsDir(), Size: info.Size()}
+}
+
+func RejectExistingSymlinkComponents(root, relativePath string) error {
+	rootDir, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer rootDir.Close()
+
+	current := "."
+	for _, segment := range strings.Split(relativePath, string(os.PathSeparator)) {
+		if segment == "" || segment == "." {
+			continue
+		}
+		current = filepath.Join(current, segment)
+		info, err := rootDir.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("workspace path uses symlink component %q", filepath.Join(root, current))
+		}
+	}
+	return nil
+}
+
+func readDirFromRoot(rootDir *os.Root, rel string) ([]fs.DirEntry, error) {
+	dir, err := rootDir.Open(rel)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	return dir.ReadDir(-1)
+}
+
+func (fsys *FS) walkRootDir(rootDir *os.Root, rel string, visit func(absPath, relPath string, entry DirEntry) error) error {
+	info, err := rootDir.Stat(rel)
+	if err != nil {
+		return err
+	}
+	name := filepath.Base(rel)
+	if rel == "." {
+		name = "."
+	}
+	entry := dirEntryFromFileInfo(name, info)
+	absPath := filepath.Join(fsys.root, rel)
+	if rel == "." {
+		absPath = fsys.root
+	}
+	if err := visit(absPath, rel, entry); err != nil {
+		if err == filepath.SkipDir && entry.IsDir {
+			return nil
+		}
+		return err
+	}
+	if !entry.IsDir {
+		return nil
+	}
+	entries, err := readDirFromRoot(rootDir, rel)
+	if err != nil {
+		return err
+	}
+	for _, child := range entries {
+		childRel := filepath.Join(rel, child.Name())
+		childEntry := dirEntryFromDirEntry(child)
+		if childEntry.IsDir {
+			err = fsys.walkRootDir(rootDir, childRel, visit)
+		} else {
+			err = visit(filepath.Join(fsys.root, childRel), childRel, childEntry)
+		}
+		switch {
+		case err == nil:
+			continue
+		case err == filepath.SkipDir:
+			continue
+		case err == filepath.SkipAll:
+			return err
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func (fsys *FS) openRootRelative(path string) (*os.Root, string, error) {
+	rootDir, err := os.OpenRoot(fsys.root)
+	if err != nil {
+		return nil, "", err
+	}
+	rel, err := filepath.Rel(fsys.root, path)
+	if err != nil {
+		rootDir.Close()
+		return nil, "", err
+	}
+	return rootDir, rel, nil
+}

--- a/internal/workspacefs/workspacefs.go
+++ b/internal/workspacefs/workspacefs.go
@@ -224,8 +224,6 @@ func dirEntryFromDirEntry(entry fs.DirEntry) DirEntry {
 	result := DirEntry{Name: entry.Name(), Type: entry.Type(), IsDir: entry.IsDir()}
 	if info, err := entry.Info(); err == nil {
 		result.Size = info.Size()
-		result.Type = info.Mode().Type()
-		result.IsDir = info.IsDir()
 	}
 	return result
 }

--- a/internal/workspacefs/workspacefs_test.go
+++ b/internal/workspacefs/workspacefs_test.go
@@ -178,6 +178,36 @@ func TestReadDirRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestReadDirReportsSymlinkWithoutFollowing(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	entries, _, err := fsys.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name != "linked" {
+			continue
+		}
+		if entry.Type&os.ModeSymlink == 0 {
+			t.Fatalf("linked type = %v, want symlink bit", entry.Type)
+		}
+		if entry.IsDir {
+			t.Fatal("linked IsDir = true, want false for symlink entry")
+		}
+		return
+	}
+	t.Fatal("linked entry not found")
+}
+
 func TestWalkDirRejectsSymlinkEscape(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()
@@ -195,6 +225,44 @@ func TestWalkDirRejectsSymlinkEscape(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected walk through symlink component to be rejected")
+	}
+}
+
+func TestWalkDirDoesNotRecurseIntoSymlinkDirectory(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var got []string
+	err = fsys.WalkDir(".", func(_ string, rel string, entry DirEntry) error {
+		got = append(got, filepath.ToSlash(rel))
+		if rel == "linked" {
+			if entry.Type&os.ModeSymlink == 0 {
+				t.Fatalf("linked type = %v, want symlink bit", entry.Type)
+			}
+			if entry.IsDir {
+				t.Fatal("linked IsDir = true, want false for symlink entry")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if !containsString(got, "linked") {
+		t.Fatalf("walked paths = %#v, want linked", got)
+	}
+	if containsString(got, "linked/secret.txt") {
+		t.Fatalf("walked symlink target file: %#v", got)
 	}
 }
 
@@ -224,4 +292,13 @@ func TestWalkDirVisitsWorkspaceRelativePaths(t *testing.T) {
 	if want := []string{"a/b/file.txt"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("walked files = %#v, want %#v", got, want)
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workspacefs/workspacefs_test.go
+++ b/internal/workspacefs/workspacefs_test.go
@@ -1,0 +1,227 @@
+package workspacefs
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSafeJoinRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	cases := []string{
+		"../outside",
+		filepath.Join("..", "outside"),
+		filepath.Clean(filepath.Join("nested", "..", "..", "outside")),
+	}
+	for _, relativePath := range cases {
+		t.Run(relativePath, func(t *testing.T) {
+			if _, err := SafeJoin(root, relativePath); err == nil {
+				t.Fatal("expected escaping path to be rejected")
+			}
+		})
+	}
+}
+
+func TestSafeJoinRejectsExistingSymlinkComponents(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if _, err := SafeJoin(root, filepath.Join("linked", "file.txt")); err == nil {
+		t.Fatal("expected symlink component to be rejected")
+	}
+}
+
+func TestSafeJoinAllowsNestedLocalPaths(t *testing.T) {
+	root := t.TempDir()
+	got, err := SafeJoin(root, filepath.Join("nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("SafeJoin: %v", err)
+	}
+	want := filepath.Join(root, "nested", "file.txt")
+	if got != want {
+		t.Errorf("joined path = %q, want %q", got, want)
+	}
+}
+
+func TestWriteFileRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = fsys.WriteFile(filepath.Join("linked", "owned.txt"), []byte("owned"), 0o644)
+	if err == nil {
+		t.Fatal("expected write through symlink component to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("error = %q, want symlink component", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "owned.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestAppendFileRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = fsys.AppendFile(filepath.Join("linked", "owned.txt"), []byte("owned"), 0o644)
+	if err == nil {
+		t.Fatal("expected append through symlink component to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "owned.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestOpenStatAndRemoveRejectSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, _, err := fsys.Open(filepath.Join("linked", "secret.txt")); err == nil {
+		t.Fatal("expected open through symlink component to be rejected")
+	}
+	if _, _, err := fsys.Stat(filepath.Join("linked", "secret.txt")); err == nil {
+		t.Fatal("expected stat through symlink component to be rejected")
+	}
+	if _, err := fsys.Remove(filepath.Join("linked", "secret.txt")); err == nil {
+		t.Fatal("expected remove through symlink component to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "secret.txt")); statErr != nil {
+		t.Fatalf("outside file stat error = %v, want preserved", statErr)
+	}
+}
+
+func TestOpenStatAndRemoveUseWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	info, abs, err := fsys.Stat("note.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() != int64(len("hello")) {
+		t.Fatalf("size = %d, want %d", info.Size(), len("hello"))
+	}
+	if abs != filepath.Join(root, "note.txt") {
+		t.Fatalf("abs = %q", abs)
+	}
+
+	file, _, err := fsys.Open("note.txt")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer file.Close()
+	buf := make([]byte, 5)
+	n, err := file.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "hello" {
+		t.Fatalf("read = %q, want hello", got)
+	}
+
+	if _, err := fsys.Remove("note.txt"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "note.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stat after remove = %v, want not exist", err)
+	}
+}
+
+func TestReadDirRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, _, err := fsys.ReadDir("linked"); err == nil {
+		t.Fatal("expected read dir through symlink component to be rejected")
+	}
+}
+
+func TestWalkDirRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	err = fsys.WalkDir("linked", func(string, string, DirEntry) error {
+		t.Fatal("visit should not be called")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected walk through symlink component to be rejected")
+	}
+}
+
+func TestWalkDirVisitsWorkspaceRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "b", "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	fsys, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var got []string
+	err = fsys.WalkDir("a", func(_ string, rel string, entry DirEntry) error {
+		if !entry.IsDir {
+			got = append(got, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if want := []string{"a/b/file.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("walked files = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add WorkspaceFS as the shared workspace-bound filesystem layer for Hecate-controlled reads, writes, patch targets, and ACP terminal file callbacks.
- Add ProcessRunner and GitRunner seams so sandbox execution and internal git operations go through bounded, testable runners instead of ad hoc process calls.
- Route agent loop tools, sandbox writes, chat/task patch helpers, changed-file revert, and adapter diff capture through the new runtime seams.
- Document the WorkspaceFS/GitRunner security posture in `docs/security.md`.

## Validation

- `rtk go test -race -timeout 10m ./...`
- `rtk go vet ./...`
- `rtk just docs-format-check`

## Notes

This is intentionally runtime/security infrastructure work. It does not change the operator-facing chat flow, but it makes file/process/git boundaries explicit and easier to audit.
