### PR TITLE
feat(security): add optional runtime token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,11 @@ HECATE_ALLOW_NON_LOOPBACK_BIND=0
 # one of these explicit origins. `just dev` supplies the Vite hot-reload origins
 # automatically; set this for custom dev servers or reverse-proxy frontends.
 # HECATE_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
-# Optional shared runtime token for Hecate-native `/hecate/v1/*` APIs.
-# Provider-compatible `/v1/*` and `/healthz` stay unchanged. Hecate-aware
-# clients send it as `X-Hecate-Runtime-Token`; the operator UI reads
-# `hecate.runtimeToken` from sessionStorage/localStorage when you enable this.
+# Optional shared runtime token for Hecate-native `/hecate/v1/*` control-plane
+# APIs. Provider-compatible `/v1/*` inference endpoints and `/healthz` stay
+# unchanged. Hecate-aware clients send it as `X-Hecate-Runtime-Token`; the
+# operator UI reads `hecate.runtimeToken` from sessionStorage/localStorage when
+# you enable this.
 # HECATE_RUNTIME_TOKEN=
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ HECATE_ALLOW_NON_LOOPBACK_BIND=0
 # one of these explicit origins. `just dev` supplies the Vite hot-reload origins
 # automatically; set this for custom dev servers or reverse-proxy frontends.
 # HECATE_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+# Optional shared runtime token for Hecate-native `/hecate/v1/*` APIs.
+# Provider-compatible `/v1/*` and `/healthz` stay unchanged. Hecate-aware
+# clients send it as `X-Hecate-Runtime-Token`; the operator UI reads
+# `hecate.runtimeToken` from sessionStorage/localStorage when you enable this.
+# HECATE_RUNTIME_TOKEN=
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper
 # processes such as `hecate-acp`. Leave empty for normal local dev; the gateway

--- a/cmd/hecate/mcp.go
+++ b/cmd/hecate/mcp.go
@@ -19,6 +19,8 @@ import (
 // Configuration is environment-only:
 //   - HECATE_BASE_URL   — gateway URL, e.g. http://127.0.0.1:8765
 //     (default: http://127.0.0.1:8765)
+//   - HECATE_RUNTIME_TOKEN — optional token for Hecate-native APIs when
+//     the gateway was started with the same value.
 //
 // We deliberately don't read config.LoadFromEnv() — the MCP subprocess
 // runs out-of-process from the gateway and shouldn't share its config
@@ -32,6 +34,7 @@ func runMCPServer(commandName string) {
 	srv := server.NewServer("hecate", version.Version)
 	srv.SetDescription("Hecate gateway: read-only inspection of tasks, chat sessions, and recent traffic.")
 	client := server.NewGatewayClient(baseURL)
+	client.SetRuntimeToken(os.Getenv("HECATE_RUNTIME_TOKEN"))
 	server.RegisterDefaultTools(srv, client)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -33,6 +33,7 @@ Both sides speak [MCP spec](https://modelcontextprotocol.io/) `2025-11-25`.
 ## Hecate as MCP server
 
 The server runs as a subcommand of the `gateway` binary on stdio, talking back to a running gateway over its public REST API. Operators add it to their MCP client's config, and the agent runtime surfaces become callable from inside the editor.
+When the gateway is started with `HECATE_RUNTIME_TOKEN`, set the same environment variable on the MCP server entry so it can send `X-Hecate-Runtime-Token` to `/hecate/v1/*`.
 
 ### What's available
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -21,6 +21,13 @@ OTLP collector/export endpoints keep their standard protocol paths
 an OpenTelemetry collector. Those are not Hecate product resources. Hecate's
 local trace lookup for the operator UI is `GET /hecate/v1/traces`.
 
+Set `HECATE_RUNTIME_TOKEN` to require Hecate-aware clients to send
+`X-Hecate-Runtime-Token` on `/hecate/v1/*`. This guard does not apply to
+provider-compatible `/v1/*` paths or `/healthz`, so OpenAI/Anthropic-shaped
+clients keep their existing auth shape. The operator UI sends the header when
+`hecate.runtimeToken` is present in `sessionStorage` or `localStorage`; the MCP
+server reads the same value from its `HECATE_RUNTIME_TOKEN` environment.
+
 Legacy Hecate-native `/v1/*` and `/admin/*` paths are intentionally not kept as
 compatibility shims in this alpha branch. Unknown API-shaped paths return 404
 rather than falling through to the embedded UI shell.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -22,11 +22,13 @@ an OpenTelemetry collector. Those are not Hecate product resources. Hecate's
 local trace lookup for the operator UI is `GET /hecate/v1/traces`.
 
 Set `HECATE_RUNTIME_TOKEN` to require Hecate-aware clients to send
-`X-Hecate-Runtime-Token` on `/hecate/v1/*`. This guard does not apply to
-provider-compatible `/v1/*` paths or `/healthz`, so OpenAI/Anthropic-shaped
-clients keep their existing auth shape. The operator UI sends the header when
-`hecate.runtimeToken` is present in `sessionStorage` or `localStorage`; the MCP
-server reads the same value from its `HECATE_RUNTIME_TOKEN` environment.
+`X-Hecate-Runtime-Token` on `/hecate/v1/*`. This protects the Hecate-native
+control plane only. It does not apply to provider-compatible `/v1/*` paths or
+`/healthz`, so OpenAI/Anthropic-shaped inference clients keep their existing
+auth shape and are not authenticated by this token. The operator UI sends the
+header when `hecate.runtimeToken` is present in `sessionStorage` or
+`localStorage`; the MCP server reads the same value from its
+`HECATE_RUNTIME_TOKEN` environment.
 
 Legacy Hecate-native `/v1/*` and `/admin/*` paths are intentionally not kept as
 compatibility shims in this alpha branch. Unknown API-shaped paths return 404

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
 
 - The gateway binds to `127.0.0.1:8765` by default.
 - Browser requests are same-origin checked: by default, an `Origin` header must match the gateway host. Custom browser frontends must be listed in `HECATE_ALLOWED_ORIGINS`.
-- `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This is an opt-in local guard for Hecate-aware clients; it is not multi-user authentication and it does not wrap provider-compatible `/v1/*` endpoints.
+- `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This protects the Hecate control plane, not provider-compatible inference: it is an opt-in local guard for Hecate-aware clients, not multi-user authentication, and it does not wrap `/v1/*` endpoints.
 - Hecate is not designed to be exposed directly on a network.
 - If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,6 +8,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
 
 - The gateway binds to `127.0.0.1:8765` by default.
 - Browser requests are same-origin checked: by default, an `Origin` header must match the gateway host. Custom browser frontends must be listed in `HECATE_ALLOWED_ORIGINS`.
+- `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This is an opt-in local guard for Hecate-aware clients; it is not multi-user authentication and it does not wrap provider-compatible `/v1/*` endpoints.
 - Hecate is not designed to be exposed directly on a network.
 - If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"log/slog"
 	"net/http"
@@ -21,6 +22,8 @@ import (
 )
 
 var httpServerTracer = otel.Tracer("github.com/hecatehq/hecate/internal/api")
+
+const runtimeTokenHeader = "X-Hecate-Runtime-Token"
 
 type middleware func(http.Handler) http.Handler
 
@@ -154,6 +157,34 @@ func SameOriginMiddlewareWithAllowedOrigins(allowedOrigins []string) middleware 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func RuntimeTokenMiddleware(token string) middleware {
+	token = strings.TrimSpace(token)
+	return func(next http.Handler) http.Handler {
+		if token == "" {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isHecateAPIPath(r.URL.Path) || runtimeTokenMatches(r.Header.Get(runtimeTokenHeader), token) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			WriteError(w, http.StatusUnauthorized, errCodeUnauthorized, "runtime token is required")
+		})
+	}
+}
+
+func isHecateAPIPath(path string) bool {
+	return path == "/hecate/v1" || strings.HasPrefix(path, "/hecate/v1/")
+}
+
+func runtimeTokenMatches(got, want string) bool {
+	got = strings.TrimSpace(got)
+	if got == "" || len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
 }
 
 func sameOriginAllowed(r *http.Request, allowedOrigins map[string]struct{}) bool {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -265,5 +269,95 @@ func TestSameOriginMiddlewareWithAllowedOriginsRejectsCrossOriginBrowserRequest(
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestRuntimeTokenMiddleware(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		token  string
+		header string
+		want   int
+	}{
+		{
+			name: "disabled allows hecate api",
+			path: "/hecate/v1/whoami",
+			want: http.StatusNoContent,
+		},
+		{
+			name:  "requires token for hecate api",
+			path:  "/hecate/v1/whoami",
+			token: "local-runtime-token-123456",
+			want:  http.StatusUnauthorized,
+		},
+		{
+			name:   "allows matching token",
+			path:   "/hecate/v1/whoami",
+			token:  "local-runtime-token-123456",
+			header: "local-runtime-token-123456",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:   "rejects wrong token",
+			path:   "/hecate/v1/whoami",
+			token:  "local-runtime-token-123456",
+			header: "local-runtime-token-abcdef",
+			want:   http.StatusUnauthorized,
+		},
+		{
+			name:  "leaves provider compatible api alone",
+			path:  "/v1/models",
+			token: "local-runtime-token-123456",
+			want:  http.StatusNoContent,
+		},
+		{
+			name:  "leaves healthz alone",
+			path:  "/healthz",
+			token: "local-runtime-token-123456",
+			want:  http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := RuntimeTokenMiddleware(tt.token)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.header != "" {
+				req.Header.Set(runtimeTokenHeader, tt.header)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewServerWiresRuntimeTokenMiddleware(t *testing.T) {
+	token := "local-runtime-token-123456"
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{
+		Server: config.ServerConfig{RuntimeToken: token},
+	}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	req.Header.Set(runtimeTokenHeader, token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status with token = %d, want %d", rec.Code, http.StatusOK)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ func NewServer(logger *slog.Logger, handler *Handler) http.Handler {
 		RequestIDMiddleware,
 		OTelHTTPSpanMiddleware,
 		SameOriginMiddlewareWithAllowedOrigins(handler.config.Server.AllowedOrigins),
+		RuntimeTokenMiddleware(handler.config.Server.RuntimeToken),
 		LoggingMiddleware(logger),
 		RecoveryMiddleware(logger),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type ServerConfig struct {
 	Address                    string
 	AllowNonLoopbackBind       bool
 	AllowedOrigins             []string
+	RuntimeToken               string
 	PublicURL                  string
 	DataDir                    string
 	BootstrapFile              string
@@ -351,6 +352,7 @@ func LoadFromEnv() Config {
 			Address:              getEnv("HECATE_ADDRESS", "127.0.0.1:8765"),
 			AllowNonLoopbackBind: getEnvBool("HECATE_ALLOW_NON_LOOPBACK_BIND", false),
 			AllowedOrigins:       splitCSV(getEnv("HECATE_ALLOWED_ORIGINS", "")),
+			RuntimeToken:         getEnv("HECATE_RUNTIME_TOKEN", ""),
 			// PublicURL is written to hecate.runtime.json for local
 			// diagnostics. Empty means derive from Address.
 			PublicURL: getEnv("HECATE_PUBLIC_URL", ""),
@@ -498,6 +500,9 @@ func (c Config) Validate() error {
 		if !validAllowedOrigin(origin) {
 			errs = append(errs, fmt.Errorf("HECATE_ALLOWED_ORIGINS entries must be exact http(s) origins without path/query/fragment (got %q)", origin))
 		}
+	}
+	if token := strings.TrimSpace(c.Server.RuntimeToken); token != "" && len(token) < 24 {
+		errs = append(errs, errors.New("HECATE_RUNTIME_TOKEN must be at least 24 characters when set"))
 	}
 
 	validPolicies := map[string]struct{}{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,15 @@ func TestLoadFromEnvAllowedOrigins(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvRuntimeToken(t *testing.T) {
+	t.Setenv("HECATE_RUNTIME_TOKEN", "local-runtime-token-123456")
+
+	cfg := LoadFromEnv()
+	if cfg.Server.RuntimeToken != "local-runtime-token-123456" {
+		t.Fatalf("RuntimeToken = %q, want configured token", cfg.Server.RuntimeToken)
+	}
+}
+
 func TestListenAddressIsLoopback(t *testing.T) {
 	t.Parallel()
 
@@ -303,6 +312,19 @@ func TestValidateRejectsInvalidAllowedOrigin(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_ALLOWED_ORIGINS") {
 		t.Fatalf("Validate() error = %q, want HECATE_ALLOWED_ORIGINS", err)
+	}
+}
+
+func TestValidateRejectsShortRuntimeToken(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Server.RuntimeToken = "short"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid runtime token error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_RUNTIME_TOKEN") {
+		t.Fatalf("Validate() error = %q, want HECATE_RUNTIME_TOKEN", err)
 	}
 }
 

--- a/internal/mcp/server/gateway.go
+++ b/internal/mcp/server/gateway.go
@@ -18,8 +18,9 @@ import (
 // services because the MCP server is meant to run as a separate
 // subprocess of the operator's MCP-aware editor.
 type GatewayClient struct {
-	BaseURL    string
-	HTTPClient *http.Client
+	BaseURL      string
+	RuntimeToken string
+	HTTPClient   *http.Client
 }
 
 // NewGatewayClient constructs a GatewayClient with a default 30-second
@@ -31,6 +32,10 @@ func NewGatewayClient(baseURL string) *GatewayClient {
 		BaseURL:    strings.TrimRight(baseURL, "/"),
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 	}
+}
+
+func (c *GatewayClient) SetRuntimeToken(token string) {
+	c.RuntimeToken = strings.TrimSpace(token)
 }
 
 // Get issues a GET against `path` (joined onto BaseURL) and decodes
@@ -68,6 +73,9 @@ func (c *GatewayClient) do(ctx context.Context, method, path string, query url.V
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
+	if c.RuntimeToken != "" {
+		req.Header.Set("X-Hecate-Runtime-Token", c.RuntimeToken)
+	}
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/mcp/server/tools_test.go
+++ b/internal/mcp/server/tools_test.go
@@ -85,6 +85,27 @@ func TestTool_ListTasks_EmptyState(t *testing.T) {
 	}
 }
 
+func TestGatewayClient_SendsRuntimeToken(t *testing.T) {
+	srv := fakeGateway(t, map[string]http.HandlerFunc{
+		"/hecate/v1/tasks": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("X-Hecate-Runtime-Token"); got != "local-runtime-token-123456" {
+				t.Fatalf("X-Hecate-Runtime-Token = %q, want configured token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	})
+	client := NewGatewayClient(srv.URL)
+	client.SetRuntimeToken("local-runtime-token-123456")
+
+	server := NewServer("t", "0")
+	RegisterDefaultTools(server, client)
+	_, err := registeredToolFor(t, server, "list_tasks")(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("list_tasks: %v", err)
+	}
+}
+
 func TestTool_GetTaskStatus_RequiresID(t *testing.T) {
 	server := NewServer("t", "0")
 	RegisterDefaultTools(server, NewGatewayClient("http://unused"))

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -42,6 +42,8 @@ describe("api client", () => {
   });
 
   afterEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
     vi.unstubAllGlobals();
   });
 
@@ -375,6 +377,36 @@ describe("api client", () => {
       const options = buildRequestOptions({ method: "POST", body: { x: 1 } });
       const headers = new Headers(options.headers);
       expect(headers.get("Authorization")).toBeNull();
+    });
+
+    it("sends the optional runtime token from session storage", () => {
+      window.sessionStorage.setItem("hecate.runtimeToken", "local-runtime-token-123456");
+
+      const options = buildRequestOptions({ method: "POST", body: { x: 1 } }, "/hecate/v1/tasks");
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("X-Hecate-Runtime-Token")).toBe("local-runtime-token-123456");
+    });
+
+    it("falls back to the optional runtime token from local storage", () => {
+      window.localStorage.setItem("hecate.runtimeToken", "local-runtime-token-abcdef");
+
+      const options = buildRequestOptions({ method: "GET" }, "/hecate/v1/whoami");
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("X-Hecate-Runtime-Token")).toBe("local-runtime-token-abcdef");
+    });
+
+    it("does not send the optional runtime token to provider-compatible paths", () => {
+      window.sessionStorage.setItem("hecate.runtimeToken", "local-runtime-token-123456");
+
+      const options = buildRequestOptions(
+        { method: "POST", body: { messages: [] } },
+        "/v1/chat/completions",
+      );
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("X-Hecate-Runtime-Token")).toBeNull();
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -73,6 +73,8 @@ type ErrorPayload = {
 };
 
 const HECATE_API = "/hecate/v1";
+const HECATE_RUNTIME_TOKEN_HEADER = "X-Hecate-Runtime-Token";
+const HECATE_RUNTIME_TOKEN_STORAGE_KEY = "hecate.runtimeToken";
 
 // PersistedContentBlock mirrors internal/api.OpenAIPersistedContentBlock.
 // Used on history-replay paths so Anthropic thinking / redacted_thinking /
@@ -441,9 +443,10 @@ export async function streamChatSession(
   onEvent: (event: ChatStreamEvent) => void,
   signal?: AbortSignal,
 ): Promise<void> {
+  const url = `${HECATE_API}/chat/sessions/${encodeURIComponent(id)}/stream`;
   const response = await fetchWithNetworkError(
-    `${HECATE_API}/chat/sessions/${encodeURIComponent(id)}/stream`,
-    { ...buildRequestOptions({}), signal },
+    url,
+    { ...buildRequestOptions({}, url), signal },
   );
   if (!response.ok) {
     throw await apiError(response, "request failed");
@@ -890,9 +893,10 @@ export async function streamTaskRun(
   afterSequence = 0,
   signal?: AbortSignal,
 ): Promise<void> {
+  const url = `${HECATE_API}/tasks/${encodeURIComponent(taskID)}/runs/${encodeURIComponent(runID)}/stream?after_sequence=${encodeURIComponent(String(afterSequence))}`;
   const response = await fetchWithNetworkError(
-    `${HECATE_API}/tasks/${encodeURIComponent(taskID)}/runs/${encodeURIComponent(runID)}/stream?after_sequence=${encodeURIComponent(String(afterSequence))}`,
-    { ...buildRequestOptions({}), signal },
+    url,
+    { ...buildRequestOptions({}, url), signal },
   );
   if (!response.ok) {
     throw await apiError(response, "request failed");
@@ -955,9 +959,10 @@ export async function chatCompletionsStream(
   payload: ChatCompletionPayload,
   onChunk: (delta: string) => void,
 ): Promise<{ headers: RuntimeHeaders; finishReason: string; toolCalls: StreamedToolCall[] }> {
+  const url = "/v1/chat/completions";
   const response = await fetchWithNetworkError(
-    "/v1/chat/completions",
-    buildRequestOptions({ method: "POST", body: { ...payload, stream: true } }),
+    url,
+    buildRequestOptions({ method: "POST", body: { ...payload, stream: true } }, url),
   );
   if (!response.ok) {
     throw await apiError(response, "request failed");
@@ -1035,9 +1040,10 @@ export async function chatCompletionsStream(
 export async function chatCompletions(
   payload: ChatCompletionPayload,
 ): Promise<{ data: ChatResponse; headers: RuntimeHeaders }> {
+  const url = "/v1/chat/completions";
   const response = await fetchWithNetworkError(
-    "/v1/chat/completions",
-    buildRequestOptions({ method: "POST", body: payload }),
+    url,
+    buildRequestOptions({ method: "POST", body: payload }, url),
   );
   if (!response.ok) {
     throw await apiError(response, "request failed");
@@ -1067,10 +1073,14 @@ function readRuntimeHeaders(response: Response): RuntimeHeaders {
   };
 }
 
-export function buildRequestOptions(options: RequestOptions): RequestInit {
+export function buildRequestOptions(options: RequestOptions, url = ""): RequestInit {
   const headers = new Headers();
   if (options.body !== undefined) {
     headers.set("Content-Type", "application/json");
+  }
+  const runtimeToken = readRuntimeToken();
+  if (runtimeToken && isHecateNativeURL(url)) {
+    headers.set(HECATE_RUNTIME_TOKEN_HEADER, runtimeToken);
   }
 
   return {
@@ -1078,6 +1088,23 @@ export function buildRequestOptions(options: RequestOptions): RequestInit {
     headers,
     body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
   };
+}
+
+function isHecateNativeURL(url: string): boolean {
+  return url === HECATE_API || url.startsWith(`${HECATE_API}/`);
+}
+
+function readRuntimeToken(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return (
+      window.sessionStorage.getItem(HECATE_RUNTIME_TOKEN_STORAGE_KEY)?.trim() ||
+      window.localStorage.getItem(HECATE_RUNTIME_TOKEN_STORAGE_KEY)?.trim() ||
+      ""
+    );
+  } catch {
+    return "";
+  }
 }
 
 // ApiError preserves the HTTP status alongside the error message so
@@ -1113,7 +1140,7 @@ export class ApiError extends Error {
 }
 
 export async function fetchJSON<T>(url: string, options: RequestOptions = {}): Promise<T> {
-  const response = await fetchWithNetworkError(url, buildRequestOptions(options));
+  const response = await fetchWithNetworkError(url, buildRequestOptions(options, url));
   if (!response.ok) {
     throw await apiError(response, "request failed");
   }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -444,10 +444,7 @@ export async function streamChatSession(
   signal?: AbortSignal,
 ): Promise<void> {
   const url = `${HECATE_API}/chat/sessions/${encodeURIComponent(id)}/stream`;
-  const response = await fetchWithNetworkError(
-    url,
-    { ...buildRequestOptions({}, url), signal },
-  );
+  const response = await fetchWithNetworkError(url, { ...buildRequestOptions({}, url), signal });
   if (!response.ok) {
     throw await apiError(response, "request failed");
   }
@@ -894,10 +891,7 @@ export async function streamTaskRun(
   signal?: AbortSignal,
 ): Promise<void> {
   const url = `${HECATE_API}/tasks/${encodeURIComponent(taskID)}/runs/${encodeURIComponent(runID)}/stream?after_sequence=${encodeURIComponent(String(afterSequence))}`;
-  const response = await fetchWithNetworkError(
-    url,
-    { ...buildRequestOptions({}, url), signal },
-  );
+  const response = await fetchWithNetworkError(url, { ...buildRequestOptions({}, url), signal });
   if (!response.ok) {
     throw await apiError(response, "request failed");
   }


### PR DESCRIPTION
## Summary
- add opt-in `HECATE_RUNTIME_TOKEN` protection for Hecate-native `/hecate/v1/*` APIs using `X-Hecate-Runtime-Token`
- make the token scope explicit: it protects Hecate's control plane, not provider-compatible inference
- leave `/healthz` and provider-compatible `/v1/*` endpoints unchanged so OpenAI/Anthropic-shaped clients keep their existing auth behavior
- teach the operator UI and Hecate MCP server to send the token when configured
- document the boundary and configuration in env, security, runtime API, and MCP docs

## Notes
This is a local guard for Hecate-aware clients, not multi-user auth. It does not try to hide secrets from the same OS user, and it intentionally avoids changing OpenAI/Anthropic-compatible client behavior. Enabling the token does not authenticate `/v1/*` inference endpoints.

## Verification
- `GOCACHE="/private/tmp/hecate-runtime-token/.gocache" go test ./internal/api ./internal/config ./internal/mcp/server`
- `GOCACHE="/private/tmp/hecate-runtime-token/.gocache" go vet ./internal/api ./internal/config ./internal/mcp/server ./cmd/hecate`
- `GOCACHE="/private/tmp/hecate-runtime-token/.gocache" go test ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/lib/api.test.ts`
- `cd ui && bun run test`
- `git ls-files -z '*.md' '*.mdc' | xargs -0 /Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check`
