### PR TITLE
fix(ui): inherit workspace from selected project

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -21,7 +21,7 @@ const test = baseTest.extend<{ page: Page }>({
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   // Chat is the default workspace
@@ -295,6 +295,7 @@ test("New chat creates an external-agent session with controls before the first 
           agent_name: "Codex",
           driver_kind: "acp",
           native_session_id: "native-codex-e2e",
+          project_id: "proj_e2e",
           workspace: "/tmp/hecate-e2e",
           status: "idle",
           config_options: [
@@ -318,7 +319,7 @@ test("New chat creates an external-agent session with controls before the first 
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "codex");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -332,7 +333,7 @@ test("New chat creates an external-agent session with controls before the first 
       agent_id: "codex",
       workspace: "/tmp/hecate-e2e",
     });
-  await expect(page.getByRole("button", { name: "Model" })).toContainText("Fast");
+  await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText("Fast");
   await page.getByRole("button", { name: "Choose agent for new chat" }).click();
   await expect(page.getByRole("option", { name: /Codex/ })).toHaveAttribute(
     "aria-selected",
@@ -360,7 +361,7 @@ test("New Hecate chat asks for workspace before creating a tools-on session", as
   });
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
-    window.localStorage.removeItem("hecate.agentWorkspace");
+    window.localStorage.removeItem("hecate.project");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -413,7 +414,7 @@ test("New external-agent chat asks for workspace without flashing an inline erro
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "codex");
-    window.localStorage.removeItem("hecate.agentWorkspace");
+    window.localStorage.removeItem("hecate.project");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -476,6 +477,7 @@ test("New external-agent chat with model setup shows controls and composer toget
         agent_name: "Grok Build",
         driver_kind: "acp",
         native_session_id: "native-grok-build-e2e",
+        project_id: "proj_e2e",
         workspace: "/tmp/hecate-e2e",
         status: "idle",
         config_options: createBody.config_options ?? [],
@@ -514,7 +516,7 @@ test("New external-agent chat with model setup shows controls and composer toget
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "grok_build");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -525,15 +527,19 @@ test("New external-agent chat with model setup shows controls and composer toget
   await expect(
     page.getByRole("button", { name: /Chat Grok Build chat, Grok Build/i }),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Model" })).toContainText("Pick a model");
+  await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText(
+    "Pick a model",
+  );
   await expect(page.locator("textarea")).toBeVisible();
   await page.locator("textarea").fill("Build a tiny app");
   await expect(page.locator("button[type='submit']")).toBeDisabled();
 
-  await page.getByRole("button", { name: "Model" }).click();
+  await page.getByRole("button", { name: "Model", exact: true }).click();
   await page.getByRole("option", { name: "Grok Build 0429" }).click();
 
-  await expect(page.getByRole("button", { name: "Model" })).toContainText("Grok Build 0429");
+  await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText(
+    "Grok Build 0429",
+  );
   await expect(page.locator("button[type='submit']")).toBeEnabled();
 });
 
@@ -544,7 +550,7 @@ test("external-agent chat uses the shared fake lifecycle for transcript and dele
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -580,7 +586,7 @@ test("external-agent running turns keep controls stable and request cancel throu
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "grok_build");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -684,7 +690,7 @@ test("New chat falls back to Hecate when the remembered external agent needs set
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "cursor_agent");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
@@ -723,6 +729,7 @@ test("sidebar rename works for agent-chat sessions", async ({ page }) => {
             id: "rename-chat-e2e",
             title,
             agent_id: "codex",
+            project_id: "proj_e2e",
             workspace: "/tmp/hecate-e2e",
             status: "idle",
             message_count: 0,
@@ -747,6 +754,7 @@ test("sidebar rename works for agent-chat sessions", async ({ page }) => {
           id: "rename-chat-e2e",
           title,
           agent_id: "codex",
+          project_id: "proj_e2e",
           workspace: "/tmp/hecate-e2e",
           status: "idle",
           messages: [],
@@ -1388,7 +1396,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
   await page.unrouteAll({ behavior: "ignoreErrors" });
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
+    window.localStorage.setItem("hecate.project", "proj_e2e_workspace");
   });
   await mockGatewayAPIs(page);
 
@@ -1429,6 +1437,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
         id: "chat-hecate-e2e",
         title: body.title || "show diff",
         agent_id: "hecate",
+        project_id: "proj_e2e_workspace",
         provider: body.provider || "",
         model: body.model || "qwen2.5",
         capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
@@ -1560,7 +1569,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
   await page.unrouteAll({ behavior: "ignoreErrors" });
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
+    window.localStorage.setItem("hecate.project", "proj_e2e_workspace");
   });
   await mockGatewayAPIs(page, {
     settingsConfig: {
@@ -2067,7 +2076,7 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
       "hecate.chatTargetBySessionID",
       JSON.stringify({ "chat-busy-e2e": "model" }),
     );
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
+    window.localStorage.setItem("hecate.project", "proj_e2e_workspace");
   });
   await mockGatewayAPIs(page, {
     settingsConfig: {
@@ -2235,7 +2244,7 @@ test("Hecate Chat rehydrates an awaiting-approval task and resolves it after ref
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.chatSessionID", "chat-approval-refresh-e2e");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e-workspace");
+    window.localStorage.setItem("hecate.project", "proj_e2e_workspace");
   });
   await mockGatewayAPIs(page, {
     settingsConfig: {
@@ -2611,7 +2620,7 @@ test("selected-model readiness can switch to the backend-suggested fallback mode
     window.localStorage.setItem("hecate.chatTarget", "model");
     window.localStorage.setItem("hecate.providerFilter", "auto");
     window.localStorage.setItem("hecate.model", "claude-sonnet-4-6");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
 
   await page.goto("/");
@@ -3069,6 +3078,7 @@ async function openExternalAgentReadinessFixture(page: Page, fixture: ExternalAd
     agent_name: fixture.name,
     driver_kind: "acp",
     native_session_id: `native-${fixture.id}-e2e`,
+    project_id: "proj_e2e",
     workspace: "/tmp/hecate-e2e",
     status: "idle",
     message_count: 0,
@@ -3115,7 +3125,7 @@ async function openExternalAgentReadinessFixture(page: Page, fixture: ExternalAd
     ({ adapterID, chatSessionID }) => {
       window.localStorage.setItem("hecate.chatTarget", "external_agent");
       window.localStorage.setItem("hecate.agentAdapterID", adapterID);
-      window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+      window.localStorage.setItem("hecate.project", "proj_e2e");
       window.localStorage.setItem("hecate.chatSessionID", chatSessionID);
     },
     { adapterID: fixture.id, chatSessionID: sessionID },
@@ -3202,6 +3212,7 @@ async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture
     agent_name: "Claude Code",
     driver_kind: "acp",
     native_session_id: "native-claude-code-e2e",
+    project_id: "proj_e2e",
     workspace: "/tmp/hecate-e2e",
     status: "idle",
     message_count: 0,
@@ -3277,7 +3288,7 @@ async function openClaudeExternalAgent(page: Page, fixture: ClaudeAdapterFixture
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
     window.localStorage.setItem("hecate.chatSessionID", "claude-code-onboarding-e2e");
   });
   await page.goto("/");

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { test as base, type Page } from "@playwright/test";
+import type { ProjectRecord } from "../src/types/project";
 
 // ── Mock data ─────────────────────────────────────────────────────────────────
 
@@ -69,6 +70,43 @@ export const MOCK_PRESETS = [
     protocol: "openai",
     base_url: "http://127.0.0.1:8080/v1",
     description: "Local inference via llama.cpp.",
+  },
+];
+
+export const MOCK_PROJECTS: ProjectRecord[] = [
+  {
+    id: "proj_e2e",
+    name: "E2E workspace",
+    roots: [
+      {
+        id: "root_e2e",
+        path: "/tmp/hecate-e2e",
+        kind: "workspace",
+        active: true,
+        created_at: "2026-05-14T12:00:00Z",
+        updated_at: "2026-05-14T12:00:00Z",
+      },
+    ],
+    default_root_id: "root_e2e",
+    created_at: "2026-05-14T12:00:00Z",
+    updated_at: "2026-05-14T12:00:00Z",
+  },
+  {
+    id: "proj_e2e_workspace",
+    name: "E2E workspace alternate",
+    roots: [
+      {
+        id: "root_e2e_workspace",
+        path: "/tmp/hecate-e2e-workspace",
+        kind: "workspace",
+        active: true,
+        created_at: "2026-05-14T12:00:00Z",
+        updated_at: "2026-05-14T12:00:00Z",
+      },
+    ],
+    default_root_id: "root_e2e_workspace",
+    created_at: "2026-05-14T12:00:00Z",
+    updated_at: "2026-05-14T12:00:00Z",
   },
 ];
 
@@ -311,6 +349,7 @@ export type GatewayMockOptions = {
   // empty list — tests that need a populated table pass
   // MOCK_SETTINGS_CONFIG_WITH_PROVIDERS (or any custom shape).
   settingsConfig?: SettingsConfig;
+  projects?: ProjectRecord[];
 };
 
 export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {}) {
@@ -325,6 +364,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
   const state: SettingsConfig = JSON.parse(
     JSON.stringify(opts.settingsConfig ?? MOCK_SETTINGS_CONFIG),
   );
+  const projects: ProjectRecord[] = JSON.parse(JSON.stringify(opts.projects ?? MOCK_PROJECTS));
   const chatSessions: any[] = [];
   let chatSequence = 1;
 
@@ -352,6 +392,10 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
 
   await page.route("/hecate/v1/providers/presets*", (r) =>
     r.fulfill(ok({ object: "list", data: MOCK_FULL_PRESETS })),
+  );
+
+  await page.route("/hecate/v1/projects*", (r) =>
+    r.fulfill(ok({ object: "projects", data: projects })),
   );
 
   await page.route("/hecate/v1/agent-adapters*", (r) =>
@@ -400,6 +444,7 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           native_session_id: isExternal ? `native-${chatSequence}` : "",
           provider: body.provider || "auto",
           model: body.model || "",
+          project_id: body.project_id || "",
           capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
           rtk_enabled: Boolean(body.rtk_enabled),
           workspace: body.workspace || "/tmp/hecate-e2e",

--- a/ui/e2e/provider-lifecycle.spec.ts
+++ b/ui/e2e/provider-lifecycle.spec.ts
@@ -13,7 +13,7 @@ async function expectComposerNotRunnable(page: Page) {
 
 test("adding and deleting a provider keeps chat available", async ({ page }) => {
   await page.addInitScript(() => {
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-e2e");
+    window.localStorage.setItem("hecate.project", "proj_e2e");
   });
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -260,7 +260,17 @@ describe("ConsoleShell navigation", () => {
         {
           id: "proj_1",
           name: "Hecate",
-          roots: [],
+          roots: [
+            {
+              id: "root_1",
+              path: "/Users/alice/dev/hecate",
+              kind: "workspace",
+              active: true,
+              created_at: "2026-05-21T10:00:00Z",
+              updated_at: "2026-05-21T10:00:00Z",
+            },
+          ],
+          default_root_id: "root_1",
           created_at: "2026-05-21T10:00:00Z",
           updated_at: "2026-05-21T10:00:00Z",
         },
@@ -325,7 +335,17 @@ describe("ConsoleShell navigation", () => {
         {
           id: "proj_1",
           name: "Hecate",
-          roots: [],
+          roots: [
+            {
+              id: "root_1",
+              path: "/Users/alice/dev/hecate",
+              kind: "workspace",
+              active: true,
+              created_at: "2026-05-21T10:00:00Z",
+              updated_at: "2026-05-21T10:00:00Z",
+            },
+          ],
+          default_root_id: "root_1",
           created_at: "2026-05-21T10:00:00Z",
           updated_at: "2026-05-21T10:00:00Z",
         },
@@ -370,7 +390,17 @@ describe("ConsoleShell navigation", () => {
         {
           id: "proj_1",
           name: "Hecate",
-          roots: [],
+          roots: [
+            {
+              id: "root_1",
+              path: "/Users/alice/dev/hecate",
+              kind: "workspace",
+              active: true,
+              created_at: "2026-05-21T10:00:00Z",
+              updated_at: "2026-05-21T10:00:00Z",
+            },
+          ],
+          default_root_id: "root_1",
           created_at: "2026-05-21T10:00:00Z",
           updated_at: "2026-05-21T10:00:00Z",
         },

--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -7,7 +7,7 @@
 // override map), workspace + external-agent selection, and the
 // pagination state for agent chat sessions.
 //
-// Eight fields are persisted via `usePersistedState`; the rest
+// Seven fields are persisted via `usePersistedState`; the rest
 // are `useState` since they're in-flight or session-bound. One
 // field (providerFilter) keeps a legacy useState + mount-read
 // effect pattern — see the inline comment for the e2e timing
@@ -169,11 +169,7 @@ export function ChatProvider({
   const [agentConfigOptions, setAgentConfigOptions] = useState<ChatConfigOptionRecord[]>(
     initialState?.agentConfigOptions ?? [],
   );
-  const [agentWorkspace, setAgentWorkspace] = usePersistedState(
-    "hecate.agentWorkspace",
-    parseStoredString,
-    initialState?.agentWorkspace ?? "",
-  );
+  const [agentWorkspace, setAgentWorkspace] = useState(initialState?.agentWorkspace ?? "");
   const [agentWorkspaceBranch, setAgentWorkspaceBranch] = useState(
     initialState?.agentWorkspaceBranch ?? "",
   );

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -49,6 +49,7 @@ import {
   renderChatSessionSummary,
 } from "../../runtimeConsoleChatHelpers";
 import { modelSelectionHasNoToolCalling } from "../../../lib/chat-setup-readiness";
+import { projectByID, projectDefaultWorkspace } from "../../../lib/project-workspace";
 import {
   type ChatExecutionMode,
   type HecateChatTarget,
@@ -357,6 +358,25 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     setAgentWorkspaceBranch("");
   }
 
+  function workspaceForProjectID(projectID: string): string {
+    const id = projectID.trim();
+    if (!id) return "";
+    const project =
+      id === activeProjectID ? projects.activeProject : projectByID(projects.state.projects, id);
+    return projectDefaultWorkspace(project);
+  }
+
+  function workspaceForNewChat(projectID: string): string {
+    const id = projectID.trim();
+    const inherited = workspaceForProjectID(id);
+    if (inherited) return inherited;
+    return id ? "" : agentWorkspace.trim();
+  }
+
+  function workspaceForActiveTurn(): string {
+    return activeChatSession?.workspace?.trim() || workspaceForNewChat(activeProjectID);
+  }
+
   function setChatTarget(nextTarget: ChatTarget) {
     if (activeChatSessionID && activeChatSession) {
       const currentExternal = chatSessionIsExternal(activeChatSession);
@@ -416,7 +436,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       execution_mode: executionMode,
       provider_filter: providerFilter,
       model,
-      workspace: agentWorkspace.trim(),
+      workspace: workspaceForActiveTurn(),
       system_prompt: systemPrompt,
       agent_id: executionMode === "external_agent" ? agentAdapterID : "hecate",
       created_at: new Date().toISOString(),
@@ -485,7 +505,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     setRuntimeHeaders(null);
     const isExternalAgent = turnExecutionMode === "external_agent";
     const isModelTurn = turnExecutionMode === "direct_model";
-    const turnWorkspace = queued?.workspace ?? agentWorkspace.trim();
+    let turnWorkspace = queued?.workspace ?? workspaceForActiveTurn();
     const turnSystemPrompt = queued?.system_prompt ?? systemPrompt;
     const turnAgentID = queued?.agent_id ?? agentAdapterID;
     setStreamingContent(
@@ -499,10 +519,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     let streamPromise: Promise<void> | null = null;
 
     try {
-      if (!isModelTurn && !turnWorkspace) {
-        setChatErrorState(chatWorkspaceRequiredError());
-        return;
-      }
       if (!isExternalAgent && !turnModel) {
         setChatErrorState(chatModelRequiredError());
         return;
@@ -522,6 +538,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
           sessionID = "";
           setActiveChatSessionID("");
         }
+      }
+      turnWorkspace = turnWorkspace || sessionForSubmit?.workspace?.trim() || "";
+      if (!isModelTurn && !turnWorkspace) {
+        setChatErrorState(chatWorkspaceRequiredError());
+        return;
       }
       if (sessionID && sessionForSubmit?.agent_id) {
         const activeExternal = sessionForSubmit.agent_id !== "hecate";
@@ -740,7 +761,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         : !requestedAgentID && defaultChatTarget === "external_agent";
     if (createExternalAgent) {
       const externalAgentID = requestedAgentID || agentAdapterID;
-      const workspace = agentWorkspace.trim();
+      const workspace = workspaceForNewChat(createProjectID);
       if (!workspace) {
         setChatErrorState(chatWorkspaceRequiredError());
         setActiveChatSessionID("");
@@ -787,7 +808,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       providerFilter,
       model: requestedModel,
     });
-    const workspace = agentWorkspace.trim();
+    const workspace = workspaceForNewChat(createProjectID);
     if (executionMode === "hecate_task" && !workspace) {
       setChatErrorState(chatWorkspaceRequiredError());
       setActiveChatSessionID("");
@@ -802,12 +823,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         agent_id: "hecate",
         provider: providerFilter === "auto" ? "" : providerFilter,
         model: requestedModel,
-        ...(executionMode === "hecate_task"
-          ? {
-              workspace,
-              rtk_enabled: hecateRTKEnabled,
-            }
-          : {}),
+        ...(workspace ? { workspace } : {}),
+        ...(executionMode === "hecate_task" ? { rtk_enabled: hecateRTKEnabled } : {}),
       });
       setActiveChatSessionID(created.data.id);
       setChatTargetBySessionID((current) => {
@@ -848,10 +865,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       if (selection.model) {
         setModel(selection.model);
       }
-      if (payload.data.workspace) {
-        setAgentWorkspace(payload.data.workspace);
-        setAgentWorkspaceBranch(payload.data.workspace_branch ?? "");
-      }
+      setAgentWorkspace(payload.data.workspace ?? "");
+      setAgentWorkspaceBranch(payload.data.workspace_branch ?? "");
     } catch (error) {
       const msg = error instanceof Error ? error.message : "failed to load agent chat";
       setActiveChatSessionID("");

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -7,6 +7,7 @@ import { useChatActions } from "../../app/state/coordinators/chat";
 import { useNewChatAgentID, useChatTarget } from "../../app/state/derived";
 import { useWiredSettingsActions } from "../../app/state/coordinators/wired";
 import { formatAbsoluteTime } from "../../lib/format";
+import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type { AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ChatSessionRecord } from "../../types/chat";
 import type { ProjectRecord } from "../../types/project";
@@ -105,9 +106,13 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
   const pendingDeleteChat = sessions.find((session) => session.id === deleteChatID) ?? null;
   const pendingDeleteProject =
     projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
+  const selectedProjectWorkspace = projectDefaultWorkspace(activeProject);
+  const workspaceForNewChat = projects.activeProjectID
+    ? selectedProjectWorkspace
+    : chat.state.agentWorkspace.trim();
   const selectedNewChatUsesWorkspace = newChatAgentID !== "hecate" || chatTarget === "agent";
   const workspaceRequiredForNewChat =
-    isAgentChat && selectedNewChatUsesWorkspace && !chat.state.agentWorkspace.trim();
+    isAgentChat && selectedNewChatUsesWorkspace && !workspaceForNewChat;
 
   function statusForAgent(agentID: ChatAgentOptionID) {
     const adapter =
@@ -131,7 +136,13 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
 
   function selectProjectScope(projectID: string) {
     const scopedSessions = filterSidebarSessionsByProject(sessions, projectID);
+    const project =
+      projectID === ""
+        ? null
+        : (projects.state.projects.find((item) => item.id === projectID) ?? null);
     void projects.actions.selectProject(projectID);
+    chat.actions.setAgentWorkspace(projectID ? projectDefaultWorkspace(project) : "");
+    chat.actions.setAgentWorkspaceBranch("");
     if (activeSessionID && scopedSessions.some((session) => session.id === activeSessionID)) {
       return;
     }
@@ -790,12 +801,7 @@ function ProjectRow({
 }
 
 function projectDetail(project: ProjectRecord): string {
-  return (
-    project.roots.find((root) => root.active)?.path ??
-    project.roots[0]?.path ??
-    project.description ??
-    ""
-  );
+  return projectDefaultWorkspace(project) || project.description || "";
 }
 
 function filterSidebarSessionsByProject(

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -9,6 +9,7 @@ import {
   createRuntimeConsoleFixture,
 } from "../../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
+import type { ProjectRecord } from "../../types/project";
 
 const originalNavigatorClipboardDescriptor = Object.getOwnPropertyDescriptor(
   navigator,
@@ -290,6 +291,63 @@ describe("ChatView input", () => {
     await user.click(screen.getByRole("button", { name: "Choose workspace" }));
     expect(chooseAgentWorkspace).toHaveBeenCalled();
     expect(createChatSession).not.toHaveBeenCalled();
+  });
+
+  it("uses the selected project root as the workspace for new external-agent chats", async () => {
+    const createChatSession = vi.fn(async () => undefined);
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [
+        {
+          id: "root_1",
+          path: "/workspace/hecate",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-29T00:00:00Z",
+          updated_at: "2026-05-29T00:00:00Z",
+        },
+      ],
+      default_root_id: "root_1",
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const { state, actions } = setup(
+      {
+        activeProjectID: "proj_1",
+        projects: [project],
+        chatTarget: "external_agent",
+        agentAdapterID: "grok_build",
+        newChatAgentID: "grok_build",
+        agentWorkspace: "",
+        activeChatSessionID: "",
+        activeChatSession: null,
+        agentAdapters: [
+          {
+            id: "grok_build",
+            name: "Grok Build",
+            kind: "acp",
+            command: "grok",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+      },
+      { createChatSession },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const user = userEvent.setup();
+    const newChatButton = screen.getByRole("button", { name: "New Grok Build chat" });
+    expect(newChatButton).not.toBeDisabled();
+    expect(
+      screen.queryByText("Choose a workspace in the chat view before starting agent chats."),
+    ).toBeNull();
+
+    await user.click(newChatButton);
+
+    expect(createChatSession).toHaveBeenCalledWith({ agentID: "grok_build", projectID: "proj_1" });
   });
 
   it("allows direct Hecate model chats before a workspace is selected", async () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useApprovals } from "../../app/state/approvals";
 import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
+import { useProjects } from "../../app/state/projects";
 import { useRuntime } from "../../app/state/runtime";
 import { useSettings } from "../../app/state/settings";
 import { useChatActions } from "../../app/state/coordinators/chat";
@@ -23,6 +24,7 @@ import { describeGatewayError } from "../../lib/error-diagnostics";
 import { resolveExternalAgentReadiness } from "../../lib/external-agent-readiness";
 import { buildSelectedModelIssue } from "../../lib/provider-issues";
 import { providerDisplayName } from "../../lib/provider-utils";
+import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type { AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ChatConfigOptionRecord, ChatSessionRecord, ChatUsageRecord } from "../../types/chat";
 import type { LocalProviderDiscoveryRecord, ProviderFilter } from "../../types/provider";
@@ -63,6 +65,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const runtime = useRuntime();
   const chat = useChat();
   const providersAndModels = useProvidersAndModels();
+  const projects = useProjects();
   const approvals = useApprovals();
   const settings = useSettings();
   const chatTarget = useChatTarget();
@@ -78,6 +81,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   });
   const providerActions = useWiredProviderActions();
   const dashboardActions = useWiredDashboardActions();
+  const activeProjectWorkspace = projectDefaultWorkspace(projects.activeProject);
+  const agentWorkspace = chat.state.agentWorkspace || activeProjectWorkspace;
   // Compose the legacy `state` and `actions` lookalikes so the JSX
   // below stays close to the pre-migration shape. Each field is read
   // off the slice (or computed via a derived hook) the field used to
@@ -92,7 +97,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     agentAdapterApprovalMode: providersAndModels.state.agentAdapterApprovalMode,
     agentAdapterHealthByID: providersAndModels.state.agentAdapterHealthByID,
     agentAdapterHealthLoadingByID: providersAndModels.state.agentAdapterHealthLoadingByID,
-    agentWorkspace: chat.state.agentWorkspace,
+    agentWorkspace,
     chatCancelling: chat.state.chatCancelling,
     chatError: chat.state.chatError,
     chatErrorCode: chat.state.chatErrorCode,

--- a/ui/src/features/runs/TasksView.test.tsx
+++ b/ui/src/features/runs/TasksView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getModels, getProviders, getTasks } from "../../lib/api";
@@ -7,6 +7,7 @@ import {
   createRuntimeConsoleFixture,
 } from "../../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
+import type { ProjectRecord } from "../../types/project";
 import { streamTurnCostKey, TasksView } from "./TasksView";
 
 vi.mock("../../lib/api", async (importOriginal) => {
@@ -22,6 +23,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
 const localSession = { label: "Local" };
 
 afterEach(() => {
+  window.localStorage.clear();
   vi.mocked(getTasks).mockReset();
   vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(getModels).mockReset();
@@ -56,5 +58,52 @@ describe("TasksView empty state", () => {
     // One button lives in the task sidebar; the second is the
     // main-pane start affordance for an empty task workspace.
     expect(screen.getAllByRole("button", { name: "New task" }).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("seeds new tasks from the selected project's default workspace", async () => {
+    window.localStorage.setItem("hecate.agentWorkspace", "/stale/chat/workspace");
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      default_root_id: "root_default",
+      roots: [
+        {
+          id: "root_active",
+          path: "/workspace/active",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-29T00:00:00Z",
+          updated_at: "2026-05-29T00:00:00Z",
+        },
+        {
+          id: "root_default",
+          path: "/workspace/default",
+          kind: "workspace",
+          active: false,
+          created_at: "2026-05-29T00:00:00Z",
+          updated_at: "2026-05-29T00:00:00Z",
+        },
+      ],
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      projects: [project],
+      activeProjectID: project.id,
+    });
+
+    render(withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Start a task")).toBeTruthy();
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "New task" })[0]);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Workspace path") as HTMLInputElement).value).toBe(
+        "/workspace/default",
+      );
+    });
   });
 });

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -26,6 +26,8 @@ import {
   useEnsureProviderPresetsLoaded,
   useProvidersAndModels,
 } from "../../app/state/providersAndModels";
+import { useProjects } from "../../app/state/projects";
+import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderRecord } from "../../types/provider";
 import type {
@@ -43,15 +45,6 @@ import { NewTaskSlideOver, type CreateTaskPayload } from "./NewTaskSlideOver";
 
 type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
-
-function readStoredAgentWorkspace(): string {
-  if (typeof window === "undefined") return "";
-  try {
-    return window.localStorage.getItem("hecate.agentWorkspace")?.trim() ?? "";
-  } catch {
-    return "";
-  }
-}
 
 export function streamTurnCostKey(turnIndex: number | undefined): number | null {
   if (typeof turnIndex !== "number" || !Number.isFinite(turnIndex) || turnIndex < 0) {
@@ -124,7 +117,6 @@ export function TasksView({
   const [busyAction, setBusyAction] = useState("");
   const [notice, setNotice] = useState<{ tone: "success" | "error"; message: string } | null>(null);
   const [newTaskOpen, setNewTaskOpen] = useState(false);
-  const [defaultTaskWorkspace, setDefaultTaskWorkspace] = useState(readStoredAgentWorkspace);
   const [availableModels, setAvailableModels] = useState<ModelRecord[]>([]);
   // Provider catalog feeds the new-task slideover's provider picker
   // and the model picker's per-row "(provider name)" suffix. Loaded
@@ -135,6 +127,8 @@ export function TasksView({
   const [availableProviders, setAvailableProviders] = useState<ProviderRecord[]>([]);
   useEnsureProviderPresetsLoaded();
   const providerPresets = useProvidersAndModels().state.providerPresets;
+  const projects = useProjects();
+  const defaultTaskWorkspace = projectDefaultWorkspace(projects.activeProject);
 
   const streamCursorRef = useRef(0);
 
@@ -575,7 +569,6 @@ export function TasksView({
         onSelect={(id) => void handleSelectTask(id)}
         onDelete={(id) => void handleDeleteTask(id)}
         onNewTask={() => {
-          setDefaultTaskWorkspace(readStoredAgentWorkspace());
           setNewTaskOpen(true);
         }}
         onRefresh={() => void loadTasks(selectedTaskID, selectedRunID)}
@@ -614,7 +607,6 @@ export function TasksView({
         <TaskStartState
           loading={loading}
           onNewTask={() => {
-            setDefaultTaskWorkspace(readStoredAgentWorkspace());
             setNewTaskOpen(true);
           }}
         />

--- a/ui/src/lib/project-workspace.test.ts
+++ b/ui/src/lib/project-workspace.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { projectByID, projectDefaultWorkspace } from "./project-workspace";
+import type { ProjectRecord, ProjectRootRecord } from "../types/project";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_1",
+    path: "/workspace/default",
+    kind: "workspace",
+    active: false,
+    created_at: "2026-05-29T00:00:00Z",
+    updated_at: "2026-05-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<ProjectRecord>): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [],
+    created_at: "2026-05-29T00:00:00Z",
+    updated_at: "2026-05-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("project workspace helpers", () => {
+  it("uses the default root before active or first roots", () => {
+    const record = project({
+      default_root_id: "root_default",
+      roots: [
+        root({ id: "root_active", path: "/workspace/active", active: true }),
+        root({ id: "root_default", path: "/workspace/default" }),
+      ],
+    });
+
+    expect(projectDefaultWorkspace(record)).toBe("/workspace/default");
+  });
+
+  it("falls back to the active root, then the first root", () => {
+    expect(
+      projectDefaultWorkspace(
+        project({
+          roots: [
+            root({ id: "root_first", path: "/workspace/first" }),
+            root({ id: "root_active", path: "/workspace/active", active: true }),
+          ],
+        }),
+      ),
+    ).toBe("/workspace/active");
+
+    expect(
+      projectDefaultWorkspace(
+        project({
+          roots: [root({ id: "root_first", path: "/workspace/first" })],
+        }),
+      ),
+    ).toBe("/workspace/first");
+  });
+
+  it("returns an empty workspace for no project or root", () => {
+    expect(projectDefaultWorkspace(null)).toBe("");
+    expect(projectDefaultWorkspace(project({ roots: [] }))).toBe("");
+  });
+
+  it("finds projects by trimmed id", () => {
+    const record = project({ id: "proj_hecate" });
+
+    expect(projectByID([record], " proj_hecate ")).toBe(record);
+    expect(projectByID([record], "")).toBeNull();
+    expect(projectByID([record], "missing")).toBeNull();
+  });
+});

--- a/ui/src/lib/project-workspace.ts
+++ b/ui/src/lib/project-workspace.ts
@@ -1,0 +1,16 @@
+import type { ProjectRecord } from "../types/project";
+
+export function projectByID(projects: ProjectRecord[], projectID: string): ProjectRecord | null {
+  const id = projectID.trim();
+  if (!id) return null;
+  return projects.find((project) => project.id === id) ?? null;
+}
+
+export function projectDefaultWorkspace(project: ProjectRecord | null | undefined): string {
+  if (!project) return "";
+  const defaultRoot = project.default_root_id
+    ? project.roots.find((root) => root.id === project.default_root_id)
+    : undefined;
+  const root = defaultRoot ?? project.roots.find((item) => item.active) ?? project.roots[0];
+  return root?.path.trim() ?? "";
+}

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -11,6 +11,7 @@ import { RuntimeProvider } from "../app/state/runtime";
 import { SettingsProvider } from "../app/state/settings";
 import { UsageProvider } from "../app/state/usage";
 import { useRuntimeConsole } from "./runtime-console-test-composer";
+import type { ProjectRecord } from "../types/project";
 
 // This suite is the canonical regression net for the composed
 // slice + coordinator viewmodel — historically owned by
@@ -18,12 +19,18 @@ import { useRuntimeConsole } from "./runtime-console-test-composer";
 // after the production facade was retired. Each renderHook call
 // needs the full provider chain; the wrapper composes them so the
 // test bodies don't have to thread it through every call.
-function SliceProviders({ children }: { children: ReactNode }) {
+function SliceProviders({
+  children,
+  projects,
+}: {
+  children: ReactNode;
+  projects?: ProjectRecord[];
+}) {
   return (
     <RuntimeProvider>
       <UsageProvider>
         <ProvidersAndModelsProvider>
-          <ProjectsProvider>
+          <ProjectsProvider initialState={projects ? { projects } : undefined}>
             <ChatProvider>
               <RetentionProvider>
                 <ApprovalsProvider>
@@ -38,8 +45,16 @@ function SliceProviders({ children }: { children: ReactNode }) {
   );
 }
 
-function renderRuntimeConsoleHook(options?: Omit<RenderHookOptions<unknown>, "wrapper">) {
-  return renderHook(() => useRuntimeConsole(), { ...options, wrapper: SliceProviders });
+type RuntimeConsoleHookOptions = Omit<RenderHookOptions<unknown>, "wrapper"> & {
+  projects?: ProjectRecord[];
+};
+
+function renderRuntimeConsoleHook(options?: RuntimeConsoleHookOptions) {
+  const { projects, ...renderOptions } = options ?? {};
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <SliceProviders projects={projects}>{children}</SliceProviders>;
+  }
+  return renderHook(() => useRuntimeConsole(), { ...renderOptions, wrapper: Wrapper });
 }
 
 // Single-user mode: every endpoint is unauthenticated and the gateway
@@ -138,7 +153,6 @@ describe("useRuntimeConsole", () => {
   });
 
   it("treats a cancelled workspace picker as a quiet no-op", async () => {
-    window.localStorage.setItem("hecate.agentWorkspace", "/workspace/current");
     fetchMock.mockImplementation(
       defaultBackendMock({
         "/hecate/v1/workspace-dialog": () =>
@@ -151,6 +165,9 @@ describe("useRuntimeConsole", () => {
 
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/workspace/current");
+    });
 
     let selected = false;
     await act(async () => {
@@ -358,7 +375,6 @@ describe("useRuntimeConsole", () => {
   it("creates an external-agent session from the selected agent and workspace", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-project");
     let createBody: any = null;
     fetchMock.mockImplementation(
       defaultBackendMock({
@@ -394,6 +410,9 @@ describe("useRuntimeConsole", () => {
 
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/tmp/hecate-project");
+    });
 
     await act(async () => {
       await result.current.actions.createChatSession();
@@ -411,7 +430,6 @@ describe("useRuntimeConsole", () => {
 
   it("uses the new-chat agent selection instead of the active external session", async () => {
     window.localStorage.setItem("hecate.chatSessionID", "a1");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     let createBody: any = null;
     fetchMock.mockImplementation(
@@ -465,6 +483,9 @@ describe("useRuntimeConsole", () => {
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
     await waitFor(() => expect(result.current.state.activeChatSessionID).toBe("a1"));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/tmp/hecate");
+    });
     expect(result.current.state.newChatAgentID).toBe("hecate");
 
     await act(async () => {
@@ -604,21 +625,30 @@ describe("useRuntimeConsole", () => {
     window.localStorage.setItem("hecate.chatTarget", "model");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     window.localStorage.setItem("hecate.project", "proj_1");
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [
+        {
+          id: "root_1",
+          path: "/tmp/hecate-project",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-21T10:00:00Z",
+          updated_at: "2026-05-21T10:00:00Z",
+        },
+      ],
+      default_root_id: "root_1",
+      created_at: "2026-05-21T10:00:00Z",
+      updated_at: "2026-05-21T10:00:00Z",
+    };
     let createBody: any = null;
     fetchMock.mockImplementation(
       defaultBackendMock({
         "/hecate/v1/projects": () =>
           jsonResponse({
             object: "projects",
-            data: [
-              {
-                id: "proj_1",
-                name: "Hecate",
-                roots: [],
-                created_at: "2026-05-21T10:00:00Z",
-                updated_at: "2026-05-21T10:00:00Z",
-              },
-            ],
+            data: [project],
           }),
         "/hecate/v1/chat/sessions": (init) => {
           if (init?.method === "POST") {
@@ -642,7 +672,7 @@ describe("useRuntimeConsole", () => {
       }),
     );
 
-    const { result } = renderRuntimeConsoleHook();
+    const { result } = renderRuntimeConsoleHook({ projects: [project] });
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -653,6 +683,7 @@ describe("useRuntimeConsole", () => {
       agent_id: "hecate",
       model: "gpt-4o-mini",
       project_id: "proj_1",
+      workspace: "/tmp/hecate-project",
     });
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
@@ -660,10 +691,31 @@ describe("useRuntimeConsole", () => {
   it("honors an explicit project scope when creating a Hecate chat", async () => {
     window.localStorage.setItem("hecate.chatTarget", "model");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [
+        {
+          id: "root_1",
+          path: "/tmp/hecate",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-21T10:00:00Z",
+          updated_at: "2026-05-21T10:00:00Z",
+        },
+      ],
+      default_root_id: "root_1",
+      created_at: "2026-05-21T10:00:00Z",
+      updated_at: "2026-05-21T10:00:00Z",
+    };
     let createBody: any = null;
     fetchMock.mockImplementation(
       defaultBackendMock({
+        "/hecate/v1/projects": () =>
+          jsonResponse({
+            object: "projects",
+            data: [project],
+          }),
         "/hecate/v1/chat/sessions": (init) => {
           if (init?.method === "POST") {
             createBody = JSON.parse(String(init.body ?? "{}"));
@@ -686,7 +738,7 @@ describe("useRuntimeConsole", () => {
       }),
     );
 
-    const { result } = renderRuntimeConsoleHook();
+    const { result } = renderRuntimeConsoleHook({ projects: [project] });
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -705,10 +757,31 @@ describe("useRuntimeConsole", () => {
   it("honors an explicit project scope when creating an external-agent chat", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-project");
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [
+        {
+          id: "root_1",
+          path: "/tmp/hecate-project",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-21T10:00:00Z",
+          updated_at: "2026-05-21T10:00:00Z",
+        },
+      ],
+      default_root_id: "root_1",
+      created_at: "2026-05-21T10:00:00Z",
+      updated_at: "2026-05-21T10:00:00Z",
+    };
     let createBody: any = null;
     fetchMock.mockImplementation(
       defaultBackendMock({
+        "/hecate/v1/projects": () =>
+          jsonResponse({
+            object: "projects",
+            data: [project],
+          }),
         "/hecate/v1/agent-adapters": () =>
           jsonResponse({
             object: "agent_adapters",
@@ -736,7 +809,7 @@ describe("useRuntimeConsole", () => {
       }),
     );
 
-    const { result } = renderRuntimeConsoleHook();
+    const { result } = renderRuntimeConsoleHook({ projects: [project] });
     await waitFor(() => expect(result.current.state.loading).toBe(false));
 
     await act(async () => {
@@ -791,7 +864,6 @@ describe("useRuntimeConsole", () => {
 
   it("creates a Hecate chat shell when no model is selected", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
     window.localStorage.removeItem("hecate.model");
     let createBody: any = null;
     fetchMock.mockImplementation(
@@ -820,6 +892,9 @@ describe("useRuntimeConsole", () => {
 
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/tmp/hecate");
+    });
 
     await act(async () => {
       await result.current.actions.createChatSession();
@@ -839,7 +914,6 @@ describe("useRuntimeConsole", () => {
 
   it("drops a stale selected model when creating a new Hecate chat shell", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
     window.localStorage.setItem("hecate.model", "missing-model");
     let createBody: any = null;
     fetchMock.mockImplementation(
@@ -869,6 +943,9 @@ describe("useRuntimeConsole", () => {
 
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/tmp/hecate");
+    });
 
     await act(async () => {
       await result.current.actions.createChatSession();
@@ -1086,7 +1163,6 @@ describe("useRuntimeConsole", () => {
   it("does not create or select a chat when eager external-agent prepare fails", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");
-    window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate-project");
     fetchMock.mockImplementation(
       defaultBackendMock({
         "/hecate/v1/agent-adapters": () =>
@@ -1113,6 +1189,9 @@ describe("useRuntimeConsole", () => {
 
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
+    await act(async () => {
+      result.current.actions.setAgentWorkspace("/tmp/hecate-project");
+    });
 
     await act(async () => {
       await result.current.actions.createChatSession();


### PR DESCRIPTION
## Summary

- Stop restoring stale chat workspace state from localStorage so `No project` does not silently inherit an old workspace.
- Resolve new-chat workspace from the selected project's default/active root before falling back to manual workspace state.
- Keep external-agent and Hecate task chat creation disabled when the selected project has no usable workspace, while still allowing direct model chats without a workspace.
- Add project workspace helper coverage plus UI/coordinator regressions for project-scoped Hecate and external-agent chat creation.

## Tests

- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `git diff --check`
