### PR TITLE
refactor(api): keep task run streams read-only

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -85,11 +85,13 @@ The seven-step chain spans `pkg/types/` → `internal/api/` → `internal/provid
    live task storage into `TaskRunStreamEventData`.
 2. `internal/api/task_run_stream_writer.go` writes the SSE frames.
 
-Keep the stream contract forward-moving: new `snapshot` rows should carry the
-current `TaskRunStreamEventData` shape, and older alpha rows can replay as they
-were stored. Do not mutate historical `run_event` rows; the event log is
-append-only. Handler changes should stay focused on request setup, polling, and
-cancellation.
+Keep the stream contract forward-moving: persisted snapshot payloads should
+carry the current `TaskRunStreamEventData` shape when they are written, and
+older alpha rows can replay as they were stored. Do not mutate historical
+`run_event` rows; the event log is append-only. The stream endpoint is
+read-only; it may emit projected live frames with the latest persisted sequence,
+but must not append synthetic `snapshot` events. Handler changes should stay
+focused on request setup, polling, and cancellation.
 
 ### Change chat-session / ACP adapter behavior
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -80,8 +80,11 @@ Per-run state SSE (`/hecate/v1/tasks/{id}/runs/{run_id}/stream`) emits
 `TaskRunStreamEventData` snapshots optimized for the operator UI. Its
 `event_type` field mirrors the persisted event that produced the snapshot.
 The stream is a projection over the append-only event log plus current run
-storage. New `snapshot` rows carry the current stream shape; older alpha rows
-replay as they were stored rather than being normalized or migrated.
+storage. Persisted snapshot payloads carry the current stream shape when they
+are written; older alpha rows replay as they were stored rather than being
+normalized or migrated.
+The stream endpoint itself is read-only: live projection frames are not appended
+to `run_events`.
 
 ## Runtime snapshot payloads
 
@@ -485,7 +488,7 @@ Emitted when task-scoped metadata changed in a way that affects the run's view (
 
 ### `snapshot`
 
-The per-run stream writes one of these every time it detects a state change between heartbeats. Subscribers reconnecting via `Last-Event-ID` rely on these to backfill state. Distinguishable from real lifecycle events by `type=snapshot` in JSON event lists and `event_type=snapshot` in per-run state SSE; the `data.snapshot` key holds the rebuilt `TaskRunStreamEventData` JSON.
+Legacy alpha builds wrote one of these when the per-run stream detected a state change between heartbeats. Current builds keep the stream endpoint read-only, so new live projection frames are not persisted as `snapshot` events. Existing rows remain distinguishable from real lifecycle events by `type=snapshot` in JSON event lists and `event_type=snapshot` in per-run state SSE; the `data.snapshot` key holds the rebuilt `TaskRunStreamEventData` JSON.
 
 | Extra key  | Type     | Notes                                                            |
 | ---------- | -------- | ---------------------------------------------------------------- |

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -272,8 +272,9 @@ so the operator UI can drive approval banners and progress surfaces without a
 separate refetch (`TaskRunStreamEventData.Approvals`). The frame's `event_type`
 mirrors the persisted event that produced the state refresh.
 The frame is a read-time projection over the append-only run-event log and live
-run storage. Hecate writes the current stream payload shape for new snapshots
-and does not rewrite older alpha event rows when the shape grows.
+run storage. When the stream emits a projected live snapshot without a newer
+persisted event, the SSE `id` and `data.sequence` stay on the latest persisted
+cursor instead of creating a new `run_event` row.
 
 The frame also includes a normalized `activity` array for clients that want a
 coding-agent-style timeline without reconstructing it from raw steps and

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -150,6 +151,46 @@ func TestTaskApprovalRejectTerminalStateE2E(t *testing.T) {
 	}
 }
 
+func TestTaskRunStreamResumeDoesNotAppendEventsE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=shell_exec",
+	)
+
+	taskID := e2eCreateApprovalShellTask(t, baseURL, workDir)
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/start", `{}`)
+	if started.Data.Status != "awaiting_approval" {
+		t.Fatalf("started run status = %q, want awaiting_approval", started.Data.Status)
+	}
+	cancelled := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/cancel", `{"reason":"operator stop"}`)
+	if cancelled.Data.Status != "cancelled" {
+		t.Fatalf("cancelled run status = %q, want cancelled", cancelled.Data.Status)
+	}
+
+	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+taskID+"/runs/"+started.Data.ID+"/events")
+	if len(events.Data) == 0 {
+		t.Fatal("events = 0, want terminal run events")
+	}
+	lastSequence := events.Data[len(events.Data)-1].Sequence
+	if lastSequence == 0 {
+		t.Fatalf("last event sequence = 0; events=%+v", events.Data)
+	}
+
+	finalSnapshot := e2eReadTerminalTaskRunSnapshotAfter(t, baseURL, taskID, started.Data.ID, lastSequence)
+	if finalSnapshot.Data.Sequence != int(lastSequence) {
+		t.Fatalf("resumed stream sequence = %d, want cursor %d", finalSnapshot.Data.Sequence, lastSequence)
+	}
+	if finalSnapshot.Data.Run.Status != "cancelled" || !finalSnapshot.Data.Terminal {
+		t.Fatalf("resumed stream final snapshot = %+v, want terminal cancelled", finalSnapshot.Data)
+	}
+
+	afterStream := getJSON[e2eTaskEventsResponse](t, fmt.Sprintf("%s/hecate/v1/tasks/%s/runs/%s/events?after_sequence=%d", baseURL, taskID, started.Data.ID, lastSequence))
+	if len(afterStream.Data) != 0 {
+		t.Fatalf("stream appended %d run events after cursor %d, want read-only stream", len(afterStream.Data), lastSequence)
+	}
+}
+
 func e2eCreateApprovalShellTask(t *testing.T, baseURL, workDir string) string {
 	t.Helper()
 	body := fmt.Sprintf(`{
@@ -171,7 +212,16 @@ func e2eCreateApprovalShellTask(t *testing.T, baseURL, workDir string) string {
 
 func e2eReadTerminalTaskRunSnapshot(t *testing.T, baseURL, taskID, runID string) e2eTaskRunStreamResponse {
 	t.Helper()
-	resp, err := http.Get(baseURL + "/hecate/v1/tasks/" + taskID + "/runs/" + runID + "/stream") //nolint:noctx
+	return e2eReadTerminalTaskRunSnapshotAfter(t, baseURL, taskID, runID, 0)
+}
+
+func e2eReadTerminalTaskRunSnapshotAfter(t *testing.T, baseURL, taskID, runID string, afterSequence int64) e2eTaskRunStreamResponse {
+	t.Helper()
+	streamURL := baseURL + "/hecate/v1/tasks/" + taskID + "/runs/" + runID + "/stream"
+	if afterSequence > 0 {
+		streamURL += "?after_sequence=" + strconv.FormatInt(afterSequence, 10)
+	}
+	resp, err := http.Get(streamURL) //nolint:noctx
 	if err != nil {
 		t.Fatalf("GET run stream: %v", err)
 	}
@@ -190,6 +240,14 @@ func e2eReadTerminalTaskRunSnapshot(t *testing.T, baseURL, taskID, runID string)
 		}
 		if payload.Data.Run.ID == "" {
 			continue
+		}
+		if afterSequence > 0 {
+			if payload.Data.Sequence != int(afterSequence) {
+				t.Fatalf("stream sequence = %d, want cursor %d", payload.Data.Sequence, afterSequence)
+			}
+			if event.ID != strconv.FormatInt(afterSequence, 10) {
+				t.Fatalf("stream id = %q, want %d", event.ID, afterSequence)
+			}
 		}
 		if event.Event == "done" {
 			sawDone = true
@@ -323,8 +381,9 @@ type e2eTaskEventsResponse struct {
 }
 
 type e2eEventEnvelope struct {
-	Type string         `json:"type"`
-	Data map[string]any `json:"data"`
+	Sequence int64          `json:"sequence,omitempty"`
+	Type     string         `json:"type"`
+	Data     map[string]any `json:"data"`
 }
 
 type e2eTaskRunStreamResponse struct {

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -116,25 +116,13 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 			stream.writeError(err)
 			return
 		}
-		snapshot, stateJSON, err := projector.snapshotEventData(state)
+		stateJSON, err := taskRunStreamStateJSON(state)
 		if err != nil {
 			stream.writeError(err)
 			return
 		}
-		if stateJSON != lastStateJSON {
-			event, appendErr := h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
-				TaskID:    task.ID,
-				RunID:     runID,
-				EventType: "snapshot",
-				Data:      map[string]any{"snapshot": snapshot},
-				RequestID: state.Run.RequestID,
-				TraceID:   state.Run.TraceID,
-				CreatedAt: time.Now().UTC(),
-			})
-			if appendErr == nil {
-				afterSequence = event.Sequence
-				state.Sequence = int(event.Sequence)
-			}
+		if string(stateJSON) != lastStateJSON {
+			state.Sequence = int(afterSequence)
 			state.EventType = "snapshot"
 			state.Terminal = types.IsTerminalTaskRunStatus(state.Run.Status)
 			payload, marshalErr := taskRunStreamSnapshotPayload(state)
@@ -142,12 +130,12 @@ func (h *Handler) HandleTaskRunStream(w http.ResponseWriter, r *http.Request) {
 				stream.writeError(marshalErr)
 				return
 			}
-			stream.writeSnapshotPayload(int64(state.Sequence), payload)
+			stream.writeSnapshotPayload(afterSequence, payload)
 			if state.Terminal {
-				stream.writeDonePayload(int64(state.Sequence), payload)
+				stream.writeDonePayload(afterSequence, payload)
 			}
 			stream.flush()
-			lastStateJSON = stateJSON
+			lastStateJSON = string(stateJSON)
 			if state.Terminal {
 				return
 			}
@@ -220,7 +208,7 @@ func (h *Handler) HandleAppendTaskRunEvent(w http.ResponseWriter, r *http.Reques
 	projector := newTaskRunStreamProjector(h.taskStore)
 	state, err := projector.liveState(ctx, task.ID, run.ID)
 	if err == nil {
-		if snapshot, _, snapshotErr := projector.snapshotEventData(state); snapshotErr == nil {
+		if snapshot, snapshotErr := projector.snapshotEventData(state); snapshotErr == nil {
 			extra["snapshot"] = snapshot
 		}
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -5212,8 +5212,11 @@ func TestTaskRunStreamResumeWithAfterSequence(t *testing.T) {
 		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
-		if payload.Data.Sequence <= int(afterSequence) {
-			t.Fatalf("sequence = %d, want > %d", payload.Data.Sequence, afterSequence)
+		if payload.Data.Sequence != int(afterSequence) {
+			t.Fatalf("sequence = %d, want projected cursor %d", payload.Data.Sequence, afterSequence)
+		}
+		if event.ID != strconv.FormatInt(afterSequence, 10) {
+			t.Fatalf("SSE id = %q, want %d", event.ID, afterSequence)
 		}
 		if event.Event == "done" {
 			sawDone = true
@@ -5225,6 +5228,10 @@ func TestTaskRunStreamResumeWithAfterSequence(t *testing.T) {
 	}
 	if !sawDone {
 		t.Fatal("did not observe done event after stream resume")
+	}
+	afterStream := mustRequestJSON[TaskRunEventsResponse](newAPITestClient(t, handler), http.MethodGet, fmt.Sprintf("/hecate/v1/tasks/%s/runs/%s/events?after_sequence=%d", created.Data.ID, started.Data.ID, afterSequence), "")
+	if len(afterStream.Data) != 0 {
+		t.Fatalf("stream appended %d run events after resume cursor, want read-only stream", len(afterStream.Data))
 	}
 }
 
@@ -5275,8 +5282,11 @@ func TestTaskRunStreamResumeWithLastEventID(t *testing.T) {
 		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
 			t.Fatalf("Unmarshal() error = %v", err)
 		}
-		if payload.Data.Sequence <= int(last) {
-			t.Fatalf("sequence = %d, want > %d", payload.Data.Sequence, last)
+		if payload.Data.Sequence != int(last) {
+			t.Fatalf("sequence = %d, want projected cursor %d", payload.Data.Sequence, last)
+		}
+		if event.ID != strconv.FormatInt(last, 10) {
+			t.Fatalf("SSE id = %q, want %d", event.ID, last)
 		}
 		if event.Event == "done" {
 			return

--- a/internal/api/task_run_stream_projector.go
+++ b/internal/api/task_run_stream_projector.go
@@ -97,16 +97,16 @@ func (p taskRunStreamProjector) liveState(ctx context.Context, taskID, runID str
 	}, nil
 }
 
-func (p taskRunStreamProjector) snapshotEventData(state TaskRunStreamEventData) (map[string]any, string, error) {
+func (p taskRunStreamProjector) snapshotEventData(state TaskRunStreamEventData) (map[string]any, error) {
 	stateJSON, err := taskRunStreamStateJSON(state)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	var snapshot map[string]any
 	if err := json.Unmarshal(stateJSON, &snapshot); err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	return snapshot, string(stateJSON), nil
+	return snapshot, nil
 }
 
 func (p taskRunStreamProjector) decodeEventData(event types.TaskRunEvent) (TaskRunStreamEventData, bool, error) {

--- a/internal/api/task_run_stream_projector_test.go
+++ b/internal/api/task_run_stream_projector_test.go
@@ -111,12 +111,9 @@ func TestTaskRunStreamProjector_SnapshotEventDataUsesCurrentStreamShape(t *testi
 			Status: "pending",
 		}},
 	}
-	snapshot, stateJSON, err := projector.snapshotEventData(state)
+	snapshot, err := projector.snapshotEventData(state)
 	if err != nil {
 		t.Fatalf("snapshotEventData() error = %v", err)
-	}
-	if stateJSON == "" {
-		t.Fatal("stateJSON is empty")
 	}
 	approvals, ok := snapshot["approvals"].([]any)
 	if !ok {


### PR DESCRIPTION
## Summary

- Make the per-run task SSE stream read-only by removing the synthetic `snapshot` `run_event` append from `HandleTaskRunStream`.
- Keep projected live frames on the latest persisted event cursor, so resumed streams do not fabricate a higher `sequence` without a matching durable event.
- Add API and binary e2e coverage proving resumed terminal streams emit projected `snapshot`/`done` frames without appending run events.
- Update runtime/events docs and backend agent guidance with the read-only stream contract.

Stacked on #245.

## Tests

- `go test ./internal/api -run 'TestTaskRunStreamResumeWith|TestTaskRunStreamProjector|TestTaskRunStreamWriter|TestDecodeTurnCost' -count=1`
- `go test ./internal/api -count=1`
- `go test ./...`
- `go vet ./...`
- `go test -tags e2e ./e2e/... -run 'TestTaskRunStreamResumeDoesNotAppendEventsE2E|TestTaskApproval(Cancel|Reject)TerminalStateE2E' -count=1 -timeout 5m`
- `go test -tags e2e ./e2e/... -count=1 -timeout 5m` (first run hit transient sqlite `SQLITE_BUSY` under parallel load; rerun passed)
- `go test -race -timeout 10m ./...`
- `just docs-check`
- `git diff --check feature/run-stream-projector...HEAD`
