### PR TITLE
refactor(runtime): centralize event payload builders

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -174,9 +174,10 @@ When changing this path:
 
 1. Pick an event-protocol name from the existing taxonomy before adding a new dotted name. Prefer generic families such as `tool.*`, `policy.*`, `gap.*`, and `error.*` with specific details in `data` over subsystem-specific names.
 2. Write normal run events through the event recorder path: orchestrator code uses `r.emitRunEvent(...)`, and HTTP/API-owned writes use `internal/runtimeevents.Recorder`. Avoid direct `store.AppendRunEvent` calls outside storage tests and the store-level terminal transition path (`ApplyRunTerminalTransition`), where the event write must remain in the same transaction as the terminal state mutation.
-3. In orchestrator code, call `r.emitRunEvent(ctx, taskID, runID, "your.event.type", ..., extraDataMap)` at the right life-cycle moment. Emit the event **before** handing off to the queue — see the emit-before-enqueue gotcha above.
-4. Document the event and its payload in `docs/events.md`.
-5. If high-cardinality, wire into `internal/retention/retention.go` as a new subsystem (see `turn_events` for the pattern).
+3. Put shared event payload shapes in `internal/runtimeevents` as small builder functions that return `map[string]any`; reuse existing builders such as `ApprovalRequested`, `ApprovalResolved`, `TurnCompleted`, `PatchApplied`, and `PatchReverted` instead of recreating key sets inline.
+4. In orchestrator code, call `r.emitRunEvent(ctx, taskID, runID, "your.event.type", ..., extraDataMap)` at the right life-cycle moment. Emit the event **before** handing off to the queue — see the emit-before-enqueue gotcha above.
+5. Document the event and its payload in `docs/events.md`.
+6. If high-cardinality, wire into `internal/retention/retention.go` as a new subsystem (see `turn_events` for the pattern).
 
 ### Add a start-time validation error (HTTP 422)
 

--- a/internal/api/handler_tasks_patches.go
+++ b/internal/api/handler_tasks_patches.go
@@ -205,12 +205,7 @@ func (h *Handler) HandleRevertTaskRunPatch(w http.ResponseWriter, r *http.Reques
 		TaskID:    updated.TaskID,
 		RunID:     updated.RunID,
 		EventType: "tool.file.reverted",
-		Data: map[string]any{
-			"artifact_id":     updated.ID,
-			"path":            updated.Path,
-			"artifact_status": updated.Status,
-			"before_existed":  beforeExisted,
-		},
+		Data:      runtimeevents.PatchReverted(updated, beforeExisted),
 		RequestID: RequestIDFromContext(ctx),
 		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
 	})
@@ -268,11 +263,7 @@ func (h *Handler) HandleApplyTaskRunPatch(w http.ResponseWriter, r *http.Request
 		TaskID:    updated.TaskID,
 		RunID:     updated.RunID,
 		EventType: "tool.file.applied",
-		Data: map[string]any{
-			"artifact_id":     updated.ID,
-			"path":            updated.Path,
-			"artifact_status": updated.Status,
-		},
+		Data:      runtimeevents.PatchApplied(updated),
 		RequestID: RequestIDFromContext(ctx),
 		TraceID:   telemetry.TraceIDsFromContext(ctx).TraceID,
 	})

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/internal/workspace"
@@ -910,14 +911,14 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 	// includes prior runs in the resume chain so a long chain shows
 	// total task spend, not just per-run.
 	for _, tc := range execution.TurnCosts {
-		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "turn.completed", requestID, trace.TraceID, map[string]any{
-			"turn_index":                      tc.Turn,
-			"step_id":                         tc.StepID,
-			"cost_micros_usd":                 tc.CostMicrosUSD,
-			"run_cumulative_cost_micros_usd":  tc.CumulativeMicrosUSD,
-			"task_cumulative_cost_micros_usd": run.PriorCostMicrosUSD + tc.CumulativeMicrosUSD,
-			"tool_calls":                      tc.ToolCallCount,
-		})
+		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "turn.completed", requestID, trace.TraceID, runtimeevents.TurnCompleted(runtimeevents.TurnCompletedFields{
+			TurnIndex:                   tc.Turn,
+			StepID:                      tc.StepID,
+			CostMicrosUSD:               tc.CostMicrosUSD,
+			RunCumulativeCostMicrosUSD:  tc.CumulativeMicrosUSD,
+			TaskCumulativeCostMicrosUSD: run.PriorCostMicrosUSD + tc.CumulativeMicrosUSD,
+			ToolCalls:                   tc.ToolCallCount,
+		}))
 	}
 
 	// Persist mid-loop approvals the executor emitted (agent_loop
@@ -932,7 +933,7 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		if _, err := r.store.CreateApproval(ctx, approval); err != nil {
 			return nil, err
 		}
-		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.requested", requestID, trace.TraceID, approvalRequestedEventData(approval))
+		_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.requested", requestID, trace.TraceID, runtimeevents.ApprovalRequested(approval))
 	}
 
 	resultKind := telemetry.ResultSuccess
@@ -1080,22 +1081,6 @@ func taskForRun(task types.Task, run types.TaskRun) types.Task {
 		executionTask.SandboxAllowedRoot = run.WorkspacePath
 	}
 	return executionTask
-}
-
-func approvalRequestedEventData(approval types.TaskApproval) map[string]any {
-	data := map[string]any{
-		"approval_id":   approval.ID,
-		"kind":          approval.Kind,
-		"status":        approval.Status,
-		"policy_reason": approval.Reason,
-	}
-	if approval.StepID != "" {
-		data["step_id"] = approval.StepID
-	}
-	if approval.RequestedBy != "" {
-		data["requested_by"] = approval.RequestedBy
-	}
-	return data
 }
 
 func defaultWorkerID() string {

--- a/internal/orchestrator/runner_approvals.go
+++ b/internal/orchestrator/runner_approvals.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -108,7 +109,7 @@ func (r *Runner) ResumeTaskAfterApproval(ctx context.Context, task types.Task, a
 		return nil, err
 	}
 
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, types.ApprovalResolvedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, runtimeevents.ApprovalResolved(approval))
 	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "run.queued", requestID, trace.TraceID, map[string]any{"resume": true})
 
 	if err := r.enqueueRun(task.ID, run.ID); err != nil {
@@ -273,7 +274,7 @@ func (r *Runner) RejectTaskAfterApproval(ctx context.Context, task types.Task, a
 	if err != nil {
 		return nil, err
 	}
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, types.ApprovalResolvedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.resolved", requestID, trace.TraceID, runtimeevents.ApprovalResolved(approval))
 	return &StartTaskResult{
 		Task:    task,
 		Run:     run,
@@ -376,6 +377,6 @@ func (r *Runner) createApprovalForTask(ctx context.Context, trace *profiler.Trac
 		})
 		return types.TaskApproval{}, err
 	}
-	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.requested", requestID, trace.TraceID, approvalRequestedEventData(approval))
+	_, _ = r.emitRunEvent(ctx, task.ID, run.ID, "approval.requested", requestID, trace.TraceID, runtimeevents.ApprovalRequested(approval))
 	return approval, nil
 }

--- a/internal/runtimeevents/payloads.go
+++ b/internal/runtimeevents/payloads.go
@@ -59,7 +59,10 @@ func PatchApplied(artifact types.TaskArtifact) map[string]any {
 }
 
 func PatchReverted(artifact types.TaskArtifact, beforeExisted bool) map[string]any {
-	data := PatchApplied(artifact)
-	data["before_existed"] = beforeExisted
-	return data
+	return map[string]any{
+		"artifact_id":     artifact.ID,
+		"path":            artifact.Path,
+		"artifact_status": artifact.Status,
+		"before_existed":  beforeExisted,
+	}
 }

--- a/internal/runtimeevents/payloads.go
+++ b/internal/runtimeevents/payloads.go
@@ -1,0 +1,65 @@
+package runtimeevents
+
+import "github.com/hecatehq/hecate/pkg/types"
+
+type TurnCompletedFields struct {
+	TurnIndex                   int
+	StepID                      string
+	CostMicrosUSD               int64
+	RunCumulativeCostMicrosUSD  int64
+	TaskCumulativeCostMicrosUSD int64
+	ToolCalls                   int
+}
+
+func ApprovalRequested(approval types.TaskApproval) map[string]any {
+	data := map[string]any{
+		"approval_id":   approval.ID,
+		"kind":          approval.Kind,
+		"status":        approval.Status,
+		"policy_reason": approval.Reason,
+	}
+	if approval.StepID != "" {
+		data["step_id"] = approval.StepID
+	}
+	if approval.RequestedBy != "" {
+		data["requested_by"] = approval.RequestedBy
+	}
+	return data
+}
+
+func ApprovalResolved(approval types.TaskApproval) map[string]any {
+	return map[string]any{
+		"approval_id": approval.ID,
+		"decision":    approval.Status,
+		"by":          approval.ResolvedBy,
+		"comment":     approval.ResolutionNote,
+		"scope":       "once",
+		"kind":        approval.Kind,
+		"status":      approval.Status,
+	}
+}
+
+func TurnCompleted(fields TurnCompletedFields) map[string]any {
+	return map[string]any{
+		"turn_index":                      fields.TurnIndex,
+		"step_id":                         fields.StepID,
+		"cost_micros_usd":                 fields.CostMicrosUSD,
+		"run_cumulative_cost_micros_usd":  fields.RunCumulativeCostMicrosUSD,
+		"task_cumulative_cost_micros_usd": fields.TaskCumulativeCostMicrosUSD,
+		"tool_calls":                      fields.ToolCalls,
+	}
+}
+
+func PatchApplied(artifact types.TaskArtifact) map[string]any {
+	return map[string]any{
+		"artifact_id":     artifact.ID,
+		"path":            artifact.Path,
+		"artifact_status": artifact.Status,
+	}
+}
+
+func PatchReverted(artifact types.TaskArtifact, beforeExisted bool) map[string]any {
+	data := PatchApplied(artifact)
+	data["before_existed"] = beforeExisted
+	return data
+}

--- a/internal/runtimeevents/payloads_test.go
+++ b/internal/runtimeevents/payloads_test.go
@@ -1,0 +1,135 @@
+package runtimeevents_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/runtimeevents"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestPayloads_ApprovalRequested(t *testing.T) {
+	t.Parallel()
+
+	approval := types.TaskApproval{
+		ID:          "approval-1",
+		Kind:        "agent_loop_tool_call",
+		Status:      "pending",
+		Reason:      "tool requires approval",
+		StepID:      "step-1",
+		RequestedBy: "agent",
+	}
+
+	got := runtimeevents.ApprovalRequested(approval)
+	want := map[string]any{
+		"approval_id":   "approval-1",
+		"kind":          "agent_loop_tool_call",
+		"status":        "pending",
+		"policy_reason": "tool requires approval",
+		"step_id":       "step-1",
+		"requested_by":  "agent",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ApprovalRequested() = %+v, want %+v", got, want)
+	}
+}
+
+func TestPayloads_ApprovalRequestedOmitsEmptyOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	got := runtimeevents.ApprovalRequested(types.TaskApproval{
+		ID:     "approval-1",
+		Kind:   "shell_command",
+		Status: "pending",
+		Reason: "shell execution requires approval",
+	})
+
+	if _, ok := got["step_id"]; ok {
+		t.Fatalf("step_id present in %+v, want omitted", got)
+	}
+	if _, ok := got["requested_by"]; ok {
+		t.Fatalf("requested_by present in %+v, want omitted", got)
+	}
+}
+
+func TestPayloads_ApprovalResolved(t *testing.T) {
+	t.Parallel()
+
+	approval := types.TaskApproval{
+		ID:             "approval-1",
+		Kind:           "agent_loop_tool_call",
+		Status:         "rejected",
+		ResolvedBy:     "operator",
+		ResolutionNote: "not safe",
+	}
+
+	got := runtimeevents.ApprovalResolved(approval)
+	want := map[string]any{
+		"approval_id": "approval-1",
+		"decision":    "rejected",
+		"by":          "operator",
+		"comment":     "not safe",
+		"scope":       "once",
+		"kind":        "agent_loop_tool_call",
+		"status":      "rejected",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ApprovalResolved() = %+v, want %+v", got, want)
+	}
+}
+
+func TestPayloads_TurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	got := runtimeevents.TurnCompleted(runtimeevents.TurnCompletedFields{
+		TurnIndex:                   2,
+		StepID:                      "step-model-2",
+		CostMicrosUSD:               42,
+		RunCumulativeCostMicrosUSD:  100,
+		TaskCumulativeCostMicrosUSD: 250,
+		ToolCalls:                   3,
+	})
+	want := map[string]any{
+		"turn_index":                      2,
+		"step_id":                         "step-model-2",
+		"cost_micros_usd":                 int64(42),
+		"run_cumulative_cost_micros_usd":  int64(100),
+		"task_cumulative_cost_micros_usd": int64(250),
+		"tool_calls":                      3,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TurnCompleted() = %+v, want %+v", got, want)
+	}
+}
+
+func TestPayloads_PatchAppliedAndReverted(t *testing.T) {
+	t.Parallel()
+
+	artifact := types.TaskArtifact{
+		ID:     "artifact-1",
+		Path:   "src/app.go",
+		Status: "applied",
+	}
+
+	applied := runtimeevents.PatchApplied(artifact)
+	wantApplied := map[string]any{
+		"artifact_id":     "artifact-1",
+		"path":            "src/app.go",
+		"artifact_status": "applied",
+	}
+	if !reflect.DeepEqual(applied, wantApplied) {
+		t.Fatalf("PatchApplied() = %+v, want %+v", applied, wantApplied)
+	}
+
+	artifact.Status = "reverted"
+	reverted := runtimeevents.PatchReverted(artifact, true)
+	wantReverted := map[string]any{
+		"artifact_id":     "artifact-1",
+		"path":            "src/app.go",
+		"artifact_status": "reverted",
+		"before_existed":  true,
+	}
+	if !reflect.DeepEqual(reverted, wantReverted) {
+		t.Fatalf("PatchReverted() = %+v, want %+v", reverted, wantReverted)
+	}
+}

--- a/internal/runtimeevents/payloads_test.go
+++ b/internal/runtimeevents/payloads_test.go
@@ -102,7 +102,7 @@ func TestPayloads_TurnCompleted(t *testing.T) {
 	}
 }
 
-func TestPayloads_PatchAppliedAndReverted(t *testing.T) {
+func TestPayloads_PatchApplied(t *testing.T) {
 	t.Parallel()
 
 	artifact := types.TaskArtifact{
@@ -120,8 +120,17 @@ func TestPayloads_PatchAppliedAndReverted(t *testing.T) {
 	if !reflect.DeepEqual(applied, wantApplied) {
 		t.Fatalf("PatchApplied() = %+v, want %+v", applied, wantApplied)
 	}
+}
 
-	artifact.Status = "reverted"
+func TestPayloads_PatchReverted(t *testing.T) {
+	t.Parallel()
+
+	artifact := types.TaskArtifact{
+		ID:     "artifact-1",
+		Path:   "src/app.go",
+		Status: "reverted",
+	}
+
 	reverted := runtimeevents.PatchReverted(artifact, true)
 	wantReverted := map[string]any{
 		"artifact_id":     "artifact-1",

--- a/internal/runtimeevents/recorder.go
+++ b/internal/runtimeevents/recorder.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+type RunEventAppender interface {
+	AppendRunEvent(ctx context.Context, event types.TaskRunEvent) (types.TaskRunEvent, error)
+}
 
 type SnapshotFunc func(ctx context.Context, taskID, runID string) (map[string]any, error)
 
@@ -33,7 +36,7 @@ const (
 )
 
 type Recorder struct {
-	store    taskstate.Store
+	store    RunEventAppender
 	snapshot SnapshotFunc
 	now      func() time.Time
 }
@@ -50,7 +53,7 @@ type Event struct {
 	SnapshotPlacement SnapshotPlacement
 }
 
-func NewRecorder(store taskstate.Store, opts ...Option) Recorder {
+func NewRecorder(store RunEventAppender, opts ...Option) Recorder {
 	recorder := Recorder{
 		store: store,
 		now:   time.Now,

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -523,7 +524,7 @@ func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalR
 			TaskID:    task.ID,
 			RunID:     run.ID,
 			EventType: approvalEventType,
-			Data:      types.ApprovalResolvedEventData(approval),
+			Data:      runtimeevents.ApprovalResolved(approval),
 			RequestID: tr.Run.RequestID,
 			TraceID:   tr.Run.TraceID,
 			CreatedAt: finishedAt,

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/runtimeevents"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -712,7 +713,7 @@ func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr Termina
 			TaskID:    task.ID,
 			RunID:     run.ID,
 			EventType: approvalEventType,
-			Data:      types.ApprovalResolvedEventData(approval),
+			Data:      runtimeevents.ApprovalResolved(approval),
 			RequestID: tr.Run.RequestID,
 			TraceID:   tr.Run.TraceID,
 			CreatedAt: finishedAt,

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -248,18 +248,6 @@ type TaskRunEvent struct {
 	TraceID   string
 }
 
-func ApprovalResolvedEventData(approval TaskApproval) map[string]any {
-	return map[string]any{
-		"approval_id": approval.ID,
-		"decision":    approval.Status,
-		"by":          approval.ResolvedBy,
-		"comment":     approval.ResolutionNote,
-		"scope":       "once",
-		"kind":        approval.Kind,
-		"status":      approval.Status,
-	}
-}
-
 func IsTerminalTaskRunStatus(status string) bool {
 	switch status {
 	case "completed", "failed", "cancelled":

--- a/pkg/types/task_test.go
+++ b/pkg/types/task_test.go
@@ -115,28 +115,3 @@ func TestTaskJSONRoundTrip_NoMCPServers_OmitsField(t *testing.T) {
 		t.Errorf("got.MCPServers = %+v, want empty (no MCPServers configured)", got.MCPServers)
 	}
 }
-
-func TestApprovalResolvedEventData(t *testing.T) {
-	t.Parallel()
-	approval := TaskApproval{
-		ID:             "approval-1",
-		Kind:           "agent_loop_tool_call",
-		Status:         "rejected",
-		ResolvedBy:     "operator",
-		ResolutionNote: "not safe",
-	}
-
-	got := ApprovalResolvedEventData(approval)
-	want := map[string]any{
-		"approval_id": "approval-1",
-		"decision":    "rejected",
-		"by":          "operator",
-		"comment":     "not safe",
-		"scope":       "once",
-		"kind":        "agent_loop_tool_call",
-		"status":      "rejected",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ApprovalResolvedEventData() = %+v, want %+v", got, want)
-	}
-}


### PR DESCRIPTION
## Summary

- Add `internal/runtimeevents` payload builders for approval requested/resolved, turn completed, and patch applied/reverted run-event payloads.
- Route orchestrator, taskstate terminal transition, and API patch event payloads through the shared builders while preserving existing `map[string]any` shapes.
- Move approval-resolved payload ownership out of `pkg/types` and into the runtime event layer.
- Update backend guidance so future event types use recorder + payload builder conventions.

## Tests

- `go test ./internal/runtimeevents ./internal/taskstate ./internal/orchestrator ./internal/api ./pkg/types`
- `go test -tags e2e ./e2e -run 'TestTaskApproval|TestTaskRunStream|TestTaskRunExternal' -count=1`\n- `go vet ./internal/runtimeevents ./internal/taskstate ./internal/orchestrator ./internal/api ./pkg/types`\n- `go test -race -timeout 10m ./internal/runtimeevents ./internal/taskstate ./internal/orchestrator ./internal/api ./pkg/types`\n- `git diff --check`\n