### PR TITLE
refactor(api): split task run stream projection

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -77,6 +77,20 @@ The seven-step chain spans `pkg/types/` → `internal/api/` → `internal/provid
 3. Update the `docs/mcp.md` tool table.
 4. Tests in `internal/mcp/server/tools_test.go` using the `fakeGateway` helper.
 
+### Change task-run streaming
+
+`GET /hecate/v1/tasks/{id}/runs/{run_id}/stream` has two seams:
+
+1. `internal/api/task_run_stream_projector.go` maps persisted run events plus
+   live task storage into `TaskRunStreamEventData`.
+2. `internal/api/task_run_stream_writer.go` writes the SSE frames.
+
+Keep the stream contract forward-moving: new `snapshot` rows should carry the
+current `TaskRunStreamEventData` shape, and older alpha rows can replay as they
+were stored. Do not mutate historical `run_event` rows; the event log is
+append-only. Handler changes should stay focused on request setup, polling, and
+cancellation.
+
 ### Change chat-session / ACP adapter behavior
 
 Chat sessions separate ownership from turn execution:

--- a/docs/events.md
+++ b/docs/events.md
@@ -79,6 +79,9 @@ envelope:
 Per-run state SSE (`/hecate/v1/tasks/{id}/runs/{run_id}/stream`) emits
 `TaskRunStreamEventData` snapshots optimized for the operator UI. Its
 `event_type` field mirrors the persisted event that produced the snapshot.
+The stream is a projection over the append-only event log plus current run
+storage. New `snapshot` rows carry the current stream shape; older alpha rows
+replay as they were stored rather than being normalized or migrated.
 
 ## Runtime snapshot payloads
 
@@ -98,10 +101,10 @@ protocol-shaped `data` payloads instead.
 Store-level terminal transitions (`run.finished`, `run.failed`,
 `run.cancelled`, `approval.resolved`, and `task.updated` events emitted while
 atomically terminalizing a run) persist only their event-specific keys. The
-per-run state SSE handler rebuilds the final run/step/artifact/approval snapshot
+per-run stream projector rebuilds the final run/step/artifact/approval snapshot
 from storage after reading those terminal events.
 
-Caller-driven events (`POST /hecate/v1/tasks/.../events`) instead serialize the rebuilt stream state under a `snapshot` key. The decoder in the per-run SSE handler honors both shapes; public event envelopes strip `snapshot` for the same reason they strip `run` / `steps` / `artifacts`.
+Caller-driven events (`POST /hecate/v1/tasks/.../events`) instead serialize the rebuilt stream state under a `snapshot` key. The per-run stream projector honors both shapes; public event envelopes strip `snapshot` for the same reason they strip `run` / `steps` / `artifacts`.
 
 The internal persisted row is compact and is mapped to the public envelope on
 read:
@@ -482,7 +485,7 @@ Emitted when task-scoped metadata changed in a way that affects the run's view (
 
 ### `snapshot`
 
-The per-run SSE handler writes one of these every time it detects a state change between heartbeats. Subscribers reconnecting via `Last-Event-ID` rely on these to backfill state. Distinguishable from real lifecycle events by `type=snapshot` in JSON event lists and `event_type=snapshot` in per-run state SSE; the `data.snapshot` key holds the rebuilt `TaskRunStreamEventData` JSON.
+The per-run stream writes one of these every time it detects a state change between heartbeats. Subscribers reconnecting via `Last-Event-ID` rely on these to backfill state. Distinguishable from real lifecycle events by `type=snapshot` in JSON event lists and `event_type=snapshot` in per-run state SSE; the `data.snapshot` key holds the rebuilt `TaskRunStreamEventData` JSON.
 
 | Extra key  | Type     | Notes                                                            |
 | ---------- | -------- | ---------------------------------------------------------------- |

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -271,6 +271,9 @@ current run state, steps, artifacts, activity, and approvals scoped to that run
 so the operator UI can drive approval banners and progress surfaces without a
 separate refetch (`TaskRunStreamEventData.Approvals`). The frame's `event_type`
 mirrors the persisted event that produced the state refresh.
+The frame is a read-time projection over the append-only run-event log and live
+run storage. Hecate writes the current stream payload shape for new snapshots
+and does not rewrite older alpha event rows when the shape grows.
 
 The frame also includes a normalized `activity` array for clients that want a
 coding-agent-style timeline without reconstructing it from raw steps and

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -351,19 +351,43 @@ func readBody(t *testing.T, resp *http.Response) string {
 }
 
 type sseEvent struct {
-	Data string
+	ID    string
+	Event string
+	Data  string
 }
 
 func readSSE(t *testing.T, resp *http.Response) []sseEvent {
 	t.Helper()
 	defer resp.Body.Close()
 	var events []sseEvent
+	var current sseEvent
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "data: ") {
-			events = append(events, sseEvent{Data: strings.TrimPrefix(line, "data: ")})
+		if line == "" {
+			if current.ID != "" || current.Event != "" || current.Data != "" {
+				events = append(events, current)
+				current = sseEvent{}
+			}
+			continue
 		}
+		if strings.HasPrefix(line, "id: ") {
+			current.ID = strings.TrimPrefix(line, "id: ")
+			continue
+		}
+		if strings.HasPrefix(line, "event: ") {
+			current.Event = strings.TrimPrefix(line, "event: ")
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") {
+			if current.Data != "" {
+				current.Data += "\n"
+			}
+			current.Data += strings.TrimPrefix(line, "data: ")
+		}
+	}
+	if current.ID != "" || current.Event != "" || current.Data != "" {
+		events = append(events, current)
 	}
 	return events
 }

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestTaskApprovalCancelTerminalStateE2E(t *testing.T) {
@@ -181,8 +180,9 @@ func e2eReadTerminalTaskRunSnapshot(t *testing.T, baseURL, taskID, runID string)
 		t.Fatalf("stream content-type = %q, want text/event-stream", ct)
 	}
 	events := readSSE(t, resp)
-	deadline := time.Now().Add(1 * time.Second)
-	var last e2eTaskRunStreamResponse
+	var terminal e2eTaskRunStreamResponse
+	var sawTerminal bool
+	var sawDone bool
 	for _, event := range events {
 		var payload e2eTaskRunStreamResponse
 		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
@@ -191,16 +191,28 @@ func e2eReadTerminalTaskRunSnapshot(t *testing.T, baseURL, taskID, runID string)
 		if payload.Data.Run.ID == "" {
 			continue
 		}
-		last = payload
+		if event.Event == "done" {
+			sawDone = true
+			if !payload.Data.Terminal {
+				t.Fatalf("done stream terminal = false, want true")
+			}
+			if payload.Data.Sequence == 0 {
+				t.Fatalf("done stream sequence = 0, want persisted sequence")
+			}
+			continue
+		}
 		if payload.Data.Terminal || payload.Data.Run.Status == "cancelled" || payload.Data.Run.Status == "failed" || payload.Data.Run.Status == "completed" {
-			return payload
+			terminal = payload
+			sawTerminal = true
 		}
 	}
-	if time.Now().Before(deadline) && last.Data.Run.ID != "" {
-		return last
+	if !sawTerminal {
+		t.Fatalf("terminal stream snapshot not found in %d SSE payloads", len(events))
 	}
-	t.Fatalf("terminal stream snapshot not found in %d SSE payloads", len(events))
-	return e2eTaskRunStreamResponse{}
+	if !sawDone {
+		t.Fatalf("terminal stream done event not found in %d SSE payloads", len(events))
+	}
+	return terminal
 }
 
 func assertE2EEventOrder(t *testing.T, events []e2eEventEnvelope, want []string) {
@@ -317,6 +329,7 @@ type e2eEventEnvelope struct {
 
 type e2eTaskRunStreamResponse struct {
 	Data struct {
+		Sequence  int               `json:"sequence,omitempty"`
 		Terminal  bool              `json:"terminal,omitempty"`
 		EventType string            `json:"event_type,omitempty"`
 		Run       e2eTaskRun        `json:"run"`

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -433,6 +433,7 @@ func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session cha
 func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sessionID, messageID string) (types.TaskRun, error) {
 	ticker := time.NewTicker(hecateAgentPollInterval)
 	defer ticker.Stop()
+	projector := newTaskRunStreamProjector(h.taskStore)
 	var lastStatus string
 	var lastActivitySignature string
 	var lastContent string
@@ -446,7 +447,7 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 		}
 		taskActivities := []chat.Activity(nil)
 		activitySignature := ""
-		if state, stateErr := h.buildTaskRunStreamState(ctx, taskID, runID); stateErr == nil {
+		if state, stateErr := projector.liveState(ctx, taskID, runID); stateErr == nil {
 			taskActivities = agentChatActivitiesFromTaskActivity(state.Activity)
 			activitySignature = agentChatActivitySignature(taskActivities)
 		}

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -1120,11 +1120,6 @@ func patchContent(diff, prefix string) (string, bool, error) {
 	return strings.Join(contentLines, "\n") + "\n", existed, nil
 }
 
-// decodeTurnCostFromEventData lifts the per-turn cost figures out of
-// the turn.completed event payload. The runner writes them as
-// a flat map; we pull the keys defensively (event.Data is map[string]any
-// after a JSON round-trip, so numerics arrive as float64).
-
 func newTaskID() string {
 	return newOpaqueTaskResourceID("task")
 }

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -11,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/eventprotocol"
-	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -38,6 +35,8 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 	runID := run.ID
 
 	writeSSEHeaders(w)
+	projector := newTaskRunStreamProjector(h.taskStore)
+	stream := newTaskRunStreamWriter(w, flusher)
 
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
@@ -49,71 +48,34 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 	for {
 		events, err := h.taskStore.ListRunEvents(ctx, task.ID, runID, afterSequence, 200)
 		if err != nil {
-			fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-			flusher.Flush()
+			stream.writeError(err)
 			return
 		}
 		for _, event := range events {
-			state, ok, err := h.decodeTaskRunEventData(event)
+			state, err := projector.projectEvent(ctx, task.ID, runID, event)
 			if err != nil {
-				fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-				flusher.Flush()
-				return
-			}
-			if !ok {
-				// Some events carry an overlay (e.g. turn.completed
-				// passes a Turn cost block) but no full snapshot. Save
-				// the overlay across the rebuild so it survives.
-				overlayTurn := state.Turn
-				state, err = h.buildTaskRunStreamState(ctx, task.ID, runID)
-				if err != nil {
-					fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-					flusher.Flush()
-					return
-				}
-				state.Turn = overlayTurn
-			} else if state.Approvals == nil {
-				// Historical snapshots saved before approvals were
-				// included in the SSE payload have a nil Approvals
-				// slice. Top up from the live store so the UI doesn't
-				// see "no approvals" and clear its banner. Without
-				// this, replaying an old run would briefly show then
-				// hide the approval card on every reconnect.
-				if live, liveErr := h.buildTaskRunStreamState(ctx, task.ID, runID); liveErr == nil {
-					state.Approvals = live.Approvals
-				}
-			}
-			state.Sequence = int(event.Sequence)
-			state.EventType = event.EventType
-			state.Terminal = types.IsTerminalTaskRunStatus(state.Run.Status)
-
-			payload, err := json.Marshal(TaskRunStreamEventResponse{
-				Object: "task_run_stream_event",
-				Data:   state,
-			})
-			if err != nil {
-				fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-				flusher.Flush()
+				stream.writeError(err)
 				return
 			}
 
-			fmt.Fprintf(w, "id: %d\nevent: snapshot\ndata: %s\n\n", event.Sequence, payload)
+			payload, err := taskRunStreamSnapshotPayload(state)
+			if err != nil {
+				stream.writeError(err)
+				return
+			}
+			stream.writeSnapshotPayload(event.Sequence, payload)
 			if state.Terminal {
-				finalState, err := h.buildTaskRunStreamState(ctx, task.ID, runID)
-				if err == nil {
-					finalState.Sequence = int(event.Sequence)
-					finalState.EventType = state.EventType
-					finalState.Terminal = true
-					if finalPayload, marshalErr := json.Marshal(TaskRunStreamEventResponse{Object: "task_run_stream_event", Data: finalState}); marshalErr == nil {
+				if finalState, ok := projector.terminalLiveState(ctx, task.ID, runID, event.Sequence, state.EventType); ok {
+					if finalPayload, marshalErr := taskRunStreamSnapshotPayload(finalState); marshalErr == nil {
 						payload = finalPayload
-						fmt.Fprintf(w, "id: %d\nevent: snapshot\ndata: %s\n\n", event.Sequence, payload)
+						stream.writeSnapshotPayload(event.Sequence, payload)
 					}
 				}
-				fmt.Fprintf(w, "id: %d\nevent: done\ndata: %s\n\n", event.Sequence, payload)
+				stream.writeDonePayload(event.Sequence, payload)
 			}
-			flusher.Flush()
+			stream.flush()
 			afterSequence = event.Sequence
-			if stateJSON, marshalErr := json.Marshal(state); marshalErr == nil {
+			if stateJSON, marshalErr := taskRunStreamStateJSON(state); marshalErr == nil {
 				lastStateJSON = string(stateJSON)
 			}
 			if state.Terminal {
@@ -121,21 +83,17 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		state, err := h.buildTaskRunStreamState(ctx, task.ID, runID)
+		state, err := projector.liveState(ctx, task.ID, runID)
 		if err != nil {
-			fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-			flusher.Flush()
+			stream.writeError(err)
 			return
 		}
-		stateJSON, err := json.Marshal(state)
+		snapshot, stateJSON, err := projector.snapshotEventData(state)
 		if err != nil {
-			fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
-			flusher.Flush()
+			stream.writeError(err)
 			return
 		}
-		if string(stateJSON) != lastStateJSON {
-			var snapshot map[string]any
-			_ = json.Unmarshal(stateJSON, &snapshot)
+		if stateJSON != lastStateJSON {
 			event, appendErr := h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
 				TaskID:    task.ID,
 				RunID:     runID,
@@ -151,18 +109,17 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 			}
 			state.EventType = "snapshot"
 			state.Terminal = types.IsTerminalTaskRunStatus(state.Run.Status)
-			payload, marshalErr := json.Marshal(TaskRunStreamEventResponse{Object: "task_run_stream_event", Data: state})
+			payload, marshalErr := taskRunStreamSnapshotPayload(state)
 			if marshalErr != nil {
-				fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", marshalErr.Error())
-				flusher.Flush()
+				stream.writeError(marshalErr)
 				return
 			}
-			fmt.Fprintf(w, "id: %d\nevent: snapshot\ndata: %s\n\n", state.Sequence, payload)
+			stream.writeSnapshotPayload(int64(state.Sequence), payload)
 			if state.Terminal {
-				fmt.Fprintf(w, "id: %d\nevent: done\ndata: %s\n\n", state.Sequence, payload)
+				stream.writeDonePayload(int64(state.Sequence), payload)
 			}
-			flusher.Flush()
-			lastStateJSON = string(stateJSON)
+			stream.flush()
+			lastStateJSON = stateJSON
 			if state.Terminal {
 				return
 			}
@@ -173,8 +130,7 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-ticker.C:
 		case <-heartbeat.C:
-			fmt.Fprint(w, ": keep-alive\n\n")
-			flusher.Flush()
+			stream.writeKeepAlive()
 		}
 	}
 }
@@ -232,12 +188,12 @@ func (h *Handler) HandleAppendTaskRunEvent(w http.ResponseWriter, r *http.Reques
 	if req.Note != "" {
 		extra["note"] = req.Note
 	}
-	state, err := h.buildTaskRunStreamState(ctx, task.ID, run.ID)
+	projector := newTaskRunStreamProjector(h.taskStore)
+	state, err := projector.liveState(ctx, task.ID, run.ID)
 	if err == nil {
-		stateJSON, _ := json.Marshal(state)
-		var snapshot map[string]any
-		_ = json.Unmarshal(stateJSON, &snapshot)
-		extra["snapshot"] = snapshot
+		if snapshot, _, snapshotErr := projector.snapshotEventData(state); snapshotErr == nil {
+			extra["snapshot"] = snapshot
+		}
 	}
 	event, err := h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
 		TaskID:    task.ID,
@@ -271,164 +227,6 @@ func parseAfterSequence(r *http.Request) int64 {
 		return 0
 	}
 	return value
-}
-
-func (h *Handler) buildTaskRunStreamState(ctx context.Context, taskID, runID string) (TaskRunStreamEventData, error) {
-	run, found, err := h.taskStore.GetRun(ctx, taskID, runID)
-	if err != nil {
-		return TaskRunStreamEventData{}, err
-	}
-	if !found {
-		return TaskRunStreamEventData{}, fmt.Errorf("task run not found")
-	}
-	steps, err := h.taskStore.ListSteps(ctx, runID)
-	if err != nil {
-		return TaskRunStreamEventData{}, err
-	}
-	artifacts, err := h.taskStore.ListArtifacts(ctx, taskstate.ArtifactFilter{TaskID: taskID, RunID: runID})
-	if err != nil {
-		return TaskRunStreamEventData{}, err
-	}
-	// Approvals are listed per-task by the store; we filter to the
-	// current run because the streamed state is run-scoped. A failure
-	// here is non-fatal — emit the snapshot without approvals rather
-	// than dropping the whole stream, so the run/steps view still
-	// updates. The UI's separate /hecate/v1/tasks/{id}/approvals fetch acts
-	// as a fallback for that edge case.
-	taskApprovals, err := h.taskStore.ListApprovals(ctx, taskID)
-	if err != nil {
-		taskApprovals = nil
-	}
-
-	stepItems := make([]TaskStepItem, 0, len(steps))
-	for _, step := range steps {
-		stepItems = append(stepItems, renderTaskStep(step))
-	}
-	artifactItems := make([]TaskArtifactItem, 0, len(artifacts))
-	for _, artifact := range artifacts {
-		artifactItems = append(artifactItems, renderTaskArtifact(artifact))
-	}
-	approvalItems := make([]TaskApprovalItem, 0, len(taskApprovals))
-	for _, approval := range taskApprovals {
-		if approval.RunID != runID {
-			continue
-		}
-		approvalItems = append(approvalItems, renderTaskApproval(approval))
-	}
-	activityItems := buildTaskActivityItems(stepItems, artifactItems, approvalItems, run)
-	return TaskRunStreamEventData{
-		Run:       renderTaskRun(run),
-		Steps:     stepItems,
-		Artifacts: artifactItems,
-		Activity:  activityItems,
-		Approvals: approvalItems,
-	}, nil
-}
-
-func (h *Handler) decodeTaskRunEventData(event types.TaskRunEvent) (TaskRunStreamEventData, bool, error) {
-	if event.Data == nil {
-		return TaskRunStreamEventData{}, false, nil
-	}
-	// `turn.completed` is the per-turn cost telemetry the runner
-	// emits; its payload is a flat map (no `snapshot` envelope). We
-	// don't have enough state to fabricate a full snapshot here — the
-	// caller falls through to buildTaskRunStreamState — but we DO want
-	// to attach the per-turn breakdown so the UI can render a live
-	// cost-per-turn summary without subscribing to /hecate/v1/events.
-	if event.EventType == "turn.completed" {
-		turn := decodeTurnCostFromEventData(event.Data)
-		return TaskRunStreamEventData{Turn: turn}, false, nil
-	}
-	snapshot, ok := event.Data["snapshot"]
-	if ok {
-		raw, err := json.Marshal(snapshot)
-		if err != nil {
-			return TaskRunStreamEventData{}, false, err
-		}
-		var decoded TaskRunStreamEventData
-		if err := json.Unmarshal(raw, &decoded); err != nil {
-			return TaskRunStreamEventData{}, false, err
-		}
-		return decoded, true, nil
-	}
-	raw, err := json.Marshal(event.Data)
-	if err != nil {
-		return TaskRunStreamEventData{}, false, err
-	}
-	var typed struct {
-		Run       types.TaskRun        `json:"run"`
-		Steps     []types.TaskStep     `json:"steps"`
-		Artifacts []types.TaskArtifact `json:"artifacts"`
-	}
-	if err := json.Unmarshal(raw, &typed); err == nil && typed.Run.ID != "" {
-		stepItems := make([]TaskStepItem, 0, len(typed.Steps))
-		for _, step := range typed.Steps {
-			stepItems = append(stepItems, renderTaskStep(step))
-		}
-		artifactItems := make([]TaskArtifactItem, 0, len(typed.Artifacts))
-		for _, artifact := range typed.Artifacts {
-			artifactItems = append(artifactItems, renderTaskArtifact(artifact))
-		}
-		return TaskRunStreamEventData{
-			Run:       renderTaskRun(typed.Run),
-			Steps:     stepItems,
-			Artifacts: artifactItems,
-		}, true, nil
-	}
-	var decoded TaskRunStreamEventData
-	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return TaskRunStreamEventData{}, false, nil
-	}
-	if decoded.Run.ID == "" {
-		return TaskRunStreamEventData{}, false, nil
-	}
-	return decoded, true, nil
-}
-
-// decodeTurnCostFromEventData lifts the per-turn cost figures out of
-// the turn.completed event payload. The runner writes them as
-// a flat map; we pull the keys defensively (event.Data is map[string]any
-// after a JSON round-trip, so numerics arrive as float64).
-func decodeTurnCostFromEventData(data map[string]any) *TaskRunStreamTurnCost {
-	if data == nil {
-		return nil
-	}
-	asInt := func(v any) int {
-		switch n := v.(type) {
-		case float64:
-			return int(n)
-		case int:
-			return n
-		case int64:
-			return int(n)
-		}
-		return 0
-	}
-	asInt64 := func(v any) int64 {
-		switch n := v.(type) {
-		case float64:
-			return int64(n)
-		case int:
-			return int64(n)
-		case int64:
-			return n
-		}
-		return 0
-	}
-	asString := func(v any) string {
-		if s, ok := v.(string); ok {
-			return s
-		}
-		return ""
-	}
-	return &TaskRunStreamTurnCost{
-		Turn:                    asInt(data["turn_index"]),
-		StepID:                  asString(data["step_id"]),
-		CostMicrosUSD:           asInt64(data["cost_micros_usd"]),
-		RunCumulativeMicrosUSD:  asInt64(data["run_cumulative_cost_micros_usd"]),
-		TaskCumulativeMicrosUSD: asInt64(data["task_cumulative_cost_micros_usd"]),
-		ToolCallCount:           asInt(data["tool_calls"]),
-	}
 }
 
 func (h *Handler) loadAuthorizedTask(ctx context.Context, w http.ResponseWriter, r *http.Request) (types.Task, bool) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -5034,15 +5034,15 @@ func TestTaskRunStream_AgentTurnCompletedFlowsTurnOverlayIntoSnapshot(t *testing
 	// End-to-end check on the Turn overlay path:
 	//
 	//   1. Runner emits `turn.completed` to the run-event log
-	//   2. SSE handler reads the event, decodeTaskRunEventData treats
-	//      it as Turn-only (ok=false)
-	//   3. Handler preserves the overlay across buildTaskRunStreamState
+	//   2. SSE projector reads the event, treats it as Turn-only
+	//      (ok=false)
+	//   3. Projector preserves the overlay across live-state rebuild
 	//   4. Final snapshot carries BOTH the rebuilt Run/Steps/Artifacts
 	//      AND the Turn block
 	//
 	// The unit tests in turn_cost_stream_test.go pin steps 2-3 in
 	// isolation. This test pins the wire-up: a regression that, say,
-	// ran buildTaskRunStreamState without preserving overlayTurn
+	// rebuilt live state without preserving overlayTurn
 	// would silently swallow per-turn cost on the SSE feed without
 	// any unit test failing. We POST the event via the public
 	// /events endpoint so we don't need a real LLM.
@@ -5134,7 +5134,7 @@ func TestTaskRunStream_AgentTurnCompletedFlowsTurnOverlayIntoSnapshot(t *testing
 		//   b) Turn fields match what we POSTed (no key rename
 		//      regression in decodeTurnCostFromEventData)
 		//   c) Run.ID is also set (proves the overlay was merged
-		//      AFTER buildTaskRunStreamState rebuilt full state —
+		//      AFTER the projector rebuilt full state —
 		//      not a Turn-only payload that lost the rest of the
 		//      run context)
 		if payload.Data.Turn == nil {

--- a/internal/api/task_run_stream_projector.go
+++ b/internal/api/task_run_stream_projector.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type taskRunStreamProjector struct {
+	store taskstate.Store
+}
+
+func newTaskRunStreamProjector(store taskstate.Store) taskRunStreamProjector {
+	return taskRunStreamProjector{store: store}
+}
+
+func (p taskRunStreamProjector) projectEvent(ctx context.Context, taskID, runID string, event types.TaskRunEvent) (TaskRunStreamEventData, error) {
+	state, ok, err := p.decodeEventData(event)
+	if err != nil {
+		return TaskRunStreamEventData{}, err
+	}
+	if !ok {
+		overlayTurn := state.Turn
+		state, err = p.liveState(ctx, taskID, runID)
+		if err != nil {
+			return TaskRunStreamEventData{}, err
+		}
+		state.Turn = overlayTurn
+	}
+	state.Sequence = int(event.Sequence)
+	state.EventType = event.EventType
+	state.Terminal = types.IsTerminalTaskRunStatus(state.Run.Status)
+	return state, nil
+}
+
+func (p taskRunStreamProjector) terminalLiveState(ctx context.Context, taskID, runID string, sequence int64, eventType string) (TaskRunStreamEventData, bool) {
+	state, err := p.liveState(ctx, taskID, runID)
+	if err != nil {
+		return TaskRunStreamEventData{}, false
+	}
+	state.Sequence = int(sequence)
+	state.EventType = eventType
+	state.Terminal = true
+	return state, true
+}
+
+func (p taskRunStreamProjector) liveState(ctx context.Context, taskID, runID string) (TaskRunStreamEventData, error) {
+	run, found, err := p.store.GetRun(ctx, taskID, runID)
+	if err != nil {
+		return TaskRunStreamEventData{}, err
+	}
+	if !found {
+		return TaskRunStreamEventData{}, fmt.Errorf("task run not found")
+	}
+	steps, err := p.store.ListSteps(ctx, runID)
+	if err != nil {
+		return TaskRunStreamEventData{}, err
+	}
+	artifacts, err := p.store.ListArtifacts(ctx, taskstate.ArtifactFilter{TaskID: taskID, RunID: runID})
+	if err != nil {
+		return TaskRunStreamEventData{}, err
+	}
+	// Approvals are listed per-task by the store; filter to the
+	// current run because the streamed state is run-scoped. Failure is
+	// non-fatal: keep run/step progress flowing, and let the UI's
+	// separate approvals fetch act as fallback for that edge case.
+	taskApprovals, err := p.store.ListApprovals(ctx, taskID)
+	if err != nil {
+		taskApprovals = nil
+	}
+
+	stepItems := make([]TaskStepItem, 0, len(steps))
+	for _, step := range steps {
+		stepItems = append(stepItems, renderTaskStep(step))
+	}
+	artifactItems := make([]TaskArtifactItem, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		artifactItems = append(artifactItems, renderTaskArtifact(artifact))
+	}
+	approvalItems := make([]TaskApprovalItem, 0, len(taskApprovals))
+	for _, approval := range taskApprovals {
+		if approval.RunID != runID {
+			continue
+		}
+		approvalItems = append(approvalItems, renderTaskApproval(approval))
+	}
+	activityItems := buildTaskActivityItems(stepItems, artifactItems, approvalItems, run)
+	return TaskRunStreamEventData{
+		Run:       renderTaskRun(run),
+		Steps:     stepItems,
+		Artifacts: artifactItems,
+		Activity:  activityItems,
+		Approvals: approvalItems,
+	}, nil
+}
+
+func (p taskRunStreamProjector) snapshotEventData(state TaskRunStreamEventData) (map[string]any, string, error) {
+	stateJSON, err := taskRunStreamStateJSON(state)
+	if err != nil {
+		return nil, "", err
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(stateJSON, &snapshot); err != nil {
+		return nil, "", err
+	}
+	return snapshot, string(stateJSON), nil
+}
+
+func (p taskRunStreamProjector) decodeEventData(event types.TaskRunEvent) (TaskRunStreamEventData, bool, error) {
+	if event.Data == nil {
+		return TaskRunStreamEventData{}, false, nil
+	}
+	// `turn.completed` is a flat per-turn cost payload. It is not a
+	// full stream snapshot, but the Turn overlay must survive the
+	// live-state rebuild so the UI can render the latest turn cost.
+	if event.EventType == "turn.completed" {
+		turn := decodeTurnCostFromEventData(event.Data)
+		return TaskRunStreamEventData{Turn: turn}, false, nil
+	}
+	snapshot, ok := event.Data["snapshot"]
+	if ok {
+		raw, err := json.Marshal(snapshot)
+		if err != nil {
+			return TaskRunStreamEventData{}, false, err
+		}
+		var decoded TaskRunStreamEventData
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return TaskRunStreamEventData{}, false, err
+		}
+		return decoded, true, nil
+	}
+	raw, err := json.Marshal(event.Data)
+	if err != nil {
+		return TaskRunStreamEventData{}, false, err
+	}
+	var typed struct {
+		Run       types.TaskRun        `json:"run"`
+		Steps     []types.TaskStep     `json:"steps"`
+		Artifacts []types.TaskArtifact `json:"artifacts"`
+	}
+	if err := json.Unmarshal(raw, &typed); err == nil && typed.Run.ID != "" {
+		stepItems := make([]TaskStepItem, 0, len(typed.Steps))
+		for _, step := range typed.Steps {
+			stepItems = append(stepItems, renderTaskStep(step))
+		}
+		artifactItems := make([]TaskArtifactItem, 0, len(typed.Artifacts))
+		for _, artifact := range typed.Artifacts {
+			artifactItems = append(artifactItems, renderTaskArtifact(artifact))
+		}
+		return TaskRunStreamEventData{
+			Run:       renderTaskRun(typed.Run),
+			Steps:     stepItems,
+			Artifacts: artifactItems,
+		}, true, nil
+	}
+	var decoded TaskRunStreamEventData
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return TaskRunStreamEventData{}, false, nil
+	}
+	if decoded.Run.ID == "" {
+		return TaskRunStreamEventData{}, false, nil
+	}
+	return decoded, true, nil
+}
+
+// decodeTurnCostFromEventData lifts per-turn cost figures out of the
+// turn.completed event payload. Numerics are tolerant of both in-process
+// integers and JSON-roundtripped float64 values.
+func decodeTurnCostFromEventData(data map[string]any) *TaskRunStreamTurnCost {
+	if data == nil {
+		return nil
+	}
+	asInt := func(v any) int {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		case int64:
+			return int(n)
+		}
+		return 0
+	}
+	asInt64 := func(v any) int64 {
+		switch n := v.(type) {
+		case float64:
+			return int64(n)
+		case int:
+			return int64(n)
+		case int64:
+			return n
+		}
+		return 0
+	}
+	asString := func(v any) string {
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return ""
+	}
+	return &TaskRunStreamTurnCost{
+		Turn:                    asInt(data["turn_index"]),
+		StepID:                  asString(data["step_id"]),
+		CostMicrosUSD:           asInt64(data["cost_micros_usd"]),
+		RunCumulativeMicrosUSD:  asInt64(data["run_cumulative_cost_micros_usd"]),
+		TaskCumulativeMicrosUSD: asInt64(data["task_cumulative_cost_micros_usd"]),
+		ToolCallCount:           asInt(data["tool_calls"]),
+	}
+}

--- a/internal/api/task_run_stream_projector_test.go
+++ b/internal/api/task_run_stream_projector_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestTaskRunStreamProjector_TurnCompletedMergesOverlayWithLiveState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	seedTaskRunStreamProjectorRun(t, ctx, store, "task-turn", "run-turn", "running")
+	projector := newTaskRunStreamProjector(store)
+
+	state, err := projector.projectEvent(ctx, "task-turn", "run-turn", types.TaskRunEvent{
+		Sequence:  7,
+		EventType: "turn.completed",
+		Data: map[string]any{
+			"turn_index":                      float64(3),
+			"step_id":                         "step-turn",
+			"cost_micros_usd":                 float64(4200),
+			"run_cumulative_cost_micros_usd":  float64(8200),
+			"task_cumulative_cost_micros_usd": float64(12000),
+			"tool_calls":                      float64(2),
+		},
+	})
+	if err != nil {
+		t.Fatalf("projectEvent() error = %v", err)
+	}
+	if state.Run.ID != "run-turn" {
+		t.Fatalf("Run.ID = %q, want run-turn", state.Run.ID)
+	}
+	if state.Sequence != 7 || state.EventType != "turn.completed" {
+		t.Fatalf("stream metadata = sequence %d event_type %q, want 7 turn.completed", state.Sequence, state.EventType)
+	}
+	if state.Terminal {
+		t.Fatal("Terminal = true, want false for running live state")
+	}
+	if state.Turn == nil {
+		t.Fatal("Turn is nil, want turn overlay")
+	}
+	if state.Turn.Turn != 3 || state.Turn.StepID != "step-turn" || state.Turn.CostMicrosUSD != 4200 {
+		t.Fatalf("Turn = %+v, want turn=3 step=step-turn cost=4200", state.Turn)
+	}
+}
+
+func TestTaskRunStreamProjector_DoesNotTopUpSnapshotApprovals(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	seedTaskRunStreamProjectorRun(t, ctx, store, "task-approval", "run-approval", "awaiting_approval")
+	_, err := store.CreateApproval(ctx, types.TaskApproval{
+		ID:          "approval-1",
+		TaskID:      "task-approval",
+		RunID:       "run-approval",
+		StepID:      "step-approval",
+		Kind:        "shell_exec",
+		Status:      "pending",
+		Reason:      "shell command",
+		RequestedBy: "agent_loop",
+		CreatedAt:   time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("CreateApproval() error = %v", err)
+	}
+
+	snapshot := map[string]any{
+		"run": map[string]any{
+			"id":      "run-approval",
+			"task_id": "task-approval",
+			"status":  "awaiting_approval",
+		},
+	}
+	projector := newTaskRunStreamProjector(store)
+	state, err := projector.projectEvent(ctx, "task-approval", "run-approval", types.TaskRunEvent{
+		Sequence:  11,
+		EventType: "snapshot",
+		Data:      map[string]any{"snapshot": snapshot},
+	})
+	if err != nil {
+		t.Fatalf("projectEvent() error = %v", err)
+	}
+	if len(state.Approvals) != 0 {
+		t.Fatalf("Approvals = %+v, want none because persisted snapshot omitted them", state.Approvals)
+	}
+	if _, ok := snapshot["approvals"]; ok {
+		t.Fatal("snapshot was mutated with approvals")
+	}
+}
+
+func TestTaskRunStreamProjector_SnapshotEventDataUsesCurrentStreamShape(t *testing.T) {
+	t.Parallel()
+
+	projector := newTaskRunStreamProjector(nil)
+	state := TaskRunStreamEventData{
+		Run: renderTaskRun(types.TaskRun{
+			ID:     "run-shape",
+			TaskID: "task-shape",
+			Status: "running",
+		}),
+		Approvals: []TaskApprovalItem{{
+			ID:     "approval-shape",
+			TaskID: "task-shape",
+			RunID:  "run-shape",
+			Status: "pending",
+		}},
+	}
+	snapshot, stateJSON, err := projector.snapshotEventData(state)
+	if err != nil {
+		t.Fatalf("snapshotEventData() error = %v", err)
+	}
+	if stateJSON == "" {
+		t.Fatal("stateJSON is empty")
+	}
+	approvals, ok := snapshot["approvals"].([]any)
+	if !ok {
+		t.Fatalf("snapshot approvals = %#v, want JSON array", snapshot["approvals"])
+	}
+	if len(approvals) != 1 {
+		t.Fatalf("snapshot approvals = %d, want 1", len(approvals))
+	}
+}
+
+func seedTaskRunStreamProjectorRun(t *testing.T, ctx context.Context, store taskstate.Store, taskID, runID, status string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := store.CreateTask(ctx, types.Task{
+		ID:        taskID,
+		Title:     taskID,
+		Prompt:    "projector test",
+		Status:    status,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := store.CreateRun(ctx, types.TaskRun{
+		ID:        runID,
+		TaskID:    taskID,
+		Number:    1,
+		Status:    status,
+		StartedAt: now,
+		RequestID: "req-" + runID,
+		TraceID:   "trace-" + runID,
+	}); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+}

--- a/internal/api/task_run_stream_writer.go
+++ b/internal/api/task_run_stream_writer.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type taskRunStreamWriter struct {
+	w       io.Writer
+	flusher http.Flusher
+}
+
+func newTaskRunStreamWriter(w io.Writer, flusher http.Flusher) taskRunStreamWriter {
+	return taskRunStreamWriter{w: w, flusher: flusher}
+}
+
+func taskRunStreamSnapshotPayload(state TaskRunStreamEventData) ([]byte, error) {
+	return json.Marshal(TaskRunStreamEventResponse{
+		Object: "task_run_stream_event",
+		Data:   state,
+	})
+}
+
+func taskRunStreamStateJSON(state TaskRunStreamEventData) ([]byte, error) {
+	return json.Marshal(state)
+}
+
+func (s taskRunStreamWriter) writeSnapshotPayload(sequence int64, payload []byte) {
+	fmt.Fprintf(s.w, "id: %d\nevent: snapshot\ndata: %s\n\n", sequence, payload)
+}
+
+func (s taskRunStreamWriter) writeDonePayload(sequence int64, payload []byte) {
+	fmt.Fprintf(s.w, "id: %d\nevent: done\ndata: %s\n\n", sequence, payload)
+}
+
+func (s taskRunStreamWriter) writeError(err error) {
+	fmt.Fprintf(s.w, "event: error\ndata: {\"error\":{\"message\":%q}}\n\n", err.Error())
+	s.flush()
+}
+
+func (s taskRunStreamWriter) writeKeepAlive() {
+	fmt.Fprint(s.w, ": keep-alive\n\n")
+	s.flush()
+}
+
+func (s taskRunStreamWriter) flush() {
+	if s.flusher != nil {
+		s.flusher.Flush()
+	}
+}

--- a/internal/api/task_run_stream_writer_test.go
+++ b/internal/api/task_run_stream_writer_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestTaskRunStreamWriter_WritesSnapshotAndDoneFrames(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	writer := newTaskRunStreamWriter(&buf, nil)
+	payload, err := taskRunStreamSnapshotPayload(TaskRunStreamEventData{
+		Sequence:  42,
+		Terminal:  true,
+		EventType: "run.completed",
+		Run: renderTaskRun(types.TaskRun{
+			ID:     "run-writer",
+			TaskID: "task-writer",
+			Status: "completed",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("taskRunStreamSnapshotPayload() error = %v", err)
+	}
+
+	writer.writeSnapshotPayload(42, payload)
+	writer.writeDonePayload(42, payload)
+
+	got := buf.String()
+	if strings.Count(got, "id: 42\n") != 2 {
+		t.Fatalf("stream ids = %q, want two id: 42 frames", got)
+	}
+	if !strings.Contains(got, "event: snapshot\n") {
+		t.Fatalf("stream = %q, want snapshot frame", got)
+	}
+	if !strings.Contains(got, "event: done\n") {
+		t.Fatalf("stream = %q, want done frame", got)
+	}
+	if !strings.Contains(got, `"object":"task_run_stream_event"`) {
+		t.Fatalf("stream = %q, want task_run_stream_event payload", got)
+	}
+}
+
+func TestTaskRunStreamWriter_WritesErrorAndKeepAlive(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	writer := newTaskRunStreamWriter(&buf, nil)
+
+	writer.writeError(assertErr("projection failed"))
+	writer.writeKeepAlive()
+
+	got := buf.String()
+	if !strings.Contains(got, "event: error\n") {
+		t.Fatalf("stream = %q, want error frame", got)
+	}
+	if !strings.Contains(got, `"projection failed"`) {
+		t.Fatalf("stream = %q, want error message", got)
+	}
+	if !strings.Contains(got, ": keep-alive\n\n") {
+		t.Fatalf("stream = %q, want keep-alive comment", got)
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string {
+	return string(e)
+}

--- a/internal/api/turn_cost_stream_test.go
+++ b/internal/api/turn_cost_stream_test.go
@@ -74,13 +74,13 @@ func TestDecodeTurnCostFromEventData_TolerantToInts(t *testing.T) {
 	}
 }
 
-// TestDecodeTaskRunEventData_TurnCompletedReturnsTurnOverlay
-// verifies the decoder treats turn.completed as a Turn-only
-// overlay (ok=false so the streaming handler rebuilds full state)
-// while still populating Turn so the overlay can be merged after.
-func TestDecodeTaskRunEventData_TurnCompletedReturnsTurnOverlay(t *testing.T) {
+// TestTaskRunStreamProjector_DecodeTurnCompletedReturnsTurnOverlay
+// verifies the projector decoder treats turn.completed as a Turn-only
+// overlay (ok=false so projection rebuilds full state) while still
+// populating Turn so the overlay can be merged after.
+func TestTaskRunStreamProjector_DecodeTurnCompletedReturnsTurnOverlay(t *testing.T) {
 	t.Parallel()
-	h := &Handler{}
+	projector := newTaskRunStreamProjector(nil)
 	event := types.TaskRunEvent{
 		EventType: "turn.completed",
 		Data: map[string]any{
@@ -92,15 +92,15 @@ func TestDecodeTaskRunEventData_TurnCompletedReturnsTurnOverlay(t *testing.T) {
 			"step_id":                         "step-1",
 		},
 	}
-	state, ok, err := h.decodeTaskRunEventData(event)
+	state, ok, err := projector.decodeEventData(event)
 	if err != nil {
-		t.Fatalf("decodeTaskRunEventData error = %v", err)
+		t.Fatalf("decodeEventData error = %v", err)
 	}
 	if ok {
 		// `ok=false` is intentional — turn.completed payloads
-		// don't carry a full snapshot; the streaming handler treats
+		// don't carry a full snapshot; the stream projector treats
 		// false as "rebuild from store, then merge overlay".
-		t.Errorf("decodeTaskRunEventData(turn.completed) ok = true, want false (overlay-only)")
+		t.Errorf("decodeEventData(turn.completed) ok = true, want false (overlay-only)")
 	}
 	if state.Turn == nil {
 		t.Fatal("state.Turn is nil — overlay was not populated")
@@ -122,12 +122,12 @@ func TestDecodeTaskRunEventData_TurnCompletedReturnsTurnOverlay(t *testing.T) {
 	}
 }
 
-// TestDecodeTaskRunEventData_OtherEventsUnaffected confirms the new
+// TestTaskRunStreamProjector_DecodeOtherEventsUnaffected confirms the new
 // turn.completed branch doesn't accidentally short-circuit
 // other event types — the existing snapshot-decode path stays.
-func TestDecodeTaskRunEventData_OtherEventsUnaffected(t *testing.T) {
+func TestTaskRunStreamProjector_DecodeOtherEventsUnaffected(t *testing.T) {
 	t.Parallel()
-	h := &Handler{}
+	projector := newTaskRunStreamProjector(nil)
 	// Snapshot-shaped event (the legacy path).
 	event := types.TaskRunEvent{
 		EventType: "run.started",
@@ -137,12 +137,12 @@ func TestDecodeTaskRunEventData_OtherEventsUnaffected(t *testing.T) {
 			},
 		},
 	}
-	state, ok, err := h.decodeTaskRunEventData(event)
+	state, ok, err := projector.decodeEventData(event)
 	if err != nil {
-		t.Fatalf("decodeTaskRunEventData error = %v", err)
+		t.Fatalf("decodeEventData error = %v", err)
 	}
 	if !ok {
-		t.Fatal("decodeTaskRunEventData(run.started) ok = false, want true")
+		t.Fatal("decodeEventData(run.started) ok = false, want true")
 	}
 	if state.Run.ID != "run-A" {
 		t.Errorf("state.Run.ID = %q, want run-A", state.Run.ID)


### PR DESCRIPTION
## Summary

- Split task-run SSE projection out of `HandleTaskRunStream` into a focused projector that maps persisted run events plus live task storage into `TaskRunStreamEventData`.
- Split SSE frame formatting into a small writer seam, keeping the HTTP handler focused on request setup, polling, cancellation, and stream control flow.
- Keep the stream contract forward-moving: new snapshots carry the current stream shape, while older alpha rows replay as stored instead of being normalized at read time.
- Reuse the projector for Hecate Chat task activity projection and document the new seams.

## Tests

- `go test ./internal/api -run 'TestTaskRunStreamProjector|TestTaskRunStreamWriter|TestDecodeTurnCost' -count=1`
- `go test ./internal/api -count=1`
- `go test ./...`
- `go vet ./...`
- `go test -tags e2e ./e2e/... -run 'TestTaskApproval(Cancel|Reject)TerminalStateE2E' -count=1 -timeout 5m`
- `go test -tags e2e ./e2e/... -count=1 -timeout 5m`
- `go test -race -timeout 10m ./...`
- `just docs-check`
- `git diff --check`
