### PR TITLE
fix(providers): clarify readiness repair guidance

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -287,3 +287,6 @@ the empty-chat state: compact readiness copy must still show the
 discovered-model count plus the highest-signal health/block/error diagnostics
 and a short repair path, so operators are not forced to send a doomed prompt or
 inspect raw provider JSON.
+If configured local providers appear in the empty-chat state but no routable
+model is available, treat it as a discovery freshness issue first: start the
+local provider app, pull or load a model there, then refresh Connections.

--- a/internal/gateway/provider_model_readiness.go
+++ b/internal/gateway/provider_model_readiness.go
@@ -75,7 +75,7 @@ func providerModelReadiness(entries []catalog.Entry, provider, model string) Pro
 		}
 		out.Reason = "provider_missing"
 		out.Message = fmt.Sprintf("Provider %q is not configured.", provider)
-		out.OperatorAction = "Choose Auto routing, select a configured provider, or add this provider in Settings."
+		out.OperatorAction = "Choose Auto routing, select a configured provider, or add this provider in Connections."
 		out.SuggestedModels = suggestedModels(entries, "")
 		return out
 	}

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -305,6 +305,7 @@ func TestProviderModelReadiness(t *testing.T) {
 		wantStatus          string
 		wantSuggestions     bool
 		rejectSuggestion    string
+		wantActionContains  string
 	}{
 		{
 			name:                "explicit provider reports model",
@@ -347,12 +348,13 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantSuggestions:     true,
 		},
 		{
-			name:         "missing provider",
-			provider:     "missing",
-			model:        "llama3.1:8b",
-			wantProvider: "missing",
-			wantReason:   "provider_missing",
-			wantStatus:   "blocked",
+			name:               "missing provider",
+			provider:           "missing",
+			model:              "llama3.1:8b",
+			wantProvider:       "missing",
+			wantReason:         "provider_missing",
+			wantStatus:         "blocked",
+			wantActionContains: "Connections",
 		},
 		{
 			name:                "auto finds routable provider",
@@ -415,6 +417,9 @@ func TestProviderModelReadiness(t *testing.T) {
 			}
 			if !got.Ready && got.OperatorAction == "" {
 				t.Fatalf("operator_action is empty for blocked readiness: %#v", got)
+			}
+			if tt.wantActionContains != "" && !strings.Contains(got.OperatorAction, tt.wantActionContains) {
+				t.Fatalf("operator_action = %q, want substring %q", got.OperatorAction, tt.wantActionContains)
 			}
 			if got.Ready && len(got.SuggestedModels) > 0 {
 				t.Fatalf("suggested_models = %#v for ready response, want none", got.SuggestedModels)

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -33,6 +33,21 @@ describe("resolveChatSetupRepairState", () => {
     });
   });
 
+  it("explains that configured providers may need refresh or loaded models", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "model",
+      modelRouteUnavailable: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "no_routable_model",
+      title: "No routable model",
+    });
+    expect(repair?.message).toContain("refresh Connections");
+    expect(repair?.message).toContain("loading a model");
+  });
+
   it("uses backend suggested models as the primary selected-model repair", () => {
     const repair = resolveChatSetupRepairState({
       ...base,

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -71,6 +71,29 @@ describe("resolveChatSetupRepairState", () => {
     });
   });
 
+  it("routes stale selected models without a suggestion back to Connections", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "agent",
+      selectedModelIssue: {
+        title: "Selected model is unavailable",
+        message: "No routable provider reports mistral.",
+        providerLabel: "Ollama",
+        model: "mistral",
+        suggestedModel: "",
+        details: [],
+        steps: [],
+      },
+    });
+
+    expect(repair).toMatchObject({
+      kind: "selected_model_not_ready",
+      action: "open_connections",
+      actionLabel: "Open Connections",
+      suggestedModel: "",
+    });
+  });
+
   it("requires a workspace for task-backed Hecate Chat", () => {
     const repair = resolveChatSetupRepairState({
       ...base,

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -89,7 +89,7 @@ export function resolveChatSetupRepairState({
       kind: hasConfiguredProviders ? "no_routable_model" : "no_provider",
       title: hasConfiguredProviders ? "No routable model" : "No model provider configured",
       message: hasConfiguredProviders
-        ? "Hecate can see provider configuration, but no provider currently reports a routable model."
+        ? "Providers are configured, but none currently report a routable model. Start the local provider or refresh Connections after loading a model."
         : "Add a model provider before sending through Hecate.",
       action: "open_connections",
       actionLabel: "Open Connections",


### PR DESCRIPTION
## Summary
- point missing-provider repair guidance at Connections instead of Settings
- make the no-routable-model chat repair state explain local provider refresh/model loading
- cover backend and UI copy paths with tests

## Validation
- `go test ./internal/gateway`
- `go vet ./internal/gateway`
- `cd ui && bun run test -- src/lib/chat-setup-readiness.test.ts`
- `cd ui && bun run typecheck`
