### PR TITLE
fix(ui): hide stale agent activity after terminal runs

### DIFF
--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -298,6 +298,29 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText("1 file changed, 2 insertions(+), 1 deletion(-)")).toBeInTheDocument();
   });
 
+  it("does not duplicate backend files_changed rows when diffStat is supplied", () => {
+    const activities: ChatActivityRecord[] = [
+      { type: "tool_call", title: "git_exec", status: "completed" },
+      {
+        type: "files_changed",
+        title: "Files changed",
+        status: "completed",
+        detail: "2 files changed, 72 insertions(+), 3 deletions(-)",
+      },
+    ];
+    render(
+      <TranscriptActivityTimeline
+        activities={activities}
+        diffStat="ui/src/a.tsx | 54 ++++++++++++++++++\nui/src/b.tsx | 21 +++++++--\n2 files changed, 72 insertions(+), 3 deletions(-)"
+      />,
+    );
+
+    expect(screen.getAllByText("Files changed")).toHaveLength(1);
+    expect(screen.getAllByText("2 files changed, 72 insertions(+), 3 deletions(-)")).toHaveLength(
+      1,
+    );
+  });
+
   it("hides the 'started' activity when a terminal activity has appeared", () => {
     const activities: ChatActivityRecord[] = [
       { type: "started", title: "Started" },

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -107,7 +107,7 @@ export function TranscriptActivityTimeline({
   defaultOpen?: boolean;
   renderAdvancedActivity?: (activity: ChatActivityRecord) => ReactNode;
 }) {
-  const visible = orderVisibleActivities(compactAgentActivities(activities));
+  const visible = orderVisibleActivities(compactAgentActivities(activities, Boolean(diffStat)));
   const details = orderVisibleActivities(compactDetailActivities(activities, Boolean(diffStat)));
   const primary = diffStat ? [...visible, fileChangesActivity(diffStat)] : visible;
   const terminal = terminalAgentActivity(activities);

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -155,6 +155,34 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText("Ran git")).toBeInTheDocument();
   });
 
+  it("hides resumed-session metadata after a cancelled run", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="cancelled"
+        content=""
+        activities={[
+          {
+            type: "resumed",
+            title: "Resumed external session",
+            status: "completed",
+            detail: "Grok Build restored native-1",
+          },
+          {
+            type: "cancelled",
+            title: "Cancelled",
+            status: "cancelled",
+            detail: "stopped before the run finished",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("agent run cancelled")).toBeInTheDocument();
+    expect(screen.queryByText("Resumed external session")).toBeNull();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+  });
+
   it("keeps diagnostic failed activity rows with distinct details", () => {
     render(
       <TranscriptMessageRow
@@ -547,5 +575,31 @@ describe("TranscriptMessageRow", () => {
   it("does not render the raw adapter output details when rawOutput equals content", () => {
     render(<TranscriptMessageRow {...baseProps} content="final answer" rawOutput="final answer" />);
     expect(screen.queryByText(/raw adapter output/)).toBeNull();
+  });
+
+  it("does not render routine cancellation raw output", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="cancelled"
+        content=""
+        rawOutput="context canceled"
+      />,
+    );
+    expect(screen.getByText("agent run cancelled")).toBeInTheDocument();
+    expect(screen.queryByText(/raw adapter output/)).toBeNull();
+    expect(screen.queryByText("context canceled")).toBeNull();
+  });
+
+  it("keeps non-routine raw output on cancelled runs", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="cancelled"
+        content=""
+        rawOutput="adapter refused cancellation: pending approval"
+      />,
+    );
+    expect(screen.getByText(/raw adapter output/)).toBeInTheDocument();
   });
 });

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -102,6 +102,59 @@ describe("TranscriptMessageRow", () => {
     expect(screen.queryByText("Failed")).toBeNull();
   });
 
+  it("hides stale running placeholders after a failed run", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content=""
+        error="launch model required: select a model for Grok Build before starting the external agent"
+        activities={[
+          {
+            type: "running",
+            title: "Running",
+            status: "running",
+            detail: "Waiting for ACP output",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("agent run failed")).toBeInTheDocument();
+    expect(screen.queryByText(/working/)).toBeNull();
+    expect(screen.queryByText("Running")).toBeNull();
+    expect(screen.queryByText("Waiting for ACP output")).toBeNull();
+  });
+
+  it("keeps failed tool diagnostics while hiding stale running placeholders", () => {
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        badge="failed"
+        content=""
+        error="tool failed"
+        activities={[
+          {
+            type: "running",
+            title: "Running",
+            status: "running",
+            detail: "Waiting for ACP output",
+          },
+          {
+            type: "tool_call",
+            title: "git_exec",
+            status: "failed",
+            detail: "git status failed",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Running")).toBeNull();
+    expect(screen.getByText(/1 failed tool/)).toBeInTheDocument();
+    expect(screen.getByText("Ran git")).toBeInTheDocument();
+  });
+
   it("keeps diagnostic failed activity rows with distinct details", () => {
     render(
       <TranscriptMessageRow

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -104,9 +104,11 @@ export function TranscriptMessageRow({
     !(activities ?? []).some((activity) => activity.type === "tool_call");
   const visibleActivities =
     isAssistant && activities?.length
-      ? activities.filter(
-          (activity) => !failed || !duplicatesFailureNotice(activity, error || content),
-        )
+      ? activities.filter((activity) => {
+          if ((failed || cancelled) && isStaleTerminalPlaceholder(activity)) return false;
+          if (failed && duplicatesFailureNotice(activity, error || content)) return false;
+          return true;
+        })
       : activities;
   const renderActivityAdvanced =
     isAssistant && visibleActivities?.length
@@ -477,6 +479,12 @@ function isLikelyTransientAgentNarration(text: string): boolean {
 
 function isActiveAgentActivity(activity: ChatActivityRecord): boolean {
   return activity.status === "running" || activity.status === "in_progress";
+}
+
+function isStaleTerminalPlaceholder(activity: ChatActivityRecord): boolean {
+  return (
+    isActiveAgentActivity(activity) && (activity.type === "running" || activity.type === "started")
+  );
 }
 
 function shouldRenderFailedContent(content: string, error?: string): boolean {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -90,12 +90,16 @@ export function TranscriptMessageRow({
   const [hovered, setHovered] = useState(false);
   const isAssistant = role === "assistant";
   const hasTokenData = isAssistant && (promptTokens ?? 0) > 0;
-  const showRawOutput =
-    isAssistant && rawOutput && rawOutput.trim() && rawOutput.trim() !== content.trim();
-  const waitingForAgentOutput =
-    isAssistant && !content.trim() && activities?.some(isActiveAgentActivity);
   const failed = isAssistant && badge === "failed";
   const cancelled = isAssistant && badge === "cancelled";
+  const showRawOutput =
+    isAssistant &&
+    rawOutput &&
+    rawOutput.trim() &&
+    rawOutput.trim() !== content.trim() &&
+    !(cancelled && isRoutineCancellationRawOutput(rawOutput));
+  const waitingForAgentOutput =
+    isAssistant && !content.trim() && activities?.some(isActiveAgentActivity);
   const thinkingForAgent =
     isAssistant &&
     badge === "running" &&
@@ -105,6 +109,7 @@ export function TranscriptMessageRow({
   const visibleActivities =
     isAssistant && activities?.length
       ? activities.filter((activity) => {
+          if ((failed || cancelled) && isTerminalSessionMetadata(activity)) return false;
           if ((failed || cancelled) && isStaleTerminalPlaceholder(activity)) return false;
           if (failed && duplicatesFailureNotice(activity, error || content)) return false;
           return true;
@@ -485,6 +490,16 @@ function isStaleTerminalPlaceholder(activity: ChatActivityRecord): boolean {
   return (
     isActiveAgentActivity(activity) && (activity.type === "running" || activity.type === "started")
   );
+}
+
+function isTerminalSessionMetadata(activity: ChatActivityRecord): boolean {
+  return (
+    activity.type === "resumed" || activity.type === "started" || activity.type === "recovered"
+  );
+}
+
+function isRoutineCancellationRawOutput(rawOutput: string): boolean {
+  return rawOutput.trim().toLowerCase() === "context canceled";
 }
 
 function shouldRenderFailedContent(content: string, error?: string): boolean {

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -194,6 +194,15 @@ describe("compactAgentActivities", () => {
     ];
     expect(compactAgentActivities(items)).toEqual([items[1]]);
   });
+
+  it("drops backend files_changed rows when a diffStat row will be synthesized", () => {
+    const items = [
+      activity({ type: "tool_call", title: "Ran tool" }),
+      activity({ type: "files_changed", title: "Files changed", detail: "2 files changed" }),
+    ];
+    expect(compactAgentActivities(items, true)).toEqual([items[0]]);
+    expect(compactAgentActivities(items, false)).toEqual(items);
+  });
 });
 
 describe("compactDetailActivities", () => {
@@ -288,6 +297,18 @@ describe("activityDisplay", () => {
       title: "Thinking",
       detail: "3 model turns completed",
     });
+  });
+
+  it("does not surface verbose adapter thinking text in the activity row", () => {
+    expect(
+      activityDisplay(
+        activity({
+          type: "thinking",
+          title: "Thinking",
+          detail: "The user wants to see the current git diff in their repository.",
+        }),
+      ),
+    ).toEqual({ title: "Thinking" });
   });
 
   it("renders the files_changed summary directly", () => {

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -34,7 +34,10 @@ export function parseDiffStatRows(diffStat: string): Array<{ path: string; chang
     .filter((row): row is { path: string; change: string } => row !== null);
 }
 
-export function compactAgentActivities(activities: ChatActivityRecord[]): ChatActivityRecord[] {
+export function compactAgentActivities(
+  activities: ChatActivityRecord[],
+  hasDiffStat = false,
+): ChatActivityRecord[] {
   const hiddenTypes = new Set(["artifact", "changed_files", "final_answer", "output"]);
   const terminalIndex = pickTerminalActivityIndex(activities);
   const lastTaskRunIndex = lastIndexOfTaskRunActivity(activities);
@@ -42,6 +45,7 @@ export function compactAgentActivities(activities: ChatActivityRecord[]): ChatAc
   const out: ChatActivityRecord[] = [];
   for (const [index, activity] of activities.entries()) {
     if (hiddenTypes.has(activity.type)) continue;
+    if (hasDiffStat && activity.type === "files_changed") continue;
     if (activity.type === "completed" && activity.title.toLowerCase() === "final answer") continue;
     if (isTerminalRunSummary(activity)) continue;
     // Drop terminal-shaped rows that aren't the chosen one. The
@@ -211,6 +215,9 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
   }
   if (activity.type === "thinking" && isModelTurnActivity(activity)) {
     return { title: "Thinking", detail: modelTurnDetail(activity) };
+  }
+  if (activity.type === "thinking") {
+    return { title: "Thinking" };
   }
   if (activity.type === "model_turns") {
     return { title: "Thinking", detail: activity.detail };

--- a/ui/src/lib/runtime-trace.test.ts
+++ b/ui/src/lib/runtime-trace.test.ts
@@ -531,6 +531,51 @@ describe("buildSpanWaterfall", () => {
 });
 
 describe("buildTraceTimeline", () => {
+  it("dedupes root-span mirror events in the operator event flow", () => {
+    const timeline = buildTraceTimeline(
+      [
+        span({
+          span_id: "root",
+          name: "gateway.request",
+          start_time: "2026-05-11T06:14:05.428427Z",
+          events: [
+            {
+              name: "chat.run.started",
+              timestamp: "2026-05-11T06:14:05.428427Z",
+              attributes: {
+                "hecate.agent_adapter.id": "grok_build",
+                "hecate.agent_adapter.name": "Grok Build",
+              },
+            },
+          ],
+        }),
+        span({
+          span_id: "chat",
+          parent_span_id: "root",
+          name: "agent_chat.run",
+          events: [
+            {
+              name: "chat.run.started",
+              timestamp: "2026-05-11T06:14:05.428427Z",
+              attributes: {
+                "hecate.agent_adapter.name": "Grok Build",
+                "hecate.agent_adapter.id": "grok_build",
+              },
+            },
+          ],
+        }),
+      ],
+      "2026-05-11T06:14:05.428427Z",
+    );
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({
+      name: "chat.run.started",
+      spanName: "agent_chat.run",
+      phase: "chat",
+    });
+  });
+
   it("uses sub-ms event offsets instead of collapsing them to 0 ms", () => {
     const timeline = buildTraceTimeline(
       [

--- a/ui/src/lib/runtime-trace.ts
+++ b/ui/src/lib/runtime-trace.ts
@@ -71,18 +71,19 @@ export function buildTraceTimeline(
   spans: TraceSpanRecord[],
   traceStartedAt?: string,
 ): TraceTimelineItem[] {
-  const flattened: TraceTimelineItem[] = [];
+  const byEvent = new Map<string, { item: TraceTimelineItem; rootMirror: boolean }>();
   const startSource = traceStartedAt || spans[0]?.start_time || "";
   const startMs = parseISOWithSubMs(startSource);
 
   for (const span of spans) {
+    const rootMirror = !span.parent_span_id && span.name === "gateway.request";
     for (const event of span.events ?? []) {
       const currentMs = parseISOWithSubMs(event.timestamp);
       const offsetMs =
         Number.isFinite(startMs) && Number.isFinite(currentMs)
           ? Math.max(0, currentMs - startMs)
           : 0;
-      flattened.push({
+      const item = {
         name: event.name,
         timestamp: event.timestamp,
         offsetMs,
@@ -91,12 +92,39 @@ export function buildTraceTimeline(
         spanKind: span.kind || "internal",
         phase: tracePhaseFromEvent(event.name),
         attributes: event.attributes,
-      });
+      };
+      const key = traceTimelineEventKey(event);
+      const existing = byEvent.get(key);
+      if (!existing || (existing.rootMirror && !rootMirror)) {
+        byEvent.set(key, { item, rootMirror });
+      }
     }
   }
 
+  const flattened = Array.from(byEvent.values(), ({ item }) => item);
   flattened.sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp));
   return flattened;
+}
+
+function traceTimelineEventKey(event: {
+  name: string;
+  timestamp: string;
+  attributes?: unknown;
+}): string {
+  return [event.name, event.timestamp, stableTraceValueKey(event.attributes ?? null)].join(
+    "\u0000",
+  );
+}
+
+function stableTraceValueKey(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableTraceValueKey).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableTraceValueKey(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }
 
 function formatTraceOffsetMs(ms: number): string {


### PR DESCRIPTION
What changed
- Hide stale active placeholder activity rows after an assistant message is already failed or cancelled.
- Keep real failed tool diagnostics visible so operators still get useful run detail.
- Add regression coverage for the failed Grok-style launch path and for failed tools with stale running placeholders.

Why
- A terminal failed run could still show a confusing working/Running activity row underneath the failure notice. This makes the transcript read like one coherent terminal state.

Tests run
- cd ui && rtk bun run format:check
- cd ui && rtk bun run typecheck
- cd ui && rtk bun run test -- TranscriptMessageRow.test.tsx TranscriptActivityTimeline.test.tsx ChatView.test.tsx
- cd ui && rtk bun run test

Intentional non-goals
- No backend activity schema changes.
- No changes to raw adapter output or diagnostic failed tool rows.