### PR TITLE
Add Cobra command dispatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,3 +106,4 @@ VOLUME ["/data"]
 EXPOSE 8765
 USER nonroot:nonroot
 ENTRYPOINT ["/usr/local/bin/hecate"]
+CMD ["serve"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -45,3 +45,4 @@ VOLUME ["/data"]
 EXPOSE 8765
 USER nonroot:nonroot
 ENTRYPOINT ["/usr/local/bin/hecate"]
+CMD ["serve"]

--- a/cmd/hecate/cli.go
+++ b/cmd/hecate/cli.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hecatehq/hecate/internal/version"
+)
+
+func main() {
+	if err := newRootCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}
+
+func newRootCommand() *cobra.Command {
+	var printVersion bool
+
+	root := &cobra.Command{
+		Use:           "hecate",
+		Short:         "Local AI runtime console",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			if printVersion {
+				printVersionString(cmd.OutOrStdout())
+				return
+			}
+			runServe()
+		},
+	}
+	root.CompletionOptions.DisableDefaultCmd = true
+	root.Flags().BoolVarP(&printVersion, "version", "v", false, "print the version and exit")
+
+	root.AddCommand(newServeCommand())
+	root.AddCommand(newVersionCommand())
+	root.AddCommand(newMCPCommand())
+	root.AddCommand(newLegacyMCPServerCommand())
+
+	return root
+}
+
+func newServeCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Hecate runtime",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServe()
+		},
+	}
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the Hecate version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			printVersionString(cmd.OutOrStdout())
+		},
+	}
+}
+
+func newMCPCommand() *cobra.Command {
+	mcp := &cobra.Command{
+		Use:   "mcp",
+		Short: "Run Hecate protocol surfaces",
+	}
+	mcp.AddCommand(&cobra.Command{
+		Use:   "serve",
+		Short: "Start the Hecate MCP server over stdio",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runMCPServer("hecate mcp serve")
+		},
+	})
+	return mcp
+}
+
+func newLegacyMCPServerCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "mcp-server",
+		Short:  "Start the Hecate MCP server over stdio",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runMCPServer("hecate mcp-server")
+		},
+	}
+}
+
+func printVersionString(w io.Writer) {
+	fmt.Fprintln(w, version.Version)
+}

--- a/cmd/hecate/cli_test.go
+++ b/cmd/hecate/cli_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/version"
+)
+
+func TestCLI_VersionAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"version"},
+		{"--version"},
+		{"-v"},
+	} {
+		args := args
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+
+			var stdout bytes.Buffer
+			cmd := newRootCommand()
+			cmd.SetArgs(args)
+			cmd.SetOut(&stdout)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute(%v): %v", args, err)
+			}
+			if got := strings.TrimSpace(stdout.String()); got != version.Version {
+				t.Fatalf("stdout = %q, want %q", got, version.Version)
+			}
+		})
+	}
+}
+
+func TestCLI_HelpListsCommandTree(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"help"})
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(help): %v", err)
+	}
+
+	help := stdout.String()
+	for _, want := range []string{"serve", "mcp", "version"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help output does not contain %q:\n%s", want, help)
+		}
+	}
+	for _, unwanted := range []string{"acp", "completion", "mcp-server"} {
+		if strings.Contains(help, unwanted) {
+			t.Fatalf("help output contains %q:\n%s", unwanted, help)
+		}
+	}
+}
+
+func TestCLI_MCPHelpListsServeOnly(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"mcp", "help"})
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(mcp help): %v", err)
+	}
+
+	help := stdout.String()
+	if !strings.Contains(help, "serve") {
+		t.Fatalf("mcp help output does not contain serve:\n%s", help)
+	}
+	if strings.Contains(help, "acp") {
+		t.Fatalf("mcp help output contains acp:\n%s", help)
+	}
+}
+
+func TestCLI_LegacyMCPServerCommandIsHidden(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRootCommand()
+	legacy, _, err := cmd.Find([]string{"mcp-server"})
+	if err != nil {
+		t.Fatalf("Find(mcp-server): %v", err)
+	}
+	if legacy == nil || legacy.Name() != "mcp-server" {
+		t.Fatalf("Find(mcp-server) = %#v, want legacy command", legacy)
+	}
+	if !legacy.Hidden {
+		t.Fatal("legacy mcp-server command should be hidden from help")
+	}
+}

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -38,23 +38,7 @@ import (
 	"github.com/hecatehq/hecate/internal/version"
 )
 
-func main() {
-	// Tiny manual flag parse: a single `--version` / `-v` short-circuit.
-	// We don't want to pull in the full flag package here because the rest
-	// of configuration is env-driven; mixing the two would muddle the
-	// surface. Anything other than `--version`/`-v` falls through to the
-	// regular env-driven startup.
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "--version", "-v", "version":
-			fmt.Println(version.Version)
-			return
-		case "mcp-server":
-			runMCPServer()
-			return
-		}
-	}
-
+func runServe() {
 	cfg := config.LoadFromEnv()
 	if err := cfg.Validate(); err != nil {
 		slog.Error("config validation failed", slog.Any("error", err))

--- a/cmd/hecate/mcp.go
+++ b/cmd/hecate/mcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hecatehq/hecate/internal/version"
 )
 
-// runMCPServer is the entry point for `hecate mcp-server`. It runs an
+// runMCPServer is the entry point for `hecate mcp serve`. It runs an
 // MCP server on stdio, talking back to a running Hecate gateway over
 // HTTP.
 //
@@ -24,7 +24,7 @@ import (
 // runs out-of-process from the gateway and shouldn't share its config
 // surface. Operators add this to Claude Desktop / Cursor / Zed by
 // pointing their `mcpServers` config at the hecate binary.
-func runMCPServer() {
+func runMCPServer(commandName string) {
 	baseURL := strings.TrimSpace(os.Getenv("HECATE_BASE_URL"))
 	if baseURL == "" {
 		baseURL = "http://127.0.0.1:8765"
@@ -47,9 +47,9 @@ func runMCPServer() {
 		cancel()
 	}()
 
-	fmt.Fprintln(os.Stderr, "hecate mcp-server: started on stdio, talking to "+baseURL)
+	fmt.Fprintln(os.Stderr, commandName+": started on stdio, talking to "+baseURL)
 	if err := srv.Serve(ctx, os.Stdin, os.Stdout); err != nil {
-		fmt.Fprintln(os.Stderr, "hecate mcp-server: "+err.Error())
+		fmt.Fprintln(os.Stderr, commandName+": "+err.Error())
 		os.Exit(1)
 	}
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -229,7 +229,7 @@ Recognized markers: `[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, `[act
 Top-level entry points:
 
 ```
-cmd/hecate/            # main runtime entry point (gateway service, embedded UI, `mcp-server` subcommand)
+cmd/hecate/            # main runtime entry point (gateway service, embedded UI, CLI commands)
 ui/                     # React app (Vite + Bun); src/ is the source, dist/ is the embed target
 website/                # Astro homepage for hecate.sh
 tauri/                  # native desktop app (Tauri 2.x); wraps `hecate` as a sidecar
@@ -252,7 +252,7 @@ controlplane            # persisted providers, secrets, and policy settings
 eventprotocol           # typed agent-event envelope + emitter (see docs/event-protocol-v1.md)
 gateway                 # request lifecycle: policy, router, retry/fallback
 governor                # policy rules, route gates, and append-only usage events
-mcp                     # Hecate-as-MCP-server implementation (the `hecate mcp-server` subcommand)
+mcp                     # Hecate-as-MCP-server implementation (the `hecate mcp serve` command)
 models                  # model identity + canonical-name resolution
 orchestrator            # task runtime: queue, runner, executors, sandbox boundary
 policy                  # declarative deny / rewrite policy rules

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -105,7 +105,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
   "mcpServers": {
     "hecate": {
       "command": "hecate",
-      "args": ["mcp-server"],
+      "args": ["mcp", "serve"],
       "env": {
         "HECATE_BASE_URL": "http://127.0.0.1:8765"
       }
@@ -129,10 +129,10 @@ printf '%s\n%s\n%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"smoke","version":"0"}}}' \
   '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
-  | hecate mcp-server
+  | hecate mcp serve
 ```
 
-Expected output: two JSON-RPC responses on stdout (initialize result + tools list). The startup line `hecate mcp-server: started on stdio, talking to ...` goes to stderr, which the protocol channel ignores.
+Expected output: two JSON-RPC responses on stdout (initialize result + tools list). The startup line `hecate mcp serve: started on stdio, talking to ...` goes to stderr, which the protocol channel ignores.
 
 ### Behavior notes
 

--- a/docs/rfcs/cli-structure.md
+++ b/docs/rfcs/cli-structure.md
@@ -1,8 +1,22 @@
 # CLI structure for `hecate`
 
-> **Status:** proposed; not implemented.
-> **Current source of truth:** [`cmd/hecate/main.go`](../../cmd/hecate/main.go) (current manual flag parse) and [`docs/mcp.md`](../mcp.md) (operator-facing MCP documentation).
-> **Next action:** land a structured command package, move runtime startup to `hecate serve`, and make bare `hecate` the terminal operator UI.
+> **Status:** partially implemented.
+> **Current source of truth:** [`cmd/hecate/cli.go`](../../cmd/hecate/cli.go), [`cmd/hecate/main.go`](../../cmd/hecate/main.go), and [`docs/mcp.md`](../mcp.md).
+> **Next action:** make bare `hecate` the terminal operator UI, then add `hecate ui`, `status`, `about`, and `doctor` in focused follow-up PRs.
+
+## Implementation status
+
+The first command-tree slice is implemented with Cobra:
+
+- `hecate serve` starts the runtime / HTTP API / embedded UI server.
+- `hecate mcp serve` starts the stdio MCP server.
+- `hecate version`, `hecate --version`, and `hecate -v` print the version.
+- Bare `hecate` still starts the runtime as a temporary compatibility alias.
+- `hecate mcp-server` still works as a hidden compatibility alias.
+
+Not implemented yet: the terminal operator UI for bare `hecate`, `hecate ui`,
+`status`, `about`, `doctor`, auth commands, ACP server commands, and
+`migrate`.
 
 ## Problem
 
@@ -326,6 +340,10 @@ internal/browseropen/    # cross-platform local browser opener if worth splittin
 under `internal/` so tests can exercise it without shelling out to the binary.
 
 ## Breaking changes and migration
+
+The first Cobra slice is intentionally compatibility-preserving: bare `hecate`
+and `hecate mcp-server` still work while internal launch sites and docs move to
+the new names. The breaking changes below are the target state for the TUI PR.
 
 Breaking changes:
 

--- a/e2e/approval_reconcile_test.go
+++ b/e2e/approval_reconcile_test.go
@@ -58,7 +58,7 @@ func TestApprovalReconcilePersistsAndFlipsAcrossRestart(t *testing.T) {
 
 	// ── First start: bring the gateway up to materialize the schema.
 	addr1 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd1 := exec.Command(bin)
+	cmd1 := exec.Command(bin, "serve")
 	cmd1.Dir = workDir
 	cmd1.Env = append([]string{"HECATE_ADDRESS=" + addr1}, commonEnv...)
 	cmd1.Stdout = io.Discard
@@ -88,7 +88,7 @@ func TestApprovalReconcilePersistsAndFlipsAcrossRestart(t *testing.T) {
 	// requests. By the time /healthz responds, the row is already
 	// flipped — we never observe it in pending state via the API.
 	addr2 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd2 := exec.Command(bin)
+	cmd2 := exec.Command(bin, "serve")
 	cmd2.Dir = workDir
 	cmd2.Env = append([]string{"HECATE_ADDRESS=" + addr2}, commonEnv...)
 	cmd2.Stdout = io.Discard
@@ -144,7 +144,7 @@ func TestApprovalGrantPersistsAcrossRestart(t *testing.T) {
 	}
 
 	addr1 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd1 := exec.Command(bin)
+	cmd1 := exec.Command(bin, "serve")
 	cmd1.Dir = workDir
 	cmd1.Env = append([]string{"HECATE_ADDRESS=" + addr1}, commonEnv...)
 	cmd1.Stdout = io.Discard
@@ -173,7 +173,7 @@ func TestApprovalGrantPersistsAcrossRestart(t *testing.T) {
 	_ = cmd1.Wait()
 
 	addr2 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd2 := exec.Command(bin)
+	cmd2 := exec.Command(bin, "serve")
 	cmd2.Dir = workDir
 	cmd2.Env = append([]string{"HECATE_ADDRESS=" + addr2}, commonEnv...)
 	cmd2.Stdout = io.Discard

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -143,7 +143,7 @@ func gatewayServer(t *testing.T, extraEnv ...string) string {
 	env = append(env, extraEnv...)
 	env = append(env, autoPreconfiguredEnv(extraEnv)...)
 
-	cmd := exec.Command(bin)
+	cmd := exec.Command(bin, "serve")
 	cmd.Env = env
 	output := newTailBuffer(64 * 1024)
 	cmd.Stdout = output
@@ -1446,7 +1446,7 @@ func TestBootstrapAutoGenerationDefaultPath(t *testing.T) {
 	// First start: no token / no data dir env. Cwd-rooted defaults apply,
 	// so the bootstrap file should land at <workDir>/.data/...
 	addr1 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd1 := exec.Command(bin)
+	cmd1 := exec.Command(bin, "serve")
 	cmd1.Dir = workDir
 	cmd1.Env = []string{
 		"PATH=" + os.Getenv("PATH"),
@@ -1509,7 +1509,7 @@ func TestBootstrapAutoGenerationDefaultPath(t *testing.T) {
 	// reused, not regenerated, so the persisted control-plane secret
 	// survives restart.
 	addr2 := fmt.Sprintf("127.0.0.1:%d", freePort(t))
-	cmd2 := exec.Command(bin)
+	cmd2 := exec.Command(bin, "serve")
 	cmd2.Dir = workDir
 	cmd2.Env = []string{
 		"PATH=" + os.Getenv("PATH"),

--- a/e2e/ollama_test.go
+++ b/e2e/ollama_test.go
@@ -329,7 +329,7 @@ func startGatewayProcess(extraEnv ...string) (string, error) {
 	env = append(env, extraEnv...)
 	env = append(env, autoPreconfiguredEnv(extraEnv)...)
 
-	cmd := exec.Command(bin)
+	cmd := exec.Command(bin, "serve")
 	cmd.Env = env
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard

--- a/e2e/shutdown_smoke_test.go
+++ b/e2e/shutdown_smoke_test.go
@@ -53,7 +53,7 @@ func TestSystemShutdownSmokeExitsCleanly(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	baseURL := "http://" + addr
 
-	cmd := exec.Command(bin)
+	cmd := exec.Command(bin, "serve")
 	cmd.Env = append(os.Environ(),
 		"HECATE_ADDRESS="+addr,
 		"HECATE_DATA_DIR="+t.TempDir(),

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/coder/acp-go-sdk v0.13.0
 	github.com/ncruces/zenity v0.10.14
+	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
@@ -34,11 +35,13 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josephspurrier/goversioninfo v1.4.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	golang.org/x/image v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coder/acp-go-sdk v0.13.0 h1:IAKBDIbe/iBfKAGikeIndzb8fowt4ioD+gCtSU4HwMA=
 github.com/coder/acp-go-sdk v0.13.0/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -30,6 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josephspurrier/goversioninfo v1.4.1 h1:5LvrkP+n0tg91J9yTkoVnt/QgNnrI1t4uSsWjIonrqY=
 github.com/josephspurrier/goversioninfo v1.4.1/go.mod h1:JWzv5rKQr+MmW+LvM412ToT/IkYDZjaclF2pKDss8IY=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -44,6 +47,11 @@ github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844 h1:GranzK4hv1/pq
 github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844/go.mod h1:T1TLSfyWVBRXVGzWd0o9BI4kfoO9InEgfQe4NV3mLz8=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -84,6 +92,7 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/image v0.20.0 h1:7cVCUjQwfL18gyBJOmYvptfSHS8Fb3YUDtfLIZ7Nbpw=
 golang.org/x/image v0.20.0/go.mod h1:0a88To4CYVBAHp5FXJm8o7QbUl37Vd85ply1vyD8auM=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=

--- a/just/docs.just
+++ b/just/docs.just
@@ -78,7 +78,7 @@ screenshots: _ui-deps
 	just build
 	mkdir -p .data
 	echo "starting gateway in background…"
-	./hecate > .data/screenshots-gateway.log 2>&1 & echo $! > .data/screenshots-gateway.pid
+	./hecate serve > .data/screenshots-gateway.log 2>&1 & echo $! > .data/screenshots-gateway.pid
 	for i in 1 2 3 4 5 6 7 8 9 10; do \
 	  curl -sf http://127.0.0.1:8765/healthz > /dev/null && break; \
 	  sleep 0.3; \

--- a/just/go.just
+++ b/just/go.just
@@ -88,7 +88,7 @@ serve *args:
 	set -a; \
 	[ -f ./.env ] && . ./.env; \
 	set +a; \
-	./hecate
+	./hecate serve
 
 # Run the gateway from source. Sources .env when present. Optional arg: --reset.
 dev *args: _go-cache

--- a/tauri/src-tauri/src/sidecar.rs
+++ b/tauri/src-tauri/src/sidecar.rs
@@ -297,6 +297,7 @@ pub async fn spawn_and_wait(app: &AppHandle) -> Result<GatewayHandle, String> {
     // is synchronous and can be called from the window-close event handler
     // without an async runtime.
     let mut child = std::process::Command::new(&bin)
+        .arg("serve")
         .env("HECATE_ADDRESS", &addr)
         .env("HECATE_BACKEND", "sqlite")
         .env("HECATE_PUBLIC_URL", &base_url)


### PR DESCRIPTION
## Summary
- add a Cobra-backed command tree with `hecate serve`, `hecate mcp serve`, and version aliases
- keep bare `hecate` and hidden `hecate mcp-server` compatibility paths for this first slice
- migrate Docker, Tauri, e2e helpers, just recipes, and MCP docs to the new explicit command names
- update the CLI RFC with the implemented status and remaining follow-up work

## Validation
- `go test ./cmd/hecate ./internal/mcp/server`
- `go test -tags e2e -run TestGatewayVersionFlag ./e2e`
- `just docs-check`
- `just test`
- `just build-go`
- `cargo test sidecar::tests` after `just tauri-test-sidecar`
- manual smoke: `./hecate version`, `./hecate --version`, `./hecate -v`, `./hecate help`, `./hecate mcp --help`, MCP initialize/tools-list through `./hecate mcp serve`
