### PR TITLE
fix(runtime): apply terminal run transitions atomically

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -82,7 +82,7 @@ Per-run state SSE (`/hecate/v1/tasks/{id}/runs/{run_id}/stream`) emits
 
 ## Runtime snapshot payloads
 
-Every event written by the orchestrator (`emitRunEvent`) automatically merges three keys into its `data` map:
+Most events written through the runner event helper (`emitRunEvent`) automatically merge three keys into the persisted `data` map:
 
 | Key         | Type             | Notes                                                               |
 | ----------- | ---------------- | ------------------------------------------------------------------- |
@@ -90,10 +90,16 @@ Every event written by the orchestrator (`emitRunEvent`) automatically merges th
 | `steps`     | `[]TaskStep`     | Every step recorded for this run so far                             |
 | `artifacts` | `[]TaskArtifact` | Every artifact recorded for this run so far                         |
 
-The per-run state SSE decoder uses those keys to reconstruct complete operator
-snapshots without a separate fetch. Public event-list and cross-run-feed
+The per-run state SSE decoder can use those keys to reconstruct complete
+operator snapshots without a separate fetch. Public event-list and cross-run-feed
 responses intentionally strip these runtime snapshot keys and return compact,
 protocol-shaped `data` payloads instead.
+
+Store-level terminal transitions (`run.finished`, `run.failed`,
+`run.cancelled`, `approval.resolved`, and `task.updated` events emitted while
+atomically terminalizing a run) persist only their event-specific keys. The
+per-run state SSE handler rebuilds the final run/step/artifact/approval snapshot
+from storage after reading those terminal events.
 
 Caller-driven events (`POST /hecate/v1/tasks/.../events`) instead serialize the rebuilt stream state under a `snapshot` key. The decoder in the per-run SSE handler honors both shapes; public event envelopes strip `snapshot` for the same reason they strip `run` / `steps` / `artifacts`.
 
@@ -153,8 +159,9 @@ A worker claimed the run and started executing. For resumed runs the payload car
 ### `run.finished` / `run.failed`
 
 Terminal status emit. Successful runs emit `run.finished`; failed runs emit
-`run.failed`. Read `data.run.status` or the `status` extra for the persisted
-run status.
+`run.failed`. Public event envelopes expose `data.final_status="completed"` for
+`run.finished`; raw persisted terminal payloads carry the `status` / `error`
+extras below.
 
 | Extra key | Type     | Notes                                                     |
 | --------- | -------- | --------------------------------------------------------- |

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -1,0 +1,226 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTaskApprovalCancelTerminalStateE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=shell_exec",
+	)
+
+	taskID := e2eCreateApprovalShellTask(t, baseURL, workDir)
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/start", `{}`)
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("started run status = %q, want awaiting_approval", started.Data.Status)
+	}
+
+	approvals := getJSON[e2eTaskApprovalsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/approvals")
+	if len(approvals.Data) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(approvals.Data))
+	}
+	if approvals.Data[0].Status != "pending" {
+		t.Fatalf("approval status = %q, want pending", approvals.Data[0].Status)
+	}
+
+	cancelled := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/cancel", `{"reason":"operator stop"}`)
+	if cancelled.Data.Status != "cancelled" {
+		t.Fatalf("cancelled run status = %q, want cancelled", cancelled.Data.Status)
+	}
+	if !strings.Contains(cancelled.Data.LastError, "operator stop") {
+		t.Fatalf("cancelled run last_error = %q, want operator stop", cancelled.Data.LastError)
+	}
+
+	afterCancel := getJSON[e2eTaskApprovalsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/approvals")
+	if len(afterCancel.Data) != 1 {
+		t.Fatalf("approvals after cancel = %d, want 1", len(afterCancel.Data))
+	}
+	if afterCancel.Data[0].Status != "cancelled" || afterCancel.Data[0].ResolvedBy != "system" {
+		t.Fatalf("approval after cancel = %+v, want system-cancelled", afterCancel.Data[0])
+	}
+
+	steps := getJSON[e2eTaskStepsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/steps")
+	for _, step := range steps.Data {
+		if step.Status == "awaiting_approval" || step.Status == "running" {
+			t.Fatalf("active step after cancel = %+v, want terminal/non-active step state", step)
+		}
+	}
+
+	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/events")
+	assertE2EEventOrder(t, events.Data, []string{"run.created", "approval.requested", "run.awaiting_approval", "approval.resolved", "run.cancelled", "task.updated"})
+	assertE2EApprovalResolved(t, events.Data, approvals.Data[0].ID, "cancelled", "system")
+
+	finalSnapshot := e2eReadTerminalTaskRunSnapshot(t, baseURL, taskID, started.Data.ID)
+	if finalSnapshot.Data.Run.Status != "cancelled" {
+		t.Fatalf("terminal stream run status = %q, want cancelled", finalSnapshot.Data.Run.Status)
+	}
+	if finalSnapshot.Data.Terminal != true {
+		t.Fatalf("terminal stream flag = false, want true")
+	}
+	if len(finalSnapshot.Data.Approvals) != 1 {
+		t.Fatalf("terminal stream approvals = %d, want 1", len(finalSnapshot.Data.Approvals))
+	}
+	if finalSnapshot.Data.Approvals[0].Status != "cancelled" {
+		t.Fatalf("terminal stream approval status = %q, want cancelled", finalSnapshot.Data.Approvals[0].Status)
+	}
+	for _, approval := range finalSnapshot.Data.Approvals {
+		if approval.Status == "pending" {
+			t.Fatalf("terminal stream carried pending approval: %+v", approval)
+		}
+	}
+	for _, step := range finalSnapshot.Data.Steps {
+		if step.Status == "awaiting_approval" || step.Status == "running" {
+			t.Fatalf("terminal stream carried active step: %+v", step)
+		}
+	}
+}
+
+func e2eCreateApprovalShellTask(t *testing.T, baseURL, workDir string) string {
+	t.Helper()
+	body := fmt.Sprintf(`{
+		"title": "approval cancel e2e",
+		"prompt": "cancel before approval",
+		"execution_kind": "shell",
+		"shell_command": "printf 'should-not-run\n'",
+		"working_directory": %q,
+		"sandbox_allowed_root": %q,
+		"workspace_mode": "in_place",
+		"timeout_ms": 10000
+	}`, workDir, workDir)
+	resp := postJSONDecode[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks", body)
+	if resp.Data.ID == "" {
+		t.Fatal("created task id is empty")
+	}
+	return resp.Data.ID
+}
+
+func e2eReadTerminalTaskRunSnapshot(t *testing.T, baseURL, taskID, runID string) e2eTaskRunStreamResponse {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/hecate/v1/tasks/" + taskID + "/runs/" + runID + "/stream") //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET run stream: %v", err)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		resp.Body.Close()
+		t.Fatalf("stream content-type = %q, want text/event-stream", ct)
+	}
+	events := readSSE(t, resp)
+	deadline := time.Now().Add(1 * time.Second)
+	var last e2eTaskRunStreamResponse
+	for _, event := range events {
+		var payload e2eTaskRunStreamResponse
+		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
+			continue
+		}
+		if payload.Data.Run.ID == "" {
+			continue
+		}
+		last = payload
+		if payload.Data.Terminal || payload.Data.Run.Status == "cancelled" || payload.Data.Run.Status == "failed" || payload.Data.Run.Status == "completed" {
+			return payload
+		}
+	}
+	if time.Now().Before(deadline) && last.Data.Run.ID != "" {
+		return last
+	}
+	t.Fatalf("terminal stream snapshot not found in %d SSE payloads", len(events))
+	return e2eTaskRunStreamResponse{}
+}
+
+func assertE2EEventOrder(t *testing.T, events []e2eEventEnvelope, want []string) {
+	t.Helper()
+	cursor := 0
+	for _, event := range events {
+		if cursor >= len(want) {
+			break
+		}
+		if event.Type == want[cursor] {
+			cursor++
+		}
+	}
+	if cursor == len(want) {
+		return
+	}
+	got := make([]string, 0, len(events))
+	for _, event := range events {
+		got = append(got, event.Type)
+	}
+	t.Fatalf("missing event order tail %v; got %v", want[cursor:], got)
+}
+
+func assertE2EApprovalResolved(t *testing.T, events []e2eEventEnvelope, approvalID, status, by string) {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != "approval.resolved" {
+			continue
+		}
+		if event.Data["approval_id"] == approvalID && event.Data["status"] == status && event.Data["by"] == by {
+			return
+		}
+	}
+	t.Fatalf("approval.resolved approval=%q status=%q by=%q not found in %+v", approvalID, status, by, events)
+}
+
+type e2eTaskResponse struct {
+	Data struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+type e2eTaskRunResponse struct {
+	Data e2eTaskRun `json:"data"`
+}
+
+type e2eTaskRun struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	LastError string `json:"last_error,omitempty"`
+}
+
+type e2eTaskApprovalsResponse struct {
+	Data []e2eTaskApproval `json:"data"`
+}
+
+type e2eTaskApproval struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	ResolvedBy string `json:"resolved_by,omitempty"`
+}
+
+type e2eTaskStepsResponse struct {
+	Data []e2eTaskStep `json:"data"`
+}
+
+type e2eTaskStep struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	ErrorKind string `json:"error_kind,omitempty"`
+}
+
+type e2eTaskEventsResponse struct {
+	Data []e2eEventEnvelope `json:"data"`
+}
+
+type e2eEventEnvelope struct {
+	Type string         `json:"type"`
+	Data map[string]any `json:"data"`
+}
+
+type e2eTaskRunStreamResponse struct {
+	Data struct {
+		Terminal  bool              `json:"terminal,omitempty"`
+		EventType string            `json:"event_type,omitempty"`
+		Run       e2eTaskRun        `json:"run"`
+		Steps     []e2eTaskStep     `json:"steps,omitempty"`
+		Approvals []e2eTaskApproval `json:"approvals,omitempty"`
+	} `json:"data"`
+}

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -84,6 +84,73 @@ func TestTaskApprovalCancelTerminalStateE2E(t *testing.T) {
 	}
 }
 
+func TestTaskApprovalRejectTerminalStateE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=shell_exec",
+	)
+
+	taskID := e2eCreateApprovalShellTask(t, baseURL, workDir)
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/start", `{}`)
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("started run status = %q, want awaiting_approval", started.Data.Status)
+	}
+
+	approvals := getJSON[e2eTaskApprovalsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/approvals")
+	if len(approvals.Data) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(approvals.Data))
+	}
+	if approvals.Data[0].Status != "pending" {
+		t.Fatalf("approval status = %q, want pending", approvals.Data[0].Status)
+	}
+
+	resolved := postJSONDecode[e2eTaskApprovalResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/approvals/"+approvals.Data[0].ID+"/resolve", `{"decision":"reject","note":"not safe"}`)
+	if resolved.Data.Status != "rejected" {
+		t.Fatalf("resolved approval status = %q, want rejected", resolved.Data.Status)
+	}
+	if resolved.Data.ResolvedBy != "operator" || resolved.Data.ResolutionNote != "not safe" {
+		t.Fatalf("resolved approval = %+v, want operator rejection note", resolved.Data)
+	}
+
+	repeated := postJSON(t, baseURL+"/hecate/v1/tasks/"+taskID+"/approvals/"+approvals.Data[0].ID+"/resolve", `{"decision":"approve"}`, nil)
+	if repeated.StatusCode != http.StatusConflict {
+		t.Fatalf("repeat resolve status = %d, want 409; body=%s", repeated.StatusCode, readBody(t, repeated))
+	}
+	repeated.Body.Close()
+
+	run := getJSON[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID)
+	if run.Data.Status != "cancelled" || run.Data.LastError != "approval rejected" {
+		t.Fatalf("run after reject = %+v, want cancelled approval rejected", run.Data)
+	}
+	task := getJSON[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks/"+taskID)
+	if task.Data.Status != "cancelled" || task.Data.LastError != "approval rejected" {
+		t.Fatalf("task after reject = %+v, want cancelled approval rejected", task.Data)
+	}
+
+	steps := getJSON[e2eTaskStepsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/steps")
+	for _, step := range steps.Data {
+		if step.Status == "awaiting_approval" || step.Status == "running" {
+			t.Fatalf("active step after reject = %+v, want terminal/non-active step state", step)
+		}
+	}
+
+	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/events")
+	assertE2EEventTypes(t, events.Data, "approval.resolved", "run.cancelled", "task.updated")
+	assertE2EApprovalResolved(t, events.Data, approvals.Data[0].ID, "rejected", "operator")
+
+	finalSnapshot := e2eReadTerminalTaskRunSnapshot(t, baseURL, taskID, started.Data.ID)
+	if finalSnapshot.Data.Run.Status != "cancelled" || finalSnapshot.Data.Run.LastError != "approval rejected" {
+		t.Fatalf("terminal stream run = %+v, want cancelled approval rejected", finalSnapshot.Data.Run)
+	}
+	if !finalSnapshot.Data.Terminal {
+		t.Fatalf("terminal stream flag = false, want true")
+	}
+	if len(finalSnapshot.Data.Approvals) != 1 || finalSnapshot.Data.Approvals[0].Status != "rejected" {
+		t.Fatalf("terminal stream approvals = %+v, want one rejected approval", finalSnapshot.Data.Approvals)
+	}
+}
+
 func e2eCreateApprovalShellTask(t *testing.T, baseURL, workDir string) string {
 	t.Helper()
 	body := fmt.Sprintf(`{
@@ -170,9 +237,28 @@ func assertE2EApprovalResolved(t *testing.T, events []e2eEventEnvelope, approval
 	t.Fatalf("approval.resolved approval=%q status=%q by=%q not found in %+v", approvalID, status, by, events)
 }
 
+func assertE2EEventTypes(t *testing.T, events []e2eEventEnvelope, want ...string) {
+	t.Helper()
+	seen := make(map[string]bool, len(events))
+	for _, event := range events {
+		seen[event.Type] = true
+	}
+	for _, eventType := range want {
+		if !seen[eventType] {
+			got := make([]string, 0, len(events))
+			for _, event := range events {
+				got = append(got, event.Type)
+			}
+			t.Fatalf("missing event %q; got %v", eventType, got)
+		}
+	}
+}
+
 type e2eTaskResponse struct {
 	Data struct {
-		ID string `json:"id"`
+		ID        string `json:"id"`
+		Status    string `json:"status,omitempty"`
+		LastError string `json:"last_error,omitempty"`
 	} `json:"data"`
 }
 
@@ -190,10 +276,15 @@ type e2eTaskApprovalsResponse struct {
 	Data []e2eTaskApproval `json:"data"`
 }
 
+type e2eTaskApprovalResponse struct {
+	Data e2eTaskApproval `json:"data"`
+}
+
 type e2eTaskApproval struct {
-	ID         string `json:"id"`
-	Status     string `json:"status"`
-	ResolvedBy string `json:"resolved_by,omitempty"`
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	ResolvedBy     string `json:"resolved_by,omitempty"`
+	ResolutionNote string `json:"resolution_note,omitempty"`
 }
 
 type e2eTaskStepsResponse struct {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -753,66 +753,25 @@ func (r *Runner) cancelRunWithMessage(ctx context.Context, task types.Task, run 
 	}
 
 	now := time.Now().UTC()
-	cancelledApprovals := r.cancelPendingApprovalsForRun(ctx, task, run, message, now)
-
-	run.Status = "cancelled"
-	run.LastError = message
-	run.FinishedAt = now
-	run.OtelStatusCode = "error"
-	run.OtelStatusMessage = message
-	if requestID != "" {
-		run.RequestID = requestID
-	}
-	if traceID != "" {
-		run.TraceID = traceID
-	}
-	var err error
-	run, err = r.store.UpdateRun(ctx, run)
+	result, err := r.applyTerminalRunTransition(ctx, terminalRunTransition{
+		Task:                     task,
+		Run:                      run,
+		Status:                   "cancelled",
+		Message:                  message,
+		RequestID:                requestID,
+		TraceID:                  traceID,
+		Trace:                    trace,
+		Now:                      now,
+		CancelActiveSteps:        true,
+		CancelStreamingArtifacts: true,
+		CancelPendingApprovals:   true,
+		EmitTaskUpdated:          true,
+		EventData:                map[string]any{"reason": message},
+	})
 	if err != nil {
 		return types.TaskRun{}, err
 	}
-
-	steps, _ := r.store.ListSteps(ctx, run.ID)
-	for _, step := range steps {
-		if step.Status == "running" || step.Status == "awaiting_approval" {
-			step.Status = "cancelled"
-			step.Result = telemetry.ResultError
-			step.Error = message
-			step.ErrorKind = "run_cancelled"
-			step.FinishedAt = now
-			_, _ = r.store.UpdateStep(ctx, step)
-		}
-	}
-
-	artifacts, _ := r.store.ListArtifacts(ctx, taskstate.ArtifactFilter{TaskID: task.ID, RunID: run.ID})
-	for _, artifact := range artifacts {
-		if artifact.Status == "streaming" {
-			artifact.Status = "cancelled"
-			_, _ = r.store.UpdateArtifact(ctx, artifact)
-		}
-	}
-
-	task.Status = "cancelled"
-	task.LatestRunID = run.ID
-	task.LastError = message
-	if task.StartedAt.IsZero() {
-		task.StartedAt = run.StartedAt
-	}
-	task.FinishedAt = now
-	task.UpdatedAt = now
-	if requestID != "" {
-		task.LatestRequestID = requestID
-	}
-	if traceID != "" {
-		task.LatestTraceID = traceID
-	}
-	if _, err := r.store.UpdateTask(ctx, task); err != nil {
-		return types.TaskRun{}, err
-	}
-	r.emitApprovalResolvedEventsForRun(ctx, trace, task, run, cancelledApprovals, requestID, traceID)
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.cancelled", requestID, traceID, map[string]any{"reason": message})
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "task.updated", requestID, traceID, nil)
-	return run, nil
+	return result.Run, nil
 }
 
 // Shutdown stops the runner's queue workers, cancels every in-flight
@@ -1027,41 +986,35 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		// than overwriting it with zero.
 		run.TotalCostMicrosUSD = execution.CostMicrosUSD
 	}
-	emitTerminalEvent := true
-	if currentRun, found, err := r.store.GetRun(ctx, task.ID, run.ID); err == nil && found {
-		// CancelRun persists the terminal cancelled state and emits the
-		// authoritative run.cancelled event while the worker may still be
-		// unwinding. Keep persisting the latest run/task snapshots here, but
-		// don't emit a duplicate terminal event if the same status is already
-		// stored.
-		if types.IsTerminalTaskRunStatus(currentRun.Status) && currentRun.Status == run.Status {
-			emitTerminalEvent = false
-		}
-	}
-	if _, err := r.store.UpdateRun(ctx, run); err != nil {
+	transition, err := r.applyTerminalRunTransition(ctx, terminalRunTransition{
+		Task:                   task,
+		Run:                    run,
+		Status:                 run.Status,
+		Message:                execution.LastError,
+		RequestID:              requestID,
+		TraceID:                trace.TraceID,
+		Trace:                  trace,
+		Now:                    finishedAt,
+		SuppressDuplicateEvent: true,
+		UpdateRun: func(target *types.TaskRun) {
+			target.Provider = run.Provider
+			target.ProviderKind = run.ProviderKind
+			target.Model = run.Model
+			target.StepCount = len(persistedSteps)
+			target.ArtifactCount = len(persistedArtifacts)
+			target.TotalCostMicrosUSD = run.TotalCostMicrosUSD
+			target.OtelStatusCode = run.OtelStatusCode
+			target.OtelStatusMessage = run.OtelStatusMessage
+		},
+		UpdateTask: func(target *types.Task) {
+			target.RootTraceID = trace.TraceID
+		},
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	task.LatestRunID = run.ID
-	task.Status = run.Status
-	if task.StartedAt.IsZero() {
-		task.StartedAt = run.StartedAt
-	}
-	task.FinishedAt = finishedAt
-	task.UpdatedAt = finishedAt
-	task.RootTraceID = trace.TraceID
-	task.LatestTraceID = trace.TraceID
-	task.LatestRequestID = requestID
-	task.LastError = execution.LastError
-	if _, err := r.store.UpdateTask(ctx, task); err != nil {
-		return nil, err
-	}
-	if emitTerminalEvent {
-		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, terminalRunEventType(run.Status), requestID, trace.TraceID, map[string]any{
-			"error":  run.LastError,
-			"status": run.Status,
-		})
-	}
+	task = transition.Task
+	run = transition.Run
 
 	return &StartTaskResult{
 		Task:      task,

--- a/internal/orchestrator/runner_approval_lifecycle_test.go
+++ b/internal/orchestrator/runner_approval_lifecycle_test.go
@@ -283,8 +283,7 @@ func TestRunnerCancelRun_CancelsPendingApprovalAndAwaitingStep(t *testing.T) {
 			events := listApprovalLifecycleEvents(t, ctx, tc.store, task.ID, run.ID)
 			assertEventType(t, events, "run.cancelled")
 			assertApprovalEvent(t, events, "cancelled")
-			assertApprovalEventRunStatus(t, events, "cancelled", "cancelled")
-			assertApprovalEventStepStatus(t, events, "cancelled", step.ID, "cancelled")
+			assertApprovalEventNoSnapshot(t, events, "cancelled")
 			assertEventType(t, events, "task.updated")
 		})
 	}
@@ -424,6 +423,19 @@ func assertApprovalEventStepStatus(t *testing.T, events []types.TaskRunEvent, de
 		}
 	}
 	t.Fatalf("approval.resolved %q missing step %q in %+v", decision, stepID, steps)
+}
+
+func assertApprovalEventNoSnapshot(t *testing.T, events []types.TaskRunEvent, decision string) {
+	t.Helper()
+	event := approvalEvent(t, events, decision)
+	if event == nil {
+		t.Fatalf("missing approval.resolved decision %q in events %+v", decision, events)
+	}
+	for _, key := range []string{"run", "steps", "artifacts", "snapshot"} {
+		if _, ok := event.Data[key]; ok {
+			t.Fatalf("approval.resolved %q carried %q snapshot data: %+v", decision, key, event.Data)
+		}
+	}
 }
 
 func approvalEvent(t *testing.T, events []types.TaskRunEvent, decision string) *types.TaskRunEvent {

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -108,7 +108,7 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		return nil, err
 	}
 
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, approvalResolvedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, types.ApprovalResolvedEventData(approval))
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.queued", requestID, trace.TraceID, map[string]any{"resume": true})
 
 	if err := r.enqueueRun(task.ID, run.ID); err != nil {
@@ -225,18 +225,6 @@ func normalizeApprovalDecision(decision string) (string, error) {
 	}
 }
 
-func approvalResolvedEventData(approval types.TaskApproval) map[string]any {
-	return map[string]any{
-		"approval_id": approval.ID,
-		"decision":    approval.Status,
-		"by":          approval.ResolvedBy,
-		"comment":     approval.ResolutionNote,
-		"scope":       "once",
-		"kind":        approval.Kind,
-		"status":      approval.Status,
-	}
-}
-
 func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, approval types.TaskApproval, idgen func(prefix string) string) (*StartTaskResult, error) {
 	if r.store == nil {
 		return nil, fmt.Errorf("task store is not configured")
@@ -285,7 +273,7 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 	if err != nil {
 		return nil, err
 	}
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, approvalResolvedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, types.ApprovalResolvedEventData(approval))
 	return &StartTaskResult{
 		Task:    task,
 		Run:     run,

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -294,43 +294,6 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 	}, nil
 }
 
-func (r *Runner) cancelPendingApprovalsForRun(ctx context.Context, task types.Task, run types.TaskRun, message string, now time.Time) []types.TaskApproval {
-	approvals, err := r.store.ListApprovals(ctx, task.ID)
-	if err != nil {
-		return nil
-	}
-	cancelled := make([]types.TaskApproval, 0, len(approvals))
-	for _, approval := range approvals {
-		if approval.RunID != run.ID || approval.Status != "pending" {
-			continue
-		}
-		approval.Status = "cancelled"
-		approval.ResolutionNote = message
-		approval.ResolvedBy = "system"
-		approval.ResolvedAt = now
-		updated, ok, err := r.store.UpdatePendingApproval(ctx, approval)
-		if err != nil {
-			continue
-		}
-		if !ok {
-			continue
-		}
-		cancelled = append(cancelled, updated)
-	}
-	return cancelled
-}
-
-func (r *Runner) emitApprovalResolvedEventsForRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, approvals []types.TaskApproval, requestID, traceID string) {
-	for _, updated := range approvals {
-		waitMS := int64(0)
-		if !updated.CreatedAt.IsZero() {
-			waitMS = updated.ResolvedAt.Sub(updated.CreatedAt).Milliseconds()
-		}
-		r.recordApprovalResolved(ctx, trace, task.ID, run.ID, updated, "cancelled", waitMS)
-		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, traceID, approvalResolvedEventData(updated))
-	}
-}
-
 func (r *Runner) recordApprovalResolved(ctx context.Context, trace *profiler.Trace, taskID, runID string, approval types.TaskApproval, decision string, waitMS int64) {
 	attrs := map[string]any{
 		telemetry.AttrHecatePhase:          "approval",

--- a/internal/orchestrator/runner_io.go
+++ b/internal/orchestrator/runner_io.go
@@ -67,28 +67,27 @@ func (r *Runner) gitSummaryArtifact(ctx context.Context, task types.Task, run ty
 }
 
 func (r *Runner) finalizeFailedRun(ctx context.Context, trace *profiler.Trace, task types.Task, run types.TaskRun, requestID, status, message string) error {
-	if currentRun, found, err := r.store.GetRun(ctx, task.ID, run.ID); err == nil && found {
-		// Cancellation can arrive through the HTTP API while the worker is
-		// still unwinding a cancelled executor. In that case CancelRun has
-		// already persisted the terminal run/task state and emitted the
-		// authoritative run.cancelled event; re-emitting it here creates
-		// duplicate terminal events under racey shutdown/cancel timing.
-		if types.IsTerminalTaskRunStatus(currentRun.Status) && currentRun.Status == status {
-			return nil
-		}
-	}
 	now := time.Now().UTC()
 	var failedRunDurationMS int64
 	if !run.StartedAt.IsZero() {
 		failedRunDurationMS = now.Sub(run.StartedAt).Milliseconds()
 	}
-	run.Status = status
-	run.LastError = message
-	run.FinishedAt = now
-	run.OtelStatusCode = "error"
-	run.OtelStatusMessage = message
-	if _, err := r.store.UpdateRun(ctx, run); err != nil {
+	result, err := r.applyTerminalRunTransition(ctx, terminalRunTransition{
+		Task:                       task,
+		Run:                        run,
+		Status:                     status,
+		Message:                    message,
+		RequestID:                  requestID,
+		TraceID:                    trace.TraceID,
+		Trace:                      trace,
+		Now:                        now,
+		SkipIfStoredTerminalStatus: true,
+	})
+	if err != nil {
 		return err
+	}
+	if result.Skipped {
+		return nil
 	}
 	r.metrics.RecordRun(ctx, telemetry.RunMetricsRecord{
 		TaskID:        task.ID,
@@ -98,16 +97,7 @@ func (r *Runner) finalizeFailedRun(ctx context.Context, trace *profiler.Trace, t
 		Model:         run.Model,
 		DurationMS:    failedRunDurationMS,
 	})
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, terminalRunEventType(status), requestID, trace.TraceID, map[string]any{"error": message, "status": status})
-	task.Status = status
-	task.LatestRunID = run.ID
-	task.LastError = message
-	task.FinishedAt = now
-	task.UpdatedAt = now
-	task.LatestTraceID = trace.TraceID
-	task.LatestRequestID = requestID
-	_, err := r.store.UpdateTask(ctx, task)
-	return err
+	return nil
 }
 
 func (r *Runner) upsertStep(ctx context.Context, step types.TaskStep) error {

--- a/internal/orchestrator/runner_terminal.go
+++ b/internal/orchestrator/runner_terminal.go
@@ -1,0 +1,151 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type terminalRunTransition struct {
+	Task      types.Task
+	Run       types.TaskRun
+	Status    string
+	Message   string
+	RequestID string
+	TraceID   string
+	Trace     *profiler.Trace
+	Now       time.Time
+
+	CancelActiveSteps          bool
+	CancelStreamingArtifacts   bool
+	CancelPendingApprovals     bool
+	EmitTaskUpdated            bool
+	SuppressDuplicateEvent     bool
+	SkipIfStoredTerminalStatus bool
+
+	UpdateRun  func(*types.TaskRun)
+	UpdateTask func(*types.Task)
+
+	EventData map[string]any
+}
+
+type terminalRunTransitionResult struct {
+	Task    types.Task
+	Run     types.TaskRun
+	Skipped bool
+}
+
+func (r *Runner) applyTerminalRunTransition(ctx context.Context, tr terminalRunTransition) (terminalRunTransitionResult, error) {
+	if tr.Now.IsZero() {
+		tr.Now = time.Now().UTC()
+	}
+	emitTerminalEvent := true
+	if currentRun, found, err := r.store.GetRun(ctx, tr.Task.ID, tr.Run.ID); err == nil && found {
+		if types.IsTerminalTaskRunStatus(currentRun.Status) && currentRun.Status == tr.Status {
+			if tr.SkipIfStoredTerminalStatus {
+				return terminalRunTransitionResult{Task: tr.Task, Run: currentRun, Skipped: true}, nil
+			}
+			if tr.SuppressDuplicateEvent {
+				emitTerminalEvent = false
+			}
+		}
+	}
+
+	run := tr.Run
+	run.Status = tr.Status
+	run.LastError = tr.Message
+	run.FinishedAt = tr.Now
+	if tr.Status == "completed" {
+		run.OtelStatusCode = firstNonEmpty(run.OtelStatusCode, "ok")
+	} else {
+		run.OtelStatusCode = "error"
+		run.OtelStatusMessage = tr.Message
+	}
+	if tr.RequestID != "" {
+		run.RequestID = tr.RequestID
+	}
+	if tr.TraceID != "" {
+		run.TraceID = tr.TraceID
+	}
+	if tr.UpdateRun != nil {
+		tr.UpdateRun(&run)
+	}
+	task := tr.Task
+	task.Status = tr.Status
+	task.LatestRunID = run.ID
+	task.LastError = tr.Message
+	if task.StartedAt.IsZero() {
+		task.StartedAt = run.StartedAt
+	}
+	task.FinishedAt = tr.Now
+	task.UpdatedAt = tr.Now
+	if tr.RequestID != "" {
+		task.LatestRequestID = tr.RequestID
+	}
+	if tr.TraceID != "" {
+		task.LatestTraceID = tr.TraceID
+	}
+	if tr.UpdateTask != nil {
+		tr.UpdateTask(&task)
+	}
+
+	var terminalEvent *taskstate.RunEventSpec
+	if emitTerminalEvent {
+		data := tr.EventData
+		if data == nil {
+			data = map[string]any{"error": tr.Message, "status": tr.Status}
+		}
+		terminalEvent = &taskstate.RunEventSpec{
+			EventType: terminalRunEventType(run.Status),
+			Data:      data,
+			RequestID: tr.RequestID,
+			TraceID:   tr.TraceID,
+			CreatedAt: tr.Now,
+		}
+	}
+	var taskUpdatedEvent *taskstate.RunEventSpec
+	if tr.EmitTaskUpdated {
+		taskUpdatedEvent = &taskstate.RunEventSpec{
+			EventType: "task.updated",
+			RequestID: tr.RequestID,
+			TraceID:   tr.TraceID,
+			CreatedAt: tr.Now,
+		}
+	}
+	result, err := r.store.ApplyRunTerminalTransition(ctx, taskstate.TerminalRunTransition{
+		Task:                          task,
+		Run:                           run,
+		FinishedAt:                    tr.Now,
+		CancelActiveSteps:             tr.CancelActiveSteps,
+		ActiveStepError:               tr.Message,
+		ActiveStepErrorKind:           "run_cancelled",
+		ActiveStepResult:              telemetry.ResultError,
+		CancelStreamingArtifacts:      tr.CancelStreamingArtifacts,
+		CancelPendingApprovals:        tr.CancelPendingApprovals,
+		PendingApprovalStatus:         "cancelled",
+		PendingApprovalResolvedBy:     "system",
+		PendingApprovalResolutionNote: tr.Message,
+		ApprovalResolvedEventType:     "approval.resolved",
+		TerminalEvent:                 terminalEvent,
+		TaskUpdatedEvent:              taskUpdatedEvent,
+	})
+	if err != nil {
+		return terminalRunTransitionResult{}, err
+	}
+	for _, approval := range result.CancelledApprovals {
+		waitMS := int64(0)
+		if !approval.CreatedAt.IsZero() {
+			waitMS = approval.ResolvedAt.Sub(approval.CreatedAt).Milliseconds()
+		}
+		r.recordApprovalResolved(ctx, tr.Trace, result.Task.ID, result.Run.ID, approval, "cancelled", waitMS)
+	}
+
+	return terminalRunTransitionResult{
+		Task: result.Task,
+		Run:  result.Run,
+	}, nil
+}

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -49,6 +49,10 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreListEventsCrossRunFilters(t, factory(t))
 	})
+	t.Run(name+"/ApplyRunTerminalTransition", func(t *testing.T) {
+		t.Parallel()
+		runStoreApplyRunTerminalTransition(t, factory(t))
+	})
 	t.Run(name+"/ListRunsByFilterStatusSet", func(t *testing.T) {
 		t.Parallel()
 		runStoreListRunsByFilterStatusSet(t, factory(t))
@@ -436,6 +440,213 @@ func runStoreListEventsCrossRunFilters(t *testing.T, store Store) {
 			t.Fatalf("len = %d, want 2 (limit honored)", len(events))
 		}
 	})
+}
+
+func runStoreApplyRunTerminalTransition(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Minute)
+	finishedAt := now.Add(time.Minute)
+	task := types.Task{
+		ID:        "task-terminal",
+		Status:    "awaiting_approval",
+		CreatedAt: now,
+		UpdatedAt: now,
+		StartedAt: now,
+	}
+	run := types.TaskRun{
+		ID:        "run-terminal",
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "awaiting_approval",
+		StartedAt: now,
+		RequestID: "req-terminal",
+		TraceID:   "trace-terminal",
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	awaitingStep := types.TaskStep{
+		ID:        "step-awaiting",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Index:     1,
+		Status:    "awaiting_approval",
+		StartedAt: now,
+	}
+	doneStep := types.TaskStep{
+		ID:        "step-done",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Index:     2,
+		Status:    "completed",
+		StartedAt: now,
+	}
+	if _, err := store.AppendStep(ctx, awaitingStep); err != nil {
+		t.Fatalf("AppendStep(awaiting): %v", err)
+	}
+	if _, err := store.AppendStep(ctx, doneStep); err != nil {
+		t.Fatalf("AppendStep(done): %v", err)
+	}
+	approval := types.TaskApproval{
+		ID:          "approval-terminal",
+		TaskID:      task.ID,
+		RunID:       run.ID,
+		StepID:      awaitingStep.ID,
+		Kind:        "tool_call",
+		Status:      "pending",
+		RequestedBy: "agent",
+		CreatedAt:   now,
+	}
+	if _, err := store.CreateApproval(ctx, approval); err != nil {
+		t.Fatalf("CreateApproval: %v", err)
+	}
+	streamingArtifact := types.TaskArtifact{
+		ID:        "artifact-streaming",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Status:    "streaming",
+		CreatedAt: now,
+	}
+	readyArtifact := types.TaskArtifact{
+		ID:        "artifact-ready",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Status:    "ready",
+		CreatedAt: now,
+	}
+	if _, err := store.CreateArtifact(ctx, streamingArtifact); err != nil {
+		t.Fatalf("CreateArtifact(streaming): %v", err)
+	}
+	if _, err := store.CreateArtifact(ctx, readyArtifact); err != nil {
+		t.Fatalf("CreateArtifact(ready): %v", err)
+	}
+
+	run.Status = "cancelled"
+	run.LastError = "run cancelled: operator stop"
+	run.FinishedAt = finishedAt
+	run.OtelStatusCode = "error"
+	run.OtelStatusMessage = run.LastError
+	task.Status = "cancelled"
+	task.LatestRunID = run.ID
+	task.LastError = run.LastError
+	task.FinishedAt = finishedAt
+	task.UpdatedAt = finishedAt
+	result, err := store.ApplyRunTerminalTransition(ctx, TerminalRunTransition{
+		Task:                          task,
+		Run:                           run,
+		FinishedAt:                    finishedAt,
+		CancelActiveSteps:             true,
+		ActiveStepResult:              "error",
+		ActiveStepError:               run.LastError,
+		ActiveStepErrorKind:           "run_cancelled",
+		CancelStreamingArtifacts:      true,
+		CancelPendingApprovals:        true,
+		PendingApprovalStatus:         "cancelled",
+		PendingApprovalResolvedBy:     "system",
+		PendingApprovalResolutionNote: run.LastError,
+		ApprovalResolvedEventType:     "approval.resolved",
+		TerminalEvent: &RunEventSpec{
+			EventType: "run.cancelled",
+			Data:      map[string]any{"reason": run.LastError},
+			RequestID: run.RequestID,
+			TraceID:   run.TraceID,
+			CreatedAt: finishedAt,
+		},
+		TaskUpdatedEvent: &RunEventSpec{
+			EventType: "task.updated",
+			RequestID: run.RequestID,
+			TraceID:   run.TraceID,
+			CreatedAt: finishedAt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRunTerminalTransition: %v", err)
+	}
+	if result.Run.Status != "cancelled" || result.Task.Status != "cancelled" {
+		t.Fatalf("result statuses task=%q run=%q, want cancelled/cancelled", result.Task.Status, result.Run.Status)
+	}
+	if len(result.CancelledApprovals) != 1 || result.CancelledApprovals[0].Status != "cancelled" {
+		t.Fatalf("cancelled approvals = %+v, want one cancelled", result.CancelledApprovals)
+	}
+	if result.CancelledApprovals[0].ResolvedBy != "system" || result.CancelledApprovals[0].ResolutionNote != run.LastError {
+		t.Fatalf("cancelled approval resolution = %+v", result.CancelledApprovals[0])
+	}
+
+	storedRun, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%v err=%v", found, err)
+	}
+	if storedRun.Status != "cancelled" || storedRun.LastError != run.LastError {
+		t.Fatalf("stored run = %+v, want cancelled with last_error", storedRun)
+	}
+	storedTask, found, err := store.GetTask(ctx, task.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask: found=%v err=%v", found, err)
+	}
+	if storedTask.Status != "cancelled" || storedTask.LastError != run.LastError {
+		t.Fatalf("stored task = %+v, want cancelled with last_error", storedTask)
+	}
+	storedAwaitingStep, found, err := store.GetStep(ctx, run.ID, awaitingStep.ID)
+	if err != nil || !found {
+		t.Fatalf("GetStep(awaiting): found=%v err=%v", found, err)
+	}
+	if storedAwaitingStep.Status != "cancelled" || storedAwaitingStep.ErrorKind != "run_cancelled" {
+		t.Fatalf("awaiting step = %+v, want cancelled run_cancelled", storedAwaitingStep)
+	}
+	storedDoneStep, found, err := store.GetStep(ctx, run.ID, doneStep.ID)
+	if err != nil || !found {
+		t.Fatalf("GetStep(done): found=%v err=%v", found, err)
+	}
+	if storedDoneStep.Status != "completed" {
+		t.Fatalf("done step status = %q, want completed", storedDoneStep.Status)
+	}
+	storedStreamingArtifact, found, err := store.GetArtifact(ctx, task.ID, streamingArtifact.ID)
+	if err != nil || !found {
+		t.Fatalf("GetArtifact(streaming): found=%v err=%v", found, err)
+	}
+	if storedStreamingArtifact.Status != "cancelled" {
+		t.Fatalf("streaming artifact status = %q, want cancelled", storedStreamingArtifact.Status)
+	}
+	storedReadyArtifact, found, err := store.GetArtifact(ctx, task.ID, readyArtifact.ID)
+	if err != nil || !found {
+		t.Fatalf("GetArtifact(ready): found=%v err=%v", found, err)
+	}
+	if storedReadyArtifact.Status != "ready" {
+		t.Fatalf("ready artifact status = %q, want ready", storedReadyArtifact.Status)
+	}
+
+	events, err := store.ListRunEvents(ctx, task.ID, run.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	wantTypes := []string{"approval.resolved", "run.cancelled", "task.updated"}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("events len = %d, want %d: %+v", len(events), len(wantTypes), events)
+	}
+	for i, want := range wantTypes {
+		if events[i].EventType != want {
+			t.Fatalf("event[%d] type = %q, want %q", i, events[i].EventType, want)
+		}
+		if events[i].Sequence <= 0 {
+			t.Fatalf("event[%d] sequence = %d, want positive", i, events[i].Sequence)
+		}
+		rawRun, ok := events[i].Data["run"].(map[string]any)
+		if ok {
+			if rawRun["Status"] != "cancelled" {
+				t.Fatalf("event[%d] run status = %v, want cancelled", i, rawRun["Status"])
+			}
+		} else if typedRun, ok := events[i].Data["run"].(types.TaskRun); ok {
+			if typedRun.Status != "cancelled" {
+				t.Fatalf("event[%d] run status = %q, want cancelled", i, typedRun.Status)
+			}
+		} else {
+			t.Fatalf("event[%d] missing run snapshot: %+v", i, events[i].Data)
+		}
+	}
 }
 
 func runStoreListRunsByFilterStatusSet(t *testing.T, store Store) {

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -53,6 +53,14 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreApplyRunTerminalTransition(t, factory(t))
 	})
+	t.Run(name+"/ApplyRunTerminalTransitionPreservesChildrenWithoutCancelFlags", func(t *testing.T) {
+		t.Parallel()
+		runStoreApplyRunTerminalTransitionPreservesChildrenWithoutCancelFlags(t, factory(t))
+	})
+	t.Run(name+"/ApplyRunTerminalTransitionRequiresStoredRunTaskMatch", func(t *testing.T) {
+		t.Parallel()
+		runStoreApplyRunTerminalTransitionRequiresStoredRunTaskMatch(t, factory(t))
+	})
 	t.Run(name+"/ListRunsByFilterStatusSet", func(t *testing.T) {
 		t.Parallel()
 		runStoreListRunsByFilterStatusSet(t, factory(t))
@@ -653,6 +661,222 @@ func assertNoTerminalEventSnapshot(t *testing.T, event types.TaskRunEvent) {
 		if _, ok := event.Data[key]; ok {
 			t.Fatalf("%s event carried %q snapshot data: %+v", event.EventType, key, event.Data)
 		}
+	}
+}
+
+func runStoreApplyRunTerminalTransitionPreservesChildrenWithoutCancelFlags(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Minute)
+	finishedAt := now.Add(time.Minute)
+	task := types.Task{
+		ID:        "task-terminal-preserve",
+		Status:    "running",
+		CreatedAt: now,
+		UpdatedAt: now,
+		StartedAt: now,
+	}
+	run := types.TaskRun{
+		ID:        "run-terminal-preserve",
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "running",
+		StartedAt: now,
+		RequestID: "req-terminal-preserve",
+		TraceID:   "trace-terminal-preserve",
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	runningStep := types.TaskStep{
+		ID:        "step-running",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Index:     1,
+		Status:    "running",
+		StartedAt: now,
+	}
+	awaitingStep := types.TaskStep{
+		ID:        "step-awaiting",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Index:     2,
+		Status:    "awaiting_approval",
+		StartedAt: now,
+	}
+	if _, err := store.AppendStep(ctx, runningStep); err != nil {
+		t.Fatalf("AppendStep(running): %v", err)
+	}
+	if _, err := store.AppendStep(ctx, awaitingStep); err != nil {
+		t.Fatalf("AppendStep(awaiting): %v", err)
+	}
+	approval := types.TaskApproval{
+		ID:          "approval-preserved",
+		TaskID:      task.ID,
+		RunID:       run.ID,
+		StepID:      awaitingStep.ID,
+		Kind:        "tool_call",
+		Status:      "pending",
+		RequestedBy: "agent",
+		CreatedAt:   now,
+	}
+	if _, err := store.CreateApproval(ctx, approval); err != nil {
+		t.Fatalf("CreateApproval: %v", err)
+	}
+	artifact := types.TaskArtifact{
+		ID:        "artifact-preserved",
+		TaskID:    task.ID,
+		RunID:     run.ID,
+		Status:    "streaming",
+		CreatedAt: now,
+	}
+	if _, err := store.CreateArtifact(ctx, artifact); err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	run.Status = "completed"
+	run.FinishedAt = finishedAt
+	run.OtelStatusCode = "ok"
+	task.Status = "completed"
+	task.LatestRunID = run.ID
+	task.FinishedAt = finishedAt
+	task.UpdatedAt = finishedAt
+	result, err := store.ApplyRunTerminalTransition(ctx, TerminalRunTransition{
+		Task:       task,
+		Run:        run,
+		FinishedAt: finishedAt,
+		TerminalEvent: &RunEventSpec{
+			EventType: "run.finished",
+			Data:      map[string]any{"status": "completed"},
+			RequestID: run.RequestID,
+			TraceID:   run.TraceID,
+			CreatedAt: finishedAt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRunTerminalTransition: %v", err)
+	}
+	if result.Run.Status != "completed" || result.Task.Status != "completed" {
+		t.Fatalf("result statuses task=%q run=%q, want completed/completed", result.Task.Status, result.Run.Status)
+	}
+	if len(result.CancelledApprovals) != 0 {
+		t.Fatalf("cancelled approvals = %+v, want none without cancel flag", result.CancelledApprovals)
+	}
+
+	storedApproval, found, err := store.GetApproval(ctx, task.ID, approval.ID)
+	if err != nil || !found {
+		t.Fatalf("GetApproval: found=%v err=%v", found, err)
+	}
+	if storedApproval.Status != "pending" || !storedApproval.ResolvedAt.IsZero() {
+		t.Fatalf("stored approval = %+v, want pending/unresolved", storedApproval)
+	}
+	storedRunningStep, found, err := store.GetStep(ctx, run.ID, runningStep.ID)
+	if err != nil || !found {
+		t.Fatalf("GetStep(running): found=%v err=%v", found, err)
+	}
+	if storedRunningStep.Status != "running" {
+		t.Fatalf("running step status = %q, want running", storedRunningStep.Status)
+	}
+	storedAwaitingStep, found, err := store.GetStep(ctx, run.ID, awaitingStep.ID)
+	if err != nil || !found {
+		t.Fatalf("GetStep(awaiting): found=%v err=%v", found, err)
+	}
+	if storedAwaitingStep.Status != "awaiting_approval" {
+		t.Fatalf("awaiting step status = %q, want awaiting_approval", storedAwaitingStep.Status)
+	}
+	storedArtifact, found, err := store.GetArtifact(ctx, task.ID, artifact.ID)
+	if err != nil || !found {
+		t.Fatalf("GetArtifact: found=%v err=%v", found, err)
+	}
+	if storedArtifact.Status != "streaming" {
+		t.Fatalf("artifact status = %q, want streaming", storedArtifact.Status)
+	}
+
+	events, err := store.ListRunEvents(ctx, task.ID, run.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != "run.finished" {
+		t.Fatalf("events = %+v, want only run.finished", events)
+	}
+	assertNoTerminalEventSnapshot(t, events[0])
+	if events[0].Data["status"] != "completed" {
+		t.Fatalf("run.finished data = %+v, want compact status", events[0].Data)
+	}
+}
+
+func runStoreApplyRunTerminalTransitionRequiresStoredRunTaskMatch(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:        "task-terminal-mismatch",
+		Status:    "running",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	otherTask := types.Task{
+		ID:        "task-terminal-owner",
+		Status:    "running",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	run := types.TaskRun{
+		ID:        "run-terminal-mismatch",
+		TaskID:    otherTask.ID,
+		Number:    1,
+		Status:    "running",
+		StartedAt: now,
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask(task): %v", err)
+	}
+	if _, err := store.CreateTask(ctx, otherTask); err != nil {
+		t.Fatalf("CreateTask(other): %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	mismatchedRun := run
+	mismatchedRun.TaskID = task.ID
+	mismatchedRun.Status = "cancelled"
+	mismatchedRun.LastError = "wrong owner"
+	_, err := store.ApplyRunTerminalTransition(ctx, TerminalRunTransition{
+		Task: task,
+		Run:  mismatchedRun,
+		TerminalEvent: &RunEventSpec{
+			EventType: "run.cancelled",
+			Data:      map[string]any{"reason": mismatchedRun.LastError},
+		},
+	})
+	if err == nil {
+		t.Fatal("ApplyRunTerminalTransition succeeded for a run owned by another task")
+	}
+
+	storedTask, found, err := store.GetTask(ctx, task.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(task): found=%v err=%v", found, err)
+	}
+	if storedTask.Status != "running" || storedTask.LastError != "" {
+		t.Fatalf("task after failed transition = %+v, want unchanged running task", storedTask)
+	}
+	storedRun, found, err := store.GetRun(ctx, otherTask.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun(owner): found=%v err=%v", found, err)
+	}
+	if storedRun.TaskID != otherTask.ID || storedRun.Status != "running" || storedRun.LastError != "" {
+		t.Fatalf("run after failed transition = %+v, want unchanged owner/running run", storedRun)
+	}
+	events, err := store.ListRunEvents(ctx, task.ID, run.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents(wrong task): %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events for failed transition = %+v, want none", events)
 	}
 }
 

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -634,17 +634,24 @@ func runStoreApplyRunTerminalTransition(t *testing.T, store Store) {
 		if events[i].Sequence <= 0 {
 			t.Fatalf("event[%d] sequence = %d, want positive", i, events[i].Sequence)
 		}
-		rawRun, ok := events[i].Data["run"].(map[string]any)
-		if ok {
-			if rawRun["Status"] != "cancelled" {
-				t.Fatalf("event[%d] run status = %v, want cancelled", i, rawRun["Status"])
-			}
-		} else if typedRun, ok := events[i].Data["run"].(types.TaskRun); ok {
-			if typedRun.Status != "cancelled" {
-				t.Fatalf("event[%d] run status = %q, want cancelled", i, typedRun.Status)
-			}
-		} else {
-			t.Fatalf("event[%d] missing run snapshot: %+v", i, events[i].Data)
+		assertNoTerminalEventSnapshot(t, events[i])
+	}
+	if got := events[0].Data; got["approval_id"] != approval.ID || got["decision"] != "cancelled" || got["status"] != "cancelled" || got["by"] != "system" {
+		t.Fatalf("approval.resolved data = %+v, want compact cancelled approval data", got)
+	}
+	if got := events[1].Data; got["reason"] != run.LastError {
+		t.Fatalf("run.cancelled data = %+v, want reason %q", got, run.LastError)
+	}
+	if events[2].Data != nil && len(events[2].Data) != 0 {
+		t.Fatalf("task.updated data = %+v, want no extra keys", events[2].Data)
+	}
+}
+
+func assertNoTerminalEventSnapshot(t *testing.T, event types.TaskRunEvent) {
+	t.Helper()
+	for _, key := range []string{"run", "steps", "artifacts", "snapshot"} {
+		if _, ok := event.Data[key]; ok {
+			t.Fatalf("%s event carried %q snapshot data: %+v", event.EventType, key, event.Data)
 		}
 	}
 }

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -507,7 +507,7 @@ func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalR
 			TaskID:    task.ID,
 			RunID:     run.ID,
 			EventType: approvalEventType,
-			Data:      terminalSnapshotData(run, steps, artifacts, approvalResolvedEventData(approval)),
+			Data:      types.ApprovalResolvedEventData(approval),
 			RequestID: tr.Run.RequestID,
 			TraceID:   tr.Run.TraceID,
 			CreatedAt: finishedAt,
@@ -516,12 +516,10 @@ func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalR
 	}
 	if tr.TerminalEvent != nil {
 		event := terminalEventFromSpec(*tr.TerminalEvent, task.ID, run.ID, finishedAt)
-		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
 		events = append(events, s.appendRunEventLocked(event))
 	}
 	if tr.TaskUpdatedEvent != nil {
 		event := terminalEventFromSpec(*tr.TaskUpdatedEvent, task.ID, run.ID, finishedAt)
-		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
 		events = append(events, s.appendRunEventLocked(event))
 	}
 

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -421,6 +421,176 @@ func (s *MemoryStore) AppendRunEvent(_ context.Context, event types.TaskRunEvent
 	return event, nil
 }
 
+func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalRunTransition) (TerminalRunTransitionResult, error) {
+	if err := validateTerminalTransition(tr); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.tasks[tr.Task.ID]; !ok {
+		return TerminalRunTransitionResult{}, fmt.Errorf("task %q not found", tr.Task.ID)
+	}
+	if _, ok := s.runs[tr.Run.ID]; !ok {
+		return TerminalRunTransitionResult{}, fmt.Errorf("run %q not found", tr.Run.ID)
+	}
+
+	finishedAt := terminalTransitionFinishedAt(tr)
+	task := tr.Task
+	run := tr.Run
+	if task.UpdatedAt.IsZero() {
+		task.UpdatedAt = finishedAt
+	}
+	if task.FinishedAt.IsZero() {
+		task.FinishedAt = finishedAt
+	}
+	if run.FinishedAt.IsZero() {
+		run.FinishedAt = finishedAt
+	}
+	s.tasks[task.ID] = task
+	s.runs[run.ID] = run
+
+	cancelledApprovals := make([]types.TaskApproval, 0)
+	if tr.CancelPendingApprovals {
+		status := firstNonEmptyString(tr.PendingApprovalStatus, "cancelled")
+		resolvedBy := firstNonEmptyString(tr.PendingApprovalResolvedBy, "system")
+		note := firstNonEmptyString(tr.PendingApprovalResolutionNote, run.LastError)
+		for id, approval := range s.approvals {
+			if approval.TaskID != task.ID || approval.RunID != run.ID || approval.Status != "pending" {
+				continue
+			}
+			approval.Status = status
+			approval.ResolvedBy = resolvedBy
+			approval.ResolutionNote = note
+			approval.ResolvedAt = finishedAt
+			s.approvals[id] = approval
+			cancelledApprovals = append(cancelledApprovals, approval)
+		}
+		sort.Slice(cancelledApprovals, func(i, j int) bool {
+			return cancelledApprovals[i].CreatedAt.Before(cancelledApprovals[j].CreatedAt)
+		})
+	}
+
+	if tr.CancelActiveSteps {
+		result := firstNonEmptyString(tr.ActiveStepResult, "error")
+		errorKind := firstNonEmptyString(tr.ActiveStepErrorKind, "run_cancelled")
+		stepError := firstNonEmptyString(tr.ActiveStepError, run.LastError)
+		for id, step := range s.steps {
+			if step.RunID != run.ID || (step.Status != "running" && step.Status != "awaiting_approval") {
+				continue
+			}
+			step.Status = "cancelled"
+			step.Result = result
+			step.Error = stepError
+			step.ErrorKind = errorKind
+			step.FinishedAt = finishedAt
+			s.steps[id] = step
+		}
+	}
+
+	if tr.CancelStreamingArtifacts {
+		for id, artifact := range s.artifacts {
+			if artifact.TaskID != task.ID || artifact.RunID != run.ID || artifact.Status != "streaming" {
+				continue
+			}
+			artifact.Status = "cancelled"
+			s.artifacts[id] = artifact
+		}
+	}
+
+	steps := s.listStepsLocked(run.ID)
+	artifacts := s.listArtifactsLocked(ArtifactFilter{TaskID: task.ID, RunID: run.ID})
+	events := make([]types.TaskRunEvent, 0, len(cancelledApprovals)+2)
+	approvalEventType := firstNonEmptyString(tr.ApprovalResolvedEventType, "approval.resolved")
+	for _, approval := range cancelledApprovals {
+		event := types.TaskRunEvent{
+			TaskID:    task.ID,
+			RunID:     run.ID,
+			EventType: approvalEventType,
+			Data:      terminalSnapshotData(run, steps, artifacts, approvalResolvedEventData(approval)),
+			RequestID: tr.Run.RequestID,
+			TraceID:   tr.Run.TraceID,
+			CreatedAt: finishedAt,
+		}
+		events = append(events, s.appendRunEventLocked(event))
+	}
+	if tr.TerminalEvent != nil {
+		event := terminalEventFromSpec(*tr.TerminalEvent, task.ID, run.ID, finishedAt)
+		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
+		events = append(events, s.appendRunEventLocked(event))
+	}
+	if tr.TaskUpdatedEvent != nil {
+		event := terminalEventFromSpec(*tr.TaskUpdatedEvent, task.ID, run.ID, finishedAt)
+		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
+		events = append(events, s.appendRunEventLocked(event))
+	}
+
+	return TerminalRunTransitionResult{
+		Task:               task,
+		Run:                run,
+		Steps:              steps,
+		Artifacts:          artifacts,
+		CancelledApprovals: cancelledApprovals,
+		Events:             events,
+	}, nil
+}
+
+func (s *MemoryStore) appendRunEventLocked(event types.TaskRunEvent) types.TaskRunEvent {
+	if event.Sequence <= 0 {
+		event.Sequence = s.nextSeq
+		s.nextSeq++
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	event.ID = fmt.Sprintf("%d", event.Sequence)
+	s.events[event.RunID] = append(s.events[event.RunID], event)
+	return event
+}
+
+func (s *MemoryStore) listStepsLocked(runID string) []types.TaskStep {
+	items := make([]types.TaskStep, 0)
+	for _, step := range s.steps {
+		if runID != "" && step.RunID != runID {
+			continue
+		}
+		items = append(items, step)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Index == items[j].Index {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].Index < items[j].Index
+	})
+	return items
+}
+
+func (s *MemoryStore) listArtifactsLocked(filter ArtifactFilter) []types.TaskArtifact {
+	items := make([]types.TaskArtifact, 0)
+	for _, artifact := range s.artifacts {
+		if filter.TaskID != "" && artifact.TaskID != filter.TaskID {
+			continue
+		}
+		if filter.RunID != "" && artifact.RunID != filter.RunID {
+			continue
+		}
+		if filter.StepID != "" && artifact.StepID != filter.StepID {
+			continue
+		}
+		if filter.Kind != "" && artifact.Kind != filter.Kind {
+			continue
+		}
+		items = append(items, artifact)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	if filter.Limit > 0 && len(items) > filter.Limit {
+		items = items[:filter.Limit]
+	}
+	return items
+}
+
 func (s *MemoryStore) ListRunEvents(_ context.Context, taskID, runID string, afterSequence int64, limit int) ([]types.TaskRunEvent, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -431,8 +431,12 @@ func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalR
 	if _, ok := s.tasks[tr.Task.ID]; !ok {
 		return TerminalRunTransitionResult{}, fmt.Errorf("task %q not found", tr.Task.ID)
 	}
-	if _, ok := s.runs[tr.Run.ID]; !ok {
+	storedRun, ok := s.runs[tr.Run.ID]
+	if !ok {
 		return TerminalRunTransitionResult{}, fmt.Errorf("run %q not found", tr.Run.ID)
+	}
+	if storedRun.TaskID != tr.Task.ID {
+		return TerminalRunTransitionResult{}, fmt.Errorf("run %q does not belong to task %q", tr.Run.ID, tr.Task.ID)
 	}
 
 	finishedAt := terminalTransitionFinishedAt(tr)

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -704,7 +704,7 @@ func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr Termina
 			TaskID:    task.ID,
 			RunID:     run.ID,
 			EventType: approvalEventType,
-			Data:      terminalSnapshotData(run, steps, artifacts, approvalResolvedEventData(approval)),
+			Data:      types.ApprovalResolvedEventData(approval),
 			RequestID: tr.Run.RequestID,
 			TraceID:   tr.Run.TraceID,
 			CreatedAt: finishedAt,
@@ -717,7 +717,6 @@ func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr Termina
 	}
 	if tr.TerminalEvent != nil {
 		event := terminalEventFromSpec(*tr.TerminalEvent, task.ID, run.ID, finishedAt)
-		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
 		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
 		if err != nil {
 			return TerminalRunTransitionResult{}, err
@@ -726,7 +725,6 @@ func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr Termina
 	}
 	if tr.TaskUpdatedEvent != nil {
 		event := terminalEventFromSpec(*tr.TaskUpdatedEvent, task.ID, run.ID, finishedAt)
-		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
 		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
 		if err != nil {
 			return TerminalRunTransitionResult{}, err

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -598,6 +598,155 @@ func (s *SQLiteStore) AppendRunEvent(ctx context.Context, event types.TaskRunEve
 	return event, nil
 }
 
+func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr TerminalRunTransition) (TerminalRunTransitionResult, error) {
+	if err := validateTerminalTransition(tr); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	defer tx.Rollback()
+
+	if err := sqliteRequireRow(ctx, tx, fmt.Sprintf(`SELECT 1 FROM %s WHERE id = ?`, s.tasksTable), tr.Task.ID); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	if err := sqliteRequireRow(ctx, tx, fmt.Sprintf(`SELECT 1 FROM %s WHERE id = ? AND task_id = ?`, s.runsTable), tr.Run.ID, tr.Task.ID); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+
+	finishedAt := terminalTransitionFinishedAt(tr)
+	task := tr.Task
+	run := tr.Run
+	if task.UpdatedAt.IsZero() {
+		task.UpdatedAt = finishedAt
+	}
+	if task.FinishedAt.IsZero() {
+		task.FinishedAt = finishedAt
+	}
+	if run.FinishedAt.IsZero() {
+		run.FinishedAt = finishedAt
+	}
+
+	cancelledApprovals := make([]types.TaskApproval, 0)
+	if tr.CancelPendingApprovals {
+		pending, err := s.sqliteListApprovalsTx(ctx, tx, task.ID, run.ID, "pending")
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		status := firstNonEmptyString(tr.PendingApprovalStatus, "cancelled")
+		resolvedBy := firstNonEmptyString(tr.PendingApprovalResolvedBy, "system")
+		note := firstNonEmptyString(tr.PendingApprovalResolutionNote, run.LastError)
+		for _, approval := range pending {
+			approval.Status = status
+			approval.ResolvedBy = resolvedBy
+			approval.ResolutionNote = note
+			approval.ResolvedAt = finishedAt
+			if err := s.sqliteUpdateApprovalTx(ctx, tx, approval); err != nil {
+				return TerminalRunTransitionResult{}, err
+			}
+			cancelledApprovals = append(cancelledApprovals, approval)
+		}
+	}
+
+	if tr.CancelActiveSteps {
+		active, err := s.sqliteListActiveStepsTx(ctx, tx, run.ID)
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		result := firstNonEmptyString(tr.ActiveStepResult, "error")
+		errorKind := firstNonEmptyString(tr.ActiveStepErrorKind, "run_cancelled")
+		stepError := firstNonEmptyString(tr.ActiveStepError, run.LastError)
+		for _, step := range active {
+			step.Status = "cancelled"
+			step.Result = result
+			step.Error = stepError
+			step.ErrorKind = errorKind
+			step.FinishedAt = finishedAt
+			if err := s.sqliteUpdateStepTx(ctx, tx, step); err != nil {
+				return TerminalRunTransitionResult{}, err
+			}
+		}
+	}
+
+	if tr.CancelStreamingArtifacts {
+		streaming, err := s.sqliteListArtifactsTx(ctx, tx, ArtifactFilter{TaskID: task.ID, RunID: run.ID}, "streaming")
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		for _, artifact := range streaming {
+			artifact.Status = "cancelled"
+			if err := s.sqliteUpdateArtifactTx(ctx, tx, artifact); err != nil {
+				return TerminalRunTransitionResult{}, err
+			}
+		}
+	}
+
+	if err := s.sqliteUpdateRunTx(ctx, tx, run); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	if err := s.sqliteUpdateTaskTx(ctx, tx, task); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+
+	steps, err := s.sqliteListStepsTx(ctx, tx, run.ID)
+	if err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	artifacts, err := s.sqliteListArtifactsTx(ctx, tx, ArtifactFilter{TaskID: task.ID, RunID: run.ID}, "")
+	if err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	events := make([]types.TaskRunEvent, 0, len(cancelledApprovals)+2)
+	approvalEventType := firstNonEmptyString(tr.ApprovalResolvedEventType, "approval.resolved")
+	for _, approval := range cancelledApprovals {
+		event := types.TaskRunEvent{
+			TaskID:    task.ID,
+			RunID:     run.ID,
+			EventType: approvalEventType,
+			Data:      terminalSnapshotData(run, steps, artifacts, approvalResolvedEventData(approval)),
+			RequestID: tr.Run.RequestID,
+			TraceID:   tr.Run.TraceID,
+			CreatedAt: finishedAt,
+		}
+		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		events = append(events, inserted)
+	}
+	if tr.TerminalEvent != nil {
+		event := terminalEventFromSpec(*tr.TerminalEvent, task.ID, run.ID, finishedAt)
+		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
+		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		events = append(events, inserted)
+	}
+	if tr.TaskUpdatedEvent != nil {
+		event := terminalEventFromSpec(*tr.TaskUpdatedEvent, task.ID, run.ID, finishedAt)
+		event.Data = terminalSnapshotData(run, steps, artifacts, event.Data)
+		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
+		if err != nil {
+			return TerminalRunTransitionResult{}, err
+		}
+		events = append(events, inserted)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return TerminalRunTransitionResult{}, err
+	}
+	return TerminalRunTransitionResult{
+		Task:               task,
+		Run:                run,
+		Steps:              steps,
+		Artifacts:          artifacts,
+		CancelledApprovals: cancelledApprovals,
+		Events:             events,
+	}, nil
+}
+
 func (s *SQLiteStore) ListRunEvents(ctx context.Context, taskID, runID string, afterSequence int64, limit int) ([]types.TaskRunEvent, error) {
 	if limit <= 0 {
 		limit = 200
@@ -738,6 +887,252 @@ func (s *SQLiteStore) Prune(ctx context.Context, maxAge time.Duration, maxCount 
 	}
 
 	return int(deleted), nil
+}
+
+func sqliteRequireRow(ctx context.Context, tx *sql.Tx, query string, args ...any) error {
+	var found int
+	err := tx.QueryRowContext(ctx, query, args...).Scan(&found)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("required row not found")
+	}
+	return err
+}
+
+func (s *SQLiteStore) sqliteUpdateTaskTx(ctx context.Context, tx *sql.Tx, task types.Task) error {
+	payload, err := json.Marshal(task)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, updated_at = ?, payload = ?
+		WHERE id = ?
+	`, s.tasksTable), task.Status, task.UpdatedAt, string(payload), task.ID)
+	if err != nil {
+		return err
+	}
+	return sqliteRequireRowsAffected(res, "task", task.ID)
+}
+
+func (s *SQLiteStore) sqliteUpdateRunTx(ctx context.Context, tx *sql.Tx, run types.TaskRun) error {
+	payload, err := json.Marshal(run)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, started_at = ?, payload = ?
+		WHERE id = ? AND task_id = ?
+	`, s.runsTable), run.Status, run.StartedAt, string(payload), run.ID, run.TaskID)
+	if err != nil {
+		return err
+	}
+	return sqliteRequireRowsAffected(res, "run", run.ID)
+}
+
+func (s *SQLiteStore) sqliteUpdateStepTx(ctx context.Context, tx *sql.Tx, step types.TaskStep) error {
+	payload, err := json.Marshal(step)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, payload = ?
+		WHERE id = ? AND run_id = ?
+	`, s.stepsTable), step.Status, string(payload), step.ID, step.RunID)
+	if err != nil {
+		return err
+	}
+	return sqliteRequireRowsAffected(res, "step", step.ID)
+}
+
+func (s *SQLiteStore) sqliteUpdateApprovalTx(ctx context.Context, tx *sql.Tx, approval types.TaskApproval) error {
+	payload, err := json.Marshal(approval)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, payload = ?
+		WHERE id = ? AND task_id = ?
+	`, s.approvalsTable), approval.Status, string(payload), approval.ID, approval.TaskID)
+	if err != nil {
+		return err
+	}
+	return sqliteRequireRowsAffected(res, "approval", approval.ID)
+}
+
+func (s *SQLiteStore) sqliteUpdateArtifactTx(ctx context.Context, tx *sql.Tx, artifact types.TaskArtifact) error {
+	payload, err := json.Marshal(artifact)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET status = ?, payload = ?
+		WHERE id = ? AND task_id = ?
+	`, s.artifactsTable), artifact.Status, string(payload), artifact.ID, artifact.TaskID)
+	if err != nil {
+		return err
+	}
+	return sqliteRequireRowsAffected(res, "artifact", artifact.ID)
+}
+
+func sqliteRequireRowsAffected(res sql.Result, kind, id string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("%s %q not found", kind, id)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) sqliteListApprovalsTx(ctx context.Context, tx *sql.Tx, taskID, runID, status string) ([]types.TaskApproval, error) {
+	args := []any{taskID, runID}
+	query := fmt.Sprintf(`
+		SELECT payload
+		FROM %s
+		WHERE task_id = ? AND run_id = ?
+	`, s.approvalsTable)
+	if status != "" {
+		args = append(args, status)
+		query += " AND status = ?"
+	}
+	query += " ORDER BY created_at ASC, id ASC"
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]types.TaskApproval, 0)
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, err
+		}
+		var approval types.TaskApproval
+		if err := json.Unmarshal([]byte(payload), &approval); err != nil {
+			return nil, err
+		}
+		items = append(items, approval)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) sqliteListActiveStepsTx(ctx context.Context, tx *sql.Tx, runID string) ([]types.TaskStep, error) {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT payload
+		FROM %s
+		WHERE run_id = ? AND status IN ('running', 'awaiting_approval')
+		ORDER BY step_index ASC, id ASC
+	`, s.stepsTable), runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLiteSteps(rows)
+}
+
+func (s *SQLiteStore) sqliteListStepsTx(ctx context.Context, tx *sql.Tx, runID string) ([]types.TaskStep, error) {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT payload
+		FROM %s
+		WHERE run_id = ?
+		ORDER BY step_index ASC, id ASC
+	`, s.stepsTable), runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLiteSteps(rows)
+}
+
+func scanSQLiteSteps(rows *sql.Rows) ([]types.TaskStep, error) {
+	items := make([]types.TaskStep, 0)
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, err
+		}
+		var step types.TaskStep
+		if err := json.Unmarshal([]byte(payload), &step); err != nil {
+			return nil, err
+		}
+		items = append(items, step)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) sqliteListArtifactsTx(ctx context.Context, tx *sql.Tx, filter ArtifactFilter, status string) ([]types.TaskArtifact, error) {
+	args := []any{}
+	where := []string{"1=1"}
+	if filter.TaskID != "" {
+		args = append(args, filter.TaskID)
+		where = append(where, "task_id = ?")
+	}
+	if filter.RunID != "" {
+		args = append(args, filter.RunID)
+		where = append(where, "run_id = ?")
+	}
+	if filter.StepID != "" {
+		args = append(args, filter.StepID)
+		where = append(where, "step_id = ?")
+	}
+	if filter.Kind != "" {
+		args = append(args, filter.Kind)
+		where = append(where, "kind = ?")
+	}
+	if status != "" {
+		args = append(args, status)
+		where = append(where, "status = ?")
+	}
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT payload
+		FROM %s
+		WHERE %s
+		ORDER BY created_at DESC, id DESC
+	`, s.artifactsTable, strings.Join(where, " AND ")), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]types.TaskArtifact, 0)
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, err
+		}
+		var artifact types.TaskArtifact
+		if err := json.Unmarshal([]byte(payload), &artifact); err != nil {
+			return nil, err
+		}
+		items = append(items, artifact)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) sqliteInsertRunEventTx(ctx context.Context, tx *sql.Tx, event types.TaskRunEvent) (types.TaskRunEvent, error) {
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(event.Data)
+	if err != nil {
+		return types.TaskRunEvent{}, err
+	}
+	var id int64
+	err = tx.QueryRowContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (task_id, run_id, event_type, event_data, request_id, trace_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		RETURNING sequence
+	`, s.eventsTable), event.TaskID, event.RunID, event.EventType, string(payload), event.RequestID, event.TraceID, event.CreatedAt.UTC().Format(time.RFC3339Nano)).Scan(&id)
+	if err != nil {
+		return types.TaskRunEvent{}, err
+	}
+	event.Sequence = id
+	event.ID = fmt.Sprintf("%d", id)
+	return event, nil
 }
 
 // sqlitePlaceholders returns "?, ?, ?" for n placeholders. Keeps the

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -46,6 +46,43 @@ type EventFilter struct {
 	Limit         int
 }
 
+type RunEventSpec struct {
+	EventType string
+	Data      map[string]any
+	RequestID string
+	TraceID   string
+	CreatedAt time.Time
+}
+
+type TerminalRunTransition struct {
+	Task       types.Task
+	Run        types.TaskRun
+	FinishedAt time.Time
+
+	CancelActiveSteps             bool
+	ActiveStepError               string
+	ActiveStepErrorKind           string
+	ActiveStepResult              string
+	CancelStreamingArtifacts      bool
+	CancelPendingApprovals        bool
+	PendingApprovalStatus         string
+	PendingApprovalResolvedBy     string
+	PendingApprovalResolutionNote string
+
+	ApprovalResolvedEventType string
+	TerminalEvent             *RunEventSpec
+	TaskUpdatedEvent          *RunEventSpec
+}
+
+type TerminalRunTransitionResult struct {
+	Task               types.Task
+	Run                types.TaskRun
+	Steps              []types.TaskStep
+	Artifacts          []types.TaskArtifact
+	CancelledApprovals []types.TaskApproval
+	Events             []types.TaskRunEvent
+}
+
 type Store interface {
 	Backend() string
 	CreateTask(ctx context.Context, task types.Task) (types.Task, error)
@@ -78,6 +115,7 @@ type Store interface {
 	UpdateArtifact(ctx context.Context, artifact types.TaskArtifact) (types.TaskArtifact, error)
 
 	AppendRunEvent(ctx context.Context, event types.TaskRunEvent) (types.TaskRunEvent, error)
+	ApplyRunTerminalTransition(ctx context.Context, transition TerminalRunTransition) (TerminalRunTransitionResult, error)
 	ListRunEvents(ctx context.Context, taskID, runID string, afterSequence int64, limit int) ([]types.TaskRunEvent, error)
 	// ListEvents returns events across runs/tasks ordered by ascending
 	// global sequence. Used by the public events stream so external

--- a/internal/taskstate/terminal.go
+++ b/internal/taskstate/terminal.go
@@ -1,0 +1,94 @@
+package taskstate
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func validateTerminalTransition(tr TerminalRunTransition) error {
+	if tr.Task.ID == "" {
+		return fmt.Errorf("task id is required")
+	}
+	if tr.Run.ID == "" {
+		return fmt.Errorf("run id is required")
+	}
+	if tr.Run.TaskID != "" && tr.Run.TaskID != tr.Task.ID {
+		return fmt.Errorf("run %q does not belong to task %q", tr.Run.ID, tr.Task.ID)
+	}
+	return nil
+}
+
+func terminalTransitionFinishedAt(tr TerminalRunTransition) time.Time {
+	if !tr.FinishedAt.IsZero() {
+		return tr.FinishedAt
+	}
+	if !tr.Run.FinishedAt.IsZero() {
+		return tr.Run.FinishedAt
+	}
+	if !tr.Task.FinishedAt.IsZero() {
+		return tr.Task.FinishedAt
+	}
+	return time.Now().UTC()
+}
+
+func terminalEventFromSpec(spec RunEventSpec, taskID, runID string, createdAt time.Time) types.TaskRunEvent {
+	if spec.CreatedAt.IsZero() {
+		spec.CreatedAt = createdAt
+	}
+	return types.TaskRunEvent{
+		TaskID:    taskID,
+		RunID:     runID,
+		EventType: spec.EventType,
+		Data:      copyEventData(spec.Data),
+		RequestID: spec.RequestID,
+		TraceID:   spec.TraceID,
+		CreatedAt: spec.CreatedAt,
+	}
+}
+
+func terminalSnapshotData(run types.TaskRun, steps []types.TaskStep, artifacts []types.TaskArtifact, extra map[string]any) map[string]any {
+	data := map[string]any{
+		"run":       run,
+		"steps":     steps,
+		"artifacts": artifacts,
+	}
+	for key, value := range extra {
+		data[key] = value
+	}
+	return data
+}
+
+func copyEventData(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(data))
+	for key, value := range data {
+		copied[key] = value
+	}
+	return copied
+}
+
+func approvalResolvedEventData(approval types.TaskApproval) map[string]any {
+	return map[string]any{
+		"approval_id": approval.ID,
+		"decision":    approval.Status,
+		"by":          approval.ResolvedBy,
+		"comment":     approval.ResolutionNote,
+		"scope":       "once",
+		"kind":        approval.Kind,
+		"status":      approval.Status,
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/taskstate/terminal.go
+++ b/internal/taskstate/terminal.go
@@ -49,18 +49,6 @@ func terminalEventFromSpec(spec RunEventSpec, taskID, runID string, createdAt ti
 	}
 }
 
-func terminalSnapshotData(run types.TaskRun, steps []types.TaskStep, artifacts []types.TaskArtifact, extra map[string]any) map[string]any {
-	data := map[string]any{
-		"run":       run,
-		"steps":     steps,
-		"artifacts": artifacts,
-	}
-	for key, value := range extra {
-		data[key] = value
-	}
-	return data
-}
-
 func copyEventData(data map[string]any) map[string]any {
 	if data == nil {
 		return nil
@@ -70,18 +58,6 @@ func copyEventData(data map[string]any) map[string]any {
 		copied[key] = value
 	}
 	return copied
-}
-
-func approvalResolvedEventData(approval types.TaskApproval) map[string]any {
-	return map[string]any{
-		"approval_id": approval.ID,
-		"decision":    approval.Status,
-		"by":          approval.ResolvedBy,
-		"comment":     approval.ResolutionNote,
-		"scope":       "once",
-		"kind":        approval.Kind,
-		"status":      approval.Status,
-	}
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -248,6 +248,18 @@ type TaskRunEvent struct {
 	TraceID   string
 }
 
+func ApprovalResolvedEventData(approval TaskApproval) map[string]any {
+	return map[string]any{
+		"approval_id": approval.ID,
+		"decision":    approval.Status,
+		"by":          approval.ResolvedBy,
+		"comment":     approval.ResolutionNote,
+		"scope":       "once",
+		"kind":        approval.Kind,
+		"status":      approval.Status,
+	}
+}
+
 func IsTerminalTaskRunStatus(status string) bool {
 	switch status {
 	case "completed", "failed", "cancelled":

--- a/pkg/types/task_test.go
+++ b/pkg/types/task_test.go
@@ -115,3 +115,28 @@ func TestTaskJSONRoundTrip_NoMCPServers_OmitsField(t *testing.T) {
 		t.Errorf("got.MCPServers = %+v, want empty (no MCPServers configured)", got.MCPServers)
 	}
 }
+
+func TestApprovalResolvedEventData(t *testing.T) {
+	t.Parallel()
+	approval := TaskApproval{
+		ID:             "approval-1",
+		Kind:           "agent_loop_tool_call",
+		Status:         "rejected",
+		ResolvedBy:     "operator",
+		ResolutionNote: "not safe",
+	}
+
+	got := ApprovalResolvedEventData(approval)
+	want := map[string]any{
+		"approval_id": "approval-1",
+		"decision":    "rejected",
+		"by":          "operator",
+		"comment":     "not safe",
+		"scope":       "once",
+		"kind":        "agent_loop_tool_call",
+		"status":      "rejected",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ApprovalResolvedEventData() = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a store-level terminal run transition contract shared by memory and sqlite
- route runner cancel/fail/finish paths through the centralized terminal transition helper
- add store conformance and binary e2e coverage for approval cancellation terminal state

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/taskstate ./internal/orchestrator ./internal/api -count=1`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go test -tags e2e -run TestTaskApprovalCancelTerminalStateE2E -count=1 -timeout 3m ./e2e/...`
- `GOCACHE="$PWD/.gocache" go test -tags e2e -count=1 -timeout 3m ./e2e/...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `git diff --check`