### PR TITLE
fix(ui): polish external agent readiness

### DIFF
--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -407,4 +407,31 @@ func runStoreReconcileInterruptedRuns(t *testing.T, store Store) {
 	if count != 0 {
 		t.Fatalf("second reconciled count = %d, want 0", count)
 	}
+
+	orphaned, err := store.Create(ctx, Session{
+		ID:              "chat_orphaned_external",
+		Title:           "Orphaned external run",
+		AgentID:         "grok_build",
+		DriverKind:      "acp",
+		NativeSessionID: "native_orphaned",
+		Workspace:       "/tmp/hecate",
+		Status:          "running",
+	})
+	if err != nil {
+		t.Fatalf("Create(orphaned): %v", err)
+	}
+	count, err = ReconcileInterruptedRuns(ctx, store, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("ReconcileInterruptedRuns orphaned: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("orphaned reconciled count = %d, want 1", count)
+	}
+	got, ok, err = store.Get(ctx, orphaned.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get(orphaned): ok=%v err=%v", ok, err)
+	}
+	if got.Status != "cancelled" {
+		t.Fatalf("orphaned session status = %q, want cancelled", got.Status)
+	}
 }

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -2939,6 +2939,147 @@ type ClaudeAdapterFixture = {
   healthStatus?: "ready" | "auth_required" | "not_installed" | "error";
 };
 
+type ExternalAdapterFixture = ClaudeAdapterFixture & {
+  id: string;
+  name: string;
+  command: string;
+  args?: string[];
+};
+
+async function openExternalAgentReadinessFixture(page: Page, fixture: ExternalAdapterFixture) {
+  const sessionID = `${fixture.id}-onboarding-e2e`;
+  const adapter = {
+    id: fixture.id,
+    name: fixture.name,
+    kind: "acp",
+    command: fixture.command,
+    args: fixture.args,
+    available: fixture.available ?? true,
+    status: fixture.available === false ? "missing" : "available",
+    error: fixture.available === false ? `${fixture.command} command not found` : undefined,
+    description: `Run ${fixture.name} through ACP as a long-lived external coding-agent session supervised by Hecate.`,
+    cost_mode: "external",
+    auth_status: fixture.authStatus ?? "unknown",
+    auth_error:
+      fixture.authStatus === "unauthenticated"
+        ? `Run ${fixture.command.replace(/\s+.*/, "")} login`
+        : undefined,
+  };
+  const status = fixture.available === false ? "not_installed" : (fixture.healthStatus ?? "ready");
+
+  await page.route("/hecate/v1/agent-adapters*", async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    if (method === "POST" && url.includes(`/${fixture.id}/probe`)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "agent_adapter_probe",
+          data: {
+            adapter:
+              status === "ready"
+                ? { ...adapter, auth_status: "ok", auth_error: undefined }
+                : adapter,
+            health: {
+              adapter_id: fixture.id,
+              status,
+              stage:
+                status === "ready"
+                  ? "ready"
+                  : status === "not_installed"
+                    ? "lookup"
+                    : "new_session",
+              path: fixture.available === false ? undefined : `/usr/local/bin/${fixture.command}`,
+              hint:
+                status === "auth_required"
+                  ? `${fixture.name} needs local sign-in before use.`
+                  : undefined,
+              error:
+                status === "not_installed" ? `${fixture.command} command not found` : undefined,
+              duration_ms: 20,
+            },
+          },
+        }),
+      });
+      return;
+    }
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "agent_adapters", data: [adapter] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  const session = {
+    id: sessionID,
+    title: `${fixture.name} chat`,
+    agent_id: fixture.id,
+    agent_name: fixture.name,
+    driver_kind: "acp",
+    native_session_id: `native-${fixture.id}-e2e`,
+    workspace: "/tmp/hecate-e2e",
+    status: "idle",
+    message_count: 0,
+    config_options: [],
+    messages: [],
+    created_at: "2026-05-14T10:00:00Z",
+    updated_at: "2026-05-14T10:00:00Z",
+  };
+  await page.route(/\/hecate\/v1\/chat\/sessions(?:\/.*)?(?:\?.*)?$/, async (route) => {
+    const method = route.request().method();
+    const path = new URL(route.request().url()).pathname;
+    if (method === "GET" && path === "/hecate/v1/chat/sessions") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "chat_sessions", data: [session] }),
+      });
+      return;
+    }
+    if (method === "GET" && path === `/hecate/v1/chat/sessions/${sessionID}`) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "chat_session", data: session }),
+      });
+      return;
+    }
+    if (method === "GET" && path === `/hecate/v1/chat/sessions/${sessionID}/stream`) {
+      await route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+      return;
+    }
+    if (method === "GET" && path === `/hecate/v1/chat/sessions/${sessionID}/approvals`) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "chat_approvals", data: [] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.addInitScript(
+    ({ adapterID, chatSessionID }) => {
+      window.localStorage.setItem("hecate.chatTarget", "external_agent");
+      window.localStorage.setItem("hecate.agentAdapterID", adapterID);
+      window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+      window.localStorage.setItem("hecate.chatSessionID", chatSessionID);
+    },
+    { adapterID: fixture.id, chatSessionID: sessionID },
+  );
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  await page
+    .getByRole("button", { name: new RegExp(`Chat ${fixture.name} chat, ${fixture.name}`) })
+    .click();
+}
+
 async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture = {}) {
   const adapter = {
     id: "claude_code",
@@ -3129,6 +3270,42 @@ test("Claude Code setup stays visible when the probe requires local auth", async
   await expect(page.getByText("Set up Claude Code")).toBeVisible();
   await expect(page.getByText(/Claude Code needs local CLI sign-in/)).toBeVisible();
   await page.locator("textarea").fill("hello from Claude Code");
+  await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
+});
+
+test("Cursor Agent setup explains CLI sign-in without launching the CLI", async ({ page }) => {
+  await openExternalAgentReadinessFixture(page, {
+    id: "cursor_agent",
+    name: "Cursor Agent",
+    command: "cursor-agent",
+    available: true,
+    authStatus: "unauthenticated",
+    healthStatus: "auth_required",
+  });
+
+  await expect(page.getByText("Set up Cursor Agent")).toBeVisible();
+  await expect(page.getByText(/cursor-agent login/)).toBeVisible();
+  await page.locator("textarea").fill("hello from Cursor Agent");
+  await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
+});
+
+test("Grok Build setup mentions CLI sign-in and model selection without launching the CLI", async ({
+  page,
+}) => {
+  await openExternalAgentReadinessFixture(page, {
+    id: "grok_build",
+    name: "Grok Build",
+    command: "grok",
+    args: ["agent", "stdio"],
+    available: true,
+    authStatus: "unauthenticated",
+    healthStatus: "auth_required",
+  });
+
+  await expect(page.getByText("Set up Grok Build")).toBeVisible();
+  await expect(page.getByText(/grok login/)).toBeVisible();
+  await expect(page.getByText(/model selected/)).toBeVisible();
+  await page.locator("textarea").fill("hello from Grok Build");
   await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
 });
 

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -170,8 +170,10 @@ export function ChatTranscript({
             ? m.model || activeChatSession?.model || "Hecate Chat"
             : m.agent_name || m.agent_id;
           const agentRuntime =
+            role === "assistant" ? formatAgentRuntimeMeta(m.run_id, m.duration_ms) : "";
+          const agentRuntimeTitle =
             role === "assistant"
-              ? formatAgentRuntimeMeta(m.run_id, m.duration_ms, m.native_session_id)
+              ? formatAgentRuntimeMetaTitle(m.run_id, m.duration_ms, m.native_session_id)
               : "";
           const taskID = m.execution_mode === "hecate_task" ? m.task_id : "";
           const taskRunID = taskID ? m.run_id : "";
@@ -188,6 +190,7 @@ export function ChatTranscript({
               time={time}
               badge={role === "assistant" ? m.agent_status || m.cost_mode : undefined}
               runtimeMeta={agentRuntime}
+              runtimeMetaTitle={agentRuntimeTitle}
               taskLink={
                 isHecateAgentChat && role === "assistant" && taskID
                   ? {
@@ -594,20 +597,26 @@ function formatTraceLinkTitle(requestID: string, traceID?: string): string {
     .join(" · ");
 }
 
-function formatAgentRuntimeMeta(
-  runID?: string,
-  durationMS?: number,
-  nativeSessionID?: string,
-): string {
+function formatAgentRuntimeMeta(runID?: string, durationMS?: number): string {
   const parts: string[] = [];
-  if (nativeSessionID) {
-    parts.push(`ACP ${nativeSessionID.slice(0, 12)}`);
-  }
   if (runID) {
     parts.push(`Run ${compactID(runID, ["run_"], 12)}`);
   }
   if (durationMS && durationMS > 0) {
     parts.push(formatDurationMs(durationMS));
   }
+  return parts.join(" · ");
+}
+
+function formatAgentRuntimeMetaTitle(
+  runID?: string,
+  durationMS?: number,
+  nativeSessionID?: string,
+): string {
+  const parts = [
+    runID ? `Run ${runID}` : "",
+    nativeSessionID ? `Native session ${nativeSessionID}` : "",
+    durationMS && durationMS > 0 ? `Duration ${formatDurationMs(durationMS)}` : "",
+  ].filter(Boolean);
   return parts.join(" · ");
 }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3201,7 +3201,8 @@ describe("ChatView external-agent target", () => {
     await userEvent.click(modeToggle);
     expect(actions.setChatConfigOption).toHaveBeenCalledWith("a1", "auto_approve", true);
     expect(screen.getByText("Looks good.")).toBeTruthy();
-    expect(screen.getAllByText(/ACP native_codex/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/ACP native_codex/)).toBeNull();
+    expect(screen.getByTitle(/Native session native_codex_1/)).toBeTruthy();
     const traceButton = screen.getByRole("button", { name: /Open Trace req_code/i });
     expect(traceButton).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -406,6 +406,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     modelRouteUnavailable,
     selectedModelIssue,
     workspace: state.agentWorkspace,
+    selectedAgentID: selectedAgent?.id,
     selectedAgentName: selectedAgent?.name,
     selectedAgentAvailable: Boolean(selectedAgent?.available),
     anyAgentAvailable: availableAgents.length > 0,

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -20,9 +20,10 @@ import {
   type ChatSetupRepairState,
 } from "../../lib/chat-setup-readiness";
 import { describeGatewayError } from "../../lib/error-diagnostics";
+import { resolveExternalAgentReadiness } from "../../lib/external-agent-readiness";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import { providerDisplayName } from "../../lib/provider-utils";
-import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../../types/agent-adapter";
+import type { AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ChatConfigOptionRecord, ChatSessionRecord, ChatUsageRecord } from "../../types/chat";
 import type { LocalProviderDiscoveryRecord, ProviderFilter } from "../../types/provider";
 import { AgentApprovalAutoModeBanner, AgentApprovalsBanner } from "./AgentApprovalBanner";
@@ -237,7 +238,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     ? (state.agentAdapterHealthByID.get(activeAgentAdapterID) ?? null)
     : null;
 
-  const externalAgentSetupRequired = needsExternalAgentSetup(selectedAgent, selectedAgentHealth);
+  const externalAgentSetupRequired = resolveExternalAgentReadiness(
+    selectedAgent,
+    selectedAgentHealth,
+  ).needsRepair;
   const availableAgents = state.agentAdapters.filter((adapter) => adapter.available);
   const configuredProviders = state.settingsConfig?.providers ?? [];
   const providerConfigLoaded = state.settingsConfig !== null;
@@ -991,17 +995,6 @@ function composerVisibleRepair(repair: ChatSetupRepairState | null): ChatSetupRe
     default:
       return null;
   }
-}
-
-function needsExternalAgentSetup(
-  adapter: AgentAdapterRecord | undefined,
-  health: AgentAdapterHealthRecord | null,
-): boolean {
-  if (!adapter) return false;
-  if (health?.status === "ready") return false;
-  if (!adapter.available || health?.status === "not_installed") return true;
-  if (health?.status === "auth_required" || health?.status === "error") return true;
-  return adapter.auth_status === "unauthenticated" || adapter.auth_status === "billing";
 }
 
 function emptyStateAlreadyShowsRepair(

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -15,6 +15,12 @@ import { useRuntime } from "../../app/state/runtime";
 import { useSettings } from "../../app/state/settings";
 import { formatLocaleDateTime } from "../../lib/format";
 import {
+  humanizeProbeError,
+  resolveExternalAgentReadiness,
+  shouldShowProbeError,
+  type ExternalAgentReadinessTone,
+} from "../../lib/external-agent-readiness";
+import {
   providerFleetRepairHint,
   providerReadinessMeaning,
   providerRepairActionLabel,
@@ -726,28 +732,22 @@ function AdapterStatusRow({
   onCopyCommand: (command: string) => void;
   onProbeAdapter: (adapter: AgentAdapterRecord) => void;
 }) {
-  // Collapse discovery, probe, and auth into one operator-facing state
-  // so adapters don't show as both "missing" and "auth unknown".
-  const probeVerifiedAuth = health?.status === "ready";
-  const displayAuthStatus = probeVerifiedAuth ? "ok" : adapter.auth_status;
-  const displayAuthError = probeVerifiedAuth ? "" : adapter.auth_error;
-  const loginCommand = adapterLoginCommand(adapter);
-  const localAuthNeedsRepair =
-    displayAuthStatus === "unauthenticated" || health?.status === "auth_required";
-  const showLocalAuthSetup = Boolean(loginCommand) && !probeVerifiedAuth && localAuthNeedsRepair;
+  const readiness = resolveExternalAgentReadiness(adapter, health);
+  const loginCommand = readiness.loginCommand;
+  const showLocalAuthSetup =
+    Boolean(loginCommand) && !readiness.verifiedByProbe && readiness.kind === "sign_in";
   const visibleHealthError =
     health && shouldShowProbeError(health) ? humanizeProbeError(health.error ?? "") : "";
   const healthPath = health?.path ?? "";
-  const state = adapterStatusState(adapter, health, displayAuthStatus, showLocalAuthSetup);
-  const detail = adapterStatusDetail(adapter, health, state, visibleHealthError, displayAuthError);
+  const detail = adapterStatusDetail(readiness, visibleHealthError);
   const showHealthDetail = Boolean(
-    detail && health && !showLocalAuthSetup && (health.hint || visibleHealthError),
+    detail && health && !showLocalAuthSetup && (readiness.detail || visibleHealthError),
   );
   const showAuthDetail = Boolean(detail && !health && !showLocalAuthSetup);
   const showAuthMetadata = Boolean(
-    displayAuthStatus && displayAuthStatus === "ok" && !showLocalAuthSetup && !health,
+    readiness.authStatus && readiness.authStatus === "ok" && !showLocalAuthSetup && !health,
   );
-  const showHealthDebugMetadata = state?.kind === "ready" || state?.kind === "issue";
+  const showHealthDebugMetadata = readiness.kind === "ready" || readiness.kind === "issue";
   const showHealthPath = Boolean(
     healthPath && showHealthDebugMetadata && !showLocalAuthSetup && !isDevOverridePath(healthPath),
   );
@@ -776,19 +776,17 @@ function AdapterStatusRow({
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t2)" }}>
             {adapter.id}
           </span>
-          {state && (
-            <span
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                color: chipColor(state.tone),
-                textTransform: "uppercase",
-                letterSpacing: "0.04em",
-              }}
-            >
-              {state.label}
-            </span>
-          )}
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: chipColor(readiness.tone),
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {readiness.label}
+          </span>
           {adapter.version_outside_range && (
             <span
               data-testid={`external-agents-adapter-${adapter.id}-version-warning`}
@@ -831,7 +829,7 @@ function AdapterStatusRow({
           )}
           {showAuthMetadata && (
             <span>
-              auth <span style={{ color: "var(--t1)" }}>{displayAuthStatus}</span>
+              auth <span style={{ color: "var(--t1)" }}>{readiness.authStatus}</span>
             </span>
           )}
           {showHealthPath && (
@@ -1009,104 +1007,28 @@ function isDevOverridePath(path: string): boolean {
   return path.startsWith("dev-override://");
 }
 
-function shouldShowProbeError(health: AgentAdapterHealthRecord): boolean {
-  const error = health.error?.trim() ?? "";
-  if (!error) return false;
-  if (error.includes("HECATE_AGENT_ADAPTER_DEV_OVERRIDES")) return false;
-  if (error.startsWith("forced ")) return false;
-  return true;
-}
-
-type ChipTone = "green" | "amber" | "red" | "muted";
-type AdapterStatusKind = "ready" | "sign_in" | "setup" | "billing" | "issue";
-type AdapterStatusState = {
-  kind: AdapterStatusKind;
-  tone: ChipTone;
-  label: string;
-};
+type ChipTone = ExternalAgentReadinessTone;
 type AdapterStatusDetail = {
   tone: ChipTone;
   message: string;
 };
 
-function adapterStatusState(
-  adapter: AgentAdapterRecord,
-  health: AgentAdapterHealthRecord | null,
-  authStatus: string | undefined,
-  showLocalAuthSetup: boolean,
-): AdapterStatusState | null {
-  if (health?.status === "ready") return { kind: "ready", tone: "green", label: "ready" };
-  if (isBillingStatus(authStatus, health))
-    return { kind: "billing", tone: "amber", label: "billing" };
-  if (
-    showLocalAuthSetup ||
-    authStatus === "unauthenticated" ||
-    health?.status === "auth_required"
-  ) {
-    return { kind: "sign_in", tone: "amber", label: "sign in" };
-  }
-  if (!adapter.available || health?.status === "not_installed" || isSetupProbe(health)) {
-    return { kind: "setup", tone: "muted", label: "not configured" };
-  }
-  if (health?.status === "error") {
-    return { kind: "issue", tone: "amber", label: "needs attention" };
-  }
-  if (authStatus && authStatus !== "ok" && authStatus !== "unknown") {
-    return { kind: "issue", tone: "amber", label: "needs attention" };
-  }
-  return null;
-}
-
 function adapterStatusDetail(
-  adapter: AgentAdapterRecord,
-  health: AgentAdapterHealthRecord | null,
-  state: AdapterStatusState | null,
+  readiness: ReturnType<typeof resolveExternalAgentReadiness>,
   visibleHealthError: string,
-  authError: string | undefined,
 ): AdapterStatusDetail | null {
-  if (!state) return null;
-  if (state.kind === "ready" || state.kind === "sign_in") return null;
+  if (readiness.kind === "ready" || readiness.kind === "sign_in") return null;
 
-  if (state.kind === "setup") {
+  if (readiness.kind === "setup") {
     return {
       tone: "muted",
-      message: `Set up to use: ${health?.hint || authError || adapterSetupHint(adapter)}`,
+      message: `Set up to use: ${readiness.detail || readiness.setupHint}`,
     };
   }
 
-  const message = health?.hint || authError || visibleHealthError;
+  const message = readiness.detail || visibleHealthError;
   if (!message) return null;
-  return { tone: state.tone, message };
-}
-
-function isBillingStatus(
-  authStatus: string | undefined,
-  health: AgentAdapterHealthRecord | null,
-): boolean {
-  if (authStatus === "billing") return true;
-  const text = `${health?.hint ?? ""} ${health?.error ?? ""}`.toLowerCase();
-  return Boolean(health?.status === "error" && text.includes("billing"));
-}
-
-function isSetupProbe(health: AgentAdapterHealthRecord | null): boolean {
-  if (!health || health.status !== "error") return false;
-  const text = `${health.hint ?? ""} ${health.error ?? ""}`.toLowerCase();
-  return (
-    text.includes("app cli missing") ||
-    text.includes("command was not found") ||
-    text.includes("setup docs:") ||
-    text.startsWith("install ")
-  );
-}
-
-function adapterSetupHint(adapter: AgentAdapterRecord): string {
-  if (adapter.managed_package) {
-    return `Install Node/npm so Hecate can manage "${adapter.managed_package}", or install ${adapter.command} directly.`;
-  }
-  if (adapter.docs_url) {
-    return `Install ${adapter.name} and ensure ${adapter.command} is on PATH. Setup docs: ${adapter.docs_url}`;
-  }
-  return `Install ${adapter.name} and ensure ${adapter.command} is on PATH.`;
+  return { tone: readiness.tone, message };
 }
 
 function chipColor(tone: ChipTone): string {
@@ -1122,40 +1044,8 @@ function chipColor(tone: ChipTone): string {
   }
 }
 
-function adapterLoginCommand(adapter: AgentAdapterRecord): string {
-  switch (adapter.id) {
-    case "codex":
-      return "codex login";
-    case "claude_code":
-      return "claude /login";
-    case "cursor_agent":
-      return "cursor-agent login";
-    case "grok_build":
-      return "grok login";
-    default:
-      return "";
-  }
-}
-
 function externalAgentSetupFocusTarget(adapterID: string): string {
   return `external-agent-auth-setup-${adapterID}`;
-}
-
-function humanizeProbeError(error: string): string {
-  const trimmed = error.trim();
-  if (!trimmed) return "";
-  try {
-    const parsed = JSON.parse(trimmed) as {
-      message?: unknown;
-      data?: { error?: unknown };
-    };
-    const message = typeof parsed.message === "string" ? parsed.message : "";
-    const detail = typeof parsed.data?.error === "string" ? parsed.data.error : "";
-    if (message && detail) return `${message}: ${detail}`;
-    return detail || message || trimmed;
-  } catch {
-    return trimmed;
-  }
 }
 
 function GrantRow({

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -143,6 +143,7 @@ describe("TranscriptMessageRow", () => {
       <TranscriptMessageRow
         {...baseProps}
         runtimeMeta="Run run_123 · 2.0s"
+        runtimeMetaTitle="Run run_123 · Native session native_123"
         taskLink={{ label: "Task task_123", onClick: onOpenTask }}
         traceLink={{ label: "Trace req_1234", onClick: onOpenTrace }}
       />,
@@ -153,7 +154,9 @@ describe("TranscriptMessageRow", () => {
 
     expect(onOpenTask).toHaveBeenCalledTimes(1);
     expect(onOpenTrace).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Run run_123 · 2.0s")).toBeInTheDocument();
+    const meta = screen.getByText("Run run_123 · 2.0s");
+    expect(meta).toBeInTheDocument();
+    expect(meta).toHaveAttribute("title", "Run run_123 · Native session native_123");
   });
 
   it("renders the agent usage line when adapter-reported usage is present", () => {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -27,6 +27,7 @@ export function TranscriptMessageRow({
   costUsd,
   badge,
   runtimeMeta,
+  runtimeMetaTitle,
   taskLink,
   traceLink,
   activities,
@@ -55,6 +56,7 @@ export function TranscriptMessageRow({
   costUsd?: string;
   badge?: string;
   runtimeMeta?: string;
+  runtimeMetaTitle?: string;
   agentSessionID?: string;
   taskLink?: { label: string; title?: string; onClick: () => void };
   traceLink?: { label: string; title?: string; onClick: () => void };
@@ -163,7 +165,10 @@ export function TranscriptMessageRow({
               />
             )}
             {isAssistant && runtimeMeta && (
-              <span style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
+              <span
+                title={runtimeMetaTitle}
+                style={{ fontSize: 10, color: "var(--t3)", fontFamily: "var(--font-mono)" }}
+              >
                 {runtimeMeta}
               </span>
             )}

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -141,6 +141,7 @@ describe("resolveChatSetupRepairState", () => {
     const repair = resolveChatSetupRepairState({
       ...base,
       target: "external_agent",
+      selectedAgentID: "cursor_agent",
       selectedAgentName: "Cursor Agent",
       externalAgentSetupRequired: true,
     });
@@ -151,6 +152,24 @@ describe("resolveChatSetupRepairState", () => {
       action: "open_agent_setup",
       actionLabel: "Open setup",
     });
+    expect(repair?.message).toContain("cursor-agent login");
+  });
+
+  it("uses Grok Build setup copy that mentions sign-in and model selection", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentID: "grok_build",
+      selectedAgentName: "Grok Build",
+      externalAgentSetupRequired: true,
+    });
+
+    expect(repair).toMatchObject({
+      kind: "external_agent_setup",
+      title: "Set up Grok Build",
+    });
+    expect(repair?.message).toContain("grok login");
+    expect(repair?.message).toContain("model selected");
   });
 });
 

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -34,6 +34,7 @@ export function resolveChatSetupRepairState({
   modelRouteUnavailable,
   selectedModelIssue,
   workspace,
+  selectedAgentID,
   selectedAgentName,
   selectedAgentAvailable,
   anyAgentAvailable,
@@ -44,6 +45,7 @@ export function resolveChatSetupRepairState({
   modelRouteUnavailable: boolean;
   selectedModelIssue: SelectedModelIssue | null;
   workspace: string;
+  selectedAgentID?: string;
   selectedAgentName?: string;
   selectedAgentAvailable: boolean;
   anyAgentAvailable: boolean;
@@ -68,7 +70,7 @@ export function resolveChatSetupRepairState({
       return {
         kind: "external_agent_setup",
         title: `Set up ${agent}`,
-        message: `${agent} needs local CLI sign-in before Hecate can start a session.`,
+        message: externalAgentSetupMessage(selectedAgentID, agent),
         action: "open_agent_setup",
         actionLabel: "Open setup",
         tone: "amber",
@@ -116,6 +118,19 @@ export function resolveChatSetupRepairState({
   }
 
   return null;
+}
+
+function externalAgentSetupMessage(agentID: string | undefined, agent: string): string {
+  switch (agentID) {
+    case "cursor_agent":
+      return "Cursor Agent needs the local CLI installed, available on PATH, and signed in with cursor-agent login before Hecate can start a session.";
+    case "grok_build":
+      return "Grok Build needs the Grok CLI installed, signed in with grok login, and a model selected before Hecate can start a session.";
+    case "claude_code":
+      return "Claude Code needs local CLI sign-in before Hecate can start a session.";
+    default:
+      return `${agent} needs local CLI sign-in before Hecate can start a session.`;
+  }
 }
 
 function workspaceRepair(): ChatSetupRepairState {

--- a/ui/src/lib/external-agent-readiness.test.ts
+++ b/ui/src/lib/external-agent-readiness.test.ts
@@ -69,6 +69,26 @@ describe("resolveExternalAgentReadiness", () => {
     expect(readiness.detail).not.toContain("Install");
   });
 
+  it("includes Claude Code token alternatives in sign-in guidance", () => {
+    const readiness = resolveExternalAgentReadiness(
+      adapter({
+        id: "claude_code",
+        name: "Claude Code",
+        command: "claude",
+        auth_status: "unauthenticated",
+        auth_error: "",
+      }),
+      null,
+    );
+
+    expect(readiness).toMatchObject({
+      kind: "sign_in",
+      detail:
+        "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment.",
+      needsRepair: true,
+    });
+  });
+
   it("keeps unprobed available agents muted until a probe verifies readiness", () => {
     const readiness = resolveExternalAgentReadiness(adapter({ auth_status: "unknown" }), null);
 

--- a/ui/src/lib/external-agent-readiness.test.ts
+++ b/ui/src/lib/external-agent-readiness.test.ts
@@ -55,6 +55,32 @@ describe("resolveExternalAgentReadiness", () => {
     });
   });
 
+  it("uses sign-in guidance instead of install copy for installed unauthenticated agents", () => {
+    const readiness = resolveExternalAgentReadiness(
+      adapter({ auth_status: "unauthenticated", auth_error: "" }),
+      null,
+    );
+
+    expect(readiness).toMatchObject({
+      kind: "sign_in",
+      detail: "Run cursor-agent login, or set CURSOR_API_KEY for the adapter environment.",
+      needsRepair: true,
+    });
+    expect(readiness.detail).not.toContain("Install");
+  });
+
+  it("keeps unprobed available agents muted until a probe verifies readiness", () => {
+    const readiness = resolveExternalAgentReadiness(adapter({ auth_status: "unknown" }), null);
+
+    expect(readiness).toMatchObject({
+      kind: "unverified",
+      label: "not verified",
+      tone: "muted",
+      needsRepair: false,
+      verifiedByProbe: false,
+    });
+  });
+
   it("uses adapter-specific setup guidance for Grok Build", () => {
     const readiness = resolveExternalAgentReadiness(
       adapter({

--- a/ui/src/lib/external-agent-readiness.test.ts
+++ b/ui/src/lib/external-agent-readiness.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveExternalAgentReadiness } from "./external-agent-readiness";
+import type { AgentAdapterRecord } from "../types/agent-adapter";
+
+function adapter(overrides: Partial<AgentAdapterRecord> = {}): AgentAdapterRecord {
+  return {
+    id: "cursor_agent",
+    name: "Cursor Agent",
+    kind: "acp",
+    command: "cursor-agent",
+    available: true,
+    status: "available",
+    cost_mode: "external",
+    ...overrides,
+  };
+}
+
+describe("resolveExternalAgentReadiness", () => {
+  it("lets a ready probe override stale auth metadata", () => {
+    const readiness = resolveExternalAgentReadiness(
+      adapter({ auth_status: "unauthenticated", auth_error: "old auth error" }),
+      {
+        adapter_id: "cursor_agent",
+        status: "ready",
+        stage: "session",
+        duration_ms: 200,
+      },
+    );
+
+    expect(readiness).toMatchObject({
+      kind: "ready",
+      label: "ready",
+      needsRepair: false,
+      authStatus: "ok",
+      authError: "",
+      verifiedByProbe: true,
+    });
+  });
+
+  it("turns auth probe failures into a sign-in repair", () => {
+    const readiness = resolveExternalAgentReadiness(adapter(), {
+      adapter_id: "cursor_agent",
+      status: "auth_required",
+      stage: "initialize",
+      hint: "Run cursor-agent login.",
+      duration_ms: 200,
+    });
+
+    expect(readiness).toMatchObject({
+      kind: "sign_in",
+      loginCommand: "cursor-agent login",
+      detail: "Run cursor-agent login.",
+      needsRepair: true,
+    });
+  });
+
+  it("uses adapter-specific setup guidance for Grok Build", () => {
+    const readiness = resolveExternalAgentReadiness(
+      adapter({
+        id: "grok_build",
+        name: "Grok Build",
+        command: "grok",
+        available: false,
+        status: "missing",
+      }),
+      null,
+    );
+
+    expect(readiness).toMatchObject({
+      kind: "setup",
+      loginCommand: "grok login",
+      needsRepair: true,
+    });
+    expect(readiness.setupHint).toContain("Grok CLI");
+    expect(readiness.setupHint).toContain("model selected");
+  });
+});

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -1,6 +1,12 @@
 import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../types/agent-adapter";
 
-export type ExternalAgentReadinessKind = "ready" | "sign_in" | "setup" | "billing" | "issue";
+export type ExternalAgentReadinessKind =
+  | "ready"
+  | "unverified"
+  | "sign_in"
+  | "setup"
+  | "billing"
+  | "issue";
 export type ExternalAgentReadinessTone = "green" | "amber" | "red" | "muted";
 
 export type ExternalAgentReadiness = {
@@ -10,6 +16,7 @@ export type ExternalAgentReadiness = {
   needsRepair: boolean;
   loginCommand: string;
   setupHint: string;
+  signInHint: string;
   detail?: string;
   authStatus?: string;
   authError?: string;
@@ -28,6 +35,7 @@ export function resolveExternalAgentReadiness(
       needsRepair: true,
       loginCommand: "",
       setupHint: "Choose an available external agent in Connections.",
+      signInHint: "Choose an available external agent in Connections.",
       verifiedByProbe: false,
     };
   }
@@ -37,6 +45,7 @@ export function resolveExternalAgentReadiness(
   const authError = verifiedByProbe ? "" : adapter.auth_error;
   const loginCommand = externalAgentLoginCommand(adapter);
   const setupHint = externalAgentSetupHint(adapter);
+  const signInHint = externalAgentSignInHint(adapter);
   const localAuthNeedsRepair =
     authStatus === "unauthenticated" || health?.status === "auth_required";
   const visibleProbeError =
@@ -50,6 +59,7 @@ export function resolveExternalAgentReadiness(
       needsRepair: false,
       loginCommand,
       setupHint,
+      signInHint,
       authStatus,
       authError,
       verifiedByProbe,
@@ -64,6 +74,7 @@ export function resolveExternalAgentReadiness(
       needsRepair: true,
       loginCommand,
       setupHint,
+      signInHint,
       detail: health?.hint || authError || visibleProbeError || "Check billing or subscription.",
       authStatus,
       authError,
@@ -79,7 +90,8 @@ export function resolveExternalAgentReadiness(
       needsRepair: true,
       loginCommand,
       setupHint,
-      detail: health?.hint || authError || setupHint,
+      signInHint,
+      detail: health?.hint || authError || signInHint,
       authStatus,
       authError,
       verifiedByProbe,
@@ -94,6 +106,7 @@ export function resolveExternalAgentReadiness(
       needsRepair: true,
       loginCommand,
       setupHint,
+      signInHint,
       detail: health?.hint || authError || setupHint,
       authStatus,
       authError,
@@ -112,6 +125,7 @@ export function resolveExternalAgentReadiness(
       needsRepair: true,
       loginCommand,
       setupHint,
+      signInHint,
       detail: health?.hint || authError || visibleProbeError || setupHint,
       authStatus,
       authError,
@@ -120,12 +134,14 @@ export function resolveExternalAgentReadiness(
   }
 
   return {
-    kind: "ready",
-    tone: "green",
-    label: "ready",
+    kind: "unverified",
+    tone: "muted",
+    label: "not verified",
     needsRepair: false,
     loginCommand,
     setupHint,
+    signInHint,
+    detail: "Test this agent in Connections to verify local auth before the first prompt.",
     authStatus,
     authError,
     verifiedByProbe,
@@ -144,6 +160,21 @@ export function externalAgentLoginCommand(adapter: AgentAdapterRecord): string {
       return "grok login";
     default:
       return "";
+  }
+}
+
+export function externalAgentSignInHint(adapter: AgentAdapterRecord): string {
+  switch (adapter.id) {
+    case "codex":
+      return "Run codex login in Terminal, then test the agent again.";
+    case "claude_code":
+      return "Run claude /login in Terminal, then test Claude Code again.";
+    case "cursor_agent":
+      return "Run cursor-agent login, or set CURSOR_API_KEY for the adapter environment.";
+    case "grok_build":
+      return "Run grok login, or set XAI_API_KEY for the adapter environment.";
+    default:
+      return externalAgentSetupHint(adapter);
   }
 }
 
@@ -198,6 +229,9 @@ function isBillingStatus(
 }
 
 function isSetupProbe(health: AgentAdapterHealthRecord | null): boolean {
+  // The gateway currently reports setup-shaped probe failures as normalized
+  // hint/error text instead of a structured reason. Keep this parser local to
+  // the readiness helper until the probe response grows a reason field.
   if (!health || health.status !== "error") return false;
   const text = `${health.hint ?? ""} ${health.error ?? ""}`.toLowerCase();
   return (

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -168,7 +168,7 @@ export function externalAgentSignInHint(adapter: AgentAdapterRecord): string {
     case "codex":
       return "Run codex login in Terminal, then test the agent again.";
     case "claude_code":
-      return "Run claude /login in Terminal, then test Claude Code again.";
+      return "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment.";
     case "cursor_agent":
       return "Run cursor-agent login, or set CURSOR_API_KEY for the adapter environment.";
     case "grok_build":

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -1,0 +1,209 @@
+import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../types/agent-adapter";
+
+export type ExternalAgentReadinessKind = "ready" | "sign_in" | "setup" | "billing" | "issue";
+export type ExternalAgentReadinessTone = "green" | "amber" | "red" | "muted";
+
+export type ExternalAgentReadiness = {
+  kind: ExternalAgentReadinessKind;
+  tone: ExternalAgentReadinessTone;
+  label: string;
+  needsRepair: boolean;
+  loginCommand: string;
+  setupHint: string;
+  detail?: string;
+  authStatus?: string;
+  authError?: string;
+  verifiedByProbe: boolean;
+};
+
+export function resolveExternalAgentReadiness(
+  adapter: AgentAdapterRecord | undefined,
+  health: AgentAdapterHealthRecord | null,
+): ExternalAgentReadiness {
+  if (!adapter) {
+    return {
+      kind: "setup",
+      tone: "muted",
+      label: "not configured",
+      needsRepair: true,
+      loginCommand: "",
+      setupHint: "Choose an available external agent in Connections.",
+      verifiedByProbe: false,
+    };
+  }
+
+  const verifiedByProbe = health?.status === "ready";
+  const authStatus = verifiedByProbe ? "ok" : adapter.auth_status;
+  const authError = verifiedByProbe ? "" : adapter.auth_error;
+  const loginCommand = externalAgentLoginCommand(adapter);
+  const setupHint = externalAgentSetupHint(adapter);
+  const localAuthNeedsRepair =
+    authStatus === "unauthenticated" || health?.status === "auth_required";
+  const visibleProbeError =
+    health && shouldShowProbeError(health) ? humanizeProbeError(health.error ?? "") : "";
+
+  if (verifiedByProbe) {
+    return {
+      kind: "ready",
+      tone: "green",
+      label: "ready",
+      needsRepair: false,
+      loginCommand,
+      setupHint,
+      authStatus,
+      authError,
+      verifiedByProbe,
+    };
+  }
+
+  if (isBillingStatus(authStatus, health)) {
+    return {
+      kind: "billing",
+      tone: "amber",
+      label: "billing",
+      needsRepair: true,
+      loginCommand,
+      setupHint,
+      detail: health?.hint || authError || visibleProbeError || "Check billing or subscription.",
+      authStatus,
+      authError,
+      verifiedByProbe,
+    };
+  }
+
+  if (localAuthNeedsRepair) {
+    return {
+      kind: "sign_in",
+      tone: "amber",
+      label: "sign in",
+      needsRepair: true,
+      loginCommand,
+      setupHint,
+      detail: health?.hint || authError || setupHint,
+      authStatus,
+      authError,
+      verifiedByProbe,
+    };
+  }
+
+  if (!adapter.available || health?.status === "not_installed" || isSetupProbe(health)) {
+    return {
+      kind: "setup",
+      tone: "muted",
+      label: "not configured",
+      needsRepair: true,
+      loginCommand,
+      setupHint,
+      detail: health?.hint || authError || setupHint,
+      authStatus,
+      authError,
+      verifiedByProbe,
+    };
+  }
+
+  if (
+    health?.status === "error" ||
+    (authStatus && authStatus !== "ok" && authStatus !== "unknown")
+  ) {
+    return {
+      kind: "issue",
+      tone: "amber",
+      label: "needs attention",
+      needsRepair: true,
+      loginCommand,
+      setupHint,
+      detail: health?.hint || authError || visibleProbeError || setupHint,
+      authStatus,
+      authError,
+      verifiedByProbe,
+    };
+  }
+
+  return {
+    kind: "ready",
+    tone: "green",
+    label: "ready",
+    needsRepair: false,
+    loginCommand,
+    setupHint,
+    authStatus,
+    authError,
+    verifiedByProbe,
+  };
+}
+
+export function externalAgentLoginCommand(adapter: AgentAdapterRecord): string {
+  switch (adapter.id) {
+    case "codex":
+      return "codex login";
+    case "claude_code":
+      return "claude /login";
+    case "cursor_agent":
+      return "cursor-agent login";
+    case "grok_build":
+      return "grok login";
+    default:
+      return "";
+  }
+}
+
+export function externalAgentSetupHint(adapter: AgentAdapterRecord): string {
+  if (adapter.id === "cursor_agent") {
+    return "Install Cursor's command-line agent, confirm cursor-agent is on PATH, then run cursor-agent login.";
+  }
+  if (adapter.id === "grok_build") {
+    return "Install the Grok CLI, confirm grok is on PATH, then run grok login. Grok Build also needs a model selected before send.";
+  }
+  if (adapter.managed_package) {
+    return `Install Node/npm so Hecate can manage "${adapter.managed_package}", or install ${adapter.command} directly.`;
+  }
+  if (adapter.docs_url) {
+    return `Install ${adapter.name} and ensure ${adapter.command} is on PATH. Setup docs: ${adapter.docs_url}`;
+  }
+  return `Install ${adapter.name} and ensure ${adapter.command} is on PATH.`;
+}
+
+export function shouldShowProbeError(health: AgentAdapterHealthRecord): boolean {
+  const error = health.error?.trim() ?? "";
+  if (!error) return false;
+  if (error.includes("HECATE_AGENT_ADAPTER_DEV_OVERRIDES")) return false;
+  if (error.startsWith("forced ")) return false;
+  return true;
+}
+
+export function humanizeProbeError(error: string): string {
+  const trimmed = error.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      data?: { error?: unknown };
+    };
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    const detail = typeof parsed.data?.error === "string" ? parsed.data.error : "";
+    if (message && detail) return `${message}: ${detail}`;
+    return detail || message || trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+function isBillingStatus(
+  authStatus: string | undefined,
+  health: AgentAdapterHealthRecord | null,
+): boolean {
+  if (authStatus === "billing") return true;
+  const text = `${health?.hint ?? ""} ${health?.error ?? ""}`.toLowerCase();
+  return Boolean(health?.status === "error" && text.includes("billing"));
+}
+
+function isSetupProbe(health: AgentAdapterHealthRecord | null): boolean {
+  if (!health || health.status !== "error") return false;
+  const text = `${health.hint ?? ""} ${health.error ?? ""}`.toLowerCase();
+  return (
+    text.includes("app cli missing") ||
+    text.includes("command was not found") ||
+    text.includes("setup docs:") ||
+    text.startsWith("install ")
+  );
+}


### PR DESCRIPTION
## What changed
- Shares one external-agent readiness helper between Connections and Chat so discovery, probe, auth, billing, and setup states are interpreted consistently.
- Adds adapter-specific repair copy for Cursor Agent and Grok Build, including the exact local sign-in commands and the Grok Build model-selection requirement.
- Quiets transcript runtime metadata by keeping run/duration visible while moving native session details into hover text.
- Adds restart reconciliation coverage for an external-agent session that is restored as running without a live assistant message.
- Broadens fake browser coverage for Cursor Agent and Grok Build setup states, without launching real external tools.

## Commits
- `fix(ui): share external agent readiness`
- `fix(ui): clarify adapter setup repairs`
- `fix(ui): quiet transcript runtime metadata`
- `test(chat): cover external session restart reconciliation`
- `test(ui): broaden external agent readiness e2e`

## Tests run
- `go test ./internal/chat`
- `go vet ./internal/chat`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `cd ui && bun run format:check`
- `cd ui && bunx playwright test ui/e2e/chat.spec.ts --grep "external-agent chat uses|external-agent running|Cursor Agent setup|Grok Build setup|Claude Code setup stays"`

## Non-goals
- No new settings panels.
- No real external CLIs are invoked by tests.
- No broad chat architecture rewrite.
