### PR TITLE
feat(security): add optional inference token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ HECATE_ALLOW_NON_LOOPBACK_BIND=0
 # operator UI reads `hecate.runtimeToken` from sessionStorage/localStorage when
 # you enable this.
 # HECATE_RUNTIME_TOKEN=
+# Optional shared token for provider-compatible inference ingress:
+# GET /v1/models, POST /v1/chat/completions, and POST /v1/messages. Clients
+# may send it as `Authorization: Bearer ...` or `x-api-key: ...`. It does not
+# protect `/hecate/v1/*`, `/healthz`, or OTLP `/v1/traces|metrics|logs`.
+# The operator UI reads `hecate.inferenceToken` from sessionStorage/localStorage
+# when you enable this.
+# HECATE_INFERENCE_TOKEN=
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper
 # processes such as `hecate-acp`. Leave empty for normal local dev; the gateway

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,13 @@ The [Quick Start](../README.md#quick-start) covers `docker run` end-to-end. This
 
 Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests, but same-origin is not a network security boundary. If you change `HECATE_ADDRESS` to expose Hecate beyond the local machine, startup now requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`; set it only with your own access controls, firewall, or reverse proxy in front. The current security model is documented in [Security](security.md).
 
+For exposed provider-compatible inference (`/v1/models`, `/v1/chat/completions`,
+and `/v1/messages`), `HECATE_INFERENCE_TOKEN` adds an optional shared-token
+gate. Clients can send the token with the `Authorization: Bearer ...` header or
+the `x-api-key` header. It is a local deployment guard, not user management;
+keep using a reverse proxy, firewall, VPN, or equivalent control for anything
+reachable beyond your own machine.
+
 ## Contents
 
 - [Image pinning](#image-pinning)

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -23,10 +23,11 @@ local trace lookup for the operator UI is `GET /hecate/v1/traces`.
 
 Set `HECATE_RUNTIME_TOKEN` to require Hecate-aware clients to send
 `X-Hecate-Runtime-Token` on `/hecate/v1/*`. This protects the Hecate-native
-control plane only. It does not apply to provider-compatible `/v1/*` paths or
-`/healthz`. The operator UI sends the header when `hecate.runtimeToken` is
-present in `sessionStorage` or `localStorage`; the MCP server reads the same
-value from its `HECATE_RUNTIME_TOKEN` environment.
+control plane, including Hecate-native chat and task routes that can spend
+configured provider credentials. It does not apply to provider-compatible
+`/v1/*` paths or `/healthz`. The operator UI sends the header when
+`hecate.runtimeToken` is present in `sessionStorage` or `localStorage`; the MCP
+server reads the same value from its `HECATE_RUNTIME_TOKEN` environment.
 
 Set `HECATE_INFERENCE_TOKEN` to require a shared token on the
 provider-compatible inference routes: `GET /v1/models`,

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -24,11 +24,19 @@ local trace lookup for the operator UI is `GET /hecate/v1/traces`.
 Set `HECATE_RUNTIME_TOKEN` to require Hecate-aware clients to send
 `X-Hecate-Runtime-Token` on `/hecate/v1/*`. This protects the Hecate-native
 control plane only. It does not apply to provider-compatible `/v1/*` paths or
-`/healthz`, so OpenAI/Anthropic-shaped inference clients keep their existing
-auth shape and are not authenticated by this token. The operator UI sends the
-header when `hecate.runtimeToken` is present in `sessionStorage` or
-`localStorage`; the MCP server reads the same value from its
-`HECATE_RUNTIME_TOKEN` environment.
+`/healthz`. The operator UI sends the header when `hecate.runtimeToken` is
+present in `sessionStorage` or `localStorage`; the MCP server reads the same
+value from its `HECATE_RUNTIME_TOKEN` environment.
+
+Set `HECATE_INFERENCE_TOKEN` to require a shared token on the
+provider-compatible inference routes: `GET /v1/models`,
+`POST /v1/chat/completions`, and `POST /v1/messages`. Clients may send it as
+either `Authorization: Bearer <token>` or `x-api-key: <token>`, so standard
+OpenAI- and Anthropic-shaped SDK configuration continues to work. This token
+does not wrap `/hecate/v1/*`, `/healthz`, static UI assets, or OTLP collector
+paths such as `/v1/traces`, `/v1/metrics`, and `/v1/logs`. The operator UI
+sends it to local provider-compatible paths when `hecate.inferenceToken` is
+present in `sessionStorage` or `localStorage`.
 
 Legacy Hecate-native `/v1/*` and `/admin/*` paths are intentionally not kept as
 compatibility shims in this alpha branch. Unknown API-shaped paths return 404

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
 
 - The gateway binds to `127.0.0.1:8765` by default.
 - Browser requests are same-origin checked: by default, an `Origin` header must match the gateway host. Custom browser frontends must be listed in `HECATE_ALLOWED_ORIGINS`.
-- `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This protects the Hecate control plane, not provider-compatible inference: it is an opt-in local guard for Hecate-aware clients, not multi-user authentication, and it does not wrap `/v1/*` endpoints.
+- `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This protects the Hecate control plane, including Hecate-native chat and task routes that can spend configured provider credentials. It is an opt-in local guard for Hecate-aware clients, not multi-user authentication, and it does not wrap `/v1/*` endpoints.
 - `HECATE_INFERENCE_TOKEN` can require `Authorization: Bearer <token>` or `x-api-key: <token>` on the provider-compatible inference routes: `GET /v1/models`, `POST /v1/chat/completions`, and `POST /v1/messages`. It does not protect Hecate-native `/hecate/v1/*`, `/healthz`, static UI assets, or OTLP `/v1/traces`, `/v1/metrics`, and `/v1/logs`.
 - Hecate is not designed to be exposed directly on a network.
 - If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
@@ -61,7 +61,7 @@ Hecate stores local configuration and operational state on disk.
 - Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
 - External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own, proxy, or pool those accounts. See [External agent adapters](external-agent-adapters.md#credential-and-account-boundaries) for credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok Build.
 - Stdio MCP servers inherit only runtime-essential environment variables from the gateway. Server credentials must be configured explicitly on that MCP server entry.
-- If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach an unprotected provider-compatible `/v1/*` inference route may be able to spend those credentials. Use your own network access control, and set `HECATE_INFERENCE_TOKEN` when SDK clients can supply a shared token.
+- If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach an unprotected inference path may be able to spend those credentials. Use your own network access control; set `HECATE_INFERENCE_TOKEN` for provider-compatible `/v1/*` clients and `HECATE_RUNTIME_TOKEN` for Hecate-native chat, task, and control-plane clients.
 
 ### Bootstrap key today
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
 - The gateway binds to `127.0.0.1:8765` by default.
 - Browser requests are same-origin checked: by default, an `Origin` header must match the gateway host. Custom browser frontends must be listed in `HECATE_ALLOWED_ORIGINS`.
 - `HECATE_RUNTIME_TOKEN` can require `X-Hecate-Runtime-Token` on Hecate-native `/hecate/v1/*` APIs. This protects the Hecate control plane, not provider-compatible inference: it is an opt-in local guard for Hecate-aware clients, not multi-user authentication, and it does not wrap `/v1/*` endpoints.
+- `HECATE_INFERENCE_TOKEN` can require `Authorization: Bearer <token>` or `x-api-key: <token>` on the provider-compatible inference routes: `GET /v1/models`, `POST /v1/chat/completions`, and `POST /v1/messages`. It does not protect Hecate-native `/hecate/v1/*`, `/healthz`, static UI assets, or OTLP `/v1/traces`, `/v1/metrics`, and `/v1/logs`.
 - Hecate is not designed to be exposed directly on a network.
 - If you bind Hecate to anything other than loopback, startup requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`. Set it only when you have your own firewall, reverse proxy, or access-control layer in front.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.
@@ -60,7 +61,7 @@ Hecate stores local configuration and operational state on disk.
 - Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
 - External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own, proxy, or pool those accounts. See [External agent adapters](external-agent-adapters.md#credential-and-account-boundaries) for credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok Build.
 - Stdio MCP servers inherit only runtime-essential environment variables from the gateway. Server credentials must be configured explicitly on that MCP server entry.
-- If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach the gateway may be able to spend those credentials.
+- If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach an unprotected provider-compatible `/v1/*` inference route may be able to spend those credentials. Use your own network access control, and set `HECATE_INFERENCE_TOKEN` when SDK clients can supply a shared token.
 
 ### Bootstrap key today
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -175,16 +175,79 @@ func RuntimeTokenMiddleware(token string) middleware {
 	}
 }
 
+func InferenceTokenMiddleware(token string) middleware {
+	token = strings.TrimSpace(token)
+	return func(next http.Handler) http.Handler {
+		if token == "" {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isProviderInferenceRoute(r.Method, r.URL.Path) || inferenceTokenMatches(r, token) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			writeInferenceTokenError(w, r)
+		})
+	}
+}
+
 func isHecateAPIPath(path string) bool {
 	return path == "/hecate/v1" || strings.HasPrefix(path, "/hecate/v1/")
 }
 
 func runtimeTokenMatches(got, want string) bool {
+	return tokenMatches(got, want)
+}
+
+func tokenMatches(got, want string) bool {
 	got = strings.TrimSpace(got)
 	if got == "" || len(got) != len(want) {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func inferenceTokenMatches(r *http.Request, want string) bool {
+	if tokenMatches(bearerToken(r.Header.Get("Authorization")), want) {
+		return true
+	}
+	return tokenMatches(r.Header.Get("x-api-key"), want)
+}
+
+func bearerToken(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < len("Bearer ") || !strings.EqualFold(value[:len("Bearer")], "Bearer") {
+		return ""
+	}
+	if value[len("Bearer")] != ' ' && value[len("Bearer")] != '\t' {
+		return ""
+	}
+	return strings.TrimSpace(value[len("Bearer"):])
+}
+
+func isProviderInferenceRoute(method, path string) bool {
+	switch method + " " + path {
+	case http.MethodGet + " /v1/models",
+		http.MethodPost + " /v1/chat/completions",
+		http.MethodPost + " /v1/messages":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeInferenceTokenError(w http.ResponseWriter, r *http.Request) {
+	classified := gatewayHTTPError{
+		Status:        http.StatusUnauthorized,
+		OpenAIType:    errCodeUnauthorized,
+		AnthropicType: "authentication_error",
+		Message:       "inference token is required",
+	}
+	if r.URL.Path == "/v1/messages" {
+		writeAnthropicGatewayError(w, classified, ErrorDetails{})
+		return
+	}
+	writeOpenAIGatewayError(w, classified, ErrorDetails{})
 }
 
 func sameOriginAllowed(r *http.Request, allowedOrigins map[string]struct{}) bool {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -339,6 +340,120 @@ func TestRuntimeTokenMiddleware(t *testing.T) {
 	}
 }
 
+func TestInferenceTokenMiddleware(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		token         string
+		authorization string
+		apiKey        string
+		want          int
+		wantBody      string
+	}{
+		{
+			name:   "disabled allows provider compatible route",
+			method: http.MethodPost,
+			path:   "/v1/chat/completions",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:     "requires token for chat completions",
+			method:   http.MethodPost,
+			path:     "/v1/chat/completions",
+			token:    "local-inference-token-123456",
+			want:     http.StatusUnauthorized,
+			wantBody: `"type":"unauthorized"`,
+		},
+		{
+			name:          "allows bearer token",
+			method:        http.MethodPost,
+			path:          "/v1/chat/completions",
+			token:         "local-inference-token-123456",
+			authorization: "Bearer local-inference-token-123456",
+			want:          http.StatusNoContent,
+		},
+		{
+			name:   "allows x api key token",
+			method: http.MethodPost,
+			path:   "/v1/messages",
+			token:  "local-inference-token-123456",
+			apiKey: "local-inference-token-123456",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:          "allows one matching header when both are present",
+			method:        http.MethodPost,
+			path:          "/v1/messages",
+			token:         "local-inference-token-123456",
+			authorization: "Bearer wrong-token",
+			apiKey:        "local-inference-token-123456",
+			want:          http.StatusNoContent,
+		},
+		{
+			name:     "messages use anthropic error envelope",
+			method:   http.MethodPost,
+			path:     "/v1/messages",
+			token:    "local-inference-token-123456",
+			want:     http.StatusUnauthorized,
+			wantBody: `"type":"error"`,
+		},
+		{
+			name:   "leaves healthz alone",
+			method: http.MethodGet,
+			path:   "/healthz",
+			token:  "local-inference-token-123456",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:   "leaves hecate native api alone",
+			method: http.MethodGet,
+			path:   "/hecate/v1/whoami",
+			token:  "local-inference-token-123456",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:   "leaves otlp traces alone",
+			method: http.MethodPost,
+			path:   "/v1/traces",
+			token:  "local-inference-token-123456",
+			want:   http.StatusNoContent,
+		},
+		{
+			name:   "does not gate wrong method on models",
+			method: http.MethodPost,
+			path:   "/v1/models",
+			token:  "local-inference-token-123456",
+			want:   http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := InferenceTokenMiddleware(tt.token)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if tt.authorization != "" {
+				req.Header.Set("Authorization", tt.authorization)
+			}
+			if tt.apiKey != "" {
+				req.Header.Set("x-api-key", tt.apiKey)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, tt.want, rec.Body.String())
+			}
+			if tt.wantBody != "" && !strings.Contains(rec.Body.String(), tt.wantBody) {
+				t.Fatalf("body = %s, want substring %s", rec.Body.String(), tt.wantBody)
+			}
+		})
+	}
+}
+
 func TestNewServerWiresRuntimeTokenMiddleware(t *testing.T) {
 	token := "local-runtime-token-123456"
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -359,5 +474,20 @@ func TestNewServerWiresRuntimeTokenMiddleware(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status with token = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestNewServerWiresInferenceTokenMiddleware(t *testing.T) {
+	token := "local-inference-token-123456"
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{
+		Server: config.ServerConfig{InferenceToken: token},
+	}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,7 @@ func NewServer(logger *slog.Logger, handler *Handler) http.Handler {
 		OTelHTTPSpanMiddleware,
 		SameOriginMiddlewareWithAllowedOrigins(handler.config.Server.AllowedOrigins),
 		RuntimeTokenMiddleware(handler.config.Server.RuntimeToken),
+		InferenceTokenMiddleware(handler.config.Server.InferenceToken),
 		LoggingMiddleware(logger),
 		RecoveryMiddleware(logger),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type ServerConfig struct {
 	AllowNonLoopbackBind       bool
 	AllowedOrigins             []string
 	RuntimeToken               string
+	InferenceToken             string
 	PublicURL                  string
 	DataDir                    string
 	BootstrapFile              string
@@ -353,6 +354,7 @@ func LoadFromEnv() Config {
 			AllowNonLoopbackBind: getEnvBool("HECATE_ALLOW_NON_LOOPBACK_BIND", false),
 			AllowedOrigins:       splitCSV(getEnv("HECATE_ALLOWED_ORIGINS", "")),
 			RuntimeToken:         getEnv("HECATE_RUNTIME_TOKEN", ""),
+			InferenceToken:       getEnv("HECATE_INFERENCE_TOKEN", ""),
 			// PublicURL is written to hecate.runtime.json for local
 			// diagnostics. Empty means derive from Address.
 			PublicURL: getEnv("HECATE_PUBLIC_URL", ""),
@@ -503,6 +505,9 @@ func (c Config) Validate() error {
 	}
 	if token := strings.TrimSpace(c.Server.RuntimeToken); token != "" && len(token) < 24 {
 		errs = append(errs, errors.New("HECATE_RUNTIME_TOKEN must be at least 24 characters when set"))
+	}
+	if token := strings.TrimSpace(c.Server.InferenceToken); token != "" && len(token) < 24 {
+		errs = append(errs, errors.New("HECATE_INFERENCE_TOKEN must be at least 24 characters when set"))
 	}
 
 	validPolicies := map[string]struct{}{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,15 @@ func TestLoadFromEnvRuntimeToken(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvInferenceToken(t *testing.T) {
+	t.Setenv("HECATE_INFERENCE_TOKEN", "local-inference-token-123456")
+
+	cfg := LoadFromEnv()
+	if cfg.Server.InferenceToken != "local-inference-token-123456" {
+		t.Fatalf("InferenceToken = %q, want configured token", cfg.Server.InferenceToken)
+	}
+}
+
 func TestListenAddressIsLoopback(t *testing.T) {
 	t.Parallel()
 
@@ -325,6 +334,19 @@ func TestValidateRejectsShortRuntimeToken(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_RUNTIME_TOKEN") {
 		t.Fatalf("Validate() error = %q, want HECATE_RUNTIME_TOKEN", err)
+	}
+}
+
+func TestValidateRejectsShortInferenceToken(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Server.InferenceToken = "short"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid inference token error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_INFERENCE_TOKEN") {
+		t.Fatalf("Validate() error = %q, want HECATE_INFERENCE_TOKEN", err)
 	}
 }
 

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -373,7 +373,7 @@ describe("api client", () => {
       expect(options.method).toBe("GET");
     });
 
-    it("never sends an Authorization header (single-user mode is unauthenticated)", () => {
+    it("does not send Authorization by default", () => {
       const options = buildRequestOptions({ method: "POST", body: { x: 1 } });
       const headers = new Headers(options.headers);
       expect(headers.get("Authorization")).toBeNull();
@@ -407,6 +407,48 @@ describe("api client", () => {
       const headers = new Headers(options.headers);
 
       expect(headers.get("X-Hecate-Runtime-Token")).toBeNull();
+    });
+
+    it("sends the optional inference token to local provider-compatible paths", () => {
+      window.sessionStorage.setItem("hecate.inferenceToken", "local-inference-token-123456");
+
+      const options = buildRequestOptions(
+        { method: "POST", body: { messages: [] } },
+        "/v1/chat/completions",
+      );
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("Authorization")).toBe("Bearer local-inference-token-123456");
+    });
+
+    it("sends the optional inference token to local models lookup", () => {
+      window.localStorage.setItem("hecate.inferenceToken", "local-inference-token-abcdef");
+
+      const options = buildRequestOptions({ method: "GET" }, "/v1/models?refresh=1");
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("Authorization")).toBe("Bearer local-inference-token-abcdef");
+    });
+
+    it("does not send the optional inference token to hecate native paths", () => {
+      window.sessionStorage.setItem("hecate.inferenceToken", "local-inference-token-123456");
+
+      const options = buildRequestOptions({ method: "GET" }, "/hecate/v1/whoami");
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("Authorization")).toBeNull();
+    });
+
+    it("does not send the optional inference token to external origins", () => {
+      window.sessionStorage.setItem("hecate.inferenceToken", "local-inference-token-123456");
+
+      const options = buildRequestOptions(
+        { method: "POST", body: { messages: [] } },
+        "https://api.openai.com/v1/chat/completions",
+      );
+      const headers = new Headers(options.headers);
+
+      expect(headers.get("Authorization")).toBeNull();
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -75,6 +75,7 @@ type ErrorPayload = {
 const HECATE_API = "/hecate/v1";
 const HECATE_RUNTIME_TOKEN_HEADER = "X-Hecate-Runtime-Token";
 const HECATE_RUNTIME_TOKEN_STORAGE_KEY = "hecate.runtimeToken";
+const HECATE_INFERENCE_TOKEN_STORAGE_KEY = "hecate.inferenceToken";
 
 // PersistedContentBlock mirrors internal/api.OpenAIPersistedContentBlock.
 // Used on history-replay paths so Anthropic thinking / redacted_thinking /
@@ -1076,6 +1077,10 @@ export function buildRequestOptions(options: RequestOptions, url = ""): RequestI
   if (runtimeToken && isHecateNativeURL(url)) {
     headers.set(HECATE_RUNTIME_TOKEN_HEADER, runtimeToken);
   }
+  const inferenceToken = readInferenceToken();
+  if (inferenceToken && isLocalProviderInferenceURL(url)) {
+    headers.set("Authorization", `Bearer ${inferenceToken}`);
+  }
 
   return {
     method: options.method ?? "GET",
@@ -1088,12 +1093,40 @@ function isHecateNativeURL(url: string): boolean {
   return url === HECATE_API || url.startsWith(`${HECATE_API}/`);
 }
 
+function isLocalProviderInferenceURL(url: string): boolean {
+  const path = localURLPath(url);
+  if (!path) return false;
+  return path === "/v1/models" || path === "/v1/chat/completions" || path === "/v1/messages";
+}
+
+function localURLPath(url: string): string {
+  if (!url) return "";
+  try {
+    const base = typeof window === "undefined" ? "http://localhost" : window.location.origin;
+    const parsed = new URL(url, base);
+    if (typeof window !== "undefined" && parsed.origin !== window.location.origin) {
+      return "";
+    }
+    return parsed.pathname;
+  } catch {
+    return "";
+  }
+}
+
 function readRuntimeToken(): string {
+  return readStoredToken(HECATE_RUNTIME_TOKEN_STORAGE_KEY);
+}
+
+function readInferenceToken(): string {
+  return readStoredToken(HECATE_INFERENCE_TOKEN_STORAGE_KEY);
+}
+
+function readStoredToken(storageKey: string): string {
   if (typeof window === "undefined") return "";
   try {
     return (
-      window.sessionStorage.getItem(HECATE_RUNTIME_TOKEN_STORAGE_KEY)?.trim() ||
-      window.localStorage.getItem(HECATE_RUNTIME_TOKEN_STORAGE_KEY)?.trim() ||
+      window.sessionStorage.getItem(storageKey)?.trim() ||
+      window.localStorage.getItem(storageKey)?.trim() ||
       ""
     );
   } catch {


### PR DESCRIPTION
## Summary

Adds an opt-in shared token for provider-compatible inference ingress.

- introduces `HECATE_INFERENCE_TOKEN` with startup validation when set
- gates only `GET /v1/models`, `POST /v1/chat/completions`, and `POST /v1/messages`
- accepts both `Authorization: Bearer <token>` and `x-api-key: <token>` for SDK compatibility
- leaves `/hecate/v1/*`, `/healthz`, static UI assets, and OTLP `/v1/traces|metrics|logs` outside this token boundary
- lets the operator UI send the token from `hecate.inferenceToken` storage only to local provider-compatible inference paths
- documents the runtime/inference token split in env, runtime API, security, and deployment docs

## Verification

- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/config`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/lib/api.test.ts`
- `cd ui && bun run test`
- `./ui/node_modules/.bin/oxfmt --check .env.example docs/runtime-api.md docs/security.md docs/deployment.md`
- `cd ui && bun run format:check src/lib/api.ts src/lib/api.test.ts`
- `git diff --check`