### PR TITLE
docs(rfc): clarify project context architecture

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -2,6 +2,12 @@
 
 Hecate is an open-source local AI runtime console. The main Go runtime runs the local HTTP service, embeds the React operator UI, routes OpenAI- and Anthropic-shaped client traffic to upstream LLM providers, runs Hecate Chat tools-on turns through visible `agent_loop` tasks, supervises external coding-agent adapters from Chats, runs queued `agent_loop` tasks with policy and approval gates, and emits OpenTelemetry traces for everything it does. Hecate is local-first, deny-by-default, runtime-aware, and storage-tiered (memory / sqlite). Every endpoint, config knob, and error message exists to answer five operator questions: what did Hecate just decide, why, what did it cost, what happens on the next failure, and where is the trace.
 
+Hecate's own boundary is the runtime/control plane: projects, chats, tasks,
+providers, supervised external agents, approvals, tool policy, storage, and
+observability. Higher-level assistant behavior should be built from those
+primitives through agent profiles, presets, project memory, and context
+assembly rather than hidden prompt glue or provider-specific shortcuts.
+
 ## Repository layout
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,11 @@ direction, implemented records, and experimental parking-lot ideas.
 | [LLM context window management](rfcs/llm-context-window-management.md)                         | Active proposal for token estimation, context warnings/caps, and optional fitting policies.                                                |
 | [Event protocol v1](rfcs/event-protocol-v1.md)                                                 | Candidate event envelope; implemented for task-run event streams, but payload stability is still in progress.                              |
 
+Projects, agent profiles, presets, memory, context assembly, and context
+window management are one architecture track. Start with the
+[RFC index](rfcs/README.md#projects-context-and-memory-track) before changing
+any one of them.
+
 ## External Entry Points
 
 - [`.env.example`](../.env.example) — minimal first-run environment knobs.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -32,6 +32,22 @@ Implemented runtime behavior lives in the main docs:
 | [External agent adapters](external-agent-adapters.md)                   | Accepted. Codex, Claude Code, Cursor Agent, readiness, guardrails, approvals, diagnostics, ACP controls, streaming, cancellation, and diff inspect/revert have alpha coverage.                                                                                                      | Keep improving adapter-specific mapping, patch review UX, and convergence with task-runtime primitives.            |
 | [Projects](projects.md)                                                 | Accepted. The project store and CRUD API foundation exist with memory and SQLite backends. Chat sessions can be grouped by `project_id`; tasks, memory, profiles, and context packets are not linked yet.                                                                           | Attach tasks to projects, then layer context packets and project-scoped memory on top.                             |
 
+## Projects, Context, And Memory Track
+
+These RFCs are intentionally small and layered:
+
+1. [Projects](projects.md) provide durable identity for a codebase or work area.
+2. Agent profiles describe reusable runtime behavior for Hecate Chat or an
+   external agent. Presets are templates that create or update profiles/project
+   defaults; they are not runtime identity.
+3. [Agent memory](agent-memory.md) stores operator-approved durable context,
+   with project memory as the default shared scope.
+4. [Context assembly](context-assembly-and-injection-boundaries.md) turns chat,
+   project, profile, memory, workspace, and runtime inputs into an inspectable
+   context packet.
+5. [Context window management](llm-context-window-management.md) fits that
+   packet into a model limit without changing trust labels or source authority.
+
 ## Active Proposals
 
 | RFC                                                                                       | Status                                                                                               | Next action                                                                                        |

--- a/docs/rfcs/hecate-chat-model-capabilities.md
+++ b/docs/rfcs/hecate-chat-model-capabilities.md
@@ -41,8 +41,8 @@ requirements after the baseline bridge are:
 - task approvals resolved directly from Chats _(implemented)_
 - streamed assistant text for task-backed Hecate Agent turns _(implemented)_
 - local composer queueing while a backing task is busy _(implemented)_
-- task workspace modes exposed in the Hecate Agent chat setup
-- named Hecate Agent profiles
+- task workspace modes exposed in Hecate Chat setup
+- named agent profiles
 - richer automatic capability detection with visible status
 
 ## Why
@@ -162,15 +162,16 @@ Each message carries its own runtime snapshot: `execution_mode`, `segment_id`,
 provider/model, capabilities, workspace, and optional task/run linkage. The
 session response also exposes derived segment metadata so the UI can render
 clear transcript boundaries when a chat moves from direct model turns to
-Hecate Agent tool-backed turns and back again.
+tools-on task-backed turns and back again.
 
 External Agent sessions store their adapter id in `agent_id`. Hecate Chat
 sessions use `agent_id="hecate"`.
 
 ### Agent profiles
 
-Hecate Agent profiles are named presets for Hecate-owned agent execution. They
-should not be confused with External Agent adapters.
+Agent profiles are saved runtime configurations for Hecate Chat or an external
+agent. They should not be confused with presets, which are authoring-time
+templates, or with External Agent adapters, which are supervised subprocesses.
 
 A profile defines:
 
@@ -183,7 +184,7 @@ A profile defines:
 - cost, turn, timeout, and network guardrails
 - optional model capability requirements
 
-The initial built-in profile is the current default Hecate Agent behavior:
+The initial built-in profile is the current default Hecate Chat tools-on behavior:
 selected provider/model, selected workspace, `agent_loop`, task approvals,
 artifacts, sandboxed tool calls, and OTel. Operators can later create named
 profiles such as "Reviewer", "Builder", or "SRE" without changing the chat
@@ -379,7 +380,7 @@ and exposes external-agent approvals.
 
 Memory and SQLite must persist:
 
-- Hecate Agent profiles
+- agent profiles
 - selected `agent_profile_id`
 - `agent_id`
 - task-backed Hecate Chat task/run linkage fields on chat sessions
@@ -451,10 +452,10 @@ Done in the core bridge:
 - each assistant turn exposes user-friendly task and trace links in the message
   header
 
-Still required for a complete Hecate Agent experience:
+Still required for a complete Hecate Chat tools-on experience:
 
 - workspace modes in the chat setup
-- named Hecate Agent profiles
+- named agent profiles
 - automatic capability probing
 - broader e2e/product hardening around workspace modes, profiles, automatic
   capability detection, and mixed long-running sessions
@@ -466,7 +467,7 @@ The missing stable-scope pieces should land in this order:
 1. **Workspace modes.** Expose the same workspace choices that Tasks supports,
    store the selected mode on the session/task, and fail early when a requested
    mode cannot be honored.
-2. **Agent profiles.** Add named Hecate Agent presets for model policy,
+2. **Agent profiles.** Add named profiles for model policy,
    workspace mode, system prompt, tools/MCP, approvals, and guardrails. Store a
    snapshot on each session so history remains explainable.
 3. **Automatic probing.** Add bounded, visible capability probes for configured

--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -177,8 +177,10 @@ Projects, profiles, and presets have separate jobs:
 
 In other words: a project can choose a default agent profile, and a profile can
 be created from a preset. After application, Hecate should persist the resolved
-profile/settings. Context packets may record `source_preset_id` for audit, but
-the runtime should not depend on a mutable preset staying unchanged.
+profile/settings. Presets stay authoring-time templates; profiles are runtime
+configuration; projects are durable work scopes. Context packets may record
+`source_preset_id` for audit, but the runtime should not depend on a mutable
+preset staying unchanged.
 
 Local MCP exposure should use the same preset vocabulary rather than a separate
 taxonomy. The initial built-in MCP toolset presets are `readonly`, `operator`,


### PR DESCRIPTION
## Summary

- clarify that projects, profiles, presets, memory, context assembly, and context-window management are one layered architecture track
- tighten the profile/preset/project wording in the Projects RFC without adding a new RFC
- normalize stale "Hecate Agent profile" wording in the Hecate Chat capabilities RFC
- add a short docs-ai boundary note: Hecate is the runtime/control plane; higher-level assistant behavior should be built from runtime primitives

## Validation

- `just docs-format-check`
