### PR TITLE
Run Just recipes from repo root

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,5 @@
 set shell := ["sh", "-cu"]
+set working-directory := "."
 
 # ─── Project-wide variables ─────────────────────────────────────────────────
 gocache := ".gocache"


### PR DESCRIPTION
## Summary
- set Just's working directory to the Justfile directory
- make recipes run from the repo root even when invoked from another cwd or through `-f`
- prevent `go test ./...` from matching no packages when `just test` runs outside the repo

## Validation
- `just --dry-run test`
- `just test`
- `cd "$(mktemp -d)" && just -f /Users/chicoxyzzy/dev/hecate-maintainance/Justfile --dry-run test && just -f /Users/chicoxyzzy/dev/hecate-maintainance/Justfile test`
- `just docs-check`