### PR TITLE
feat(projects): add project context foundation

### DIFF
--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -101,6 +101,10 @@ Candidate sources are collected from the active runtime surface:
 | External imports          | Future imported Codex/Claude transcripts, PR comments, issue text, web content, raw adapter output. |
 
 Discovery is allowed to over-collect candidates. Later stages decide inclusion.
+The current project API stores only project context-source metadata (`path`,
+`kind`, `title`, `enabled`). Context assembly is the future layer that may
+resolve those sources through WorkspaceFS, label them, and decide whether they
+belong in a packet.
 
 ### 2. Trust Classification
 

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -1,6 +1,6 @@
 # Context Assembly And Injection Boundaries
 
-> **Status:** proposed; not implemented.
+> **Status:** proposed; partially implemented.
 > **Current source of truth:** [Chat sessions](../chat-sessions.md),
 > [Agent runtime](../agent-runtime.md), and [Security](../security.md) for
 > today's prompt, workspace, tool, and approval behavior.
@@ -102,9 +102,11 @@ Candidate sources are collected from the active runtime surface:
 
 Discovery is allowed to over-collect candidates. Later stages decide inclusion.
 The current project API stores only project context-source metadata (`path`,
-`kind`, `title`, `enabled`). Context assembly is the future layer that may
-resolve those sources through WorkspaceFS, label them, and decide whether they
-belong in a packet.
+`kind`, `title`, `enabled`). Chat message context packets already snapshot
+enabled project sources as provenance metadata for Hecate Chat, direct model
+turns, and External Agent turns. Context assembly is still the future layer
+that may resolve those sources through WorkspaceFS, label their contents, and
+decide whether they belong in a rendered prompt.
 
 ### 2. Trust Classification
 
@@ -127,7 +129,10 @@ evidence, not as a system message.
 ### 3. Context Packet Snapshot
 
 The assembly output is a `ContextPacket`: a durable, inspectable description of
-what was prepared for a model call.
+what was prepared for a model or adapter call. The current implementation stores
+a lightweight packet on assistant chat messages, including execution mode,
+provider/model or adapter identity, workspace, transcript count, and enabled
+project context-source metadata. It does not store source bodies yet.
 
 Sketch:
 

--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -76,6 +76,7 @@ type Project struct {
     ID              string // proj_...
     Name            string
     Roots           []ProjectRoot
+    ContextSources  []ProjectContextSource
     DefaultRootID   string
     RepoURL         string
     DefaultBranch   string
@@ -102,6 +103,14 @@ type ProjectRoot struct {
     GitBranch string
     Active    bool
 }
+
+type ProjectContextSource struct {
+    ID      string // ctxsrc_...
+    Kind    string // doc, policy, memory, external
+    Title   string
+    Path    string
+    Enabled bool
+}
 ```
 
 Rules:
@@ -110,6 +119,8 @@ Rules:
 - Existing chats and tasks without a project remain valid.
 - First implementation lets the operator create projects explicitly and attach
   new chat sessions to the selected project.
+- First implementation stores context-source metadata only. It does not read
+  those files, inject them into prompts, or create memory entries.
 - Operators can rename projects later.
 - Multiple roots can map to one project, but one root should not silently attach to many projects without operator confirmation.
 
@@ -222,8 +233,9 @@ The first implementation adds `internal/projects/` with memory and SQLite
 stores, plus `GET`/`POST`/`PATCH`/`DELETE /hecate/v1/projects`.
 
 This landed as a foundation plus chat grouping: project records and roots can be
-persisted, and chat sessions can carry `project_id`. Tasks, context packets,
-memory entries, profiles, and presets are not linked to `project_id` yet.
+persisted, trusted context-source metadata can be attached to a project, and
+chat sessions can carry `project_id`. Tasks, context packets, memory entries,
+profiles, and presets are not linked to `project_id` yet.
 
 Persist `project_id` on:
 
@@ -238,6 +250,7 @@ SQLite migration should be additive first:
 
 - New `projects` table.
 - New `project_roots` table.
+- New `project_context_sources` table for metadata-only source references.
 - Nullable `project_id` columns on existing tables.
 
 Because Hecate has no stable users yet, later cleanup can remove legacy path-derived compatibility once the new model settles.

--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -211,6 +211,10 @@ Context assembly should include both project and workspace metadata:
 - `workspace_context`: files, diffs, tool output, and runtime artifacts from the concrete workspace.
 
 This prevents future context systems from confusing “same path today” with “same durable project.”
+Today, chat message context packets already snapshot enabled project
+context-source metadata for Hecate Chat, direct model turns, and External Agent
+turns. The snapshot is provenance-only: it records configured source paths and
+labels, but does not read or inject file contents.
 
 ## UI Shape
 
@@ -261,7 +265,7 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 2. Add UI list/create/rename/delete basics.
 3. Add `project_id` to chat sessions.
 4. Add `project_id` to tasks.
-5. Thread project identity into context packets.
+5. Thread project identity into chat context packets. Done for project context-source metadata.
 6. Add project-scoped memory.
 7. Add agent-profile memory-source selection.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1026,9 +1026,10 @@ This first implementation is intentionally lightweight:
 `HECATE_BACKEND=sqlite` persists them. Chat sessions can carry an optional
 `project_id` so the operator UI can group history by project. Projects can
 also remember context-source metadata (`path`, `kind`, `title`, and whether the
-source is enabled), but Hecate does not inject those files into prompts yet.
-Tasks, memory, profiles, presets, and context packets are not linked to
-`project_id` yet.
+source is enabled). Chat message context packets include enabled source
+metadata for inspection, but Hecate does not inject those files into prompts
+yet. Tasks, memory, profiles, presets, and source-content injection are not
+linked to `project_id` yet.
 
 ### `GET /hecate/v1/projects`
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1019,13 +1019,16 @@ Status codes:
 Projects are the durable Hecate identity for a codebase or work area. A project
 can remember one or more concrete workspace roots and future defaults such as
 provider, model, agent profile, tools posture, workspace mode, system prompt,
-and compact command-output preference.
+compact command-output preference, and trusted context-source metadata.
 
 This first implementation is intentionally lightweight:
 `GET`/`POST`/`PATCH`/`DELETE /hecate/v1/projects` work, and
 `HECATE_BACKEND=sqlite` persists them. Chat sessions can carry an optional
-`project_id` so the operator UI can group history by project. Tasks, memory,
-profiles, presets, and context packets are not linked to `project_id` yet.
+`project_id` so the operator UI can group history by project. Projects can
+also remember context-source metadata (`path`, `kind`, `title`, and whether the
+source is enabled), but Hecate does not inject those files into prompts yet.
+Tasks, memory, profiles, presets, and context packets are not linked to
+`project_id` yet.
 
 ### `GET /hecate/v1/projects`
 
@@ -1053,6 +1056,17 @@ GET /hecate/v1/projects
           "updated_at": "2026-05-20T12:00:00Z"
         }
       ],
+      "context_sources": [
+        {
+          "id": "ctxsrc_...",
+          "kind": "doc",
+          "title": "README",
+          "path": "README.md",
+          "enabled": true,
+          "created_at": "2026-05-20T12:00:00Z",
+          "updated_at": "2026-05-20T12:00:00Z"
+        }
+      ],
       "default_root_id": "root_...",
       "default_provider": "ollama",
       "default_model": "qwen2.5-coder",
@@ -1075,6 +1089,8 @@ Creates a project. `name` is required. Root `id` values are optional; Hecate
 generates `root_...` IDs for roots that omit them. If `default_root_id` is
 empty and at least one root is supplied, the first root becomes the default.
 When supplied, `default_root_id` must match one of the supplied roots.
+Context source `id` values are optional; Hecate generates `ctxsrc_...` IDs for
+sources that omit them. Context sources are metadata only in this release.
 
 ```json
 POST /hecate/v1/projects
@@ -1088,6 +1104,14 @@ POST /hecate/v1/projects
       "git_remote": "git@github.com:hecatehq/hecate.git",
       "git_branch": "master",
       "active": true
+    }
+  ],
+  "context_sources": [
+    {
+      "kind": "doc",
+      "title": "README",
+      "path": "README.md",
+      "enabled": true
     }
   ],
   "default_provider": "ollama",
@@ -1124,6 +1148,8 @@ Returns one project or `404 not_found`.
 Updates project metadata and defaults. Fields are optional. When `roots` is
 present, it replaces the full root list; use this for root add/remove/reorder
 until narrower root endpoints exist.
+When `context_sources` is present, it replaces the full source-metadata list;
+use this for add/remove/reorder until narrower context-source endpoints exist.
 When `default_root_id` is supplied, it must match the replacement root list or,
 if `roots` is omitted, one of the existing roots.
 

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -832,7 +832,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		Status:        "running",
 		CostMode:      adapter.CostMode,
 		Workspace:     session.Workspace,
-		Context:       externalAgentContextPacket(session, adapter.Name),
+		Context:       h.externalAgentContextPacket(r.Context(), session, adapter.Name),
 		CreatedAt:     time.Now().UTC(),
 		StartedAt:     startedAt,
 		Activities: []chat.Activity{
@@ -1132,7 +1132,7 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 	h.agentChatLive.publishSession(updated)
 
 	history := agentChatModelHistory(session, strings.TrimSpace(req.SystemPrompt), content)
-	contextPacket := directModelContextPacket(session, provider, model, strings.TrimSpace(req.SystemPrompt))
+	contextPacket := h.directModelContextPacket(r.Context(), session, provider, model, strings.TrimSpace(req.SystemPrompt))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeDirectModel,

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -125,6 +125,8 @@ func projectContextSourceKind(kind string) string {
 	kind = strings.ToLower(strings.TrimSpace(kind))
 	switch kind {
 	case "", "doc":
+		// Operator-configured docs should render beside native workspace
+		// sources; other project kinds stay namespaced to avoid collisions.
 		return "workspace_doc"
 	default:
 		return "project_" + strings.NewReplacer(" ", "_", "-", "_").Replace(kind)

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,7 @@ import (
 
 const chatContextPacketVersion = "chat.context.v1"
 
-func directModelContextPacket(session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {
+func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeDirectModel, provider, model, session.Workspace)
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
@@ -21,11 +22,12 @@ func directModelContextPacket(session chat.Session, provider, model, systemPromp
 			Trust:  "system",
 		})
 	}
+	packet.Sources = append(packet.Sources, h.projectContextSources(ctx, session)...)
 	packet.Sources = append(packet.Sources, transcriptContextSource(packet.MessageCount))
 	return packet
 }
 
-func hecateTaskContextPacket(session chat.Session, provider, model, systemPrompt string, forceNewTask bool) chat.ContextPacket {
+func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string, forceNewTask bool) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, session.Workspace)
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
@@ -45,6 +47,7 @@ func hecateTaskContextPacket(session chat.Session, provider, model, systemPrompt
 			Trust:  "workspace",
 		})
 	}
+	packet.Sources = append(packet.Sources, h.projectContextSources(ctx, session)...)
 	taskDetail := "Continuing the existing task-backed agent loop"
 	if forceNewTask || strings.TrimSpace(session.TaskID) == "" {
 		taskDetail = "Starting a new task-backed agent loop"
@@ -61,7 +64,7 @@ func hecateTaskContextPacket(session chat.Session, provider, model, systemPrompt
 	return packet
 }
 
-func externalAgentContextPacket(session chat.Session, adapterName string) chat.ContextPacket {
+func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.Session, adapterName string) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeExternalAgent, "", "", session.Workspace)
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	if strings.TrimSpace(session.Workspace) != "" {
@@ -72,6 +75,7 @@ func externalAgentContextPacket(session chat.Session, adapterName string) chat.C
 			Trust:  "workspace",
 		})
 	}
+	packet.Sources = append(packet.Sources, h.projectContextSources(ctx, session)...)
 	if strings.TrimSpace(adapterName) == "" {
 		adapterName = "External agent"
 	}
@@ -85,6 +89,46 @@ func externalAgentContextPacket(session chat.Session, adapterName string) chat.C
 		},
 	)
 	return packet
+}
+
+func (h *Handler) projectContextSources(ctx context.Context, session chat.Session) []chat.ContextSource {
+	if h == nil || h.projects == nil || strings.TrimSpace(session.ProjectID) == "" {
+		return nil
+	}
+	project, ok, err := h.projects.Get(ctx, session.ProjectID)
+	if err != nil || !ok {
+		return nil
+	}
+	sources := make([]chat.ContextSource, 0, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		if !source.Enabled {
+			continue
+		}
+		label := strings.TrimSpace(source.Title)
+		if label == "" {
+			label = strings.TrimSpace(source.Path)
+		}
+		if label == "" {
+			continue
+		}
+		sources = append(sources, chat.ContextSource{
+			Kind:   projectContextSourceKind(source.Kind),
+			Label:  label,
+			Detail: strings.TrimSpace(source.Path),
+			Trust:  "project",
+		})
+	}
+	return sources
+}
+
+func projectContextSourceKind(kind string) string {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	switch kind {
+	case "", "doc":
+		return "workspace_doc"
+	default:
+		return "project_" + strings.NewReplacer(" ", "_", "-", "_").Replace(kind)
+	}
 }
 
 func baseChatContextPacket(mode, provider, model, workspace string) chat.ContextPacket {

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -51,44 +52,7 @@ func TestChatContextPacketsUseVisibleTranscriptCount(t *testing.T) {
 
 func TestChatContextPacketsIncludeEnabledProjectSources(t *testing.T) {
 	ctx := context.Background()
-	projectStore := projects.NewMemoryStore()
-	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
-	if _, err := projectStore.Create(ctx, projects.Project{
-		ID:        "proj_1",
-		Name:      "Hecate",
-		CreatedAt: now,
-		UpdatedAt: now,
-		ContextSources: []projects.ContextSource{
-			{
-				ID:        "ctxsrc_readme",
-				Kind:      "doc",
-				Title:     "README",
-				Path:      "README.md",
-				Enabled:   true,
-				CreatedAt: now,
-				UpdatedAt: now,
-			},
-			{
-				ID:        "ctxsrc_notes",
-				Kind:      "notes",
-				Path:      "docs/notes.md",
-				Enabled:   true,
-				CreatedAt: now,
-				UpdatedAt: now,
-			},
-			{
-				ID:        "ctxsrc_disabled",
-				Kind:      "doc",
-				Title:     "Disabled",
-				Path:      "private.md",
-				Enabled:   false,
-				CreatedAt: now,
-				UpdatedAt: now,
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Create project: %v", err)
-	}
+	projectStore := newContextPacketProjectStore(t, ctx)
 	handler := &Handler{projects: projectStore}
 	session := chat.Session{
 		ID:        "chat_1",
@@ -138,6 +102,90 @@ func TestChatContextPacketsIncludeEnabledProjectSources(t *testing.T) {
 	}
 }
 
+func TestChatContextPacketSourceOrdering(t *testing.T) {
+	ctx := context.Background()
+	handler := &Handler{projects: newContextPacketProjectStore(t, ctx)}
+	session := chat.Session{
+		ID:        "chat_1",
+		ProjectID: "proj_1",
+		Workspace: "/tmp/hecate",
+		Messages:  []chat.Message{{ID: "u1", Role: "user", Content: "first"}},
+	}
+
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "direct model",
+			got:  sourceKinds(handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", "system")),
+			want: []string{"system_prompt", "workspace_doc", "project_notes", "transcript"},
+		},
+		{
+			name: "hecate task",
+			got:  sourceKinds(handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "system", false)),
+			want: []string{"system_prompt", "workspace", "workspace_doc", "project_notes", "transcript", "task_runtime"},
+		},
+		{
+			name: "external agent",
+			got:  sourceKinds(handler.externalAgentContextPacket(ctx, session, "Cursor Agent")),
+			want: []string{"workspace", "workspace_doc", "project_notes", "transcript", "adapter_session"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !slices.Equal(tc.got, tc.want) {
+				t.Fatalf("source kinds = %v, want %v", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func newContextPacketProjectStore(t *testing.T, ctx context.Context) projects.Store {
+	t.Helper()
+	projectStore := projects.NewMemoryStore()
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if _, err := projectStore.Create(ctx, projects.Project{
+		ID:        "proj_1",
+		Name:      "Hecate",
+		CreatedAt: now,
+		UpdatedAt: now,
+		ContextSources: []projects.ContextSource{
+			{
+				ID:        "ctxsrc_readme",
+				Kind:      "doc",
+				Title:     "README",
+				Path:      "README.md",
+				Enabled:   true,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			{
+				ID:        "ctxsrc_notes",
+				Kind:      "notes",
+				Path:      "docs/notes.md",
+				Enabled:   true,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			{
+				ID:        "ctxsrc_disabled",
+				Kind:      "doc",
+				Title:     "Disabled",
+				Path:      "private.md",
+				Enabled:   false,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	return projectStore
+}
+
 func assertContextSource(t *testing.T, packet chat.ContextPacket, want chat.ContextSource) {
 	t.Helper()
 	for _, got := range packet.Sources {
@@ -146,4 +194,12 @@ func assertContextSource(t *testing.T, packet chat.ContextPacket, want chat.Cont
 		}
 	}
 	t.Fatalf("context source %+v not found in packet sources: %+v", want, packet.Sources)
+}
+
+func sourceKinds(packet chat.ContextPacket) []string {
+	kinds := make([]string, 0, len(packet.Sources))
+	for _, source := range packet.Sources {
+		kinds = append(kinds, source.Kind)
+	}
+	return kinds
 }

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projects"
 )
 
 func TestChatContextPacketsUseVisibleTranscriptCount(t *testing.T) {
@@ -25,15 +28,15 @@ func TestChatContextPacketsUseVisibleTranscriptCount(t *testing.T) {
 	}{
 		{
 			name:   "direct model",
-			packet: directModelContextPacket(session, "ollama", "llama3.1:8b", "system"),
+			packet: (&Handler{}).directModelContextPacket(context.Background(), session, "ollama", "llama3.1:8b", "system"),
 		},
 		{
 			name:   "hecate task",
-			packet: hecateTaskContextPacket(session, "ollama", "llama3.1:8b", "system", false),
+			packet: (&Handler{}).hecateTaskContextPacket(context.Background(), session, "ollama", "llama3.1:8b", "system", false),
 		},
 		{
 			name:   "external agent",
-			packet: externalAgentContextPacket(session, "Cursor Agent"),
+			packet: (&Handler{}).externalAgentContextPacket(context.Background(), session, "Cursor Agent"),
 		},
 	}
 
@@ -44,4 +47,103 @@ func TestChatContextPacketsUseVisibleTranscriptCount(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChatContextPacketsIncludeEnabledProjectSources(t *testing.T) {
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if _, err := projectStore.Create(ctx, projects.Project{
+		ID:        "proj_1",
+		Name:      "Hecate",
+		CreatedAt: now,
+		UpdatedAt: now,
+		ContextSources: []projects.ContextSource{
+			{
+				ID:        "ctxsrc_readme",
+				Kind:      "doc",
+				Title:     "README",
+				Path:      "README.md",
+				Enabled:   true,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			{
+				ID:        "ctxsrc_notes",
+				Kind:      "notes",
+				Path:      "docs/notes.md",
+				Enabled:   true,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			{
+				ID:        "ctxsrc_disabled",
+				Kind:      "doc",
+				Title:     "Disabled",
+				Path:      "private.md",
+				Enabled:   false,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	handler := &Handler{projects: projectStore}
+	session := chat.Session{
+		ID:        "chat_1",
+		ProjectID: "proj_1",
+		Workspace: "/tmp/hecate",
+		Messages:  []chat.Message{{ID: "u1", Role: "user", Content: "first"}},
+	}
+
+	packets := []struct {
+		name   string
+		packet chat.ContextPacket
+	}{
+		{
+			name:   "direct model",
+			packet: handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", ""),
+		},
+		{
+			name:   "hecate task",
+			packet: handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "", false),
+		},
+		{
+			name:   "external agent",
+			packet: handler.externalAgentContextPacket(ctx, session, "Cursor Agent"),
+		},
+	}
+
+	for _, tc := range packets {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContextSource(t, tc.packet, chat.ContextSource{
+				Kind:   "workspace_doc",
+				Label:  "README",
+				Detail: "README.md",
+				Trust:  "project",
+			})
+			assertContextSource(t, tc.packet, chat.ContextSource{
+				Kind:   "project_notes",
+				Label:  "docs/notes.md",
+				Detail: "docs/notes.md",
+				Trust:  "project",
+			})
+			for _, source := range tc.packet.Sources {
+				if source.Detail == "private.md" {
+					t.Fatalf("disabled project context source was included: %+v", source)
+				}
+			}
+		})
+	}
+}
+
+func assertContextSource(t *testing.T, packet chat.ContextPacket, want chat.ContextSource) {
+	t.Helper()
+	for _, got := range packet.Sources {
+		if got == want {
+			return
+		}
+	}
+	t.Fatalf("context source %+v not found in packet sources: %+v", want, packet.Sources)
 }

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -117,7 +117,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	}
 	h.agentChatLive.publishSession(updated)
 
-	contextPacket := hecateTaskContextPacket(session, messageSnapshot.Provider, messageSnapshot.Model, strings.TrimSpace(req.SystemPrompt), forceNewTask)
+	contextPacket := h.hecateTaskContextPacket(r.Context(), session, messageSnapshot.Provider, messageSnapshot.Model, strings.TrimSpace(req.SystemPrompt), forceNewTask)
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: messageSnapshot.ExecutionMode,

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -20,33 +20,43 @@ type projectRootRequest struct {
 	Active    *bool  `json:"active,omitempty"`
 }
 
+type projectContextSourceRequest struct {
+	ID      string `json:"id,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Path    string `json:"path"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
 type createProjectRequest struct {
-	Name                     string               `json:"name"`
-	Description              string               `json:"description,omitempty"`
-	Roots                    []projectRootRequest `json:"roots,omitempty"`
-	DefaultRootID            string               `json:"default_root_id,omitempty"`
-	DefaultProvider          string               `json:"default_provider,omitempty"`
-	DefaultModel             string               `json:"default_model,omitempty"`
-	DefaultAgentProfile      string               `json:"default_agent_profile,omitempty"`
-	DefaultToolsEnabled      *bool                `json:"default_tools_enabled,omitempty"`
-	DefaultWorkspaceMode     string               `json:"default_workspace_mode,omitempty"`
-	DefaultSystemPrompt      string               `json:"default_system_prompt,omitempty"`
-	DefaultCompactToolOutput *bool                `json:"default_compact_tool_output,omitempty"`
+	Name                     string                        `json:"name"`
+	Description              string                        `json:"description,omitempty"`
+	Roots                    []projectRootRequest          `json:"roots,omitempty"`
+	ContextSources           []projectContextSourceRequest `json:"context_sources,omitempty"`
+	DefaultRootID            string                        `json:"default_root_id,omitempty"`
+	DefaultProvider          string                        `json:"default_provider,omitempty"`
+	DefaultModel             string                        `json:"default_model,omitempty"`
+	DefaultAgentProfile      string                        `json:"default_agent_profile,omitempty"`
+	DefaultToolsEnabled      *bool                         `json:"default_tools_enabled,omitempty"`
+	DefaultWorkspaceMode     string                        `json:"default_workspace_mode,omitempty"`
+	DefaultSystemPrompt      string                        `json:"default_system_prompt,omitempty"`
+	DefaultCompactToolOutput *bool                         `json:"default_compact_tool_output,omitempty"`
 }
 
 type updateProjectRequest struct {
-	Name                     *string               `json:"name,omitempty"`
-	Description              *string               `json:"description,omitempty"`
-	Roots                    *[]projectRootRequest `json:"roots,omitempty"`
-	DefaultRootID            *string               `json:"default_root_id,omitempty"`
-	DefaultProvider          *string               `json:"default_provider,omitempty"`
-	DefaultModel             *string               `json:"default_model,omitempty"`
-	DefaultAgentProfile      *string               `json:"default_agent_profile,omitempty"`
-	DefaultToolsEnabled      *bool                 `json:"default_tools_enabled,omitempty"`
-	DefaultWorkspaceMode     *string               `json:"default_workspace_mode,omitempty"`
-	DefaultSystemPrompt      *string               `json:"default_system_prompt,omitempty"`
-	DefaultCompactToolOutput *bool                 `json:"default_compact_tool_output,omitempty"`
-	LastOpenedAt             *string               `json:"last_opened_at,omitempty"`
+	Name                     *string                        `json:"name,omitempty"`
+	Description              *string                        `json:"description,omitempty"`
+	Roots                    *[]projectRootRequest          `json:"roots,omitempty"`
+	ContextSources           *[]projectContextSourceRequest `json:"context_sources,omitempty"`
+	DefaultRootID            *string                        `json:"default_root_id,omitempty"`
+	DefaultProvider          *string                        `json:"default_provider,omitempty"`
+	DefaultModel             *string                        `json:"default_model,omitempty"`
+	DefaultAgentProfile      *string                        `json:"default_agent_profile,omitempty"`
+	DefaultToolsEnabled      *bool                          `json:"default_tools_enabled,omitempty"`
+	DefaultWorkspaceMode     *string                        `json:"default_workspace_mode,omitempty"`
+	DefaultSystemPrompt      *string                        `json:"default_system_prompt,omitempty"`
+	DefaultCompactToolOutput *bool                          `json:"default_compact_tool_output,omitempty"`
+	LastOpenedAt             *string                        `json:"last_opened_at,omitempty"`
 }
 
 func (h *Handler) HandleProjects(w http.ResponseWriter, r *http.Request) {
@@ -76,6 +86,11 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 	for idx := range project.Roots {
 		if project.Roots[idx].ID == "" {
 			project.Roots[idx].ID = newOpaqueTaskResourceID("root")
+		}
+	}
+	for idx := range project.ContextSources {
+		if project.ContextSources[idx].ID == "" {
+			project.ContextSources[idx].ID = newOpaqueTaskResourceID("ctxsrc")
 		}
 	}
 	if project.DefaultRootID == "" && len(project.Roots) > 0 {
@@ -134,6 +149,20 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		for idx := range roots {
 			if roots[idx].ID == "" {
 				roots[idx].ID = newOpaqueTaskResourceID("root")
+			}
+		}
+	}
+	var contextSources []projects.ContextSource
+	if req.ContextSources != nil {
+		var err error
+		contextSources, err = contextSourcesFromRequest(*req.ContextSources)
+		if err != nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
+		for idx := range contextSources {
+			if contextSources[idx].ID == "" {
+				contextSources[idx].ID = newOpaqueTaskResourceID("ctxsrc")
 			}
 		}
 	}
@@ -208,6 +237,9 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			if item.DefaultRootID == "" && len(item.Roots) > 0 {
 				item.DefaultRootID = item.Roots[0].ID
 			}
+		}
+		if req.ContextSources != nil {
+			item.ContextSources = contextSources
 		}
 	})
 	if errors.Is(err, projects.ErrNotFound) {
@@ -286,10 +318,15 @@ func projectFromCreateRequest(req createProjectRequest) (projects.Project, error
 	if err != nil {
 		return projects.Project{}, err
 	}
+	contextSources, err := contextSourcesFromRequest(req.ContextSources)
+	if err != nil {
+		return projects.Project{}, err
+	}
 	return projects.Project{
 		Name:                     name,
 		Description:              strings.TrimSpace(req.Description),
 		Roots:                    roots,
+		ContextSources:           contextSources,
 		DefaultRootID:            strings.TrimSpace(req.DefaultRootID),
 		DefaultProvider:          strings.TrimSpace(req.DefaultProvider),
 		DefaultModel:             strings.TrimSpace(req.DefaultModel),
@@ -322,6 +359,28 @@ func rootsFromRequest(req []projectRootRequest) ([]projects.Root, error) {
 		})
 	}
 	return roots, nil
+}
+
+func contextSourcesFromRequest(req []projectContextSourceRequest) ([]projects.ContextSource, error) {
+	sources := make([]projects.ContextSource, 0, len(req))
+	for _, item := range req {
+		path := strings.TrimSpace(item.Path)
+		if path == "" {
+			return nil, errors.New("project context source path is required")
+		}
+		enabled := true
+		if item.Enabled != nil {
+			enabled = *item.Enabled
+		}
+		sources = append(sources, projects.ContextSource{
+			ID:      strings.TrimSpace(item.ID),
+			Kind:    strings.TrimSpace(item.Kind),
+			Title:   strings.TrimSpace(item.Title),
+			Path:    path,
+			Enabled: enabled,
+		})
+	}
+	return sources, nil
 }
 
 func validateProjectDefaultRoot(defaultRootID string, roots []projects.Root) error {
@@ -390,11 +449,24 @@ func renderProject(project projects.Project) ProjectResponseItem {
 			UpdatedAt: formatOptionalTime(root.UpdatedAt),
 		})
 	}
+	contextSources := make([]ProjectContextSourceResponseItem, 0, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		contextSources = append(contextSources, ProjectContextSourceResponseItem{
+			ID:        source.ID,
+			Kind:      source.Kind,
+			Title:     source.Title,
+			Path:      source.Path,
+			Enabled:   source.Enabled,
+			CreatedAt: formatOptionalTime(source.CreatedAt),
+			UpdatedAt: formatOptionalTime(source.UpdatedAt),
+		})
+	}
 	return ProjectResponseItem{
 		ID:                       project.ID,
 		Name:                     project.Name,
 		Description:              project.Description,
 		Roots:                    roots,
+		ContextSources:           contextSources,
 		DefaultRootID:            project.DefaultRootID,
 		DefaultProvider:          project.DefaultProvider,
 		DefaultModel:             project.DefaultModel,

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -28,6 +28,7 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 		"name":"Hecate",
 		"description":"main repo",
 		"roots":[{"path":"/tmp/hecate","kind":"local","git_remote":"git@example.com:hecate/hecate.git","git_branch":"main"}],
+		"context_sources":[{"path":"README.md","title":"README"}],
 		"default_provider":"ollama",
 		"default_model":"llama3.1:8b",
 		"default_tools_enabled":true
@@ -47,12 +48,22 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 	if created.Data.DefaultRootID != created.Data.Roots[0].ID {
 		t.Fatalf("default_root_id = %q, want first root id %q", created.Data.DefaultRootID, created.Data.Roots[0].ID)
 	}
+	if len(created.Data.ContextSources) != 1 || created.Data.ContextSources[0].ID == "" {
+		t.Fatalf("created project missing generated context source id: %+v", created.Data)
+	}
+	if created.Data.ContextSources[0].Kind != "doc" || !created.Data.ContextSources[0].Enabled {
+		t.Fatalf("context source = %+v, want enabled doc source", created.Data.ContextSources[0])
+	}
 	if created.Data.LastOpenedAt != "" {
 		t.Fatalf("last_opened_at = %q, want omitted until explicitly opened", created.Data.LastOpenedAt)
 	}
 
 	rec = httptest.NewRecorder()
-	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{"name":"Renamed","default_model":"ministral-3:latest"}`))))
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"name":"Renamed",
+		"default_model":"ministral-3:latest",
+		"context_sources":[{"id":"ctx_architecture","path":"docs/architecture.md","enabled":false}]
+	}`))))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
@@ -62,6 +73,9 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 	}
 	if updated.Data.Name != "Renamed" || updated.Data.DefaultModel != "ministral-3:latest" {
 		t.Fatalf("updated project = %+v, want patched name/model", updated.Data)
+	}
+	if len(updated.Data.ContextSources) != 1 || updated.Data.ContextSources[0].ID != "ctx_architecture" || updated.Data.ContextSources[0].Enabled {
+		t.Fatalf("updated context sources = %+v, want disabled architecture source", updated.Data.ContextSources)
 	}
 
 	openedAt := time.Date(2026, 5, 20, 12, 30, 0, 0, time.UTC)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -262,21 +262,22 @@ type ProjectResponse struct {
 }
 
 type ProjectResponseItem struct {
-	ID                       string                    `json:"id"`
-	Name                     string                    `json:"name"`
-	Description              string                    `json:"description,omitempty"`
-	Roots                    []ProjectRootResponseItem `json:"roots"`
-	DefaultRootID            string                    `json:"default_root_id,omitempty"`
-	DefaultProvider          string                    `json:"default_provider,omitempty"`
-	DefaultModel             string                    `json:"default_model,omitempty"`
-	DefaultAgentProfile      string                    `json:"default_agent_profile,omitempty"`
-	DefaultToolsEnabled      *bool                     `json:"default_tools_enabled,omitempty"`
-	DefaultWorkspaceMode     string                    `json:"default_workspace_mode,omitempty"`
-	DefaultSystemPrompt      string                    `json:"default_system_prompt,omitempty"`
-	DefaultCompactToolOutput *bool                     `json:"default_compact_tool_output,omitempty"`
-	CreatedAt                string                    `json:"created_at"`
-	UpdatedAt                string                    `json:"updated_at"`
-	LastOpenedAt             string                    `json:"last_opened_at,omitempty"`
+	ID                       string                             `json:"id"`
+	Name                     string                             `json:"name"`
+	Description              string                             `json:"description,omitempty"`
+	Roots                    []ProjectRootResponseItem          `json:"roots"`
+	ContextSources           []ProjectContextSourceResponseItem `json:"context_sources"`
+	DefaultRootID            string                             `json:"default_root_id,omitempty"`
+	DefaultProvider          string                             `json:"default_provider,omitempty"`
+	DefaultModel             string                             `json:"default_model,omitempty"`
+	DefaultAgentProfile      string                             `json:"default_agent_profile,omitempty"`
+	DefaultToolsEnabled      *bool                              `json:"default_tools_enabled,omitempty"`
+	DefaultWorkspaceMode     string                             `json:"default_workspace_mode,omitempty"`
+	DefaultSystemPrompt      string                             `json:"default_system_prompt,omitempty"`
+	DefaultCompactToolOutput *bool                              `json:"default_compact_tool_output,omitempty"`
+	CreatedAt                string                             `json:"created_at"`
+	UpdatedAt                string                             `json:"updated_at"`
+	LastOpenedAt             string                             `json:"last_opened_at,omitempty"`
 }
 
 type ProjectRootResponseItem struct {
@@ -286,6 +287,16 @@ type ProjectRootResponseItem struct {
 	GitRemote string `json:"git_remote,omitempty"`
 	GitBranch string `json:"git_branch,omitempty"`
 	Active    bool   `json:"active"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type ProjectContextSourceResponseItem struct {
+	ID        string `json:"id"`
+	Kind      string `json:"kind"`
+	Title     string `json:"title,omitempty"`
+	Path      string `json:"path"`
+	Enabled   bool   `json:"enabled"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 }

--- a/internal/projects/sqlite.go
+++ b/internal/projects/sqlite.go
@@ -17,6 +17,7 @@ type SQLiteStore struct {
 	db          *sql.DB
 	projectsTbl string
 	rootsTbl    string
+	sourcesTbl  string
 }
 
 func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
@@ -27,6 +28,7 @@ func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteS
 		db:          client.DB(),
 		projectsTbl: client.QualifiedTable("projects"),
 		rootsTbl:    client.QualifiedTable("project_roots"),
+		sourcesTbl:  client.QualifiedTable("project_context_sources"),
 	}
 	if err := store.migrate(ctx); err != nil {
 		return nil, err
@@ -74,9 +76,28 @@ CREATE TABLE IF NOT EXISTS %s (
 )`, s.rootsTbl, s.projectsTbl)); err != nil {
 		return fmt.Errorf("create project roots table: %w", err)
 	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	kind TEXT NOT NULL DEFAULT 'doc',
+	title TEXT NOT NULL DEFAULT '',
+	path TEXT NOT NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id),
+	FOREIGN KEY(project_id) REFERENCES %s(id) ON DELETE CASCADE
+)`, s.sourcesTbl, s.projectsTbl)); err != nil {
+		return fmt.Errorf("create project context sources table: %w", err)
+	}
 	rootsProjectIndex := strings.Trim(s.rootsTbl, `"`) + "_project_idx"
 	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (project_id)`, rootsProjectIndex, s.rootsTbl)); err != nil {
 		return fmt.Errorf("create project roots project index: %w", err)
+	}
+	sourcesProjectIndex := strings.Trim(s.sourcesTbl, `"`) + "_project_idx"
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (project_id)`, sourcesProjectIndex, s.sourcesTbl)); err != nil {
+		return fmt.Errorf("create project context sources project index: %w", err)
 	}
 	return nil
 }
@@ -198,6 +219,7 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Projec
 	originalID := project.ID
 	originalCreatedAt := project.CreatedAt
 	originalRoots := projectRootsByID(project.Roots)
+	originalContextSources := contextSourcesByID(project.ContextSources)
 	if update != nil {
 		update(&project)
 	}
@@ -210,6 +232,7 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Projec
 	now := time.Now().UTC()
 	project.UpdatedAt = now
 	project.Roots = preserveExistingRootTimestamps(project.Roots, originalRoots, now)
+	project.ContextSources = preserveExistingContextSourceTimestamps(project.ContextSources, originalContextSources, now)
 	project = normalizeProject(project, now)
 	if err := validateProject(project); err != nil {
 		_ = tx.Rollback()
@@ -234,6 +257,10 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ?`, s.rootsTbl), strings.TrimSpace(id)); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ?`, s.sourcesTbl), strings.TrimSpace(id)); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -292,7 +319,10 @@ ON CONFLICT(id) DO UPDATE SET
 	); err != nil {
 		return err
 	}
-	return s.upsertProjectRoots(ctx, tx, project)
+	if err := s.upsertProjectRoots(ctx, tx, project); err != nil {
+		return err
+	}
+	return s.upsertProjectContextSources(ctx, tx, project)
 }
 
 func (s *SQLiteStore) upsertProjectRoots(ctx context.Context, tx *sql.Tx, project Project) error {
@@ -301,7 +331,7 @@ func (s *SQLiteStore) upsertProjectRoots(ctx context.Context, tx *sql.Tx, projec
 		return err
 	}
 
-	deleteArgs := make([]any, 0, len(project.Roots)+1)
+	deleteArgs := make([]any, 0, len(project.Roots))
 	deleteArgs = append(deleteArgs, project.ID)
 	placeholders := make([]string, 0, len(project.Roots))
 	for _, root := range project.Roots {
@@ -334,6 +364,48 @@ ON CONFLICT(project_id, id) DO UPDATE SET
 	_, err := tx.ExecContext(ctx, fmt.Sprintf(
 		`DELETE FROM %s WHERE project_id = ? AND id NOT IN (%s)`,
 		s.rootsTbl,
+		strings.Join(placeholders, ", "),
+	), deleteArgs...)
+	return err
+}
+
+func (s *SQLiteStore) upsertProjectContextSources(ctx context.Context, tx *sql.Tx, project Project) error {
+	if len(project.ContextSources) == 0 {
+		_, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ?`, s.sourcesTbl), project.ID)
+		return err
+	}
+
+	deleteArgs := make([]any, 0, len(project.ContextSources))
+	deleteArgs = append(deleteArgs, project.ID)
+	placeholders := make([]string, 0, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, project_id, kind, title, path, enabled, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, id) DO UPDATE SET
+	kind = excluded.kind,
+	title = excluded.title,
+	path = excluded.path,
+	enabled = excluded.enabled,
+	updated_at = excluded.updated_at`, s.sourcesTbl),
+			source.ID,
+			project.ID,
+			source.Kind,
+			source.Title,
+			source.Path,
+			boolToDB(source.Enabled),
+			formatTime(source.CreatedAt),
+			formatTime(source.UpdatedAt),
+		); err != nil {
+			return err
+		}
+		placeholders = append(placeholders, "?")
+		deleteArgs = append(deleteArgs, source.ID)
+	}
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(
+		`DELETE FROM %s WHERE project_id = ? AND id NOT IN (%s)`,
+		s.sourcesTbl,
 		strings.Join(placeholders, ", "),
 	), deleteArgs...)
 	return err
@@ -397,6 +469,11 @@ WHERE id = ?`, s.projectsTbl), id)
 		return Project{}, err
 	}
 	project.Roots = roots
+	sources, err := s.loadContextSourcesWith(ctx, q, project.ID)
+	if err != nil {
+		return Project{}, err
+	}
+	project.ContextSources = sources
 	return project, nil
 }
 
@@ -440,11 +517,54 @@ ORDER BY active DESC, path ASC, id ASC`, s.rootsTbl), projectID)
 	return roots, rows.Err()
 }
 
+func (s *SQLiteStore) loadContextSourcesWith(ctx context.Context, q sqliteQuerier, projectID string) ([]ContextSource, error) {
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(`
+SELECT id, kind, title, path, enabled, created_at, updated_at
+FROM %s
+WHERE project_id = ?
+ORDER BY enabled DESC, path ASC, id ASC`, s.sourcesTbl), projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var sources []ContextSource
+	for rows.Next() {
+		var source ContextSource
+		var enabled int
+		var createdAt, updatedAt string
+		if err := rows.Scan(
+			&source.ID,
+			&source.Kind,
+			&source.Title,
+			&source.Path,
+			&enabled,
+			&createdAt,
+			&updatedAt,
+		); err != nil {
+			return nil, err
+		}
+		source.Enabled = enabled != 0
+		var err error
+		if source.CreatedAt, err = parseTime(createdAt); err != nil {
+			return nil, err
+		}
+		if source.UpdatedAt, err = parseTime(updatedAt); err != nil {
+			return nil, err
+		}
+		sources = append(sources, source)
+	}
+	return sources, rows.Err()
+}
+
 func boolPtrToDB(value *bool) any {
 	if value == nil {
 		return nil
 	}
-	if *value {
+	return boolToDB(*value)
+}
+
+func boolToDB(value bool) int {
+	if value {
 		return 1
 	}
 	return 0

--- a/internal/projects/sqlite_test.go
+++ b/internal/projects/sqlite_test.go
@@ -53,6 +53,13 @@ func TestSQLiteStore_ProjectRoundTrip(t *testing.T) {
 			GitBranch: "main",
 			Active:    true,
 		}},
+		ContextSources: []ContextSource{{
+			ID:      "ctx_readme",
+			Kind:    "doc",
+			Title:   "README",
+			Path:    "README.md",
+			Enabled: true,
+		}},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -77,17 +84,24 @@ func TestSQLiteStore_ProjectRoundTrip(t *testing.T) {
 	if len(got.Roots) != 1 || got.Roots[0].GitRemote == "" {
 		t.Fatalf("roots = %+v, want persisted git metadata", got.Roots)
 	}
+	if len(got.ContextSources) != 1 || got.ContextSources[0].Path != "README.md" || got.ContextSources[0].Kind != "doc" {
+		t.Fatalf("context sources = %+v, want persisted README doc source", got.ContextSources)
+	}
 
 	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
 		item.Name = "Renamed"
 		item.Roots = []Root{{ID: "root_beta", Path: "/tmp/renamed", Active: true}}
 		item.DefaultRootID = "root_beta"
+		item.ContextSources = []ContextSource{{ID: "ctx_architecture", Path: "docs/architecture.md", Enabled: true}}
 	})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
 	if updated.Name != "Renamed" || len(updated.Roots) != 1 || updated.Roots[0].ID != "root_beta" {
 		t.Fatalf("updated = %+v, want renamed project with replaced root", updated)
+	}
+	if len(updated.ContextSources) != 1 || updated.ContextSources[0].ID != "ctx_architecture" {
+		t.Fatalf("updated context sources = %+v, want replaced source", updated.ContextSources)
 	}
 
 	items, err := store.List(ctx)
@@ -96,6 +110,9 @@ func TestSQLiteStore_ProjectRoundTrip(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].ID != "proj_alpha" {
 		t.Fatalf("items = %+v, want one project", items)
+	}
+	if len(items[0].ContextSources) != 1 || items[0].ContextSources[0].Path != "docs/architecture.md" {
+		t.Fatalf("listed context sources = %+v, want replaced source", items[0].ContextSources)
 	}
 
 	if err := store.Delete(ctx, "proj_alpha"); err != nil {
@@ -238,6 +255,58 @@ func TestSQLiteStore_UpdateUpsertsRootsWithoutResettingExistingRootCreatedAt(t *
 	}
 }
 
+func TestSQLiteStore_UpdateUpsertsContextSourcesWithoutResettingExistingCreatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteTestStore(t)
+	sourceCreatedAt := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{{
+			ID:        "ctx_readme",
+			Kind:      "doc",
+			Title:     "README",
+			Path:      "README.md",
+			Enabled:   true,
+			CreatedAt: sourceCreatedAt,
+			UpdatedAt: sourceCreatedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
+		item.ContextSources = []ContextSource{
+			{ID: "ctx_readme", Kind: "doc", Title: "README", Path: "docs/README.md", Enabled: true},
+			{ID: "ctx_notes", Kind: "doc", Title: "Notes", Path: "notes.md", Enabled: false},
+		}
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	readme := mustFindContextSource(t, updated.ContextSources, "ctx_readme")
+	if readme.Path != "docs/README.md" {
+		t.Fatalf("ctx_readme path = %q, want docs/README.md", readme.Path)
+	}
+	if !readme.CreatedAt.Equal(sourceCreatedAt) {
+		t.Fatalf("ctx_readme CreatedAt = %s, want %s", readme.CreatedAt, sourceCreatedAt)
+	}
+	if !readme.UpdatedAt.After(sourceCreatedAt) {
+		t.Fatalf("ctx_readme UpdatedAt = %s, want after %s", readme.UpdatedAt, sourceCreatedAt)
+	}
+
+	updated, err = store.Update(ctx, "proj_alpha", func(item *Project) {
+		item.ContextSources = []ContextSource{{ID: "ctx_notes", Kind: "doc", Title: "Notes", Path: "notes.md", Enabled: false}}
+	})
+	if err != nil {
+		t.Fatalf("Update removing ctx_readme: %v", err)
+	}
+	if len(updated.ContextSources) != 1 || updated.ContextSources[0].ID != "ctx_notes" {
+		t.Fatalf("context sources after removal = %+v, want only ctx_notes", updated.ContextSources)
+	}
+}
+
 func TestSQLiteStore_RejectsInvalidProject(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -256,6 +325,40 @@ func TestSQLiteStore_RejectsInvalidProject(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_UpdatePreservesUnchangedContextSourceUpdatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteTestStore(t)
+	sourceCreatedAt := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	sourceUpdatedAt := sourceCreatedAt.Add(time.Hour)
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{{
+			ID:        "ctx_readme",
+			Kind:      "doc",
+			Title:     "README",
+			Path:      "README.md",
+			Enabled:   true,
+			CreatedAt: sourceCreatedAt,
+			UpdatedAt: sourceUpdatedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
+		item.ContextSources = []ContextSource{{ID: "ctx_readme", Title: "README", Path: "README.md", Enabled: true}}
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	readme := mustFindContextSource(t, updated.ContextSources, "ctx_readme")
+	if !readme.UpdatedAt.Equal(sourceUpdatedAt) {
+		t.Fatalf("ctx_readme UpdatedAt = %s, want unchanged %s", readme.UpdatedAt, sourceUpdatedAt)
+	}
+}
+
 func mustFindRoot(t *testing.T, roots []Root, id string) Root {
 	t.Helper()
 	for _, root := range roots {
@@ -265,6 +368,17 @@ func mustFindRoot(t *testing.T, roots []Root, id string) Root {
 	}
 	t.Fatalf("root %q not found in %+v", id, roots)
 	return Root{}
+}
+
+func mustFindContextSource(t *testing.T, sources []ContextSource, id string) ContextSource {
+	t.Helper()
+	for _, source := range sources {
+		if source.ID == id {
+			return source
+		}
+	}
+	t.Fatalf("context source %q not found in %+v", id, sources)
+	return ContextSource{}
 }
 
 func TestSQLiteStore_AllowsSameRootIDAcrossProjects(t *testing.T) {

--- a/internal/projects/sqlite_test.go
+++ b/internal/projects/sqlite_test.go
@@ -155,6 +155,31 @@ func TestSQLiteStore_ListFallsBackToUpdatedAtWhenLastOpenedAtEmpty(t *testing.T)
 	}
 }
 
+func TestSQLiteStore_SortsContextSourcesLikeMemory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteTestStore(t)
+	created, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{
+			{ID: "ctx_enabled_z", Path: "zeta.md", Enabled: true},
+			{ID: "ctx_disabled_a", Path: "alpha.md", Enabled: false},
+			{ID: "ctx_enabled_a", Path: "alpha.md", Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	assertContextSourceIDs(t, created.ContextSources, []string{"ctx_enabled_a", "ctx_enabled_z", "ctx_disabled_a"})
+
+	got, ok, err := store.Get(ctx, "proj_alpha")
+	if err != nil || !ok {
+		t.Fatalf("Get ok=%v err=%v, want project", ok, err)
+	}
+	assertContextSourceIDs(t, got.ContextSources, []string{"ctx_enabled_a", "ctx_enabled_z", "ctx_disabled_a"})
+}
+
 func TestSQLiteStore_UpdateRejectsProjectIDChange(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -20,6 +20,7 @@ type Project struct {
 	Name                     string
 	Description              string
 	Roots                    []Root
+	ContextSources           []ContextSource
 	DefaultRootID            string
 	DefaultProvider          string
 	DefaultModel             string
@@ -40,6 +41,16 @@ type Root struct {
 	GitRemote string
 	GitBranch string
 	Active    bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type ContextSource struct {
+	ID        string
+	Kind      string
+	Title     string
+	Path      string
+	Enabled   bool
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -110,6 +121,7 @@ func (s *MemoryStore) Update(_ context.Context, id string, update func(*Project)
 	originalID := project.ID
 	originalCreatedAt := project.CreatedAt
 	originalRoots := projectRootsByID(project.Roots)
+	originalContextSources := contextSourcesByID(project.ContextSources)
 	if update != nil {
 		update(&project)
 	}
@@ -121,6 +133,7 @@ func (s *MemoryStore) Update(_ context.Context, id string, update func(*Project)
 	now := time.Now().UTC()
 	project.UpdatedAt = now
 	project.Roots = preserveExistingRootTimestamps(project.Roots, originalRoots, now)
+	project.ContextSources = preserveExistingContextSourceTimestamps(project.ContextSources, originalContextSources, now)
 	project = normalizeProject(project, now)
 	if err := validateProject(project); err != nil {
 		return Project{}, err
@@ -162,6 +175,9 @@ func normalizeProject(project Project, now time.Time) Project {
 	for idx := range project.Roots {
 		project.Roots[idx] = normalizeRoot(project.Roots[idx], now)
 	}
+	for idx := range project.ContextSources {
+		project.ContextSources[idx] = normalizeContextSource(project.ContextSources[idx], now)
+	}
 	if len(project.Roots) == 0 {
 		project.DefaultRootID = ""
 	} else if project.DefaultRootID == "" {
@@ -191,6 +207,26 @@ func normalizeRoot(root Root, now time.Time) Root {
 	return root
 }
 
+func normalizeContextSource(source ContextSource, now time.Time) ContextSource {
+	source.ID = strings.TrimSpace(source.ID)
+	source.Kind = strings.TrimSpace(source.Kind)
+	source.Title = strings.TrimSpace(source.Title)
+	source.Path = strings.TrimSpace(source.Path)
+	if source.Kind == "" {
+		source.Kind = "doc"
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if source.CreatedAt.IsZero() {
+		source.CreatedAt = now
+	}
+	if source.UpdatedAt.IsZero() {
+		source.UpdatedAt = source.CreatedAt
+	}
+	return source
+}
+
 func projectRootsByID(roots []Root) map[string]Root {
 	if len(roots) == 0 {
 		return nil
@@ -200,6 +236,20 @@ func projectRootsByID(roots []Root) map[string]Root {
 		id := strings.TrimSpace(root.ID)
 		if id != "" {
 			index[id] = root
+		}
+	}
+	return index
+}
+
+func contextSourcesByID(sources []ContextSource) map[string]ContextSource {
+	if len(sources) == 0 {
+		return nil
+	}
+	index := make(map[string]ContextSource, len(sources))
+	for _, source := range sources {
+		id := strings.TrimSpace(source.ID)
+		if id != "" {
+			index[id] = source
 		}
 	}
 	return index
@@ -229,6 +279,30 @@ func preserveExistingRootTimestamps(roots []Root, existing map[string]Root, now 
 	return roots
 }
 
+func preserveExistingContextSourceTimestamps(sources []ContextSource, existing map[string]ContextSource, now time.Time) []ContextSource {
+	if len(existing) == 0 {
+		return sources
+	}
+	for idx := range sources {
+		source := &sources[idx]
+		previous, ok := existing[strings.TrimSpace(source.ID)]
+		if !ok {
+			continue
+		}
+		if source.CreatedAt.IsZero() {
+			source.CreatedAt = previous.CreatedAt
+		}
+		if source.UpdatedAt.IsZero() {
+			if contextSourceMetadataEqual(*source, previous) {
+				source.UpdatedAt = previous.UpdatedAt
+			} else {
+				source.UpdatedAt = now
+			}
+		}
+	}
+	return sources
+}
+
 func rootMetadataEqual(next, previous Root) bool {
 	return strings.TrimSpace(next.ID) == strings.TrimSpace(previous.ID) &&
 		strings.TrimSpace(next.Path) == strings.TrimSpace(previous.Path) &&
@@ -236,6 +310,22 @@ func rootMetadataEqual(next, previous Root) bool {
 		strings.TrimSpace(next.GitRemote) == strings.TrimSpace(previous.GitRemote) &&
 		strings.TrimSpace(next.GitBranch) == strings.TrimSpace(previous.GitBranch) &&
 		next.Active == previous.Active
+}
+
+func contextSourceMetadataEqual(next, previous ContextSource) bool {
+	return strings.TrimSpace(next.ID) == strings.TrimSpace(previous.ID) &&
+		strings.TrimSpace(next.Path) == strings.TrimSpace(previous.Path) &&
+		normalizeContextSourceKind(next.Kind) == normalizeContextSourceKind(previous.Kind) &&
+		strings.TrimSpace(next.Title) == strings.TrimSpace(previous.Title) &&
+		next.Enabled == previous.Enabled
+}
+
+func normalizeContextSourceKind(kind string) string {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		return "doc"
+	}
+	return kind
 }
 
 func normalizeRootKind(kind string) string {
@@ -266,6 +356,19 @@ func validateProject(project Project) error {
 		}
 		rootIDs[root.ID] = struct{}{}
 	}
+	sourceIDs := make(map[string]struct{}, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		if source.ID == "" {
+			return fmt.Errorf("%w: project context source id is required", ErrInvalid)
+		}
+		if source.Path == "" {
+			return fmt.Errorf("%w: project context source path is required", ErrInvalid)
+		}
+		if _, exists := sourceIDs[source.ID]; exists {
+			return fmt.Errorf("%w: duplicate project context source id %q", ErrInvalid, source.ID)
+		}
+		sourceIDs[source.ID] = struct{}{}
+	}
 	if project.DefaultRootID != "" {
 		if _, ok := rootIDs[project.DefaultRootID]; !ok {
 			return fmt.Errorf("%w: default_root_id %q does not match a project root", ErrInvalid, project.DefaultRootID)
@@ -289,6 +392,7 @@ func hasRootID(roots []Root, id string) bool {
 
 func cloneProject(project Project) Project {
 	project.Roots = append([]Root(nil), project.Roots...)
+	project.ContextSources = append([]ContextSource(nil), project.ContextSources...)
 	project.DefaultToolsEnabled = cloneBoolPtr(project.DefaultToolsEnabled)
 	project.DefaultCompactToolOutput = cloneBoolPtr(project.DefaultCompactToolOutput)
 	return project

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -178,6 +178,7 @@ func normalizeProject(project Project, now time.Time) Project {
 	for idx := range project.ContextSources {
 		project.ContextSources[idx] = normalizeContextSource(project.ContextSources[idx], now)
 	}
+	sortContextSources(project.ContextSources)
 	if len(project.Roots) == 0 {
 		project.DefaultRootID = ""
 	} else if project.DefaultRootID == "" {
@@ -428,4 +429,16 @@ func projectSortTime(project Project) time.Time {
 		return project.UpdatedAt
 	}
 	return project.CreatedAt
+}
+
+func sortContextSources(sources []ContextSource) {
+	sort.SliceStable(sources, func(i, j int) bool {
+		if sources[i].Enabled != sources[j].Enabled {
+			return sources[i].Enabled
+		}
+		if sources[i].Path != sources[j].Path {
+			return sources[i].Path < sources[j].Path
+		}
+		return sources[i].ID < sources[j].ID
+	})
 }

--- a/internal/projects/store_test.go
+++ b/internal/projects/store_test.go
@@ -110,6 +110,31 @@ func TestMemoryStore_ListFallsBackToUpdatedAtWhenLastOpenedAtEmpty(t *testing.T)
 	}
 }
 
+func TestMemoryStore_SortsContextSourcesLikeSQLite(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	created, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{
+			{ID: "ctx_enabled_z", Path: "zeta.md", Enabled: true},
+			{ID: "ctx_disabled_a", Path: "alpha.md", Enabled: false},
+			{ID: "ctx_enabled_a", Path: "alpha.md", Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	assertContextSourceIDs(t, created.ContextSources, []string{"ctx_enabled_a", "ctx_enabled_z", "ctx_disabled_a"})
+
+	got, ok, err := store.Get(ctx, "proj_alpha")
+	if err != nil || !ok {
+		t.Fatalf("Get ok=%v err=%v, want project", ok, err)
+	}
+	assertContextSourceIDs(t, got.ContextSources, []string{"ctx_enabled_a", "ctx_enabled_z", "ctx_disabled_a"})
+}
+
 func TestMemoryStore_UpdateMissingProject(t *testing.T) {
 	t.Parallel()
 	_, err := NewMemoryStore().Update(context.Background(), "missing", nil)
@@ -320,4 +345,24 @@ func TestMemoryStore_RejectsInvalidDefaultRootID(t *testing.T) {
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Create invalid default root error = %v, want ErrInvalid", err)
 	}
+}
+
+func assertContextSourceIDs(t *testing.T, sources []ContextSource, want []string) {
+	t.Helper()
+	if len(sources) != len(want) {
+		t.Fatalf("context sources = %+v, want ids %v", sources, want)
+	}
+	for idx, source := range sources {
+		if source.ID != want[idx] {
+			t.Fatalf("context source ids = %v, want %v", contextSourceIDs(sources), want)
+		}
+	}
+}
+
+func contextSourceIDs(sources []ContextSource) []string {
+	ids := make([]string, 0, len(sources))
+	for _, source := range sources {
+		ids = append(ids, source.ID)
+	}
+	return ids
 }

--- a/internal/projects/store_test.go
+++ b/internal/projects/store_test.go
@@ -21,6 +21,11 @@ func TestMemoryStore_ProjectLifecycle(t *testing.T) {
 			Path:   " /tmp/hecate ",
 			Active: true,
 		}},
+		ContextSources: []ContextSource{{
+			ID:      "ctx_readme",
+			Path:    " README.md ",
+			Enabled: true,
+		}},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -31,14 +36,21 @@ func TestMemoryStore_ProjectLifecycle(t *testing.T) {
 	if project.Roots[0].Path != "/tmp/hecate" || project.Roots[0].Kind != "local" {
 		t.Fatalf("root = %+v, want normalized local root", project.Roots[0])
 	}
+	if project.ContextSources[0].Path != "README.md" || project.ContextSources[0].Kind != "doc" {
+		t.Fatalf("context source = %+v, want normalized doc source", project.ContextSources[0])
+	}
 
 	project.Roots[0].Path = "/mutated"
+	project.ContextSources[0].Path = "mutated.md"
 	got, ok, err := store.Get(ctx, "proj_alpha")
 	if err != nil || !ok {
 		t.Fatalf("Get ok=%v err=%v, want project", ok, err)
 	}
 	if got.Roots[0].Path != "/tmp/hecate" {
 		t.Fatalf("stored root path mutated to %q", got.Roots[0].Path)
+	}
+	if got.ContextSources[0].Path != "README.md" {
+		t.Fatalf("stored context source path mutated to %q", got.ContextSources[0].Path)
 	}
 
 	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
@@ -186,6 +198,80 @@ func TestMemoryStore_UpdatePreservesExistingRootCreatedAt(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_UpdatePreservesExistingContextSourceCreatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	sourceCreatedAt := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{{
+			ID:        "ctx_readme",
+			Kind:      "doc",
+			Title:     "README",
+			Path:      "README.md",
+			Enabled:   true,
+			CreatedAt: sourceCreatedAt,
+			UpdatedAt: sourceCreatedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
+		item.ContextSources = []ContextSource{{ID: "ctx_readme", Path: "docs/README.md", Enabled: true}}
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updated.ContextSources) != 1 {
+		t.Fatalf("context sources = %+v, want one source", updated.ContextSources)
+	}
+	if !updated.ContextSources[0].CreatedAt.Equal(sourceCreatedAt) {
+		t.Fatalf("source CreatedAt = %s, want %s", updated.ContextSources[0].CreatedAt, sourceCreatedAt)
+	}
+	if !updated.ContextSources[0].UpdatedAt.After(sourceCreatedAt) {
+		t.Fatalf("source UpdatedAt = %s, want after %s", updated.ContextSources[0].UpdatedAt, sourceCreatedAt)
+	}
+}
+
+func TestMemoryStore_UpdatePreservesUnchangedContextSourceUpdatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	sourceCreatedAt := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	sourceUpdatedAt := sourceCreatedAt.Add(time.Hour)
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		ContextSources: []ContextSource{{
+			ID:        "ctx_readme",
+			Kind:      "doc",
+			Title:     "README",
+			Path:      "README.md",
+			Enabled:   true,
+			CreatedAt: sourceCreatedAt,
+			UpdatedAt: sourceUpdatedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := store.Update(ctx, "proj_alpha", func(item *Project) {
+		item.ContextSources = []ContextSource{{ID: "ctx_readme", Title: "README", Path: "README.md", Enabled: true}}
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updated.ContextSources) != 1 {
+		t.Fatalf("context sources = %+v, want one source", updated.ContextSources)
+	}
+	if !updated.ContextSources[0].UpdatedAt.Equal(sourceUpdatedAt) {
+		t.Fatalf("source UpdatedAt = %s, want unchanged %s", updated.ContextSources[0].UpdatedAt, sourceUpdatedAt)
+	}
+}
+
 func TestMemoryStore_RejectsInvalidProject(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -201,6 +287,18 @@ func TestMemoryStore_RejectsInvalidProject(t *testing.T) {
 	})
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Create duplicate root error = %v, want ErrInvalid", err)
+	}
+
+	_, err = store.Create(ctx, Project{
+		ID:   "proj_beta",
+		Name: "Beta",
+		ContextSources: []ContextSource{
+			{ID: "ctx_dup", Path: "README.md", Enabled: true},
+			{ID: "ctx_dup", Path: "docs/README.md", Enabled: true},
+		},
+	})
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create duplicate context source error = %v, want ErrInvalid", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add durable project context-source metadata to the projects API and memory/SQLite stores.
- Include enabled project context-source metadata in chat context packets for direct model, Hecate task-backed, and External Agent turns.
- Update runtime/RFC docs to clarify that this is provenance metadata only; source contents are not injected yet.

## Validation

- `go test ./internal/api ./internal/projects`
- `go vet ./internal/api ./internal/projects`
- `just docs-format-check`
- `git diff --check`

## Notes

This is the foundation for future project-scoped context and memory. It keeps the current behavior intentionally conservative: context packets expose configured project sources for inspection, but Hecate does not read or inject those files yet.
