### PR TITLE
refactor(orchestrator): extract claimed run start transition

### DIFF
--- a/e2e/task_approval_lifecycle_test.go
+++ b/e2e/task_approval_lifecycle_test.go
@@ -429,6 +429,9 @@ type e2eTaskRun struct {
 	Provider     string `json:"provider,omitempty"`
 	ProviderKind string `json:"provider_kind,omitempty"`
 	Model        string `json:"model,omitempty"`
+	RequestID    string `json:"request_id,omitempty"`
+	TraceID      string `json:"trace_id,omitempty"`
+	RootSpanID   string `json:"root_span_id,omitempty"`
 }
 
 type e2eTaskApprovalsResponse struct {

--- a/e2e/task_run_lifecycle_test.go
+++ b/e2e/task_run_lifecycle_test.go
@@ -37,6 +37,38 @@ func TestTaskRunQueuedLifecycleE2E(t *testing.T) {
 	assertE2EEventOrder(t, events.Data, []string{"run.created", "run.queued", "run.started", "run.finished"})
 }
 
+func TestTaskRunClaimedStartTransitionPopulatesTraceE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=",
+	)
+
+	body := fmt.Sprintf(`{
+		"title": "claimed start transition e2e",
+		"prompt": "complete normally",
+		"execution_kind": "shell",
+		"shell_command": "printf 'started\n'",
+		"working_directory": %q,
+		"sandbox_allowed_root": %q,
+		"workspace_mode": "in_place",
+		"timeout_ms": 10000
+	}`, workDir, workDir)
+	created := postJSONDecode[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks", body)
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/start", `{}`)
+
+	run := waitForE2ETaskRunTerminal(t, baseURL, created.Data.ID, started.Data.ID, 10*time.Second)
+	if run.Status != "completed" {
+		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
+	}
+	if run.RequestID == "" || run.TraceID == "" || run.RootSpanID == "" {
+		t.Fatalf("run ids = request:%q trace:%q span:%q, want populated", run.RequestID, run.TraceID, run.RootSpanID)
+	}
+
+	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events")
+	assertE2EEventOrder(t, events.Data, []string{"run.created", "run.queued", "run.started", "run.finished"})
+}
+
 func TestTaskRunQueueCoordinatorDrainsMultipleTasksE2E(t *testing.T) {
 	workDir := t.TempDir()
 	baseURL := gatewayServer(t,

--- a/internal/orchestrator/runner_claimed_run_processor.go
+++ b/internal/orchestrator/runner_claimed_run_processor.go
@@ -99,11 +99,14 @@ func (p *claimedRunProcessor) beginJob() (context.Context, func()) {
 
 func (p *claimedRunProcessor) startClaimedRun(ctx context.Context) bool {
 	now := time.Now().UTC()
-
-	var queueWaitMS int64
-	if !p.run.StartedAt.IsZero() {
-		queueWaitMS = now.Sub(p.run.StartedAt).Milliseconds()
-	}
+	transition := prepareClaimedRunStartTransition(claimedRunStartTransitionInput{
+		Task:       p.task,
+		Run:        p.run,
+		RequestID:  p.requestID,
+		TraceID:    p.trace.TraceID,
+		RootSpanID: p.trace.RootSpanID(),
+		Now:        now,
+	})
 	p.queueBackend = ""
 	if p.queue != nil {
 		p.queueBackend = p.queue.Backend()
@@ -112,43 +115,24 @@ func (p *claimedRunProcessor) startClaimedRun(ctx context.Context) bool {
 		telemetry.AttrHecateTaskID:       p.task.ID,
 		telemetry.AttrHecateRunID:        p.run.ID,
 		telemetry.AttrHecateQueueBackend: p.queueBackend,
-		telemetry.AttrHecateQueueWaitMS:  queueWaitMS,
+		telemetry.AttrHecateQueueWaitMS:  transition.QueueWaitMS,
 		telemetry.AttrHecateWorkerID:     p.coordinator.workerID,
 	})
 	p.runner.metrics.RecordQueueWait(ctx, telemetry.QueueWaitRecord{
 		TaskID:       p.task.ID,
 		RunID:        p.run.ID,
 		QueueBackend: p.queueBackend,
-		WaitMS:       queueWaitMS,
+		WaitMS:       transition.QueueWaitMS,
 	})
 
-	p.run.Status = "running"
-	p.run.RequestID = p.requestID
-	p.run.TraceID = p.trace.TraceID
-	p.run.RootSpanID = p.trace.RootSpanID()
-	if p.run.StartedAt.IsZero() {
-		p.run.StartedAt = now
-	}
-	p.run.LastError = ""
-	p.run.FinishedAt = time.Time{}
-	if _, err := p.runner.store.UpdateRun(ctx, p.run); err != nil {
+	if err := persistClaimedRunStartTransition(ctx, p.runner.store, transition); err != nil {
 		return false
 	}
 
-	p.task.Status = "running"
-	p.task.LatestRunID = p.run.ID
-	if p.task.StartedAt.IsZero() {
-		p.task.StartedAt = now
-	}
-	p.task.UpdatedAt = now
-	p.task.FinishedAt = time.Time{}
-	p.task.LastError = ""
-	p.task.RootTraceID = p.trace.TraceID
-	p.task.LatestTraceID = p.trace.TraceID
-	p.task.LatestRequestID = p.requestID
-	if _, err := p.runner.store.UpdateTask(ctx, p.task); err != nil {
-		return false
-	}
+	// Downstream run.started emission, execution, and queue-ack telemetry
+	// all read the processor's current run/task snapshots.
+	p.run = transition.Run
+	p.task = transition.Task
 
 	recordOrchestratorRunStarted(p.trace, p.task.ID, p.run)
 	return true

--- a/internal/orchestrator/runner_claimed_run_processor_test.go
+++ b/internal/orchestrator/runner_claimed_run_processor_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -11,6 +12,14 @@ import (
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+type failUpdateTaskStore struct {
+	taskstate.Store
+}
+
+func (s failUpdateTaskStore) UpdateTask(context.Context, types.Task) (types.Task, error) {
+	return types.Task{}, errors.New("update task failed")
+}
 
 func newClaimedRunProcessorTestRunner(store taskstate.Store, queue RunQueue) *Runner {
 	runner := &Runner{
@@ -128,6 +137,60 @@ func TestClaimedRunProcessor_AcksNonQueuedRunWithoutStarting(t *testing.T) {
 	for _, event := range events {
 		if event.EventType == "run.started" {
 			t.Fatalf("unexpected run.started event for non-queued run: %+v", event)
+		}
+	}
+}
+
+func TestClaimedRunProcessor_DoesNotAckWhenStartTransitionPersistFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseStore := taskstate.NewMemoryStore()
+	queue := &recordingQueue{}
+	runner := newClaimedRunProcessorTestRunner(failUpdateTaskStore{Store: baseStore}, queue)
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:            "task-start-fail",
+		Title:         "Start fail",
+		Prompt:        "complete",
+		Status:        "queued",
+		ExecutionKind: "stub",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	run := types.TaskRun{
+		ID:        "run-start-fail",
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "queued",
+		StartedAt: now,
+		RequestID: "request-start-fail",
+	}
+	if _, err := baseStore.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := baseStore.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	runner.queueCoordinator.processQueuedRun(QueueClaim{
+		ClaimID: "claim-start-fail",
+		Job:     QueueJob{TaskID: task.ID, RunID: run.ID},
+	})
+
+	if len(queue.acked) != 0 {
+		t.Fatalf("acked claims = %+v, want none", queue.acked)
+	}
+	if got := runner.inFlightJobCount(); got != 0 {
+		t.Fatalf("in-flight jobs = %d, want 0", got)
+	}
+	events, err := baseStore.ListRunEvents(ctx, task.ID, run.ID, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRunEvents() error = %v", err)
+	}
+	for _, event := range events {
+		if event.EventType == "run.started" {
+			t.Fatalf("unexpected run.started event after failed start transition: %+v", event)
 		}
 	}
 }

--- a/internal/orchestrator/runner_claimed_run_start.go
+++ b/internal/orchestrator/runner_claimed_run_start.go
@@ -1,0 +1,73 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type claimedRunStartTransitionInput struct {
+	Task       types.Task
+	Run        types.TaskRun
+	RequestID  string
+	TraceID    string
+	RootSpanID string
+	Now        time.Time
+}
+
+type claimedRunStartTransition struct {
+	Task        types.Task
+	Run         types.TaskRun
+	QueueWaitMS int64
+}
+
+func prepareClaimedRunStartTransition(input claimedRunStartTransitionInput) claimedRunStartTransition {
+	now := input.Now.UTC()
+	run := input.Run
+	task := input.Task
+
+	var queueWaitMS int64
+	if !run.StartedAt.IsZero() {
+		queueWaitMS = now.Sub(run.StartedAt).Milliseconds()
+	}
+
+	run.Status = "running"
+	run.RequestID = input.RequestID
+	run.TraceID = input.TraceID
+	run.RootSpanID = input.RootSpanID
+	if run.StartedAt.IsZero() {
+		run.StartedAt = now
+	}
+	run.LastError = ""
+	run.FinishedAt = time.Time{}
+
+	task.Status = "running"
+	task.LatestRunID = run.ID
+	if task.StartedAt.IsZero() {
+		task.StartedAt = now
+	}
+	task.UpdatedAt = now
+	task.FinishedAt = time.Time{}
+	task.LastError = ""
+	task.RootTraceID = input.TraceID
+	task.LatestTraceID = input.TraceID
+	task.LatestRequestID = input.RequestID
+
+	return claimedRunStartTransition{
+		Task:        task,
+		Run:         run,
+		QueueWaitMS: queueWaitMS,
+	}
+}
+
+func persistClaimedRunStartTransition(ctx context.Context, store taskstate.Store, transition claimedRunStartTransition) error {
+	if _, err := store.UpdateRun(ctx, transition.Run); err != nil {
+		return err
+	}
+	if _, err := store.UpdateTask(ctx, transition.Task); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/orchestrator/runner_claimed_run_start_test.go
+++ b/internal/orchestrator/runner_claimed_run_start_test.go
@@ -1,0 +1,103 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestClaimedRunStartTransition_PopulatesRunAndTask(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	queuedAt := now.Add(-1500 * time.Millisecond)
+	finishedAt := now.Add(-time.Hour)
+
+	transition := prepareClaimedRunStartTransition(claimedRunStartTransitionInput{
+		Task: types.Task{
+			ID:              "task-start",
+			Status:          "queued",
+			StartedAt:       finishedAt,
+			UpdatedAt:       finishedAt,
+			FinishedAt:      finishedAt,
+			LastError:       "old task error",
+			RootTraceID:     "old-trace",
+			LatestTraceID:   "old-trace",
+			LatestRequestID: "old-request",
+		},
+		Run: types.TaskRun{
+			ID:          "run-start",
+			TaskID:      "task-start",
+			Status:      "queued",
+			StartedAt:   queuedAt,
+			FinishedAt:  finishedAt,
+			RequestID:   "old-request",
+			TraceID:     "old-trace",
+			RootSpanID:  "old-span",
+			LastError:   "old run error",
+			WorkspaceID: "workspace",
+		},
+		RequestID:  "request-new",
+		TraceID:    "trace-new",
+		RootSpanID: "span-new",
+		Now:        now,
+	})
+
+	if transition.QueueWaitMS != 1500 {
+		t.Fatalf("queue wait = %d, want 1500", transition.QueueWaitMS)
+	}
+	if transition.Run.Status != "running" {
+		t.Fatalf("run status = %q, want running", transition.Run.Status)
+	}
+	if transition.Run.RequestID != "request-new" || transition.Run.TraceID != "trace-new" || transition.Run.RootSpanID != "span-new" {
+		t.Fatalf("run ids = request:%q trace:%q span:%q, want new ids", transition.Run.RequestID, transition.Run.TraceID, transition.Run.RootSpanID)
+	}
+	if !transition.Run.StartedAt.Equal(queuedAt) {
+		t.Fatalf("run started_at = %v, want preserved queued timestamp %v", transition.Run.StartedAt, queuedAt)
+	}
+	if !transition.Run.FinishedAt.IsZero() || transition.Run.LastError != "" {
+		t.Fatalf("run terminal fields = finished:%v last_error:%q, want cleared", transition.Run.FinishedAt, transition.Run.LastError)
+	}
+	if transition.Run.WorkspaceID != "workspace" {
+		t.Fatalf("run workspace id = %q, want preserved", transition.Run.WorkspaceID)
+	}
+	if transition.Task.Status != "running" || transition.Task.LatestRunID != "run-start" {
+		t.Fatalf("task status/latest run = %q/%q, want running/run-start", transition.Task.Status, transition.Task.LatestRunID)
+	}
+	if !transition.Task.StartedAt.Equal(finishedAt) {
+		t.Fatalf("task started_at = %v, want preserved %v", transition.Task.StartedAt, finishedAt)
+	}
+	if !transition.Task.UpdatedAt.Equal(now) {
+		t.Fatalf("task updated_at = %v, want %v", transition.Task.UpdatedAt, now)
+	}
+	if !transition.Task.FinishedAt.IsZero() || transition.Task.LastError != "" {
+		t.Fatalf("task terminal fields = finished:%v last_error:%q, want cleared", transition.Task.FinishedAt, transition.Task.LastError)
+	}
+	if transition.Task.RootTraceID != "trace-new" || transition.Task.LatestTraceID != "trace-new" || transition.Task.LatestRequestID != "request-new" {
+		t.Fatalf("task trace ids = root:%q latest:%q request:%q, want new ids", transition.Task.RootTraceID, transition.Task.LatestTraceID, transition.Task.LatestRequestID)
+	}
+}
+
+func TestClaimedRunStartTransition_InitializesFreshStartTimes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 29, 12, 30, 0, 0, time.UTC)
+	transition := prepareClaimedRunStartTransition(claimedRunStartTransitionInput{
+		Task:      types.Task{ID: "task-fresh", Status: "queued"},
+		Run:       types.TaskRun{ID: "run-fresh", TaskID: "task-fresh", Status: "queued"},
+		RequestID: "request-fresh",
+		TraceID:   "trace-fresh",
+		Now:       now,
+	})
+
+	if transition.QueueWaitMS != 0 {
+		t.Fatalf("queue wait = %d, want 0", transition.QueueWaitMS)
+	}
+	if !transition.Run.StartedAt.Equal(now) {
+		t.Fatalf("run started_at = %v, want %v", transition.Run.StartedAt, now)
+	}
+	if !transition.Task.StartedAt.Equal(now) {
+		t.Fatalf("task started_at = %v, want %v", transition.Task.StartedAt, now)
+	}
+}


### PR DESCRIPTION
## Summary
- extract claimed queued-to-running run/task mutation into a focused start-transition helper
- keep claimed-run processor ownership of tracing, metrics, run.started emission, and queue ack behavior
- add unit coverage for transition field population and no-ack behavior when start persistence fails
- add e2e coverage that the real binary persists request/trace/span IDs after a queued run is claimed

## Tests
- go test ./internal/orchestrator
- go vet ./internal/orchestrator
- go test -tags e2e ./e2e -run 'TestTaskRun(QueuedLifecycle|ClaimedStartTransitionPopulatesTrace|ClaimedProcessorFinalizesFailure)E2E' -count=1\n- go vet -tags e2e ./e2e\n- git diff --check\n- go test -race -timeout 10m ./internal/orchestrator\n- go test ./...\n- go vet ./...\n