### PR TITLE
fix(agents): explain adapter probe timeouts

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -112,6 +112,10 @@ Manual setup stays in the upstream CLIs:
 
 If an adapter readiness check reports an auth failure, run the matching command
 in Terminal, then return to Connections and test the adapter again.
+If it reports a timeout or `context deadline exceeded`, the adapter did not
+finish startup or ACP session creation inside the probe window. Hecate did not
+send a prompt; close any stuck browser or login prompt, fix the CLI if needed,
+then retry from Connections.
 
 Connections refreshes adapter readiness when opened. You can also
 call the probe endpoint for a full spawn + ACP handshake + no-op session check:

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -926,7 +926,9 @@ GET /hecate/v1/agent-adapters/codex/health
   an auth-shaped error (`Authentication required`, `Please log in`, `API key`,
   `Credit balance is too low`, `401`, `403`, …).
 - `error` — anything else. `error` and `stderr` carry the verbatim diagnostic
-  so the operator can act on it.
+  so the operator can act on it. Timeout and deadline diagnostics stay in this
+  bucket with a hint to retry from Connections after resolving stuck CLI,
+  browser, or login prompts.
 
 `stage` reports which step in the sequence completed (on success) or failed (on
 error): `lookup` / `spawn` / `initialize` / `new_session` / `ready`.

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -274,6 +274,9 @@ func claudeCodeErrorNeedsAdapterVisibleAuth(errText, stderr string) bool {
 // empty when we don't have a confident recommendation.
 func classifyAdapterError(errText, stderr string) (string, string) {
 	combined := strings.ToLower(errText + "\n" + stderr)
+	if matchesAny(combined, "context deadline exceeded", "deadline exceeded", "timed out", "timeout") {
+		return ProbeStatusError, "The adapter did not finish its ACP startup check in time. Check the CLI is responsive, signed in, and not waiting on a browser or network prompt, then retry from Connections."
+	}
 	if matchesAny(combined,
 		"authentication required",
 		"unauthenticated",

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -81,6 +81,17 @@ func TestClassifyAdapterError(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("timeout includes operator hint", func(t *testing.T) {
+		t.Parallel()
+		status, hint := classifyAdapterError("context deadline exceeded", "")
+		if status != ProbeStatusError {
+			t.Fatalf("status = %q, want %q", status, ProbeStatusError)
+		}
+		if !strings.Contains(hint, "retry from Connections") {
+			t.Fatalf("hint = %q, want retry guidance", hint)
+		}
+	})
 }
 
 func TestClaudeCodeErrorNeedsAdapterVisibleAuth(t *testing.T) {

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -92,6 +92,17 @@ func TestClassifyAdapterError(t *testing.T) {
 			t.Fatalf("hint = %q, want retry guidance", hint)
 		}
 	})
+
+	t.Run("timeout in stderr includes operator hint", func(t *testing.T) {
+		t.Parallel()
+		status, hint := classifyAdapterError("initialize failed", "Error: context deadline exceeded")
+		if status != ProbeStatusError {
+			t.Fatalf("status = %q, want %q", status, ProbeStatusError)
+		}
+		if !strings.Contains(hint, "retry from Connections") {
+			t.Fatalf("hint = %q, want retry guidance", hint)
+		}
+	})
 }
 
 func TestClaudeCodeErrorNeedsAdapterVisibleAuth(t *testing.T) {


### PR DESCRIPTION
## Summary
- classify adapter ACP probe timeouts explicitly
- show an operator-facing hint to check CLI responsiveness, auth prompts, and retry from Connections
- cover timeout classification with a unit test

## Validation
- `go test ./internal/agentadapters`
- `go vet ./internal/agentadapters`
