### PR TITLE
refactor(runtime): centralize run event writes

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -173,9 +173,10 @@ When changing this path:
 ### Add a persisted run-event type
 
 1. Pick an event-protocol name from the existing taxonomy before adding a new dotted name. Prefer generic families such as `tool.*`, `policy.*`, `gap.*`, and `error.*` with specific details in `data` over subsystem-specific names.
-2. `internal/orchestrator/runner.go` → call `r.emitRunEvent(ctx, taskID, runID, "your.event.type", ..., extraDataMap)` at the right life-cycle moment. Emit the event **before** handing off to the queue — see the emit-before-enqueue gotcha above.
-3. Document the event and its payload in `docs/events.md`.
-4. If high-cardinality, wire into `internal/retention/retention.go` as a new subsystem (see `turn_events` for the pattern).
+2. Write normal run events through the event recorder path: orchestrator code uses `r.emitRunEvent(...)`, and HTTP/API-owned writes use `internal/runtimeevents.Recorder`. Avoid direct `store.AppendRunEvent` calls outside storage tests and the store-level terminal transition path (`ApplyRunTerminalTransition`), where the event write must remain in the same transaction as the terminal state mutation.
+3. In orchestrator code, call `r.emitRunEvent(ctx, taskID, runID, "your.event.type", ..., extraDataMap)` at the right life-cycle moment. Emit the event **before** handing off to the queue — see the emit-before-enqueue gotcha above.
+4. Document the event and its payload in `docs/events.md`.
+5. If high-cardinality, wire into `internal/retention/retention.go` as a new subsystem (see `turn_events` for the pattern).
 
 ### Add a start-time validation error (HTTP 422)
 

--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTaskApprovalCancelTerminalStateE2E(t *testing.T) {
@@ -191,6 +192,63 @@ func TestTaskRunStreamResumeDoesNotAppendEventsE2E(t *testing.T) {
 	}
 }
 
+func TestTaskRunExternalEventAppendStreamsE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=",
+	)
+
+	body := fmt.Sprintf(`{
+		"title": "external event e2e",
+		"prompt": "append external event",
+		"execution_kind": "shell",
+		"shell_command": "printf 'ok\n'",
+		"working_directory": %q,
+		"sandbox_allowed_root": %q,
+		"workspace_mode": "in_place",
+		"timeout_ms": 10000
+	}`, workDir, workDir)
+	created := postJSONDecode[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks", body)
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/start", `{}`)
+	run := waitForE2ETaskRunTerminal(t, baseURL, created.Data.ID, started.Data.ID, 10*time.Second)
+	if run.Status != "completed" {
+		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
+	}
+
+	before := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events")
+	if len(before.Data) == 0 {
+		t.Fatal("events before append = 0, want completed run events")
+	}
+	lastSequence := before.Data[len(before.Data)-1].Sequence
+	appended := postJSONDecode[e2eTaskEventResponse](
+		t,
+		baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events",
+		`{"type":"external.tool_result","status":"ok","note":"operator attached result","data":{"tool":"lint","result":"ok"}}`,
+	)
+	if appended.Data.Type != "external.tool_result" || appended.Data.Sequence <= lastSequence {
+		t.Fatalf("appended event = %+v, want external.tool_result after %d", appended.Data, lastSequence)
+	}
+	if appended.Data.Data["note"] != "operator attached result" || appended.Data.Data["status"] != "ok" {
+		t.Fatalf("appended event data = %+v, want operator note/status", appended.Data.Data)
+	}
+
+	frames := e2eReadTaskRunStreamPayloadsAfter(t, baseURL, created.Data.ID, started.Data.ID, lastSequence)
+	for _, frame := range frames {
+		if frame.Data.EventType != "external.tool_result" {
+			continue
+		}
+		if frame.Data.Sequence != int(appended.Data.Sequence) {
+			t.Fatalf("external stream sequence = %d, want appended sequence %d", frame.Data.Sequence, appended.Data.Sequence)
+		}
+		if frame.Data.Run.ID != started.Data.ID || frame.Data.Run.Status != "completed" || !frame.Data.Terminal {
+			t.Fatalf("external stream frame = %+v, want completed terminal run snapshot", frame.Data)
+		}
+		return
+	}
+	t.Fatalf("external.tool_result stream frame not found in %+v", frames)
+}
+
 func e2eCreateApprovalShellTask(t *testing.T, baseURL, workDir string) string {
 	t.Helper()
 	body := fmt.Sprintf(`{
@@ -271,6 +329,34 @@ func e2eReadTerminalTaskRunSnapshotAfter(t *testing.T, baseURL, taskID, runID st
 		t.Fatalf("terminal stream done event not found in %d SSE payloads", len(events))
 	}
 	return terminal
+}
+
+func e2eReadTaskRunStreamPayloadsAfter(t *testing.T, baseURL, taskID, runID string, afterSequence int64) []e2eTaskRunStreamResponse {
+	t.Helper()
+	streamURL := baseURL + "/hecate/v1/tasks/" + taskID + "/runs/" + runID + "/stream"
+	if afterSequence > 0 {
+		streamURL += "?after_sequence=" + strconv.FormatInt(afterSequence, 10)
+	}
+	resp, err := http.Get(streamURL) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET run stream: %v", err)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		resp.Body.Close()
+		t.Fatalf("stream content-type = %q, want text/event-stream", ct)
+	}
+	events := readSSE(t, resp)
+	payloads := make([]e2eTaskRunStreamResponse, 0, len(events))
+	for _, event := range events {
+		var payload e2eTaskRunStreamResponse
+		if err := json.Unmarshal([]byte(event.Data), &payload); err != nil {
+			continue
+		}
+		if payload.Data.Run.ID != "" {
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
 }
 
 func assertE2EEventOrder(t *testing.T, events []e2eEventEnvelope, want []string) {
@@ -378,6 +464,10 @@ type e2eTaskStep struct {
 
 type e2eTaskEventsResponse struct {
 	Data []e2eEventEnvelope `json:"data"`
+}
+
+type e2eTaskEventResponse struct {
+	Data e2eEventEnvelope `json:"data"`
 }
 
 type e2eEventEnvelope struct {

--- a/internal/api/handler_tasks_patches.go
+++ b/internal/api/handler_tasks_patches.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/internal/workspacefs"
@@ -201,7 +201,7 @@ func (h *Handler) HandleRevertTaskRunPatch(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	_, _ = h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
+	_, _ = h.taskRunEventRecorder().Append(ctx, runtimeevents.Event{
 		TaskID:    updated.TaskID,
 		RunID:     updated.RunID,
 		EventType: "tool.file.reverted",
@@ -213,7 +213,6 @@ func (h *Handler) HandleRevertTaskRunPatch(w http.ResponseWriter, r *http.Reques
 		},
 		RequestID: RequestIDFromContext(ctx),
 		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
-		CreatedAt: time.Now().UTC(),
 	})
 	WriteJSON(w, http.StatusOK, TaskPatchResponse{
 		Object: "task_patch",
@@ -265,7 +264,7 @@ func (h *Handler) HandleApplyTaskRunPatch(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	_, _ = h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
+	_, _ = h.taskRunEventRecorder().Append(ctx, runtimeevents.Event{
 		TaskID:    updated.TaskID,
 		RunID:     updated.RunID,
 		EventType: "tool.file.applied",
@@ -276,7 +275,6 @@ func (h *Handler) HandleApplyTaskRunPatch(w http.ResponseWriter, r *http.Request
 		},
 		RequestID: RequestIDFromContext(ctx),
 		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
-		CreatedAt: time.Now().UTC(),
 	})
 	WriteJSON(w, http.StatusOK, TaskPatchResponse{
 		Object: "task_patch",

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/eventprotocol"
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -205,21 +206,14 @@ func (h *Handler) HandleAppendTaskRunEvent(w http.ResponseWriter, r *http.Reques
 	if req.Note != "" {
 		extra["note"] = req.Note
 	}
-	projector := newTaskRunStreamProjector(h.taskStore)
-	state, err := projector.liveState(ctx, task.ID, run.ID)
-	if err == nil {
-		if snapshot, snapshotErr := projector.snapshotEventData(state); snapshotErr == nil {
-			extra["snapshot"] = snapshot
-		}
-	}
-	event, err := h.taskStore.AppendRunEvent(ctx, types.TaskRunEvent{
-		TaskID:    task.ID,
-		RunID:     run.ID,
-		EventType: eventType,
-		Data:      extra,
-		RequestID: RequestIDFromContext(ctx),
-		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
-		CreatedAt: time.Now().UTC(),
+	event, err := h.taskRunEventRecorder().Append(ctx, runtimeevents.Event{
+		TaskID:       task.ID,
+		RunID:        run.ID,
+		EventType:    eventType,
+		Data:         extra,
+		RequestID:    RequestIDFromContext(ctx),
+		TraceID:      telemetry.TraceIDsFromContext(ctx).TraceID,
+		SnapshotMode: runtimeevents.SnapshotBestEffort,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -207,13 +207,14 @@ func (h *Handler) HandleAppendTaskRunEvent(w http.ResponseWriter, r *http.Reques
 		extra["note"] = req.Note
 	}
 	event, err := h.taskRunEventRecorder().Append(ctx, runtimeevents.Event{
-		TaskID:       task.ID,
-		RunID:        run.ID,
-		EventType:    eventType,
-		Data:         extra,
-		RequestID:    RequestIDFromContext(ctx),
-		TraceID:      telemetry.TraceIDsFromContext(ctx).TraceID,
-		SnapshotMode: runtimeevents.SnapshotBestEffort,
+		TaskID:            task.ID,
+		RunID:             run.ID,
+		EventType:         eventType,
+		Data:              extra,
+		RequestID:         RequestIDFromContext(ctx),
+		TraceID:           telemetry.TraceIDsFromContext(ctx).TraceID,
+		SnapshotMode:      runtimeevents.SnapshotBestEffort,
+		SnapshotPlacement: runtimeevents.SnapshotOverridesData,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3836,7 +3836,8 @@ func TestTasksCreateListAndGet(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	handler := newTestHTTPHandlerForProviders(logger, nil, config.Config{})
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	handler := NewServer(logger, apiHandler)
 	tasks := newTaskTestClient(t, handler)
 
 	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Upgrade TypeScript","prompt":"Upgrade the UI workspace to TypeScript 7 beta.","repo":"hecate","base_branch":"main","workspace_mode":"ephemeral","requested_model":"gpt-5.4-mini","requested_provider":"openai","budget_micros_usd":500000}`)
@@ -5299,7 +5300,8 @@ func TestTaskRunEventsAppendAndList(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	handler := newTestHTTPHandlerForProviders(logger, nil, config.Config{})
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	handler := NewServer(logger, apiHandler)
 	tasks := newTaskTestClient(t, handler)
 
 	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Event run","prompt":"Run with events."}`)
@@ -5334,6 +5336,22 @@ func TestTaskRunEventsAppendAndList(t *testing.T) {
 	}
 	if !foundExternal {
 		t.Fatal("missing appended external.tool_result event")
+	}
+
+	rawEvents, err := apiHandler.taskStore.ListRunEvents(context.Background(), created.Data.ID, started.Data.ID, baseSequence, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	if len(rawEvents) != 1 {
+		t.Fatalf("raw events after append = %d, want 1", len(rawEvents))
+	}
+	snapshot, ok := rawEvents[0].Data["snapshot"].(map[string]any)
+	if !ok {
+		t.Fatalf("raw appended event snapshot = %#v, want persisted stream snapshot", rawEvents[0].Data["snapshot"])
+	}
+	run, ok := snapshot["run"].(map[string]any)
+	if !ok || run["id"] != started.Data.ID {
+		t.Fatalf("raw appended event snapshot run = %#v, want id %q", snapshot["run"], started.Data.ID)
 	}
 }
 

--- a/internal/api/task_run_event_recorder.go
+++ b/internal/api/task_run_event_recorder.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/runtimeevents"
+)
+
+func (h *Handler) taskRunEventRecorder() runtimeevents.Recorder {
+	return runtimeevents.NewRecorder(h.taskStore, runtimeevents.WithSnapshot(h.taskRunStreamSnapshotData))
+}
+
+func (h *Handler) taskRunStreamSnapshotData(ctx context.Context, taskID, runID string) (map[string]any, error) {
+	projector := newTaskRunStreamProjector(h.taskStore)
+	state, err := projector.liveState(ctx, taskID, runID)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := projector.snapshotEventData(state)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"snapshot": snapshot}, nil
+}

--- a/internal/orchestrator/runner_io.go
+++ b/internal/orchestrator/runner_io.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -299,27 +300,28 @@ func (r *Runner) emitRunEvent(ctx context.Context, taskID, runID, eventType, req
 	if r.store == nil || runID == "" {
 		return types.TaskRunEvent{}, nil
 	}
+	return runtimeevents.NewRecorder(r.store, runtimeevents.WithSnapshot(r.runEventSnapshot)).Append(ctx, runtimeevents.Event{
+		TaskID:            taskID,
+		RunID:             runID,
+		EventType:         eventType,
+		Data:              extra,
+		RequestID:         requestID,
+		TraceID:           traceID,
+		SnapshotMode:      runtimeevents.SnapshotRequired,
+		SnapshotPlacement: runtimeevents.SnapshotProvidesBase,
+	})
+}
+
+func (r *Runner) runEventSnapshot(ctx context.Context, taskID, runID string) (map[string]any, error) {
 	run, _, err := r.store.GetRun(ctx, taskID, runID)
 	if err != nil {
-		return types.TaskRunEvent{}, err
+		return nil, err
 	}
 	steps, _ := r.store.ListSteps(ctx, runID)
 	artifacts, _ := r.store.ListArtifacts(ctx, taskstate.ArtifactFilter{TaskID: taskID, RunID: runID})
-	data := map[string]any{
+	return map[string]any{
 		"run":       run,
 		"steps":     steps,
 		"artifacts": artifacts,
-	}
-	for key, value := range extra {
-		data[key] = value
-	}
-	return r.store.AppendRunEvent(ctx, types.TaskRunEvent{
-		TaskID:    taskID,
-		RunID:     runID,
-		EventType: eventType,
-		Data:      data,
-		RequestID: requestID,
-		TraceID:   traceID,
-		CreatedAt: time.Now().UTC(),
-	})
+	}, nil
 }

--- a/internal/runtimeevents/recorder.go
+++ b/internal/runtimeevents/recorder.go
@@ -1,0 +1,138 @@
+package runtimeevents
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type SnapshotFunc func(ctx context.Context, taskID, runID string) (map[string]any, error)
+
+type Option func(*Recorder)
+
+type SnapshotMode int
+
+const (
+	SnapshotNone SnapshotMode = iota
+	SnapshotRequired
+	SnapshotBestEffort
+)
+
+type SnapshotPlacement int
+
+const (
+	// SnapshotOverridesData preserves the historical API append behavior:
+	// caller data is written first, then recorder-owned snapshot fields win.
+	SnapshotOverridesData SnapshotPlacement = iota
+	// SnapshotProvidesBase preserves the historical orchestrator behavior:
+	// snapshot fields are the base runtime state, then event-specific fields win.
+	SnapshotProvidesBase
+)
+
+type Recorder struct {
+	store    taskstate.Store
+	snapshot SnapshotFunc
+	now      func() time.Time
+}
+
+type Event struct {
+	TaskID            string
+	RunID             string
+	EventType         string
+	Data              map[string]any
+	RequestID         string
+	TraceID           string
+	CreatedAt         time.Time
+	SnapshotMode      SnapshotMode
+	SnapshotPlacement SnapshotPlacement
+}
+
+func NewRecorder(store taskstate.Store, opts ...Option) Recorder {
+	recorder := Recorder{
+		store: store,
+		now:   time.Now,
+	}
+	for _, opt := range opts {
+		opt(&recorder)
+	}
+	return recorder
+}
+
+func WithSnapshot(snapshot SnapshotFunc) Option {
+	return func(r *Recorder) {
+		r.snapshot = snapshot
+	}
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(r *Recorder) {
+		if now != nil {
+			r.now = now
+		}
+	}
+}
+
+func (r Recorder) Append(ctx context.Context, event Event) (types.TaskRunEvent, error) {
+	if r.store == nil {
+		return types.TaskRunEvent{}, fmt.Errorf("run event recorder store is not configured")
+	}
+
+	data := copyEventData(event.Data)
+	if event.SnapshotMode != SnapshotNone {
+		if r.snapshot == nil {
+			if event.SnapshotMode != SnapshotBestEffort {
+				return types.TaskRunEvent{}, fmt.Errorf("run event snapshot function is not configured")
+			}
+		} else {
+			snapshot, err := r.snapshot(ctx, event.TaskID, event.RunID)
+			if err != nil {
+				if event.SnapshotMode != SnapshotBestEffort {
+					return types.TaskRunEvent{}, err
+				}
+			} else if event.SnapshotPlacement == SnapshotProvidesBase {
+				data = mergeEventData(snapshot, data)
+			} else {
+				data = mergeEventData(data, snapshot)
+			}
+		}
+	}
+
+	createdAt := event.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = r.now()
+	}
+	return r.store.AppendRunEvent(ctx, types.TaskRunEvent{
+		TaskID:    event.TaskID,
+		RunID:     event.RunID,
+		EventType: event.EventType,
+		Data:      data,
+		RequestID: event.RequestID,
+		TraceID:   event.TraceID,
+		CreatedAt: createdAt.UTC(),
+	})
+}
+
+func mergeEventData(base, overlay map[string]any) map[string]any {
+	out := copyEventData(base)
+	if out == nil && len(overlay) > 0 {
+		out = make(map[string]any, len(overlay))
+	}
+	for key, value := range overlay {
+		out[key] = value
+	}
+	return out
+}
+
+func copyEventData(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(data))
+	for key, value := range data {
+		copied[key] = value
+	}
+	return copied
+}

--- a/internal/runtimeevents/recorder_test.go
+++ b/internal/runtimeevents/recorder_test.go
@@ -1,0 +1,154 @@
+package runtimeevents_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/runtimeevents"
+	"github.com/hecatehq/hecate/internal/taskstate"
+)
+
+func TestRecorder_AppendAttachesSnapshotAndClonesData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	now := time.Date(2026, 5, 29, 12, 30, 0, 0, time.FixedZone("offset", 3600))
+	recorder := runtimeevents.NewRecorder(store,
+		runtimeevents.WithClock(func() time.Time { return now }),
+		runtimeevents.WithSnapshot(func(_ context.Context, taskID, runID string) (map[string]any, error) {
+			if taskID != "task-1" || runID != "run-1" {
+				t.Fatalf("snapshot ids = %q/%q, want task-1/run-1", taskID, runID)
+			}
+			return map[string]any{
+				"snapshot": map[string]any{"run_id": runID},
+			}, nil
+		}),
+	)
+	data := map[string]any{"note": "original"}
+
+	event, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:       "task-1",
+		RunID:        "run-1",
+		EventType:    "external.event",
+		Data:         data,
+		RequestID:    "req-1",
+		TraceID:      "trace-1",
+		SnapshotMode: runtimeevents.SnapshotRequired,
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	data["note"] = "mutated"
+
+	if event.CreatedAt.Location() != time.UTC || !event.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %v (%v), want UTC instant %v", event.CreatedAt, event.CreatedAt.Location(), now)
+	}
+	if event.RequestID != "req-1" || event.TraceID != "trace-1" {
+		t.Fatalf("request/trace = %q/%q, want req-1/trace-1", event.RequestID, event.TraceID)
+	}
+	if event.Data["note"] != "original" {
+		t.Fatalf("event note = %v, want original cloned value", event.Data["note"])
+	}
+	snapshot, ok := event.Data["snapshot"].(map[string]any)
+	if !ok || snapshot["run_id"] != "run-1" {
+		t.Fatalf("event snapshot = %#v, want run_id=run-1", event.Data["snapshot"])
+	}
+}
+
+func TestRecorder_AppendSnapshotProvidesBaseLetsEventDataOverrideSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	recorder := runtimeevents.NewRecorder(store,
+		runtimeevents.WithSnapshot(func(context.Context, string, string) (map[string]any, error) {
+			return map[string]any{
+				"run":    "snapshot-run",
+				"reason": "snapshot-reason",
+			}, nil
+		}),
+	)
+
+	event, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:            "task-1",
+		RunID:             "run-1",
+		EventType:         "run.note",
+		Data:              map[string]any{"reason": "caller-reason"},
+		SnapshotMode:      runtimeevents.SnapshotRequired,
+		SnapshotPlacement: runtimeevents.SnapshotProvidesBase,
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if event.Data["run"] != "snapshot-run" {
+		t.Fatalf("run = %v, want snapshot-run", event.Data["run"])
+	}
+	if event.Data["reason"] != "caller-reason" {
+		t.Fatalf("reason = %v, want caller override", event.Data["reason"])
+	}
+}
+
+func TestRecorder_AppendOptionalSnapshotFailureStillWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	recorder := runtimeevents.NewRecorder(store,
+		runtimeevents.WithSnapshot(func(context.Context, string, string) (map[string]any, error) {
+			return nil, errors.New("snapshot unavailable")
+		}),
+	)
+
+	event, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:       "task-1",
+		RunID:        "run-1",
+		EventType:    "external.event",
+		Data:         map[string]any{"note": "still write"},
+		SnapshotMode: runtimeevents.SnapshotBestEffort,
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if event.Data["note"] != "still write" {
+		t.Fatalf("note = %v, want still write", event.Data["note"])
+	}
+
+	events, err := store.ListRunEvents(ctx, "task-1", "run-1", 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+}
+
+func TestRecorder_AppendRequiredSnapshotFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	recorder := runtimeevents.NewRecorder(store,
+		runtimeevents.WithSnapshot(func(context.Context, string, string) (map[string]any, error) {
+			return nil, errors.New("snapshot unavailable")
+		}),
+	)
+
+	if _, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:       "task-1",
+		RunID:        "run-1",
+		EventType:    "run.note",
+		SnapshotMode: runtimeevents.SnapshotRequired,
+	}); err == nil {
+		t.Fatal("Append() error = nil, want snapshot error")
+	}
+	events, err := store.ListRunEvents(ctx, "task-1", "run-1", 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events = %d, want no write after required snapshot failure", len(events))
+	}
+}

--- a/internal/runtimeevents/recorder_test.go
+++ b/internal/runtimeevents/recorder_test.go
@@ -91,6 +91,39 @@ func TestRecorder_AppendSnapshotProvidesBaseLetsEventDataOverrideSnapshot(t *tes
 	}
 }
 
+func TestRecorder_AppendSnapshotOverridesDataLetsSnapshotOverrideEventData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	recorder := runtimeevents.NewRecorder(store,
+		runtimeevents.WithSnapshot(func(context.Context, string, string) (map[string]any, error) {
+			return map[string]any{
+				"snapshot": "snapshot-value",
+				"reason":   "snapshot-reason",
+			}, nil
+		}),
+	)
+
+	event, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:            "task-1",
+		RunID:             "run-1",
+		EventType:         "external.event",
+		Data:              map[string]any{"reason": "caller-reason"},
+		SnapshotMode:      runtimeevents.SnapshotRequired,
+		SnapshotPlacement: runtimeevents.SnapshotOverridesData,
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if event.Data["snapshot"] != "snapshot-value" {
+		t.Fatalf("snapshot = %v, want snapshot-value", event.Data["snapshot"])
+	}
+	if event.Data["reason"] != "snapshot-reason" {
+		t.Fatalf("reason = %v, want snapshot override", event.Data["reason"])
+	}
+}
+
 func TestRecorder_AppendOptionalSnapshotFailureStillWrites(t *testing.T) {
 	t.Parallel()
 
@@ -150,5 +183,29 @@ func TestRecorder_AppendRequiredSnapshotFailureReturnsError(t *testing.T) {
 	}
 	if len(events) != 0 {
 		t.Fatalf("events = %d, want no write after required snapshot failure", len(events))
+	}
+}
+
+func TestRecorder_AppendRequiredSnapshotWithoutFunctionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	recorder := runtimeevents.NewRecorder(store)
+
+	if _, err := recorder.Append(ctx, runtimeevents.Event{
+		TaskID:       "task-1",
+		RunID:        "run-1",
+		EventType:    "run.note",
+		SnapshotMode: runtimeevents.SnapshotRequired,
+	}); err == nil {
+		t.Fatal("Append() error = nil, want missing snapshot function error")
+	}
+	events, err := store.ListRunEvents(ctx, "task-1", "run-1", 0, 10)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events = %d, want no write after missing snapshot function", len(events))
 	}
 }


### PR DESCRIPTION
## Summary

- Add `internal/runtimeevents.Recorder` as the normal run-event write path.
- Route API-owned event writes and orchestrator `emitRunEvent` through the recorder while keeping store-level terminal transitions as the atomic exception.
- Add unit/API/e2e coverage for recorder snapshot behavior and external event stream replay.
- Update backend agent guidance to document run-event write ownership.

## Tests

- `go test ./internal/runtimeevents ./internal/api ./internal/orchestrator`
- `go test -tags e2e ./e2e -run 'TestTaskApproval|TestTaskRunStream|TestTaskRunExternal' -count=1`\n- `go test -race -timeout 10m ./internal/runtimeevents ./internal/api ./internal/orchestrator`\n- `go vet ./internal/runtimeevents ./internal/api ./internal/orchestrator`\n- `git diff --check`\n