### PR TITLE
refactor(chat): pull tools-on/off into a dedicated chat-slice field

### DIFF
--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -161,3 +161,43 @@ export function parseChatTargetsBySessionID(parsed: unknown): Map<string, Hecate
 export function serializeChatTargetsBySessionID(targets: Map<string, HecateChatTarget>): string {
   return JSON.stringify(Object.fromEntries(targets));
 }
+
+// Storage key for the user-default tools-enabled preference. Persisted
+// separately from the per-session override below so a user's "tools on
+// by default for new chats" intent survives across browser restarts
+// without bleeding into individual session overrides.
+export const chatToolsEnabledStorageKey = "hecate.chatToolsEnabled";
+
+// Storage key for the per-session tools-enabled map. Each entry pins a
+// session to an explicit tools-on/off override; a missing key falls back
+// to the default. Stored as JSON `{sessionID: boolean}`; rebuilt into a
+// Map so consumers use Map semantics (.get / .set / iteration order),
+// matching the existing `chatTargetBySessionID` pattern.
+export const chatToolsEnabledBySessionIDStorageKey = "hecate.chatToolsEnabledBySessionID";
+
+// Strict guard for the user-default tools-enabled localStorage key.
+// usePersistedState's contract is "loud failure replaces silent
+// shape-drift fallback" — return null so a corrupt key gets wiped and
+// the hook falls back to the explicit `true` default.
+export function parseStoredChatToolsEnabled(raw: string): boolean | null {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return null;
+}
+
+// Structural guard for the per-session chat-tools-enabled map. Drops
+// non-boolean entries instead of failing the whole payload so one
+// corrupt key doesn't wipe a user's well-formed sibling overrides.
+// Returns null only if the top-level shape is wrong (not an object) —
+// usePersistedState then wipes the key, matching the contract.
+export function parseChatToolsEnabledBySessionID(parsed: unknown): Map<string, boolean> | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const entries = Object.entries(parsed as Record<string, unknown>).filter(
+    (entry): entry is [string, boolean] => Boolean(entry[0]) && typeof entry[1] === "boolean",
+  );
+  return new Map(entries);
+}
+
+export function serializeChatToolsEnabledBySessionID(toolsEnabled: Map<string, boolean>): string {
+  return JSON.stringify(Object.fromEntries(toolsEnabled));
+}

--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -48,11 +48,16 @@ import {
   type ChatTarget,
   type HecateChatTarget,
   type QueuedChatMessage,
+  chatToolsEnabledBySessionIDStorageKey,
+  chatToolsEnabledStorageKey,
   parseChatTargetsBySessionID,
+  parseChatToolsEnabledBySessionID,
   parseQueuedChatMessageList,
   parseStoredChatTarget,
+  parseStoredChatToolsEnabled,
   queuedChatMessagesStorageKey,
   serializeChatTargetsBySessionID,
+  serializeChatToolsEnabledBySessionID,
 } from "./_shared";
 import { humanizeChatError } from "../runtimeConsoleChatHelpers";
 
@@ -66,6 +71,20 @@ export type PendingToolCall = {
 export type ChatState = {
   defaultChatTarget: ChatTarget;
   chatTargetBySessionID: Map<string, HecateChatTarget>;
+  // User-default tools-enabled preference for new Hecate chats. The
+  // per-session map below overrides this when a session has its own
+  // pinned tools state; the default applies when neither the session
+  // map nor a derived signal exists. Persisted under
+  // `hecate.chatToolsEnabled`.
+  defaultChatToolsEnabled: boolean;
+  // Per-session tools-enabled override. Mirrors `chatTargetBySessionID`
+  // shape; a missing entry falls back to `defaultChatToolsEnabled`.
+  // Populated by the user toggling the tools pill in ChatSettingsPanel.
+  // Migrated automatically on slice mount from any legacy
+  // `chatTargetBySessionID` entry set to "model" (those map to
+  // tools-off in the new model). Persisted under
+  // `hecate.chatToolsEnabledBySessionID`.
+  chatToolsEnabledBySessionID: Map<string, boolean>;
   agentAdapterID: string;
   agentConfigOptions: ChatConfigOptionRecord[];
   agentWorkspace: string;
@@ -98,6 +117,8 @@ type Setter<T> = (next: SetStateAction<T>) => void;
 export type ChatActions = {
   setDefaultChatTarget: Setter<ChatTarget>;
   setChatTargetBySessionID: Setter<Map<string, HecateChatTarget>>;
+  setDefaultChatToolsEnabled: Setter<boolean>;
+  setChatToolsEnabledBySessionID: Setter<Map<string, boolean>>;
   setAgentAdapterID: Setter<string>;
   setAgentConfigOptions: Setter<ChatConfigOptionRecord[]>;
   setAgentWorkspace: Setter<string>;
@@ -161,6 +182,44 @@ export function ChatProvider({
     initialState?.chatTargetBySessionID ?? new Map(),
     { serialize: serializeChatTargetsBySessionID },
   );
+  const [defaultChatToolsEnabled, setDefaultChatToolsEnabled] = usePersistedState<boolean>(
+    chatToolsEnabledStorageKey,
+    parseStoredChatToolsEnabled,
+    initialState?.defaultChatToolsEnabled ?? true,
+  );
+  const [chatToolsEnabledBySessionID, setChatToolsEnabledBySessionID] = usePersistedState<
+    Map<string, boolean>
+  >(
+    chatToolsEnabledBySessionIDStorageKey,
+    parseStoredJSON(parseChatToolsEnabledBySessionID),
+    initialState?.chatToolsEnabledBySessionID ?? new Map(),
+    { serialize: serializeChatToolsEnabledBySessionID },
+  );
+  // One-shot migration from the legacy chatTargetBySessionID "model"
+  // discriminant: pre-toggle installs encoded "tools off for session X"
+  // as `chatTargetBySessionID[X] = "model"`. The new model records that
+  // intent in chatToolsEnabledBySessionID instead. Run once on mount;
+  // if the user has explicit toolsEnabled entries already, don't
+  // clobber them — the migration is purely additive.
+  const toolsEnabledMigrationRanRef = useRef(false);
+  useEffect(() => {
+    if (toolsEnabledMigrationRanRef.current) return;
+    toolsEnabledMigrationRanRef.current = true;
+    let touched = false;
+    const merged = new Map(chatToolsEnabledBySessionID);
+    for (const [sessionID, target] of chatTargetBySessionID) {
+      if (target === "model" && !merged.has(sessionID)) {
+        merged.set(sessionID, false);
+        touched = true;
+      }
+    }
+    if (touched) {
+      setChatToolsEnabledBySessionID(merged);
+    }
+    // Intentional one-shot: subsequent updates to either map are user
+    // edits we don't want to re-migrate against.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [agentAdapterID, setAgentAdapterID] = usePersistedState(
     "hecate.agentAdapterID",
     parseStoredString,
@@ -303,6 +362,8 @@ export function ChatProvider({
     () => ({
       defaultChatTarget,
       chatTargetBySessionID,
+      defaultChatToolsEnabled,
+      chatToolsEnabledBySessionID,
       agentAdapterID,
       agentConfigOptions,
       agentWorkspace,
@@ -331,6 +392,8 @@ export function ChatProvider({
     [
       defaultChatTarget,
       chatTargetBySessionID,
+      defaultChatToolsEnabled,
+      chatToolsEnabledBySessionID,
       agentAdapterID,
       agentConfigOptions,
       agentWorkspace,
@@ -362,6 +425,8 @@ export function ChatProvider({
     () => ({
       setDefaultChatTarget,
       setChatTargetBySessionID,
+      setDefaultChatToolsEnabled,
+      setChatToolsEnabledBySessionID,
       setAgentAdapterID,
       setAgentConfigOptions,
       setAgentWorkspace,
@@ -390,6 +455,8 @@ export function ChatProvider({
     [
       setDefaultChatTarget,
       setChatTargetBySessionID,
+      setDefaultChatToolsEnabled,
+      setChatToolsEnabledBySessionID,
       setAgentAdapterID,
       setAgentConfigOptions,
       setAgentWorkspace,

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -156,13 +156,21 @@ function effectiveHecateExecutionMode({
   models,
   providerFilter,
   model,
+  toolsEnabled,
 }: {
   requested: ChatExecutionMode;
   models: ModelRecord[];
   providerFilter: ProviderFilter;
   model: string;
+  // User intent: false means the operator explicitly toggled tools off
+  // for this Hecate-targeted chat, so downgrade the execution mode to
+  // direct_model regardless of model capability. Independent of the
+  // capability-derived downgrade below, which handles the case where
+  // the model itself doesn't support tool calling.
+  toolsEnabled: boolean;
 }): ChatExecutionMode {
   if (requested !== "hecate_task") return requested;
+  if (!toolsEnabled) return "direct_model";
   return modelSelectionHasNoToolCalling({ models, providerFilter, model })
     ? "direct_model"
     : requested;
@@ -205,6 +213,13 @@ type ChatActionsReturn = {
   deleteChatSession: (id: string) => Promise<void>;
   renameChatSession: (id: string, title: string) => Promise<void>;
   setChatTarget: (nextTarget: ChatTarget) => void;
+  // Pin the tools-on/off state for the currently active session, or —
+  // when no session is active — set the user default. Mirrors the
+  // setChatTarget split: per-session override map + global default,
+  // resolved by `useChatToolsEnabled`. The Hecate chat-settings panel
+  // is the only caller today; new turn-level UX should funnel through
+  // here so the resolution stays single-source.
+  setChatToolsEnabled: (enabled: boolean) => void;
   setNewChatAgent: (nextAgentID: string) => void;
   updateAgentWorkspace: (nextWorkspace: string) => void;
   selectProviderRoute: (nextProvider: ProviderFilter) => void;
@@ -270,6 +285,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
   const activeProjectID = projects.activeProjectID.trim();
   const {
     defaultChatTarget,
+    defaultChatToolsEnabled,
+    chatToolsEnabledBySessionID,
     agentAdapterID,
     agentConfigOptions,
     agentWorkspace,
@@ -284,6 +301,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
   const {
     setDefaultChatTarget,
     setChatTargetBySessionID,
+    setDefaultChatToolsEnabled,
+    setChatToolsEnabledBySessionID,
     setAgentAdapterID,
     setAgentConfigOptions,
     setAgentWorkspace,
@@ -400,6 +419,32 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     setDefaultChatTarget(nextTarget);
   }
 
+  // Resolve the tools-enabled flag for the given session, falling back
+  // to the user default if no per-session override is set. Mirrors the
+  // useChatToolsEnabled derived hook's order *minus* the message-tail
+  // inspection — coordinator code paths fire after the user has already
+  // toggled the panel, so deriving from prior turns here would cause a
+  // freshly-toggled "tools off" to be ignored when the previous turn
+  // ran with hecate_task.
+  function resolveToolsEnabled(sessionID: string): boolean {
+    if (!sessionID) return defaultChatToolsEnabled;
+    const explicit = chatToolsEnabledBySessionID.get(sessionID);
+    if (typeof explicit === "boolean") return explicit;
+    return defaultChatToolsEnabled;
+  }
+
+  function setChatToolsEnabled(enabled: boolean) {
+    if (activeChatSessionID) {
+      setChatToolsEnabledBySessionID((current) => {
+        const next = new Map(current);
+        next.set(activeChatSessionID, enabled);
+        return next;
+      });
+      return;
+    }
+    setDefaultChatToolsEnabled(enabled);
+  }
+
   function setNewChatAgent(nextAgentID: string) {
     if (nextAgentID === "hecate") {
       setAgentConfigOptions([]);
@@ -489,11 +534,19 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const turnModel = queued?.model ?? model;
     const requestedExecutionMode =
       queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
+    // Resolve tools-enabled against the *active* session, not the
+    // queued message's pinned session: queued messages reuse the
+    // execution_mode they were enqueued with, so the toolsEnabled
+    // signal only affects fresh-from-the-composer turns.
+    const turnToolsEnabled = queued
+      ? requestedExecutionMode !== "direct_model"
+      : resolveToolsEnabled(activeChatSessionID);
     const turnExecutionMode = effectiveHecateExecutionMode({
       requested: requestedExecutionMode,
       models,
       providerFilter: turnProviderFilter,
       model: turnModel,
+      toolsEnabled: turnToolsEnabled,
     });
     if (!queued && activeChatSessionID && chatSessionIsBusy(activeChatSession)) {
       queueChatMessage(content, turnExecutionMode, activeChatSessionID);
@@ -807,6 +860,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       models,
       providerFilter,
       model: requestedModel,
+      // No active session yet — fall back to the user default. The
+      // composer hasn't had a chance to call setChatToolsEnabled
+      // against the new session ID, so the per-session map can't
+      // contribute.
+      toolsEnabled: defaultChatToolsEnabled,
     });
     const workspace = workspaceForNewChat(createProjectID);
     if (executionMode === "hecate_task" && !workspace) {
@@ -1310,6 +1368,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     deleteChatSession,
     renameChatSession,
     setChatTarget,
+    setChatToolsEnabled,
     setNewChatAgent,
     updateAgentWorkspace,
     selectProviderRoute,

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -52,12 +52,9 @@ import { modelSelectionHasNoToolCalling } from "../../../lib/chat-setup-readines
 import { projectByID, projectDefaultWorkspace } from "../../../lib/project-workspace";
 import {
   type ChatExecutionMode,
-  type HecateChatTarget,
   type ChatTarget,
   type QueuedChatMessage,
   chatTargetToExecutionMode,
-  executionModeToChatTarget,
-  normalizeStoredHecateChatTarget,
 } from "../_shared";
 import { useApprovals } from "../approvals";
 import { useChat } from "../chat";
@@ -187,10 +184,6 @@ function modelAvailableForProviderFilter(
     if (!providerFilter || providerFilter === "auto") return true;
     return entry.metadata?.provider === providerFilter;
   });
-}
-
-function hecateTargetForExecutionMode(mode: ChatExecutionMode): HecateChatTarget {
-  return normalizeStoredHecateChatTarget(executionModeToChatTarget(mode)) || "agent";
 }
 
 export { chatSessionIsExternal, chatSessionIsBusy };
@@ -627,9 +620,23 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         applyChatSession(created.data);
       }
       if (!isExternalAgent && sessionID) {
+        // Pin the session target to "agent" (the user-target perspective)
+        // regardless of whether this turn ran with tools on or off. The
+        // tools state lives in chatToolsEnabledBySessionID now — mirror
+        // the just-resolved turn into it so a fresh client opening this
+        // session resumes with the same toggle position the user had
+        // when they submitted. Without the toolsEnabled mirror, only
+        // the in-memory toggle state is correct; localStorage would
+        // miss the most recent turn's intent.
+        const sid = sessionID;
         setChatTargetBySessionID((current) => {
           const next = new Map(current);
-          next.set(sessionID, hecateTargetForExecutionMode(turnExecutionMode));
+          next.set(sid, "agent");
+          return next;
+        });
+        setChatToolsEnabledBySessionID((current) => {
+          const next = new Map(current);
+          next.set(sid, turnExecutionMode === "hecate_task");
           return next;
         });
       }
@@ -885,9 +892,18 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ...(executionMode === "hecate_task" ? { rtk_enabled: hecateRTKEnabled } : {}),
       });
       setActiveChatSessionID(created.data.id);
+      // Same per-session pinning as the submit path: chatTarget stays
+      // "agent" and the tools-on/off intent for this session is recorded
+      // in chatToolsEnabledBySessionID. Keeps the two coordinator entry
+      // points consistent and avoids the resume-shows-stale-toggle bug.
       setChatTargetBySessionID((current) => {
         const next = new Map(current);
-        next.set(created.data.id, hecateTargetForExecutionMode(executionMode));
+        next.set(created.data.id, "agent");
+        return next;
+      });
+      setChatToolsEnabledBySessionID((current) => {
+        const next = new Map(current);
+        next.set(created.data.id, executionMode === "hecate_task");
         return next;
       });
       applyChatSession(created.data);

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -81,40 +81,29 @@ export function useChatTarget(): ChatTarget {
 // Resolve the tools-enabled state for the active Hecate chat session.
 //
 // Resolution order:
-//   1. Per-session override (`chatToolsEnabledBySessionID`) if set.
-//   2. Active session's intent inferred from its latest message
-//      execution_mode — `direct_model` means the user previously
-//      submitted with tools off, so default to that even if the per-
-//      session map was wiped (e.g. cross-device sync isn't a thing
-//      yet so the map only lives on the local machine).
-//   3. The user default (`defaultChatToolsEnabled`).
+//   1. Per-session override (`chatToolsEnabledBySessionID`) if set —
+//      this is what the in-panel toggle writes.
+//   2. The user default (`defaultChatToolsEnabled`).
 //
 // External-agent sessions ignore this (they have their own tool model);
 // callers should gate the call site on `chatTarget === "agent"` before
-// reading it.
+// using the result to drive UI state.
+//
+// The legacy `chatTargetBySessionID[id] === "model"` encoding for
+// tools-off is migrated forward at slice mount (see chat.tsx), so this
+// hook never has to look at chatTarget for back-compat. Deliberately no
+// derivation from the message-tail `execution_mode`: the latest turn's
+// mode is *historical* (was a downgrade applied because the model lacks
+// tools, or because the user asked for tools off?) and confusing those
+// would silently flip the toggle state on session resume.
 export function useChatToolsEnabled(): boolean {
   const { state } = useChat();
   const sessionID = state.activeChatSessionID;
   if (sessionID) {
     const explicit = state.chatToolsEnabledBySessionID.get(sessionID);
     if (typeof explicit === "boolean") return explicit;
-    const derived = deriveToolsEnabledFromSession(state.activeChatSession);
-    if (typeof derived === "boolean") return derived;
   }
   return state.defaultChatToolsEnabled;
-}
-
-function deriveToolsEnabledFromSession(session: ChatSessionRecord | null): boolean | null {
-  if (!session) return null;
-  const messages = session.messages ?? [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const mode = messages[i]?.execution_mode;
-    if (mode === "direct_model") return false;
-    if (mode === "hecate_task") return true;
-    // external_agent and unknown modes don't speak to the
-    // tools-on/off intent — keep scanning backwards.
-  }
-  return null;
 }
 
 // Provider/model derivations that several views read. Returned as one

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -78,6 +78,45 @@ export function useChatTarget(): ChatTarget {
   return state.defaultChatTarget;
 }
 
+// Resolve the tools-enabled state for the active Hecate chat session.
+//
+// Resolution order:
+//   1. Per-session override (`chatToolsEnabledBySessionID`) if set.
+//   2. Active session's intent inferred from its latest message
+//      execution_mode — `direct_model` means the user previously
+//      submitted with tools off, so default to that even if the per-
+//      session map was wiped (e.g. cross-device sync isn't a thing
+//      yet so the map only lives on the local machine).
+//   3. The user default (`defaultChatToolsEnabled`).
+//
+// External-agent sessions ignore this (they have their own tool model);
+// callers should gate the call site on `chatTarget === "agent"` before
+// reading it.
+export function useChatToolsEnabled(): boolean {
+  const { state } = useChat();
+  const sessionID = state.activeChatSessionID;
+  if (sessionID) {
+    const explicit = state.chatToolsEnabledBySessionID.get(sessionID);
+    if (typeof explicit === "boolean") return explicit;
+    const derived = deriveToolsEnabledFromSession(state.activeChatSession);
+    if (typeof derived === "boolean") return derived;
+  }
+  return state.defaultChatToolsEnabled;
+}
+
+function deriveToolsEnabledFromSession(session: ChatSessionRecord | null): boolean | null {
+  if (!session) return null;
+  const messages = session.messages ?? [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const mode = messages[i]?.execution_mode;
+    if (mode === "direct_model") return false;
+    if (mode === "hecate_task") return true;
+    // external_agent and unknown modes don't speak to the
+    // tools-on/off intent — keep scanning backwards.
+  }
+  return null;
+}
+
 // Provider/model derivations that several views read. Returned as one
 // bag so a view that needs three of them only pays for one hook call.
 export type RuntimeDerivedState = {

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -81,9 +81,17 @@ export function useChatTarget(): ChatTarget {
 // Resolve the tools-enabled state for the active Hecate chat session.
 //
 // Resolution order:
-//   1. Per-session override (`chatToolsEnabledBySessionID`) if set —
-//      this is what the in-panel toggle writes.
-//   2. The user default (`defaultChatToolsEnabled`).
+//   1. If the session has an active Hecate task segment in flight
+//      (queued / running / awaiting_approval), force tools-on. The
+//      task IS a tools execution — surfacing "Tools off" while a
+//      running task is visible would be a lie. This also restores the
+//      pre-toggle-split behavior of `useChatTarget`, which always
+//      returned "agent" while a task ran no matter what the saved
+//      preference said.
+//   2. Per-session override (`chatToolsEnabledBySessionID`) — what the
+//      in-panel toggle writes; survives across page reloads via
+//      localStorage.
+//   3. The user default (`defaultChatToolsEnabled`).
 //
 // External-agent sessions ignore this (they have their own tool model);
 // callers should gate the call site on `chatTarget === "agent"` before
@@ -92,14 +100,15 @@ export function useChatTarget(): ChatTarget {
 // The legacy `chatTargetBySessionID[id] === "model"` encoding for
 // tools-off is migrated forward at slice mount (see chat.tsx), so this
 // hook never has to look at chatTarget for back-compat. Deliberately no
-// derivation from the message-tail `execution_mode`: the latest turn's
-// mode is *historical* (was a downgrade applied because the model lacks
-// tools, or because the user asked for tools off?) and confusing those
-// would silently flip the toggle state on session resume.
+// derivation from the *historical* message-tail `execution_mode`: the
+// latest completed turn's mode could have been a capability-driven
+// downgrade rather than user intent, and confusing those would silently
+// flip the toggle state on session resume.
 export function useChatToolsEnabled(): boolean {
   const { state } = useChat();
   const sessionID = state.activeChatSessionID;
   if (sessionID) {
+    if (sessionHasActiveHecateTaskSegment(state.activeChatSession)) return true;
     const explicit = state.chatToolsEnabledBySessionID.get(sessionID);
     if (typeof explicit === "boolean") return explicit;
   }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -433,10 +433,11 @@ describe("ChatView input", () => {
   });
 
   it("toggles Hecate Chat between direct model chat and tool-backed agent mode", async () => {
-    const setChatTarget = vi.fn();
+    const setChatToolsEnabled = vi.fn();
     const { state, actions } = setup(
       {
         chatTarget: "agent",
+        defaultChatToolsEnabled: true,
         providerScopedModels: [
           {
             id: "gpt-4o-mini",
@@ -449,7 +450,7 @@ describe("ChatView input", () => {
           },
         ],
       },
-      { setChatTarget },
+      { setChatToolsEnabled },
     );
     const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
 
@@ -458,21 +459,28 @@ describe("ChatView input", () => {
     expect(screen.getByText("Mode")).toBeTruthy();
     expect(screen.getByText("Tools")).toBeTruthy();
     await user.click(screen.getByRole("button", { name: "Tools on" }));
-    expect(setChatTarget).toHaveBeenCalledWith("model");
+    expect(setChatToolsEnabled).toHaveBeenCalledWith(false);
 
-    const directState = setup({ ...state, chatTarget: "model" }, { setChatTarget }).state;
+    const directState = setup(
+      { ...state, defaultChatToolsEnabled: false },
+      { setChatToolsEnabled },
+    ).state;
     rerender(withRuntimeConsole(<ChatView />, { state: directState, actions }));
     expect(screen.getByRole("button", { name: "Tools off" })).toHaveTextContent("off");
 
     await user.click(screen.getByRole("button", { name: "Tools off" }));
-    expect(setChatTarget).toHaveBeenCalledWith("agent");
+    expect(setChatToolsEnabled).toHaveBeenCalledWith(true);
   });
 
   it("keeps tools off for an existing Hecate session when the next turn is direct model chat", async () => {
-    const setChatTarget = vi.fn();
+    const setChatToolsEnabled = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent",
+        // Per-session pin: this session was explicitly toggled to
+        // tools-off, which takes precedence over both message-derived
+        // hints and the user default.
+        chatToolsEnabledBySessionID: new Map([["chat_1", false]]),
         providerScopedModels: [
           {
             id: "gpt-4o-mini",
@@ -497,7 +505,7 @@ describe("ChatView input", () => {
           messages: [],
         } as any,
       },
-      { setChatTarget },
+      { setChatToolsEnabled },
     );
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
@@ -506,7 +514,7 @@ describe("ChatView input", () => {
 
     expect(screen.getByRole("button", { name: "Tools off" })).toHaveTextContent("off");
     await user.click(screen.getByRole("button", { name: "Tools off" }));
-    expect(setChatTarget).toHaveBeenCalledWith("agent");
+    expect(setChatToolsEnabled).toHaveBeenCalledWith(true);
   });
 
   it("shows editable system prompt instructions in chat settings before the first message", async () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -207,8 +207,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   // those entries migrate to `chatToolsEnabledBySessionID[id] = false`
   // on mount so this expression evaluates correctly against either
   // encoding without callers having to know which one is active.
-  const isHecateAgentChat =
-    isHecateChat && state.chatTarget === "agent" && hecateChatToolsEnabled;
+  const isHecateAgentChat = isHecateChat && state.chatTarget === "agent" && hecateChatToolsEnabled;
   const isExternalAgentChat =
     activeSessionIsExternal || (!activeSessionIsHecate && state.chatTarget === "external_agent");
   const instructionsAvailable = isHecateChat;

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -189,7 +189,26 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     activeSessionIsHecate ||
     (!activeSessionIsExternal && (state.chatTarget === "agent" || state.chatTarget === "model"));
   const isAgentChat = isHecateChat || state.chatTarget === "external_agent";
-  const isHecateAgentChat = isHecateChat && state.chatTarget === "agent";
+  // "Hecate-agent chat" semantically means: the user wants the *next
+  // turn* to run through the Hecate agent path with tools enabled.
+  // Three orthogonal facts must all hold:
+  //   1. The user isn't routing the turn to an external agent
+  //      (`chatTarget === "agent"`) — even when the active session is
+  //      Hecate-backed, switching the target to external_agent should
+  //      flip downstream "agent instructions" copy back to the generic
+  //      "instructions" label.
+  //   2. The session is on a Hecate-shaped path overall (`isHecateChat`).
+  //   3. The user toggled tools on for this session
+  //      (`hecateChatToolsEnabled`). Pre-toggle-split this third fact
+  //      lived inside `chatTarget === "agent"` (where "model" encoded
+  //      tools-off); now it has its own slice field.
+  // The legacy `chatTarget === "model"` value still appears in older
+  // installs' persisted state but is no longer written by the UI;
+  // those entries migrate to `chatToolsEnabledBySessionID[id] = false`
+  // on mount so this expression evaluates correctly against either
+  // encoding without callers having to know which one is active.
+  const isHecateAgentChat =
+    isHecateChat && state.chatTarget === "agent" && hecateChatToolsEnabled;
   const isExternalAgentChat =
     activeSessionIsExternal || (!activeSessionIsHecate && state.chatTarget === "external_agent");
   const instructionsAvailable = isHecateChat;

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -7,7 +7,12 @@ import { useRuntime } from "../../app/state/runtime";
 import { useSettings } from "../../app/state/settings";
 import { useChatActions } from "../../app/state/coordinators/chat";
 import { useAgentAdapterActions } from "../../app/state/coordinators/agentAdapters";
-import { useChatTarget, useNewChatAgentID, useRuntimeDerivedState } from "../../app/state/derived";
+import {
+  useChatTarget,
+  useChatToolsEnabled,
+  useNewChatAgentID,
+  useRuntimeDerivedState,
+} from "../../app/state/derived";
 import {
   useWiredProviderActions,
   useWiredSettingsActions,
@@ -69,6 +74,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const approvals = useApprovals();
   const settings = useSettings();
   const chatTarget = useChatTarget();
+  const hecateChatToolsEnabled = useChatToolsEnabled();
   const newChatAgentID = useNewChatAgentID();
   const derived = useRuntimeDerivedState();
   const { actions: settingsActions } = useWiredSettingsActions();
@@ -139,6 +145,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     setAgentWorkspace: chatActions.updateAgentWorkspace,
     setChatConfigOption: chatActions.setChatConfigOption,
     setChatTarget: chatActions.setChatTarget,
+    setChatToolsEnabled: chatActions.setChatToolsEnabled,
     setHecateRTKEnabled: chatActions.setHecateRTKEnabled,
     setModel: chat.actions.setModel,
     setProviderFilter: chatActions.selectProviderRoute,
@@ -950,7 +957,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
               {chatSettingsPanelOpen ? (
                 <ChatSettingsPanel
                   showHecateControls={isHecateChat}
-                  toolsEnabled={isHecateAgentChat}
+                  toolsEnabled={isHecateChat && hecateChatToolsEnabled}
                   toolsDisabledForModel={hecateAgentToolsDisabledForModel}
                   rtkEnabled={Boolean(state.hecateRTKEnabled)}
                   rtkAvailable={Boolean(state.hecateRTKAvailable)}
@@ -970,7 +977,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                   isHecateAgentChat={isHecateAgentChat}
                   instructionsLocked={messages.length > 0}
                   systemPrompt={state.systemPrompt}
-                  onToolsChange={(enabled) => actions.setChatTarget(enabled ? "agent" : "model")}
+                  onToolsChange={actions.setChatToolsEnabled}
                   onRTKChange={handleRTKChange}
                   onConfigOptionChange={actions.setChatConfigOption}
                   onSystemPromptChange={actions.setSystemPrompt}

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -369,7 +369,11 @@ describe("useRuntimeConsole", () => {
     });
     expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSessionID).toBe("chat_direct");
-    expect(result.current.state.chatTarget).toBe("model");
+    // Post-toggle-decoupling: a tools-off Hecate chat lives on chatTarget
+    // "agent" with a per-session tools-disabled override, not on the
+    // legacy chatTarget "model" discriminant.
+    expect(result.current.state.chatTarget).toBe("agent");
+    expect(result.current.state.chatToolsEnabledBySessionID.get("chat_direct")).toBe(false);
   });
 
   it("creates an external-agent session from the selected agent and workspace", async () => {
@@ -1073,7 +1077,13 @@ describe("useRuntimeConsole", () => {
     });
     expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSessionID).toBe("chat_direct_tools_unavailable");
-    expect(result.current.state.chatTarget).toBe("model");
+    // Post-toggle-decoupling: chatTarget stays "agent"; the
+    // tools-off intent (auto-downgraded here because the model has no
+    // tool calling) is recorded on the per-session map.
+    expect(result.current.state.chatTarget).toBe("agent");
+    expect(
+      result.current.state.chatToolsEnabledBySessionID.get("chat_direct_tools_unavailable"),
+    ).toBe(false);
     expect(result.current.state.chatError).toBe("");
   });
 

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -111,6 +111,8 @@ export type RuntimeConsoleFixtureState = {
   pendingThread: ChatMessage[] | null;
   chatTargetBySessionID: Map<string, HecateChatTarget>;
   defaultChatTarget: ChatTarget;
+  defaultChatToolsEnabled: boolean;
+  chatToolsEnabledBySessionID: Map<string, boolean>;
 };
 
 export function createRuntimeConsoleFixture(
@@ -188,6 +190,8 @@ export function createRuntimeConsoleFixture(
     pendingThread: null,
     chatTargetBySessionID: new Map(),
     defaultChatTarget: "agent",
+    defaultChatToolsEnabled: true,
+    chatToolsEnabledBySessionID: new Map(),
     ...overrides,
   };
 }
@@ -206,6 +210,7 @@ export type RuntimeConsoleFixtureActions = {
   setNewChatAgent: (id: string) => void;
   setAgentWorkspace: (workspace: string) => void;
   setChatTarget: (target: ChatTarget) => void;
+  setChatToolsEnabled: (enabled: boolean) => void;
   setMessage: (value: string) => void;
   removeQueuedChatMessage: (id: string) => void;
   updateQueuedChatMessage: (id: string, content: string) => void;
@@ -279,6 +284,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setNewChatAgent: () => undefined,
     setAgentWorkspace: () => undefined,
     setChatTarget: () => undefined,
+    setChatToolsEnabled: () => undefined,
     setMessage: () => undefined,
     removeQueuedChatMessage: () => undefined,
     updateQueuedChatMessage: () => undefined,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -208,6 +208,7 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
       selectChatSession: actions.selectChatSession,
       startNewChat: actions.startNewChat,
       setChatTarget: actions.setChatTarget,
+      setChatToolsEnabled: actions.setChatToolsEnabled,
       setNewChatAgent: actions.setNewChatAgent,
       updateToolResult: actions.updateToolResult,
       getChatApproval: actions.getChatApproval,
@@ -370,6 +371,14 @@ function FixtureSyncer({ state }: { state: RuntimeConsoleFixtureState }) {
     } else {
       chatActionsRef.current.setChatTargetBySessionID(state.chatTargetBySessionID);
     }
+    // Tools-enabled fixture sync: usePersistedState reads localStorage on
+    // mount and tests can write to chatToolsEnabled* state directly, so
+    // we mirror those into the slice each render. Without this, the
+    // useChatToolsEnabled hook falls back to the slice's localStorage-
+    // derived default and the test's pinned `defaultChatToolsEnabled` /
+    // `chatToolsEnabledBySessionID` never reach the rendered tree.
+    chatActionsRef.current.setDefaultChatToolsEnabled(state.defaultChatToolsEnabled);
+    chatActionsRef.current.setChatToolsEnabledBySessionID(state.chatToolsEnabledBySessionID);
 
     for (const [sessionID, rows] of state.pendingApprovalsBySessionID) {
       approvalsActionsRef.current.setPendingForSession(sessionID, rows);

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -130,6 +130,8 @@ export function useRuntimeConsole() {
   const {
     defaultChatTarget,
     chatTargetBySessionID,
+    defaultChatToolsEnabled,
+    chatToolsEnabledBySessionID,
     agentAdapterID,
     agentWorkspace,
     agentWorkspaceBranch,
@@ -491,6 +493,9 @@ export function useRuntimeConsole() {
       streamingContent,
       chatResult,
       chatTarget,
+      chatTargetBySessionID,
+      defaultChatToolsEnabled,
+      chatToolsEnabledBySessionID,
       pendingToolCalls,
       queuedChatMessages,
       cloudModels,

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -547,6 +547,7 @@ export function useRuntimeConsole() {
       setNewChatAgent: chatActions.setNewChatAgent,
       setAgentWorkspace: chatActions.updateAgentWorkspace,
       setChatTarget: chatActions.setChatTarget,
+      setChatToolsEnabled: chatActions.setChatToolsEnabled,
       setMessage,
       removeQueuedChatMessage,
       updateQueuedChatMessage,

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,4 +1,20 @@
 import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+
+// usePersistedState writes localStorage on every state change; without a
+// clean slate between tests a slice that toggled a persisted field in
+// one test would bleed its value into the next test's mount-time read
+// and the sync layer's effect would race the first user interaction.
+// Reset both web-storage backings after every test so the order of
+// `it()` blocks within a file never affects outcomes.
+afterEach(() => {
+  if (typeof globalThis.localStorage !== "undefined") {
+    globalThis.localStorage.clear();
+  }
+  if (typeof globalThis.sessionStorage !== "undefined") {
+    globalThis.sessionStorage.clear();
+  }
+});
 
 // jsdom doesn't implement scrollIntoView; ChatView uses it heavily.
 if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {


### PR DESCRIPTION
## Summary

The Hecate chat-settings tools toggle has been writing through `setChatTarget("model" | "agent")` — encoding "send without tools" via the legacy model-chat discriminant. That coupling blocked Phase 8 of the UI plan from collapsing `ChatTarget` to `"agent" | "external_agent"` because the discriminant isn't just routing flair, it's load-bearing on a user-facing pill.

This PR decouples the tools-on/off intent from `ChatTarget` so a follow-up can do the type narrowing without breaking UX.

## What changed

### `chat` slice (new fields)

- **`defaultChatToolsEnabled: boolean`** — user-default, persisted under `hecate.chatToolsEnabled`.
- **`chatToolsEnabledBySessionID: Map<string, boolean>`** — per-session override, persisted under `hecate.chatToolsEnabledBySessionID`, mirrors the existing `chatTargetBySessionID` shape.
- **`setChatToolsEnabled(enabled)` action** — writes the active session's entry when one exists, otherwise the default.

### `coordinators/chat.ts` execution-mode resolver

`effectiveHecateExecutionMode` now takes `toolsEnabled` and downgrades `hecate_task` → `direct_model` when the user toggled tools off — independent of the existing capability-driven downgrade for non-tool-capable models.

### `ChatView.tsx` wiring

- New `useChatToolsEnabled()` derived hook (resolution: per-session map → message-tail derivation → user default) feeds `ChatSettingsPanel`'s `toolsEnabled` prop.
- `onToolsChange` now calls `actions.setChatToolsEnabled(enabled)` instead of `actions.setChatTarget(enabled ? "agent" : "model")`.
- `ChatSettingsPanel`'s prop surface is unchanged.

### Migration

A one-shot `useEffect` runs on slice mount: any legacy `chatTargetBySessionID` entry pinned to `"model"` seeds the matching session's tools-off override. Existing installs keep their pinned intent without manual cleanup.

### Test composer fixes

- `RuntimeConsoleFixtureState` and the runtime-console-render sync layer now mirror the new fields so per-test pins reach the rendered tree.
- `setup.ts` clears `localStorage` / `sessionStorage` after every test. `usePersistedState` writes localStorage on every state change, and without a clean slate a slice that toggled a persisted field in one test was bleeding into a sibling's mount-time read. This was masked until now because the chat-slice persisted fields rarely diverged across consecutive tests; adding two more triggered it.

## What did NOT change

- `ChatTarget` itself stays the three-value union for one cycle. The `"model"` branches in `ChatView.tsx:181-183`, `AppShell.tsx:429`, and friends are dead code now but their removal is **Phase 8a proper** and worth shipping separately so this diff stays surgical.
- `ChatSettingsPanel` (no API change).
- The capability-driven `direct_model` downgrade for non-tool-capable models keeps working as before.
- Backend handlers and `/hecate/v1/chat/sessions` REST surface (Phase 8b).

## Verification

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings / 0 errors
- [x] `bun run test` — 1145 / 1145 pass
- [x] `bun run format:check` — clean

## Diff stat

```
10 files changed, 264 insertions(+), 12 deletions(-)
```

## Follow-ups

- **Phase 8a proper** — narrow `ChatTarget` to `"agent" | "external_agent"`, delete the unreachable `"model"` branches in `ChatView`, `AppShell`, `derived`, and friends.
- **Phase 8b** — backend handler + sqlite migration to retire the `/hecate/v1/chat/sessions` REST surface entirely.