### PR TITLE
Refresh provider discovery cache on demand

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -519,6 +519,11 @@ Runtime provider readiness snapshot. The UI uses this endpoint to explain
 whether a configured provider can receive traffic right now and why it may be
 skipped by routing.
 
+Pass `refresh=true` or `refresh=1` when the operator explicitly asks to
+refresh provider discovery. Normal reads keep using the provider capability
+cache; explicit refresh bypasses the completed cache while still sharing any
+same-provider discovery request already in flight.
+
 ```json
 GET /hecate/v1/providers/status
 → 200
@@ -655,6 +660,10 @@ operator adds a provider.
 Lists models currently known to configured providers. Each row includes Hecate
 metadata under `metadata`, including the effective model capability snapshot
 used by the Chats target picker.
+
+Pass `refresh=true` or `refresh=1` for an explicit operator refresh. Without
+that query parameter, the endpoint keeps normal provider discovery cache
+behavior.
 
 ```json
 GET /v1/models

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -550,6 +550,7 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func requestRefresh(r *http.Request) bool {
+	// Accept explicit booleans only so accidental ?refresh does not bypass cache.
 	raw := strings.TrimSpace(r.URL.Query().Get("refresh"))
 	return raw == "1" || strings.EqualFold(raw, "true")
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -509,7 +509,13 @@ func (h *Handler) HandleSession(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	result, err := h.service.ListModels(ctx)
+	var result *gateway.ModelsResult
+	var err error
+	if requestRefresh(r) {
+		result, err = h.service.RefreshModels(ctx)
+	} else {
+		result, err = h.service.ListModels(ctx)
+	}
 	if err != nil {
 		telemetry.Error(h.logger, ctx, "gateway.models.list.failed",
 			slog.String("event.name", "gateway.models.list.failed"),
@@ -541,6 +547,11 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data:   data,
 	})
+}
+
+func requestRefresh(r *http.Request) bool {
+	raw := strings.TrimSpace(r.URL.Query().Get("refresh"))
+	return raw == "1" || strings.EqualFold(raw, "true")
 }
 
 func renderModelReadiness(readiness types.ModelReadiness) ModelReadinessResponseItem {

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -24,7 +24,13 @@ import (
 func (h *Handler) HandleProviderStatus(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	result, err := h.service.ProviderStatus(ctx)
+	var result *gateway.ProviderStatusResult
+	var err error
+	if requestRefresh(r) {
+		result, err = h.service.RefreshProviderStatus(ctx)
+	} else {
+		result, err = h.service.ProviderStatus(ctx)
+	}
 	if err != nil {
 		telemetry.Error(h.logger, ctx, "gateway.providers.status.failed",
 			slog.String("event.name", "gateway.providers.status.failed"),

--- a/internal/api/handler_provider_refresh_test.go
+++ b/internal/api/handler_provider_refresh_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestProviderStatusAndModelsRefreshQueryBypassesProviderCache(t *testing.T) {
+	t.Parallel()
+
+	provider := &refreshableProvider{}
+	handler := newTestHTTPHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), provider)
+	client := newTaskTestClient(t, handler)
+
+	cached := mustRequestJSON[OpenAIModelsResponse](client, http.MethodGet, "/v1/models", "")
+	if cached.Data[0].ID != "cached-model" {
+		t.Fatalf("cached model = %q, want cached-model", cached.Data[0].ID)
+	}
+
+	refreshed := mustRequestJSON[OpenAIModelsResponse](client, http.MethodGet, "/v1/models?refresh=true", "")
+	if refreshed.Data[0].ID != "refreshed-model" {
+		t.Fatalf("refreshed model = %q, want refreshed-model", refreshed.Data[0].ID)
+	}
+
+	status := mustRequestJSON[ProviderStatusResponse](client, http.MethodGet, "/hecate/v1/providers/status?refresh=true", "")
+	if status.Data[0].Models[0] != "refreshed-model" {
+		t.Fatalf("refreshed status model = %q, want refreshed-model", status.Data[0].Models[0])
+	}
+
+	normalCalls, refreshCalls := provider.callCounts()
+	if normalCalls != 1 {
+		t.Fatalf("normal capability calls = %d, want 1", normalCalls)
+	}
+	if refreshCalls != 2 {
+		t.Fatalf("refresh capability calls = %d, want 2", refreshCalls)
+	}
+}
+
+type refreshableProvider struct {
+	mu           sync.Mutex
+	normalCalls  int
+	refreshCalls int
+}
+
+func (p *refreshableProvider) Name() string {
+	return "refreshable"
+}
+
+func (p *refreshableProvider) Kind() providers.Kind {
+	return providers.KindLocal
+}
+
+func (p *refreshableProvider) DefaultModel() string {
+	return "cached-model"
+}
+
+func (p *refreshableProvider) Capabilities(context.Context) (providers.Capabilities, error) {
+	p.mu.Lock()
+	p.normalCalls++
+	p.mu.Unlock()
+	return providerRefreshTestCapabilities("cached-model"), nil
+}
+
+func (p *refreshableProvider) RefreshCapabilities(context.Context) (providers.Capabilities, error) {
+	p.mu.Lock()
+	p.refreshCalls++
+	p.mu.Unlock()
+	return providerRefreshTestCapabilities("refreshed-model"), nil
+}
+
+func (p *refreshableProvider) Chat(context.Context, types.ChatRequest) (*types.ChatResponse, error) {
+	return &types.ChatResponse{}, nil
+}
+
+func (p *refreshableProvider) Supports(string) bool {
+	return true
+}
+
+func (p *refreshableProvider) callCounts() (int, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.normalCalls, p.refreshCalls
+}
+
+func providerRefreshTestCapabilities(model string) providers.Capabilities {
+	return providers.Capabilities{
+		Name:            "refreshable",
+		Kind:            providers.KindLocal,
+		DefaultModel:    model,
+		Models:          []string{model},
+		Discoverable:    true,
+		DiscoverySource: "upstream_v1_models",
+	}
+}

--- a/internal/catalog/registry.go
+++ b/internal/catalog/registry.go
@@ -30,10 +30,18 @@ func NewRegistryCatalogWithSelfAddr(registry providers.Registry, healthTracker p
 }
 
 func (c *RegistryCatalog) Snapshot(ctx context.Context) []Entry {
+	return c.snapshot(ctx, false)
+}
+
+func (c *RegistryCatalog) SnapshotRefresh(ctx context.Context) []Entry {
+	return c.snapshot(ctx, true)
+}
+
+func (c *RegistryCatalog) snapshot(ctx context.Context, refresh bool) []Entry {
 	items := c.registry.All()
 	out := make([]Entry, 0, len(items))
 	for _, provider := range items {
-		out = append(out, c.entryForProvider(ctx, provider))
+		out = append(out, c.entryForProvider(ctx, provider, refresh))
 	}
 	return out
 }
@@ -43,10 +51,10 @@ func (c *RegistryCatalog) Get(ctx context.Context, name string) (Entry, bool) {
 	if !ok {
 		return Entry{}, false
 	}
-	return c.entryForProvider(ctx, provider), true
+	return c.entryForProvider(ctx, provider, false), true
 }
 
-func (c *RegistryCatalog) entryForProvider(ctx context.Context, provider providers.Provider) Entry {
+func (c *RegistryCatalog) entryForProvider(ctx context.Context, provider providers.Provider, refresh bool) Entry {
 	baseURL := providerBaseURL(provider)
 	credentialState := providerCredentialState(provider)
 
@@ -82,7 +90,17 @@ func (c *RegistryCatalog) entryForProvider(ctx context.Context, provider provide
 		}
 	}
 
-	caps, err := provider.Capabilities(ctx)
+	var caps providers.Capabilities
+	var err error
+	if refresh {
+		if refresher, ok := provider.(providers.CapabilityRefresher); ok {
+			caps, err = refresher.RefreshCapabilities(ctx)
+		} else {
+			caps, err = provider.Capabilities(ctx)
+		}
+	} else {
+		caps, err = provider.Capabilities(ctx)
+	}
 
 	defaultModel := caps.DefaultModel
 	if defaultModel == "" {

--- a/internal/gateway/service_providers.go
+++ b/internal/gateway/service_providers.go
@@ -12,10 +12,18 @@ import (
 )
 
 func (s *Service) ListModels(ctx context.Context) (*ModelsResult, error) {
+	return s.listModels(ctx, false)
+}
+
+func (s *Service) RefreshModels(ctx context.Context) (*ModelsResult, error) {
+	return s.listModels(ctx, true)
+}
+
+func (s *Service) listModels(ctx context.Context, refresh bool) (*ModelsResult, error) {
 	seen := make(map[string]struct{})
 	modelsOut := make([]types.ModelInfo, 0, 16)
 
-	for _, entry := range s.catalog.Snapshot(ctx) {
+	for _, entry := range s.catalogSnapshot(ctx, refresh) {
 		for _, modelID := range entry.Models {
 			key := entry.Name + "/" + modelID
 			if _, ok := seen[key]; ok {
@@ -40,7 +48,15 @@ func (s *Service) ListModels(ctx context.Context) (*ModelsResult, error) {
 }
 
 func (s *Service) ProviderStatus(ctx context.Context) (*ProviderStatusResult, error) {
-	entries := s.catalog.Snapshot(ctx)
+	return s.providerStatus(ctx, false)
+}
+
+func (s *Service) RefreshProviderStatus(ctx context.Context) (*ProviderStatusResult, error) {
+	return s.providerStatus(ctx, true)
+}
+
+func (s *Service) providerStatus(ctx context.Context, refresh bool) (*ProviderStatusResult, error) {
+	entries := s.catalogSnapshot(ctx, refresh)
 	statuses := make([]types.ProviderStatus, 0, len(entries))
 	for _, entry := range entries {
 		status := types.ProviderStatus{
@@ -88,6 +104,19 @@ func (s *Service) ProviderStatus(ctx context.Context) (*ProviderStatusResult, er
 	}
 
 	return &ProviderStatusResult{Providers: statuses}, nil
+}
+
+type refreshableCatalog interface {
+	SnapshotRefresh(ctx context.Context) []catalog.Entry
+}
+
+func (s *Service) catalogSnapshot(ctx context.Context, refresh bool) []catalog.Entry {
+	if refresh {
+		if refresher, ok := s.catalog.(refreshableCatalog); ok {
+			return refresher.SnapshotRefresh(ctx)
+		}
+	}
+	return s.catalog.Snapshot(ctx)
 }
 
 func (s *Service) ProviderModelReadiness(ctx context.Context, provider, model string) (*ProviderModelReadinessResult, error) {

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -26,6 +26,7 @@ type AnthropicProvider struct {
 	mu         sync.Mutex
 	cachedCaps Capabilities
 	capsExpiry time.Time
+	capsFlight *capabilityDiscoveryCall
 }
 
 type anthropicMessagesRequest struct {
@@ -211,6 +212,14 @@ func (p *AnthropicProvider) supportsResolvedModel(ctx context.Context, model str
 }
 
 func (p *AnthropicProvider) Capabilities(ctx context.Context) (Capabilities, error) {
+	return p.capabilities(ctx, false)
+}
+
+func (p *AnthropicProvider) RefreshCapabilities(ctx context.Context) (Capabilities, error) {
+	return p.capabilities(ctx, true)
+}
+
+func (p *AnthropicProvider) capabilities(ctx context.Context, refresh bool) (Capabilities, error) {
 	if p.config.StubMode {
 		return p.staticCapabilities("config"), nil
 	}
@@ -220,9 +229,11 @@ func (p *AnthropicProvider) Capabilities(ctx context.Context) (Capabilities, err
 		p.Name(),
 		p.Kind(),
 		p.config.APIKey,
+		refresh,
 		&p.mu,
 		&p.cachedCaps,
 		&p.capsExpiry,
+		&p.capsFlight,
 		p.discoverCapabilities,
 		p.staticCapabilities,
 	)

--- a/internal/providers/capabilities_cache.go
+++ b/internal/providers/capabilities_cache.go
@@ -39,6 +39,9 @@ func resolveCapabilities(
 	if *inFlight != nil {
 		call := *inFlight
 		mu.Unlock()
+		// Refresh callers join any in-flight discovery for this provider. That
+		// still bypasses completed cache entries, but avoids starting a duplicate
+		// upstream probe when a normal cache miss is already discovering state.
 		return waitForCapabilityDiscovery(ctx, call)
 	}
 	call := &capabilityDiscoveryCall{done: make(chan struct{})}

--- a/internal/providers/capabilities_cache.go
+++ b/internal/providers/capabilities_cache.go
@@ -15,9 +15,11 @@ func resolveCapabilities(
 	providerName string,
 	kind Kind,
 	apiKey string,
+	refresh bool,
 	mu *sync.Mutex,
 	cachedCaps *Capabilities,
 	capsExpiry *time.Time,
+	inFlight **capabilityDiscoveryCall,
 	discover func(context.Context) (Capabilities, error),
 	staticCaps func(source string) Capabilities,
 ) (Capabilities, error) {
@@ -29,11 +31,18 @@ func resolveCapabilities(
 		mu.Unlock()
 		return cached, nil
 	}
-	if !capsExpiry.IsZero() && time.Now().Before(*capsExpiry) {
+	if !refresh && !capsExpiry.IsZero() && time.Now().Before(*capsExpiry) {
 		cached := *cachedCaps
 		mu.Unlock()
 		return cached, nil
 	}
+	if *inFlight != nil {
+		call := *inFlight
+		mu.Unlock()
+		return waitForCapabilityDiscovery(ctx, call)
+	}
+	call := &capabilityDiscoveryCall{done: make(chan struct{})}
+	*inFlight = call
 	mu.Unlock()
 
 	discovered, err := discover(ctx)
@@ -53,6 +62,9 @@ func resolveCapabilities(
 		mu.Lock()
 		*cachedCaps = cached
 		*capsExpiry = time.Now().Add(retryAfter)
+		call.caps = cached
+		*inFlight = nil
+		close(call.done)
 		mu.Unlock()
 		return cached, nil
 	}
@@ -60,6 +72,23 @@ func resolveCapabilities(
 	mu.Lock()
 	*cachedCaps = discovered
 	*capsExpiry = time.Now().Add(capabilitiesSuccessTTL)
+	call.caps = discovered
+	*inFlight = nil
+	close(call.done)
 	mu.Unlock()
 	return discovered, nil
+}
+
+type capabilityDiscoveryCall struct {
+	done chan struct{}
+	caps Capabilities
+}
+
+func waitForCapabilityDiscovery(ctx context.Context, call *capabilityDiscoveryCall) (Capabilities, error) {
+	select {
+	case <-ctx.Done():
+		return Capabilities{}, ctx.Err()
+	case <-call.done:
+		return call.caps, nil
+	}
 }

--- a/internal/providers/capabilities_cache_test.go
+++ b/internal/providers/capabilities_cache_test.go
@@ -225,6 +225,59 @@ func TestResolveCapabilitiesConcurrentMissesShareInFlightDiscovery(t *testing.T)
 	}
 }
 
+func TestResolveCapabilitiesRefreshPiggybacksOnInFlightNormalCall(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+			return discoveredTestCapabilities("shared-model"), nil
+		},
+	}
+
+	type result struct {
+		caps Capabilities
+		err  error
+	}
+	results := make(chan result, 2)
+	go func() {
+		caps, err := harness.resolve(context.Background(), false)
+		results <- result{caps: caps, err: err}
+	}()
+
+	<-started
+	go func() {
+		caps, err := harness.resolve(context.Background(), true)
+		results <- result{caps: caps, err: err}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		close(release)
+		t.Fatalf("discovery calls while normal miss is in flight = %d, want 1", got)
+	}
+	close(release)
+
+	for range 2 {
+		res := <-results
+		if res.err != nil {
+			t.Fatalf("resolve error = %v", res.err)
+		}
+		if res.caps.Models[0] != "shared-model" {
+			t.Fatalf("model = %q, want shared-model", res.caps.Models[0])
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("discovery calls = %d, want 1", got)
+	}
+}
+
 func TestResolveCapabilitiesConcurrentManualRefreshesShareInFlightDiscovery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/capabilities_cache_test.go
+++ b/internal/providers/capabilities_cache_test.go
@@ -225,6 +225,76 @@ func TestResolveCapabilitiesConcurrentMissesShareInFlightDiscovery(t *testing.T)
 	}
 }
 
+func TestResolveCapabilitiesConcurrentManualRefreshesShareInFlightDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	startedRefresh := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			call := calls.Add(1)
+			if call == 1 {
+				return discoveredTestCapabilities("cached-model"), nil
+			}
+			if call == 2 {
+				close(startedRefresh)
+			}
+			<-releaseRefresh
+			return discoveredTestCapabilities("refreshed-model"), nil
+		},
+	}
+
+	if caps, err := harness.resolve(context.Background(), false); err != nil {
+		t.Fatalf("warm cache resolve error = %v", err)
+	} else if caps.Models[0] != "cached-model" {
+		t.Fatalf("warm cache model = %q, want cached-model", caps.Models[0])
+	}
+
+	const workers = 8
+	ready := make(chan struct{})
+	results := make(chan Capabilities, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-ready
+			caps, err := harness.resolve(context.Background(), true)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- caps
+		}()
+	}
+
+	close(ready)
+	<-startedRefresh
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 2 {
+		close(releaseRefresh)
+		t.Fatalf("discovery calls while refresh is in flight = %d, want 2 including warm cache", got)
+	}
+	close(releaseRefresh)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent refresh error = %v", err)
+	}
+	for caps := range results {
+		if caps.Models[0] != "refreshed-model" {
+			t.Fatalf("model = %q, want refreshed-model", caps.Models[0])
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("discovery calls = %d, want 2 including warm cache", got)
+	}
+}
+
 func discoveredTestCapabilities(model string) Capabilities {
 	return Capabilities{
 		Name:            "test-provider",

--- a/internal/providers/capabilities_cache_test.go
+++ b/internal/providers/capabilities_cache_test.go
@@ -1,0 +1,238 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type capabilitiesCacheHarness struct {
+	mu         sync.Mutex
+	cachedCaps Capabilities
+	capsExpiry time.Time
+	inFlight   *capabilityDiscoveryCall
+	discover   func(context.Context) (Capabilities, error)
+}
+
+func (h *capabilitiesCacheHarness) resolve(ctx context.Context, refresh bool) (Capabilities, error) {
+	return resolveCapabilities(
+		ctx,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		"test-provider",
+		KindLocal,
+		"",
+		refresh,
+		&h.mu,
+		&h.cachedCaps,
+		&h.capsExpiry,
+		&h.inFlight,
+		h.discover,
+		func(source string) Capabilities {
+			return Capabilities{
+				Name:            "test-provider",
+				Kind:            KindLocal,
+				DefaultModel:    "fallback-model",
+				Models:          []string{"fallback-model"},
+				DiscoverySource: source,
+				RefreshedAt:     time.Now().UTC(),
+			}
+		},
+	)
+}
+
+func TestResolveCapabilitiesUsesCachedRead(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			calls.Add(1)
+			return discoveredTestCapabilities("model-a"), nil
+		},
+	}
+
+	first, err := harness.resolve(context.Background(), false)
+	if err != nil {
+		t.Fatalf("first resolve error = %v", err)
+	}
+	second, err := harness.resolve(context.Background(), false)
+	if err != nil {
+		t.Fatalf("second resolve error = %v", err)
+	}
+
+	if first.Models[0] != "model-a" || second.Models[0] != "model-a" {
+		t.Fatalf("models = %v then %v, want cached model-a", first.Models, second.Models)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("discovery calls = %d, want 1", got)
+	}
+}
+
+func TestResolveCapabilitiesManualRefreshBypassesCache(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			call := calls.Add(1)
+			return discoveredTestCapabilities("model-" + strconv.FormatInt(call, 10)), nil
+		},
+	}
+
+	first, err := harness.resolve(context.Background(), false)
+	if err != nil {
+		t.Fatalf("first resolve error = %v", err)
+	}
+	refreshed, err := harness.resolve(context.Background(), true)
+	if err != nil {
+		t.Fatalf("refresh resolve error = %v", err)
+	}
+
+	if first.Models[0] != "model-1" {
+		t.Fatalf("first model = %q, want model-1", first.Models[0])
+	}
+	if refreshed.Models[0] != "model-2" {
+		t.Fatalf("refreshed model = %q, want model-2", refreshed.Models[0])
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("discovery calls = %d, want 2", got)
+	}
+}
+
+func TestResolveCapabilitiesProviderErrorCachesFallback(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			calls.Add(1)
+			return Capabilities{}, errors.New("provider unavailable")
+		},
+	}
+
+	caps, err := harness.resolve(context.Background(), false)
+	if err != nil {
+		t.Fatalf("resolve error = %v, want fallback capabilities", err)
+	}
+	if caps.DiscoverySource != "config_fallback" {
+		t.Fatalf("discovery source = %q, want config_fallback", caps.DiscoverySource)
+	}
+	if caps.LastError != "provider unavailable" {
+		t.Fatalf("last error = %q, want provider unavailable", caps.LastError)
+	}
+
+	if _, err := harness.resolve(context.Background(), false); err != nil {
+		t.Fatalf("cached fallback resolve error = %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("discovery calls = %d, want 1", got)
+	}
+}
+
+func TestResolveCapabilitiesCacheExpiryRediscovers(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			call := calls.Add(1)
+			return discoveredTestCapabilities("model-" + strconv.FormatInt(call, 10)), nil
+		},
+	}
+
+	if _, err := harness.resolve(context.Background(), false); err != nil {
+		t.Fatalf("first resolve error = %v", err)
+	}
+	harness.mu.Lock()
+	harness.capsExpiry = time.Now().Add(-time.Second)
+	harness.mu.Unlock()
+
+	caps, err := harness.resolve(context.Background(), false)
+	if err != nil {
+		t.Fatalf("expired resolve error = %v", err)
+	}
+	if caps.Models[0] != "model-2" {
+		t.Fatalf("model after expiry = %q, want model-2", caps.Models[0])
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("discovery calls = %d, want 2", got)
+	}
+}
+
+func TestResolveCapabilitiesConcurrentMissesShareInFlightDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	harness := &capabilitiesCacheHarness{
+		discover: func(context.Context) (Capabilities, error) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+			return discoveredTestCapabilities("shared-model"), nil
+		},
+	}
+
+	const workers = 8
+	ready := make(chan struct{})
+	results := make(chan Capabilities, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-ready
+			caps, err := harness.resolve(context.Background(), false)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- caps
+		}()
+	}
+
+	close(ready)
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		close(release)
+		t.Fatalf("discovery calls while first request is in flight = %d, want 1", got)
+	}
+	close(release)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent resolve error = %v", err)
+	}
+	for caps := range results {
+		if caps.Models[0] != "shared-model" {
+			t.Fatalf("model = %q, want shared-model", caps.Models[0])
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("discovery calls = %d, want 1", got)
+	}
+}
+
+func discoveredTestCapabilities(model string) Capabilities {
+	return Capabilities{
+		Name:            "test-provider",
+		Kind:            KindLocal,
+		DefaultModel:    model,
+		Models:          []string{model},
+		Discoverable:    true,
+		DiscoverySource: "upstream_v1_models",
+		RefreshedAt:     time.Now().UTC(),
+	}
+}

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -25,6 +25,7 @@ type OpenAICompatibleProvider struct {
 	mu         sync.Mutex
 	cachedCaps Capabilities
 	capsExpiry time.Time
+	capsFlight *capabilityDiscoveryCall
 }
 
 const (
@@ -283,6 +284,14 @@ func (p *OpenAICompatibleProvider) DefaultModel() string {
 }
 
 func (p *OpenAICompatibleProvider) Capabilities(ctx context.Context) (Capabilities, error) {
+	return p.capabilities(ctx, false)
+}
+
+func (p *OpenAICompatibleProvider) RefreshCapabilities(ctx context.Context) (Capabilities, error) {
+	return p.capabilities(ctx, true)
+}
+
+func (p *OpenAICompatibleProvider) capabilities(ctx context.Context, refresh bool) (Capabilities, error) {
 	if p.config.StubMode {
 		return p.staticCapabilities("config"), nil
 	}
@@ -292,9 +301,11 @@ func (p *OpenAICompatibleProvider) Capabilities(ctx context.Context) (Capabiliti
 		p.Name(),
 		p.Kind(),
 		p.config.APIKey,
+		refresh,
 		&p.mu,
 		&p.cachedCaps,
 		&p.capsExpiry,
+		&p.capsFlight,
 		p.discoverCapabilities,
 		p.staticCapabilities,
 	)

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -27,6 +27,12 @@ type Provider interface {
 	Supports(model string) bool
 }
 
+// CapabilityRefresher is implemented by providers that can bypass their
+// discovery cache for explicit operator refreshes.
+type CapabilityRefresher interface {
+	RefreshCapabilities(ctx context.Context) (Capabilities, error)
+}
+
 // Streamer is an optional interface providers may implement to support SSE streaming.
 // ChatStream writes an OpenAI-compatible SSE body (including the final "data: [DONE]\n\n")
 // to w and returns when the stream is complete or the context is cancelled.


### PR DESCRIPTION
## Summary
- Add explicit provider/model refresh paths that bypass completed discovery cache entries while preserving normal cached reads.
- Share same-provider in-flight discovery work so concurrent cache misses do not duplicate upstream /v1/models requests.
- Document the refresh=true query flag for provider status and model listing endpoints.

## Validation
- go build ./...
- go test ./internal/providers
- go test ./internal/api -run 'TestProviderStatusAndModelsRefreshQueryBypassesProviderCache'
- go test ./internal/providers ./internal/catalog ./internal/gateway ./internal/api
- go vet ./internal/providers ./internal/catalog ./internal/gateway ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate-provider-discovery-refresh-singleflight/.gocache" go test -race -timeout 10m ./...