### PR TITLE
fix(observability): compact event attributes

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -93,6 +93,9 @@ The trace endpoint returns:
 - the final provider, model, and route reason
 
 The Observability workspace in the operator UI surfaces traces, request history, and run-state cards.
+The event flow keeps high-signal attributes compact by showing the first few
+inline, while hover titles and the trace details drawer preserve the complete
+attribute keys and values for debugging.
 
 ![Observability workspace — request history, run-state cards, and span tree](screenshots/observe.png)
 

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -1329,6 +1329,10 @@ describe("ObservabilityView", () => {
     expect(normalizedInlineStyle(eventFlow, "max-height")).toBe("min(320px,42vh)");
     expect(eventFlow.style.overflowY).toBe("auto");
     expect(eventFlow.textContent).toMatch(/\+1 more/);
+    expect(eventFlow.textContent).toMatch(/gen ai\.provider\.name/);
+    expect(
+      eventFlow.querySelector('[title="gen_ai.provider.name: openai"]'),
+    ).toBeTruthy();
     expect(document.body.textContent).not.toMatch(/★/);
 
     // Click the longest child to expand its attributes inline.

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -1330,9 +1330,7 @@ describe("ObservabilityView", () => {
     expect(eventFlow.style.overflowY).toBe("auto");
     expect(eventFlow.textContent).toMatch(/\+1 more/);
     expect(eventFlow.textContent).toMatch(/gen ai\.provider\.name/);
-    expect(
-      eventFlow.querySelector('[title="gen_ai.provider.name: openai"]'),
-    ).toBeTruthy();
+    expect(eventFlow.querySelector('[title="gen_ai.provider.name: openai"]')).toBeTruthy();
     expect(document.body.textContent).not.toMatch(/★/);
 
     // Click the longest child to expand its attributes inline.

--- a/ui/src/features/overview/ObservabilityView.test.tsx
+++ b/ui/src/features/overview/ObservabilityView.test.tsx
@@ -1234,7 +1234,13 @@ describe("ObservabilityView", () => {
           {
             name: "provider.request.started",
             timestamp: new Date(t0.getTime() + 55).toISOString(),
-            attributes: { "gen_ai.provider.name": "openai" },
+            attributes: {
+              "gen_ai.provider.name": "openai",
+              "gen_ai.request.model": "gpt-4o",
+              "hecate.provider.kind": "cloud",
+              "hecate.route.reason": "selected",
+              "hecate.extra": "kept in diagnostics",
+            },
           },
         ],
       },
@@ -1322,6 +1328,7 @@ describe("ObservabilityView", () => {
     const eventFlow = expectHTMLElement('[data-testid="trace-event-flow"]');
     expect(normalizedInlineStyle(eventFlow, "max-height")).toBe("min(320px,42vh)");
     expect(eventFlow.style.overflowY).toBe("auto");
+    expect(eventFlow.textContent).toMatch(/\+1 more/);
     expect(document.body.textContent).not.toMatch(/★/);
 
     // Click the longest child to expand its attributes inline.

--- a/ui/src/features/overview/observability/TraceDetail.tsx
+++ b/ui/src/features/overview/observability/TraceDetail.tsx
@@ -319,6 +319,7 @@ export function TraceDetail({
                           .map(([key, value]) => (
                             <span
                               key={key}
+                              title={`${key}: ${String(value)}`}
                               style={{
                                 fontFamily: "var(--font-mono)",
                                 fontSize: 10,
@@ -331,6 +332,17 @@ export function TraceDetail({
                               </span>
                             </span>
                           ))}
+                        {Object.keys(event.attributes).length > 4 && (
+                          <span
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 10,
+                              color: "var(--t3)",
+                            }}
+                          >
+                            +{Object.keys(event.attributes).length - 4} more
+                          </span>
+                        )}
                       </div>
                     )
                   )}


### PR DESCRIPTION
## Summary
- keep event-flow rows compact by showing only the first few attributes inline
- expose full attribute details through hover titles
- show a `+N more` indicator when extra attributes are hidden

## Validation
- `cd ui && bun run test -- src/features/overview/ObservabilityView.test.tsx`
- `cd ui && bun run typecheck`
