### PR TITLE
Add nightly maintenance report

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,65 @@
+name: Nightly Maintenance
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  maintenance:
+    name: Maintenance report
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ui/package.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache maintenance binaries
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/just
+            ~/.cargo/bin/lychee
+          key: maintenance-tools-${{ runner.os }}-just-1.50.0-lychee-0.24.2
+
+      - name: Install maintenance tools
+        run: |
+          command -v just >/dev/null 2>&1 || cargo install just --locked --version 1.50.0
+          command -v lychee >/dev/null 2>&1 || cargo install lychee --locked --version 0.24.2
+
+      - name: Install UI dependencies
+        run: bun install --frozen-lockfile
+        working-directory: ui
+
+      - name: Install website dependencies
+        run: bun install --frozen-lockfile
+        working-directory: website
+
+      - name: Run nightly maintenance
+        run: just maintenance-nightly
+
+      - name: Upload maintenance report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: maintenance-report
+          path: .maintenance/
+          retention-days: 14
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # generated bootstrap/control-plane key and sqlite databases, so it must stay
 # local. The Go cache dirs are opt-in repo-local caches used by local scripts.
 .data/
+.maintenance/
 .gocache/
 .gomodcache/
 .gopath/

--- a/docs-ai/skills/maintenance/SKILL.md
+++ b/docs-ai/skills/maintenance/SKILL.md
@@ -17,6 +17,7 @@ when the task is maintenance-shaped rather than feature-shaped.
 - Reviewing dependency drift across Go, UI, website, Tauri/Rust, Docker, or
   GitHub Actions.
 - Keeping CI/local verification recipes aligned.
+- Updating scheduled nightly maintenance checks and report behavior.
 
 ## Read first
 
@@ -37,6 +38,10 @@ when the task is maintenance-shaped rather than feature-shaped.
    broader upkeep.
 6. Summarize what was checked, what was intentionally skipped, and which
    cleanup candidates still need operator judgment.
+
+For nightly workflow changes, run `just maintenance-nightly` when feasible. If
+that is too expensive for the turn, run `just maintenance` plus the narrow
+script/workflow checks and say exactly what was skipped.
 
 ## Guardrails
 

--- a/docs-ai/tasks/maintenance.md
+++ b/docs-ai/tasks/maintenance.md
@@ -46,6 +46,20 @@ Use this before merging broad runtime changes, release prep, or anything that
 touches startup, config loading, Docker, UI e2e journeys, task execution, or
 the embedded runtime binary.
 
+### Nightly scheduled gate
+
+The GitHub Actions nightly maintenance workflow runs:
+
+```bash
+just maintenance-nightly
+```
+
+It writes `.maintenance/maintenance-report.md`, appends the same report to the
+GitHub Actions job summary, and uploads the whole `.maintenance/` directory as
+a short-lived artifact. Deterministic checks (`just maintenance` and
+`just test-race`) fail the workflow. External link rot is informational and is
+captured in the report without turning the run red.
+
 ## Branch and worktree hygiene
 
 Use `just branches-report` before pruning. Treat its output as a report, not an

--- a/just/maintenance.just
+++ b/just/maintenance.just
@@ -3,6 +3,10 @@
 # Run the cheap recurring maintenance gate.
 maintenance: docs-check go-format-check ui-format-check website-format-check vet test ui-lint website-lint ui-test
 
+# Run the nightly maintenance report locally.
+maintenance-nightly:
+	bun scripts/nightly-maintenance.ts
+
 # Report local branch and worktree cleanup candidates.
 branches-report:
 	git fetch origin --prune

--- a/scripts/nightly-maintenance.ts
+++ b/scripts/nightly-maintenance.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+// nightly-maintenance.ts - run scheduled maintenance checks and write a report.
+//
+// Hard checks fail the workflow. Informational checks are captured in the
+// report without changing the exit code.
+
+import { appendFileSync, mkdirSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { spawnSync } from "child_process";
+
+type CheckKind = "hard" | "informational";
+
+type Check = {
+  name: string;
+  command: string[];
+  kind: CheckKind;
+  logFile: string;
+};
+
+type CheckResult = Check & {
+  status: "pass" | "fail";
+  exitCode: number | null;
+};
+
+const root = resolve(import.meta.dir, "..");
+const outDir = resolve(root, ".maintenance");
+mkdirSync(outDir, { recursive: true });
+
+const checks: Check[] = [
+  {
+    name: "just maintenance",
+    command: ["just", "maintenance"],
+    kind: "hard",
+    logFile: "maintenance.log",
+  },
+  {
+    name: "just test-race",
+    command: ["just", "test-race"],
+    kind: "hard",
+    logFile: "test-race.log",
+  },
+  {
+    name: "just check-links-external",
+    command: ["just", "check-links-external"],
+    kind: "informational",
+    logFile: "external-links.log",
+  },
+];
+
+function runCheck(check: Check): CheckResult {
+  const startedAt = new Date().toISOString();
+  console.log(`running ${check.kind} check: ${check.name}`);
+  const result = spawnSync(check.command[0], check.command.slice(1), {
+    cwd: root,
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const finishedAt = new Date().toISOString();
+  const exitCode = result.status;
+  const status = exitCode === 0 && !result.error ? "pass" : "fail";
+  const logPath = resolve(outDir, check.logFile);
+
+  writeFileSync(
+    logPath,
+    [
+      `$ ${check.command.join(" ")}`,
+      `started_at=${startedAt}`,
+      `finished_at=${finishedAt}`,
+      `exit_code=${exitCode ?? "signal"}`,
+      result.error ? `error=${result.error.message}` : "",
+      "",
+      "## stdout",
+      result.stdout || "",
+      "",
+      "## stderr",
+      result.stderr || "",
+    ].join("\n"),
+  );
+
+  console.log(`${status}: ${check.name} -> ${check.logFile}`);
+  return { ...check, status, exitCode };
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function reportFor(results: CheckResult[]): string {
+  const hard = results.filter((r) => r.kind === "hard");
+  const informational = results.filter((r) => r.kind === "informational");
+  const failed = results.filter((r) => r.status === "fail");
+  const commit = process.env.GITHUB_SHA ?? runGit(["rev-parse", "HEAD"]);
+  const branch = process.env.GITHUB_REF_NAME ?? runGit(["branch", "--show-current"]);
+  const runURL =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : "";
+
+  const lines: string[] = [
+    "# Nightly Maintenance Report",
+    "",
+    `- Date: ${new Date().toISOString()}`,
+    `- Branch: ${branch || "unknown"}`,
+    `- Commit: ${commit || "unknown"}`,
+  ];
+  if (runURL) {
+    lines.push(`- Run: ${runURL}`);
+  }
+
+  lines.push("", "## Hard Checks", "", "| Check | Result | Log |", "| --- | --- | --- |");
+  for (const result of hard) {
+    lines.push(`| ${escapeCell(result.name)} | ${result.status} | ${escapeCell(result.logFile)} |`);
+  }
+
+  lines.push("", "## Informational Checks", "", "| Check | Result | Log |", "| --- | --- | --- |");
+  for (const result of informational) {
+    lines.push(`| ${escapeCell(result.name)} | ${result.status} | ${escapeCell(result.logFile)} |`);
+  }
+
+  lines.push("", "## Notes", "");
+  if (failed.length === 0) {
+    lines.push("- No failing checks.");
+  } else {
+    for (const result of failed) {
+      lines.push(`- ${result.name} failed; see ${result.logFile}.`);
+    }
+  }
+
+  lines.push("", "Artifacts include the Markdown report plus one log file per check.", "");
+
+  return lines.join("\n");
+}
+
+function runGit(args: string[]): string {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+const results = checks.map(runCheck);
+const report = reportFor(results);
+const reportPath = resolve(outDir, "maintenance-report.md");
+writeFileSync(reportPath, report + "\n");
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+  appendFileSync(summaryPath, report + "\n");
+}
+
+const missingSections = ["## Hard Checks", "## Informational Checks"].filter(
+  (section) => !report.includes(section),
+);
+if (missingSections.length > 0) {
+  console.error(`maintenance report missing sections: ${missingSections.join(", ")}`);
+  process.exit(1);
+}
+
+const hardFailed = results.some((result) => result.kind === "hard" && result.status === "fail");
+process.exit(hardFailed ? 1 : 0);


### PR DESCRIPTION
## Summary

- add a scheduled nightly maintenance workflow plus manual dispatch
- add `scripts/nightly-maintenance.ts` to run hard checks, soft external link checks, and write a Markdown report
- append the report to the GitHub Actions job summary and upload `.maintenance/` as a short-lived artifact
- add `just maintenance-nightly` as the local entrypoint and document the nightly behavior

## Validation

- `just docs-check`
- `just maintenance-nightly`
- `./ui/node_modules/.bin/oxfmt --check scripts/nightly-maintenance.ts`
- `just --dry-run maintenance-nightly`