### PR TITLE
Require acknowledgement for non-loopback binds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,13 @@
 # Server
 # This is the client-facing gateway address for Codex/Claude-style traffic.
 # Provider BASE_URL values below are upstream model endpoints, not this gateway URL.
-# Binds to loopback by default. Override to 0.0.0.0:8765 to expose on
-# all interfaces (and put a reverse proxy / firewall in front of it).
+# Binds to loopback by default. Override to 0.0.0.0:8765 only when you
+# also set HECATE_ALLOW_NON_LOOPBACK_BIND=1 and put a reverse proxy,
+# firewall, or equivalent access-control layer in front of it.
 # The Docker image overrides to 0.0.0.0 because the container's network
 # is itself the boundary.
 HECATE_ADDRESS=127.0.0.1:8765
+HECATE_ALLOW_NON_LOOPBACK_BIND=0
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper
 # processes such as `hecate-acp`. Leave empty for normal local dev; the gateway

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ COPY --from=go-builder /out/hecate /usr/local/bin/hecate
 COPY --from=go-builder --chown=65532:65532 /out/data /data
 
 ENV HECATE_ADDRESS=0.0.0.0:8765 \
+    HECATE_ALLOW_NON_LOOPBACK_BIND=1 \
     HECATE_PUBLIC_URL=http://127.0.0.1:8765 \
     HECATE_DATA_DIR=/data \
     HECATE_SQLITE_PATH=/data/hecate.db \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -24,18 +24,12 @@ ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/hecate /usr/local/bin/hecate
 COPY --from=prep --chown=65532:65532 /data /data
 
-ENV GATEWAY_ADDRESS=0.0.0.0:8765 \
-    GATEWAY_PUBLIC_URL=http://127.0.0.1:8765 \
-    GATEWAY_DATA_DIR=/data \
-    GATEWAY_SQLITE_PATH=/data/hecate.db \
-    GATEWAY_MULTI_TENANT=false \
-    GATEWAY_CONTROL_PLANE_BACKEND=sqlite \
-    GATEWAY_RETENTION_HISTORY_BACKEND=sqlite \
-    GATEWAY_CHAT_SESSIONS_BACKEND=sqlite \
-    GATEWAY_TASKS_BACKEND=sqlite \
-    GATEWAY_TASK_QUEUE_BACKEND=sqlite \
-    GATEWAY_CACHE_BACKEND=sqlite \
-    GATEWAY_BUDGET_BACKEND=sqlite \
+ENV HECATE_ADDRESS=0.0.0.0:8765 \
+    HECATE_ALLOW_NON_LOOPBACK_BIND=1 \
+    HECATE_PUBLIC_URL=http://127.0.0.1:8765 \
+    HECATE_DATA_DIR=/data \
+    HECATE_SQLITE_PATH=/data/hecate.db \
+    HECATE_BACKEND=sqlite \
     PROVIDER_OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 \
     PROVIDER_LMSTUDIO_BASE_URL=http://host.docker.internal:1234/v1 \
     PROVIDER_LLAMACPP_BASE_URL=http://host.docker.internal:8080/v1 \

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -44,6 +44,16 @@ func runServe() {
 		slog.Error("config validation failed", slog.Any("error", err))
 		os.Exit(1)
 	}
+	if err := cfg.Server.ValidateNetworkExposure(); err != nil {
+		slog.Error("network exposure guard failed", slog.Any("error", err))
+		os.Exit(1)
+	}
+	if !config.ListenAddressIsLoopback(cfg.Server.Address) {
+		slog.Warn("gateway binding beyond loopback; ensure an access-control layer protects Hecate",
+			slog.String("listen_addr", cfg.Server.Address),
+			slog.String("ack_env", "HECATE_ALLOW_NON_LOOPBACK_BIND"),
+		)
+	}
 
 	// Resolve the auto-generated control-plane encryption key. Env values
 	// win when set; otherwise the value is loaded from the bootstrap file

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 The [Quick Start](../README.md#quick-start) covers `docker run` end-to-end. This page is the reference for everything past the first run: pinning images, the compose profile, the binary install, storage tiers, and rate limits.
 
-Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests, but same-origin is not a network security boundary. If you change `HECATE_ADDRESS` to expose Hecate beyond the local machine, put your own access controls, firewall, or reverse proxy in front. The current security model is documented in [Security](security.md).
+Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests, but same-origin is not a network security boundary. If you change `HECATE_ADDRESS` to expose Hecate beyond the local machine, startup now requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`; set it only with your own access controls, firewall, or reverse proxy in front. The current security model is documented in [Security](security.md).
 
 ## Contents
 
@@ -32,7 +32,11 @@ When the working tree is a checkout of the source, `docker compose up` rebuilds 
 
 The Docker image starts `hecate` by default. The container sets
 `HECATE_PUBLIC_URL=http://127.0.0.1:8765`, which is the host URL users normally
-reach through `-p 8765:8765` or `docker compose`.
+reach through `-p 8765:8765` or `docker compose`. The image also sets
+`HECATE_ALLOW_NON_LOOPBACK_BIND=1` because container processes must listen on
+`0.0.0.0` for the published port to work. Treat the host-side published port as
+the exposed surface and protect it with host firewall rules or a reverse proxy
+when it is reachable beyond your own machine.
 
 If a `docker run` (or `docker compose up`) errors with `bind: address already in use` on `:8765`, a previous `just dev` / `just run` / `./hecate` is still listening from another shell. Free the port with `just stop` and retry; `just dev`, `just run`, and `just serve` also auto-run `stop` before starting so successive launches don't pile up.
 
@@ -48,6 +52,12 @@ tar -xzf hecate_0.1.0-alpha.42_linux_amd64.tar.gz
 ```
 
 The `hecate` binary starts the gateway service, embeds the React operator UI, listens on `127.0.0.1:8765` by default, and stores state under `HECATE_DATA_DIR` (default `.data/`). No additional runtime dependencies — the binaries are statically linked and CGO-free.
+
+To bind the bare binary beyond loopback, set both variables and provide your own network protection:
+
+```bash
+HECATE_ADDRESS=0.0.0.0:8765 HECATE_ALLOW_NON_LOOPBACK_BIND=1 ./hecate
+```
 
 To pin the data directory to a known location:
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -14,8 +14,9 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
 - There is not yet a dedicated migration CLI or rollback workflow.
 - The gateway defaults to `127.0.0.1:8765` and enforces same-origin browser
   requests, but same-origin is not a network security boundary. If you bind it
-  beyond the local machine, bring your own access controls, firewall, or reverse
-  proxy. The practical threat model lives in [Security](security.md).
+  beyond the local machine, Hecate requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`;
+  bring your own access controls, firewall, or reverse proxy. The practical
+  threat model lives in [Security](security.md).
 
 ## Provider Lifecycle
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -108,7 +108,7 @@ Acceptance after the run:
 - `docker pull ghcr.io/hecatehq/hecate:X.Y.Z` succeeds (no `v` prefix —
   goreleaser uses bare semver as the docker tag). The image contains
   `/usr/local/bin/hecate`; the entrypoint is `/usr/local/bin/hecate`.
-- `docker run --rm -p 8765:8765 ghcr.io/hecatehq/hecate:X.Y.Z` then
+- `docker run --rm -p 127.0.0.1:8765:8765 ghcr.io/hecatehq/hecate:X.Y.Z` then
   `curl :8765/healthz` returns `version: "X.Y.Z"`.
 
 ## Alpha gate

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,7 +9,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
 - The gateway binds to `127.0.0.1:8765` by default.
 - Browser requests are same-origin checked, but same-origin is not a network security boundary.
 - Hecate is not designed to be exposed directly on a network.
-- If you bind Hecate to anything other than loopback, put your own firewall, reverse proxy, or access-control layer in front.
+- If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.
 - Do not run Hecate on a shared host where untrusted local users can access the gateway port or data directory.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -32,6 +33,7 @@ type Config struct {
 
 type ServerConfig struct {
 	Address                    string
+	AllowNonLoopbackBind       bool
 	PublicURL                  string
 	DataDir                    string
 	BootstrapFile              string
@@ -345,7 +347,8 @@ func LoadFromEnv() Config {
 	providersCfg := loadProvidersFromEnv()
 	return Config{
 		Server: ServerConfig{
-			Address: getEnv("HECATE_ADDRESS", "127.0.0.1:8765"),
+			Address:              getEnv("HECATE_ADDRESS", "127.0.0.1:8765"),
+			AllowNonLoopbackBind: getEnvBool("HECATE_ALLOW_NON_LOOPBACK_BIND", false),
 			// PublicURL is written to hecate.runtime.json for local
 			// diagnostics. Empty means derive from Address.
 			PublicURL: getEnv("HECATE_PUBLIC_URL", ""),
@@ -708,6 +711,32 @@ func deriveOTelSignalEndpoint(endpoint, transport, httpPath string) string {
 
 func normalizeOTelTransport(value string) string {
 	return telemetry.NormalizeOTLPTransport(value)
+}
+
+func (cfg ServerConfig) ValidateNetworkExposure() error {
+	if ListenAddressIsLoopback(cfg.Address) || cfg.AllowNonLoopbackBind {
+		return nil
+	}
+	return fmt.Errorf("HECATE_ADDRESS %q binds beyond loopback; set HECATE_ALLOW_NON_LOOPBACK_BIND=1 only when a firewall, reverse proxy, or equivalent access-control layer protects the gateway", cfg.Address)
+}
+
+func ListenAddressIsLoopback(address string) bool {
+	host := strings.TrimSpace(address)
+	if host == "" {
+		return false
+	}
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	host = strings.Trim(strings.TrimSpace(host), "[]")
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,78 @@ func TestLoadFromEnvTraceBodyModeDefaultsToMetadata(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvNonLoopbackBindAcknowledgement(t *testing.T) {
+	t.Setenv("HECATE_ALLOW_NON_LOOPBACK_BIND", "true")
+
+	cfg := LoadFromEnv()
+	if !cfg.Server.AllowNonLoopbackBind {
+		t.Fatal("AllowNonLoopbackBind = false, want true")
+	}
+}
+
+func TestLoadFromEnvNonLoopbackBindAcknowledgementZeroStaysFalse(t *testing.T) {
+	t.Setenv("HECATE_ALLOW_NON_LOOPBACK_BIND", "0")
+
+	cfg := LoadFromEnv()
+	if cfg.Server.AllowNonLoopbackBind {
+		t.Fatal("AllowNonLoopbackBind = true for HECATE_ALLOW_NON_LOOPBACK_BIND=0, want false")
+	}
+}
+
+func TestListenAddressIsLoopback(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		address string
+		want    bool
+	}{
+		{name: "ipv4 loopback", address: "127.0.0.1:8765", want: true},
+		{name: "ipv6 loopback", address: "[::1]:8765", want: true},
+		{name: "localhost", address: "localhost:8765", want: true},
+		{name: "wildcard ipv4", address: "0.0.0.0:8765", want: false},
+		{name: "wildcard ipv6", address: "[::]:8765", want: false},
+		{name: "empty host", address: ":8765", want: false},
+		{name: "public ip", address: "203.0.113.10:8765", want: false},
+		{name: "host name", address: "hecate.example.com:8765", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ListenAddressIsLoopback(tc.address); got != tc.want {
+				t.Fatalf("ListenAddressIsLoopback(%q) = %v, want %v", tc.address, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerConfigValidateNetworkExposure(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cfg     ServerConfig
+		wantErr bool
+	}{
+		{name: "loopback default", cfg: ServerConfig{Address: "127.0.0.1:8765"}},
+		{name: "empty host without acknowledgement", cfg: ServerConfig{Address: ":8765"}, wantErr: true},
+		{name: "wildcard without acknowledgement", cfg: ServerConfig{Address: "0.0.0.0:8765"}, wantErr: true},
+		{name: "wildcard with acknowledgement", cfg: ServerConfig{Address: "0.0.0.0:8765", AllowNonLoopbackBind: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.cfg.ValidateNetworkExposure()
+			if tc.wantErr && err == nil {
+				t.Fatal("ValidateNetworkExposure() error = nil, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateNetworkExposure() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestLoadFromEnvTraceBodyModeOverride(t *testing.T) {
 	t.Setenv("HECATE_TRACE_BODY_MODE", "redacted_text")
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -260,6 +260,6 @@ console.log("\nWhen CI finishes, sync the manifest/docs commits back locally:");
 console.log("  git pull --ff-only origin master");
 console.log(`\nWhen CI completes (~5-10 min), verify the published image:`);
 console.log(`  docker pull ghcr.io/hecatehq/hecate:${semver}`);
-console.log(`  docker run --rm -p 8765:8765 ghcr.io/hecatehq/hecate:${semver}`);
+console.log(`  docker run --rm -p 127.0.0.1:8765:8765 ghcr.io/hecatehq/hecate:${semver}`);
 console.log(`\nTo recover if CI fails:`);
 console.log(`  git push --delete origin ${version} && git tag -d ${version}`);


### PR DESCRIPTION
## Summary

- fail startup when `HECATE_ADDRESS` binds beyond loopback unless `HECATE_ALLOW_NON_LOOPBACK_BIND=1` is set
- log a warning when the non-loopback acknowledgement is active
- set the acknowledgement in Docker images, where listening on `0.0.0.0` is required for published ports
- repair `Dockerfile.release` to use the active `HECATE_*` env names instead of the stale `GATEWAY_*` block, including `HECATE_BACKEND=sqlite` for durable release containers
- update deployment/security docs and release snippets to prefer loopback host publishing
- add config tests for loopback classification, `HECATE_ALLOW_NON_LOOPBACK_BIND=0`, and the acknowledgement guard

## Validation

- `go test ./internal/config ./cmd/hecate`
- `go test ./internal/config`
- `go test ./...`
- `./ui/node_modules/.bin/oxfmt --check .env.example docs/deployment.md docs/security.md docs/known-limitations.md docs/release.md`
- `git diff --check`

## Notes

The worktree has unrelated Tauri/UI edits that are intentionally not included in this branch.