### PR TITLE
feat(providers): add Fireworks AI as a built-in cloud preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,7 @@ HECATE_CONTROL_PLANE_SECRET_KEY=
 # For client integration recipes (Codex / Claude Code), see docs/client-integration.md.
 #
 # Built-in preset names:
-#   anthropic, deepseek, gemini, groq, llamacpp, lmstudio, localai, mistral, ollama, openai, perplexity, together_ai, xai
+#   anthropic, deepseek, fireworks, gemini, groq, llamacpp, lmstudio, localai, mistral, ollama, openai, perplexity, together_ai, xai
 #
 # Runtime support today:
 #   - OpenAI-compatible chat + /v1/models discovery
@@ -88,6 +88,8 @@ HECATE_CONTROL_PLANE_SECRET_KEY=
 PROVIDER_ANTHROPIC_API_KEY=
 
 PROVIDER_DEEPSEEK_API_KEY=
+
+PROVIDER_FIREWORKS_API_KEY=
 
 PROVIDER_GEMINI_API_KEY=
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -79,7 +79,7 @@ Each row has a trash button. Clicking it confirms via a browser dialog and then 
 
 ## Built-in presets
 
-The gateway ships with thirteen provider presets. None of them are auto-added — operators pick from the catalog when adding a provider.
+The gateway ships with fourteen provider presets. None of them are auto-added — operators pick from the catalog when adding a provider.
 
 ### Cloud presets
 
@@ -87,6 +87,7 @@ The gateway ships with thirteen provider presets. None of them are auto-added �
 | ------------- | ------------- | --------------------------------------------------------- |
 | `anthropic`   | Anthropic     | `https://api.anthropic.com/v1`                            |
 | `deepseek`    | DeepSeek      | `https://api.deepseek.com/v1`                             |
+| `fireworks`   | Fireworks AI  | `https://api.fireworks.ai/inference/v1`                   |
 | `gemini`      | Google Gemini | `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `groq`        | Groq          | `https://api.groq.com/openai/v1`                          |
 | `mistral`     | Mistral       | `https://api.mistral.ai/v1`                               |

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -60,6 +60,22 @@ var builtInProviders = []BuiltInProvider{
 		Models:       []string{"deepseek-chat", "deepseek-reasoner"},
 	},
 	{
+		ID:           "fireworks",
+		Name:         "Fireworks AI",
+		Kind:         "cloud",
+		Protocol:     "openai",
+		BaseURL:      "https://api.fireworks.ai/inference/v1",
+		APIKeyEnv:    "PROVIDER_FIREWORKS_API_KEY",
+		DocsURL:      "https://docs.fireworks.ai/getting-started/introduction",
+		Description:  "OpenAI-compatible preset for Fireworks.ai serverless inference (Kimi, Llama, Qwen, DeepSeek, gpt-oss, and other open-weight models). Hecate discovers available models from /v1/models; model IDs are namespaced like `accounts/fireworks/models/<slug>`.",
+		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
+		// No seed list. The Fireworks catalog changes weekly and slugs
+		// are long; pre-populating creates stale-content debt. /v1/models
+		// discovery covers the surface; operators can also browse
+		// https://fireworks.ai/models for the canonical name.
+		Models: nil,
+	},
+	{
 		ID:           "gemini",
 		Name:         "Google Gemini",
 		Kind:         "cloud",

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -281,6 +281,14 @@ export const MOCK_FULL_PRESETS = [
     description: "Google Gemini.",
   },
   {
+    id: "fireworks",
+    name: "Fireworks AI",
+    kind: "cloud",
+    protocol: "openai",
+    base_url: "https://api.fireworks.ai/inference/v1",
+    description: "Fireworks AI serverless inference.",
+  },
+  {
     id: "groq",
     name: "Groq",
     kind: "cloud",


### PR DESCRIPTION
## Summary

Adds [Fireworks AI](https://fireworks.ai) as a first-class cloud preset alongside Groq, Together AI, DeepSeek, etc. Operators can already wire Fireworks up as a custom OpenAI-compatible provider today; this lifts it into the AddProviderModal preset picker so it's one click instead of a manual base-URL paste.

Concretely unblocks running Kimi K2, gpt-oss-120b, Qwen3, DeepSeek V3, and the rest of the open-weight catalog Fireworks hosts.

## Preset shape

\`\`\`go
{
    ID:           "fireworks",
    Name:         "Fireworks AI",
    Kind:         "cloud",
    Protocol:     "openai",
    BaseURL:      "https://api.fireworks.ai/inference/v1",
    APIKeyEnv:    "PROVIDER_FIREWORKS_API_KEY",
    DocsURL:      "https://docs.fireworks.ai/getting-started/introduction",
    ...
    Models: nil,  // discovery-only; see note below
}
\`\`\`

**No seed model list.** The Fireworks catalog churns weekly and slugs are long (\`accounts/fireworks/models/<slug>\`) — pre-populating creates stale-content debt and gives operators a fixed list that lies the moment Fireworks ships a new model. \`/v1/models\` discovery covers the surface as soon as the API key is configured; operators can also browse <https://fireworks.ai/models> for canonical names.

This makes Fireworks the second cloud preset that intentionally ships without seed models (alongside the local presets, where the seed list is also empty for the same reason: dynamic catalog).

## Files

Mirrored to every spot that pins the preset list:

- \`internal/config/provider_catalog.go\` — the source of truth.
- \`.env.example\` — \`PROVIDER_FIREWORKS_API_KEY=\` line + bumped the comment listing built-in preset names.
- \`docs/providers.md\` — cloud-presets table row + bumped count \"thirteen\" → \"fourteen\".
- \`ui/e2e/fixtures.ts\` — \`MOCK_FULL_PRESETS\` so e2e tests keep matching reality.

## Test plan

- [x] \`go test ./internal/config/... ./internal/providers/... ./internal/api/...\` — pass.
- [x] \`bun run typecheck\` — clean.
- [x] \`go build ./cmd/hecate\` — succeeds.
- [x] \`gofmt -s -l\` + \`oxfmt --check\` — clean.
- [ ] Manual smoke: configure Fireworks via the new preset, confirm \`/v1/models\` discovery surfaces Kimi K2 et al., send one \`/v1/chat/completions\` against Kimi.