### PR TITLE
fix(security): require explicit browser origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@
 # is itself the boundary.
 HECATE_ADDRESS=127.0.0.1:8765
 HECATE_ALLOW_NON_LOOPBACK_BIND=0
+# Browser requests must either come from the same host as the gateway or from
+# one of these explicit origins. `just dev` supplies the Vite hot-reload origins
+# automatically; set this for custom dev servers or reverse-proxy frontends.
+# HECATE_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper
 # processes such as `hecate-acp`. Leave empty for normal local dev; the gateway

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,6 +108,7 @@ Default addresses:
 - Vite dev server (UI hot reload): `http://127.0.0.1:5173`
 
 The Vite dev server proxies every `/hecate/*`, `/v1/*`, and `/healthz` request to `:8765`, so the UI runs hot while the gateway runs as-is.
+`just dev` allows the two default Vite origins (`http://127.0.0.1:5173` and `http://localhost:5173`) through the same-origin guard. If you use a different dev server or port, set `HECATE_ALLOWED_ORIGINS` to that exact origin before starting the gateway.
 
 ## Website
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,7 +7,7 @@ Hecate is local-first, single-operator software. This page documents the securit
 Hecate assumes the operator trusts their own machine, local user account, and selected workspaces.
 
 - The gateway binds to `127.0.0.1:8765` by default.
-- Browser requests are same-origin checked, but same-origin is not a network security boundary.
+- Browser requests are same-origin checked: by default, an `Origin` header must match the gateway host. Custom browser frontends must be listed in `HECATE_ALLOWED_ORIGINS`.
 - Hecate is not designed to be exposed directly on a network.
 - If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -5,10 +5,10 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -136,20 +136,27 @@ func LoggingMiddleware(logger *slog.Logger) middleware {
 // Accepts when:
 //   - The Origin host matches the request Host exactly (production: the
 //     embedded UI is served by the gateway, so same-origin trivially).
-//   - The Origin's hostname resolves to a loopback address (dev: a Vite
-//     dev server on http://localhost:5173 proxies to http://127.0.0.1:8765,
-//     so Host and Origin disagree but both ends sit on loopback).
+//   - The full Origin is explicitly configured via HECATE_ALLOWED_ORIGINS
+//     (dev: Vite on http://127.0.0.1:5173 proxies to the gateway, so Host and
+//     Origin disagree even though both are local).
 func SameOriginMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !sameOriginAllowed(r) {
-			WriteError(w, http.StatusForbidden, errCodeForbidden, "cross-origin browser request rejected")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
+	return SameOriginMiddlewareWithAllowedOrigins(nil)(next)
 }
 
-func sameOriginAllowed(r *http.Request) bool {
+func SameOriginMiddlewareWithAllowedOrigins(allowedOrigins []string) middleware {
+	allowed := normalizeAllowedOrigins(allowedOrigins)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !sameOriginAllowed(r, allowed) {
+				WriteError(w, http.StatusForbidden, errCodeForbidden, "cross-origin browser request rejected")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func sameOriginAllowed(r *http.Request, allowedOrigins map[string]struct{}) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return true
@@ -161,17 +168,41 @@ func sameOriginAllowed(r *http.Request) bool {
 	if u.Host == r.Host {
 		return true
 	}
-	hostname := u.Hostname()
-	if hostname == "" {
+	key, ok := originKey(origin)
+	if !ok {
 		return false
 	}
-	if hostname == "localhost" {
-		return true
+	_, ok = allowedOrigins[key]
+	return ok
+}
+
+func normalizeAllowedOrigins(origins []string) map[string]struct{} {
+	allowed := make(map[string]struct{}, len(origins))
+	for _, origin := range origins {
+		key, ok := originKey(origin)
+		if ok {
+			allowed[key] = struct{}{}
+		}
 	}
-	if ip := net.ParseIP(hostname); ip != nil && ip.IsLoopback() {
-		return true
+	return allowed
+}
+
+func originKey(raw string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", false
 	}
-	return false
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", false
+	}
+	if u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", false
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", false
+	}
+	return scheme + "://" + strings.ToLower(u.Host), true
 }
 
 func RecoveryMiddleware(logger *slog.Logger) middleware {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -167,3 +167,103 @@ func TestOTelHTTPSpanMiddlewareEmitsRequestSpan(t *testing.T) {
 		t.Error("hecate.request_id attribute missing")
 	}
 }
+
+func TestSameOriginAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		origin  string
+		allowed []string
+		want    bool
+	}{
+		{
+			name: "no origin header",
+			host: "127.0.0.1:8765",
+			want: true,
+		},
+		{
+			name:   "same host",
+			host:   "127.0.0.1:8765",
+			origin: "http://127.0.0.1:8765",
+			want:   true,
+		},
+		{
+			name:   "localhost dev origin rejected by default",
+			host:   "127.0.0.1:8765",
+			origin: "http://localhost:5173",
+			want:   false,
+		},
+		{
+			name:   "loopback ip dev origin rejected by default",
+			host:   "127.0.0.1:8765",
+			origin: "http://127.0.0.1:5173",
+			want:   false,
+		},
+		{
+			name:    "configured dev origin allowed",
+			host:    "127.0.0.1:8765",
+			origin:  "http://127.0.0.1:5173",
+			allowed: []string{"http://127.0.0.1:5173"},
+			want:    true,
+		},
+		{
+			name:    "configured origin matches scheme",
+			host:    "127.0.0.1:8765",
+			origin:  "https://127.0.0.1:5173",
+			allowed: []string{"http://127.0.0.1:5173"},
+			want:    false,
+		},
+		{
+			name:    "allowed origin accepts trailing slash",
+			host:    "127.0.0.1:8765",
+			origin:  "http://localhost:5173",
+			allowed: []string{"http://localhost:5173/"},
+			want:    true,
+		},
+		{
+			name:    "allowed origin with path ignored",
+			host:    "127.0.0.1:8765",
+			origin:  "http://localhost:5173",
+			allowed: []string{"http://localhost:5173/app"},
+			want:    false,
+		},
+		{
+			name:   "malformed origin rejected",
+			host:   "127.0.0.1:8765",
+			origin: "://localhost:5173",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://"+tt.host+"/v1/chat/completions", nil)
+			req.Host = tt.host
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			got := sameOriginAllowed(req, normalizeAllowedOrigins(tt.allowed))
+			if got != tt.want {
+				t.Fatalf("sameOriginAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSameOriginMiddlewareWithAllowedOriginsRejectsCrossOriginBrowserRequest(t *testing.T) {
+	handler := SameOriginMiddlewareWithAllowedOrigins(nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8765/v1/chat/completions", nil)
+	req.Host = "127.0.0.1:8765"
+	req.Header.Set("Origin", "http://localhost:5173")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,7 +29,7 @@ func NewServer(logger *slog.Logger, handler *Handler) http.Handler {
 		TraceContextMiddleware,
 		RequestIDMiddleware,
 		OTelHTTPSpanMiddleware,
-		SameOriginMiddleware,
+		SameOriginMiddlewareWithAllowedOrigins(handler.config.Server.AllowedOrigins),
 		LoggingMiddleware(logger),
 		RecoveryMiddleware(logger),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 type ServerConfig struct {
 	Address                    string
 	AllowNonLoopbackBind       bool
+	AllowedOrigins             []string
 	PublicURL                  string
 	DataDir                    string
 	BootstrapFile              string
@@ -349,6 +350,7 @@ func LoadFromEnv() Config {
 		Server: ServerConfig{
 			Address:              getEnv("HECATE_ADDRESS", "127.0.0.1:8765"),
 			AllowNonLoopbackBind: getEnvBool("HECATE_ALLOW_NON_LOOPBACK_BIND", false),
+			AllowedOrigins:       splitCSV(getEnv("HECATE_ALLOWED_ORIGINS", "")),
 			// PublicURL is written to hecate.runtime.json for local
 			// diagnostics. Empty means derive from Address.
 			PublicURL: getEnv("HECATE_PUBLIC_URL", ""),
@@ -492,6 +494,11 @@ func (c Config) Validate() error {
 			errs = append(errs, fmt.Errorf("HECATE_PUBLIC_URL must be an absolute http(s) URL (got %q)", publicURL))
 		}
 	}
+	for _, origin := range c.Server.AllowedOrigins {
+		if !validAllowedOrigin(origin) {
+			errs = append(errs, fmt.Errorf("HECATE_ALLOWED_ORIGINS entries must be exact http(s) origins without path/query/fragment (got %q)", origin))
+		}
+	}
 
 	validPolicies := map[string]struct{}{
 		"shell_exec": {}, "git_exec": {}, "file_write": {},
@@ -616,6 +623,21 @@ func durationEnvKeys() []string {
 		"HECATE_CHAT_IDLE_TIMEOUT",
 		"HECATE_SQLITE_BUSY_TIMEOUT",
 	}
+}
+
+func validAllowedOrigin(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
+	if u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	return u.Path == "" || u.Path == "/"
 }
 
 func loadOTelFromEnv() OTelConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -76,6 +77,16 @@ func TestLoadFromEnvNonLoopbackBindAcknowledgementZeroStaysFalse(t *testing.T) {
 	cfg := LoadFromEnv()
 	if cfg.Server.AllowNonLoopbackBind {
 		t.Fatal("AllowNonLoopbackBind = true for HECATE_ALLOW_NON_LOOPBACK_BIND=0, want false")
+	}
+}
+
+func TestLoadFromEnvAllowedOrigins(t *testing.T) {
+	t.Setenv("HECATE_ALLOWED_ORIGINS", "http://127.0.0.1:5173, http://localhost:5173")
+
+	cfg := LoadFromEnv()
+	want := []string{"http://127.0.0.1:5173", "http://localhost:5173"}
+	if !reflect.DeepEqual(cfg.Server.AllowedOrigins, want) {
+		t.Fatalf("AllowedOrigins = %#v, want %#v", cfg.Server.AllowedOrigins, want)
 	}
 }
 
@@ -279,6 +290,19 @@ func TestValidateRejectsInvalidPublicURL(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PUBLIC_URL") {
 		t.Fatalf("Validate() error = %q, want HECATE_PUBLIC_URL", err)
+	}
+}
+
+func TestValidateRejectsInvalidAllowedOrigin(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Server.AllowedOrigins = []string{"http://localhost:5173/app"}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid allowed origin error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_ALLOWED_ORIGINS") {
+		t.Fatalf("Validate() error = %q, want HECATE_ALLOWED_ORIGINS", err)
 	}
 }
 

--- a/just/go.just
+++ b/just/go.just
@@ -111,6 +111,8 @@ dev *args: _go-cache
 	set -a; \
 	[ -f ./.env ] && . ./.env; \
 	set +a; \
+	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
+	export HECATE_ALLOWED_ORIGINS; \
 	{{go_env}} go run ./cmd/hecate
 
 # Run the gateway from source with external-agent adapter visuals forced to a
@@ -133,6 +135,8 @@ dev-agent-adapters overrides *args: _go-cache
 	set -a; \
 	[ -f ./.env ] && . ./.env; \
 	set +a; \
+	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
+	export HECATE_ALLOWED_ORIGINS; \
 	HECATE_AGENT_ADAPTER_DEV_OVERRIDES="{{overrides}}" {{go_env}} go run ./cmd/hecate
 
 # Run the gateway with all external-agent adapters shown as not installed.


### PR DESCRIPTION
## Summary
- tighten browser Origin checks so loopback dev origins are no longer trusted by default
- add HECATE_ALLOWED_ORIGINS for exact custom frontend origins and validate malformed entries at startup
- keep documented Vite hot-reload flow working through explicit just dev defaults

## Verification
- GOCACHE="/private/tmp/hecate-same-origin/.gocache" go test ./internal/api ./internal/config
- GOCACHE="/private/tmp/hecate-same-origin/.gocache" go vet ./internal/api ./internal/config
- GOCACHE="/private/tmp/hecate-same-origin/.gocache" go test ./...
- git ls-files -z '*.md' '*.mdc' | xargs -0 /Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check