### PR TITLE
refactor(providers): drop static seed-list from BuiltInProvider

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,8 +323,11 @@ type OpenAICompatibleProviderConfig struct {
 	StubResponse string        `json:"stub_response"`
 	DefaultModel string        `json:"default_model"`
 	Enabled      bool          `json:"enabled"`
-	// KnownModels is the curated catalog from the built-in preset. It populates the
-	// static capabilities when no API key is set and live discovery is skipped.
+	// KnownModels is an operator-supplied static catalog override. Populated only
+	// via PROVIDER_<NAME>_MODELS env (comma-separated), it populates the static
+	// capabilities when no API key is set and live discovery is skipped. Empty
+	// by default — Hecate prefers live `/v1/models` discovery over hard-coded
+	// lists that bit-rot as upstream catalogs churn.
 	KnownModels []string `json:"known_models,omitempty"`
 	// AnthropicCacheDisabled opts the Anthropic adapter out of
 	// auto-attaching `cache_control: {"type":"ephemeral"}` markers on

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -21,12 +21,6 @@ type BuiltInProvider struct {
 	DocsURL      string
 	Description  string
 	StubResponse string
-	// Models is a curated list of well-known model IDs for the provider, used as
-	// the static catalog when API-driven discovery isn't possible (no API key, or
-	// the upstream is unreachable). When discovery succeeds, the live `/v1/models`
-	// response replaces this. Local providers leave this empty since their catalog
-	// is fully dynamic (depends on what the user has loaded).
-	Models []string
 }
 
 var builtInProviders = []BuiltInProvider{
@@ -41,11 +35,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://platform.claude.com/docs/en/about-claude/models/overview",
 		Description:  "Native Anthropic Messages API preset. This uses Hecate's Anthropic protocol path and discovers available models from /v1/models.",
 		StubResponse: "Stubbed Anthropic response.",
-		Models: []string{
-			"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6",
-			"claude-haiku-4-5", "claude-3-7-sonnet-latest", "claude-3-5-sonnet-latest",
-			"claude-3-5-haiku-latest",
-		},
 	},
 	{
 		ID:           "deepseek",
@@ -57,7 +46,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://api-docs.deepseek.com/",
 		Description:  "OpenAI-compatible preset for DeepSeek hosted APIs. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models:       []string{"deepseek-chat", "deepseek-reasoner"},
 	},
 	{
 		ID:           "gemini",
@@ -69,10 +57,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://ai.google.dev/gemini-api/docs/openai",
 		Description:  "OpenAI-compatible preset for Gemini through Google's compatibility layer. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
-			"gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-pro", "gemini-1.5-flash",
-		},
 	},
 	{
 		ID:           "groq",
@@ -84,12 +68,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://console.groq.com/docs/models",
 		Description:  "OpenAI-compatible preset for Groq's low-latency inference API. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"llama-3.3-70b-versatile", "llama-3.1-8b-instant", "llama-3.1-70b-versatile",
-			"openai/gpt-oss-120b", "openai/gpt-oss-20b",
-			"deepseek-r1-distill-llama-70b", "qwen/qwen3-32b",
-			"mixtral-8x7b-32768", "gemma2-9b-it",
-		},
 	},
 	{
 		ID:           "llamacpp",
@@ -131,11 +109,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://docs.mistral.ai/getting-started/models/models_overview/",
 		Description:  "OpenAI-compatible preset for Mistral hosted models. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"mistral-large-latest", "mistral-medium-latest", "mistral-small-latest",
-			"codestral-latest", "ministral-8b-latest", "ministral-3b-latest",
-			"pixtral-large-latest", "open-mistral-nemo",
-		},
 	},
 	{
 		ID:           "ollama",
@@ -157,12 +130,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://developers.openai.com/api/docs/models",
 		Description:  "Default cloud preset using the OpenAI-compatible Chat Completions API. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"gpt-4o", "gpt-4o-mini", "gpt-4o-2024-11-20",
-			"gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
-			"o1", "o1-mini", "o3", "o3-mini", "o4-mini",
-			"gpt-4-turbo", "gpt-3.5-turbo",
-		},
 	},
 	{
 		ID:           "perplexity",
@@ -176,9 +143,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://docs.perplexity.ai/docs/sonar/openai-compatibility",
 		Description:  "OpenAI-compatible preset for Perplexity Sonar models. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"sonar", "sonar-pro", "sonar-reasoning-pro", "sonar-deep-research",
-		},
 	},
 	{
 		ID:           "together_ai",
@@ -190,14 +154,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://docs.together.ai/docs/inference-models",
 		Description:  "OpenAI-compatible preset for Together AI hosted models. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
-			"meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-			"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-			"meta-llama/Llama-3.3-70B-Instruct-Turbo",
-			"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1",
-			"Qwen/Qwen2.5-72B-Instruct-Turbo", "mistralai/Mixtral-8x22B-Instruct-v0.1",
-		},
 	},
 	{
 		ID:           "xai",
@@ -209,10 +165,6 @@ var builtInProviders = []BuiltInProvider{
 		DocsURL:      "https://docs.x.ai/docs/models",
 		Description:  "OpenAI-compatible preset for xAI Grok models. Hecate discovers available models from /v1/models.",
 		StubResponse: "Stubbed response from the AI Agent Runtime MVP.",
-		Models: []string{
-			"grok-4", "grok-3", "grok-3-mini", "grok-2", "grok-2-vision",
-			"grok-beta", "grok-vision-beta",
-		},
 	},
 }
 
@@ -273,6 +225,5 @@ func (p BuiltInProvider) RuntimeConfig() OpenAICompatibleProviderConfig {
 		StubMode:     false,
 		StubResponse: p.StubResponse,
 		DefaultModel: p.DefaultModel,
-		KnownModels:  append([]string(nil), p.Models...),
 	}
 }

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -377,8 +377,11 @@ func (p *OpenAICompatibleProvider) Chat(ctx context.Context, req types.ChatReque
 }
 
 func (p *OpenAICompatibleProvider) staticCapabilities(source string) Capabilities {
-	// Prefer the curated KnownModels list (populated from the built-in preset)
-	// so users see the full catalog even when no API key is configured.
+	// KnownModels is an operator-supplied static override (only set via
+	// PROVIDER_<NAME>_MODELS env). When empty — the common case — the picker
+	// stays empty until /v1/models discovery succeeds; the runtime no longer
+	// ships hard-coded model lists per built-in preset because they bit-rot
+	// as upstream catalogs churn.
 	models := append([]string(nil), p.config.KnownModels...)
 	if p.config.DefaultModel != "" && !contains(models, p.config.DefaultModel) {
 		models = append(models, p.config.DefaultModel)

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -231,7 +231,6 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 			cfg.AnthropicCacheDisabled = m.anthropicCacheDisabled
 		}
 		if builtIn, ok := builtInForControlPlaneProvider(item); ok {
-			cfg.KnownModels = append([]string(nil), builtIn.Models...)
 			cfg.ChatPath = builtIn.ChatPath
 			cfg.ModelsPath = builtIn.ModelsPath
 		}


### PR DESCRIPTION
## Summary

Every cloud preset shipped a curated \`Models: []string{...}\` list that was copied into \`OpenAICompatibleProviderConfig.KnownModels\` at runtime and surfaced via \`staticCapabilities()\` as a fallback when no API key was set or live discovery was skipped.

The intent was a nice cold-start UX (\"see what models you'll get before you configure\"). In practice the lists bit-rot the moment upstream catalogs churn:

- Groq listed \`mixtral-8x7b-32768\` — **deprecated by Groq**.
- Anthropic listed \`claude-opus-4-7\` — **does not exist**.
- Together / Fireworks-class providers churn weekly; any seed list lies within days of shipping.

The runtime already prefers \`/v1/models\` discovery over the seed list, and the API surface (\`/hecate/v1/providers/presets\`) does **not** expose Models to clients — so removing the field has zero external contract impact. It just stops carrying around a maintenance burden whose only job was to look pretty before the operator finished onboarding.

## Diff

```
internal/config/config.go             |  7 +++--
internal/config/provider_catalog.go   | 49 -----------------------------------
internal/providers/openai.go          |  7 +++--
internal/providers/runtime_manager.go |  1 -
4 files changed, 10 insertions(+), 54 deletions(-)
```

## What changes

- **\`BuiltInProvider.Models\` field gone** — and all nine \`Models: []string{...}\` entries with it (anthropic, deepseek, gemini, groq, mistral, openai, perplexity, together_ai, xai). The four local presets and Fireworks already had no seed list — they now match the pattern.
- **\`RuntimeConfig()\` no longer copies** \`KnownModels\` from the catalog.
- **\`runtime_manager.go\` no longer mirrors** the catalog seed into per-runtime config.
- **\`KnownModels\` field stays on \`OpenAICompatibleProviderConfig\`** — \`PROVIDER_<NAME>_MODELS\` env still populates it as an operator escape hatch (useful for air-gapped deployments where discovery is unavailable).
- **\`staticCapabilities\` comment updated** in \`openai.go\` to reflect the new world.

## User-visible impact on cold start

| Operator state | Before | After |
|---|---|---|
| Added cloud preset, no API key | Picker shows curated list (often lying about deprecated/missing models) | Picker empty until they paste the key |
| Added cloud preset + valid API key | Discovery runs, real catalog populates | **Unchanged** |
| Set \`PROVIDER_OPENAI_MODELS=gpt-4o,gpt-4.1\` env | Override wins | **Unchanged** |

## Verification

- \`go build ./...\` — succeeds.
- \`go test ./internal/config/... ./internal/providers/... ./internal/api/...\` — pass.
- \`go test -race ./...\` — all packages pass.

## Test plan

- [ ] CI green (\`test.yml\` runs the full Go matrix).
- [ ] Smoke: add OpenAI preset without API key → confirm empty picker (the new behavior).
- [ ] Smoke: add OpenAI preset with API key → confirm discovery populates real models.
- [ ] Smoke: set \`PROVIDER_OPENAI_MODELS=test-1,test-2\` → confirm override still works.