### PR TITLE
fix(ui): preserve failed agent transcript text

### DIFF
--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -40,6 +40,113 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText("adapter exited 1")).toBeInTheDocument();
   });
 
+  it("keeps failed run content when it differs from the error", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content="I updated the README before the tool failed."
+        error="adapter exited 1"
+      />,
+    );
+
+    expect(screen.getByText("I updated the README before the tool failed.")).toBeInTheDocument();
+    expect(screen.getByText("agent run failed")).toBeInTheDocument();
+    expect(screen.getByText("adapter exited 1")).toBeInTheDocument();
+  });
+
+  it("does not duplicate failed run content when content is just the error", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content="adapter exited 1"
+        error="adapter exited 1"
+      />,
+    );
+
+    expect(screen.getAllByText("adapter exited 1")).toHaveLength(1);
+  });
+
+  it("does not render whitespace-only failed run content", () => {
+    render(
+      <TranscriptMessageRow {...baseProps} badge="failed" content="   " error="adapter exited 1" />,
+    );
+
+    expect(screen.getByText("agent run failed")).toBeInTheDocument();
+    expect(screen.getByText("adapter exited 1")).toBeInTheDocument();
+    expect(screen.queryByText(/^\s+$/)).toBeNull();
+  });
+
+  it("hides generic failed activity rows that repeat the failure notice", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content=""
+        error="launch model required: select a model for Grok Build before starting the external agent"
+        activities={[
+          {
+            type: "failed",
+            title: "Failed",
+            status: "failed",
+            detail:
+              "launch model required: select a model for Grok Build before starting the external agent",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("agent run failed")).toBeInTheDocument();
+    expect(screen.getAllByText(/launch model required/)).toHaveLength(1);
+    expect(screen.queryByText("Failed")).toBeNull();
+  });
+
+  it("keeps diagnostic failed activity rows with distinct details", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content=""
+        error="agent run failed"
+        activities={[
+          {
+            type: "run_result",
+            title: "LLM call failed on turn 2: timeout",
+            status: "failed",
+            terminal: true,
+            detail: "rate limit exceeded",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("LLM call failed on turn 2: timeout")).toBeInTheDocument();
+  });
+
+  it("keeps failed tool-call rows even when their title looks generic", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content=""
+        error="tool failed"
+        activities={[
+          {
+            type: "tool_call",
+            title: "failed",
+            status: "failed",
+            detail: "tool failed",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("agent run failed")).toBeInTheDocument();
+    expect(screen.getByText(/1 failed tool/)).toBeInTheDocument();
+    expect(screen.getAllByText("failed")).toHaveLength(2);
+  });
+
   it("strips the recovery marker from the visible failure message", () => {
     render(
       <TranscriptMessageRow

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -102,10 +102,16 @@ export function TranscriptMessageRow({
     content.trim() !== "" &&
     isLikelyTransientAgentNarration(content) &&
     !(activities ?? []).some((activity) => activity.type === "tool_call");
-  const renderActivityAdvanced =
+  const visibleActivities =
     isAssistant && activities?.length
+      ? activities.filter(
+          (activity) => !failed || !duplicatesFailureNotice(activity, error || content),
+        )
+      : activities;
+  const renderActivityAdvanced =
+    isAssistant && visibleActivities?.length
       ? (activity: ChatActivityRecord) =>
-          renderAgentActivityAdvanced(activity, activities, taskLink)
+          renderAgentActivityAdvanced(activity, visibleActivities, taskLink)
       : undefined;
 
   return (
@@ -194,9 +200,15 @@ export function TranscriptMessageRow({
             </div>
           </div>
           {failed ? (
-            <AgentRunNotice status="failed" message={error || content} action={setupAction} />
+            <>
+              {shouldRenderFailedContent(content, error) ? (
+                <TranscriptMarkdown content={content} />
+              ) : null}
+              <AgentRunNotice status="failed" message={error || content} action={setupAction} />
+            </>
           ) : cancelled ? (
             <>
+              {/* Cancel messages may be normalized by the backend; preserve partial text as-is. */}
               {content.trim() ? <TranscriptMarkdown content={content} /> : null}
               <AgentRunNotice
                 status="cancelled"
@@ -231,9 +243,9 @@ export function TranscriptMessageRow({
           ) : (
             <TranscriptMarkdown content={content} />
           )}
-          {isAssistant && activities && activities.length > 0 && (
+          {isAssistant && visibleActivities && visibleActivities.length > 0 && (
             <TranscriptActivityTimeline
-              activities={activities}
+              activities={visibleActivities}
               diffStat={diffStat}
               renderAdvancedActivity={renderActivityAdvanced}
             />
@@ -465,6 +477,25 @@ function isLikelyTransientAgentNarration(text: string): boolean {
 
 function isActiveAgentActivity(activity: ChatActivityRecord): boolean {
   return activity.status === "running" || activity.status === "in_progress";
+}
+
+function shouldRenderFailedContent(content: string, error?: string): boolean {
+  const visible = content.trim();
+  if (!visible) return false;
+  return visible !== (error ?? "").trim();
+}
+
+function duplicatesFailureNotice(activity: ChatActivityRecord, message: string): boolean {
+  if (activity.type !== "failed" && activity.status !== "failed") return false;
+  if (activity.type === "tool_call") return false;
+  // Keep this title list in sync with generic terminal failure rows from
+  // internal/api/handler_chat_activities.go and handler_chat.go. Richer
+  // diagnostic titles should remain visible in the activity timeline.
+  const title = activity.title.trim().toLowerCase();
+  if (title !== "failed" && title !== "run failed") return false;
+  const detail = activity.detail?.trim() ?? "";
+  if (!detail) return true;
+  return detail === message.trim();
 }
 
 function AgentRunNotice({


### PR DESCRIPTION
## What changed
- Preserve distinct assistant transcript text on failed agent runs.
- Keep the failure notice below the preserved text so the operator sees both partial output and the failure reason.
- Avoid duplicating content when the assistant content is only the same error string.

## Why
External-agent failures could replace useful partial agent text with only the failure notice. Cancelled runs already kept partial output, so this makes failed and cancelled transcript behavior more consistent and keeps raw adapter details out of the main reading path.

## Tests
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- TranscriptMessageRow.test.tsx TranscriptActivityTimeline.test.tsx ChatView.test.tsx`
- `cd ui && bun run test`

## Non-goals
- No changes to backend adapter execution or activity generation.
- No changes to raw adapter output disclosure behavior.
