### PR TITLE
fix(ui): harden external agent chat lifecycle

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -66,6 +66,58 @@ async function switchToModel(page: Page, selectModel = true) {
   }
 }
 
+async function mockAvailableAgentAdapters(page: Page) {
+  await page.route("/hecate/v1/agent-adapters*", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "agent_adapters",
+        data: [
+          {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+          {
+            id: "claude_code",
+            name: "Claude Code",
+            kind: "acp",
+            command: "claude-agent-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+          {
+            id: "cursor_agent",
+            name: "Cursor Agent",
+            kind: "acp",
+            command: "cursor-agent",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+          {
+            id: "grok_build",
+            name: "Grok Build",
+            kind: "acp",
+            command: "grok",
+            args: ["agent", "stdio"],
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+      }),
+    });
+  });
+}
+
 test("renders the message textarea and send button", async ({ page }) => {
   await startHecateChat(page);
   await expect(page.locator("textarea")).toBeVisible();
@@ -483,6 +535,81 @@ test("New external-agent chat with model setup shows controls and composer toget
 
   await expect(page.getByRole("button", { name: "Model" })).toContainText("Grok Build 0429");
   await expect(page.locator("button[type='submit']")).toBeEnabled();
+});
+
+test("external-agent chat uses the shared fake lifecycle for transcript and delete", async ({
+  page,
+}) => {
+  await mockAvailableAgentAdapters(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByRole("button", { name: "New Claude Code chat", exact: true }).click();
+  const chatRow = page.getByRole("button", {
+    name: /Chat Claude Code chat, Claude Code/i,
+  });
+  await expect(chatRow).toBeVisible();
+
+  await page.locator("textarea").fill("Summarize the current workspace");
+  await page.locator("button[type='submit']").click();
+
+  await expect(page.getByText("Summarize the current workspace", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Agent response to: Summarize the current workspace", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("completed").first()).toBeVisible();
+  await expect(page.getByText("raw adapter output · 2 lines")).toBeVisible();
+  await page.getByText("raw adapter output · 2 lines").click();
+  await expect(page.getByText(/agent_message_chunk/)).toBeVisible();
+
+  await chatRow.hover();
+  await page.getByRole("button", { name: "Delete chat Claude Code chat" }).click();
+  await page.getByRole("button", { name: "Delete chat", exact: true }).last().click();
+  await expect(chatRow).toHaveCount(0);
+});
+
+test("external-agent running turns keep controls stable and request cancel through the fake backend", async ({
+  page,
+}) => {
+  await mockAvailableAgentAdapters(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatTarget", "external_agent");
+    window.localStorage.setItem("hecate.agentAdapterID", "grok_build");
+    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+  });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  let cancelPosts = 0;
+  await page.route("/hecate/v1/chat/sessions/*/cancel", async (route) => {
+    cancelPosts += 1;
+    await route.fallback();
+  });
+
+  await page.getByRole("button", { name: "New Grok Build chat", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: /Chat Grok Build chat, Grok Build/i }),
+  ).toBeVisible();
+
+  await page.locator("textarea").fill("Keep running while I inspect the controls [[keep-running]]");
+  await page.locator("button[type='submit']").click();
+
+  await expect(page.getByRole("button", { name: "Choose agent for new chat" })).toBeVisible();
+  await expect(page.locator("textarea")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop external agent" })).toBeVisible();
+
+  const stop = page.getByRole("button", { name: "Stop external agent" });
+  await stop.click();
+
+  await expect.poll(() => cancelPosts).toBe(1);
+  await expect(stop).toBeDisabled();
+  await expect(stop).toHaveAttribute("title", "Stopping...");
+  await expect(page.getByText("Stopping...")).toBeVisible();
 });
 
 test("New chat falls back to Hecate when the remembered external agent needs setup", async ({

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -358,7 +358,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
     r.fulfill(ok({ object: "agent_adapters", data: MOCK_AGENT_ADAPTERS })),
   );
 
-  await page.route("/hecate/v1/chat/sessions*", async (route) => {
+  await page.route(/\/hecate\/v1\/chat\/sessions(?:\/.*)?(?:\?.*)?$/, async (route) => {
     const request = route.request();
     const method = request.method();
     const url = new URL(request.url());
@@ -408,7 +408,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           message_count: 0,
           created_at: now(),
           updated_at: now(),
-          config_options: isExternal ? [] : undefined,
+          config_options: isExternal ? (body.config_options ?? []) : undefined,
           segments: [],
           messages: [],
         };
@@ -461,6 +461,50 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       return;
     }
 
+    if (parts[1] === "cancel" && method === "POST") {
+      const activeSegment = [...(session.segments ?? [])]
+        .reverse()
+        .find((segment: any) =>
+          ["running", "in_progress", "awaiting_approval", "pending"].includes(
+            String(segment.status || ""),
+          ),
+        );
+      const assistant = [...(session.messages ?? [])]
+        .reverse()
+        .find((message: any) => message.role === "assistant");
+
+      session.status = "cancelled";
+      session.updated_at = now();
+      if (activeSegment) {
+        activeSegment.status = "cancelled";
+        activeSegment.updated_at = now();
+      }
+      if (assistant) {
+        assistant.status = "cancelled";
+        assistant.error = assistant.error || "Stopped by operator.";
+        assistant.completed_at = now();
+        assistant.activities = [
+          ...(assistant.activities ?? []).map((activity: any) =>
+            ["running", "in_progress", "pending", "awaiting_approval"].includes(
+              String(activity.status || ""),
+            )
+              ? { ...activity, status: "cancelled" }
+              : activity,
+          ),
+          {
+            id: `cancelled-${chatSequence}`,
+            type: "cancelled",
+            title: "Run cancelled",
+            status: "cancelled",
+            terminal: true,
+            created_at: now(),
+          },
+        ];
+      }
+      await route.fulfill(ok({ object: "chat_session", data: session }));
+      return;
+    }
+
     if (parts[1] === "settings" && method === "PATCH") {
       const body = JSON.parse(request.postData() || "{}");
       if (typeof body.rtk_enabled === "boolean") session.rtk_enabled = body.rtk_enabled;
@@ -488,30 +532,99 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       const executionMode =
         body.execution_mode ||
         (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "direct_model");
+      const sequence = chatSequence;
+      const segmentID = `segment-${sequence}`;
+      const isExternal = executionMode === "external_agent";
+      const keepRunning = isExternal && content.includes("[[keep-running]]");
+      if (isExternal) {
+        session.segments = [
+          ...(session.segments ?? []),
+          {
+            id: segmentID,
+            execution_mode: executionMode,
+            workspace: session.workspace,
+            status: keepRunning ? "running" : "completed",
+            message_count: 2,
+            started_at: now(),
+            updated_at: now(),
+          },
+        ];
+      }
       session.messages.push(
         {
-          id: `agent-msg-user-${chatSequence}`,
+          id: `agent-msg-user-${sequence}`,
           execution_mode: executionMode,
+          segment_id: isExternal ? segmentID : undefined,
           role: "user",
           content,
           created_at: now(),
         },
         {
-          id: `agent-msg-assistant-${chatSequence}`,
+          id: `agent-msg-assistant-${sequence}`,
           execution_mode: executionMode,
+          segment_id: isExternal ? segmentID : undefined,
           role: "assistant",
           content:
             executionMode === "direct_model"
               ? `Direct response to: ${content}`
-              : `Agent response to: ${content}`,
-          status: "completed",
+              : keepRunning
+                ? "I'll inspect that now."
+                : `Agent response to: ${content}`,
+          status: keepRunning ? "running" : "completed",
+          raw_output: isExternal
+            ? [
+                `{"type":"agent_message_chunk","text":"${keepRunning ? "I'll inspect that now." : `Agent response to: ${content}`}"}`,
+                `{"type":"session_update","status":"${keepRunning ? "running" : "completed"}"}`,
+              ].join("\n")
+            : undefined,
+          activities: isExternal
+            ? [
+                {
+                  id: `started-${sequence}`,
+                  type: "started",
+                  title: `${session.agent_name || "External agent"} started`,
+                  status: "completed",
+                  created_at: now(),
+                },
+                {
+                  id: `thinking-${sequence}`,
+                  type: "thinking",
+                  title: "Thinking",
+                  detail: "Read the prompt and planned the response.",
+                  status: keepRunning ? "running" : "completed",
+                  created_at: now(),
+                },
+                {
+                  id: `stdout-${sequence}`,
+                  type: "artifact",
+                  title: "agent-stdout.txt",
+                  status: "ready",
+                  kind: "stdout",
+                  artifact_id: `stdout-${sequence}`,
+                  artifact_size_bytes: 32,
+                  artifact_preview: "fake adapter wrote a transcript event",
+                  created_at: now(),
+                },
+                ...(keepRunning
+                  ? []
+                  : [
+                      {
+                        id: `completed-${sequence}`,
+                        type: "completed",
+                        title: "Run completed",
+                        status: "completed",
+                        terminal: true,
+                        created_at: now(),
+                      },
+                    ]),
+              ]
+            : undefined,
           provider: body.provider || session.provider,
           model: body.model || session.model,
           workspace: session.workspace,
-          run_id:
-            executionMode === "direct_model" ? `model_run_${chatSequence}` : `run_${chatSequence}`,
-          request_id: `req_${chatSequence}`,
-          trace_id: `trace_${chatSequence}`,
+          run_id: executionMode === "direct_model" ? `model_run_${sequence}` : `run_${sequence}`,
+          request_id: `req_${sequence}`,
+          trace_id: `trace_${sequence}`,
           cost_mode: executionMode === "external_agent" ? "external" : "hecate",
           created_at: now(),
         },
@@ -519,7 +632,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       chatSequence += 1;
       session.provider = body.provider || session.provider;
       session.model = body.model || session.model;
-      session.status = "completed";
+      session.status = keepRunning ? "running" : "completed";
       session.message_count = session.messages.length;
       session.updated_at = now();
       await route.fulfill(ok({ object: "chat_session", data: session }));

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3893,6 +3893,56 @@ describe("ChatView external-agent target", () => {
     expect(screen.getByText("Stopping...")).toBeTruthy();
   });
 
+  it("shows stop controls for a restored running external-agent session", async () => {
+    const cancelAgentChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        chatLoading: false,
+        agentWorkspace: "/tmp/hecate",
+        agentAdapters: [
+          {
+            id: "grok_build",
+            name: "Grok Build",
+            kind: "acp",
+            command: "grok",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+        activeChatSessionID: "a1",
+        activeChatSession: {
+          id: "a1",
+          title: "Running work",
+          agent_id: "grok_build",
+          driver_kind: "acp",
+          workspace: "/tmp/hecate",
+          status: "idle",
+          segments: [
+            {
+              id: "seg_1",
+              execution_mode: "external_agent",
+              workspace: "/tmp/hecate",
+              status: "running",
+              message_count: 2,
+            },
+          ],
+          messages: [],
+        } as any,
+      },
+      { cancelAgentChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const user = userEvent.setup();
+    expect(screen.getByRole("button", { name: "Stop external agent" })).toBeTruthy();
+    expect(screen.getByText("External Agent is working. New messages will queue.")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Stop external agent" }));
+    expect(cancelAgentChat).toHaveBeenCalledTimes(1);
+  });
+
   it("renders failed agent runs as an error notice with raw diagnostics separate", () => {
     const { state, actions } = setup({
       chatTarget: "external_agent",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -330,6 +330,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const nothingRunnable = !state.loading && modelRouteUnavailable && agentRouteUnavailable;
   const activeHecateAgentSegment = activeTaskBackedHecateSegment(state.activeChatSession);
   const hecateAgentBusy = isHecateChat && Boolean(activeHecateAgentSegment);
+  const externalAgentBusy =
+    isExternalAgentChat && externalAgentSessionIsBusy(state.activeChatSession);
   const activeHecateTaskID = activeHecateAgentSegment?.task_id || "";
   const activeHecateRunID = activeHecateAgentSegment?.latest_run_id || "";
   const hecateAgentModelLocked = isHecateChat && Boolean(activeHecateAgentSegment);
@@ -456,7 +458,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     !streaming &&
     state.pendingToolCalls.length === 0 &&
     (emptyStateExplainsModelRoute || emptyStateExplainsSetupRepair || externalAgentModelRequired);
-  const agentBusy = isAgentChat && (streaming || hecateAgentBusy);
+  const agentBusy = isAgentChat && (streaming || hecateAgentBusy || externalAgentBusy);
   const queueingMessage = agentBusy && Boolean(state.message.trim());
   const messageSendBlocked =
     !agentBusy &&
@@ -1096,6 +1098,27 @@ function findLatestAgentUsage(session: ChatSessionRecord | null): ChatUsageRecor
     if (usage && !agentUsageEmpty(usage)) return usage;
   }
   return null;
+}
+
+function externalAgentSessionIsBusy(session: ChatSessionRecord | null): boolean {
+  const busy = (status?: string) =>
+    status === "queued" ||
+    status === "running" ||
+    status === "in_progress" ||
+    status === "awaiting_approval" ||
+    status === "pending";
+  if (!session?.agent_id || session.agent_id === "hecate") return false;
+  if (busy(session.status)) return true;
+  if (
+    (session.segments ?? []).some(
+      (segment) => segment.execution_mode === "external_agent" && busy(segment.status),
+    )
+  ) {
+    return true;
+  }
+  return (session.messages ?? []).some(
+    (message) => message.role === "assistant" && busy(message.status),
+  );
 }
 
 function agentUsageEmpty(usage: ChatUsageRecord): boolean {


### PR DESCRIPTION
## What changed
- Adds fake external-agent browser coverage for the main daily lifecycle: create a session, send a prompt, read the transcript, inspect quiet raw adapter output, delete the chat, and request cancel for a running turn.
- Extends the shared Playwright gateway fixture so external-agent sessions can carry segments, activities, raw output, running state, cancel responses, and config options without launching real external tools.
- Fixes restored running external-agent sessions so the composer shows the same queue and Stop controls after reload/rehydration.

## Why
The previous merged work covered persistence, reset, setup copy, adapter timeout guidance, patch/revert safety, and trace metadata compactness. This follow-up picks up the remaining unmerged lifecycle/control slice from the external-agent support audit, so active external-agent chats behave coherently in daily use and have fake e2e protection.

## Tests run
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `cd ui && bunx playwright test ui/e2e/chat.spec.ts --grep "external-agent chat uses|external-agent running"`

## Non-goals
- No real external CLIs are invoked.
- No new settings panels or broad chat architecture changes.
