### PR TITLE
fix(agent): use ACP model controls for Grok Build

### DIFF
--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -16,11 +16,11 @@ it, Hecate starts a fresh native session and keeps the Hecate transcript.
 
 ## Supported adapters
 
-| Adapter      | How Hecate starts it                                                                                                      | Auth expected by the underlying agent                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Codex        | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works                    | Operator-owned Codex auth visible to the adapter                   |
-| Claude Code  | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works | Operator-owned Claude Code / Anthropic auth visible to Claude Code |
-| Cursor Agent | `cursor-agent acp`                                                                                                        | Operator-owned Cursor Agent auth visible to `cursor-agent`         |
+| Adapter      | How Hecate starts it                                                                                                        | Auth expected by the underlying agent                              |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Codex        | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works                      | Operator-owned Codex auth visible to the adapter                   |
+| Claude Code  | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works   | Operator-owned Claude Code / Anthropic auth visible to Claude Code |
+| Cursor Agent | `cursor-agent acp`                                                                                                          | Operator-owned Cursor Agent auth visible to `cursor-agent`         |
 | Grok Build   | `grok agent ... stdio`; ACP model state drives the model picker; optional launch controls add `--reasoning-effort <effort>` | Operator-owned Grok auth or `XAI_API_KEY` visible to `grok`        |
 
 ## Credential and account boundaries

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -16,12 +16,12 @@ it, Hecate starts a fresh native session and keeps the Hecate transcript.
 
 ## Supported adapters
 
-| Adapter      | How Hecate starts it                                                                                                        | Auth expected by the underlying agent                              |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Codex        | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works                      | Operator-owned Codex auth visible to the adapter                   |
-| Claude Code  | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works   | Operator-owned Claude Code / Anthropic auth visible to Claude Code |
-| Cursor Agent | `cursor-agent acp`                                                                                                          | Operator-owned Cursor Agent auth visible to `cursor-agent`         |
-| Grok Build   | `grok agent ... stdio`; ACP model state drives the model picker; optional launch controls add `--reasoning-effort <effort>` | Operator-owned Grok auth or `XAI_API_KEY` visible to `grok`        |
+| Adapter      | How Hecate starts it                                                                                                      | Auth expected by the underlying agent                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Codex        | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works                    | Operator-owned Codex auth visible to the adapter                   |
+| Claude Code  | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works | Operator-owned Claude Code / Anthropic auth visible to Claude Code |
+| Cursor Agent | `cursor-agent acp`                                                                                                        | Operator-owned Cursor Agent auth visible to `cursor-agent`         |
+| Grok Build   | `grok agent ... stdio`                                                                                                    | Operator-owned Grok auth or `XAI_API_KEY` visible to `grok`        |
 
 ## Credential and account boundaries
 
@@ -50,9 +50,8 @@ adapter process, while authentication and billing stay with the provider.
    agent picker.
 3. Choose the workspace directory the external agent is allowed to work in.
 4. If model, reasoning, or mode controls appear above the message composer,
-   choose the values you want. Grok Build reports its model picker through ACP
-   after the chat session is prepared; reasoning is optional and can stay at
-   **Pick reasoning**.
+   choose the values you want. Some controls are launch-time choices and some
+   appear after the ACP session is prepared.
 5. Click **New chat**. Hecate starts the adapter session immediately. The
    message input appears after that session exists, while launch controls can be
    shown earlier so required values can be selected first.
@@ -75,14 +74,13 @@ External Agent controls have two sources:
 
 - **Launch controls** come from Hecate's adapter catalog and can appear before a
   concrete chat session exists. Hecate passes the selected values as process
-  arguments when it starts or restarts the adapter. Grok Build uses this path
-  for `--reasoning-effort`.
+  arguments when it starts or restarts the adapter.
 - **ACP session controls** come from the adapter during `session/new`,
   `session/load`, or `session/set_config_option`. Hecate surfaces them in the
-  composer and chat settings after the External Agent chat exists. Grok Build
-  exposes models through ACP model state; changing that picker uses ACP
-  `session/set_model`. The same ACP model-state bridge is shared by any ACP
-  adapter that reports `models` from `session/new` or `session/load`.
+  composer and chat settings after the External Agent chat exists. If an
+  adapter reports ACP model state from `session/new` or `session/load`, Hecate
+  surfaces that state as the model control and applies model changes with ACP
+  `session/set_model`.
 
 The controls are adapter-defined: Codex / Claude Code / Cursor Agent / Grok
 Build decide which model, mode, or reasoning selectors exist and what the labels
@@ -130,19 +128,13 @@ call the probe endpoint for a full spawn + ACP handshake + no-op session check:
 curl -X POST http://127.0.0.1:8765/hecate/v1/agent-adapters/codex/probe | jq
 ```
 
-For Codex and Claude, Hecate does not require `codex-acp` or
-`claude-agent-acp` to be installed on `PATH`. If the direct command is missing
-but `npx` is available, Hecate creates a small launcher in the operator cache
-directory and runs the official ACP npm package from there. Cursor Agent still
-requires the Cursor Agent CLI because its ACP mode is shipped by `cursor-agent`.
-Grok Build similarly requires the `grok` CLI because its ACP mode is shipped by
-`grok agent stdio`. Hecate does not pin a Grok model by default. Grok's ACP
-`session/new` / `session/load` responses provide the model list and current
-model, and Hecate applies model changes with ACP `session/set_model`. Grok Build
-does not currently expose reasoning as an ACP session configuration option, so
-choosing reasoning starts or restarts the adapter with
-`--reasoning-effort <effort>`; current Grok Build CLIs accept `none`, `minimal`,
-`low`, `medium`, `high`, and `xhigh`.
+Some adapters run through Hecate-managed launchers when the direct ACP command
+is missing and `npx` is available; Hecate creates those launchers in the
+operator cache directory and runs the official ACP npm package from there.
+Other adapters ship ACP mode inside the vendor CLI, so that CLI must be
+installed and visible on `PATH`. Hecate does not pin an external-agent model by
+default. When an ACP adapter reports model state, the adapter-provided model
+list and current model become the chat model control.
 
 By default the managed launcher directory is the user cache location:
 
@@ -208,39 +200,27 @@ start Hecate from an environment where `npx` is available. Hecate also checks
 common operator locations such as Volta, mise/asdf shims, Homebrew, and
 `/usr/bin`.
 
-### Cursor Agent
+### Direct CLI adapters
 
 ```sh
 command -v cursor-agent
 cursor-agent acp --help
 cursor-agent login
-```
-
-Cursor Agent can also authenticate through:
-
-```sh
-export CURSOR_API_KEY=...
-```
-
-If a run fails with `Authentication required. Please run 'agent login' first, or
-set CURSOR_API_KEY environment variable.`, authenticate Cursor Agent in the same
-environment that starts Hecate.
-
-### Grok Build
-
-```sh
 command -v grok
 grok login
 ```
 
-Headless environments can authenticate through:
+Headless environments can authenticate through vendor-supported API keys:
 
 ```sh
+export CURSOR_API_KEY=...
 export XAI_API_KEY=...
 ```
 
-If discovery cannot find `grok`, install Grok Build from the xAI CLI docs and
-restart Hecate from an environment where the command is on `PATH`.
+If discovery cannot find a direct CLI adapter, install the vendor CLI and
+restart Hecate from an environment where the command is on `PATH`. If a run
+fails with an authentication-required message, authenticate the CLI in the same
+environment that starts Hecate.
 
 ## Manual smoke
 

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -21,7 +21,7 @@ it, Hecate starts a fresh native session and keeps the Hecate transcript.
 | Codex        | Hecate-managed launcher for `@zed-industries/codex-acp` via local `npx`; direct `codex-acp` also works                    | Operator-owned Codex auth visible to the adapter                   |
 | Claude Code  | Hecate-managed launcher for `@agentclientprotocol/claude-agent-acp` via local `npx`; direct `claude-agent-acp` also works | Operator-owned Claude Code / Anthropic auth visible to Claude Code |
 | Cursor Agent | `cursor-agent acp`                                                                                                        | Operator-owned Cursor Agent auth visible to `cursor-agent`         |
-| Grok Build   | `grok agent ... stdio`; selected launch controls add `--model <id>` and optional `--reasoning-effort <effort>`            | Operator-owned Grok auth or `XAI_API_KEY` visible to `grok`        |
+| Grok Build   | `grok agent ... stdio`; ACP model state drives the model picker; optional launch controls add `--reasoning-effort <effort>` | Operator-owned Grok auth or `XAI_API_KEY` visible to `grok`        |
 
 ## Credential and account boundaries
 
@@ -50,8 +50,9 @@ adapter process, while authentication and billing stay with the provider.
    agent picker.
 3. Choose the workspace directory the external agent is allowed to work in.
 4. If model, reasoning, or mode controls appear above the message composer,
-   choose the values you want before creating the chat. Grok Build requires an
-   explicit model; reasoning is optional and can stay at **Pick reasoning**.
+   choose the values you want. Grok Build reports its model picker through ACP
+   after the chat session is prepared; reasoning is optional and can stay at
+   **Pick reasoning**.
 5. Click **New chat**. Hecate starts the adapter session immediately. The
    message input appears after that session exists, while launch controls can be
    shown earlier so required values can be selected first.
@@ -75,10 +76,12 @@ External Agent controls have two sources:
 - **Launch controls** come from Hecate's adapter catalog and can appear before a
   concrete chat session exists. Hecate passes the selected values as process
   arguments when it starts or restarts the adapter. Grok Build uses this path
-  for `--model` and `--reasoning-effort`.
+  for `--reasoning-effort`.
 - **ACP session controls** come from the adapter during `session/new`,
   `session/load`, or `session/set_config_option`. Hecate surfaces them in the
-  composer and chat settings after the External Agent chat exists.
+  composer and chat settings after the External Agent chat exists. Grok Build
+  exposes models through ACP model state; changing that picker uses ACP
+  `session/set_model`.
 
 The controls are adapter-defined: Codex / Claude Code / Cursor Agent / Grok
 Build decide which model, mode, or reasoning selectors exist and what the labels
@@ -132,16 +135,12 @@ but `npx` is available, Hecate creates a small launcher in the operator cache
 directory and runs the official ACP npm package from there. Cursor Agent still
 requires the Cursor Agent CLI because its ACP mode is shipped by `cursor-agent`.
 Grok Build similarly requires the `grok` CLI because its ACP mode is shipped by
-`grok agent stdio`. Hecate does not pin a Grok model by default. When
-`grok models` is available, Hecate uses that output to populate the Grok Build
-model selector; if the command is unavailable or empty, the selector still shows
-the explicit "Pick a model" state. Open Terminal and check `grok models` (or
-re-test the adapter from Connections) if no real choices appear. Hecate keeps a
-short in-process cache of launch help and model-list output so repeated catalog
-refreshes do not keep spawning the CLI. Session creation returns
-`chat.model_required` until a real model can be selected. Choosing a model starts
-or restarts the adapter with `--model <id>`. Choosing reasoning starts or
-restarts it with `--reasoning-effort <effort>`.
+`grok agent stdio`. Hecate does not pin a Grok model by default. Grok's ACP
+`session/new` / `session/load` responses provide the model list and current
+model, and Hecate applies model changes with ACP `session/set_model`. Choosing
+reasoning starts or restarts the adapter with `--reasoning-effort <effort>`;
+current Grok Build CLIs accept `none`, `minimal`, `low`, `medium`, `high`, and
+`xhigh`.
 
 By default the managed launcher directory is the user cache location:
 

--- a/docs/external-agent-adapters.md
+++ b/docs/external-agent-adapters.md
@@ -81,7 +81,8 @@ External Agent controls have two sources:
   `session/load`, or `session/set_config_option`. Hecate surfaces them in the
   composer and chat settings after the External Agent chat exists. Grok Build
   exposes models through ACP model state; changing that picker uses ACP
-  `session/set_model`.
+  `session/set_model`. The same ACP model-state bridge is shared by any ACP
+  adapter that reports `models` from `session/new` or `session/load`.
 
 The controls are adapter-defined: Codex / Claude Code / Cursor Agent / Grok
 Build decide which model, mode, or reasoning selectors exist and what the labels
@@ -137,10 +138,11 @@ requires the Cursor Agent CLI because its ACP mode is shipped by `cursor-agent`.
 Grok Build similarly requires the `grok` CLI because its ACP mode is shipped by
 `grok agent stdio`. Hecate does not pin a Grok model by default. Grok's ACP
 `session/new` / `session/load` responses provide the model list and current
-model, and Hecate applies model changes with ACP `session/set_model`. Choosing
-reasoning starts or restarts the adapter with `--reasoning-effort <effort>`;
-current Grok Build CLIs accept `none`, `minimal`, `low`, `medium`, `high`, and
-`xhigh`.
+model, and Hecate applies model changes with ACP `session/set_model`. Grok Build
+does not currently expose reasoning as an ACP session configuration option, so
+choosing reasoning starts or restarts the adapter with
+`--reasoning-effort <effort>`; current Grok Build CLIs accept `none`, `minimal`,
+`low`, `medium`, `high`, and `xhigh`.
 
 By default the managed launcher directory is the user cache location:
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -790,40 +790,7 @@ GET /hecate/v1/agent-adapters
       "cost_mode": "external",
       "docs_url": "https://docs.x.ai/build/cli/headless-scripting#acp",
       "supported_range": ">=0.1.0",
-      "auth_status": "ok",
-      "config_options": [
-        {
-          "id": "model",
-          "name": "Model",
-          "description": "Model passed to the external-agent process when Hecate starts or restarts it.",
-          "category": "model",
-          "type": "select",
-          "current_value": "__hecate_no_model_selected__",
-          "options": [
-            {
-              "value": "__hecate_no_model_selected__",
-              "name": "Pick a model",
-              "description": "Do not pass --model when starting the external agent."
-            }
-          ]
-        },
-        {
-          "id": "reasoning_effort",
-          "name": "Reasoning",
-          "description": "Reasoning effort passed to Grok Build when Hecate starts or restarts it.",
-          "category": "thought_level",
-          "type": "select",
-          "current_value": "__hecate_no_reasoning_selected__",
-          "options": [
-            { "value": "__hecate_no_reasoning_selected__", "name": "Pick reasoning" },
-            { "value": "low", "name": "Low" },
-            { "value": "medium", "name": "Medium" },
-            { "value": "high", "name": "High" },
-            { "value": "xhigh", "name": "XHigh" },
-            { "value": "max", "name": "Max" }
-          ]
-        }
-      ]
+      "auth_status": "ok"
     },
     {
       "id": "cursor_agent",
@@ -1318,12 +1285,13 @@ failing only after execution starts.
 
 For external-agent `agent_id` values, session creation also starts or restores
 the native ACP session immediately. Clients may include `config_options`
-selected from the adapter catalog; Hecate validates required launch options and
-uses them when starting the adapter process. After the ACP session exists,
-adapter-owned `config_options` are returned with the session so clients can
-render them before the first prompt. If the adapter binary is missing,
-unauthenticated, missing a required launch option, or fails its ACP handshake,
-session creation fails and Hecate removes the empty chat record.
+selected from the adapter catalog when a catalog row exposes Hecate-managed
+launch controls; Hecate validates required launch options and uses them when
+starting the adapter process. After the ACP session exists, adapter-owned
+`config_options` are returned with the session so clients can render them before
+the first prompt. If the adapter binary is missing, unauthenticated, missing a
+required launch option, or fails its ACP handshake, session creation fails and
+Hecate removes the empty chat record.
 
 ```json
 POST /hecate/v1/chat/sessions
@@ -1359,7 +1327,7 @@ POST /hecate/v1/chat/sessions
 }
 ```
 
-External Agent creation with launch options:
+External Agent creation with ACP session controls:
 
 ```json
 POST /hecate/v1/chat/sessions
@@ -1372,14 +1340,8 @@ POST /hecate/v1/chat/sessions
       "name": "Model",
       "category": "model",
       "type": "select",
+      "source": "acp_model",
       "current_value": "chosen-model-id"
-    },
-    {
-      "id": "reasoning_effort",
-      "name": "Reasoning",
-      "category": "thought_level",
-      "type": "select",
-      "current_value": "medium"
     }
   ]
 }
@@ -1399,14 +1361,8 @@ POST /hecate/v1/chat/sessions
         "name": "Model",
         "category": "model",
         "type": "select",
+        "source": "acp_model",
         "current_value": "chosen-model-id"
-      },
-      {
-        "id": "reasoning_effort",
-        "name": "Reasoning",
-        "category": "thought_level",
-        "type": "select",
-        "current_value": "medium"
       }
     ],
     "messages": []

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -886,9 +886,11 @@ options to `POST /hecate/v1/chat/sessions`. Values prefixed with
 `__hecate_no_` are explicit "not selected" sentinels. Some options are optional;
 launch-model options can be required by the adapter definition and cause
 `400 chat.model_required` at session creation until a real value is selected.
-When an adapter uses CLI help or model-list commands to populate launch controls,
-the catalog endpoint reuses a short in-process cache instead of spawning the CLI
-on every refresh.
+Adapter-owned ACP model state appears on the prepared chat session instead of
+the catalog row and is updated with ACP `session/set_model`. When an adapter
+uses CLI help or model-list commands to populate launch controls, the catalog
+endpoint reuses a short in-process cache instead of spawning the CLI on every
+refresh.
 
 ### `POST /hecate/v1/agent-adapters/{id}/probe`
 

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -423,7 +423,7 @@ func (s *acpSession) SetACPModel(ctx context.Context, req SetSessionConfigOption
 		SessionId: acp.SessionId(s.nativeID),
 		ModelId:   acp.UnstableModelId(value),
 	}); err != nil {
-		return SetSessionConfigOptionResult{}, err
+		return SetSessionConfigOptionResult{}, fmt.Errorf("select ACP model for %q: %w", s.adapter.ID, err)
 	}
 
 	s.configMu.Lock()
@@ -503,6 +503,8 @@ func mergeACPSessionConfigOptions(options []agentcontrols.ConfigOption, models *
 	if !ok || hasModelConfigOption(options) {
 		return options
 	}
+	// Surfacing ACP model state as a writable control relies on the adapter
+	// also supporting the matching unstable set-model RPC.
 	return append(options, modelOption)
 }
 

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -150,12 +150,27 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 			Cwd:        workspace,
 			McpServers: []acp.McpServer{},
 		})
-		cancel()
 		if loadErr == nil {
 			nativeID = previousNativeSessionID
 			resumed = true
 			configOptions = agentcontrols.FromACPOptions(loaded.ConfigOptions)
+			configOptions = appendACPModelConfigOption(configOptions, loaded.Models)
 			configOptions, managedConfig = appendLaunchConfigOptions(ctx, command, adapter, configOptions, selectedOptions)
+			configOptions, loadErr = applySelectedACPModel(loadCtx, conn, nativeID, adapter, configOptions, selectedOptions)
+			if loadErr != nil {
+				recovery = fmt.Sprintf("could not restore ACP session %s: %v", previousNativeSessionID, loadErr)
+				if sessionLogger != nil {
+					sessionLogger.Warn("previous ACP session model selection failed",
+						slog.String("native_session_id", previousNativeSessionID),
+						slog.Any("error", loadErr),
+					)
+				}
+				nativeID = ""
+				resumed = false
+			}
+		}
+		cancel()
+		if loadErr == nil && nativeID != "" {
 			if sessionLogger != nil {
 				sessionLogger.Info("previous ACP session loaded",
 					slog.String("native_session_id", nativeID),
@@ -181,8 +196,8 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 			Cwd:        workspace,
 			McpServers: []acp.McpServer{},
 		})
-		cancel()
 		if err != nil {
+			cancel()
 			if sessionLogger != nil {
 				sessionLogger.Warn("ACP session creation failed", slog.Any("error", err))
 			}
@@ -191,7 +206,17 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		}
 		nativeID = string(created.SessionId)
 		configOptions = agentcontrols.FromACPOptions(created.ConfigOptions)
+		configOptions = appendACPModelConfigOption(configOptions, created.Models)
 		configOptions, managedConfig = appendLaunchConfigOptions(ctx, command, adapter, configOptions, selectedOptions)
+		configOptions, err = applySelectedACPModel(newCtx, conn, nativeID, adapter, configOptions, selectedOptions)
+		cancel()
+		if err != nil {
+			if sessionLogger != nil {
+				sessionLogger.Warn("ACP session model selection failed", slog.Any("error", err))
+			}
+			terminateProcess(cmd)
+			return nil, false, "", fmt.Errorf("select ACP model for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
+		}
 		if sessionLogger != nil {
 			sessionLogger.Info("ACP session created",
 				slog.String("native_session_id", nativeID),
@@ -293,6 +318,10 @@ func (m *SessionManager) SetSessionConfigOption(ctx context.Context, req SetSess
 		}
 		return result, nil
 	}
+	if session.isACPModelConfigOption(req.ConfigID) {
+		m.mu.Unlock()
+		return session.SetACPModel(ctx, req)
+	}
 	m.mu.Unlock()
 	return session.SetConfigOption(ctx, req)
 }
@@ -305,6 +334,18 @@ func (s *acpSession) isManagedConfigOption(configID string) bool {
 	}
 	_, ok := s.managedConfig[strings.TrimSpace(configID)]
 	return ok
+}
+
+func (s *acpSession) isACPModelConfigOption(configID string) bool {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+	configID = strings.TrimSpace(configID)
+	for _, option := range s.configOptions {
+		if option.ID == configID && option.Source == agentcontrols.ConfigOptionSourceACPModel {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *acpSession) SetManagedConfigOption(req SetSessionConfigOptionRequest) (SetSessionConfigOptionResult, error) {
@@ -345,6 +386,53 @@ func configOptionAllowsValue(option agentcontrols.ConfigOption, value string) bo
 		}
 	}
 	return false
+}
+
+func (s *acpSession) SetACPModel(ctx context.Context, req SetSessionConfigOptionRequest) (SetSessionConfigOptionResult, error) {
+	if req.BoolValue != nil {
+		return SetSessionConfigOptionResult{}, fmt.Errorf("ACP model option %q requires a string value", req.ConfigID)
+	}
+	value := strings.TrimSpace(req.Value)
+	if value == "" {
+		return SetSessionConfigOptionResult{}, fmt.Errorf("value is required")
+	}
+	s.configMu.Lock()
+	options := cloneConfigOptions(s.configOptions)
+	modelIndex := -1
+	for i := range options {
+		if options[i].ID == req.ConfigID && options[i].Source == agentcontrols.ConfigOptionSourceACPModel {
+			modelIndex = i
+			break
+		}
+	}
+	if modelIndex < 0 {
+		s.configMu.Unlock()
+		return SetSessionConfigOptionResult{}, fmt.Errorf("ACP model option %q not found", req.ConfigID)
+	}
+	if !configOptionAllowsValue(options[modelIndex], value) {
+		s.configMu.Unlock()
+		return SetSessionConfigOptionResult{}, fmt.Errorf("value %q is not available for %s %s", value, s.adapter.Name, options[modelIndex].Name)
+	}
+	s.configMu.Unlock()
+
+	if _, err := s.conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
+		SessionId: acp.SessionId(s.nativeID),
+		ModelId:   acp.UnstableModelId(value),
+	}); err != nil {
+		return SetSessionConfigOptionResult{}, err
+	}
+
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+	options = cloneConfigOptions(s.configOptions)
+	for i := range options {
+		if options[i].ID == req.ConfigID && options[i].Source == agentcontrols.ConfigOptionSourceACPModel {
+			options[i].CurrentValue = value
+			s.configOptions = options
+			return SetSessionConfigOptionResult{ConfigOptions: cloneConfigOptions(options)}, nil
+		}
+	}
+	return SetSessionConfigOptionResult{}, fmt.Errorf("ACP model option %q not found", req.ConfigID)
 }
 
 func (s *acpSession) SetConfigOption(ctx context.Context, req SetSessionConfigOptionRequest) (SetSessionConfigOptionResult, error) {
@@ -402,6 +490,51 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 		copy(out[i].Options, options[i].Options)
 	}
 	return out
+}
+
+func appendACPModelConfigOption(options []agentcontrols.ConfigOption, models *acp.SessionModelState) []agentcontrols.ConfigOption {
+	modelOption, ok := agentcontrols.FromACPModelState(models)
+	if !ok || hasModelConfigOption(options) {
+		return options
+	}
+	return append(options, modelOption)
+}
+
+func applySelectedACPModel(ctx context.Context, conn *acp.ClientSideConnection, nativeID string, adapter Adapter, options, selected []agentcontrols.ConfigOption) ([]agentcontrols.ConfigOption, error) {
+	value := selectedConfigOptionValue(selected, "model")
+	if value == "" || strings.HasPrefix(value, "__hecate_no_") {
+		return options, nil
+	}
+	out := cloneConfigOptions(options)
+	for i := range out {
+		if out[i].ID != "model" || out[i].Source != agentcontrols.ConfigOptionSourceACPModel {
+			continue
+		}
+		if out[i].CurrentValue == value {
+			return out, nil
+		}
+		if !configOptionAllowsValue(out[i], value) {
+			return nil, fmt.Errorf("value %q is not available for %s %s", value, adapter.Name, out[i].Name)
+		}
+		if _, err := conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
+			SessionId: acp.SessionId(nativeID),
+			ModelId:   acp.UnstableModelId(value),
+		}); err != nil {
+			return nil, err
+		}
+		out[i].CurrentValue = value
+		return out, nil
+	}
+	return options, nil
+}
+
+func selectedConfigOptionValue(options []agentcontrols.ConfigOption, id string) string {
+	for _, option := range options {
+		if option.ID == id {
+			return strings.TrimSpace(option.CurrentValue)
+		}
+	}
+	return ""
 }
 
 func (s *acpSession) Close(ctx context.Context) error {

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -153,8 +153,10 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		if loadErr == nil {
 			nativeID = previousNativeSessionID
 			resumed = true
-			configOptions = agentcontrols.FromACPOptions(loaded.ConfigOptions)
-			configOptions = appendACPModelConfigOption(configOptions, loaded.Models)
+			configOptions = mergeACPSessionConfigOptions(
+				agentcontrols.FromACPOptions(loaded.ConfigOptions),
+				loaded.Models,
+			)
 			configOptions, managedConfig = appendLaunchConfigOptions(ctx, command, adapter, configOptions, selectedOptions)
 			configOptions, loadErr = applySelectedACPModel(loadCtx, conn, nativeID, adapter, configOptions, selectedOptions)
 			if loadErr != nil {
@@ -205,8 +207,10 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 			return nil, false, "", fmt.Errorf("create ACP session for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 		}
 		nativeID = string(created.SessionId)
-		configOptions = agentcontrols.FromACPOptions(created.ConfigOptions)
-		configOptions = appendACPModelConfigOption(configOptions, created.Models)
+		configOptions = mergeACPSessionConfigOptions(
+			agentcontrols.FromACPOptions(created.ConfigOptions),
+			created.Models,
+		)
 		configOptions, managedConfig = appendLaunchConfigOptions(ctx, command, adapter, configOptions, selectedOptions)
 		configOptions, err = applySelectedACPModel(newCtx, conn, nativeID, adapter, configOptions, selectedOptions)
 		cancel()
@@ -445,6 +449,7 @@ func (s *acpSession) SetConfigOption(ctx context.Context, req SetSessionConfigOp
 	if err != nil {
 		return SetSessionConfigOptionResult{}, err
 	}
+	previousOptions := s.configOptionsSnapshot()
 	resp, err := s.conn.SetSessionConfigOption(ctx, acpReq)
 	if err != nil {
 		return SetSessionConfigOptionResult{}, err
@@ -453,6 +458,7 @@ func (s *acpSession) SetConfigOption(ctx context.Context, req SetSessionConfigOp
 	if resp.ConfigOptions != nil && options == nil {
 		options = []agentcontrols.ConfigOption{}
 	}
+	options = preserveACPModelConfigOption(options, previousOptions)
 	s.setConfigOptions(options)
 	return SetSessionConfigOptionResult{ConfigOptions: options}, nil
 }
@@ -492,12 +498,24 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 	return out
 }
 
-func appendACPModelConfigOption(options []agentcontrols.ConfigOption, models *acp.SessionModelState) []agentcontrols.ConfigOption {
+func mergeACPSessionConfigOptions(options []agentcontrols.ConfigOption, models *acp.SessionModelState) []agentcontrols.ConfigOption {
 	modelOption, ok := agentcontrols.FromACPModelState(models)
 	if !ok || hasModelConfigOption(options) {
 		return options
 	}
 	return append(options, modelOption)
+}
+
+func preserveACPModelConfigOption(options, previous []agentcontrols.ConfigOption) []agentcontrols.ConfigOption {
+	if hasModelConfigOption(options) {
+		return options
+	}
+	for _, option := range previous {
+		if option.Source == agentcontrols.ConfigOptionSourceACPModel {
+			return append(options, cloneConfigOptions([]agentcontrols.ConfigOption{option})...)
+		}
+	}
+	return options
 }
 
 func applySelectedACPModel(ctx context.Context, conn *acp.ClientSideConnection, nativeID string, adapter Adapter, options, selected []agentcontrols.ConfigOption) ([]agentcontrols.ConfigOption, error) {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -130,6 +130,93 @@ func TestACPSessionConfigOptionsSnapshotPreservesNilAndEmpty(t *testing.T) {
 	}
 }
 
+func TestSessionManagerUsesACPModelStateForGrok(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
+	installFakeACPExecutable(t, "grok")
+	workspace := t.TempDir()
+	manager := NewSessionManager()
+
+	prepared, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_grok_model",
+		AdapterID: "grok_build",
+		Workspace: workspace,
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+	if prepared.NativeSessionID == "" {
+		t.Fatal("native session id is empty")
+	}
+	model := findConfigOption(prepared.ConfigOptions, "model")
+	if model == nil {
+		t.Fatalf("config options = %#v, want ACP model option", prepared.ConfigOptions)
+	}
+	if model.Source != agentcontrols.ConfigOptionSourceACPModel || model.CurrentValue != "model-a" {
+		t.Fatalf("model option = %#v, want ACP model-a", *model)
+	}
+
+	updated, err := manager.SetSessionConfigOption(context.Background(), SetSessionConfigOptionRequest{
+		SessionID: "chat_grok_model",
+		ConfigID:  "model",
+		Value:     "model-b",
+	})
+	if err != nil {
+		t.Fatalf("SetSessionConfigOption(model): %v", err)
+	}
+	model = findConfigOption(updated.ConfigOptions, "model")
+	if model == nil || model.CurrentValue != "model-b" || model.Source != agentcontrols.ConfigOptionSourceACPModel {
+		t.Fatalf("updated options = %#v, want ACP model-b", updated.ConfigOptions)
+	}
+
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      "chat_grok_model",
+		AdapterID:      "grok_build",
+		Workspace:      workspace,
+		Prompt:         "after model switch",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+		ConfigOptions:  updated.ConfigOptions,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.NativeSessionID != prepared.NativeSessionID {
+		t.Fatalf("native session id = %q, want unchanged %q", run.NativeSessionID, prepared.NativeSessionID)
+	}
+}
+
+func TestSessionManagerAppliesSelectedACPModelDuringPrepare(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
+	installFakeACPExecutable(t, "grok")
+
+	manager := NewSessionManager()
+	prepared, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_grok_preselected_model",
+		AdapterID: "grok_build",
+		Workspace: t.TempDir(),
+		ConfigOptions: []agentcontrols.ConfigOption{{
+			ID:           "model",
+			CurrentValue: "model-b",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+	model := findConfigOption(prepared.ConfigOptions, "model")
+	if model == nil || model.CurrentValue != "model-b" || model.Source != agentcontrols.ConfigOptionSourceACPModel {
+		t.Fatalf("config options = %#v, want preselected ACP model-b", prepared.ConfigOptions)
+	}
+}
+
+func findConfigOption(options []agentcontrols.ConfigOption, id string) *agentcontrols.ConfigOption {
+	for i := range options {
+		if options[i].ID == id {
+			return &options[i]
+		}
+	}
+	return nil
+}
+
 func TestTrimToolSummaryPreservesUTF8(t *testing.T) {
 	input := strings.Repeat("界", 121)
 	got := trimToolSummary(input)
@@ -1375,9 +1462,10 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
+		os.Getenv("HECATE_FAKE_ACP_MODELS"),
 		os.Args[0],
 	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
@@ -1396,6 +1484,7 @@ type fakeACPAgent struct {
 type fakeACPSession struct {
 	turns  int
 	cancel context.CancelFunc
+	model  string
 }
 
 func newFakeACPAgent() *fakeACPAgent {
@@ -1422,9 +1511,12 @@ func (a *fakeACPAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.N
 	}
 	id := fmt.Sprintf("fake_session_%d", time.Now().UnixNano())
 	a.mu.Lock()
-	a.sessions[id] = &fakeACPSession{}
+	a.sessions[id] = &fakeACPSession{model: "model-a"}
 	a.mu.Unlock()
-	return acp.NewSessionResponse{SessionId: acp.SessionId(id)}, nil
+	return acp.NewSessionResponse{
+		SessionId: acp.SessionId(id),
+		Models:    fakeACPModelState("model-a"),
+	}, nil
 }
 
 func (a *fakeACPAgent) LoadSession(_ context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
@@ -1432,9 +1524,9 @@ func (a *fakeACPAgent) LoadSession(_ context.Context, params acp.LoadSessionRequ
 		return acp.LoadSessionResponse{}, fmt.Errorf("fake persisted session %s not found", params.SessionId)
 	}
 	a.mu.Lock()
-	a.sessions[string(params.SessionId)] = &fakeACPSession{}
+	a.sessions[string(params.SessionId)] = &fakeACPSession{model: "model-a"}
 	a.mu.Unlock()
-	return acp.LoadSessionResponse{}, nil
+	return acp.LoadSessionResponse{Models: fakeACPModelState("model-a")}, nil
 }
 
 func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
@@ -1516,6 +1608,21 @@ func (a *fakeACPAgent) SetSessionConfigOption(context.Context, acp.SetSessionCon
 	return acp.SetSessionConfigOptionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)
 }
 
+func (a *fakeACPAgent) UnstableSetSessionModel(_ context.Context, params acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error) {
+	session, err := a.session(params.SessionId)
+	if err != nil {
+		return acp.UnstableSetSessionModelResponse{}, err
+	}
+	model := string(params.ModelId)
+	if model != "model-a" && model != "model-b" {
+		return acp.UnstableSetSessionModelResponse{}, fmt.Errorf("model %q not available", model)
+	}
+	a.mu.Lock()
+	session.model = model
+	a.mu.Unlock()
+	return acp.UnstableSetSessionModelResponse{}, nil
+}
+
 func (a *fakeACPAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
 	return acp.SetSessionModeResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetMode)
 }
@@ -1528,6 +1635,19 @@ func (a *fakeACPAgent) session(id acp.SessionId) (*fakeACPSession, error) {
 		return nil, fmt.Errorf("session %q not found", id)
 	}
 	return session, nil
+}
+
+func fakeACPModelState(current string) *acp.SessionModelState {
+	if os.Getenv("HECATE_FAKE_ACP_MODELS") != "1" {
+		return nil
+	}
+	return &acp.SessionModelState{
+		CurrentModelId: acp.ModelId(current),
+		AvailableModels: []acp.ModelInfo{
+			{ModelId: acp.ModelId("model-a"), Name: "Model A"},
+			{ModelId: acp.ModelId("model-b"), Name: "Model B"},
+		},
+	}
 }
 
 func promptText(blocks []acp.ContentBlock) string {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -130,7 +130,47 @@ func TestACPSessionConfigOptionsSnapshotPreservesNilAndEmpty(t *testing.T) {
 	}
 }
 
-func TestSessionManagerUsesACPModelStateForGrok(t *testing.T) {
+func TestSessionManagerUsesACPModelStateForBuiltInACPAdapters(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
+
+	tests := []struct {
+		adapterID string
+		command   string
+	}{
+		{adapterID: "codex", command: "codex-acp"},
+		{adapterID: "claude_code", command: "claude-agent-acp"},
+		{adapterID: "cursor_agent", command: "cursor-agent"},
+		{adapterID: "grok_build", command: "grok"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.adapterID, func(t *testing.T) {
+			installFakeACPExecutable(t, tt.command)
+			manager := NewSessionManager()
+
+			prepared, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+				SessionID: "chat_" + tt.adapterID + "_model",
+				AdapterID: tt.adapterID,
+				Workspace: t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("PrepareSession: %v", err)
+			}
+			if prepared.NativeSessionID == "" {
+				t.Fatal("native session id is empty")
+			}
+			model := findConfigOption(prepared.ConfigOptions, "model")
+			if model == nil {
+				t.Fatalf("config options = %#v, want ACP model option", prepared.ConfigOptions)
+			}
+			if model.Source != agentcontrols.ConfigOptionSourceACPModel || model.CurrentValue != "model-a" {
+				t.Fatalf("model option = %#v, want ACP model-a", *model)
+			}
+		})
+	}
+}
+
+func TestSessionManagerChangesACPModelWithoutRestartingSession(t *testing.T) {
 	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
 	installFakeACPExecutable(t, "grok")
 	workspace := t.TempDir()
@@ -144,16 +184,6 @@ func TestSessionManagerUsesACPModelStateForGrok(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareSession: %v", err)
 	}
-	if prepared.NativeSessionID == "" {
-		t.Fatal("native session id is empty")
-	}
-	model := findConfigOption(prepared.ConfigOptions, "model")
-	if model == nil {
-		t.Fatalf("config options = %#v, want ACP model option", prepared.ConfigOptions)
-	}
-	if model.Source != agentcontrols.ConfigOptionSourceACPModel || model.CurrentValue != "model-a" {
-		t.Fatalf("model option = %#v, want ACP model-a", *model)
-	}
 
 	updated, err := manager.SetSessionConfigOption(context.Background(), SetSessionConfigOptionRequest{
 		SessionID: "chat_grok_model",
@@ -163,7 +193,7 @@ func TestSessionManagerUsesACPModelStateForGrok(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetSessionConfigOption(model): %v", err)
 	}
-	model = findConfigOption(updated.ConfigOptions, "model")
+	model := findConfigOption(updated.ConfigOptions, "model")
 	if model == nil || model.CurrentValue != "model-b" || model.Source != agentcontrols.ConfigOptionSourceACPModel {
 		t.Fatalf("updated options = %#v, want ACP model-b", updated.ConfigOptions)
 	}
@@ -182,6 +212,43 @@ func TestSessionManagerUsesACPModelStateForGrok(t *testing.T) {
 	}
 	if run.NativeSessionID != prepared.NativeSessionID {
 		t.Fatalf("native session id = %q, want unchanged %q", run.NativeSessionID, prepared.NativeSessionID)
+	}
+}
+
+func TestSessionManagerPreservesACPModelWhenAdapterConfigOptionsChange(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
+	t.Setenv("HECATE_FAKE_ACP_CONFIG_OPTIONS", "1")
+	installFakeACPExecutable(t, "cursor-agent")
+
+	manager := NewSessionManager()
+	prepared, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_cursor_config",
+		AdapterID: "cursor_agent",
+		Workspace: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+	if model := findConfigOption(prepared.ConfigOptions, "model"); model == nil || model.Source != agentcontrols.ConfigOptionSourceACPModel {
+		t.Fatalf("prepared config options = %#v, want ACP model option", prepared.ConfigOptions)
+	}
+	if mode := findConfigOption(prepared.ConfigOptions, "mode"); mode == nil || mode.CurrentValue != "ask" {
+		t.Fatalf("prepared config options = %#v, want mode=ask", prepared.ConfigOptions)
+	}
+
+	updated, err := manager.SetSessionConfigOption(context.Background(), SetSessionConfigOptionRequest{
+		SessionID: "chat_cursor_config",
+		ConfigID:  "mode",
+		Value:     "auto",
+	})
+	if err != nil {
+		t.Fatalf("SetSessionConfigOption(mode): %v", err)
+	}
+	if model := findConfigOption(updated.ConfigOptions, "model"); model == nil || model.Source != agentcontrols.ConfigOptionSourceACPModel || model.CurrentValue != "model-a" {
+		t.Fatalf("updated config options = %#v, want preserved ACP model option", updated.ConfigOptions)
+	}
+	if mode := findConfigOption(updated.ConfigOptions, "mode"); mode == nil || mode.CurrentValue != "auto" {
+		t.Fatalf("updated config options = %#v, want mode=auto", updated.ConfigOptions)
 	}
 }
 
@@ -1462,10 +1529,11 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_MODELS"),
+		os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS"),
 		os.Args[0],
 	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
@@ -1514,8 +1582,9 @@ func (a *fakeACPAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.N
 	a.sessions[id] = &fakeACPSession{model: "model-a"}
 	a.mu.Unlock()
 	return acp.NewSessionResponse{
-		SessionId: acp.SessionId(id),
-		Models:    fakeACPModelState("model-a"),
+		SessionId:     acp.SessionId(id),
+		ConfigOptions: fakeACPConfigOptions("ask"),
+		Models:        fakeACPModelState("model-a"),
 	}, nil
 }
 
@@ -1526,7 +1595,10 @@ func (a *fakeACPAgent) LoadSession(_ context.Context, params acp.LoadSessionRequ
 	a.mu.Lock()
 	a.sessions[string(params.SessionId)] = &fakeACPSession{model: "model-a"}
 	a.mu.Unlock()
-	return acp.LoadSessionResponse{Models: fakeACPModelState("model-a")}, nil
+	return acp.LoadSessionResponse{
+		ConfigOptions: fakeACPConfigOptions("ask"),
+		Models:        fakeACPModelState("model-a"),
+	}, nil
 }
 
 func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
@@ -1604,8 +1676,20 @@ func (a *fakeACPAgent) ResumeSession(context.Context, acp.ResumeSessionRequest) 
 	return acp.ResumeSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionResume)
 }
 
-func (a *fakeACPAgent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
-	return acp.SetSessionConfigOptionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)
+func (a *fakeACPAgent) SetSessionConfigOption(_ context.Context, params acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	if os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS") != "1" {
+		return acp.SetSessionConfigOptionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)
+	}
+	if params.ValueId == nil || string(params.ValueId.ConfigId) != "mode" {
+		return acp.SetSessionConfigOptionResponse{}, fmt.Errorf("unexpected config option request: %#v", params)
+	}
+	value := string(params.ValueId.Value)
+	if value != "ask" && value != "auto" {
+		return acp.SetSessionConfigOptionResponse{}, fmt.Errorf("mode %q not available", value)
+	}
+	return acp.SetSessionConfigOptionResponse{
+		ConfigOptions: fakeACPConfigOptions(value),
+	}, nil
 }
 
 func (a *fakeACPAgent) UnstableSetSessionModel(_ context.Context, params acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error) {
@@ -1647,6 +1731,24 @@ func fakeACPModelState(current string) *acp.SessionModelState {
 			{ModelId: acp.ModelId("model-a"), Name: "Model A"},
 			{ModelId: acp.ModelId("model-b"), Name: "Model B"},
 		},
+	}
+}
+
+func fakeACPConfigOptions(current string) []acp.SessionConfigOption {
+	if os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS") != "1" {
+		return nil
+	}
+	options := acp.SessionConfigSelectOptionsUngrouped{
+		{Value: acp.SessionConfigValueId("ask"), Name: "Ask"},
+		{Value: acp.SessionConfigValueId("auto"), Name: "Auto"},
+	}
+	return []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Id:           acp.SessionConfigId("mode"),
+			Name:         "Mode",
+			CurrentValue: acp.SessionConfigValueId(current),
+			Options:      acp.SessionConfigSelectOptions{Ungrouped: &options},
+		}},
 	}
 }
 

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -215,6 +215,35 @@ func TestSessionManagerChangesACPModelWithoutRestartingSession(t *testing.T) {
 	}
 }
 
+func TestSessionManagerWrapsACPModelSetErrors(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
+	t.Setenv("HECATE_FAKE_ACP_SET_MODEL_ERROR", "adapter rejected model switch")
+	installFakeACPExecutable(t, "grok")
+	manager := NewSessionManager()
+
+	_, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_grok_model_error",
+		AdapterID: "grok_build",
+		Workspace: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+
+	_, err = manager.SetSessionConfigOption(context.Background(), SetSessionConfigOptionRequest{
+		SessionID: "chat_grok_model_error",
+		ConfigID:  "model",
+		Value:     "model-b",
+	})
+	if err == nil {
+		t.Fatal("SetSessionConfigOption(model) succeeded, want wrapped ACP model error")
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, `select ACP model for "grok_build":`) || !strings.Contains(errText, "adapter rejected model switch") {
+		t.Fatalf("error = %q, want wrapped ACP model selection context", errText)
+	}
+}
+
 func TestSessionManagerPreservesACPModelWhenAdapterConfigOptionsChange(t *testing.T) {
 	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
 	t.Setenv("HECATE_FAKE_ACP_CONFIG_OPTIONS", "1")
@@ -1529,11 +1558,12 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_MODELS"),
 		os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS"),
+		os.Getenv("HECATE_FAKE_ACP_SET_MODEL_ERROR"),
 		os.Args[0],
 	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
@@ -1693,6 +1723,9 @@ func (a *fakeACPAgent) SetSessionConfigOption(_ context.Context, params acp.SetS
 }
 
 func (a *fakeACPAgent) UnstableSetSessionModel(_ context.Context, params acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error) {
+	if errMessage := strings.TrimSpace(os.Getenv("HECATE_FAKE_ACP_SET_MODEL_ERROR")); errMessage != "" {
+		return acp.UnstableSetSessionModelResponse{}, fmt.Errorf("%s", errMessage)
+	}
 	session, err := a.session(params.SessionId)
 	if err != nil {
 		return acp.UnstableSetSessionModelResponse{}, err

--- a/internal/agentadapters/launch_config_test.go
+++ b/internal/agentadapters/launch_config_test.go
@@ -11,57 +11,43 @@ import (
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 )
 
-func TestLaunchConfig_AppendsGrokModelOptionWithUnsetSelection(t *testing.T) {
+func TestLaunchConfig_AppendsGrokReasoningOption(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {
 		t.Fatal("grok_build adapter not found")
 	}
 	got, managed := appendLaunchConfigOptions(context.Background(), "", adapter, nil, nil)
-	if len(got) != 2 {
-		t.Fatalf("options = %#v, want model and reasoning launch options", got)
-	}
-	if _, ok := managed["model"]; !ok {
-		t.Fatalf("managed config ids = %#v, want model", managed)
+	if len(got) != 1 {
+		t.Fatalf("options = %#v, want reasoning launch option", got)
 	}
 	if _, ok := managed["reasoning_effort"]; !ok {
 		t.Fatalf("managed config ids = %#v, want reasoning_effort", managed)
 	}
-	option := got[0]
-	if option.ID != "model" || option.Category != "model" || option.Source != agentcontrols.ConfigOptionSourceLaunch || option.CurrentValue != launchModelUnsetValue {
-		t.Fatalf("launch model option = %#v, want model category with unset current", option)
-	}
-	if len(option.Options) != 1 || option.Options[0].Value != launchModelUnsetValue {
-		t.Fatalf("model candidates = %#v, want unset option only without discovery", option.Options)
-	}
-	if option.Options[0].Name != "Pick a model" {
-		t.Fatalf("unset option name = %q, want Pick a model", option.Options[0].Name)
-	}
-	reasoning := got[1]
+	reasoning := got[0]
 	if reasoning.ID != "reasoning_effort" || reasoning.Category != "thought_level" || reasoning.Source != agentcontrols.ConfigOptionSourceLaunch {
 		t.Fatalf("reasoning option = %#v, want thought_level launch option", reasoning)
 	}
-	if len(reasoning.Options) != 6 || reasoning.Options[0].Name != "Pick reasoning" {
+	if len(reasoning.Options) != 7 || reasoning.Options[0].Name != "Pick reasoning" {
 		t.Fatalf("reasoning candidates = %#v, want unset plus levels", reasoning.Options)
+	}
+	if reasoning.Options[1].Value != "none" || reasoning.Options[2].Value != "minimal" || reasoning.Options[len(reasoning.Options)-1].Value != "xhigh" {
+		t.Fatalf("reasoning candidates = %#v, want Grok-accepted levels", reasoning.Options)
 	}
 }
 
-func TestLaunchConfig_OptionForSetSeedsMissingModel(t *testing.T) {
-	option, ok := LaunchConfigOptionForSet("grok_build", "model", "grok-latest")
+func TestLaunchConfig_OptionForSetSeedsMissingReasoning(t *testing.T) {
+	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "high")
 	if !ok {
-		t.Fatal("LaunchConfigOptionForSet(model) = false, want true")
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort) = false, want true")
 	}
-	if option.ID != "model" || option.Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("option identity = %#v, want launch model", option)
+	if option.ID != "reasoning_effort" || option.Source != agentcontrols.ConfigOptionSourceLaunch {
+		t.Fatalf("option identity = %#v, want launch reasoning", option)
 	}
-	if option.CurrentValue != "grok-latest" {
-		t.Fatalf("current value = %q, want requested model", option.CurrentValue)
+	if option.CurrentValue != "high" {
+		t.Fatalf("current value = %q, want requested reasoning", option.CurrentValue)
 	}
-	found := false
-	for _, candidate := range option.Options {
-		found = found || candidate.Value == "grok-latest"
-	}
-	if !found {
-		t.Fatalf("options = %#v, want requested model included", option.Options)
+	if _, ok := LaunchConfigOptionForSet("grok_build", "model", "grok-latest"); ok {
+		t.Fatal("LaunchConfigOptionForSet(model) = true, want Grok model owned by ACP")
 	}
 }
 
@@ -69,47 +55,46 @@ func TestLaunchConfig_OptionForSetRejectsUnknownStaticOption(t *testing.T) {
 	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "turbo"); ok {
 		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=turbo) = true, want false")
 	}
-	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "high")
-	if !ok {
-		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=high) = false, want true")
+	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "max"); ok {
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=max) = true, want false")
 	}
-	if option.CurrentValue != "high" {
-		t.Fatalf("current value = %q, want high", option.CurrentValue)
+	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "minimal")
+	if !ok {
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=minimal) = false, want true")
+	}
+	if option.CurrentValue != "minimal" {
+		t.Fatalf("current value = %q, want minimal", option.CurrentValue)
+	}
+	for _, candidate := range option.Options {
+		if candidate.Value == "max" {
+			t.Fatalf("options = %#v, want no rejected max value", option.Options)
+		}
 	}
 }
 
-func TestLaunchConfig_UsesBaseArgsUntilModelSelected(t *testing.T) {
+func TestLaunchConfig_UsesBaseArgsWithoutGrokReasoning(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {
 		t.Fatal("grok_build adapter not found")
 	}
-	got := adapterWithLaunchConfig(adapter, []agentcontrols.ConfigOption{{
-		ID:           "model",
-		CurrentValue: launchModelUnsetValue,
-	}})
+	got := adapterWithLaunchConfig(adapter, nil)
 	want := []string{"agent", "stdio"}
 	if !sameArgs(got.Args, want) {
 		t.Fatalf("args = %#v, want %#v", got.Args, want)
 	}
 }
 
-func TestLaunchConfig_RequiresExplicitModelSelection(t *testing.T) {
+func TestLaunchConfig_DoesNotRequireGrokLaunchModelSelection(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {
 		t.Fatal("grok_build adapter not found")
 	}
-	if err := validateLaunchConfig(adapter, nil); err == nil {
-		t.Fatal("validateLaunchConfig accepted a missing launch model")
-	}
-	if err := validateLaunchConfig(adapter, []agentcontrols.ConfigOption{{ID: "model", CurrentValue: launchModelUnsetValue}}); err == nil {
-		t.Fatal("validateLaunchConfig accepted an unset launch model")
-	}
-	if err := validateLaunchConfig(adapter, []agentcontrols.ConfigOption{{ID: "model", CurrentValue: "model-a"}}); err != nil {
-		t.Fatalf("validateLaunchConfig returned error with selected model: %v", err)
+	if err := validateLaunchConfig(adapter, nil); err != nil {
+		t.Fatalf("validateLaunchConfig returned error without Grok launch model: %v", err)
 	}
 }
 
-func TestLaunchConfig_UsesSelectedModelInArgs(t *testing.T) {
+func TestLaunchConfig_IgnoresGrokACPModelInLaunchArgs(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {
 		t.Fatal("grok_build adapter not found")
@@ -118,7 +103,7 @@ func TestLaunchConfig_UsesSelectedModelInArgs(t *testing.T) {
 		ID:           "model",
 		CurrentValue: "model-a",
 	}})
-	want := []string{"agent", "--model", "model-a", "stdio"}
+	want := []string{"agent", "stdio"}
 	if !sameArgs(got.Args, want) {
 		t.Fatalf("args = %#v, want %#v", got.Args, want)
 	}
@@ -133,16 +118,27 @@ func TestLaunchConfig_UsesSelectedReasoningInArgs(t *testing.T) {
 		{ID: "model", CurrentValue: "model-a"},
 		{ID: "reasoning_effort", CurrentValue: "high"},
 	})
-	want := []string{"agent", "--model", "model-a", "--reasoning-effort", "high", "stdio"}
+	want := []string{"agent", "--reasoning-effort", "high", "stdio"}
 	if !sameArgs(got.Args, want) {
 		t.Fatalf("args = %#v, want %#v", got.Args, want)
 	}
 }
 
 func TestLaunchConfig_DoesNotAppendModelWhenACPAlreadyProvidesModel(t *testing.T) {
-	adapter, ok := BuiltInByID("grok_build")
-	if !ok {
-		t.Fatal("grok_build adapter not found")
+	adapter := Adapter{
+		ID:   "custom",
+		Name: "Custom",
+		LaunchModel: LaunchModelConfig{
+			ConfigID:    "model",
+			ArgTemplate: []string{"--model", "{model}"},
+		},
+		LaunchOptions: []LaunchSelectConfig{{
+			ConfigID:    "reasoning_effort",
+			Name:        "Reasoning",
+			Category:    "thought_level",
+			ArgTemplate: []string{"--reasoning", "{reasoning_effort}"},
+			Options:     []LaunchSelectOption{{ID: "high", Name: "High"}},
+		}},
 	}
 	options := []agentcontrols.ConfigOption{{
 		ID:       "native_model",

--- a/internal/agentadapters/launch_config_test.go
+++ b/internal/agentadapters/launch_config_test.go
@@ -11,64 +11,23 @@ import (
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 )
 
-func TestLaunchConfig_AppendsGrokReasoningOption(t *testing.T) {
+func TestLaunchConfig_GrokUsesACPControlsOnly(t *testing.T) {
 	adapter, ok := BuiltInByID("grok_build")
 	if !ok {
 		t.Fatal("grok_build adapter not found")
 	}
 	got, managed := appendLaunchConfigOptions(context.Background(), "", adapter, nil, nil)
-	if len(got) != 1 {
-		t.Fatalf("options = %#v, want reasoning launch option", got)
+	if len(got) != 0 {
+		t.Fatalf("options = %#v, want no Hecate-managed launch options", got)
 	}
-	if _, ok := managed["reasoning_effort"]; !ok {
-		t.Fatalf("managed config ids = %#v, want reasoning_effort", managed)
-	}
-	reasoning := got[0]
-	if reasoning.ID != "reasoning_effort" || reasoning.Category != "thought_level" || reasoning.Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("reasoning option = %#v, want thought_level launch option", reasoning)
-	}
-	if len(reasoning.Options) != 7 || reasoning.Options[0].Name != "Pick reasoning" {
-		t.Fatalf("reasoning candidates = %#v, want unset plus levels", reasoning.Options)
-	}
-	if reasoning.Options[1].Value != "none" || reasoning.Options[2].Value != "minimal" || reasoning.Options[len(reasoning.Options)-1].Value != "xhigh" {
-		t.Fatalf("reasoning candidates = %#v, want Grok-accepted levels", reasoning.Options)
-	}
-}
-
-func TestLaunchConfig_OptionForSetSeedsMissingReasoning(t *testing.T) {
-	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "high")
-	if !ok {
-		t.Fatal("LaunchConfigOptionForSet(reasoning_effort) = false, want true")
-	}
-	if option.ID != "reasoning_effort" || option.Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("option identity = %#v, want launch reasoning", option)
-	}
-	if option.CurrentValue != "high" {
-		t.Fatalf("current value = %q, want requested reasoning", option.CurrentValue)
+	if len(managed) != 0 {
+		t.Fatalf("managed config ids = %#v, want none", managed)
 	}
 	if _, ok := LaunchConfigOptionForSet("grok_build", "model", "grok-latest"); ok {
 		t.Fatal("LaunchConfigOptionForSet(model) = true, want Grok model owned by ACP")
 	}
-}
-
-func TestLaunchConfig_OptionForSetRejectsUnknownStaticOption(t *testing.T) {
-	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "turbo"); ok {
-		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=turbo) = true, want false")
-	}
-	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "max"); ok {
-		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=max) = true, want false")
-	}
-	option, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "minimal")
-	if !ok {
-		t.Fatal("LaunchConfigOptionForSet(reasoning_effort=minimal) = false, want true")
-	}
-	if option.CurrentValue != "minimal" {
-		t.Fatalf("current value = %q, want minimal", option.CurrentValue)
-	}
-	for _, candidate := range option.Options {
-		if candidate.Value == "max" {
-			t.Fatalf("options = %#v, want no rejected max value", option.Options)
-		}
+	if _, ok := LaunchConfigOptionForSet("grok_build", "reasoning_effort", "high"); ok {
+		t.Fatal("LaunchConfigOptionForSet(reasoning_effort) = true, want ACP-owned controls only")
 	}
 }
 
@@ -104,21 +63,6 @@ func TestLaunchConfig_IgnoresGrokACPModelInLaunchArgs(t *testing.T) {
 		CurrentValue: "model-a",
 	}})
 	want := []string{"agent", "stdio"}
-	if !sameArgs(got.Args, want) {
-		t.Fatalf("args = %#v, want %#v", got.Args, want)
-	}
-}
-
-func TestLaunchConfig_UsesSelectedReasoningInArgs(t *testing.T) {
-	adapter, ok := BuiltInByID("grok_build")
-	if !ok {
-		t.Fatal("grok_build adapter not found")
-	}
-	got := adapterWithLaunchConfig(adapter, []agentcontrols.ConfigOption{
-		{ID: "model", CurrentValue: "model-a"},
-		{ID: "reasoning_effort", CurrentValue: "high"},
-	})
-	want := []string{"agent", "--reasoning-effort", "high", "stdio"}
 	if !sameArgs(got.Args, want) {
 		t.Fatalf("args = %#v, want %#v", got.Args, want)
 	}

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -295,38 +295,14 @@ func BuiltIns() []Adapter {
 			SupportedRange: ">=0.1.0",
 		},
 		{
-			ID:               "grok_build",
-			Name:             "Grok Build",
-			Command:          "grok",
-			Args:             []string{"agent"},
-			LaunchSuffixArgs: []string{"stdio"},
+			ID:      "grok_build",
+			Name:    "Grok Build",
+			Command: "grok",
+			Args:    []string{"agent", "stdio"},
 			CandidatePaths: []string{
 				"${HOME}/.local/bin/grok",
 				"/opt/homebrew/bin/grok",
 				"/usr/local/bin/grok",
-			},
-			LaunchOptions: []LaunchSelectConfig{
-				// Grok Build exposes model selection through ACP session
-				// model state, but reasoning is still a launch flag rather
-				// than an ACP session config option.
-				{
-					ConfigID:         "reasoning_effort",
-					Name:             "Reasoning",
-					Description:      "Reasoning effort passed to Grok Build when Hecate starts or restarts it.",
-					Category:         "thought_level",
-					UnsetValue:       "__hecate_no_reasoning_selected__",
-					UnsetName:        "Pick reasoning",
-					UnsetDescription: "Use Grok Build's default reasoning effort.",
-					ArgTemplate:      []string{"--reasoning-effort", "{reasoning_effort}"},
-					Options: []LaunchSelectOption{
-						{ID: "none", Name: "None"},
-						{ID: "minimal", Name: "Minimal"},
-						{ID: "low", Name: "Low"},
-						{ID: "medium", Name: "Medium"},
-						{ID: "high", Name: "High"},
-						{ID: "xhigh", Name: "XHigh"},
-					},
-				},
 			},
 			Kind:           "acp",
 			Description:    "Run Grok Build through its ACP mode as a long-lived external coding-agent session supervised by Hecate.",

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -305,11 +305,6 @@ func BuiltIns() []Adapter {
 				"/opt/homebrew/bin/grok",
 				"/usr/local/bin/grok",
 			},
-			LaunchModel: LaunchModelConfig{
-				ConfigID:    "model",
-				ArgTemplate: []string{"--model", "{model}"},
-				ListArgs:    []string{"models"},
-			},
 			LaunchOptions: []LaunchSelectConfig{
 				{
 					ConfigID:         "reasoning_effort",
@@ -321,11 +316,12 @@ func BuiltIns() []Adapter {
 					UnsetDescription: "Use Grok Build's default reasoning effort.",
 					ArgTemplate:      []string{"--reasoning-effort", "{reasoning_effort}"},
 					Options: []LaunchSelectOption{
+						{ID: "none", Name: "None"},
+						{ID: "minimal", Name: "Minimal"},
 						{ID: "low", Name: "Low"},
 						{ID: "medium", Name: "Medium"},
 						{ID: "high", Name: "High"},
 						{ID: "xhigh", Name: "XHigh"},
-						{ID: "max", Name: "Max"},
 					},
 				},
 			},

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -306,6 +306,9 @@ func BuiltIns() []Adapter {
 				"/usr/local/bin/grok",
 			},
 			LaunchOptions: []LaunchSelectConfig{
+				// Grok Build exposes model selection through ACP session
+				// model state, but reasoning is still a launch flag rather
+				// than an ACP session config option.
 				{
 					ConfigID:         "reasoning_effort",
 					Name:             "Reasoning",

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -42,8 +42,8 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["grok_build"]; strings.Join(got.Args, " ") != "agent" || strings.Join(got.LaunchSuffixArgs, " ") != "stdio" {
 		t.Fatalf("grok_build adapter args = %#v", got.Args)
 	}
-	if got := found["grok_build"]; got.LaunchModel.ConfigID != "model" || len(got.LaunchModel.ListArgs) == 0 {
-		t.Fatalf("grok_build launch model config = %#v", got.LaunchModel)
+	if got := found["grok_build"]; got.LaunchModel.ConfigID != "" || len(got.LaunchModel.ListArgs) != 0 || len(got.LaunchModel.ArgTemplate) != 0 {
+		t.Fatalf("grok_build launch model config = %#v, want ACP-owned model state", got.LaunchModel)
 	}
 	if got := found["grok_build"]; len(got.LaunchOptions) != 1 || got.LaunchOptions[0].ConfigID != "reasoning_effort" {
 		t.Fatalf("grok_build launch options = %#v", got.LaunchOptions)

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -39,14 +39,14 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["grok_build"]; got.Command != "grok" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("grok_build adapter = %#v", got)
 	}
-	if got := found["grok_build"]; strings.Join(got.Args, " ") != "agent" || strings.Join(got.LaunchSuffixArgs, " ") != "stdio" {
+	if got := found["grok_build"]; strings.Join(got.Args, " ") != "agent stdio" || len(got.LaunchSuffixArgs) != 0 {
 		t.Fatalf("grok_build adapter args = %#v", got.Args)
 	}
 	if got := found["grok_build"]; got.LaunchModel.ConfigID != "" || len(got.LaunchModel.ListArgs) != 0 || len(got.LaunchModel.ArgTemplate) != 0 {
 		t.Fatalf("grok_build launch model config = %#v, want ACP-owned model state", got.LaunchModel)
 	}
-	if got := found["grok_build"]; len(got.LaunchOptions) != 1 || got.LaunchOptions[0].ConfigID != "reasoning_effort" {
-		t.Fatalf("grok_build launch options = %#v", got.LaunchOptions)
+	if got := found["grok_build"]; len(got.LaunchOptions) != 0 {
+		t.Fatalf("grok_build launch options = %#v, want ACP-owned controls only", got.LaunchOptions)
 	}
 }
 

--- a/internal/agentcontrols/config_options.go
+++ b/internal/agentcontrols/config_options.go
@@ -11,7 +11,8 @@ const (
 	ConfigOptionTypeBoolean = "boolean"
 	ConfigOptionTypeUnknown = "unknown"
 
-	ConfigOptionSourceLaunch = "launch"
+	ConfigOptionSourceLaunch   = "launch"
+	ConfigOptionSourceACPModel = "acp_model"
 )
 
 // ConfigOption is Hecate's stable projection of ACP session config
@@ -64,6 +65,51 @@ func FromACPOptions(options []acp.SessionConfigOption) []ConfigOption {
 		}
 	}
 	return out
+}
+
+// FromACPModelState converts ACP's model-specific state into the same stable
+// option projection the UI already uses for model pickers.
+func FromACPModelState(models *acp.SessionModelState) (ConfigOption, bool) {
+	if models == nil {
+		return ConfigOption{}, false
+	}
+	current := string(models.CurrentModelId)
+	options := make([]ConfigSelectOption, 0, len(models.AvailableModels))
+	foundCurrent := current == ""
+	for _, model := range models.AvailableModels {
+		value := string(model.ModelId)
+		if value == "" {
+			continue
+		}
+		name := model.Name
+		if name == "" {
+			name = value
+		}
+		if value == current {
+			foundCurrent = true
+		}
+		options = append(options, ConfigSelectOption{
+			Value:       value,
+			Name:        name,
+			Description: derefString(model.Description),
+		})
+	}
+	if !foundCurrent {
+		options = append([]ConfigSelectOption{{
+			Value: current,
+			Name:  current,
+		}}, options...)
+	}
+	return ConfigOption{
+		ID:           "model",
+		Name:         "Model",
+		Description:  "Model selected through the agent's ACP session.",
+		Category:     "model",
+		Source:       ConfigOptionSourceACPModel,
+		Type:         ConfigOptionTypeSelect,
+		CurrentValue: current,
+		Options:      options,
+	}, true
 }
 
 // BuildACPSetRequest converts a SetConfigOptionRequest to the ACP wire shape.

--- a/internal/agentcontrols/config_options_test.go
+++ b/internal/agentcontrols/config_options_test.go
@@ -91,6 +91,44 @@ func TestFromACPOptions_PreservesUnknownVariants(t *testing.T) {
 	}
 }
 
+func TestFromACPModelState_NormalizesModelPicker(t *testing.T) {
+	description := "larger context"
+	got, ok := FromACPModelState(&acp.SessionModelState{
+		CurrentModelId: acp.ModelId("smart"),
+		AvailableModels: []acp.ModelInfo{
+			{ModelId: acp.ModelId("fast"), Name: "Fast"},
+			{ModelId: acp.ModelId("smart"), Name: "Smart", Description: &description},
+		},
+	})
+	if !ok {
+		t.Fatal("FromACPModelState ok = false, want true")
+	}
+	if got.ID != "model" || got.Category != "model" || got.Source != ConfigOptionSourceACPModel {
+		t.Fatalf("model option identity = %#v", got)
+	}
+	if got.CurrentValue != "smart" {
+		t.Fatalf("current value = %q, want smart", got.CurrentValue)
+	}
+	if len(got.Options) != 2 || got.Options[1].Description != "larger context" {
+		t.Fatalf("model options = %#v, want ACP models with descriptions", got.Options)
+	}
+}
+
+func TestFromACPModelState_PreservesCurrentModelWhenMissingFromList(t *testing.T) {
+	got, ok := FromACPModelState(&acp.SessionModelState{
+		CurrentModelId: acp.ModelId("custom"),
+		AvailableModels: []acp.ModelInfo{
+			{ModelId: acp.ModelId("fast"), Name: "Fast"},
+		},
+	})
+	if !ok {
+		t.Fatal("FromACPModelState ok = false, want true")
+	}
+	if len(got.Options) != 2 || got.Options[0].Value != "custom" {
+		t.Fatalf("model options = %#v, want current model preserved first", got.Options)
+	}
+}
+
 func TestBuildACPSetRequest_SelectAndBoolean(t *testing.T) {
 	selectReq, err := BuildACPSetRequest(SetConfigOptionRequest{SessionID: "sess", ConfigID: "model", Value: "smart"})
 	if err != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1087,7 +1087,7 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 	}
 }
 
-func TestAgentAdaptersIncludesLaunchConfigOptions(t *testing.T) {
+func TestAgentAdaptersOmitsCatalogConfigOptionsForGrok(t *testing.T) {
 	t.Setenv("HECATE_AGENT_ADAPTER_DEV_OVERRIDES", "grok_build=ready")
 
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
@@ -1105,14 +1105,8 @@ func TestAgentAdaptersIncludesLaunchConfigOptions(t *testing.T) {
 	if grok == nil {
 		t.Fatalf("missing grok_build adapter: %#v", response.Data)
 	}
-	if len(grok.ConfigOptions) != 1 {
-		t.Fatalf("grok config options = %#v, want launch reasoning only before ACP session", grok.ConfigOptions)
-	}
-	if grok.ConfigOptions[0].ID != "reasoning_effort" {
-		t.Fatalf("grok reasoning option = %#v, want reasoning_effort", grok.ConfigOptions[0])
-	}
-	if grok.ConfigOptions[0].Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("grok reasoning option source = %q, want launch", grok.ConfigOptions[0].Source)
+	if len(grok.ConfigOptions) != 0 {
+		t.Fatalf("grok config options = %#v, want ACP-owned controls only", grok.ConfigOptions)
 	}
 }
 
@@ -2675,57 +2669,6 @@ func TestAgentChatExternalStoredConfigOptionUpdatesWhenSessionInactive(t *testin
 	updated = decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/auto_approve", `{"value":true}`))
 	if got := updated.Data.ConfigOptions; len(got) != 2 || got[1].CurrentBool == nil || !*got[1].CurrentBool {
 		t.Fatalf("config options after inactive boolean set = %#v, want auto_approve true", got)
-	}
-}
-
-func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing.T) {
-	dir := t.TempDir()
-	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
-	runner := &fakeAgentChatRunner{
-		configOptions: []agentcontrols.ConfigOption{
-			{
-				ID:           "reasoning_effort",
-				Name:         "Reasoning",
-				Category:     "thought_level",
-				Source:       agentcontrols.ConfigOptionSourceLaunch,
-				Type:         agentcontrols.ConfigOptionTypeSelect,
-				CurrentValue: "medium",
-				Options: []agentcontrols.ConfigSelectOption{
-					{Value: "medium", Name: "Medium"},
-					{Value: "high", Name: "High"},
-				},
-			},
-		},
-	}
-	apiHandler.SetAgentChatRunner(runner)
-	handler := NewServer(logger, apiHandler)
-
-	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"grok_build","workspace":%q}`, dir)))
-	runner.setConfigErr = errors.New("adapter rejected launch option")
-
-	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/reasoning_effort", `{"value":"high"}`))
-	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].CurrentValue != "high" {
-		t.Fatalf("config options after launch set = %#v, want high", got)
-	}
-}
-
-func TestAgentChatExternalLaunchConfigOptionSeedsMissingStoredOption(t *testing.T) {
-	dir := t.TempDir()
-	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
-	runner := &fakeAgentChatRunner{setConfigErr: errors.New("adapter rejected launch option")}
-	apiHandler.SetAgentChatRunner(runner)
-	handler := NewServer(logger, apiHandler)
-
-	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"grok_build","workspace":%q}`, dir)))
-	if len(created.Data.ConfigOptions) != 0 {
-		t.Fatalf("created config options = %#v, want stale session without stored launch options", created.Data.ConfigOptions)
-	}
-
-	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/reasoning_effort", `{"value":"high"}`))
-	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].ID != "reasoning_effort" || got[0].CurrentValue != "high" {
-		t.Fatalf("config options after seeded launch set = %#v, want selected reasoning", got)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1105,20 +1105,14 @@ func TestAgentAdaptersIncludesLaunchConfigOptions(t *testing.T) {
 	if grok == nil {
 		t.Fatalf("missing grok_build adapter: %#v", response.Data)
 	}
-	if len(grok.ConfigOptions) != 2 {
-		t.Fatalf("grok config options = %#v, want model and reasoning", grok.ConfigOptions)
+	if len(grok.ConfigOptions) != 1 {
+		t.Fatalf("grok config options = %#v, want launch reasoning only before ACP session", grok.ConfigOptions)
 	}
-	if grok.ConfigOptions[0].ID != "model" || grok.ConfigOptions[0].CurrentValue == "" {
-		t.Fatalf("grok model option = %#v, want populated model picker", grok.ConfigOptions[0])
+	if grok.ConfigOptions[0].ID != "reasoning_effort" {
+		t.Fatalf("grok reasoning option = %#v, want reasoning_effort", grok.ConfigOptions[0])
 	}
 	if grok.ConfigOptions[0].Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("grok model option source = %q, want launch", grok.ConfigOptions[0].Source)
-	}
-	if grok.ConfigOptions[1].ID != "reasoning_effort" {
-		t.Fatalf("grok reasoning option = %#v, want reasoning_effort", grok.ConfigOptions[1])
-	}
-	if grok.ConfigOptions[1].Source != agentcontrols.ConfigOptionSourceLaunch {
-		t.Fatalf("grok reasoning option source = %q, want launch", grok.ConfigOptions[1].Source)
+		t.Fatalf("grok reasoning option source = %q, want launch", grok.ConfigOptions[0].Source)
 	}
 }
 
@@ -2691,14 +2685,15 @@ func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing
 	runner := &fakeAgentChatRunner{
 		configOptions: []agentcontrols.ConfigOption{
 			{
-				ID:           "model",
-				Name:         "Model",
-				Category:     "model",
+				ID:           "reasoning_effort",
+				Name:         "Reasoning",
+				Category:     "thought_level",
+				Source:       agentcontrols.ConfigOptionSourceLaunch,
 				Type:         agentcontrols.ConfigOptionTypeSelect,
-				CurrentValue: "fast",
+				CurrentValue: "medium",
 				Options: []agentcontrols.ConfigSelectOption{
-					{Value: "fast", Name: "Fast"},
-					{Value: "smart", Name: "Smart"},
+					{Value: "medium", Name: "Medium"},
+					{Value: "high", Name: "High"},
 				},
 			},
 		},
@@ -2709,9 +2704,9 @@ func TestAgentChatExternalLaunchConfigOptionStoresAfterAdapterFailure(t *testing
 	created := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"grok_build","workspace":%q}`, dir)))
 	runner.setConfigErr = errors.New("adapter rejected launch option")
 
-	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"smart"}`))
-	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].CurrentValue != "smart" {
-		t.Fatalf("config options after launch set = %#v, want smart", got)
+	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/reasoning_effort", `{"value":"high"}`))
+	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].CurrentValue != "high" {
+		t.Fatalf("config options after launch set = %#v, want high", got)
 	}
 }
 
@@ -2728,9 +2723,9 @@ func TestAgentChatExternalLaunchConfigOptionSeedsMissingStoredOption(t *testing.
 		t.Fatalf("created config options = %#v, want stale session without stored launch options", created.Data.ConfigOptions)
 	}
 
-	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"grok-latest"}`))
-	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].ID != "model" || got[0].CurrentValue != "grok-latest" {
-		t.Fatalf("config options after seeded launch set = %#v, want selected model", got)
+	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/reasoning_effort", `{"value":"high"}`))
+	if got := updated.Data.ConfigOptions; len(got) != 1 || got[0].ID != "reasoning_effort" || got[0].CurrentValue != "high" {
+		t.Fatalf("config options after seeded launch set = %#v, want selected reasoning", got)
 	}
 }
 


### PR DESCRIPTION
## What changed
- Surface Grok Build ACP model state as the chat model control and apply model changes through ACP `session/set_model`.
- Stop treating Grok Build model selection as a launch-required `--model` control.
- Stop exposing Grok Build reasoning as a Hecate-managed launch control, since changing launch-only reasoning would require closing and recreating the native ACP session.
- Generalize the ACP model-state bridge so any built-in ACP adapter that reports models can surface the same model control.

## Why
Grok Build now reports models through ACP. Using that session-native control avoids unnecessary adapter restarts and removes the confusing model-required state before the ACP session is prepared. Reasoning is not surfaced by Hecate unless an adapter reports it as a live ACP session control.

## Tests
- `rtk go test ./internal/agentcontrols ./internal/agentadapters ./internal/api`
- `rtk go vet ./internal/agentcontrols ./internal/agentadapters ./internal/api`
- `rtk bash -lc "git ls-files -z '*.md' '*.mdc' | xargs -0 ./ui/node_modules/.bin/oxfmt --check"`
- `rtk bun scripts/check-mermaid.ts`
- `rtk git diff --check`

## Non-goals
- No UI layout changes.
- No real external CLI calls in tests.
