### PR TITLE
refactor(orchestrator): split agent loop runtime state

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -112,6 +112,22 @@ gateway/provider path where possible and publish snapshots through the chat
 live stream; do not fork a second chat-only event stream for Hecate-owned
 tools.
 
+Native `agent_loop` code is intentionally split by responsibility:
+
+- `executor_agent_loop.go` is the control-flow spine. Keep it focused on turn
+  progression, resume detection, final answer, approval gate, tool dispatch,
+  and ceiling checks.
+- `executor_agent_loop_chat.go` owns a fresh LLM turn: request construction,
+  streaming capture, route capture, assistant events, thinking step, turn cost,
+  and conversation snapshot.
+- `executor_agent_loop_run_state.go` owns run assembly: next step index,
+  steps/artifacts, resolved route, per-turn cost records, and final
+  `ExecutionResult` accounting.
+- `executor_agent_loop_conversation.go`, `executor_agent_loop_approval_gate.go`,
+  and `executor_agent_loop_tools.go` own conversation persistence, approval
+  decisions, and tool dispatch. Prefer extending those seams over re-growing
+  the main `Execute` loop.
+
 When changing this path:
 
 1. Keep `docs/rfcs/hecate-chat-model-capabilities.md` and

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -75,6 +75,22 @@ A run with `execution_kind=agent_loop` walks turns:
 
 The conversation is persisted as an artifact (`agent_conversation`, JSON-encoded `[]Message`) on every turn. During a streaming model turn, Hecate also refreshes that artifact with the partial assistant answer at a throttled cadence; after the provider finishes, the usual full turn snapshot replaces it. A crash mid-loop, an approval pause, or a deliberate retry-from-turn therefore all start from a known state.
 
+Each fresh LLM turn records the same runtime accounting regardless of whether
+the provider streamed or returned one response body: resolved route metadata
+(`provider`, `provider_kind`, `model`), the assistant thinking step,
+`assistant.*` run events, per-turn cost records, and the updated conversation
+snapshot. Resume-after-approval turns are different: the model has already
+produced the tool calls, so the runtime dispatches those approved calls without
+emitting a new `turn.started` or `turn.completed`.
+
+The implementation keeps those responsibilities split so the loop stays
+auditable:
+
+- `executor_agent_loop.go` owns the high-level loop: resume detection, final answer, approval gate, tool dispatch, cost-ceiling check.
+- `executor_agent_loop_chat.go` owns one fresh LLM turn: request construction, streaming capture, route capture, assistant events, thinking step, turn cost, conversation snapshot.
+- `executor_agent_loop_run_state.go` owns in-memory run assembly: next step index, steps/artifacts, resolved route, cost totals, `ExecutionResult`.
+- `executor_agent_loop_conversation.go`, `executor_agent_loop_approval_gate.go`, and `executor_agent_loop_tools.go` own conversation hydration, approval-gate decisions, and tool dispatch respectively.
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,8 +153,8 @@ sequenceDiagram
     loop turn cycle
         Agent->>LLM: Chat with messages, tools, and ProviderHint
         LLM-->>Agent: assistant message
-        Agent->>Store: emit turn.completed event
-        Agent->>Store: persist conversation snapshot
+        Agent->>Store: record thinking step, route metadata, and conversation snapshot
+        Note over Agent,Store: runner later emits turn.completed from the turn-cost record
         alt assistant emitted tool_calls
             opt any tool gated by policy (built-in or per-MCP-server)
                 Agent->>Store: persist agent_loop_tool_call approval
@@ -182,6 +182,7 @@ Three runtime invariants worth pinning (full mechanics in [`agent-runtime.md`](a
 
 - **Workspace environment system message.** The loop prepends a machine-generated system message naming the workspace path so the model uses the cloned cwd. See [`agent-runtime.md#workspace-environment-system-message`](agent-runtime.md#workspace-environment-system-message) for the wire shape and rationale.
 - **Provider hint.** `ChatRequest.Scope.ProviderHint` is set from `run.Provider` (mirrored from `task.RequestedProvider`), so the operator's pinned provider actually routes — no fallback to the default for generic model ids.
+- **Resolved route survives streaming.** Streaming and non-streaming agent turns both copy the resolved provider, provider kind, and model back onto the run result, so task detail and resumes see what actually served the turn.
 - **Cost ceiling is task-cumulative.** The per-task `BudgetMicrosUSD` is checked against `priorCost + costSpent` after each turn, where `priorCost` includes every prior run in the resume chain. A chain of resumes can't escape the ceiling.
 
 ## Storage tiers

--- a/docs/events.md
+++ b/docs/events.md
@@ -233,6 +233,14 @@ reject, the run and task terminate `cancelled` with
 
 ## Agent loop
 
+Fresh LLM turns follow this persisted-event shape: `turn.started`, zero or more
+`assistant.text_complete` / `assistant.tool_call_proposed` events,
+optionally `assistant.final_answer`, then one `turn.completed` emitted from the
+turn-cost record. Resume-after-approval dispatches do not call the model again,
+so they do not emit a new `turn.started` or `turn.completed`; the approved tool
+calls continue from the assistant message already saved in the conversation
+artifact.
+
 ### `turn.started`
 
 Emitted immediately before an `agent_loop` LLM request. Resume-after-approval

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -140,7 +140,7 @@ The `task` resource accepts these fields on `POST /hecate/v1/tasks`:
 
 - `total_cost_micros_usd` — this run's LLM spend (after routing).
 - `prior_cost_micros_usd` — cumulative spend of every prior run in this run's resume chain. Cumulative-across-task = `prior + total`.
-- `model` / `provider` — what was actually used (after routing). May differ from the task's `requested_*` when the operator picked auto.
+- `model` / `provider` / `provider_kind` — what was actually used (after routing). May differ from the task's `requested_*` when the operator picked auto. Agent-loop runs preserve these fields for both streaming and non-streaming model turns.
 
 ## Lifecycle endpoints
 

--- a/e2e/agent_loop_tool_dispatch_test.go
+++ b/e2e/agent_loop_tool_dispatch_test.go
@@ -55,9 +55,27 @@ func TestAgentLoopToolDispatchE2E(t *testing.T) {
 	if run.Status != "completed" {
 		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
 	}
+	if run.Provider != "fake" || run.ProviderKind != "local" || run.Model != agentLoopE2EModel {
+		t.Fatalf("run route = provider %q kind %q model %q, want fake/local/%s", run.Provider, run.ProviderKind, run.Model, agentLoopE2EModel)
+	}
 
 	steps := getJSON[e2eTaskStepsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/steps")
 	foundToolStep := false
+	var modelSteps []e2eTaskStep
+	if len(steps.Data) != 3 {
+		t.Fatalf("steps = %d, want 3 (model, tool, model): %+v", len(steps.Data), steps.Data)
+	}
+	for i, step := range steps.Data {
+		if step.Index != i+1 {
+			t.Fatalf("step[%d] index = %d, want %d; steps=%+v", i, step.Index, i+1, steps.Data)
+		}
+		if step.Kind == "model" {
+			modelSteps = append(modelSteps, step)
+		}
+	}
+	if len(modelSteps) != 2 {
+		t.Fatalf("model steps = %d, want 2: %+v", len(modelSteps), steps.Data)
+	}
 	for _, step := range steps.Data {
 		if step.Kind == "tool" && step.ToolName == "shell_exec" {
 			foundToolStep = true
@@ -68,6 +86,55 @@ func TestAgentLoopToolDispatchE2E(t *testing.T) {
 	}
 	if !foundToolStep {
 		t.Fatalf("shell_exec tool step not found in %+v", steps.Data)
+	}
+
+	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events")
+	assertE2EEventTypes(t, events.Data, "turn.started", "assistant.tool_call_proposed", "assistant.final_answer")
+	var turnStarted []e2eEventEnvelope
+	var turnEvents []e2eEventEnvelope
+	foundToolProposal := false
+	foundFinalAnswer := false
+	for _, event := range events.Data {
+		if event.Type == "turn.started" {
+			turnStarted = append(turnStarted, event)
+		}
+		if event.Type == "turn.completed" {
+			turnEvents = append(turnEvents, event)
+		}
+		if event.Type == "assistant.tool_call_proposed" &&
+			event.Data["tool_call_id"] == "call-shell-e2e" &&
+			event.Data["tool_name"] == "shell_exec" {
+			foundToolProposal = true
+		}
+		if event.Type == "assistant.final_answer" && strings.Contains(fmt.Sprint(event.Data["summary"]), "Tool dispatch completed.") {
+			foundFinalAnswer = true
+		}
+	}
+	if len(turnStarted) != 2 {
+		t.Fatalf("turn.started events = %d, want 2: %+v", len(turnStarted), events.Data)
+	}
+	assertE2ENumber(t, turnStarted[0].Data, "turn_index", 1)
+	assertE2ENumber(t, turnStarted[1].Data, "turn_index", 2)
+	if !foundToolProposal {
+		t.Fatalf("assistant.tool_call_proposed for call-shell-e2e not found in %+v", events.Data)
+	}
+	if !foundFinalAnswer {
+		t.Fatalf("assistant.final_answer not found in %+v", events.Data)
+	}
+	if len(turnEvents) != 2 {
+		t.Fatalf("turn.completed events = %d, want 2: %+v", len(turnEvents), events.Data)
+	}
+	assertE2ENumber(t, turnEvents[0].Data, "turn_index", 1)
+	assertE2ENumber(t, turnEvents[0].Data, "tool_calls", 1)
+	assertE2ENumber(t, turnEvents[0].Data, "run_cumulative_cost_micros_usd", 0)
+	if turnEvents[0].Data["step_id"] != modelSteps[0].ID {
+		t.Fatalf("turn 1 step_id = %v, want %s", turnEvents[0].Data["step_id"], modelSteps[0].ID)
+	}
+	assertE2ENumber(t, turnEvents[1].Data, "turn_index", 2)
+	assertE2ENumber(t, turnEvents[1].Data, "tool_calls", 0)
+	assertE2ENumber(t, turnEvents[1].Data, "run_cumulative_cost_micros_usd", 0)
+	if turnEvents[1].Data["step_id"] != modelSteps[1].ID {
+		t.Fatalf("turn 2 step_id = %v, want %s", turnEvents[1].Data["step_id"], modelSteps[1].ID)
 	}
 
 	bodies := capturedBodies(captured)
@@ -265,6 +332,17 @@ func requestAdvertisedTool(body map[string]any, toolName string) bool {
 		}
 	}
 	return false
+}
+
+func assertE2ENumber(t *testing.T, data map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := data[key].(float64)
+	if !ok {
+		t.Fatalf("%s = %T(%v), want number %v", key, data[key], data[key], want)
+	}
+	if got != want {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
 }
 
 func requestHasToolResult(body map[string]any, toolCallID, contentSubstring string) bool {

--- a/e2e/agent_loop_tool_dispatch_test.go
+++ b/e2e/agent_loop_tool_dispatch_test.go
@@ -1,0 +1,289 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const agentLoopE2EModel = "gpt-4o-mini"
+
+func TestAgentLoopToolDispatchE2E(t *testing.T) {
+	workDir := t.TempDir()
+	canonicalWorkDir, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		t.Fatalf("canonicalize temp dir: %v", err)
+	}
+	workDir = canonicalWorkDir
+	upstream, captured := fakeAgentLoopToolCallingUpstream(t)
+	baseURL := gatewayServer(t,
+		"HECATE_TASK_APPROVAL_POLICIES=",
+		"PROVIDER_FAKE_API_KEY=dummy",
+		"PROVIDER_FAKE_BASE_URL="+upstream,
+		"PROVIDER_FAKE_KIND=local",
+		"PROVIDER_FAKE_MODELS="+agentLoopE2EModel,
+	)
+
+	taskBody := fmt.Sprintf(`{
+		"title": "agent loop tool dispatch e2e",
+		"prompt": "Use shell_exec to print agent-loop-e2e, then summarize the result.",
+		"execution_kind": "agent_loop",
+		"requested_model": %q,
+		"working_directory": %q,
+		"sandbox_allowed_root": %q,
+		"workspace_mode": "in_place",
+		"timeout_ms": 10000
+	}`, agentLoopE2EModel, workDir, workDir)
+	created := postJSONDecode[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks", taskBody)
+	if created.Data.ID == "" {
+		t.Fatal("created task id is empty")
+	}
+
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/start", `{}`)
+	if started.Data.ID == "" {
+		t.Fatal("started run id is empty")
+	}
+	run := waitForE2ETaskRunTerminal(t, baseURL, created.Data.ID, started.Data.ID, 10*time.Second)
+	if run.Status != "completed" {
+		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
+	}
+
+	steps := getJSON[e2eTaskStepsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/steps")
+	foundToolStep := false
+	for _, step := range steps.Data {
+		if step.Kind == "tool" && step.ToolName == "shell_exec" {
+			foundToolStep = true
+			if step.Status != "completed" {
+				t.Fatalf("shell_exec step = %+v, want completed", step)
+			}
+		}
+	}
+	if !foundToolStep {
+		t.Fatalf("shell_exec tool step not found in %+v", steps.Data)
+	}
+
+	bodies := capturedBodies(captured)
+	if len(bodies) != 2 {
+		t.Fatalf("upstream chat requests = %d, want 2: %+v", len(bodies), bodies)
+	}
+	if !requestAdvertisedTool(bodies[0], "shell_exec") {
+		t.Fatalf("first upstream request did not advertise shell_exec tool: %+v", bodies[0])
+	}
+	if !requestHasToolResult(bodies[1], "call-shell-e2e", "agent-loop-e2e") {
+		t.Fatalf("second upstream request did not include shell tool result: %+v", bodies[1])
+	}
+}
+
+func fakeAgentLoopToolCallingUpstream(t *testing.T) (string, *capturedRequests) {
+	t.Helper()
+	captured := &capturedRequests{}
+	var chatCalls atomic.Int32
+	shellArgs := `{"command":"printf agent-loop-e2e"}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"object":"list","data":[{"id":%q,"object":"model"}]}`, agentLoopE2EModel)
+	})
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		captured.record(body)
+
+		callNumber := chatCalls.Add(1)
+		if streamed, _ := body["stream"].(bool); streamed {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			if callNumber == 1 {
+				writeAgentLoopToolCallStream(t, w, shellArgs)
+			} else {
+				writeAgentLoopFinalAnswerStream(t, w)
+			}
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if callNumber == 1 {
+			fmt.Fprintf(w, `{"id":"chatcmpl-agent-loop-1","object":"chat.completion","created":1700000000,"model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":"I will inspect.","tool_calls":[{"id":"call-shell-e2e","type":"function","function":{"name":"shell_exec","arguments":%q}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}`, agentLoopE2EModel, shellArgs)
+			return
+		}
+		fmt.Fprintf(w, `{"id":"chatcmpl-agent-loop-2","object":"chat.completion","created":1700000001,"model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":"Tool dispatch completed."},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}`, agentLoopE2EModel)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL, captured
+}
+
+func writeAgentLoopToolCallStream(t *testing.T, w http.ResponseWriter, shellArgs string) {
+	t.Helper()
+	writeOpenAIStreamChunk(t, w, map[string]any{
+		"id":      "chatcmpl-agent-loop-1",
+		"object":  "chat.completion.chunk",
+		"created": 1700000000,
+		"model":   agentLoopE2EModel,
+		"choices": []map[string]any{{
+			"index": 0,
+			"delta": map[string]any{
+				"role":    "assistant",
+				"content": "I will inspect.",
+			},
+			"finish_reason": nil,
+		}},
+	})
+	writeOpenAIStreamChunk(t, w, map[string]any{
+		"id":      "chatcmpl-agent-loop-1",
+		"object":  "chat.completion.chunk",
+		"created": 1700000000,
+		"model":   agentLoopE2EModel,
+		"choices": []map[string]any{{
+			"index": 0,
+			"delta": map[string]any{
+				"tool_calls": []map[string]any{{
+					"index": 0,
+					"id":    "call-shell-e2e",
+					"type":  "function",
+					"function": map[string]any{
+						"name":      "shell_exec",
+						"arguments": shellArgs,
+					},
+				}},
+			},
+			"finish_reason": nil,
+		}},
+	})
+	writeOpenAIStreamChunk(t, w, map[string]any{
+		"id":      "chatcmpl-agent-loop-1",
+		"object":  "chat.completion.chunk",
+		"created": 1700000000,
+		"model":   agentLoopE2EModel,
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "tool_calls",
+		}},
+	})
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	flushSSE(w)
+}
+
+func writeAgentLoopFinalAnswerStream(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	writeOpenAIStreamChunk(t, w, map[string]any{
+		"id":      "chatcmpl-agent-loop-2",
+		"object":  "chat.completion.chunk",
+		"created": 1700000001,
+		"model":   agentLoopE2EModel,
+		"choices": []map[string]any{{
+			"index": 0,
+			"delta": map[string]any{
+				"role":    "assistant",
+				"content": "Tool dispatch completed.",
+			},
+			"finish_reason": nil,
+		}},
+	})
+	writeOpenAIStreamChunk(t, w, map[string]any{
+		"id":      "chatcmpl-agent-loop-2",
+		"object":  "chat.completion.chunk",
+		"created": 1700000001,
+		"model":   agentLoopE2EModel,
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "stop",
+		}},
+	})
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	flushSSE(w)
+}
+
+func writeOpenAIStreamChunk(t *testing.T, w http.ResponseWriter, chunk map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal stream chunk: %v", err)
+	}
+	fmt.Fprintf(w, "data: %s\n\n", raw)
+	flushSSE(w)
+}
+
+func flushSSE(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func waitForE2ETaskRunTerminal(t *testing.T, baseURL, taskID, runID string, timeout time.Duration) e2eTaskRun {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last e2eTaskRun
+	for time.Now().Before(deadline) {
+		resp := getJSON[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+runID)
+		last = resp.Data
+		switch resp.Data.Status {
+		case "completed", "failed", "cancelled":
+			return resp.Data
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach terminal state within %s; last=%+v", runID, timeout, last)
+	return e2eTaskRun{}
+}
+
+func capturedBodies(c *capturedRequests) []map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]map[string]any, len(c.bodies))
+	copy(out, c.bodies)
+	return out
+}
+
+func requestAdvertisedTool(body map[string]any, toolName string) bool {
+	tools, ok := body["tools"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		fn, ok := tool["function"].(map[string]any)
+		if ok && fn["name"] == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+func requestHasToolResult(body map[string]any, toolCallID, contentSubstring string) bool {
+	messages, ok := body["messages"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawMessage := range messages {
+		msg, ok := rawMessage.(map[string]any)
+		if !ok {
+			continue
+		}
+		if msg["role"] != "tool" || msg["tool_call_id"] != toolCallID {
+			continue
+		}
+		content, _ := msg["content"].(string)
+		if strings.Contains(content, contentSubstring) {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -292,9 +292,15 @@ type e2eTaskStepsResponse struct {
 }
 
 type e2eTaskStep struct {
-	ID        string `json:"id"`
-	Status    string `json:"status"`
-	ErrorKind string `json:"error_kind,omitempty"`
+	ID            string         `json:"id"`
+	Index         int            `json:"index,omitempty"`
+	Kind          string         `json:"kind,omitempty"`
+	Status        string         `json:"status"`
+	ToolName      string         `json:"tool_name,omitempty"`
+	Input         map[string]any `json:"input,omitempty"`
+	OutputSummary map[string]any `json:"output_summary,omitempty"`
+	Error         string         `json:"error,omitempty"`
+	ErrorKind     string         `json:"error_kind,omitempty"`
 }
 
 type e2eTaskEventsResponse struct {

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -267,9 +267,12 @@ type e2eTaskRunResponse struct {
 }
 
 type e2eTaskRun struct {
-	ID        string `json:"id"`
-	Status    string `json:"status"`
-	LastError string `json:"last_error,omitempty"`
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	LastError    string `json:"last_error,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	ProviderKind string `json:"provider_kind,omitempty"`
+	Model        string `json:"model,omitempty"`
 }
 
 type e2eTaskApprovalsResponse struct {

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -595,6 +595,12 @@ func (s *Service) HandleChatStreamCapture(ctx context.Context, req types.ChatReq
 		ID:        id,
 		Model:     model,
 		CreatedAt: time.Now().UTC(),
+		Route: types.RouteDecision{
+			Provider:     handle.Metadata.Provider,
+			ProviderKind: handle.Metadata.ProviderKind,
+			Model:        handle.Metadata.Model,
+			Reason:       handle.Metadata.RouteReason,
+		},
 		Choices: []types.ChatChoice{{
 			Index: 0,
 			Message: types.Message{

--- a/internal/gateway/service_stream_capture_test.go
+++ b/internal/gateway/service_stream_capture_test.go
@@ -2,9 +2,19 @@ package gateway
 
 import (
 	"bytes"
+	"context"
 	"io"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/governor"
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/pkg/types"
 )
 
 func TestStreamHandleExecuteAndCaptureDeltasCapturesContentAndToolCalls(t *testing.T) {
@@ -53,4 +63,58 @@ func TestStreamHandleExecuteAndCaptureDeltasCapturesContentAndToolCalls(t *testi
 	if !strings.Contains(forwarded.String(), "Hello ") || !strings.Contains(forwarded.String(), "[DONE]") {
 		t.Fatalf("forwarded stream missing original chunks:\n%s", forwarded.String())
 	}
+}
+
+func TestServiceHandleChatStreamCaptureIncludesRouteMetadata(t *testing.T) {
+	t.Parallel()
+
+	provider := &streamingSequenceProvider{
+		sequenceProvider: sequenceProvider{name: "fake", kind: providers.KindLocal},
+	}
+	registry := providers.NewRegistry(provider)
+	store := governor.NewMemoryUsageStore()
+	service := NewService(Dependencies{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Router: staticFallbackRouter{
+			route: types.RouteDecision{Provider: "fake", Model: "model-b", Reason: "test-route"},
+		},
+		Governor:   governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, store, store),
+		Providers:  registry,
+		Tracer:     profiler.NewInMemoryTracer(nil),
+		Metrics:    telemetry.NewMetrics(),
+		Resilience: ResilienceOptions{MaxAttempts: 1, RetryBackoff: time.Millisecond},
+	})
+
+	resp, err := service.HandleChatStreamCapture(context.Background(), types.ChatRequest{
+		RequestID: "req-stream-route",
+		Model:     "operator-model",
+		Messages:  []types.Message{{Role: "user", Content: "hello"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleChatStreamCapture: %v", err)
+	}
+	if resp.Route.Provider != "fake" || resp.Route.ProviderKind != "local" || resp.Route.Model != "model-b" || resp.Route.Reason != "test-route" {
+		t.Fatalf("route = %+v, want fake/local/model-b/test-route", resp.Route)
+	}
+	if resp.Model != "model-b" {
+		t.Fatalf("model = %q, want streamed model-b", resp.Model)
+	}
+}
+
+type streamingSequenceProvider struct {
+	sequenceProvider
+}
+
+func (p *streamingSequenceProvider) ChatStream(_ context.Context, _ types.ChatRequest, w io.Writer) error {
+	chunks := []string{
+		`data: {"id":"chatcmpl-stream-route","model":"model-b","choices":[{"delta":{"content":"hello"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"chatcmpl-stream-route","model":"model-b","choices":[{"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, chunk := range chunks {
+		if _, err := io.WriteString(w, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -72,24 +72,14 @@ func (f AgentLLMClientFunc) Chat(ctx context.Context, req types.ChatRequest) (*t
 // assistant tool_calls without resolved results and dispatches them
 // without a second LLM call.
 type AgentLoopExecutor struct {
-	llm        AgentLLMClient
-	shell      Executor
-	file       Executor
-	git        Executor
-	maxTurns   int
-	gatedTools map[string]struct{}
-	httpPolicy HTTPRequestPolicy
-	httpClient *http.Client
+	llm            AgentLLMClient
+	maxTurns       int
+	approvalGate   agentLoopApprovalGate
+	toolDispatcher *agentLoopToolDispatcher
 	// mcpFactory builds a per-run MCP host from the task's
 	// MCPServers config. nil = no MCP support; tasks that configure
 	// MCPServers will fail with a clear error.
 	mcpFactory AgentMCPHostFactory
-	// metrics is the optional metrics seam for MCP tool calls. When
-	// set, dispatchMCPToolCall records every dispatch outcome on the
-	// hecate.orchestrator.mcp.tool_calls counter / duration
-	// histogram. nil = no metrics (the loop still runs; just no
-	// numbers).
-	metrics *telemetry.OrchestratorMetrics
 }
 
 // NewAgentLoopExecutor constructs the loop. A nil LLM client is
@@ -116,14 +106,6 @@ func NewAgentLoopExecutor(llm AgentLLMClient, shell Executor, file Executor, git
 	if maxTurns <= 0 {
 		maxTurns = 8
 	}
-	gated := make(map[string]struct{}, len(gatedTools))
-	for _, name := range gatedTools {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
-		}
-		gated[name] = struct{}{}
-	}
 	// Apply safe defaults to the HTTP policy. Operators who don't
 	// configure HECATE_TASK_HTTP_* still get sensible bounds.
 	if httpPolicy.Timeout <= 0 {
@@ -139,14 +121,16 @@ func NewAgentLoopExecutor(llm AgentLLMClient, shell Executor, file Executor, git
 	httpClient := &http.Client{Timeout: httpPolicy.Timeout}
 
 	return &AgentLoopExecutor{
-		llm:        llm,
-		shell:      shell,
-		file:       file,
-		git:        git,
-		maxTurns:   maxTurns,
-		gatedTools: gated,
-		httpPolicy: httpPolicy,
-		httpClient: httpClient,
+		llm:          llm,
+		maxTurns:     maxTurns,
+		approvalGate: newAgentLoopApprovalGate(gatedTools),
+		toolDispatcher: &agentLoopToolDispatcher{
+			shell:      shell,
+			file:       file,
+			git:        git,
+			httpPolicy: httpPolicy,
+			httpClient: httpClient,
+		},
 	}
 }
 
@@ -157,7 +141,9 @@ func NewAgentLoopExecutor(llm AgentLLMClient, shell Executor, file Executor, git
 // the same instance here so the agent loop and the runner share
 // instruments).
 func (e *AgentLoopExecutor) SetMetrics(m *telemetry.OrchestratorMetrics) {
-	e.metrics = m
+	if e.toolDispatcher != nil {
+		e.toolDispatcher.SetMetrics(m)
+	}
 }
 
 // SetMCPHostFactory wires the factory used to bring up per-task MCP
@@ -452,20 +438,18 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			// the same run is re-queued and we re-enter the loop
 			// with the same conversation tail — this branch is
 			// short-circuited by the resume-detection above.
-			gatedNames := e.gatedToolsInTurn(assistantMsg.ToolCalls, spec.Task)
-			if len(gatedNames) > 0 {
-				approval := buildApprovalForTurn(spec, turn, gatedNames, turnStartedAt)
-				awaitingStep := buildAwaitingApprovalStep(spec, nextIndex, turn, turnStartedAt, approval)
+			pause, ok := e.approvalGate.Evaluate(spec, turn, nextIndex, turnStartedAt, assistantMsg.ToolCalls)
+			if ok {
 				nextIndex++
-				if err := upsertTaskStep(spec, awaitingStep); err != nil {
+				if err := upsertTaskStep(spec, pause.Step); err != nil {
 					return nil, err
 				}
-				allSteps = append(allSteps, awaitingStep)
+				allSteps = append(allSteps, pause.Step)
 				return withRoute(&ExecutionResult{
 					Status:           "awaiting_approval",
 					Steps:            allSteps,
 					Artifacts:        allArtifacts,
-					PendingApprovals: []types.TaskApproval{approval},
+					PendingApprovals: []types.TaskApproval{pause.Approval},
 					OtelStatusCode:   "ok",
 					CostMicrosUSD:    costSpent,
 					TurnCosts:        turnCosts,
@@ -476,15 +460,15 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 		// 5. Dispatch each tool call in order.
 		callsToRun := assistantMsg.ToolCalls
 		for _, toolCall := range callsToRun {
-			toolResultText, toolStep, toolArtifacts, dispatchErr := e.dispatchToolCall(ctx, spec, toolCall, nextIndex, mcpHost)
-			if toolStep != nil {
-				if err := upsertTaskStep(spec, *toolStep); err != nil {
+			dispatch, dispatchErr := e.toolDispatcher.Dispatch(ctx, spec, toolCall, nextIndex, mcpHost)
+			if dispatch.Step != nil {
+				if err := upsertTaskStep(spec, *dispatch.Step); err != nil {
 					return nil, err
 				}
-				allSteps = append(allSteps, *toolStep)
+				allSteps = append(allSteps, *dispatch.Step)
 				nextIndex++
 			}
-			for _, art := range toolArtifacts {
+			for _, art := range dispatch.Artifacts {
 				if err := upsertTaskArtifact(spec, art); err != nil {
 					return nil, err
 				}
@@ -506,11 +490,11 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			//     non-zero / errored at runtime (sandbox rejected,
 			//     non-zero exit, file system error, HTTP non-2xx).
 			isToolError := dispatchErr != nil ||
-				toolStep == nil ||
-				(toolStep != nil && toolStep.Status == "failed")
+				dispatch.Step == nil ||
+				(dispatch.Step != nil && dispatch.Step.Status == "failed")
 			messages = append(messages, types.Message{
 				Role:       "tool",
-				Content:    toolResultText,
+				Content:    dispatch.Text,
 				ToolCallID: toolCall.ID,
 				ToolError:  isToolError,
 			})

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -172,19 +172,7 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 		return e.runWithoutLLM(ctx, spec)
 	}
 
-	startedAt := spec.StartedAt
-	if startedAt.IsZero() {
-		startedAt = time.Now().UTC()
-	}
-	baseIndex := 0
-	if spec.ResumeCheckpoint != nil && spec.ResumeCheckpoint.LastStepIndex > 0 {
-		baseIndex = spec.ResumeCheckpoint.LastStepIndex
-	}
-	nextIndex := baseIndex + 1
-
-	allSteps := make([]types.TaskStep, 0, e.maxTurns*2)
-	allArtifacts := make([]types.TaskArtifact, 0, e.maxTurns)
-
+	runState := newAgentLoopRunState(spec, e.maxTurns)
 	conversation := newAgentLoopConversation(spec)
 	tools := agentToolDefinitions()
 
@@ -198,12 +186,12 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 	var mcpHost AgentMCPHost
 	if len(spec.Task.MCPServers) > 0 {
 		if e.mcpFactory == nil {
-			return e.failedFromError(spec, nil, nil, baseIndex+1, time.Now().UTC(),
+			return e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), time.Now().UTC(),
 				"task configured mcp_servers but no MCP host factory is wired; this gateway build does not support external MCP servers")
 		}
 		host, err := e.mcpFactory(ctx, spec.Task.MCPServers)
 		if err != nil {
-			return e.failedFromError(spec, nil, nil, baseIndex+1, time.Now().UTC(),
+			return e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), time.Now().UTC(),
 				fmt.Sprintf("start mcp servers: %v", err))
 		}
 		if host != nil {
@@ -211,58 +199,6 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			defer func() { _ = host.Close() }()
 			tools = append(tools, host.Tools()...)
 		}
-	}
-
-	finalResult := &ExecutionResult{
-		Status:    "completed",
-		Steps:     allSteps,
-		Artifacts: allArtifacts,
-	}
-
-	// Per-task cost ceiling. spec.Task.BudgetMicrosUSD acts as a hard
-	// cap on the cumulative LLM spend for this *task* (across the
-	// entire resume chain), not just this run. Zero/negative disables
-	// the cap. We accumulate ChatResponse.Cost.TotalMicrosUSD after
-	// each turn and bail when (priorCost + costSpent) crosses the
-	// ceiling. Without priorCost the operator could escape the
-	// ceiling by repeatedly resuming a maxed-out run; including it
-	// here keeps the ceiling meaningful across the chain.
-	costCeiling := spec.Task.BudgetMicrosUSD
-	costSpent := int64(0)
-	priorCost := int64(0)
-	if spec.ResumeCheckpoint != nil {
-		priorCost = spec.ResumeCheckpoint.PriorCostMicrosUSD
-		// Same-run mid-approval resume: seed costSpent with the
-		// pre-pause spend so ceiling checks and the persisted Total
-		// account for it. Cross-run resumes see zero here (new run
-		// hasn't spent anything yet).
-		costSpent = spec.ResumeCheckpoint.ThisRunCostMicrosUSD
-	}
-	turnCosts := make([]TurnCostRecord, 0, e.maxTurns)
-	recordRoute := func(resp *types.ChatResponse) {
-		if resp == nil {
-			return
-		}
-		if resp.Route.Provider != "" {
-			finalResult.Provider = resp.Route.Provider
-		}
-		if resp.Route.ProviderKind != "" {
-			finalResult.ProviderKind = resp.Route.ProviderKind
-		}
-		if resp.Route.Model != "" {
-			finalResult.Model = resp.Route.Model
-		} else if resp.Model != "" {
-			finalResult.Model = resp.Model
-		}
-	}
-	withRoute := func(res *ExecutionResult) *ExecutionResult {
-		if res == nil {
-			return nil
-		}
-		res.Provider = firstNonEmpty(res.Provider, finalResult.Provider)
-		res.ProviderKind = firstNonEmpty(res.ProviderKind, finalResult.ProviderKind)
-		res.Model = firstNonEmpty(res.Model, finalResult.Model)
-		return res
 	}
 
 	// Resume detection: if the conversation tail is an assistant
@@ -273,19 +209,14 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 
 	for turn := 1; turn <= e.maxTurns; turn++ {
 		if err := ctx.Err(); err != nil {
-			finalResult.Status = "cancelled"
-			finalResult.LastError = err.Error()
-			finalResult.OtelStatusCode = "error"
-			finalResult.OtelStatusMessage = "context cancelled mid-loop"
-			finalResult.Steps = allSteps
-			finalResult.Artifacts = allArtifacts
-			finalResult.CostMicrosUSD = costSpent
-			finalResult.TurnCosts = turnCosts
-			return withRoute(finalResult), nil
+			res := runState.Result("cancelled")
+			res.LastError = err.Error()
+			res.OtelStatusCode = "error"
+			res.OtelStatusMessage = "context cancelled mid-loop"
+			return res, nil
 		}
 
 		var assistantMsg types.Message
-		var resp *types.ChatResponse
 		turnStartedAt := time.Now().UTC()
 
 		if len(pendingToolCalls) > 0 {
@@ -296,127 +227,31 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			var ok bool
 			assistantMsg, ok = conversation.TailAssistantForResume()
 			if !ok {
-				return e.failedFromError(spec, allSteps, allArtifacts, nextIndex, turnStartedAt,
+				failed, ferr := e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), turnStartedAt,
 					"resume checkpoint had pending tool calls but no assistant tail")
+				return runState.attachAccounting(failed), ferr
 			}
-			thinkingStep := buildResumeThinkingStep(spec, nextIndex, turn, turnStartedAt, assistantMsg)
-			nextIndex++
-			if err := upsertTaskStep(spec, thinkingStep); err != nil {
+			thinkingStep := buildResumeThinkingStep(spec, runState.NextStepIndex(), turn, turnStartedAt, assistantMsg)
+			if err := runState.AddStep(spec, thinkingStep); err != nil {
 				return nil, err
 			}
-			allSteps = append(allSteps, thinkingStep)
 		} else {
-			// 1. LLM round-trip.
-			//
-			// ProviderHint carries the operator's pinned provider
-			// from task.RequestedProvider (mirrored to run.Provider
-			// at run-create time). Without it the router falls back
-			// to its default — which historically picked OpenAI for
-			// generic model ids and surfaced as "api key is required
-			// for cloud provider openai" when the operator had only
-			// configured a local provider like Ollama. Empty hint
-			// preserves the existing auto-route behavior for tasks
-			// that didn't specify a provider.
-			req := types.ChatRequest{
-				RequestID: spec.RequestID,
-				Model:     spec.Run.Model,
-				Messages:  conversation.Messages(),
-				Tools:     tools,
-				Scope: types.RequestScope{
-					ProviderHint: spec.Run.Provider,
-				},
+			turnResult, failed, err := e.runLLMTurn(ctx, spec, &conversation, runState, tools, turn, turnStartedAt)
+			if failed != nil || err != nil {
+				return failed, err
 			}
-			emitAgentTurnStarted(spec, turn, req)
-			r, err := e.chatTurn(ctx, spec, conversation.ArtifactID(), conversation.Messages(), turn, req)
-			if err != nil {
-				// Annotate the common "model doesn't support tools"
-				// failure with a concrete remedy. agent_loop relies
-				// on tool calls; tiny models like smollm2:135m or
-				// embeddings-only endpoints reject the `tools` field
-				// outright. Surfacing the model name + a "pick a
-				// tool-capable model" hint saves the operator a
-				// trip to the provider's docs.
-				message := fmt.Sprintf("LLM call failed on turn %d: %v", turn, err)
-				if isModelLacksToolsError(err) {
-					message = fmt.Sprintf("LLM call failed on turn %d: model %q does not support tool-calling, which agent_loop requires. Pick a tool-capable model (e.g. gpt-4o-mini, claude-sonnet-4-6, qwen2.5-coder for Ollama). Underlying error: %v", turn, spec.Run.Model, err)
-				}
-				failed, ferr := e.failedFromError(spec, allSteps, allArtifacts, nextIndex, turnStartedAt, message)
-				if failed != nil {
-					failed.CostMicrosUSD = costSpent
-					failed.TurnCosts = turnCosts
-				}
-				return withRoute(failed), ferr
-			}
-			recordRoute(r)
-			if r == nil || len(r.Choices) == 0 {
-				failed, ferr := e.failedFromError(spec, allSteps, allArtifacts, nextIndex, turnStartedAt,
-					fmt.Sprintf("LLM returned empty response on turn %d", turn))
-				if failed != nil {
-					failed.CostMicrosUSD = costSpent
-					failed.TurnCosts = turnCosts
-				}
-				return withRoute(failed), ferr
-			}
-			resp = r
-			// Accumulate the LLM cost for this turn. Even when the
-			// per-task ceiling is disabled we surface the running
-			// total via ExecutionResult so the runner can persist
-			// per-run cost telemetry. CachedInputMicrosUSD is folded
-			// into TotalMicrosUSD upstream (see CostBreakdown), so
-			// using Total directly accounts correctly for cache hits.
-			turnCost := resp.Cost.TotalMicrosUSD
-			costSpent += turnCost
-			assistantMsg = resp.Choices[0].Message
-			emitAssistantMessageEvents(spec, turn, assistantMsg)
+			assistantMsg = turnResult.Assistant
 
-			// 2. Record this turn's "thinking" step — captures the
-			// assistant message content + which tools it asked for,
-			// plus the per-turn LLM cost in OutputSummary so the run
-			// replay UI can render cost next to the turn label
-			// without joining against the events feed.
-			thinkingStep := buildThinkingStep(spec, nextIndex, turn, turnStartedAt, assistantMsg, resp, costSpent)
-			nextIndex++
-			if err := upsertTaskStep(spec, thinkingStep); err != nil {
-				return nil, err
-			}
-			allSteps = append(allSteps, thinkingStep)
-
-			// Per-turn cost record. We surface this on ExecutionResult
-			// so the runner can emit one `turn.completed` event
-			// per turn for replay/operator UIs. CumulativeMicrosUSD is
-			// this-run-only; the runner adds priorCost when emitting.
-			turnCosts = append(turnCosts, TurnCostRecord{
-				Turn:                turn,
-				StepID:              thinkingStep.ID,
-				CostMicrosUSD:       turnCost,
-				CumulativeMicrosUSD: costSpent,
-				ToolCallCount:       len(assistantMsg.ToolCalls),
-			})
-
-			// 3. Append the assistant message to the running conversation.
-			conversation.AppendAssistant(assistantMsg)
-			// Persist snapshot — crash between LLM response and tool
-			// dispatch still leaves a recoverable state.
-			if art, err := conversation.UpsertArtifact(spec, turn, turnStartedAt); err != nil {
-				return nil, err
-			} else if art != nil && len(allArtifacts) == 0 {
-				allArtifacts = append(allArtifacts, *art)
-			}
-
-			// 4. If no tool calls, assistant gave a final answer.
+			// If no tool calls, assistant gave a final answer.
 			if len(assistantMsg.ToolCalls) == 0 {
 				emitAssistantFinalAnswer(spec, turn, assistantMsg)
-				finalArtifact := buildFinalAnswerArtifact(spec, thinkingStep.ID, turnStartedAt, assistantMsg.Content)
-				if err := upsertTaskArtifact(spec, finalArtifact); err != nil {
+				finalArtifact := buildFinalAnswerArtifact(spec, turnResult.ThinkingStep.ID, turnStartedAt, assistantMsg.Content)
+				if err := runState.AddArtifact(spec, finalArtifact); err != nil {
 					return nil, err
 				}
-				allArtifacts = append(allArtifacts, finalArtifact)
-				finalResult.Steps = allSteps
-				finalResult.Artifacts = allArtifacts
-				finalResult.OtelStatusCode = "ok"
-				finalResult.CostMicrosUSD = costSpent
-				finalResult.TurnCosts = turnCosts
-				return withRoute(finalResult), nil
+				res := runState.Result("completed")
+				res.OtelStatusCode = "ok"
+				return res, nil
 			}
 
 			// 4b. Approval gate. If any tool in this turn is gated,
@@ -427,41 +262,29 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			// the same run is re-queued and we re-enter the loop
 			// with the same conversation tail — this branch is
 			// short-circuited by the resume-detection above.
-			pause, ok := e.approvalGate.Evaluate(spec, turn, nextIndex, turnStartedAt, assistantMsg.ToolCalls)
+			pause, ok := e.approvalGate.Evaluate(spec, turn, runState.NextStepIndex(), turnStartedAt, assistantMsg.ToolCalls)
 			if ok {
-				nextIndex++
-				if err := upsertTaskStep(spec, pause.Step); err != nil {
+				if err := runState.AddStep(spec, pause.Step); err != nil {
 					return nil, err
 				}
-				allSteps = append(allSteps, pause.Step)
-				return withRoute(&ExecutionResult{
-					Status:           "awaiting_approval",
-					Steps:            allSteps,
-					Artifacts:        allArtifacts,
-					PendingApprovals: []types.TaskApproval{pause.Approval},
-					OtelStatusCode:   "ok",
-					CostMicrosUSD:    costSpent,
-					TurnCosts:        turnCosts,
-				}), nil
+				res := runState.Result("awaiting_approval")
+				res.PendingApprovals = []types.TaskApproval{pause.Approval}
+				res.OtelStatusCode = "ok"
+				return res, nil
 			}
 		}
 
 		// 5. Dispatch each tool call in order.
 		callsToRun := assistantMsg.ToolCalls
 		for _, toolCall := range callsToRun {
-			dispatch, dispatchErr := e.toolDispatcher.Dispatch(ctx, spec, toolCall, nextIndex, mcpHost)
+			dispatch, dispatchErr := e.toolDispatcher.Dispatch(ctx, spec, toolCall, runState.NextStepIndex(), mcpHost)
 			if dispatch.Step != nil {
-				if err := upsertTaskStep(spec, *dispatch.Step); err != nil {
+				if err := runState.AddStep(spec, *dispatch.Step); err != nil {
 					return nil, err
 				}
-				allSteps = append(allSteps, *dispatch.Step)
-				nextIndex++
 			}
-			for _, art := range dispatch.Artifacts {
-				if err := upsertTaskArtifact(spec, art); err != nil {
-					return nil, err
-				}
-				allArtifacts = append(allArtifacts, art)
+			if err := runState.AddArtifacts(spec, dispatch.Artifacts); err != nil {
+				return nil, err
 			}
 			// Mark the tool message as errored on any failure
 			// path so Anthropic providers can emit is_error=true
@@ -495,36 +318,26 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 		// Per-task cost ceiling check. We do this AFTER the turn is
 		// fully recorded (assistant message + tool results in the
 		// conversation snapshot) so the operator sees what was paid
-		// for. The ceiling is task-cumulative — priorCost (spend in
-		// earlier runs of the resume chain) plus costSpent (this
-		// run). Crossing the ceiling marks the run failed with an
-		// actionable error; future turns don't fire. Operators can
-		// raise the ceiling and resume to continue.
-		if costCeiling > 0 && (priorCost+costSpent) >= costCeiling {
-			msg := fmt.Sprintf("agent loop hit per-task cost ceiling: spent %d µUSD this run + %d µUSD prior = %d µUSD, ceiling %d µUSD", costSpent, priorCost, priorCost+costSpent, costCeiling)
-			finalResult.Status = "failed"
-			finalResult.LastError = msg
-			finalResult.OtelStatusCode = "error"
-			finalResult.OtelStatusMessage = "cost_ceiling_exceeded"
-			finalResult.Steps = allSteps
-			finalResult.Artifacts = allArtifacts
-			finalResult.CostMicrosUSD = costSpent
-			finalResult.TurnCosts = turnCosts
-			return withRoute(finalResult), nil
+		// for. The ceiling is task-cumulative — prior resume-chain
+		// spend plus this run's spend. Crossing the ceiling marks
+		// the run failed with an actionable error; future turns don't
+		// fire. Operators can raise the ceiling and resume to continue.
+		if msg, exceeded := runState.CostCeilingExceededMessage(); exceeded {
+			res := runState.Result("failed")
+			res.LastError = msg
+			res.OtelStatusCode = "error"
+			res.OtelStatusMessage = "cost_ceiling_exceeded"
+			return res, nil
 		}
 	}
 
 	// Hit max turns without a final answer. Mark incomplete; the user
 	// can resume the run if they want more turns.
-	finalResult.Status = "failed"
-	finalResult.LastError = fmt.Sprintf("agent loop hit maxTurns=%d without producing a final answer", e.maxTurns)
-	finalResult.OtelStatusCode = "error"
-	finalResult.OtelStatusMessage = "max_turns_exceeded"
-	finalResult.Steps = allSteps
-	finalResult.Artifacts = allArtifacts
-	finalResult.CostMicrosUSD = costSpent
-	finalResult.TurnCosts = turnCosts
-	return withRoute(finalResult), nil
+	res := runState.Result("failed")
+	res.LastError = fmt.Sprintf("agent loop hit maxTurns=%d without producing a final answer", e.maxTurns)
+	res.OtelStatusCode = "error"
+	res.OtelStatusMessage = "max_turns_exceeded"
+	return res, nil
 }
 
 func emitAgentTurnStarted(spec ExecutionSpec, turn int, req types.ChatRequest) {

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -185,17 +185,7 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 	allSteps := make([]types.TaskStep, 0, e.maxTurns*2)
 	allArtifacts := make([]types.TaskArtifact, 0, e.maxTurns)
 
-	// Build the initial conversation. On resume, we hydrate from the
-	// previous run's persisted conversation artifact so the agent
-	// continues the exact dialogue rather than restarting from scratch
-	// — preserves prior tool results, partial reasoning, and avoids
-	// re-paying for tokens already spent. Fresh runs start with just
-	// the user prompt.
-	//
-	// We don't currently inject a system prompt — the task's own
-	// Prompt carries enough intent. Per-tenant system prompts are a
-	// later add.
-	messages := hydrateConversation(spec)
+	conversation := newAgentLoopConversation(spec)
 	tools := agentToolDefinitions()
 
 	// Bring up external MCP servers if the task configured any. Their
@@ -222,12 +212,6 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			tools = append(tools, host.Tools()...)
 		}
 	}
-
-	// Stable artifact ID for this run's conversation snapshot. Same
-	// ID across turns means UpsertArtifact replaces the contents in
-	// place rather than creating a new artifact each time, so the
-	// run's artifact list stays clean.
-	conversationArtifactID := "convo-" + spec.Run.ID
 
 	finalResult := &ExecutionResult{
 		Status:    "completed",
@@ -285,7 +269,7 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 	// message with tool_calls and no following tool messages, we're
 	// resuming after operator approval. Dispatch the pending tool
 	// calls before doing the next LLM turn — they were just approved.
-	pendingToolCalls := pendingToolCallsForResume(messages)
+	pendingToolCalls := conversation.PendingToolCallsForResume()
 
 	for turn := 1; turn <= e.maxTurns; turn++ {
 		if err := ctx.Err(); err != nil {
@@ -309,7 +293,12 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			// already at the tail of `messages` (saved by the previous
 			// run). Dispatch the approved tool calls and let the next
 			// turn's LLM call reason over the results.
-			assistantMsg = messages[len(messages)-1]
+			var ok bool
+			assistantMsg, ok = conversation.TailAssistantForResume()
+			if !ok {
+				return e.failedFromError(spec, allSteps, allArtifacts, nextIndex, turnStartedAt,
+					"resume checkpoint had pending tool calls but no assistant tail")
+			}
 			thinkingStep := buildResumeThinkingStep(spec, nextIndex, turn, turnStartedAt, assistantMsg)
 			nextIndex++
 			if err := upsertTaskStep(spec, thinkingStep); err != nil {
@@ -331,14 +320,14 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			req := types.ChatRequest{
 				RequestID: spec.RequestID,
 				Model:     spec.Run.Model,
-				Messages:  messages,
+				Messages:  conversation.Messages(),
 				Tools:     tools,
 				Scope: types.RequestScope{
 					ProviderHint: spec.Run.Provider,
 				},
 			}
 			emitAgentTurnStarted(spec, turn, req)
-			r, err := e.chatTurn(ctx, spec, conversationArtifactID, messages, turn, req)
+			r, err := e.chatTurn(ctx, spec, conversation.ArtifactID(), conversation.Messages(), turn, req)
 			if err != nil {
 				// Annotate the common "model doesn't support tools"
 				// failure with a concrete remedy. agent_loop relies
@@ -405,10 +394,10 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			})
 
 			// 3. Append the assistant message to the running conversation.
-			messages = append(messages, assistantMsg)
+			conversation.AppendAssistant(assistantMsg)
 			// Persist snapshot — crash between LLM response and tool
 			// dispatch still leaves a recoverable state.
-			if art, err := upsertConversationArtifact(spec, conversationArtifactID, messages, turn, turnStartedAt); err != nil {
+			if art, err := conversation.UpsertArtifact(spec, turn, turnStartedAt); err != nil {
 				return nil, err
 			} else if art != nil && len(allArtifacts) == 0 {
 				allArtifacts = append(allArtifacts, *art)
@@ -492,16 +481,11 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (*E
 			isToolError := dispatchErr != nil ||
 				dispatch.Step == nil ||
 				(dispatch.Step != nil && dispatch.Step.Status == "failed")
-			messages = append(messages, types.Message{
-				Role:       "tool",
-				Content:    dispatch.Text,
-				ToolCallID: toolCall.ID,
-				ToolError:  isToolError,
-			})
+			conversation.AppendToolResult(toolCall.ID, dispatch.Text, isToolError)
 			_ = dispatchErr
 		}
 		// Snapshot after tool results.
-		if _, err := upsertConversationArtifact(spec, conversationArtifactID, messages, turn, turnStartedAt); err != nil {
+		if _, err := conversation.UpsertArtifact(spec, turn, turnStartedAt); err != nil {
 			return nil, err
 		}
 		// Resume mode is a one-shot — clear so subsequent turns hit
@@ -2210,77 +2194,6 @@ func buildHTTPRequestStep(spec ExecutionSpec, index int, startedAt time.Time, to
 	}
 }
 
-// pendingToolCallsForResume detects the resume-after-approval state:
-// the conversation tail is an assistant message with tool_calls and
-// no subsequent tool-role results. Returns the list of tool calls
-// that need dispatching. Empty slice = fresh turn (LLM call needed).
-func pendingToolCallsForResume(messages []types.Message) []types.ToolCall {
-	if len(messages) == 0 {
-		return nil
-	}
-	last := messages[len(messages)-1]
-	if last.Role != "assistant" || len(last.ToolCalls) == 0 {
-		return nil
-	}
-	// Tool calls in the trailing assistant message exist; check that
-	// none of them have already been resolved by a later tool message.
-	// Since we just confirmed `last` is the tail, if tool messages
-	// for these calls existed they'd be after `last` — they don't,
-	// so all calls are pending.
-	return last.ToolCalls
-}
-
-// countAssistantTurns returns the number of assistant messages in the
-// saved conversation. Each agent_loop turn produces exactly one
-// assistant message (with tool_calls or a final answer), so the count
-// equals the number of completed turns. Used by the retry-from-turn-N
-// codepath to validate the requested turn lies within range.
-func countAssistantTurns(messages []types.Message) int {
-	n := 0
-	for _, m := range messages {
-		if m.Role == "assistant" {
-			n++
-		}
-	}
-	return n
-}
-
-// truncateConversationToTurn drops the Nth assistant message and
-// everything that follows it, so the next LLM call re-issues turn N
-// against the same prior context. The system message (if present) and
-// the user prompt are preserved, as are any prior assistant turns and
-// their tool results — the operator gets to explore an alternative
-// path from turn N forward.
-//
-// turn must be >= 1 and <= countAssistantTurns(messages). turn=1
-// truncates back to just the prelude (system + user); turn=N for the
-// final turn drops only that turn's assistant message.
-//
-// Returns a fresh slice; the input is not modified.
-func truncateConversationToTurn(messages []types.Message, turn int) ([]types.Message, error) {
-	if turn < 1 {
-		return nil, fmt.Errorf("turn must be >= 1, got %d", turn)
-	}
-	assistantSeen := 0
-	cutIndex := -1
-	for i, m := range messages {
-		if m.Role != "assistant" {
-			continue
-		}
-		assistantSeen++
-		if assistantSeen == turn {
-			cutIndex = i
-			break
-		}
-	}
-	if cutIndex == -1 {
-		return nil, fmt.Errorf("turn %d not found: conversation has %d assistant turn(s)", turn, assistantSeen)
-	}
-	out := make([]types.Message, cutIndex)
-	copy(out, messages[:cutIndex])
-	return out, nil
-}
-
 // buildApprovalForTurn constructs the approval record covering one
 // or more gated tool calls in a turn. The reason text lists the tool
 // names so the operator UI can render a clear "approve agent's use of
@@ -2358,118 +2271,6 @@ func buildResumeThinkingStep(spec ExecutionSpec, index, turn int, when time.Time
 		RequestID:  spec.RequestID,
 		TraceID:    spec.TraceID,
 	}
-}
-
-// hydrateConversation returns the conversation history for this run.
-// On a fresh run, it prepends the composed system prompt (from the
-// runner's four-layer resolver) before the user prompt. On a resume,
-// it returns the JSON-decoded prior conversation from the source
-// run's persisted agent_conversation artifact — the loop continues
-// exactly where it left off, preserving tool results, prior reasoning,
-// AND the original system prompt (it's already in the saved message
-// array; we don't re-compose).
-//
-// If the resume artifact is missing or malformed (corrupt JSON, edited
-// out of band) we fall back to the fresh-start state. That degrades
-// gracefully: the agent re-plans rather than crashing.
-func hydrateConversation(spec ExecutionSpec) []types.Message {
-	if spec.ResumeCheckpoint != nil && len(spec.ResumeCheckpoint.AgentConversation) > 0 {
-		var saved []types.Message
-		if err := json.Unmarshal(spec.ResumeCheckpoint.AgentConversation, &saved); err == nil && len(saved) > 0 {
-			if prompt := strings.TrimSpace(spec.ResumeCheckpoint.AppendUserPrompt); prompt != "" {
-				saved = append(saved, types.Message{Role: "user", Content: prompt})
-			}
-			return saved
-		}
-	}
-	// Fresh run: build the prelude as
-	//   1. environment system message (workspace path) — always present
-	//      when there's a workspace, so the LLM uses the right cwd
-	//      and absolute paths in tool calls. Without this the model
-	//      reads the user prompt's mention of "/Users/foo/myrepo"
-	//      and uses that path verbatim — which lands outside the
-	//      sandbox (an isolated clone) and the run fails with
-	//      "escapes allowed root".
-	//   2. composed operator system prompt (four layers) — global /
-	//      tenant / workspace CLAUDE.md|AGENTS.md / per-task. Empty
-	//      when none of those layers contributed.
-	//   3. user prompt.
-	messages := make([]types.Message, 0, 3)
-	if env := environmentSystemMessage(spec); env != "" {
-		messages = append(messages, types.Message{Role: "system", Content: env})
-	}
-	if strings.TrimSpace(spec.SystemPrompt) != "" {
-		messages = append(messages, types.Message{Role: "system", Content: spec.SystemPrompt})
-	}
-	messages = append(messages, types.Message{Role: "user", Content: spec.Task.Prompt})
-	return messages
-}
-
-// environmentSystemMessage produces the machine-generated system
-// message that grounds the LLM in its actual sandbox: where the
-// workspace lives and what's enforced. This is environmental fact,
-// not operator-tunable directive — kept separate from
-// spec.SystemPrompt so the operator can't accidentally elide it.
-//
-// Returns "" when there's no workspace path (shouldn't happen in
-// practice, but the runner can still drive the executor with an
-// empty path in tests).
-func environmentSystemMessage(spec ExecutionSpec) string {
-	workspace := strings.TrimSpace(spec.Task.WorkingDirectory)
-	if workspace == "" {
-		workspace = strings.TrimSpace(spec.Task.SandboxAllowedRoot)
-	}
-	if workspace == "" {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("Your workspace is at: ")
-	b.WriteString(workspace)
-	b.WriteString("\n\n")
-	b.WriteString("Use this path (or paths under it) when calling tools. ")
-	b.WriteString("`shell_exec` / `git_exec` default their working_directory to the workspace when omitted; ")
-	b.WriteString("`read_file` / `list_dir` / `grep` / `glob` / `git_diff` resolve relative paths from the workspace. ")
-	b.WriteString("Tool calls that target paths outside this directory are rejected by the sandbox — ")
-	b.WriteString("don't reuse paths from the user prompt verbatim if they fall outside the workspace.")
-	return b.String()
-}
-
-// upsertConversationArtifact writes the current conversation snapshot
-// to a stable artifact ID. Returns the artifact when it's newly
-// created (or on the first call) so the caller can include it in the
-// run's artifact list. Idempotent across turns: the same ID means the
-// artifact's content is replaced in place rather than appended.
-func upsertConversationArtifact(spec ExecutionSpec, id string, messages []types.Message, turn int, when time.Time) (*types.TaskArtifact, error) {
-	if spec.UpsertArtifact == nil {
-		return nil, nil
-	}
-	payload, err := json.Marshal(messages)
-	if err != nil {
-		// Marshal failures here are fatal — every Message field is
-		// JSON-marshalable by construction; a failure would be a
-		// runtime corruption we shouldn't paper over.
-		return nil, fmt.Errorf("marshal agent conversation: %w", err)
-	}
-	art := types.TaskArtifact{
-		ID:          id,
-		TaskID:      spec.Task.ID,
-		RunID:       spec.Run.ID,
-		Kind:        "agent_conversation",
-		Name:        "agent-conversation.json",
-		Description: fmt.Sprintf("Agent loop conversation snapshot after turn %d", turn),
-		MimeType:    "application/json",
-		StorageKind: "inline",
-		ContentText: string(payload),
-		SizeBytes:   int64(len(payload)),
-		Status:      "ready",
-		CreatedAt:   when,
-		RequestID:   spec.RequestID,
-		TraceID:     spec.TraceID,
-	}
-	if err := spec.UpsertArtifact(art); err != nil {
-		return nil, err
-	}
-	return &art, nil
 }
 
 // resultFromStatus maps an executor's status string ("completed",

--- a/internal/orchestrator/executor_agent_loop_approval_gate.go
+++ b/internal/orchestrator/executor_agent_loop_approval_gate.go
@@ -1,0 +1,81 @@
+package orchestrator
+
+import (
+	"strings"
+	"time"
+
+	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type agentLoopApprovalGate struct {
+	gatedTools map[string]struct{}
+}
+
+type agentLoopApprovalPause struct {
+	Approval types.TaskApproval
+	Step     types.TaskStep
+}
+
+func newAgentLoopApprovalGate(gatedTools []string) agentLoopApprovalGate {
+	gated := make(map[string]struct{}, len(gatedTools))
+	for _, name := range gatedTools {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		gated[name] = struct{}{}
+	}
+	return agentLoopApprovalGate{gatedTools: gated}
+}
+
+func (g agentLoopApprovalGate) Evaluate(spec ExecutionSpec, turn, stepIndex int, when time.Time, calls []types.ToolCall) (agentLoopApprovalPause, bool) {
+	gatedNames := g.gatedToolsInTurn(calls, spec.Task)
+	if len(gatedNames) == 0 {
+		return agentLoopApprovalPause{}, false
+	}
+	approval := buildApprovalForTurn(spec, turn, gatedNames, when)
+	return agentLoopApprovalPause{
+		Approval: approval,
+		Step:     buildAwaitingApprovalStep(spec, stepIndex, turn, when, approval),
+	}, true
+}
+
+func (g agentLoopApprovalGate) gatedToolsInTurn(calls []types.ToolCall, task types.Task) []string {
+	seen := make(map[string]struct{}, len(calls))
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		if !g.isGated(c.Function.Name, task) {
+			continue
+		}
+		if _, dup := seen[c.Function.Name]; dup {
+			continue
+		}
+		seen[c.Function.Name] = struct{}{}
+		out = append(out, c.Function.Name)
+	}
+	return out
+}
+
+func (g agentLoopApprovalGate) isGated(toolName string, task types.Task) bool {
+	if _, ok := g.gatedTools[toolName]; ok {
+		return true
+	}
+	return mcpServerPolicy(toolName, task) == types.MCPApprovalRequireApproval
+}
+
+func mcpServerPolicy(toolName string, task types.Task) string {
+	if !isMCPToolName(toolName) {
+		return ""
+	}
+	server, _, ok := mcpclient.SplitNamespacedToolName(toolName)
+	if !ok {
+		return ""
+	}
+	for _, cfg := range task.MCPServers {
+		if cfg.Name == server {
+			return cfg.ApprovalPolicy
+		}
+	}
+	return ""
+}

--- a/internal/orchestrator/executor_agent_loop_approval_gate_test.go
+++ b/internal/orchestrator/executor_agent_loop_approval_gate_test.go
@@ -1,0 +1,118 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestAgentLoopApprovalGate_EvaluateConfiguredToolsDedupesAndBuildsPause(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.RequestID = "req-gate"
+	spec.TraceID = "trace-gate"
+	when := time.Date(2026, 5, 29, 10, 30, 0, 0, time.UTC)
+
+	gate := newAgentLoopApprovalGate([]string{" shell_exec ", "", "shell_exec"})
+	pause, ok := gate.Evaluate(spec, 2, 7, when, []types.ToolCall{
+		agentLoopToolCall("call-shell-1", "shell_exec", `{"command":"ls"}`),
+		agentLoopToolCall("call-file-1", "file_write", `{"path":"out.txt","content":"hi"}`),
+		agentLoopToolCall("call-shell-2", "shell_exec", `{"command":"pwd"}`),
+	})
+	if !ok {
+		t.Fatalf("Evaluate() ok = false, want true")
+	}
+
+	approval := pause.Approval
+	if approval.Kind != "agent_loop_tool_call" || approval.Status != "pending" {
+		t.Fatalf("approval shape = %+v, want pending agent_loop_tool_call", approval)
+	}
+	if approval.TaskID != spec.Task.ID || approval.RunID != spec.Run.ID {
+		t.Fatalf("approval task/run = %s/%s, want %s/%s", approval.TaskID, approval.RunID, spec.Task.ID, spec.Run.ID)
+	}
+	if approval.RequestID != "req-gate" || approval.TraceID != "trace-gate" {
+		t.Fatalf("approval request/trace = %s/%s", approval.RequestID, approval.TraceID)
+	}
+	if !approval.CreatedAt.Equal(when) {
+		t.Fatalf("approval CreatedAt = %s, want %s", approval.CreatedAt, when)
+	}
+	if strings.Count(approval.Reason, "shell_exec") != 1 {
+		t.Fatalf("approval reason should mention shell_exec once, got %q", approval.Reason)
+	}
+	if strings.Contains(approval.Reason, "file_write") {
+		t.Fatalf("approval reason should not mention non-gated file_write: %q", approval.Reason)
+	}
+
+	step := pause.Step
+	if step.Kind != "approval" || step.Status != "awaiting_approval" || step.Phase != "approval" {
+		t.Fatalf("approval step shape = %+v", step)
+	}
+	if step.Index != 7 || step.ApprovalID != approval.ID || step.ToolName != "builtin.agent_loop_approval" {
+		t.Fatalf("approval step linkage = %+v, approval id %q", step, approval.ID)
+	}
+	if got := step.Input["turn"]; got != 2 {
+		t.Fatalf("approval step turn input = %v, want 2", got)
+	}
+	if got := step.Input["reason"]; got != approval.Reason {
+		t.Fatalf("approval step reason input = %v, want %q", got, approval.Reason)
+	}
+	if !step.StartedAt.Equal(when) || !step.FinishedAt.Equal(when) {
+		t.Fatalf("approval step timestamps = %s/%s, want %s", step.StartedAt, step.FinishedAt, when)
+	}
+}
+
+func TestAgentLoopApprovalGate_EvaluateMCPRequireApprovalOnly(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.Task.MCPServers = []types.MCPServerConfig{
+		{Name: "github", Command: "fake", ApprovalPolicy: types.MCPApprovalRequireApproval},
+		{Name: "filesystem", Command: "fake", ApprovalPolicy: types.MCPApprovalAuto},
+		{Name: "danger", Command: "fake", ApprovalPolicy: types.MCPApprovalBlock},
+	}
+	gate := newAgentLoopApprovalGate(nil)
+
+	pause, ok := gate.Evaluate(spec, 1, 4, time.Now().UTC(), []types.ToolCall{
+		agentLoopToolCall("call-github", "mcp__github__create_issue", `{}`),
+		agentLoopToolCall("call-filesystem", "mcp__filesystem__read_file", `{}`),
+		agentLoopToolCall("call-danger", "mcp__danger__delete_repo", `{}`),
+		agentLoopToolCall("call-missing", "mcp__missing__do", `{}`),
+	})
+	if !ok {
+		t.Fatalf("Evaluate() ok = false, want true")
+	}
+	reason := pause.Approval.Reason
+	if !strings.Contains(reason, "mcp__github__create_issue") {
+		t.Fatalf("approval reason missing require_approval MCP tool: %q", reason)
+	}
+	for _, notWanted := range []string{"mcp__filesystem__read_file", "mcp__danger__delete_repo", "mcp__missing__do"} {
+		if strings.Contains(reason, notWanted) {
+			t.Fatalf("approval reason included non-gated MCP tool %q: %q", notWanted, reason)
+		}
+	}
+}
+
+func TestAgentLoopApprovalGate_NoGatedToolsDoesNotPause(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.Task.MCPServers = []types.MCPServerConfig{
+		{Name: "github", Command: "fake", ApprovalPolicy: types.MCPApprovalBlock},
+	}
+	gate := newAgentLoopApprovalGate([]string{"shell_exec"})
+
+	if _, ok := gate.Evaluate(spec, 1, 2, time.Now().UTC(), []types.ToolCall{
+		agentLoopToolCall("call-file", "file_write", `{}`),
+		agentLoopToolCall("call-blocked-mcp", "mcp__github__create_issue", `{}`),
+	}); ok {
+		t.Fatalf("Evaluate() ok = true, want false for non-gated and blocked tools")
+	}
+}
+
+func agentLoopToolCall(id, name, args string) types.ToolCall {
+	return types.ToolCall{
+		ID:   id,
+		Type: "function",
+		Function: types.ToolCallFunction{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}

--- a/internal/orchestrator/executor_agent_loop_chat.go
+++ b/internal/orchestrator/executor_agent_loop_chat.go
@@ -2,12 +2,86 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+type agentLoopLLMTurn struct {
+	Assistant    types.Message
+	ThinkingStep types.TaskStep
+}
+
+func (e *AgentLoopExecutor) runLLMTurn(ctx context.Context, spec ExecutionSpec, conversation *agentLoopConversation, runState *agentLoopRunState, tools []types.Tool, turn int, startedAt time.Time) (agentLoopLLMTurn, *ExecutionResult, error) {
+	messages := conversation.Messages()
+	req := agentLoopChatRequest(spec, messages, tools)
+	emitAgentTurnStarted(spec, turn, req)
+
+	resp, err := e.chatTurn(ctx, spec, conversation.ArtifactID(), messages, turn, req)
+	if err != nil {
+		failed, ferr := e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), startedAt, llmTurnErrorMessage(spec, turn, err))
+		return agentLoopLLMTurn{}, runState.attachAccounting(failed), ferr
+	}
+	runState.RecordRoute(resp)
+	if resp == nil || len(resp.Choices) == 0 {
+		failed, ferr := e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), startedAt,
+			fmt.Sprintf("LLM returned empty response on turn %d", turn))
+		return agentLoopLLMTurn{}, runState.attachAccounting(failed), ferr
+	}
+
+	assistantMsg := resp.Choices[0].Message
+	emitAssistantMessageEvents(spec, turn, assistantMsg)
+
+	turnCost := runState.AccumulateCost(resp)
+	thinkingStep := buildThinkingStep(spec, runState.NextStepIndex(), turn, startedAt, assistantMsg, resp, runState.CostSpent())
+	if err := runState.AddStep(spec, thinkingStep); err != nil {
+		return agentLoopLLMTurn{}, nil, err
+	}
+	runState.AddTurnCost(turn, thinkingStep.ID, turnCost, len(assistantMsg.ToolCalls))
+
+	conversation.AppendAssistant(assistantMsg)
+	if art, err := conversation.UpsertArtifact(spec, turn, startedAt); err != nil {
+		return agentLoopLLMTurn{}, nil, err
+	} else {
+		runState.TrackInitialConversationArtifact(art)
+	}
+
+	return agentLoopLLMTurn{
+		Assistant:    assistantMsg,
+		ThinkingStep: thinkingStep,
+	}, nil, nil
+}
+
+func agentLoopChatRequest(spec ExecutionSpec, messages []types.Message, tools []types.Tool) types.ChatRequest {
+	// ProviderHint carries the operator's pinned provider from
+	// task.RequestedProvider (mirrored to run.Provider at run-create
+	// time). Without it the router falls back to its default — which
+	// historically picked OpenAI for generic model ids and surfaced
+	// as "api key is required for cloud provider openai" when the
+	// operator had only configured a local provider like Ollama.
+	// Empty hint preserves the existing auto-route behavior for
+	// tasks that didn't specify a provider.
+	return types.ChatRequest{
+		RequestID: spec.RequestID,
+		Model:     spec.Run.Model,
+		Messages:  messages,
+		Tools:     tools,
+		Scope: types.RequestScope{
+			ProviderHint: spec.Run.Provider,
+		},
+	}
+}
+
+func llmTurnErrorMessage(spec ExecutionSpec, turn int, err error) string {
+	message := fmt.Sprintf("LLM call failed on turn %d: %v", turn, err)
+	if !isModelLacksToolsError(err) {
+		return message
+	}
+	return fmt.Sprintf("LLM call failed on turn %d: model %q does not support tool-calling, which agent_loop requires. Pick a tool-capable model (e.g. gpt-4o-mini, claude-sonnet-4-6, qwen2.5-coder for Ollama). Underlying error: %v", turn, spec.Run.Model, err)
+}
 
 func (e *AgentLoopExecutor) chatTurn(ctx context.Context, spec ExecutionSpec, conversationArtifactID string, messages []types.Message, turn int, req types.ChatRequest) (*types.ChatResponse, error) {
 	streamer, ok := e.llm.(AgentLLMStreamingClient)

--- a/internal/orchestrator/executor_agent_loop_conversation.go
+++ b/internal/orchestrator/executor_agent_loop_conversation.go
@@ -1,0 +1,245 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type agentLoopConversation struct {
+	artifactID string
+	messages   []types.Message
+}
+
+func newAgentLoopConversation(spec ExecutionSpec) agentLoopConversation {
+	return agentLoopConversation{
+		artifactID: "convo-" + spec.Run.ID,
+		messages:   hydrateConversation(spec),
+	}
+}
+
+func (c *agentLoopConversation) Messages() []types.Message {
+	return c.messages
+}
+
+func (c *agentLoopConversation) ArtifactID() string {
+	return c.artifactID
+}
+
+func (c *agentLoopConversation) AppendAssistant(msg types.Message) {
+	c.messages = append(c.messages, msg)
+}
+
+func (c *agentLoopConversation) AppendToolResult(toolCallID, text string, toolError bool) {
+	c.messages = append(c.messages, types.Message{
+		Role:       "tool",
+		Content:    text,
+		ToolCallID: toolCallID,
+		ToolError:  toolError,
+	})
+}
+
+func (c *agentLoopConversation) PendingToolCallsForResume() []types.ToolCall {
+	return pendingToolCallsForResume(c.messages)
+}
+
+func (c *agentLoopConversation) TailAssistantForResume() (types.Message, bool) {
+	if len(c.messages) == 0 {
+		return types.Message{}, false
+	}
+	last := c.messages[len(c.messages)-1]
+	if last.Role != "assistant" || len(last.ToolCalls) == 0 {
+		return types.Message{}, false
+	}
+	return last, true
+}
+
+func (c *agentLoopConversation) UpsertArtifact(spec ExecutionSpec, turn int, when time.Time) (*types.TaskArtifact, error) {
+	return upsertConversationArtifact(spec, c.artifactID, c.messages, turn, when)
+}
+
+// pendingToolCallsForResume detects the resume-after-approval state:
+// the conversation tail is an assistant message with tool_calls and
+// no subsequent tool-role results. Returns the list of tool calls
+// that need dispatching. Empty slice = fresh turn (LLM call needed).
+func pendingToolCallsForResume(messages []types.Message) []types.ToolCall {
+	if len(messages) == 0 {
+		return nil
+	}
+	last := messages[len(messages)-1]
+	if last.Role != "assistant" || len(last.ToolCalls) == 0 {
+		return nil
+	}
+	// Tool calls in the trailing assistant message exist; check that
+	// none of them have already been resolved by a later tool message.
+	// Since we just confirmed `last` is the tail, if tool messages
+	// for these calls existed they'd be after `last` — they don't,
+	// so all calls are pending.
+	return last.ToolCalls
+}
+
+// countAssistantTurns returns the number of assistant messages in the
+// saved conversation. Each agent_loop turn produces exactly one
+// assistant message (with tool_calls or a final answer), so the count
+// equals the number of completed turns. Used by the retry-from-turn-N
+// codepath to validate the requested turn lies within range.
+func countAssistantTurns(messages []types.Message) int {
+	n := 0
+	for _, m := range messages {
+		if m.Role == "assistant" {
+			n++
+		}
+	}
+	return n
+}
+
+// truncateConversationToTurn drops the Nth assistant message and
+// everything that follows it, so the next LLM call re-issues turn N
+// against the same prior context. The system message (if present) and
+// the user prompt are preserved, as are any prior assistant turns and
+// their tool results — the operator gets to explore an alternative
+// path from turn N forward.
+//
+// turn must be >= 1 and <= countAssistantTurns(messages). turn=1
+// truncates back to just the prelude (system + user); turn=N for the
+// final turn drops only that turn's assistant message.
+//
+// Returns a fresh slice; the input is not modified.
+func truncateConversationToTurn(messages []types.Message, turn int) ([]types.Message, error) {
+	if turn < 1 {
+		return nil, fmt.Errorf("turn must be >= 1, got %d", turn)
+	}
+	assistantSeen := 0
+	cutIndex := -1
+	for i, m := range messages {
+		if m.Role != "assistant" {
+			continue
+		}
+		assistantSeen++
+		if assistantSeen == turn {
+			cutIndex = i
+			break
+		}
+	}
+	if cutIndex == -1 {
+		return nil, fmt.Errorf("turn %d not found: conversation has %d assistant turn(s)", turn, assistantSeen)
+	}
+	out := make([]types.Message, cutIndex)
+	copy(out, messages[:cutIndex])
+	return out, nil
+}
+
+// hydrateConversation returns the conversation history for this run.
+// On a fresh run, it prepends the composed system prompt (from the
+// runner's four-layer resolver) before the user prompt. On a resume,
+// it returns the JSON-decoded prior conversation from the source
+// run's persisted agent_conversation artifact — the loop continues
+// exactly where it left off, preserving tool results, prior reasoning,
+// AND the original system prompt (it's already in the saved message
+// array; we don't re-compose).
+//
+// If the resume artifact is missing or malformed (corrupt JSON, edited
+// out of band) we fall back to the fresh-start state. That degrades
+// gracefully: the agent re-plans rather than crashing.
+func hydrateConversation(spec ExecutionSpec) []types.Message {
+	if spec.ResumeCheckpoint != nil && len(spec.ResumeCheckpoint.AgentConversation) > 0 {
+		var saved []types.Message
+		if err := json.Unmarshal(spec.ResumeCheckpoint.AgentConversation, &saved); err == nil && len(saved) > 0 {
+			if prompt := strings.TrimSpace(spec.ResumeCheckpoint.AppendUserPrompt); prompt != "" {
+				saved = append(saved, types.Message{Role: "user", Content: prompt})
+			}
+			return saved
+		}
+	}
+	// Fresh run: build the prelude as
+	//   1. environment system message (workspace path) — always present
+	//      when there's a workspace, so the LLM uses the right cwd
+	//      and absolute paths in tool calls. Without this the model
+	//      reads the user prompt's mention of "/Users/foo/myrepo"
+	//      and uses that path verbatim — which lands outside the
+	//      sandbox (an isolated clone) and the run fails with
+	//      "escapes allowed root".
+	//   2. composed operator system prompt (four layers) — global /
+	//      tenant / workspace CLAUDE.md|AGENTS.md / per-task. Empty
+	//      when none of those layers contributed.
+	//   3. user prompt.
+	messages := make([]types.Message, 0, 3)
+	if env := environmentSystemMessage(spec); env != "" {
+		messages = append(messages, types.Message{Role: "system", Content: env})
+	}
+	if strings.TrimSpace(spec.SystemPrompt) != "" {
+		messages = append(messages, types.Message{Role: "system", Content: spec.SystemPrompt})
+	}
+	messages = append(messages, types.Message{Role: "user", Content: spec.Task.Prompt})
+	return messages
+}
+
+// environmentSystemMessage produces the machine-generated system
+// message that grounds the LLM in its actual sandbox: where the
+// workspace lives and what's enforced. This is environmental fact,
+// not operator-tunable directive — kept separate from
+// spec.SystemPrompt so the operator can't accidentally elide it.
+//
+// Returns "" when there's no workspace path (shouldn't happen in
+// practice, but the runner can still drive the executor with an
+// empty path in tests).
+func environmentSystemMessage(spec ExecutionSpec) string {
+	workspace := strings.TrimSpace(spec.Task.WorkingDirectory)
+	if workspace == "" {
+		workspace = strings.TrimSpace(spec.Task.SandboxAllowedRoot)
+	}
+	if workspace == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Your workspace is at: ")
+	b.WriteString(workspace)
+	b.WriteString("\n\n")
+	b.WriteString("Use this path (or paths under it) when calling tools. ")
+	b.WriteString("`shell_exec` / `git_exec` default their working_directory to the workspace when omitted; ")
+	b.WriteString("`read_file` / `list_dir` / `grep` / `glob` / `git_diff` resolve relative paths from the workspace. ")
+	b.WriteString("Tool calls that target paths outside this directory are rejected by the sandbox — ")
+	b.WriteString("don't reuse paths from the user prompt verbatim if they fall outside the workspace.")
+	return b.String()
+}
+
+// upsertConversationArtifact writes the current conversation snapshot
+// to a stable artifact ID. Returns the artifact when it's newly
+// created (or on the first call) so the caller can include it in the
+// run's artifact list. Idempotent across turns: the same ID means the
+// artifact's content is replaced in place rather than appended.
+func upsertConversationArtifact(spec ExecutionSpec, id string, messages []types.Message, turn int, when time.Time) (*types.TaskArtifact, error) {
+	if spec.UpsertArtifact == nil {
+		return nil, nil
+	}
+	payload, err := json.Marshal(messages)
+	if err != nil {
+		// Marshal failures here are fatal — every Message field is
+		// JSON-marshalable by construction; a failure would be a
+		// runtime corruption we shouldn't paper over.
+		return nil, fmt.Errorf("marshal agent conversation: %w", err)
+	}
+	art := types.TaskArtifact{
+		ID:          id,
+		TaskID:      spec.Task.ID,
+		RunID:       spec.Run.ID,
+		Kind:        "agent_conversation",
+		Name:        "agent-conversation.json",
+		Description: fmt.Sprintf("Agent loop conversation snapshot after turn %d", turn),
+		MimeType:    "application/json",
+		StorageKind: "inline",
+		ContentText: string(payload),
+		SizeBytes:   int64(len(payload)),
+		Status:      "ready",
+		CreatedAt:   when,
+		RequestID:   spec.RequestID,
+		TraceID:     spec.TraceID,
+	}
+	if err := spec.UpsertArtifact(art); err != nil {
+		return nil, err
+	}
+	return &art, nil
+}

--- a/internal/orchestrator/executor_agent_loop_conversation_test.go
+++ b/internal/orchestrator/executor_agent_loop_conversation_test.go
@@ -1,0 +1,105 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestAgentLoopConversation_FreshRunBuildsPreludeAndStableArtifactID(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.Task.WorkingDirectory = "/workspace/run"
+	spec.SystemPrompt = "Use concise answers."
+
+	conversation := newAgentLoopConversation(spec)
+	if conversation.ArtifactID() != "convo-run-1" {
+		t.Fatalf("ArtifactID() = %q, want convo-run-1", conversation.ArtifactID())
+	}
+
+	messages := conversation.Messages()
+	if len(messages) != 3 {
+		t.Fatalf("messages = %d, want env system + operator system + user: %+v", len(messages), messages)
+	}
+	if messages[0].Role != "system" || !strings.Contains(messages[0].Content, "/workspace/run") {
+		t.Fatalf("environment system message = %+v, want workspace grounding", messages[0])
+	}
+	if messages[1].Role != "system" || messages[1].Content != "Use concise answers." {
+		t.Fatalf("operator system message = %+v", messages[1])
+	}
+	if messages[2].Role != "user" || messages[2].Content != spec.Task.Prompt {
+		t.Fatalf("user message = %+v, want task prompt", messages[2])
+	}
+}
+
+func TestAgentLoopConversation_ResumePendingToolCallsClearAfterToolResult(t *testing.T) {
+	saved := []types.Message{
+		{Role: "user", Content: "inspect"},
+		{Role: "assistant", Content: "checking", ToolCalls: []types.ToolCall{
+			agentLoopToolCall("call-1", "shell_exec", `{"command":"ls"}`),
+		}},
+	}
+	raw, err := json.Marshal(saved)
+	if err != nil {
+		t.Fatalf("marshal saved conversation: %v", err)
+	}
+	spec := newAgentLoopSpec(t)
+	spec.ResumeCheckpoint = &ResumeCheckpoint{AgentConversation: raw}
+
+	conversation := newAgentLoopConversation(spec)
+	pending := conversation.PendingToolCallsForResume()
+	if len(pending) != 1 || pending[0].ID != "call-1" {
+		t.Fatalf("pending tool calls = %+v, want call-1", pending)
+	}
+	if tail, ok := conversation.TailAssistantForResume(); !ok || tail.ToolCalls[0].ID != "call-1" {
+		t.Fatalf("TailAssistantForResume() = %+v/%v, want assistant call-1", tail, ok)
+	}
+
+	conversation.AppendToolResult("call-1", "status=completed", true)
+	if pending := conversation.PendingToolCallsForResume(); len(pending) != 0 {
+		t.Fatalf("pending after tool result = %+v, want none", pending)
+	}
+	messages := conversation.Messages()
+	last := messages[len(messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" || !last.ToolError {
+		t.Fatalf("last message = %+v, want errored tool result", last)
+	}
+}
+
+func TestAgentLoopConversation_UpsertArtifactPersistsCurrentMessages(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	var got types.TaskArtifact
+	spec.UpsertArtifact = func(artifact types.TaskArtifact) error {
+		got = artifact
+		return nil
+	}
+	when := time.Date(2026, 5, 29, 11, 45, 0, 0, time.UTC)
+	conversation := newAgentLoopConversation(spec)
+	conversation.AppendAssistant(types.Message{Role: "assistant", Content: "done"})
+
+	artifact, err := conversation.UpsertArtifact(spec, 3, when)
+	if err != nil {
+		t.Fatalf("UpsertArtifact() error = %v", err)
+	}
+	if artifact == nil {
+		t.Fatal("UpsertArtifact() artifact = nil")
+	}
+	if got.ID != "convo-run-1" || got.Kind != "agent_conversation" || got.Status != "ready" {
+		t.Fatalf("artifact shape = %+v", got)
+	}
+	if got.Description != "Agent loop conversation snapshot after turn 3" {
+		t.Fatalf("artifact description = %q", got.Description)
+	}
+	if !got.CreatedAt.Equal(when) {
+		t.Fatalf("artifact CreatedAt = %s, want %s", got.CreatedAt, when)
+	}
+	var decoded []types.Message
+	if err := json.Unmarshal([]byte(got.ContentText), &decoded); err != nil {
+		t.Fatalf("decode artifact content: %v", err)
+	}
+	if len(decoded) == 0 || decoded[len(decoded)-1].Role != "assistant" || decoded[len(decoded)-1].Content != "done" {
+		t.Fatalf("decoded conversation = %+v, want appended assistant message", decoded)
+	}
+}

--- a/internal/orchestrator/executor_agent_loop_http.go
+++ b/internal/orchestrator/executor_agent_loop_http.go
@@ -8,12 +8,10 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/hecatehq/hecate/pkg/types"
 )
 
 // The HTTP tool is the agent's only outbound-network surface. It runs
-// through e.httpClient (constructed once at executor init with the
+// through d.httpClient (constructed once at executor init with the
 // configured timeout) and applies three layers of safety:
 //
 //   1. Scheme allowlist — only http/https. file://, ftp://, gopher://
@@ -39,7 +37,7 @@ type httpRequestArgs struct {
 	Body    string            `json:"body,omitempty"`
 }
 
-func (e *AgentLoopExecutor) httpRequestTool(ctx context.Context, spec ExecutionSpec, args httpRequestArgs, stepIndex int, startedAt time.Time, toolName string) (string, *types.TaskStep, []types.TaskArtifact, error) {
+func (d *agentLoopToolDispatcher) httpRequestTool(ctx context.Context, spec ExecutionSpec, args httpRequestArgs, stepIndex int, startedAt time.Time, toolName string) (agentLoopToolDispatchResult, error) {
 	method := strings.ToUpper(strings.TrimSpace(args.Method))
 	if method == "" {
 		method = "GET"
@@ -47,32 +45,32 @@ func (e *AgentLoopExecutor) httpRequestTool(ctx context.Context, spec ExecutionS
 	switch method {
 	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD":
 	default:
-		return fmt.Sprintf("http_request: unsupported method %q", method), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: unsupported method %q", method)}, nil
 	}
 
 	parsed, err := url.Parse(strings.TrimSpace(args.URL))
 	if err != nil {
-		return fmt.Sprintf("http_request: invalid URL: %v", err), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: invalid URL: %v", err)}, nil
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return fmt.Sprintf("http_request: scheme %q is not allowed; use http or https", parsed.Scheme), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: scheme %q is not allowed; use http or https", parsed.Scheme)}, nil
 	}
 	host := parsed.Hostname()
 	if host == "" {
-		return "http_request: URL has no host", nil, nil, nil
+		return agentLoopToolDispatchResult{Text: "http_request: URL has no host"}, nil
 	}
 
 	// Hostname allowlist — exact match only.
-	if len(e.httpPolicy.AllowedHosts) > 0 {
+	if len(d.httpPolicy.AllowedHosts) > 0 {
 		ok := false
-		for _, h := range e.httpPolicy.AllowedHosts {
+		for _, h := range d.httpPolicy.AllowedHosts {
 			if strings.EqualFold(strings.TrimSpace(h), host) {
 				ok = true
 				break
 			}
 		}
 		if !ok {
-			return fmt.Sprintf("http_request: host %q is not in the configured allowlist", host), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: host %q is not in the configured allowlist", host)}, nil
 		}
 	}
 
@@ -81,9 +79,9 @@ func (e *AgentLoopExecutor) httpRequestTool(ctx context.Context, spec ExecutionS
 	// — a hostname like `internal.example.com` could legitimately
 	// resolve to 10.0.0.5, and we want to catch that, not just
 	// literal IPs in the URL.
-	if !e.httpPolicy.AllowPrivateIPs {
+	if !d.httpPolicy.AllowPrivateIPs {
 		if msg := checkPublicHost(ctx, host); msg != "" {
-			return msg, nil, nil, nil
+			return agentLoopToolDispatchResult{Text: msg}, nil
 		}
 	}
 
@@ -93,19 +91,19 @@ func (e *AgentLoopExecutor) httpRequestTool(ctx context.Context, spec ExecutionS
 	}
 	req, err := http.NewRequestWithContext(ctx, method, parsed.String(), body)
 	if err != nil {
-		return fmt.Sprintf("http_request: build request: %v", err), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: build request: %v", err)}, nil
 	}
 	for k, v := range args.Headers {
 		req.Header.Set(k, v)
 	}
 
-	resp, err := e.httpClient.Do(req)
+	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		return fmt.Sprintf("http_request: %v", err), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("http_request: %v", err)}, nil
 	}
 	defer resp.Body.Close()
 
-	max := e.httpPolicy.MaxResponseBytes
+	max := d.httpPolicy.MaxResponseBytes
 	limited := io.LimitReader(resp.Body, int64(max)+1) // +1 to detect overflow
 	raw, _ := io.ReadAll(limited)
 	truncated := false
@@ -129,5 +127,5 @@ func (e *AgentLoopExecutor) httpRequestTool(ctx context.Context, spec ExecutionS
 	if truncated {
 		fmt.Fprintf(&b, "\n…(truncated at %d bytes; configure HECATE_TASK_HTTP_MAX_RESPONSE_BYTES to widen)", max)
 	}
-	return b.String(), &step, nil, nil
+	return agentLoopToolDispatchResult{Text: b.String(), Step: &step}, nil
 }

--- a/internal/orchestrator/executor_agent_loop_llm_turn_test.go
+++ b/internal/orchestrator/executor_agent_loop_llm_turn_test.go
@@ -1,0 +1,139 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestAgentLoopLLMTurn_SuccessRecordsStateAndConversation(t *testing.T) {
+	toolCall := types.ToolCall{
+		ID:   "call-1",
+		Type: "function",
+		Function: types.ToolCallFunction{
+			Name:      "shell_exec",
+			Arguments: `{"command":"pwd"}`,
+		},
+	}
+	resp := withResolvedRoute(makeChatResp(makeAssistantMsg("I will inspect.", toolCall)))
+	resp.Cost.TotalMicrosUSD = 42
+	llm := &scriptedLLM{responses: []*types.ChatResponse{resp}}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	spec.Run.Provider = "ollama"
+	var upsertedArtifacts []types.TaskArtifact
+	spec.UpsertArtifact = func(artifact types.TaskArtifact) error {
+		upsertedArtifacts = append(upsertedArtifacts, artifact)
+		return nil
+	}
+	var eventTypes []string
+	spec.EmitRunEvent = func(eventType string, _ map[string]any) {
+		eventTypes = append(eventTypes, eventType)
+	}
+	conversation := newAgentLoopConversation(spec)
+	runState := newAgentLoopRunState(spec, 4)
+
+	turn, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, agentToolDefinitions(), 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("runLLMTurn error = %v", err)
+	}
+	if failed != nil {
+		t.Fatalf("runLLMTurn failed result = %+v, want nil", failed)
+	}
+	if turn.Assistant.Content != "I will inspect." || len(turn.Assistant.ToolCalls) != 1 {
+		t.Fatalf("assistant = %+v, want content plus one tool call", turn.Assistant)
+	}
+	if turn.ThinkingStep.Index != 1 || turn.ThinkingStep.Status != "completed" {
+		t.Fatalf("thinking step = %+v, want completed index 1", turn.ThinkingStep)
+	}
+	if runState.NextStepIndex() != 2 || len(runState.Steps()) != 1 {
+		t.Fatalf("run state steps = next %d steps %+v, want one recorded step and next index 2", runState.NextStepIndex(), runState.Steps())
+	}
+	result := runState.Result("completed")
+	assertResolvedRoute(t, result)
+	if result.CostMicrosUSD != 42 || len(result.TurnCosts) != 1 || result.TurnCosts[0].StepID != turn.ThinkingStep.ID {
+		t.Fatalf("accounting = cost %d turn costs %+v, want cost 42 tied to thinking step", result.CostMicrosUSD, result.TurnCosts)
+	}
+	messages := conversation.Messages()
+	if messages[len(messages)-1].Role != "assistant" || messages[len(messages)-1].ToolCalls[0].ID != "call-1" {
+		t.Fatalf("conversation tail = %+v, want assistant tool call", messages[len(messages)-1])
+	}
+	if len(upsertedArtifacts) != 1 || upsertedArtifacts[0].Kind != "agent_conversation" || !strings.Contains(upsertedArtifacts[0].ContentText, "call-1") {
+		t.Fatalf("upserted artifacts = %+v, want conversation snapshot containing call-1", upsertedArtifacts)
+	}
+	if len(llm.lastReqs) != 1 || llm.lastReqs[0].Scope.ProviderHint != "ollama" || len(llm.lastReqs[0].Tools) == 0 {
+		t.Fatalf("LLM request = %+v, want provider hint and tools", llm.lastReqs)
+	}
+	assertEventTypes(t, eventTypes, "turn.started", "assistant.text_complete", "assistant.tool_call_proposed")
+}
+
+func TestAgentLoopLLMTurn_EmptyResponseReturnsFailureWithRoute(t *testing.T) {
+	resp := withResolvedRoute(&types.ChatResponse{Model: "ministral-3:latest"})
+	llm := &scriptedLLM{responses: []*types.ChatResponse{resp}}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	conversation := newAgentLoopConversation(spec)
+	runState := newAgentLoopRunState(spec, 4)
+
+	_, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, agentToolDefinitions(), 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("runLLMTurn error = %v", err)
+	}
+	if failed == nil {
+		t.Fatal("runLLMTurn failed result = nil, want failed result")
+	}
+	if failed.Status != "failed" || !strings.Contains(failed.LastError, "empty response") {
+		t.Fatalf("failed result = %+v, want empty-response failure", failed)
+	}
+	assertResolvedRoute(t, failed)
+	if len(failed.Steps) != 1 || failed.Steps[0].Index != 1 || failed.Steps[0].Status != "failed" {
+		t.Fatalf("failure steps = %+v, want one failed model step at index 1", failed.Steps)
+	}
+	if countAssistantTurns(conversation.Messages()) != 0 {
+		t.Fatalf("conversation = %+v, want no assistant appended on empty response", conversation.Messages())
+	}
+}
+
+func TestAgentLoopLLMTurn_ErrorPreservesExistingAccounting(t *testing.T) {
+	llm := &erroringLLM{err: errors.New("temporary upstream failure")}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	spec.Run.Model = "gpt-test"
+	conversation := newAgentLoopConversation(spec)
+	runState := newAgentLoopRunState(spec, 4)
+	runState.RecordRoute(withResolvedRoute(&types.ChatResponse{}))
+	runState.AccumulateCost(&types.ChatResponse{Cost: types.CostBreakdown{TotalMicrosUSD: 75}})
+	runState.AddTurnCost(1, "step-prior", 75, 0)
+
+	_, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, agentToolDefinitions(), 2, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("runLLMTurn error = %v", err)
+	}
+	if failed == nil {
+		t.Fatal("runLLMTurn failed result = nil, want failed result")
+	}
+	if !strings.Contains(failed.LastError, "LLM call failed on turn 2") {
+		t.Fatalf("LastError = %q, want turn-specific LLM failure", failed.LastError)
+	}
+	if failed.CostMicrosUSD != 75 || len(failed.TurnCosts) != 1 || failed.TurnCosts[0].StepID != "step-prior" {
+		t.Fatalf("failed accounting = cost %d turn costs %+v, want prior accounting preserved", failed.CostMicrosUSD, failed.TurnCosts)
+	}
+	assertResolvedRoute(t, failed)
+}
+
+func assertEventTypes(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	seen := make(map[string]bool, len(got))
+	for _, eventType := range got {
+		seen[eventType] = true
+	}
+	for _, eventType := range want {
+		if !seen[eventType] {
+			t.Fatalf("missing event %q in %v", eventType, got)
+		}
+	}
+}

--- a/internal/orchestrator/executor_agent_loop_run_state.go
+++ b/internal/orchestrator/executor_agent_loop_run_state.go
@@ -1,0 +1,161 @@
+package orchestrator
+
+import (
+	"fmt"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type agentLoopRunState struct {
+	nextIndex int
+
+	steps     []types.TaskStep
+	artifacts []types.TaskArtifact
+
+	provider     string
+	providerKind string
+	model        string
+
+	costCeiling int64
+	priorCost   int64
+	costSpent   int64
+	turnCosts   []TurnCostRecord
+}
+
+func newAgentLoopRunState(spec ExecutionSpec, maxTurns int) *agentLoopRunState {
+	baseIndex := 0
+	costSpent := int64(0)
+	priorCost := int64(0)
+	if spec.ResumeCheckpoint != nil {
+		if spec.ResumeCheckpoint.LastStepIndex > 0 {
+			baseIndex = spec.ResumeCheckpoint.LastStepIndex
+		}
+		priorCost = spec.ResumeCheckpoint.PriorCostMicrosUSD
+		// Same-run mid-approval resume: seed costSpent with the
+		// pre-pause spend so ceiling checks and the persisted Total
+		// account for it. Cross-run resumes see zero here (new run
+		// hasn't spent anything yet).
+		costSpent = spec.ResumeCheckpoint.ThisRunCostMicrosUSD
+	}
+	return &agentLoopRunState{
+		nextIndex:   baseIndex + 1,
+		steps:       make([]types.TaskStep, 0, maxTurns*2),
+		artifacts:   make([]types.TaskArtifact, 0, maxTurns),
+		costCeiling: spec.Task.BudgetMicrosUSD,
+		priorCost:   priorCost,
+		costSpent:   costSpent,
+		turnCosts:   make([]TurnCostRecord, 0, maxTurns),
+	}
+}
+
+func (s *agentLoopRunState) NextStepIndex() int {
+	return s.nextIndex
+}
+
+func (s *agentLoopRunState) Steps() []types.TaskStep {
+	return s.steps
+}
+
+func (s *agentLoopRunState) Artifacts() []types.TaskArtifact {
+	return s.artifacts
+}
+
+func (s *agentLoopRunState) AddStep(spec ExecutionSpec, step types.TaskStep) error {
+	if err := upsertTaskStep(spec, step); err != nil {
+		return err
+	}
+	s.steps = append(s.steps, step)
+	s.nextIndex++
+	return nil
+}
+
+func (s *agentLoopRunState) AddArtifact(spec ExecutionSpec, artifact types.TaskArtifact) error {
+	if err := upsertTaskArtifact(spec, artifact); err != nil {
+		return err
+	}
+	s.artifacts = append(s.artifacts, artifact)
+	return nil
+}
+
+func (s *agentLoopRunState) AddArtifacts(spec ExecutionSpec, artifacts []types.TaskArtifact) error {
+	for _, artifact := range artifacts {
+		if err := s.AddArtifact(spec, artifact); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *agentLoopRunState) TrackInitialConversationArtifact(artifact *types.TaskArtifact) {
+	if artifact != nil && len(s.artifacts) == 0 {
+		s.artifacts = append(s.artifacts, *artifact)
+	}
+}
+
+func (s *agentLoopRunState) RecordRoute(resp *types.ChatResponse) {
+	if resp == nil {
+		return
+	}
+	if resp.Route.Provider != "" {
+		s.provider = resp.Route.Provider
+	}
+	if resp.Route.ProviderKind != "" {
+		s.providerKind = resp.Route.ProviderKind
+	}
+	if resp.Route.Model != "" {
+		s.model = resp.Route.Model
+	} else if resp.Model != "" {
+		s.model = resp.Model
+	}
+}
+
+func (s *agentLoopRunState) AccumulateCost(resp *types.ChatResponse) int64 {
+	turnCost := int64(0)
+	if resp != nil {
+		turnCost = resp.Cost.TotalMicrosUSD
+	}
+	s.costSpent += turnCost
+	return turnCost
+}
+
+func (s *agentLoopRunState) AddTurnCost(turn int, stepID string, turnCost int64, toolCallCount int) {
+	s.turnCosts = append(s.turnCosts, TurnCostRecord{
+		Turn:                turn,
+		StepID:              stepID,
+		CostMicrosUSD:       turnCost,
+		CumulativeMicrosUSD: s.costSpent,
+		ToolCallCount:       toolCallCount,
+	})
+}
+
+func (s *agentLoopRunState) CostSpent() int64 {
+	return s.costSpent
+}
+
+func (s *agentLoopRunState) CostCeilingExceededMessage() (string, bool) {
+	if s.costCeiling <= 0 || (s.priorCost+s.costSpent) < s.costCeiling {
+		return "", false
+	}
+	total := s.priorCost + s.costSpent
+	return fmt.Sprintf("agent loop hit per-task cost ceiling: spent %d µUSD this run + %d µUSD prior = %d µUSD, ceiling %d µUSD", s.costSpent, s.priorCost, total, s.costCeiling), true
+}
+
+func (s *agentLoopRunState) Result(status string) *ExecutionResult {
+	return s.attachAccounting(&ExecutionResult{
+		Status:    status,
+		Steps:     s.steps,
+		Artifacts: s.artifacts,
+	})
+}
+
+func (s *agentLoopRunState) attachAccounting(res *ExecutionResult) *ExecutionResult {
+	if res == nil {
+		return nil
+	}
+	res.Provider = firstNonEmpty(res.Provider, s.provider)
+	res.ProviderKind = firstNonEmpty(res.ProviderKind, s.providerKind)
+	res.Model = firstNonEmpty(res.Model, s.model)
+	res.CostMicrosUSD = s.costSpent
+	res.TurnCosts = s.turnCosts
+	return res
+}

--- a/internal/orchestrator/executor_agent_loop_run_state_test.go
+++ b/internal/orchestrator/executor_agent_loop_run_state_test.go
@@ -1,0 +1,142 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestAgentLoopRunState_AddStepAndArtifacts(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.ResumeCheckpoint = &ResumeCheckpoint{LastStepIndex: 4}
+	var upsertedSteps []types.TaskStep
+	var upsertedArtifacts []types.TaskArtifact
+	spec.UpsertStep = func(step types.TaskStep) error {
+		upsertedSteps = append(upsertedSteps, step)
+		return nil
+	}
+	spec.UpsertArtifact = func(artifact types.TaskArtifact) error {
+		upsertedArtifacts = append(upsertedArtifacts, artifact)
+		return nil
+	}
+	state := newAgentLoopRunState(spec, 4)
+
+	if got := state.NextStepIndex(); got != 5 {
+		t.Fatalf("NextStepIndex() = %d, want 5", got)
+	}
+	step := types.TaskStep{ID: "step-1", TaskID: spec.Task.ID, RunID: spec.Run.ID, Index: state.NextStepIndex(), Status: "completed"}
+	if err := state.AddStep(spec, step); err != nil {
+		t.Fatalf("AddStep: %v", err)
+	}
+	if got := state.NextStepIndex(); got != 6 {
+		t.Fatalf("NextStepIndex() after AddStep = %d, want 6", got)
+	}
+	if len(state.Steps()) != 1 || len(upsertedSteps) != 1 || upsertedSteps[0].ID != "step-1" {
+		t.Fatalf("step state/upserts = state %+v upserts %+v, want step-1 recorded once", state.Steps(), upsertedSteps)
+	}
+
+	artifact := types.TaskArtifact{ID: "artifact-1", TaskID: spec.Task.ID, RunID: spec.Run.ID, Kind: "summary"}
+	if err := state.AddArtifact(spec, artifact); err != nil {
+		t.Fatalf("AddArtifact: %v", err)
+	}
+	moreArtifacts := []types.TaskArtifact{
+		{ID: "artifact-2", TaskID: spec.Task.ID, RunID: spec.Run.ID, Kind: "stdout"},
+		{ID: "artifact-3", TaskID: spec.Task.ID, RunID: spec.Run.ID, Kind: "stderr"},
+	}
+	if err := state.AddArtifacts(spec, moreArtifacts); err != nil {
+		t.Fatalf("AddArtifacts: %v", err)
+	}
+	if len(state.Artifacts()) != 3 || len(upsertedArtifacts) != 3 {
+		t.Fatalf("artifact state/upserts = state %+v upserts %+v, want three artifacts", state.Artifacts(), upsertedArtifacts)
+	}
+}
+
+func TestAgentLoopRunState_TrackInitialConversationArtifactOnce(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	state := newAgentLoopRunState(spec, 4)
+
+	first := &types.TaskArtifact{ID: "conversation-1", TaskID: spec.Task.ID, RunID: spec.Run.ID, Kind: "agent_conversation"}
+	second := &types.TaskArtifact{ID: "conversation-2", TaskID: spec.Task.ID, RunID: spec.Run.ID, Kind: "agent_conversation"}
+	state.TrackInitialConversationArtifact(first)
+	state.TrackInitialConversationArtifact(second)
+	state.TrackInitialConversationArtifact(nil)
+
+	artifacts := state.Artifacts()
+	if len(artifacts) != 1 || artifacts[0].ID != "conversation-1" {
+		t.Fatalf("tracked artifacts = %+v, want only first conversation artifact", artifacts)
+	}
+}
+
+func TestAgentLoopRunState_RecordRouteAndAttachAccounting(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	state := newAgentLoopRunState(spec, 4)
+
+	resp := &types.ChatResponse{
+		Model: "fallback-model",
+		Route: types.RouteDecision{
+			Provider:     "ollama",
+			ProviderKind: "local",
+			Model:        "resolved-model",
+		},
+		Cost: types.CostBreakdown{TotalMicrosUSD: 125},
+	}
+	state.RecordRoute(resp)
+	turnCost := state.AccumulateCost(resp)
+	state.AddTurnCost(2, "step-1", turnCost, 3)
+
+	res := state.Result("completed")
+	if res.Provider != "ollama" || res.ProviderKind != "local" || res.Model != "resolved-model" {
+		t.Fatalf("route = provider %q kind %q model %q, want resolved ollama/local/resolved-model", res.Provider, res.ProviderKind, res.Model)
+	}
+	if res.CostMicrosUSD != 125 {
+		t.Fatalf("CostMicrosUSD = %d, want 125", res.CostMicrosUSD)
+	}
+	if len(res.TurnCosts) != 1 {
+		t.Fatalf("TurnCosts = %+v, want one entry", res.TurnCosts)
+	}
+	record := res.TurnCosts[0]
+	if record.Turn != 2 || record.StepID != "step-1" || record.CostMicrosUSD != 125 || record.CumulativeMicrosUSD != 125 || record.ToolCallCount != 3 {
+		t.Fatalf("TurnCosts[0] = %+v, want turn 2 step-1 cost/cumulative 125 tool calls 3", record)
+	}
+}
+
+func TestAgentLoopRunState_RecordRouteFallsBackToResponseModel(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	state := newAgentLoopRunState(spec, 4)
+
+	state.RecordRoute(&types.ChatResponse{Model: "response-model"})
+
+	res := state.Result("completed")
+	if res.Model != "response-model" {
+		t.Fatalf("Model = %q, want response-model", res.Model)
+	}
+}
+
+func TestAgentLoopRunState_CostCeilingUsesPriorAndCurrentRun(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	spec.Task.BudgetMicrosUSD = 500
+	spec.ResumeCheckpoint = &ResumeCheckpoint{
+		PriorCostMicrosUSD:   400,
+		ThisRunCostMicrosUSD: 50,
+	}
+	state := newAgentLoopRunState(spec, 4)
+
+	if _, exceeded := state.CostCeilingExceededMessage(); exceeded {
+		t.Fatalf("CostCeilingExceededMessage() exceeded before current turn, want false")
+	}
+	state.AccumulateCost(&types.ChatResponse{Cost: types.CostBreakdown{TotalMicrosUSD: 60}})
+
+	msg, exceeded := state.CostCeilingExceededMessage()
+	if !exceeded {
+		t.Fatalf("CostCeilingExceededMessage() exceeded = false, want true")
+	}
+	for _, want := range []string{"spent 110", "400", "510", "ceiling 500"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not contain %q", msg, want)
+		}
+	}
+	if got := state.Result("failed").CostMicrosUSD; got != 110 {
+		t.Fatalf("Result().CostMicrosUSD = %d, want current-run total 110", got)
+	}
+}

--- a/internal/orchestrator/executor_agent_loop_telemetry.go
+++ b/internal/orchestrator/executor_agent_loop_telemetry.go
@@ -7,15 +7,15 @@ import (
 	"github.com/hecatehq/hecate/internal/telemetry"
 )
 
-func (e *AgentLoopExecutor) recordMCPCallTelemetry(
+func (d *agentLoopToolDispatcher) recordMCPCallTelemetry(
 	ctx context.Context,
 	spec ExecutionSpec,
 	toolCallID, toolName, server, tool, result string,
 	durationMS int64,
 	errMsg string,
 ) {
-	if e.metrics != nil {
-		e.metrics.RecordMCPToolCall(ctx, telemetry.MCPToolCallRecord{
+	if d.metrics != nil {
+		d.metrics.RecordMCPToolCall(ctx, telemetry.MCPToolCallRecord{
 			Server:     server,
 			Tool:       tool,
 			Result:     result,

--- a/internal/orchestrator/executor_agent_loop_tool_dispatcher_test.go
+++ b/internal/orchestrator/executor_agent_loop_tool_dispatcher_test.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestAgentLoopToolDispatcher_DispatchShellExecRoutesToShellExecutor(t *testing.T) {
+	shell := &stubExecutor{
+		result: &ExecutionResult{
+			Status: "completed",
+			Steps: []types.TaskStep{
+				{ID: "sub-step-1", Status: "completed"},
+			},
+			Artifacts: []types.TaskArtifact{
+				{ID: "artifact-1", StepID: "sub-step-1", Kind: "stdout", Name: "stdout.txt", ContentText: "agent-loop-dispatch\n", Status: "ready"},
+			},
+		},
+	}
+	dispatcher := &agentLoopToolDispatcher{shell: shell}
+	spec := newAgentLoopSpec(t)
+
+	result, err := dispatcher.Dispatch(context.Background(), spec, agentLoopToolCall(
+		"call-shell",
+		"shell_exec",
+		`{"command":"printf agent-loop-dispatch","working_directory":"subdir"}`,
+	), 5, nil)
+	if err != nil {
+		t.Fatalf("Dispatch() error = %v", err)
+	}
+	if len(shell.calls) != 1 {
+		t.Fatalf("shell executor calls = %d, want 1", len(shell.calls))
+	}
+	gotTask := shell.calls[0]
+	if gotTask.ExecutionKind != "shell" || gotTask.ShellCommand != "printf agent-loop-dispatch" || gotTask.WorkingDirectory != "subdir" {
+		t.Fatalf("shell task = %+v, want shell command and working directory from tool args", gotTask)
+	}
+
+	if result.Step == nil {
+		t.Fatalf("Dispatch() Step = nil, want tool step")
+	}
+	step := *result.Step
+	if step.Kind != "tool" || step.Status != "completed" || step.ToolName != "shell_exec" || step.Index != 5 {
+		t.Fatalf("tool step = %+v", step)
+	}
+	if got := step.Input["command"]; got != "printf agent-loop-dispatch" {
+		t.Fatalf("step input command = %v, want printf agent-loop-dispatch", got)
+	}
+	if got := step.Input["working_directory"]; got != "subdir" {
+		t.Fatalf("step input working_directory = %v, want subdir", got)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("artifacts = %d, want 1", len(result.Artifacts))
+	}
+	if result.Artifacts[0].StepID != step.ID {
+		t.Fatalf("artifact StepID = %q, want dispatcher step ID %q", result.Artifacts[0].StepID, step.ID)
+	}
+	if !strings.Contains(result.Text, "status=completed") || !strings.Contains(result.Text, "agent-loop-dispatch") {
+		t.Fatalf("tool result text = %q, want status and stdout digest", result.Text)
+	}
+}
+
+func TestAgentLoopToolDispatcher_ShellExecInheritsWorkingDirectoryWhenArgOmitted(t *testing.T) {
+	shell := &stubExecutor{result: &ExecutionResult{Status: "completed"}}
+	dispatcher := &agentLoopToolDispatcher{shell: shell}
+	spec := newAgentLoopSpec(t)
+	spec.Task.WorkingDirectory = "/workspace/run"
+
+	_, err := dispatcher.Dispatch(context.Background(), spec, agentLoopToolCall(
+		"call-shell",
+		"shell_exec",
+		`{"command":"pwd"}`,
+	), 1, nil)
+	if err != nil {
+		t.Fatalf("Dispatch() error = %v", err)
+	}
+	if len(shell.calls) != 1 {
+		t.Fatalf("shell executor calls = %d, want 1", len(shell.calls))
+	}
+	if got := shell.calls[0].WorkingDirectory; got != "/workspace/run" {
+		t.Fatalf("shell task WorkingDirectory = %q, want inherited workspace", got)
+	}
+}
+
+func TestAgentLoopToolDispatcher_InvalidShellArgsReturnsToolErrorText(t *testing.T) {
+	shell := &stubExecutor{}
+	dispatcher := &agentLoopToolDispatcher{shell: shell}
+
+	result, err := dispatcher.Dispatch(context.Background(), newAgentLoopSpec(t), agentLoopToolCall(
+		"call-shell",
+		"shell_exec",
+		`not-json`,
+	), 1, nil)
+	if err != nil {
+		t.Fatalf("Dispatch() error = %v", err)
+	}
+	if len(shell.calls) != 0 {
+		t.Fatalf("shell executor calls = %d, want 0 for invalid args", len(shell.calls))
+	}
+	if result.Step != nil || len(result.Artifacts) != 0 {
+		t.Fatalf("invalid args result should not create step/artifacts: %+v", result)
+	}
+	if !strings.Contains(result.Text, "invalid arguments for shell_exec") {
+		t.Fatalf("result text = %q, want invalid arguments", result.Text)
+	}
+}

--- a/internal/orchestrator/executor_agent_loop_tools.go
+++ b/internal/orchestrator/executor_agent_loop_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
@@ -11,30 +12,26 @@ import (
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
-func (e *AgentLoopExecutor) isGated(toolName string, task types.Task) bool {
-	if _, ok := e.gatedTools[toolName]; ok {
-		return true
-	}
-	return mcpServerPolicy(toolName, task) == types.MCPApprovalRequireApproval
+type agentLoopToolDispatcher struct {
+	shell      Executor
+	file       Executor
+	git        Executor
+	httpPolicy HTTPRequestPolicy
+	httpClient *http.Client
+	metrics    *telemetry.OrchestratorMetrics
 }
 
-func mcpServerPolicy(toolName string, task types.Task) string {
-	if !isMCPToolName(toolName) {
-		return ""
-	}
-	server, _, ok := mcpclient.SplitNamespacedToolName(toolName)
-	if !ok {
-		return ""
-	}
-	for _, cfg := range task.MCPServers {
-		if cfg.Name == server {
-			return cfg.ApprovalPolicy
-		}
-	}
-	return ""
+type agentLoopToolDispatchResult struct {
+	Text      string
+	Step      *types.TaskStep
+	Artifacts []types.TaskArtifact
 }
 
-func (e *AgentLoopExecutor) dispatchToolCall(ctx context.Context, spec ExecutionSpec, call types.ToolCall, stepIndex int, mcpHost AgentMCPHost) (string, *types.TaskStep, []types.TaskArtifact, error) {
+func (d *agentLoopToolDispatcher) SetMetrics(m *telemetry.OrchestratorMetrics) {
+	d.metrics = m
+}
+
+func (d *agentLoopToolDispatcher) Dispatch(ctx context.Context, spec ExecutionSpec, call types.ToolCall, stepIndex int, mcpHost AgentMCPHost) (agentLoopToolDispatchResult, error) {
 	startedAt := time.Now().UTC()
 
 	// External MCP tools surface under names of the form
@@ -42,7 +39,7 @@ func (e *AgentLoopExecutor) dispatchToolCall(ctx context.Context, spec Execution
 	// built-in switch so a server can't accidentally collide with a
 	// built-in name.
 	if mcpHost != nil && isMCPToolName(call.Function.Name) {
-		return e.dispatchMCPToolCall(ctx, spec, call, stepIndex, startedAt, mcpHost)
+		return d.dispatchMCPToolCall(ctx, spec, call, stepIndex, startedAt, mcpHost)
 	}
 
 	// Decode the tool arguments. Each tool gets its own typed shape;
@@ -53,29 +50,33 @@ func (e *AgentLoopExecutor) dispatchToolCall(ctx context.Context, spec Execution
 	case "shell_exec":
 		var args shellExecArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for shell_exec: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for shell_exec: %v", err)}, nil
 		}
 		taskCopy := spec.Task
 		taskCopy.ExecutionKind = "shell"
 		taskCopy.ShellCommand = args.Command
-		taskCopy.WorkingDirectory = args.WorkingDirectory
-		return e.runSubExecutor(ctx, spec, e.shell, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
+		if args.WorkingDirectory != "" {
+			taskCopy.WorkingDirectory = args.WorkingDirectory
+		}
+		return d.runSubExecutor(ctx, spec, d.shell, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
 
 	case "git_exec":
 		var args gitExecArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for git_exec: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for git_exec: %v", err)}, nil
 		}
 		taskCopy := spec.Task
 		taskCopy.ExecutionKind = "git"
 		taskCopy.GitCommand = args.Command
-		taskCopy.WorkingDirectory = args.WorkingDirectory
-		return e.runSubExecutor(ctx, spec, e.git, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
+		if args.WorkingDirectory != "" {
+			taskCopy.WorkingDirectory = args.WorkingDirectory
+		}
+		return d.runSubExecutor(ctx, spec, d.git, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
 
 	case "file_write":
 		var args fileWriteArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for file_write: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for file_write: %v", err)}, nil
 		}
 		op := args.Operation
 		if op == "" {
@@ -86,88 +87,92 @@ func (e *AgentLoopExecutor) dispatchToolCall(ctx context.Context, spec Execution
 		taskCopy.FilePath = args.Path
 		taskCopy.FileContent = args.Content
 		taskCopy.FileOperation = op
-		return e.runSubExecutor(ctx, spec, e.file, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
+		return d.runSubExecutor(ctx, spec, d.file, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
 
 	case "file_edit":
 		var args fileEditArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for file_edit: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for file_edit: %v", err)}, nil
 		}
 		taskCopy, before, after, absPath, errMsg := prepareFileEditTask(spec, args)
 		if errMsg != "" {
-			return errMsg, nil, nil, nil
+			return agentLoopToolDispatchResult{Text: errMsg}, nil
 		}
 		if args.Propose {
-			return proposedFileEditToolResult(spec, args, stepIndex, startedAt, call.ID, call.Function.Name, absPath, before, after)
+			return dispatchResult(proposedFileEditToolResult(spec, args, stepIndex, startedAt, call.ID, call.Function.Name, absPath, before, after))
 		}
-		return e.runSubExecutor(ctx, spec, e.file, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
+		return d.runSubExecutor(ctx, spec, d.file, taskCopy, stepIndex, startedAt, call.ID, call.Function.Name)
 
 	case "read_file":
 		var args readFileArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for read_file: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for read_file: %v", err)}, nil
 		}
-		return readFileTool(spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(readFileTool(spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "grep":
 		var args grepArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for grep: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for grep: %v", err)}, nil
 		}
-		return grepTool(spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(grepTool(spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "glob":
 		var args globArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for glob: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for glob: %v", err)}, nil
 		}
-		return globTool(spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(globTool(spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "artifact_read":
 		var args artifactReadArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for artifact_read: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for artifact_read: %v", err)}, nil
 		}
-		return artifactReadTool(spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(artifactReadTool(spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "list_dir":
 		var args listDirArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for list_dir: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for list_dir: %v", err)}, nil
 		}
-		return listDirTool(spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(listDirTool(spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "git_status":
 		var args gitStatusArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for git_status: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for git_status: %v", err)}, nil
 		}
-		return gitStatusTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(gitStatusTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "git_diff":
 		var args gitDiffArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for git_diff: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for git_diff: %v", err)}, nil
 		}
-		return gitDiffTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name)
+		return dispatchResult(gitDiffTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name))
 
 	case "apply_patch":
 		var args applyPatchArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for apply_patch: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for apply_patch: %v", err)}, nil
 		}
-		return applyPatchTool(spec, args, stepIndex, startedAt, call.ID, call.Function.Name)
+		return dispatchResult(applyPatchTool(spec, args, stepIndex, startedAt, call.ID, call.Function.Name))
 
 	case "http_request":
 		var args httpRequestArgs
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return fmt.Sprintf("invalid arguments for http_request: %v", err), nil, nil, nil
+			return agentLoopToolDispatchResult{Text: fmt.Sprintf("invalid arguments for http_request: %v", err)}, nil
 		}
-		return e.httpRequestTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name)
+		return d.httpRequestTool(ctx, spec, args, stepIndex, startedAt, call.Function.Name)
 
 	default:
-		return fmt.Sprintf("unknown tool: %s", call.Function.Name), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("unknown tool: %s", call.Function.Name)}, nil
 	}
+}
+
+func dispatchResult(text string, step *types.TaskStep, artifacts []types.TaskArtifact, err error) (agentLoopToolDispatchResult, error) {
+	return agentLoopToolDispatchResult{Text: text, Step: step, Artifacts: artifacts}, err
 }
 
 func isMCPToolName(name string) bool {
@@ -181,7 +186,7 @@ func isMCPToolName(name string) bool {
 // will reject bad input via CallToolResult.IsError, which the LLM can
 // see and retry. Same shape as the other dispatch helpers so the
 // caller treats every tool uniformly.
-func (e *AgentLoopExecutor) dispatchMCPToolCall(ctx context.Context, spec ExecutionSpec, call types.ToolCall, stepIndex int, startedAt time.Time, host AgentMCPHost) (string, *types.TaskStep, []types.TaskArtifact, error) {
+func (d *agentLoopToolDispatcher) dispatchMCPToolCall(ctx context.Context, spec ExecutionSpec, call types.ToolCall, stepIndex int, startedAt time.Time, host AgentMCPHost) (agentLoopToolDispatchResult, error) {
 	args := json.RawMessage(call.Function.Arguments)
 	if len(args) == 0 {
 		// MCP servers typically expect at least `{}` rather than an
@@ -230,8 +235,8 @@ func (e *AgentLoopExecutor) dispatchMCPToolCall(ctx context.Context, spec Execut
 			"blocked":   true,
 			"text_size": len(text),
 		}
-		e.recordMCPCallTelemetry(ctx, spec, call.ID, call.Function.Name, server, toolLeaf, telemetry.MCPCallResultBlocked, durationMS, step.Error)
-		return text, &step, nil, nil
+		d.recordMCPCallTelemetry(ctx, spec, call.ID, call.Function.Name, server, toolLeaf, telemetry.MCPCallResultBlocked, durationMS, step.Error)
+		return agentLoopToolDispatchResult{Text: text, Step: &step}, nil
 	}
 
 	text, isError, err := host.Call(ctx, call.Function.Name, args)
@@ -283,13 +288,13 @@ func (e *AgentLoopExecutor) dispatchMCPToolCall(ctx context.Context, spec Execut
 		"is_error":  isError || err != nil,
 		"text_size": len(text),
 	}
-	e.recordMCPCallTelemetry(ctx, spec, call.ID, call.Function.Name, server, toolLeaf, callResult, durationMS, stepError)
-	return text, &step, nil, nil
+	d.recordMCPCallTelemetry(ctx, spec, call.ID, call.Function.Name, server, toolLeaf, callResult, durationMS, stepError)
+	return agentLoopToolDispatchResult{Text: text, Step: &step}, nil
 }
 
-func (e *AgentLoopExecutor) runSubExecutor(ctx context.Context, spec ExecutionSpec, exec Executor, task types.Task, stepIndex int, startedAt time.Time, toolCallID, toolName string) (string, *types.TaskStep, []types.TaskArtifact, error) {
+func (d *agentLoopToolDispatcher) runSubExecutor(ctx context.Context, spec ExecutionSpec, exec Executor, task types.Task, stepIndex int, startedAt time.Time, toolCallID, toolName string) (agentLoopToolDispatchResult, error) {
 	if exec == nil {
-		return fmt.Sprintf("%s tool is not configured on this gateway", toolName), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("%s tool is not configured on this gateway", toolName)}, nil
 	}
 	subSpec := ExecutionSpec{
 		Task:       task,
@@ -312,10 +317,10 @@ func (e *AgentLoopExecutor) runSubExecutor(ctx context.Context, spec ExecutionSp
 	}
 	subResult, err := exec.Execute(ctx, subSpec)
 	if err != nil {
-		return fmt.Sprintf("%s tool internal error: %v", toolName, err), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("%s tool internal error: %v", toolName, err)}, nil
 	}
 	if subResult == nil {
-		return fmt.Sprintf("%s tool returned nothing", toolName), nil, nil, nil
+		return agentLoopToolDispatchResult{Text: fmt.Sprintf("%s tool returned nothing", toolName)}, nil
 	}
 
 	// Build a single agent-loop step that summarizes the sub-tool's
@@ -361,21 +366,5 @@ func (e *AgentLoopExecutor) runSubExecutor(ctx context.Context, spec ExecutionSp
 	// stdout/file content. Full artifacts are still in the run for
 	// the UI; the LLM gets the relevant signal.
 	resultText := summarizeSubResult(subResult)
-	return resultText, &step, artifacts, nil
-}
-
-func (e *AgentLoopExecutor) gatedToolsInTurn(calls []types.ToolCall, task types.Task) []string {
-	seen := make(map[string]struct{}, len(calls))
-	out := make([]string, 0, len(calls))
-	for _, c := range calls {
-		if !e.isGated(c.Function.Name, task) {
-			continue
-		}
-		if _, dup := seen[c.Function.Name]; dup {
-			continue
-		}
-		seen[c.Function.Name] = struct{}{}
-		out = append(out, c.Function.Name)
-	}
-	return out
+	return agentLoopToolDispatchResult{Text: resultText, Step: &step, Artifacts: artifacts}, nil
 }


### PR DESCRIPTION
## Summary

- Split the agent loop runtime path further by extracting run-state/accounting and LLM-turn orchestration helpers.
- Preserve resolved route metadata for streamed chat captures so agent-loop runs keep provider/model details.
- Fix `shell_exec`/`git_exec` omitted `working_directory` handling so tool calls inherit the task workspace instead of falling back to the gateway process cwd.
- Expand unit, e2e, runtime API/events docs, architecture docs, and backend agent guidance for the new seams.

## Tests

- `git diff --check`
- `go vet ./...`
- `go test ./...`
- `go test -tags e2e ./e2e/... -count=1 -timeout 5m`
- `just docs-check`
