### PR TITLE
feat(ui): add workspace changes panel

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1049,7 +1049,7 @@ test("agent chat previews failed tool stdout and stderr in Advanced details", as
   await expect(page.getByText("On branch feature/chat-message-queue")).toBeVisible();
   await expect(page.getByText("fatal: not a git repository")).toBeVisible();
   await expect(page.getByText("Open task output")).toBeVisible();
-  await expect(page.getByText("Preview unavailable in this snapshot.")).toHaveCount(0);
+  await expect(page.getByText("No output preview was captured for this snapshot.")).toHaveCount(0);
 });
 
 test("empty model chat can add all detected local providers in one click", async ({ page }) => {
@@ -2920,7 +2920,7 @@ test("agent changed-files review inspects and reverts a captured file", async ({
   await page.waitForSelector(".hecate-activitybar");
 
   await expect(page.getByText("Updated the docs.")).toBeVisible();
-  await page.getByText("files changed · 2 files changed, 6 insertions(+), 1 deletion(-)").click();
+  await page.getByRole("button", { name: "Workspace changes: 1 change set" }).click();
   await expect(page.getByText("2 changed files")).toBeVisible();
 
   await page.getByRole("button", { name: "Inspect README.md" }).click();

--- a/ui/src/features/chats/ChatHeader.tsx
+++ b/ui/src/features/chats/ChatHeader.tsx
@@ -19,8 +19,11 @@ type Props = {
   isExternalAgentChat: boolean;
   showWorkspaceButton: boolean;
   workspacePath: string;
+  workspaceChangesCount: number;
+  workspaceChangesOpen: boolean;
   chatSettingsOpen: boolean;
   onChooseWorkspace: () => void;
+  onToggleWorkspaceChanges: () => void;
   onToggleChatSettings: () => void;
 
   // External-agent turn budget pill — only renders when the active
@@ -41,8 +44,11 @@ export function ChatHeader(props: Props) {
     isExternalAgentChat,
     showWorkspaceButton,
     workspacePath,
+    workspaceChangesCount,
+    workspaceChangesOpen,
     chatSettingsOpen,
     onChooseWorkspace,
+    onToggleWorkspaceChanges,
     onToggleChatSettings,
     activeChatSession,
   } = props;
@@ -164,6 +170,32 @@ export function ChatHeader(props: Props) {
               }}
             >
               <Icon d={Icons.folder} size={13} />
+            </button>
+          )}
+          {workspaceChangesCount > 0 && (
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              aria-expanded={workspaceChangesOpen}
+              aria-label={`Workspace changes: ${workspaceChangesCount} change set${workspaceChangesCount === 1 ? "" : "s"}`}
+              onClick={onToggleWorkspaceChanges}
+              title={`${workspaceChangesCount} workspace change set${workspaceChangesCount === 1 ? "" : "s"}`}
+              style={{
+                minWidth: 30,
+                height: 30,
+                padding: "0 7px",
+                gap: 5,
+                justifyContent: "center",
+                color: workspaceChangesOpen ? "var(--teal)" : "var(--t2)",
+                borderColor: "transparent",
+                background: workspaceChangesOpen ? "var(--teal-bg)" : "transparent",
+                boxShadow: "none",
+              }}
+            >
+              <Icon d={Icons.branch} size={13} />
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}>
+                {workspaceChangesCount}
+              </span>
             </button>
           )}
           <button

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -16,6 +16,10 @@ import { CodeBlock, Icon, Icons } from "../shared/ui";
 import { TranscriptMessageRow } from "../transcript/TranscriptMessageRow";
 
 import { compactID } from "./ChatComposer";
+import {
+  compactWorkspaceChangeLabel,
+  workspaceChangeSummaryLabel,
+} from "./ChatWorkspaceChangesPanel";
 
 export type VisibleChatMessage = {
   id: string;
@@ -71,6 +75,7 @@ type Props = {
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
+  onOpenWorkspaceChanges?: (messageID?: string) => void;
   openExternalAgentSetup: (adapterID?: string) => void;
 };
 
@@ -84,6 +89,7 @@ export function ChatTranscript({
   onNavigate,
   onOpenTask,
   onOpenTrace,
+  onOpenWorkspaceChanges,
   openExternalAgentSetup,
 }: Props) {
   const chat = useChat();
@@ -96,7 +102,6 @@ export function ChatTranscript({
   const streamingContent = chat.state.streamingContent;
   const activeChatSession = chat.state.activeChatSession;
   const pendingToolCalls = chat.state.pendingToolCalls;
-  const activeChatSessionID = chat.state.activeChatSessionID;
   const chatLoading = chat.state.chatLoading;
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -181,6 +186,16 @@ export function ChatTranscript({
           const taskRunID = taskID ? m.run_id : "";
           const traceRequestID = m.request_id;
           const traceID = m.trace_id;
+          const changedFilesSummary =
+            role === "assistant" && (m.diff_stat || m.diff)
+              ? workspaceChangeSummaryLabel({
+                  key: `workspace-files:${m.id}`,
+                  messageID: m.id,
+                  label: "",
+                  diffStat: m.diff_stat,
+                  diff: m.diff,
+                })
+              : "";
           return (
             <TranscriptMessageRow
               key={item.key}
@@ -218,13 +233,16 @@ export function ChatTranscript({
                     }
                   : undefined
               }
+              changedFilesLink={
+                changedFilesSummary
+                  ? {
+                      label: compactWorkspaceChangeLabel(m.diff_stat),
+                      title: changedFilesSummary,
+                      onClick: () => onOpenWorkspaceChanges?.(m.id),
+                    }
+                  : undefined
+              }
               activities={role === "assistant" ? m.activities : undefined}
-              diffStat={role === "assistant" ? m.diff_stat : undefined}
-              diff={role === "assistant" ? m.diff : undefined}
-              agentSessionID={activeChatSessionID}
-              onListAgentFiles={chatActions.listChatMessageFiles}
-              onGetAgentFileDiff={chatActions.getChatMessageFileDiff}
-              onRevertAgentFiles={chatActions.revertChatMessageFiles}
               rawOutput={role === "assistant" ? m.raw_output : undefined}
               agentUsage={role === "assistant" ? m.usage : undefined}
               agentTiming={role === "assistant" ? m.timing : undefined}

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3188,7 +3188,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView onOpenTrace={onOpenTrace} />, { state, actions }));
 
     expect(screen.queryByDisplayValue("/tmp/hecate")).toBeNull();
-    expect(screen.getByRole("button", { name: /workspace/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Workspace: /tmp/hecate" })).toBeTruthy();
     expect(screen.getAllByText("Codex work").length).toBeGreaterThan(0);
     expect(screen.getByText("Codex session · Completed · /tmp/hecate")).toBeTruthy();
     expect(screen.getByLabelText("External agent message controls")).toBeTruthy();
@@ -3206,14 +3206,14 @@ describe("ChatView external-agent target", () => {
     const traceButton = screen.getByRole("button", { name: /Open Trace req_code/i });
     expect(traceButton).toBeTruthy();
     expect(screen.queryByText("Starting external agent")).toBeNull();
-    expect(screen.getByText("completed · 1/2 plan · 1 tool · files changed")).toBeTruthy();
+    expect(screen.getByText("completed · 1/2 plan · 1 tool")).toBeTruthy();
     expect(screen.getByText("Inspect changes")).toBeTruthy();
     expect(screen.getByText("Summarize result")).toBeTruthy();
     expect(screen.getByText("Ran command")).toBeTruthy();
     expect(screen.getByText("README.md:12")).toBeTruthy();
-    expect(
-      screen.getByText("files changed · 2 files changed, 10 insertions(+), 4 deletions(-)"),
-    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Workspace changes: 1 change set" }));
+    expect(screen.getByText("Workspace changes")).toBeTruthy();
+    expect(screen.getByText("2 files changed, 10 insertions(+), 4 deletions(-)")).toBeTruthy();
     expect(screen.getByText("README.md")).toBeTruthy();
     expect(screen.getByText("2 +-")).toBeTruthy();
     expect(screen.getByText("ui/src/features/chats/ChatView.tsx")).toBeTruthy();
@@ -3681,9 +3681,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
-    await user.click(
-      screen.getByText("files changed · 2 files changed, 6 insertions(+), 1 deletion(-)"),
-    );
+    await user.click(screen.getByRole("button", { name: "Workspace changes: 1 change set" }));
 
     expect(await screen.findByText("2 changed files")).toBeTruthy();
     expect(listChatMessageFiles).toHaveBeenCalledWith("a1", "m2");
@@ -3741,9 +3739,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
-    await user.click(
-      screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"),
-    );
+    await user.click(screen.getByRole("button", { name: "Workspace changes: 1 change set" }));
     expect(await screen.findByText("1 changed file")).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "Inspect README.md" }));
@@ -3799,9 +3795,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
-    await user.click(
-      screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"),
-    );
+    await user.click(screen.getByRole("button", { name: "Workspace changes: 1 change set" }));
     expect(
       await screen.findByText(
         "Could not load changed files. The captured diff may no longer be available.",
@@ -3847,9 +3841,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
-    await user.click(
-      screen.getByText("files changed · 1 file changed, 2 insertions(+), 1 deletion(-)"),
-    );
+    await user.click(screen.getByRole("button", { name: "Workspace changes: 1 change set" }));
     expect(await screen.findByText("1 changed file")).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "Revert all" }));

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -35,6 +35,10 @@ import { ChatHeader } from "./ChatHeader";
 import { ChatSettingsPanel } from "./ChatSettingsPanel";
 import { ChatSidebar, sidebarSessionAgentLabel, sidebarSessionBrand } from "./ChatSidebar";
 import { ChatTranscript, buildTranscriptItems, type VisibleChatMessage } from "./ChatTranscript";
+import {
+  ChatWorkspaceChangesPanel,
+  collectChatWorkspaceChanges,
+} from "./ChatWorkspaceChangesPanel";
 import { externalAgentRequiresModelSelection, mergeAgentConfigOptions } from "./agentConfigOptions";
 import { chatAgentOption } from "./ChatAgentControls";
 import {
@@ -136,6 +140,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const [approvalModalID, setApprovalModalID] = useState<string | null>(null);
   const [workspaceEntryOpen, setWorkspaceEntryOpen] = useState(false);
   const [chatSettingsOpen, setChatSettingsOpen] = useState(false);
+  const [workspaceChangesOpen, setWorkspaceChangesOpen] = useState(false);
+  const [workspaceChangesFocusID, setWorkspaceChangesFocusID] = useState<string | null>(null);
   const [draftChatStarted, setDraftChatStarted] = useState(false);
   const [rtkOnboardingDismissed, setRTKOnboardingDismissed] = useState(false);
   const [addProviderOpen, setAddProviderOpen] = useState(false);
@@ -215,6 +221,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     state.activeChatSession?.segments,
     isHecateChat,
   );
+  const workspaceChanges = collectChatWorkspaceChanges(visibleMessages);
   const streaming = state.chatLoading;
   const chatDiagnostic = describeGatewayError(
     state.chatErrorCode,
@@ -505,6 +512,13 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   }, [selectedChatReady]);
 
   useEffect(() => {
+    if (!selectedChatReady || workspaceChanges.length === 0) {
+      setWorkspaceChangesOpen(false);
+      setWorkspaceChangesFocusID(null);
+    }
+  }, [selectedChatReady, workspaceChanges.length]);
+
+  useEffect(() => {
     if (!focusComposerAfterNewChatRef.current || !composerVisible) return;
     const frame = requestAnimationFrame(() => {
       if (!textareaRef.current) return;
@@ -544,6 +558,13 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     if (!next) return;
     actions.setAgentWorkspace(next);
     setWorkspaceEntryOpen(false);
+  }
+
+  function openWorkspaceChanges(messageID?: string) {
+    if (workspaceChanges.length === 0) return;
+    setWorkspaceChangesFocusID(messageID ?? null);
+    setChatSettingsOpen(false);
+    setWorkspaceChangesOpen(true);
   }
 
   async function refreshQuickLocalProviders() {
@@ -712,9 +733,19 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
             isExternalAgentChat={isExternalAgentChat}
             showWorkspaceButton={showHeaderWorkspaceButton}
             workspacePath={state.agentWorkspace}
+            workspaceChangesCount={workspaceChanges.length}
+            workspaceChangesOpen={workspaceChangesOpen}
             chatSettingsOpen={chatSettingsOpen}
             onChooseWorkspace={() => void chooseWorkspace()}
-            onToggleChatSettings={() => setChatSettingsOpen((open) => !open)}
+            onToggleWorkspaceChanges={() => {
+              setWorkspaceChangesFocusID(null);
+              setChatSettingsOpen(false);
+              setWorkspaceChangesOpen((open) => !open);
+            }}
+            onToggleChatSettings={() => {
+              setWorkspaceChangesOpen(false);
+              setChatSettingsOpen((open) => !open);
+            }}
             activeChatSession={state.activeChatSession}
           />
         )}
@@ -813,6 +844,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               onNavigate={onNavigate}
               onOpenTask={onOpenTask}
               onOpenTrace={onOpenTrace}
+              onOpenWorkspaceChanges={openWorkspaceChanges}
               openExternalAgentSetup={openAgentSetup}
               emptyState={
                 <ChatEmptyState
@@ -925,6 +957,19 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               onCopyCommand={actions.copyCommand}
             />
           )}
+          {selectedChatReady &&
+            isAgentChat &&
+            workspaceChangesOpen &&
+            workspaceChanges.length > 0 && (
+              <ChatWorkspaceChangesPanel
+                changes={workspaceChanges}
+                sessionID={activeSessionID}
+                focusMessageID={workspaceChangesFocusID}
+                onListFiles={chatActions.listChatMessageFiles}
+                onGetFileDiff={chatActions.getChatMessageFileDiff}
+                onRevertFiles={chatActions.revertChatMessageFiles}
+              />
+            )}
         </div>
       </div>
 

--- a/ui/src/features/chats/ChatWorkspaceChangesPanel.tsx
+++ b/ui/src/features/chats/ChatWorkspaceChangesPanel.tsx
@@ -1,0 +1,127 @@
+import type { ChatChangedFileDiffRecord, ChatChangedFileRecord } from "../../types/chat";
+import { TranscriptDiffReview } from "../transcript/TranscriptDiffReview";
+import { formatDiffStatSummary } from "../transcript/transcriptActivityHelpers";
+
+import type { VisibleChatMessage } from "./ChatTranscript";
+
+export type ChatWorkspaceChange = {
+  key: string;
+  messageID: string;
+  label: string;
+  diffStat?: string;
+  diff?: string;
+};
+
+export function collectChatWorkspaceChanges(messages: VisibleChatMessage[]): ChatWorkspaceChange[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "assistant" || (!message.diff_stat && !message.diff)) return [];
+    return [
+      {
+        key: `workspace-files:${message.id}`,
+        messageID: message.id,
+        label: workspaceChangeLabel(message),
+        diffStat: message.diff_stat,
+        diff: message.diff,
+      },
+    ];
+  });
+}
+
+export function workspaceChangeSummaryLabel(
+  change: ChatWorkspaceChange,
+  prefix = "Workspace changes",
+): string {
+  const summary = change.diffStat ? formatDiffStatSummary(change.diffStat) : "";
+  return `${prefix}${summary ? ` · ${summary}` : ""}`;
+}
+
+export function compactWorkspaceChangeLabel(diffStat?: string): string {
+  const summary = diffStat ? formatDiffStatSummary(diffStat) : "";
+  const files = summary.match(/\b(\d+)\s+files?\s+changed\b/i)?.[1];
+  if (files) return Number(files) === 1 ? "1 file" : `${files} files`;
+  return "Files changed";
+}
+
+export function ChatWorkspaceChangesPanel({
+  changes,
+  sessionID,
+  focusMessageID,
+  onListFiles,
+  onGetFileDiff,
+  onRevertFiles,
+}: {
+  changes: ChatWorkspaceChange[];
+  sessionID: string;
+  focusMessageID?: string | null;
+  onListFiles: (sessionID: string, messageID: string) => Promise<ChatChangedFileRecord[]>;
+  onGetFileDiff: (
+    sessionID: string,
+    messageID: string,
+    path: string,
+  ) => Promise<ChatChangedFileDiffRecord | null>;
+  onRevertFiles: (sessionID: string, messageID: string, paths: string[]) => Promise<boolean>;
+}) {
+  const intro =
+    "Changes are already in your workspace. Inspect captured diffs, keep them, or revert selected paths.";
+
+  return (
+    <aside
+      aria-label="Workspace changes panel"
+      style={{
+        width: "min(430px, 40vw)",
+        minWidth: 340,
+        maxWidth: 480,
+        flexShrink: 0,
+        borderLeft: "1px solid var(--border)",
+        background: "var(--bg1)",
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          borderBottom: "1px solid var(--border)",
+          padding: "14px 14px 12px",
+        }}
+      >
+        <div style={{ fontSize: 12, fontWeight: 650, color: "var(--t0)" }}>Workspace changes</div>
+        <div style={{ marginTop: 4, fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
+          {changes.length === 1
+            ? "One agent turn changed files in this workspace."
+            : `${changes.length} agent turns changed files in this workspace.`}
+        </div>
+      </div>
+      <div style={{ overflowY: "auto", padding: 14, display: "grid", gap: 10 }}>
+        <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>{intro}</div>
+        {changes.map((change) => (
+          <TranscriptDiffReview
+            key={change.key}
+            sessionID={sessionID}
+            messageID={change.messageID}
+            diffStat={change.diffStat}
+            diff={change.diff}
+            summaryLabel={workspaceChangeSummaryLabel(change, change.label)}
+            intro=""
+            testID={changes.length === 1 ? "session-diff-review" : "session-diff-review-set"}
+            defaultOpen={changes.length === 1 || change.messageID === focusMessageID}
+            onListFiles={onListFiles}
+            onGetFileDiff={onGetFileDiff}
+            onRevertFiles={onRevertFiles}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function workspaceChangeLabel(message: VisibleChatMessage): string {
+  const time = message.created_at
+    ? new Date(message.created_at).toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
+  const actor = message.agent_name || message.agent_id || message.model || "Assistant";
+  return [actor, time].filter(Boolean).join(" · ");
+}

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -294,7 +294,7 @@ describe("TaskDetail runtime activity and patches", () => {
 
     expect(screen.getByText("Ran git")).toBeTruthy();
     expect(screen.getByText("Artifacts · 2 items")).toBeTruthy();
-    expect(screen.getByText("Changed files")).toBeTruthy();
+    expect(screen.getByText("Files changed")).toBeTruthy();
     expect(screen.getAllByText("git-changes.json").length).toBeGreaterThan(0);
     expect(screen.getByText("Final answer artifact")).toBeTruthy();
     expect(screen.getAllByText("agent-final-answer.txt").length).toBeGreaterThan(0);
@@ -430,7 +430,7 @@ describe("TaskDetail runtime activity and patches", () => {
     render();
 
     await user.click(screen.getByText("Artifacts · 1 item"));
-    await user.click(screen.getByText("Preview"));
+    await user.click(screen.getByText("Output"));
 
     expect(screen.getByText("git-stdout.txt")).toBeTruthy();
     expect(screen.getByText(/On branch feature\/runtime/)).toBeTruthy();

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -16,9 +16,9 @@ describe("formatDiffStatSummary", () => {
     expect(formatDiffStatSummary(stat)).toMatch(/2 files? changed/);
   });
 
-  it("falls back to the first line when no summary is present", () => {
+  it("falls back to a compact changed-file count when no summary is present", () => {
     const stat = "src/foo.ts | 3 +-";
-    expect(formatDiffStatSummary(stat)).toBe("src/foo.ts | 3 +-");
+    expect(formatDiffStatSummary(stat)).toBe("1 changed file");
   });
 
   it("returns an empty string for empty input", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -263,8 +263,9 @@ function TimelineActivityLine({
 }
 
 function advancedSummaryLabel(activity: ChatActivityRecord): string {
-  if (activity.type === "output") return "Preview";
-  if (activity.type === "artifact" && isOutputArtifactActivity(activity)) return "Preview";
+  if (activity.type === "changed_files" || activity.type === "files_changed") return "Files";
+  if (activity.type === "output") return "Output";
+  if (activity.type === "artifact" && isOutputArtifactActivity(activity)) return "Output";
   return "Advanced";
 }
 

--- a/ui/src/features/transcript/TranscriptDiffReview.tsx
+++ b/ui/src/features/transcript/TranscriptDiffReview.tsx
@@ -10,6 +10,10 @@ type Props = {
   messageID: string;
   diffStat?: string;
   diff?: string;
+  defaultOpen?: boolean;
+  intro?: string;
+  summaryLabel?: string;
+  testID?: string;
   onListFiles?: (sessionID: string, messageID: string) => Promise<ChatChangedFileRecord[]>;
   onGetFileDiff?: (
     sessionID: string,
@@ -24,6 +28,10 @@ export function TranscriptDiffReview({
   messageID,
   diffStat,
   diff,
+  defaultOpen = false,
+  intro = "External-agent changes are already in your workspace. Inspect the captured Git diff, keep it, or revert selected paths.",
+  summaryLabel,
+  testID = "agent-diff-review",
   onListFiles,
   onGetFileDiff,
   onRevertFiles,
@@ -104,7 +112,8 @@ export function TranscriptDiffReview({
 
   return (
     <details
-      data-testid="agent-diff-review"
+      data-testid={testID}
+      open={defaultOpen}
       onToggle={(event: SyntheticEvent<HTMLDetailsElement>) => {
         if (event.currentTarget.open && files === null && !loadingFiles) {
           void loadFiles();
@@ -120,13 +129,10 @@ export function TranscriptDiffReview({
           color: "var(--t3)",
         }}
       >
-        files changed{summary ? ` · ${summary}` : ""}
+        {summaryLabel ?? `files changed${summary ? ` · ${summary}` : ""}`}
       </summary>
       <div style={{ display: "grid", gap: 8, marginTop: 6 }}>
-        <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.5 }}>
-          External-agent changes are already in your workspace. Inspect the captured Git diff, keep
-          it, or revert selected paths.
-        </div>
+        {intro && <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.5 }}>{intro}</div>}
         {!hasReviewAPI && (
           <>
             {diffStat && <DiffStatList diffStat={diffStat} />}

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -4,8 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import type {
   ChatActivityRecord,
-  ChatChangedFileDiffRecord,
-  ChatChangedFileRecord,
   ChatContextPacketRecord,
   ChatTimingRecord,
   ChatUsageRecord,
@@ -530,35 +528,9 @@ describe("TranscriptMessageRow", () => {
     render(<TranscriptMessageRow {...baseProps} activities={activities} />);
 
     await user.click(screen.getByText("Output · 1 item"));
-    await user.click(screen.getByText("Preview"));
+    await user.click(screen.getAllByText("Output")[1]);
 
     expect(screen.getByText("command output")).toBeInTheDocument();
-  });
-
-  it("renders the diff review section when diff metadata is present", () => {
-    const onListFiles: (sid: string, mid: string) => Promise<ChatChangedFileRecord[]> = vi.fn(
-      async () => [],
-    );
-    const onGetFileDiff: (
-      sid: string,
-      mid: string,
-      p: string,
-    ) => Promise<ChatChangedFileDiffRecord | null> = vi.fn(async () => null);
-    const onRevertFiles: (sid: string, mid: string, ps: string[]) => Promise<boolean> = vi.fn(
-      async () => true,
-    );
-
-    render(
-      <TranscriptMessageRow
-        {...baseProps}
-        agentSessionID="s1"
-        diffStat="src/foo.ts | 3 +-"
-        onListAgentFiles={onListFiles}
-        onGetAgentFileDiff={onGetFileDiff}
-        onRevertAgentFiles={onRevertFiles}
-      />,
-    );
-    expect(screen.getByTestId("agent-diff-review")).toBeInTheDocument();
   });
 
   it("renders the raw adapter output details when rawOutput differs from content", () => {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 
 import type {
   ChatActivityRecord,
-  ChatChangedFileDiffRecord,
-  ChatChangedFileRecord,
   ChatContextPacketRecord,
   ChatTimingRecord,
   ChatUsageRecord,
@@ -12,8 +10,7 @@ import { formatDurationMs } from "../../lib/format";
 import { CodeBlock } from "../shared/Atoms";
 import { BrandAvatar } from "../shared/BrandAvatar";
 import { Icon, Icons } from "../shared/Icons";
-import { TranscriptActivityTimeline } from "./TranscriptActivityTimeline";
-import { TranscriptDiffReview } from "./TranscriptDiffReview";
+import { DiffStatList, TranscriptActivityTimeline } from "./TranscriptActivityTimeline";
 import { TranscriptMarkdown } from "./TranscriptMarkdown";
 
 export function TranscriptMessageRow({
@@ -31,13 +28,8 @@ export function TranscriptMessageRow({
   runtimeMetaTitle,
   taskLink,
   traceLink,
+  changedFilesLink,
   activities,
-  diffStat,
-  diff,
-  agentSessionID,
-  onListAgentFiles,
-  onGetAgentFileDiff,
-  onRevertAgentFiles,
   rawOutput,
   agentUsage,
   agentTiming,
@@ -59,19 +51,10 @@ export function TranscriptMessageRow({
   badge?: string;
   runtimeMeta?: string;
   runtimeMetaTitle?: string;
-  agentSessionID?: string;
   taskLink?: { label: string; title?: string; onClick: () => void };
   traceLink?: { label: string; title?: string; onClick: () => void };
+  changedFilesLink?: { label: string; title?: string; onClick: () => void };
   activities?: ChatActivityRecord[];
-  diffStat?: string;
-  diff?: string;
-  onListAgentFiles?: (sessionID: string, messageID: string) => Promise<ChatChangedFileRecord[]>;
-  onGetAgentFileDiff?: (
-    sessionID: string,
-    messageID: string,
-    path: string,
-  ) => Promise<ChatChangedFileDiffRecord | null>;
-  onRevertAgentFiles?: (sessionID: string, messageID: string, paths: string[]) => Promise<boolean>;
   rawOutput?: string;
   agentUsage?: ChatUsageRecord;
   agentTiming?: ChatTimingRecord;
@@ -180,6 +163,13 @@ export function TranscriptMessageRow({
                 onClick={traceLink.onClick}
               />
             )}
+            {isAssistant && changedFilesLink && (
+              <HeaderMetaButton
+                label={changedFilesLink.label}
+                title={changedFilesLink.title}
+                onClick={changedFilesLink.onClick}
+              />
+            )}
             {isAssistant && runtimeMeta && (
               <span
                 title={runtimeMetaTitle}
@@ -253,7 +243,6 @@ export function TranscriptMessageRow({
           {isAssistant && visibleActivities && visibleActivities.length > 0 && (
             <TranscriptActivityTimeline
               activities={visibleActivities}
-              diffStat={diffStat}
               renderAdvancedActivity={renderActivityAdvanced}
             />
           )}
@@ -265,17 +254,6 @@ export function TranscriptMessageRow({
           )}
           {isAssistant && agentUsage && !agentUsageEmpty(agentUsage) && (
             <AgentUsage usage={agentUsage} />
-          )}
-          {isAssistant && (diff || diffStat) && (
-            <TranscriptDiffReview
-              sessionID={agentSessionID ?? ""}
-              messageID={id}
-              diffStat={diffStat}
-              diff={diff}
-              onListFiles={onListAgentFiles}
-              onGetFileDiff={onGetAgentFileDiff}
-              onRevertFiles={onRevertAgentFiles}
-            />
           )}
           {showRawOutput && (
             <details style={{ marginTop: 8 }}>
@@ -305,6 +283,10 @@ function renderAgentActivityAdvanced(
   activities: ChatActivityRecord[],
   taskLink?: { label: string; title?: string; onClick: () => void },
 ) {
+  if (activity.type === "changed_files" || activity.type === "files_changed") {
+    return <ActivityFilesPreview activity={activity} />;
+  }
+
   if (
     activity.type === "output" ||
     (activity.type === "artifact" && isOutputArtifactActivity(activity))
@@ -343,6 +325,22 @@ function renderAgentActivityAdvanced(
       )}
     </div>
   );
+}
+
+function ActivityFilesPreview({ activity }: { activity: ChatActivityRecord }) {
+  const diffStat = [activity.detail, activity.title]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join("\n");
+
+  if (!diffStat.trim()) {
+    return (
+      <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.5 }}>
+        File changes were captured, but this snapshot does not include a diffstat preview.
+      </div>
+    );
+  }
+
+  return <DiffStatList diffStat={diffStat} />;
 }
 
 function OutputArtifactPreview({ artifact }: { artifact: ChatActivityRecord }) {
@@ -399,7 +397,7 @@ function OutputArtifactPreview({ artifact }: { artifact: ChatActivityRecord }) {
         </pre>
       ) : (
         <div style={{ color: "var(--t3)", fontSize: 11, padding: "7px" }}>
-          Preview unavailable in this snapshot.
+          No output preview was captured for this snapshot.
         </div>
       )}
     </div>

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -43,8 +43,8 @@ describe("formatDiffStatSummary", () => {
     );
   });
 
-  it("falls back to the first non-empty line when no summary is present", () => {
-    expect(formatDiffStatSummary("src/foo.ts | 3 +-")).toBe("src/foo.ts | 3 +-");
+  it("falls back to a compact file count when no summary is present", () => {
+    expect(formatDiffStatSummary("src/foo.ts | 3 +-")).toBe("1 changed file");
   });
 
   it("returns empty string for empty input", () => {

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -7,7 +7,11 @@ export function formatDiffStatSummary(diffStat: string): string {
     .split(/\\n|\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  return lines.find((line) => /\bfiles? changed\b/.test(line)) || lines[0] || "";
+  const summary = lines.find((line) => /\bfiles? changed\b/.test(line));
+  if (summary) return summary;
+  const rows = parseDiffStatRows(diffStat);
+  if (rows.length > 0) return `${rows.length} changed file${rows.length === 1 ? "" : "s"}`;
+  return compactInlineDetail(lines[0] || "");
 }
 
 export function fileChangesActivity(diffStat: string): ChatActivityRecord {
@@ -232,7 +236,10 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
     return { title: "Output", detail: outputActivityDetail(activity) };
   }
   if (activity.type === "changed_files") {
-    return { title: "Changed files", detail: cleanActivityDetail(activity) || activity.title };
+    return {
+      title: "Files changed",
+      detail: formatDiffStatSummary(cleanActivityDetail(activity) || activity.title),
+    };
   }
   if (activity.type === "final_answer") {
     return {
@@ -372,9 +379,31 @@ function toolKindLabel(kind?: string): string | undefined {
 }
 
 function outputActivityDetail(activity: ChatActivityRecord): string | undefined {
-  const detail = cleanActivityDetail(activity) || activity.title;
+  const preview = activity.artifact_preview?.trim() || cleanActivityDetail(activity);
+  const lineCount = preview ? formatTextLineCount(preview) : undefined;
+  const stream = outputActivityLabel(activity);
   const size = formatBytes(activity.artifact_size_bytes);
-  return [detail, size].filter(Boolean).join(" · ") || undefined;
+  return [stream, lineCount, size].filter(Boolean).join(" · ") || undefined;
+}
+
+function outputActivityLabel(activity: ChatActivityRecord): string | undefined {
+  const label = `${activity.title} ${activity.detail ?? ""} ${activity.kind ?? ""}`.toLowerCase();
+  if (label.includes("stderr")) return "stderr";
+  if (label.includes("stdout")) return "stdout";
+  const title = activity.title.trim();
+  if (!title || title.toLowerCase() === "output") return undefined;
+  return compactInlineDetail(title);
+}
+
+function formatTextLineCount(text: string): string {
+  const count = text.split(/\r?\n/).length;
+  return `${count} line${count === 1 ? "" : "s"}`;
+}
+
+function compactInlineDetail(value: string, max = 72): string {
+  const oneLine = value.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, max - 1)}…`;
 }
 
 function formatBytes(bytes?: number): string | undefined {


### PR DESCRIPTION
## Summary
- Move chat file-change review into a workspace-level side panel opened from the chat header.
- Replace noisy inline changed-file and output details with compact transcript activity labels.
- Keep per-message changed-file pills as jump points into the workspace changes panel.

## Tests
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`

Not run: focused Playwright e2e, because `localhost:5173` was already occupied by an existing dev server.