### PR TITLE
fix(runtime): centralize approval lifecycle

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -247,7 +247,7 @@ When the LLM calls a gated tool inside an `agent_loop` run, the loop pauses. Pol
 - `network_egress` → pauses on `http_request` tool calls
 - `all_tools` → pauses on every tool call (`shell_exec`, `git_exec`, `git_status`, `git_diff`, `file_write`, `file_edit`, `apply_patch`, `read_file`, `grep`, `glob`, `artifact_read`, `list_dir`, `http_request`)
 
-The runtime emits an approval record of kind `agent_loop_tool_call`, persists the conversation snapshot, and returns `status=awaiting_approval` for the run. The UI banner shows which tools the agent wants to use. On approve, the same run is re-queued; on resume, the loop detects the trailing assistant tool_calls without resolved results, dispatches them (no second LLM call), and continues. On reject, the run terminates `failed`. On cancel, the run terminates `cancelled`, any awaiting approval step is marked `cancelled`, and the pending approval is resolved as `cancelled`.
+The runtime emits an approval record of kind `agent_loop_tool_call`, persists the conversation snapshot, and returns `status=awaiting_approval` for the run. The UI banner shows which tools the agent wants to use. On approve, the same run is re-queued; on resume, the loop detects the trailing assistant tool_calls without resolved results, dispatches them (no second LLM call), and continues. On reject, the run and task terminate `cancelled` with `last_error="approval rejected"`. On cancel, the run terminates `cancelled`, any awaiting approval step is marked `cancelled`, and the pending approval is resolved as `cancelled`.
 
 The approval banner stays in sync with the run state because approvals ride along in every SSE snapshot (`TaskRunStreamEventData.Approvals`). No separate refetch needed.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -210,7 +210,8 @@ Both shapes share these fields.
 ### `approval.resolved`
 
 The gate reached a terminal decision. After approve, the run re-queues; after
-reject, the run terminates `failed`; after cancellation, the run terminates
+reject, the run and task terminate `cancelled` with
+`last_error="approval rejected"`; after cancellation, the run terminates
 `cancelled` and the approval record is no longer actionable.
 
 | Extra key     | Type     | Notes                                                             |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,15 +38,15 @@ The server runs as a subcommand of the `gateway` binary on stdio, talking back t
 
 Seven tools — four reads and three writes:
 
-| Tool                       | Kind                            | Description                                                                                                                 |
-| -------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `list_tasks`               | read                            | Recent agent tasks: id, title, status, execution kind, step count                                                           |
-| `get_task_status`          | read                            | Detailed status of one task by id, including its latest run                                                                 |
-| `summarize_recent_traffic` | read                            | Aggregated request stats: by-provider breakdown, error rate, avg latency                                                    |
-| `search_traces`            | read                            | Search recent trace summaries by text, or fetch one exact trace by `request_id` with span/event details                     |
-| `create_task`              | write                           | Queue a new `agent_loop` task with optional title / working_directory / model / provider / budget. Returns the new task id  |
-| `resolve_approval`         | write (destructive)             | Approve or reject a pending approval gate (pre-execution or mid-loop). Approve resumes; reject terminates the run as failed |
-| `cancel_run`               | write (destructive, idempotent) | Cancel an in-flight task run. Cooperative — the worker stops at the next safe checkpoint                                    |
+| Tool                       | Kind                            | Description                                                                                                                             |
+| -------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_tasks`               | read                            | Recent agent tasks: id, title, status, execution kind, step count                                                                       |
+| `get_task_status`          | read                            | Detailed status of one task by id, including its latest run                                                                             |
+| `summarize_recent_traffic` | read                            | Aggregated request stats: by-provider breakdown, error rate, avg latency                                                                |
+| `search_traces`            | read                            | Search recent trace summaries by text, or fetch one exact trace by `request_id` with span/event details                                 |
+| `create_task`              | write                           | Queue a new `agent_loop` task with optional title / working_directory / model / provider / budget. Returns the new task id              |
+| `resolve_approval`         | write (destructive)             | Approve or reject a pending approval gate (pre-execution or mid-loop). Approve resumes; reject cancels the run with `approval rejected` |
+| `cancel_run`               | write (destructive, idempotent) | Cancel an in-flight task run. Cooperative — the worker stops at the next safe checkpoint                                                |
 
 Together the write tools turn the MCP surface into an operator-grade control plane: list tasks → see approvals → approve/reject → create new tasks → cancel runaway runs without leaving the editor.
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -230,7 +230,14 @@ The `kind` field on a `task_approval` is one of:
 - `network_egress` — pre-execution gate when `sandbox_network=true`
 - `agent_loop_tool_call` — mid-loop gate when an `agent_loop` run calls a gated tool (`shell_exec`, `http_request`, etc.). The reason text lists the tools the agent wants to use. See [`agent-runtime.md`](agent-runtime.md#approval-gating) for the full flow.
 
-Resolve payload: `{"decision": "approve" | "reject", "note": "..."}`. Approving an `agent_loop_tool_call` requeues the same run; the loop dispatches the approved tool calls without re-calling the LLM. Cancelling an `awaiting_approval` run marks the pending approval `cancelled`; resolving it afterward returns a conflict instead of mutating stale state.
+Resolve payload: `{"decision": "approve" | "reject", "note": "..."}`.
+
+Approval resolution is owned by the task runtime so approval, run, task, step, and run-event state transition together:
+
+- `approve` marks the pending approval `approved`, emits `approval.resolved`, requeues the same run (`queued`) and task (`queued`), and emits `run.queued`. For `agent_loop_tool_call`, the loop dispatches the approved tool calls without re-calling the LLM.
+- `reject` marks the pending approval `rejected`, emits `approval.resolved`, and terminalizes the run/task as `cancelled` with `last_error: "approval rejected"`. Any awaiting approval step is cancelled, and the runtime emits `run.cancelled` and `task.updated`.
+- Cancelling an `awaiting_approval` run cancels the run/task, cancels pending approvals with `resolved_by: "system"`, cancels the awaiting approval step, and emits the same terminal run/task events. Resolving that approval afterward returns `409 conflict`.
+- Resolving a non-pending approval returns `409 conflict`; cancelling an already-terminal run is a no-op and returns the current terminal run.
 
 ### Approval policy configuration
 

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -1129,17 +1129,6 @@ func newTaskID() string {
 	return newOpaqueTaskResourceID("task")
 }
 
-func normalizeApprovalDecision(value string) (string, bool) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "approve", "approved":
-		return "approved", true
-	case "reject", "rejected", "deny", "denied":
-		return "rejected", true
-	default:
-		return "", false
-	}
-}
-
 func newOpaqueTaskResourceID(prefix string) string {
 	buf := make([]byte, 12)
 	if _, err := rand.Read(buf); err != nil {

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
+	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -99,118 +99,55 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	approval, found, err := h.taskStore.GetApproval(ctx, task.ID, approvalID)
+	var req ResolveTaskApprovalRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	result, err := h.taskRunner.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
+		Task:        task,
+		ApprovalID:  approvalID,
+		Decision:    req.Decision,
+		Note:        req.Note,
+		ResolvedBy:  "operator",
+		RequestID:   RequestIDFromContext(ctx),
+		IDGenerator: newOpaqueTaskResourceID,
+	})
 	if err != nil {
+		h.writeResolveTaskApprovalError(w, r, err)
+		return
+	}
+	if result.TraceID != "" {
+		w.Header().Set("X-Trace-Id", result.TraceID)
+	}
+	if result.SpanID != "" {
+		w.Header().Set("X-Span-Id", result.SpanID)
+	}
+
+	WriteJSON(w, http.StatusOK, TaskApprovalResponse{
+		Object: "task_approval",
+		Data:   renderTaskApproval(result.Approval),
+	})
+}
+
+func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
+	switch {
+	case errors.Is(err, orchestrator.ErrInvalidApprovalDecision):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "decision must be approve or reject")
+	case errors.Is(err, orchestrator.ErrApprovalNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
+	case errors.Is(err, orchestrator.ErrApprovalRunNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
+	case errors.Is(err, orchestrator.ErrApprovalConflict):
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+	default:
 		telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.resolve.failed",
 			slog.String("event.name", "gateway.tasks.approvals.resolve.failed"),
 			slog.Any("error", err),
 		)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
 	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
-		return
-	}
-	if approval.Status != "pending" {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending")
-		return
-	}
-	run, found, err := h.taskStore.GetRun(ctx, task.ID, approval.RunID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
-		return
-	}
-	if run.Status != "awaiting_approval" {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, fmt.Sprintf("task approval is no longer actionable because run is %s", run.Status))
-		return
-	}
-
-	var req ResolveTaskApprovalRequest
-	if !decodeJSON(w, r, &req) {
-		return
-	}
-	decision, ok := normalizeApprovalDecision(req.Decision)
-	if !ok {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "decision must be approve or reject")
-		return
-	}
-
-	now := time.Now().UTC()
-	approval.Status = decision
-	approval.ResolutionNote = strings.TrimSpace(req.Note)
-	approval.ResolvedBy = "operator"
-	approval.ResolvedAt = now
-	approval, updated, err := h.taskStore.UpdatePendingApprovalForAwaitingRun(ctx, approval)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !updated {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task approval is not pending or run is no longer awaiting approval")
-		return
-	}
-	_, _ = h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
-		TaskID:    task.ID,
-		RunID:     approval.RunID,
-		EventType: "approval.resolved",
-		Data: map[string]any{
-			"approval_id": approval.ID,
-			"decision":    approval.Status,
-			"by":          approval.ResolvedBy,
-			"comment":     approval.ResolutionNote,
-			"scope":       "once",
-			"kind":        approval.Kind,
-			"status":      approval.Status,
-		},
-		RequestID: RequestIDFromContext(ctx),
-		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
-		CreatedAt: time.Now().UTC(),
-	})
-
-	switch decision {
-	case "approved":
-		result, err := h.taskRunner.ResumeTaskAfterApproval(ctx, task, approval, newOpaqueTaskResourceID)
-		if err != nil {
-			telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.resume.failed",
-				slog.String("event.name", "gateway.tasks.approvals.resume.failed"),
-				slog.Any("error", err),
-			)
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-		if result.TraceID != "" {
-			w.Header().Set("X-Trace-Id", result.TraceID)
-		}
-		if result.SpanID != "" {
-			w.Header().Set("X-Span-Id", result.SpanID)
-		}
-	case "rejected":
-		result, err := h.taskRunner.RejectTaskAfterApproval(ctx, task, approval, newOpaqueTaskResourceID)
-		if err != nil {
-			telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.reject.failed",
-				slog.String("event.name", "gateway.tasks.approvals.reject.failed"),
-				slog.Any("error", err),
-			)
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-		if result.TraceID != "" {
-			w.Header().Set("X-Trace-Id", result.TraceID)
-		}
-		if result.SpanID != "" {
-			w.Header().Set("X-Span-Id", result.SpanID)
-		}
-	}
-
-	WriteJSON(w, http.StatusOK, TaskApprovalResponse{
-		Object: "task_approval",
-		Data:   renderTaskApproval(approval),
-	})
 }
 
 func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4938,6 +4938,98 @@ func TestTaskRunStream_PendingApprovalRidesAlongInSnapshot(t *testing.T) {
 	}
 }
 
+func TestTaskRunStream_CancelledSnapshotClearsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := config.Config{Server: config.ServerConfig{TaskApprovalPolicies: []string{"shell_exec"}}}
+	handler := newTestHTTPHandlerForProviders(logger, nil, cfg)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	created := requestJSONToURL[TaskResponse](t, http.MethodPost, server.URL+"/hecate/v1/tasks", `{"title":"Cancel approval stream","prompt":"Stream cancelled approval state.","execution_kind":"shell","shell_command":"echo should-not-run","working_directory":".","timeout_ms":3000}`)
+	started := requestJSONToURL[TaskRunResponse](t, http.MethodPost, server.URL+"/hecate/v1/tasks/"+created.Data.ID+"/start", "")
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("started status = %q, want awaiting_approval", started.Data.Status)
+	}
+
+	streamReq, err := http.NewRequest(http.MethodGet, server.URL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	streamCtx, cancelStream := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelStream()
+	streamReq = streamReq.WithContext(streamCtx)
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	defer streamResp.Body.Close()
+	if got := streamResp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+
+	cancelErrCh := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancelResp, err := http.Post(server.URL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/cancel", "application/json", strings.NewReader(`{"reason":"operator stop"}`))
+		if err != nil {
+			cancelErrCh <- err
+			return
+		}
+		defer cancelResp.Body.Close()
+		io.Copy(io.Discard, cancelResp.Body)
+		if cancelResp.StatusCode != http.StatusOK {
+			cancelErrCh <- fmt.Errorf("cancel status = %d", cancelResp.StatusCode)
+			return
+		}
+		cancelErrCh <- nil
+	}()
+
+	var sawTerminal bool
+	for event := range readSSEEvents(t, streamResp.Body) {
+		if event.Event != "snapshot" && event.Event != "done" {
+			continue
+		}
+		var payload TaskRunStreamEventResponse
+		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !payload.Data.Terminal && !types.IsTerminalTaskRunStatus(payload.Data.Run.Status) {
+			continue
+		}
+		sawTerminal = true
+		if payload.Data.Run.Status != "cancelled" {
+			t.Fatalf("terminal run status = %q, want cancelled", payload.Data.Run.Status)
+		}
+		var sawRunApproval bool
+		for _, approval := range payload.Data.Approvals {
+			if approval.RunID != started.Data.ID {
+				continue
+			}
+			sawRunApproval = true
+			if approval.Status == "pending" {
+				t.Fatalf("terminal snapshot carried pending approval %#v", approval)
+			}
+			if approval.Status != "cancelled" {
+				t.Fatalf("approval status in terminal snapshot = %q, want cancelled", approval.Status)
+			}
+		}
+		if !sawRunApproval {
+			t.Fatal("terminal snapshot did not carry the cancelled approval")
+		}
+		break
+	}
+	cancelStream()
+
+	if !sawTerminal {
+		t.Fatal("did not observe terminal stream snapshot")
+	}
+	if err := <-cancelErrCh; err != nil {
+		t.Fatalf("cancel request error = %v", err)
+	}
+}
+
 func TestTaskRunStream_AgentTurnCompletedFlowsTurnOverlayIntoSnapshot(t *testing.T) {
 	// End-to-end check on the Turn overlay path:
 	//

--- a/internal/mcp/server/tools.go
+++ b/internal/mcp/server/tools.go
@@ -124,14 +124,14 @@ func RegisterDefaultTools(s *Server, client *GatewayClient) {
 		Name:  "resolve_approval",
 		Title: "Resolve a pending approval",
 		Description: "Approve or reject a pending approval gate (pre-execution or mid-loop tool call). " +
-			"On approve, the run continues from where it paused; on reject, the run terminates failed. " +
+			"On approve, the run continues from where it paused; on reject, the run is cancelled with approval rejected. " +
 			"This is irreversible — the run can't undo a rejection.",
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"task_id": {"type": "string", "minLength": 1, "description": "The task id."},
 				"approval_id": {"type": "string", "minLength": 1, "description": "The pending approval id."},
-				"decision": {"type": "string", "enum": ["approve", "reject"], "description": "approve resumes the run; reject terminates it."},
+				"decision": {"type": "string", "enum": ["approve", "reject"], "description": "approve resumes the run; reject cancels it with approval rejected."},
 				"note": {"type": "string", "description": "Optional operator note attached to the resolution (audit trail)."}
 			},
 			"required": ["task_id", "approval_id", "decision"]

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -753,6 +753,8 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	}
 
 	now := time.Now().UTC()
+	cancelledApprovals := r.cancelPendingApprovalsForRun(ctx, task, run, message, now)
+
 	run.Status = "cancelled"
 	run.LastError = message
 	run.FinishedAt = now
@@ -769,7 +771,6 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	if err != nil {
 		return types.TaskRun{}, err
 	}
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
 
 	steps, _ := r.store.ListSteps(ctx, run.ID)
 	for _, step := range steps {
@@ -808,8 +809,9 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	if _, err := r.store.UpdateTask(ctx, task); err != nil {
 		return types.TaskRun{}, err
 	}
+	r.emitApprovalResolvedEventsForRun(ctx, trace, task, run, cancelledApprovals, requestID, traceID)
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "task.updated", requestID, traceID, nil)
-	r.cancelPendingApprovalsForRun(ctx, trace, task, run, message, requestID, traceID, now)
 	return run, nil
 }
 

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -770,7 +770,6 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 		return types.TaskRun{}, err
 	}
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
-	r.cancelPendingApprovalsForRun(ctx, trace, task, run, message, requestID, traceID, now)
 
 	steps, _ := r.store.ListSteps(ctx, run.ID)
 	for _, step := range steps {
@@ -810,6 +809,7 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 		return types.TaskRun{}, err
 	}
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "task.updated", requestID, traceID, nil)
+	r.cancelPendingApprovalsForRun(ctx, trace, task, run, message, requestID, traceID, now)
 	return run, nil
 }
 

--- a/internal/orchestrator/runner_approval_lifecycle_test.go
+++ b/internal/orchestrator/runner_approval_lifecycle_test.go
@@ -1,0 +1,431 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/storage"
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type approvalLifecycleStoreCase struct {
+	name  string
+	store taskstate.Store
+}
+
+func approvalLifecycleStores(t *testing.T) []approvalLifecycleStoreCase {
+	t.Helper()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "approval-lifecycle.db"),
+		TablePrefix: "approval_lifecycle",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	sqliteStore, err := taskstate.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+
+	return []approvalLifecycleStoreCase{
+		{name: "memory", store: taskstate.NewMemoryStore()},
+		{name: "sqlite", store: sqliteStore},
+	}
+}
+
+func newApprovalLifecycleRunner(store taskstate.Store) (*Runner, *recordingQueue) {
+	queue := &recordingQueue{}
+	return &Runner{
+		logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store:    store,
+		tracer:   profiler.NewInMemoryTracer(nil),
+		queue:    queue,
+		policies: make(map[string]struct{}),
+		jobs:     make(map[string]context.CancelFunc),
+	}, queue
+}
+
+func seedAwaitingApprovalRun(t *testing.T, ctx context.Context, store taskstate.Store, suffix string) (types.Task, types.TaskRun, types.TaskStep, types.TaskApproval) {
+	t.Helper()
+	now := time.Now().UTC().Add(-time.Minute)
+	task := types.Task{
+		ID:          "task_" + suffix,
+		Title:       "Approval lifecycle",
+		Status:      "awaiting_approval",
+		LatestRunID: "run_" + suffix,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		StartedAt:   now,
+	}
+	run := types.TaskRun{
+		ID:        "run_" + suffix,
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "awaiting_approval",
+		StartedAt: now,
+		RequestID: "request_" + suffix,
+		TraceID:   "trace_" + suffix,
+	}
+	step := types.TaskStep{
+		ID:         "step_" + suffix,
+		TaskID:     task.ID,
+		RunID:      run.ID,
+		Index:      1,
+		Kind:       "approval",
+		Title:      "Awaiting approval",
+		Status:     "awaiting_approval",
+		Phase:      "approval",
+		ApprovalID: "approval_" + suffix,
+		StartedAt:  now,
+		RequestID:  run.RequestID,
+		TraceID:    run.TraceID,
+	}
+	approval := types.TaskApproval{
+		ID:          "approval_" + suffix,
+		TaskID:      task.ID,
+		RunID:       run.ID,
+		StepID:      step.ID,
+		Kind:        "shell_command",
+		Status:      "pending",
+		Reason:      "Shell execution requires approval.",
+		RequestedBy: "operator",
+		CreatedAt:   now,
+		RequestID:   run.RequestID,
+		TraceID:     run.TraceID,
+	}
+
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	if _, err := store.AppendStep(ctx, step); err != nil {
+		t.Fatalf("AppendStep() error = %v", err)
+	}
+	if _, err := store.CreateApproval(ctx, approval); err != nil {
+		t.Fatalf("CreateApproval() error = %v", err)
+	}
+	return task, run, step, approval
+}
+
+func deterministicApprovalID(prefix string) string {
+	return prefix + "_approval_lifecycle"
+}
+
+func TestRunnerResolveTaskApproval_ApprovesAndRequeuesSameRun(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, run, _, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_approve")
+			runner, queue := newApprovalLifecycleRunner(tc.store)
+
+			result, err := runner.ResolveTaskApproval(ctx, ResolveApprovalRequest{
+				Task:        task,
+				ApprovalID:  approval.ID,
+				Decision:    "approve",
+				Note:        "ship it",
+				ResolvedBy:  "operator",
+				IDGenerator: deterministicApprovalID,
+			})
+			if err != nil {
+				t.Fatalf("ResolveTaskApproval() error = %v", err)
+			}
+
+			if result.Run.ID != run.ID {
+				t.Fatalf("resolved run id = %q, want same run %q", result.Run.ID, run.ID)
+			}
+			if result.Run.Status != "queued" {
+				t.Fatalf("resolved run status = %q, want queued", result.Run.Status)
+			}
+			if result.Task.Status != "queued" {
+				t.Fatalf("resolved task status = %q, want queued", result.Task.Status)
+			}
+			if result.Approval.Status != "approved" {
+				t.Fatalf("approval status = %q, want approved", result.Approval.Status)
+			}
+			if result.Approval.ResolvedBy != "operator" || result.Approval.ResolutionNote != "ship it" || result.Approval.ResolvedAt.IsZero() {
+				t.Fatalf("approval resolution fields = by %q note %q at %v", result.Approval.ResolvedBy, result.Approval.ResolutionNote, result.Approval.ResolvedAt)
+			}
+			if len(queue.enqueued) != 1 || queue.enqueued[0].TaskID != task.ID || queue.enqueued[0].RunID != run.ID {
+				t.Fatalf("enqueued jobs = %+v, want same task/run requeued once", queue.enqueued)
+			}
+
+			storedApproval, found, err := tc.store.GetApproval(ctx, task.ID, approval.ID)
+			if err != nil || !found {
+				t.Fatalf("GetApproval() found=%v err=%v", found, err)
+			}
+			if storedApproval.Status != "approved" {
+				t.Fatalf("stored approval status = %q, want approved", storedApproval.Status)
+			}
+			storedRun, found, err := tc.store.GetRun(ctx, task.ID, run.ID)
+			if err != nil || !found {
+				t.Fatalf("GetRun() found=%v err=%v", found, err)
+			}
+			if storedRun.Status != "queued" {
+				t.Fatalf("stored run status = %q, want queued", storedRun.Status)
+			}
+			storedTask, found, err := tc.store.GetTask(ctx, task.ID)
+			if err != nil || !found {
+				t.Fatalf("GetTask() found=%v err=%v", found, err)
+			}
+			if storedTask.Status != "queued" || storedTask.LatestRunID != run.ID || storedTask.LastError != "" {
+				t.Fatalf("stored task = %+v, want queued latest run with no error", storedTask)
+			}
+
+			events := listApprovalLifecycleEvents(t, ctx, tc.store, task.ID, run.ID)
+			assertApprovalEvent(t, events, "approved")
+			assertApprovalEventRunStatus(t, events, "approved", "queued")
+			assertEventType(t, events, "run.queued")
+		})
+	}
+}
+
+func TestRunnerResolveTaskApproval_RejectCancelsRunTaskAndStep(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, run, step, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_reject")
+			runner, queue := newApprovalLifecycleRunner(tc.store)
+
+			result, err := runner.ResolveTaskApproval(ctx, ResolveApprovalRequest{
+				Task:        task,
+				ApprovalID:  approval.ID,
+				Decision:    "reject",
+				Note:        "not safe",
+				ResolvedBy:  "operator",
+				IDGenerator: deterministicApprovalID,
+			})
+			if err != nil {
+				t.Fatalf("ResolveTaskApproval() error = %v", err)
+			}
+
+			if len(queue.enqueued) != 0 {
+				t.Fatalf("enqueued jobs = %+v, want none after rejection", queue.enqueued)
+			}
+			if result.Approval.Status != "rejected" {
+				t.Fatalf("approval status = %q, want rejected", result.Approval.Status)
+			}
+			if result.Run.Status != "cancelled" || result.Run.LastError != "approval rejected" {
+				t.Fatalf("result run = %+v, want cancelled with approval rejected", result.Run)
+			}
+			if result.Task.Status != "cancelled" || result.Task.LastError != "approval rejected" {
+				t.Fatalf("result task = %+v, want cancelled with approval rejected", result.Task)
+			}
+
+			storedStep, found, err := tc.store.GetStep(ctx, run.ID, step.ID)
+			if err != nil || !found {
+				t.Fatalf("GetStep() found=%v err=%v", found, err)
+			}
+			if storedStep.Status != "cancelled" || storedStep.Error != "approval rejected" || storedStep.ErrorKind != "run_cancelled" {
+				t.Fatalf("stored step = %+v, want cancelled approval step", storedStep)
+			}
+
+			events := listApprovalLifecycleEvents(t, ctx, tc.store, task.ID, run.ID)
+			assertApprovalEvent(t, events, "rejected")
+			assertApprovalEventRunStatus(t, events, "rejected", "cancelled")
+			assertApprovalEventStepStatus(t, events, "rejected", step.ID, "cancelled")
+			assertEventType(t, events, "run.cancelled")
+			assertEventType(t, events, "task.updated")
+		})
+	}
+}
+
+func TestRunnerCancelRun_CancelsPendingApprovalAndAwaitingStep(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, run, step, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_cancel")
+			runner, _ := newApprovalLifecycleRunner(tc.store)
+
+			cancelled, err := runner.CancelRun(ctx, task, run.ID, "operator changed mind")
+			if err != nil {
+				t.Fatalf("CancelRun() error = %v", err)
+			}
+			if cancelled.Status != "cancelled" || cancelled.LastError != "run cancelled: operator changed mind" {
+				t.Fatalf("cancelled run = %+v, want cancelled with operator reason", cancelled)
+			}
+
+			storedApproval, found, err := tc.store.GetApproval(ctx, task.ID, approval.ID)
+			if err != nil || !found {
+				t.Fatalf("GetApproval() found=%v err=%v", found, err)
+			}
+			if storedApproval.Status != "cancelled" || storedApproval.ResolvedBy != "system" || storedApproval.ResolutionNote != cancelled.LastError {
+				t.Fatalf("stored approval = %+v, want system-cancelled approval", storedApproval)
+			}
+			storedStep, found, err := tc.store.GetStep(ctx, run.ID, step.ID)
+			if err != nil || !found {
+				t.Fatalf("GetStep() found=%v err=%v", found, err)
+			}
+			if storedStep.Status != "cancelled" || storedStep.Error != cancelled.LastError || storedStep.ErrorKind != "run_cancelled" {
+				t.Fatalf("stored step = %+v, want cancelled awaiting approval step", storedStep)
+			}
+			storedTask, found, err := tc.store.GetTask(ctx, task.ID)
+			if err != nil || !found {
+				t.Fatalf("GetTask() found=%v err=%v", found, err)
+			}
+			if storedTask.Status != "cancelled" || storedTask.LastError != cancelled.LastError {
+				t.Fatalf("stored task = %+v, want cancelled task with same reason", storedTask)
+			}
+
+			events := listApprovalLifecycleEvents(t, ctx, tc.store, task.ID, run.ID)
+			assertEventType(t, events, "run.cancelled")
+			assertApprovalEvent(t, events, "cancelled")
+			assertApprovalEventRunStatus(t, events, "cancelled", "cancelled")
+			assertApprovalEventStepStatus(t, events, "cancelled", step.ID, "cancelled")
+			assertEventType(t, events, "task.updated")
+		})
+	}
+}
+
+func TestRunnerResolveTaskApproval_ConflictsWhenAlreadyResolved(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, _, _, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_already_resolved")
+			runner, _ := newApprovalLifecycleRunner(tc.store)
+			approval.Status = "approved"
+			approval.ResolvedBy = "operator"
+			approval.ResolvedAt = time.Now().UTC()
+			if _, err := tc.store.UpdateApproval(ctx, approval); err != nil {
+				t.Fatalf("UpdateApproval() error = %v", err)
+			}
+
+			_, err := runner.ResolveTaskApproval(ctx, ResolveApprovalRequest{
+				Task:        task,
+				ApprovalID:  approval.ID,
+				Decision:    "approve",
+				IDGenerator: deterministicApprovalID,
+			})
+			if !errors.Is(err, ErrApprovalConflict) {
+				t.Fatalf("ResolveTaskApproval() error = %v, want ErrApprovalConflict", err)
+			}
+		})
+	}
+}
+
+func TestRunnerResolveTaskApproval_ConflictsAfterRunCancellation(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, run, _, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_cancel_then_resolve")
+			runner, _ := newApprovalLifecycleRunner(tc.store)
+			if _, err := runner.CancelRun(ctx, task, run.ID, "operator cancelled"); err != nil {
+				t.Fatalf("CancelRun() error = %v", err)
+			}
+
+			_, err := runner.ResolveTaskApproval(ctx, ResolveApprovalRequest{
+				Task:        task,
+				ApprovalID:  approval.ID,
+				Decision:    "approve",
+				IDGenerator: deterministicApprovalID,
+			})
+			if !errors.Is(err, ErrApprovalConflict) {
+				t.Fatalf("ResolveTaskApproval() error = %v, want ErrApprovalConflict", err)
+			}
+		})
+	}
+}
+
+func listApprovalLifecycleEvents(t *testing.T, ctx context.Context, store taskstate.Store, taskID, runID string) []types.TaskRunEvent {
+	t.Helper()
+	events, err := store.ListRunEvents(ctx, taskID, runID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	return events
+}
+
+func assertEventType(t *testing.T, events []types.TaskRunEvent, eventType string) {
+	t.Helper()
+	for _, event := range events {
+		if event.EventType == eventType {
+			return
+		}
+	}
+	t.Fatalf("missing event %q in %+v", eventType, eventTypes(events))
+}
+
+func assertApprovalEvent(t *testing.T, events []types.TaskRunEvent, decision string) {
+	t.Helper()
+	if approvalEvent(t, events, decision) != nil {
+		return
+	}
+	t.Fatalf("missing approval.resolved decision %q in events %+v", decision, events)
+}
+
+func assertApprovalEventRunStatus(t *testing.T, events []types.TaskRunEvent, decision, status string) {
+	t.Helper()
+	event := approvalEvent(t, events, decision)
+	if event == nil {
+		t.Fatalf("missing approval.resolved decision %q in events %+v", decision, events)
+	}
+	var run types.TaskRun
+	decodeEventField(t, (*event).Data["run"], &run)
+	if run.Status != status {
+		t.Fatalf("approval.resolved %q run status = %q, want %q", decision, run.Status, status)
+	}
+}
+
+func assertApprovalEventStepStatus(t *testing.T, events []types.TaskRunEvent, decision, stepID, status string) {
+	t.Helper()
+	event := approvalEvent(t, events, decision)
+	if event == nil {
+		t.Fatalf("missing approval.resolved decision %q in events %+v", decision, events)
+	}
+	var steps []types.TaskStep
+	decodeEventField(t, (*event).Data["steps"], &steps)
+	for _, step := range steps {
+		if step.ID == stepID {
+			if step.Status != status {
+				t.Fatalf("approval.resolved %q step %q status = %q, want %q", decision, stepID, step.Status, status)
+			}
+			return
+		}
+	}
+	t.Fatalf("approval.resolved %q missing step %q in %+v", decision, stepID, steps)
+}
+
+func approvalEvent(t *testing.T, events []types.TaskRunEvent, decision string) *types.TaskRunEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.EventType != "approval.resolved" {
+			continue
+		}
+		if event.Data["decision"] == decision && event.Data["status"] == decision {
+			return &event
+		}
+	}
+	return nil
+}
+
+func decodeEventField(t *testing.T, value any, out any) {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal event field: %v", err)
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		t.Fatalf("unmarshal event field: %v", err)
+	}
+}
+
+func eventTypes(events []types.TaskRunEvent) []string {
+	types := make([]string, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.EventType)
+	}
+	return types
+}

--- a/internal/orchestrator/runner_approval_lifecycle_test.go
+++ b/internal/orchestrator/runner_approval_lifecycle_test.go
@@ -339,6 +339,34 @@ func TestRunnerResolveTaskApproval_ConflictsAfterRunCancellation(t *testing.T) {
 	}
 }
 
+func TestRunnerApprovalHelpers_ConflictWhenRunNoLongerAwaiting(t *testing.T) {
+	for _, tc := range approvalLifecycleStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			task, run, _, approval := seedAwaitingApprovalRun(t, ctx, tc.store, tc.name+"_helper_conflict")
+			runner, _ := newApprovalLifecycleRunner(tc.store)
+
+			run.Status = "cancelled"
+			run.LastError = "operator cancelled"
+			if _, err := tc.store.UpdateRun(ctx, run); err != nil {
+				t.Fatalf("UpdateRun() error = %v", err)
+			}
+
+			approval.Status = "approved"
+			_, err := runner.ResumeTaskAfterApproval(ctx, task, approval, deterministicApprovalID)
+			if !errors.Is(err, ErrApprovalConflict) {
+				t.Fatalf("ResumeTaskAfterApproval() error = %v, want ErrApprovalConflict", err)
+			}
+
+			approval.Status = "rejected"
+			_, err = runner.RejectTaskAfterApproval(ctx, task, approval, deterministicApprovalID)
+			if !errors.Is(err, ErrApprovalConflict) {
+				t.Fatalf("RejectTaskAfterApproval() error = %v, want ErrApprovalConflict", err)
+			}
+		})
+	}
+}
+
 func listApprovalLifecycleEvents(t *testing.T, ctx context.Context, store taskstate.Store, taskID, runID string) []types.TaskRunEvent {
 	t.Helper()
 	events, err := store.ListRunEvents(ctx, taskID, runID, 0, 100)

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,43 @@ import (
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+var (
+	ErrApprovalNotFound        = errors.New("task approval not found")
+	ErrApprovalRunNotFound     = errors.New("task run not found")
+	ErrApprovalConflict        = errors.New("task approval is not actionable")
+	ErrInvalidApprovalDecision = errors.New("approval decision must be approve or reject")
+)
+
+type approvalConflictError struct {
+	message string
+}
+
+func (e approvalConflictError) Error() string {
+	return e.message
+}
+
+func (e approvalConflictError) Is(target error) bool {
+	return target == ErrApprovalConflict
+}
+
+type ResolveApprovalRequest struct {
+	Task        types.Task
+	ApprovalID  string
+	Decision    string
+	Note        string
+	ResolvedBy  string
+	RequestID   string
+	IDGenerator func(prefix string) string
+}
+
+type ResolveApprovalResult struct {
+	Approval types.TaskApproval
+	Task     types.Task
+	Run      types.TaskRun
+	TraceID  string
+	SpanID   string
+}
 
 func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, approval types.TaskApproval, idgen func(prefix string) string) (*StartTaskResult, error) {
 	if r.store == nil {
@@ -58,7 +96,6 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 	if _, err := r.store.UpdateRun(ctx, run); err != nil {
 		return nil, err
 	}
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.queued", requestID, trace.TraceID, map[string]any{"resume": true})
 
 	task.Status = "queued"
 	task.LatestRunID = run.ID
@@ -71,6 +108,9 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		return nil, err
 	}
 
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, approvalResolvedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.queued", requestID, trace.TraceID, map[string]any{"resume": true})
+
 	if err := r.enqueueRun(task.ID, run.ID); err != nil {
 		return nil, err
 	}
@@ -81,6 +121,117 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		TraceID: trace.TraceID,
 		SpanID:  trace.RootSpanID(),
 	}, nil
+}
+
+func (r *Runner) ResolveTaskApproval(ctx context.Context, req ResolveApprovalRequest) (*ResolveApprovalResult, error) {
+	if r == nil || r.store == nil {
+		return nil, fmt.Errorf("task store is not configured")
+	}
+	if req.Task.ID == "" {
+		return nil, fmt.Errorf("task id is required")
+	}
+	approvalID := strings.TrimSpace(req.ApprovalID)
+	if approvalID == "" {
+		return nil, fmt.Errorf("approval id is required")
+	}
+	decision, err := normalizeApprovalDecision(req.Decision)
+	if err != nil {
+		return nil, err
+	}
+	if req.IDGenerator == nil {
+		return nil, fmt.Errorf("resource id generator is required")
+	}
+
+	approval, found, err := r.store.GetApproval(ctx, req.Task.ID, approvalID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status != "pending" {
+		return nil, approvalConflictError{message: fmt.Sprintf("task approval is not pending (status %s)", approval.Status)}
+	}
+
+	run, found, err := r.store.GetRun(ctx, req.Task.ID, approval.RunID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrApprovalRunNotFound
+	}
+	if run.Status != "awaiting_approval" {
+		return nil, approvalConflictError{message: fmt.Sprintf("task approval is no longer actionable because run is %s", run.Status)}
+	}
+
+	now := time.Now().UTC()
+	approval.Status = decision
+	approval.ResolutionNote = strings.TrimSpace(req.Note)
+	approval.ResolvedBy = strings.TrimSpace(req.ResolvedBy)
+	if approval.ResolvedBy == "" {
+		approval.ResolvedBy = "operator"
+	}
+	approval.ResolvedAt = now
+
+	updatedApproval, updated, err := r.store.UpdatePendingApprovalForAwaitingRun(ctx, approval)
+	if err != nil {
+		return nil, err
+	}
+	if !updated {
+		return nil, approvalConflictError{message: "task approval is not pending or run is no longer awaiting approval"}
+	}
+
+	requestID := firstNonEmpty(strings.TrimSpace(req.RequestID), telemetry.RequestIDFromContext(ctx), updatedApproval.RequestID, run.RequestID)
+	if requestID == "" && req.IDGenerator != nil {
+		requestID = req.IDGenerator("request")
+	}
+	ctx = telemetry.WithRequestID(ctx, requestID)
+
+	var started *StartTaskResult
+	switch decision {
+	case "approved":
+		started, err = r.ResumeTaskAfterApproval(ctx, req.Task, updatedApproval, req.IDGenerator)
+	case "rejected":
+		started, err = r.RejectTaskAfterApproval(ctx, req.Task, updatedApproval, req.IDGenerator)
+	default:
+		err = ErrInvalidApprovalDecision
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResolveApprovalResult{
+		Approval: updatedApproval,
+		Task:     started.Task,
+		Run:      started.Run,
+		TraceID:  started.TraceID,
+		SpanID:   started.SpanID,
+	}, nil
+}
+
+func normalizeApprovalDecision(decision string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(decision)) {
+	case "approve", "approved":
+		return "approved", nil
+	case "reject", "rejected":
+		return "rejected", nil
+	case "deny", "denied":
+		return "rejected", nil
+	default:
+		return "", ErrInvalidApprovalDecision
+	}
+}
+
+func approvalResolvedEventData(approval types.TaskApproval) map[string]any {
+	return map[string]any{
+		"approval_id": approval.ID,
+		"decision":    approval.Status,
+		"by":          approval.ResolvedBy,
+		"comment":     approval.ResolutionNote,
+		"scope":       "once",
+		"kind":        approval.Kind,
+		"status":      approval.Status,
+	}
 }
 
 func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, approval types.TaskApproval, idgen func(prefix string) string) (*StartTaskResult, error) {
@@ -131,6 +282,7 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 	if err != nil {
 		return nil, err
 	}
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, approvalResolvedEventData(approval))
 	return &StartTaskResult{
 		Task:    task,
 		Run:     run,
@@ -164,15 +316,7 @@ func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, trace *profil
 			waitMS = updated.ResolvedAt.Sub(updated.CreatedAt).Milliseconds()
 		}
 		r.recordApprovalResolved(ctx, trace, task.ID, run.ID, updated, "cancelled", waitMS)
-		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, traceID, map[string]any{
-			"approval_id": updated.ID,
-			"decision":    updated.Status,
-			"by":          updated.ResolvedBy,
-			"comment":     updated.ResolutionNote,
-			"scope":       "once",
-			"kind":        updated.Kind,
-			"status":      updated.Status,
-		})
+		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, traceID, approvalResolvedEventData(updated))
 	}
 }
 
@@ -192,13 +336,15 @@ func (r *Runner) recordApprovalResolved(ctx context.Context, trace *profiler.Tra
 	if trace != nil {
 		trace.Record(telemetry.EventOrchestratorApprovalResolved, attrs)
 	}
-	r.metrics.RecordApproval(ctx, telemetry.ApprovalMetricsRecord{
-		TaskID:       taskID,
-		RunID:        runID,
-		ApprovalKind: approval.Kind,
-		Decision:     decision,
-		WaitMS:       waitMS,
-	})
+	if r.metrics != nil {
+		r.metrics.RecordApproval(ctx, telemetry.ApprovalMetricsRecord{
+			TaskID:       taskID,
+			RunID:        runID,
+			ApprovalKind: approval.Kind,
+			Decision:     decision,
+			WaitMS:       waitMS,
+		})
+	}
 }
 
 func (r *Runner) approvalRequiredForTask(task types.Task) bool {

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -291,11 +291,12 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 	}, nil
 }
 
-func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, message, requestID, traceID string, now time.Time) {
+func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Task, run types.TaskRun, message string, now time.Time) []types.TaskApproval {
 	approvals, err := r.store.ListApprovals(ctx, task.ID)
 	if err != nil {
-		return
+		return nil
 	}
+	cancelled := make([]types.TaskApproval, 0, len(approvals))
 	for _, approval := range approvals {
 		if approval.RunID != run.ID || approval.Status != "pending" {
 			continue
@@ -311,6 +312,13 @@ func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, trace *profil
 		if !ok {
 			continue
 		}
+		cancelled = append(cancelled, updated)
+	}
+	return cancelled
+}
+
+func (r *Runner) emitApprovalResolvedEventsForRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, approvals []types.TaskApproval, requestID, traceID string) {
+	for _, updated := range approvals {
 		waitMS := int64(0)
 		if !updated.CreatedAt.IsZero() {
 			waitMS = updated.ResolvedAt.Sub(updated.CreatedAt).Milliseconds()

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -64,7 +64,7 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		return nil, fmt.Errorf("task run %q not found", approval.RunID)
 	}
 	if run.Status != "awaiting_approval" {
-		return nil, fmt.Errorf("task run %q is not awaiting approval", run.ID)
+		return nil, approvalConflictError{message: fmt.Sprintf("task approval is no longer actionable because run is %s", run.Status)}
 	}
 
 	requestID := strings.TrimSpace(telemetry.RequestIDFromContext(ctx))
@@ -199,6 +199,9 @@ func (r *Runner) ResolveTaskApproval(ctx context.Context, req ResolveApprovalReq
 	if err != nil {
 		return nil, err
 	}
+	if started == nil {
+		return nil, approvalConflictError{message: "task approval resolution did not produce a runnable state"}
+	}
 
 	return &ResolveApprovalResult{
 		Approval: updatedApproval,
@@ -249,7 +252,7 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 		return nil, fmt.Errorf("task run %q not found", approval.RunID)
 	}
 	if run.Status != "awaiting_approval" {
-		return nil, fmt.Errorf("task run %q is not awaiting approval", run.ID)
+		return nil, approvalConflictError{message: fmt.Sprintf("task approval is no longer actionable because run is %s", run.Status)}
 	}
 
 	requestID := strings.TrimSpace(telemetry.RequestIDFromContext(ctx))

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -685,6 +685,22 @@ describe("TaskDetail runtime debugging", () => {
     expect(screen.getByText("context deadline exceeded")).toBeTruthy();
   });
 
+  it("labels approval rejection separately from generic cancellation", () => {
+    const run = makeRun({
+      status: "cancelled",
+      last_error: "approval rejected",
+    });
+    const task = makeTask({
+      status: "cancelled",
+      last_error: "approval rejected",
+      latest_run_id: run.id,
+    });
+    const { render } = setup({ task, run, runs: [run] });
+    render();
+
+    expect(screen.getAllByText("rejected").length).toBeGreaterThan(0);
+  });
+
   it("renders the run timeline from persisted events", () => {
     const events: TaskRunEventRecord[] = [
       makeEvent({

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -41,7 +41,7 @@ import {
   taskActivityArtifactPreview,
   taskActivityArtifactSize,
   taskActivityToTranscriptActivity,
-  taskBadgeStatus,
+  taskBadgeProps,
 } from "./taskDetailHelpers";
 
 type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
@@ -465,7 +465,7 @@ export function TaskDetail({
           background: "var(--bg1)",
         }}
       >
-        <Badge status={taskBadgeStatus(task.status)} />
+        <Badge {...taskBadgeProps(task.status, task.last_error)} />
         <span
           style={{
             fontWeight: 500,
@@ -548,7 +548,7 @@ export function TaskDetail({
                         borderBottom: "1px solid var(--border)",
                       }}
                     >
-                      <Badge status={taskBadgeStatus(r.status)} />
+                      <Badge {...taskBadgeProps(r.status, r.last_error)} />
                       <span
                         style={{
                           fontFamily: "var(--font-mono)",
@@ -690,7 +690,7 @@ export function TaskDetail({
               <div
                 style={{ display: "inline-flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}
               >
-                <Badge status={taskBadgeStatus(run.status)} />
+                <Badge {...taskBadgeProps(run.status, run.last_error)} />
                 {run.provider_kind && (
                   <Badge
                     status={run.provider_kind === "local" ? "healthy" : "disabled"}

--- a/ui/src/features/runs/TaskList.tsx
+++ b/ui/src/features/runs/TaskList.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import type { TaskRecord } from "../../types/task";
 import { Badge, Icon, Icons } from "../shared/ui";
 
+import { taskBadgeProps } from "./taskDetailHelpers";
+
 type Props = {
   tasks: TaskRecord[];
   selectedTaskID: string;
@@ -13,12 +15,6 @@ type Props = {
   onNewTask: () => void;
   onRefresh: () => void;
 };
-
-function taskBadgeStatus(status: string): string {
-  if (status === "completed") return "done";
-  if (status === "awaiting_approval") return "awaiting";
-  return status;
-}
 
 function taskKindLabel(task: TaskRecord): string {
   const kind = task.execution_kind;
@@ -149,7 +145,7 @@ export function TaskList({
               }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
-                <Badge status={taskBadgeStatus(t.status)} />
+                <Badge {...taskBadgeProps(t.status, t.last_error)} />
                 {t.execution_kind && (
                   <span
                     style={{

--- a/ui/src/features/runs/taskDetailHelpers.test.ts
+++ b/ui/src/features/runs/taskDetailHelpers.test.ts
@@ -26,6 +26,7 @@ import {
   taskActivitySubtitle,
   taskActivityTitle,
   taskActivityToTranscriptActivity,
+  taskBadgeProps,
   taskBadgeStatus,
 } from "./taskDetailHelpers";
 
@@ -110,6 +111,16 @@ describe("taskBadgeStatus", () => {
   it("passes through other statuses unchanged", () => {
     expect(taskBadgeStatus("running")).toBe("running");
     expect(taskBadgeStatus("failed")).toBe("failed");
+  });
+});
+
+describe("taskBadgeProps", () => {
+  it("labels approval rejection separately from generic cancellation", () => {
+    expect(taskBadgeProps("cancelled", "approval rejected")).toEqual({
+      status: "cancelled",
+      label: "rejected",
+    });
+    expect(taskBadgeProps("cancelled", "operator cancelled")).toEqual({ status: "cancelled" });
   });
 });
 

--- a/ui/src/features/runs/taskDetailHelpers.ts
+++ b/ui/src/features/runs/taskDetailHelpers.ts
@@ -57,6 +57,18 @@ export function taskBadgeStatus(status: string): string {
   return status;
 }
 
+export function isApprovalRejected(status: string, lastError?: string): boolean {
+  return status === "cancelled" && (lastError || "").trim().toLowerCase() === "approval rejected";
+}
+
+export function taskBadgeProps(
+  status: string,
+  lastError?: string,
+): { status: string; label?: string } {
+  if (isApprovalRejected(status, lastError)) return { status: "cancelled", label: "rejected" };
+  return { status: taskBadgeStatus(status) };
+}
+
 export function approvalCommandPreview(task: TaskRecord): string {
   if (task.execution_kind === "git" && task.git_command) return `git ${task.git_command}`;
   if (task.shell_command) return task.shell_command;

--- a/ui/src/features/shared/Atoms.tsx
+++ b/ui/src/features/shared/Atoms.tsx
@@ -36,7 +36,7 @@ export function Badge({ status, label }: { status: BadgeStatus | string; label?:
     done: { text: label || "done", cls: "badge-green" },
     completed: { text: label || "done", cls: "badge-green" },
     failed: { text: label || "failed", cls: "badge-red" },
-    cancelled: { text: label || "failed", cls: "badge-red" },
+    cancelled: { text: label || "cancelled", cls: "badge-red" },
     enabled: { text: label || "enabled", cls: "badge-green" },
     disabled: { text: label || "disabled", cls: "badge-muted" },
     healthy: { text: label || "healthy", cls: "badge-green" },


### PR DESCRIPTION
## Summary
- move task approval approve/reject handling into the runtime so approval, run, task, step, and event state transition together
- map approval conflicts consistently to 409s, including the narrow post-resolution race where a run is no longer awaiting approval
- show rejected approvals distinctly from generic cancellations in task badges
- document rejection as a cancelled run/task with `last_error: "approval rejected"` and align MCP metadata

## Behavior change
- Rejecting an approval now terminalizes the run/task as `cancelled` with `last_error: "approval rejected"` instead of `failed`.
- Generic operator cancellation still displays as `cancelled`; approval rejection displays as `rejected`.

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/orchestrator -run 'TestRunner(ResolveTaskApproval|CancelRun|ApprovalHelpers)' -count=1`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestTask(Approval|RejectApproval|RunCancellationCancelsPendingApproval)|TestTaskApprovalResolveReturnsConflict|TestTaskRunStream.*Approval|TestTaskRunStream_CancelledSnapshotClearsPendingApproval' -count=1`
- `cd ui && bun run typecheck && bun run test -- src/features/runs/taskDetailHelpers.test.ts src/features/runs/TaskDetail.test.tsx`
- `git diff --check`
