### PR TITLE
fix(ui): clarify task approval rejection state

### DIFF
--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -699,6 +699,11 @@ describe("TaskDetail runtime debugging", () => {
     render();
 
     expect(screen.getAllByText("rejected").length).toBeGreaterThan(0);
+    expect(screen.getByText("Outcome")).toBeTruthy();
+    expect(screen.getByText("Approval rejected")).toBeTruthy();
+    expect(
+      screen.getByText("The run was stopped because the pending approval was rejected."),
+    ).toBeTruthy();
   });
 
   it("renders the run timeline from persisted events", () => {
@@ -847,7 +852,7 @@ describe("TaskDetail runtime debugging", () => {
     render();
 
     expect(screen.queryByRole("button", { name: /stop run/i })).toBeNull();
-    expect(screen.getByRole("button", { name: /deny/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /reject and stop/i })).toBeTruthy();
   });
 
   it("renders approval metadata and actions in the top-level callout", async () => {
@@ -870,9 +875,10 @@ describe("TaskDetail runtime debugging", () => {
     render();
     expect(screen.getByTestId("task-approval-callout")).toBeTruthy();
     expect(screen.getByText(/Approval required/i)).toBeTruthy();
+    expect(screen.getByText(/approve or reject/i)).toBeTruthy();
     expect(screen.getByText(/Shell execution/i)).toBeTruthy();
     expect(screen.getByText(/requested by/i)).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: /approve/i }));
+    await user.click(screen.getByRole("button", { name: /approve and resume/i }));
     expect(onResolveApproval).toHaveBeenCalledWith(approval, "approve");
   });
 
@@ -902,7 +908,8 @@ describe("TaskDetail runtime debugging", () => {
     });
     render();
     expect(screen.getByText(/2 approvals required/i)).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: /approve/i })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /approve and resume/i })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /reject and stop/i })).toHaveLength(2);
   });
 });
 

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -790,7 +790,7 @@ export function TaskDetail({
                             ? "var(--red)"
                             : tone === "warning"
                               ? "var(--amber)"
-                            : "var(--t1)",
+                              : "var(--t1)",
                       fontFamily: "var(--font-mono)",
                       wordBreak: "break-word",
                     }}

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -26,7 +26,7 @@ import {
   artifactHasBytes,
   buildOutputActivityIndex,
   describeApprovalKind,
-  describeRunEvent,
+  describeRunEventRecord,
   describeRunEventNote,
   failedToolOutputArtifacts,
   isOutputArtifactActivity,
@@ -42,6 +42,7 @@ import {
   taskActivityArtifactSize,
   taskActivityToTranscriptActivity,
   taskBadgeProps,
+  taskRunOutcome,
 } from "./taskDetailHelpers";
 
 type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
@@ -264,7 +265,7 @@ function TaskApprovalCallout({
               marginTop: 2,
             }}
           >
-            This run is paused until you approve or deny the pending action.
+            This run is paused until you approve or reject the pending action.
           </div>
         </div>
       </div>
@@ -325,15 +326,16 @@ function TaskApprovalCallout({
               onClick={() => onResolveApproval(approval, "approve")}
               style={{ gap: 5 }}
             >
-              <Icon d={Icons.approve} size={13} /> Approve
+              <Icon d={Icons.approve} size={13} /> Approve and resume
             </button>
             <button
               className="btn btn-danger btn-sm"
               disabled={busyAction !== ""}
               onClick={() => onResolveApproval(approval, "reject")}
+              title="Rejecting cancels this run with reason: approval rejected."
               style={{ gap: 5 }}
             >
-              <Icon d={Icons.deny} size={13} /> Deny
+              <Icon d={Icons.deny} size={13} /> Reject and stop
             </button>
           </div>
         </div>
@@ -440,6 +442,7 @@ export function TaskDetail({
     pendingApprovals.length === 0,
   );
   const visibleEvents = events.filter(isVisibleRunEvent);
+  const runOutcome = run ? taskRunOutcome(run.status, run.last_error) : null;
 
   useEffect(() => {
     if (termRef.current) termRef.current.scrollTop = termRef.current.scrollHeight;
@@ -748,9 +751,31 @@ export function TaskDetail({
                     ),
                   ],
                   ["Trace ID", run.trace_id || "—"],
-                  ["Last error", run.last_error || "—"],
-                ] as Array<[string, ReactNode]>
-              ).map(([label, value]) => (
+                  runOutcome
+                    ? [
+                        runOutcome.label,
+                        <>
+                          <span>{runOutcome.value}</span>
+                          {runOutcome.detail && (
+                            <span
+                              style={{
+                                display: "block",
+                                marginTop: 4,
+                                color: "var(--t2)",
+                                fontFamily: "var(--font-ui)",
+                                fontSize: 11,
+                                lineHeight: 1.45,
+                              }}
+                            >
+                              {runOutcome.detail}
+                            </span>
+                          )}
+                        </>,
+                        runOutcome.tone,
+                      ]
+                    : ["Last error", "—", "muted"],
+                ] as Array<[string, ReactNode, "muted" | "error" | "warning" | undefined]>
+              ).map(([label, value, tone]) => (
                 <div key={label}>
                   <div className="kicker" style={{ marginBottom: 3 }}>
                     {label}
@@ -759,10 +784,12 @@ export function TaskDetail({
                     style={{
                       fontSize: 12,
                       color:
-                        value === "—"
+                        tone === "muted"
                           ? "var(--t3)"
-                          : label === "Last error" && value !== "—"
+                          : tone === "error"
                             ? "var(--red)"
+                            : tone === "warning"
+                              ? "var(--amber)"
                             : "var(--t1)",
                       fontFamily: "var(--font-mono)",
                       wordBreak: "break-word",
@@ -786,7 +813,7 @@ export function TaskDetail({
                 .slice()
                 .sort((left, right) => left.sequence - right.sequence)
                 .map((event) => {
-                  const meta = describeRunEvent(event.type);
+                  const meta = describeRunEventRecord(event);
                   return (
                     <div
                       key={event.event_id || `${event.sequence}-${event.type}`}

--- a/ui/src/features/runs/taskDetailHelpers.test.ts
+++ b/ui/src/features/runs/taskDetailHelpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type { TaskActivityRecord, TaskArtifactRecord, TaskRecord } from "../../types/task";
+import type {
+  TaskActivityRecord,
+  TaskArtifactRecord,
+  TaskRecord,
+  TaskRunEventRecord,
+} from "../../types/task";
 
 import {
   approvalCommandPreview,
@@ -8,6 +13,7 @@ import {
   buildOutputActivityIndex,
   describeApprovalKind,
   describeRunEvent,
+  describeRunEventRecord,
   describeRunEventNote,
   failedToolOutputArtifacts,
   isOutputArtifactActivity,
@@ -28,6 +34,7 @@ import {
   taskActivityToTranscriptActivity,
   taskBadgeProps,
   taskBadgeStatus,
+  taskRunOutcome,
 } from "./taskDetailHelpers";
 
 function activity(
@@ -58,6 +65,20 @@ function artifact(
     run_id: "r_1",
     ...overrides,
   } as TaskArtifactRecord;
+}
+
+function runEvent(overrides: Partial<TaskRunEventRecord> = {}): TaskRunEventRecord {
+  return {
+    schema_version: "1",
+    event_id: "evt_1",
+    task_id: "task_1",
+    run_id: "run_1",
+    sequence: 1,
+    occurred_at: "2026-05-28T00:00:00Z",
+    type: "run.started",
+    data: {},
+    ...overrides,
+  };
 }
 
 describe("stepColor", () => {
@@ -121,6 +142,33 @@ describe("taskBadgeProps", () => {
       label: "rejected",
     });
     expect(taskBadgeProps("cancelled", "operator cancelled")).toEqual({ status: "cancelled" });
+  });
+});
+
+describe("taskRunOutcome", () => {
+  it("describes approval rejection as an intentional stopped outcome", () => {
+    expect(taskRunOutcome("cancelled", "approval rejected")).toEqual({
+      label: "Outcome",
+      value: "Approval rejected",
+      tone: "warning",
+      detail: "The run was stopped because the pending approval was rejected.",
+    });
+  });
+
+  it("keeps failed runs on the last-error path", () => {
+    expect(taskRunOutcome("failed", "provider unavailable")).toEqual({
+      label: "Last error",
+      value: "provider unavailable",
+      tone: "error",
+    });
+  });
+
+  it("describes generic cancellation separately from approval rejection", () => {
+    expect(taskRunOutcome("cancelled", "operator stopped run")).toEqual({
+      label: "Reason",
+      value: "operator stopped run",
+      tone: "warning",
+    });
   });
 });
 
@@ -188,6 +236,36 @@ describe("describeRunEvent", () => {
     expect(describeRunEvent("custom.my_event_type")).toEqual({
       label: "custom.my event type",
       tone: "queued",
+    });
+  });
+});
+
+describe("describeRunEventRecord", () => {
+  it("labels approval resolution by the actual decision", () => {
+    const event = runEvent({
+      type: "approval.resolved",
+      data: { decision: "rejected" },
+    });
+
+    expect(describeRunEventRecord(event)).toEqual({
+      label: "Approval rejected",
+      tone: "awaiting",
+    });
+  });
+
+  it("labels approval-rejected cancellation separately from generic cancellation", () => {
+    const event = runEvent({
+      type: "run.cancelled",
+      data: { reason: "approval rejected" },
+    });
+
+    expect(describeRunEventRecord(event)).toEqual({
+      label: "Approval rejected",
+      tone: "awaiting",
+    });
+    expect(describeRunEventRecord(runEvent({ type: "run.cancelled", data: {} }))).toEqual({
+      label: "Cancelled",
+      tone: "failed",
     });
   });
 });

--- a/ui/src/features/runs/taskDetailHelpers.ts
+++ b/ui/src/features/runs/taskDetailHelpers.ts
@@ -69,6 +69,36 @@ export function taskBadgeProps(
   return { status: taskBadgeStatus(status) };
 }
 
+export type TaskRunOutcome = {
+  label: "Last error" | "Outcome" | "Reason";
+  value: string;
+  tone: "muted" | "error" | "warning";
+  detail?: string;
+};
+
+export function taskRunOutcome(status: string, lastError?: string): TaskRunOutcome {
+  const error = (lastError || "").trim();
+  if (isApprovalRejected(status, error)) {
+    return {
+      label: "Outcome",
+      value: "Approval rejected",
+      tone: "warning",
+      detail: "The run was stopped because the pending approval was rejected.",
+    };
+  }
+  if (status === "failed" && error) {
+    return { label: "Last error", value: error, tone: "error" };
+  }
+  if (status === "cancelled") {
+    return {
+      label: "Reason",
+      value: error || "Run cancelled",
+      tone: error ? "warning" : "muted",
+    };
+  }
+  return { label: "Last error", value: "—", tone: "muted" };
+}
+
 export function approvalCommandPreview(task: TaskRecord): string {
   if (task.execution_kind === "git" && task.git_command) return `git ${task.git_command}`;
   if (task.shell_command) return task.shell_command;
@@ -105,6 +135,28 @@ export function describeRunEvent(eventType: string): {
     "approval.resolved": { label: "Approval done", tone: "done" },
   };
   return labels[eventType] ?? { label: eventType.replaceAll("_", " "), tone: "queued" };
+}
+
+export function describeRunEventRecord(event: TaskRunEventRecord): {
+  label: string;
+  tone: "queued" | "running" | "awaiting" | "done" | "failed";
+} {
+  const decision = runEventString(event, "decision").toLowerCase();
+  if (event.type === "approval.resolved") {
+    if (decision === "approved") return { label: "Approval granted", tone: "done" };
+    if (decision === "rejected") return { label: "Approval rejected", tone: "awaiting" };
+    if (decision === "cancelled") return { label: "Approval cancelled", tone: "failed" };
+  }
+  const reason = runEventString(event, "reason").toLowerCase();
+  if (event.type === "run.cancelled" && reason === "approval rejected") {
+    return { label: "Approval rejected", tone: "awaiting" };
+  }
+  return describeRunEvent(event.type);
+}
+
+function runEventString(event: TaskRunEventRecord, key: string): string {
+  const value = event.data?.[key];
+  return typeof value === "string" ? value.trim() : "";
 }
 
 export function isVisibleRunEvent(event: TaskRunEventRecord): boolean {


### PR DESCRIPTION
## Summary

- Rename approval actions in task details to `Approve and resume` / `Reject and stop` so the operator sees the runtime consequence before clicking.
- Render rejected approvals as an explicit `Approval rejected` outcome instead of a generic last-error row.
- Label approval-resolution and approval-rejected cancellation events distinctly in the run timeline.
- Add focused helper and TaskDetail coverage for the rejection lifecycle UI.

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run test`