### PR TITLE
chore(chat): rewrite chat-tools comments to describe current shape

### DIFF
--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -195,12 +195,12 @@ export function ChatProvider({
     initialState?.chatToolsEnabledBySessionID ?? new Map(),
     { serialize: serializeChatToolsEnabledBySessionID },
   );
-  // One-shot migration from the legacy chatTargetBySessionID "model"
-  // discriminant: pre-toggle installs encoded "tools off for session X"
-  // as `chatTargetBySessionID[X] = "model"`. The new model records that
-  // intent in chatToolsEnabledBySessionID instead. Run once on mount;
-  // if the user has explicit toolsEnabled entries already, don't
-  // clobber them — the migration is purely additive.
+  // One-shot migration from the legacy storage key
+  // `chatTargetBySessionID`: any entry with value "model" used to
+  // encode "tools off for this session" and now lives on
+  // `chatToolsEnabledBySessionID[X] = false`. Run once on mount;
+  // explicit toolsEnabled entries the user already wrote are left
+  // alone — the migration only adds entries, never overrides.
   const toolsEnabledMigrationRanRef = useRef(false);
   useEffect(() => {
     if (toolsEnabledMigrationRanRef.current) return;

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -84,10 +84,10 @@ export function useChatTarget(): ChatTarget {
 //   1. If the session has an active Hecate task segment in flight
 //      (queued / running / awaiting_approval), force tools-on. The
 //      task IS a tools execution — surfacing "Tools off" while a
-//      running task is visible would be a lie. This also restores the
-//      pre-toggle-split behavior of `useChatTarget`, which always
-//      returned "agent" while a task ran no matter what the saved
-//      preference said.
+//      running task is visible would be a lie. The same active-task
+//      override gates `useChatTarget` to return "agent" no matter what
+//      the saved preference says, so the two derived signals stay
+//      consistent.
 //   2. Per-session override (`chatToolsEnabledBySessionID`) — what the
 //      in-panel toggle writes; survives across page reloads via
 //      localStorage.
@@ -97,13 +97,14 @@ export function useChatTarget(): ChatTarget {
 // callers should gate the call site on `chatTarget === "agent"` before
 // using the result to drive UI state.
 //
-// The legacy `chatTargetBySessionID[id] === "model"` encoding for
-// tools-off is migrated forward at slice mount (see chat.tsx), so this
-// hook never has to look at chatTarget for back-compat. Deliberately no
-// derivation from the *historical* message-tail `execution_mode`: the
-// latest completed turn's mode could have been a capability-driven
-// downgrade rather than user intent, and confusing those would silently
-// flip the toggle state on session resume.
+// `chatTargetBySessionID[id] === "model"` is a legacy storage value
+// migrated forward to `chatToolsEnabledBySessionID[id] = false` at
+// slice mount (see chat.tsx), so this hook never has to look at
+// chatTarget for back-compat. Deliberately no derivation from the
+// session's message-tail `execution_mode`: the latest completed turn's
+// mode could have been a capability-driven downgrade rather than user
+// intent, and confusing those would silently flip the toggle state on
+// session resume.
 export function useChatToolsEnabled(): boolean {
   const { state } = useChat();
   const sessionID = state.activeChatSessionID;

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -198,15 +198,12 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   //      flip downstream "agent instructions" copy back to the generic
   //      "instructions" label.
   //   2. The session is on a Hecate-shaped path overall (`isHecateChat`).
-  //   3. The user toggled tools on for this session
-  //      (`hecateChatToolsEnabled`). Pre-toggle-split this third fact
-  //      lived inside `chatTarget === "agent"` (where "model" encoded
-  //      tools-off); now it has its own slice field.
-  // The legacy `chatTarget === "model"` value still appears in older
-  // installs' persisted state but is no longer written by the UI;
-  // those entries migrate to `chatToolsEnabledBySessionID[id] = false`
-  // on mount so this expression evaluates correctly against either
-  // encoding without callers having to know which one is active.
+  //   3. The user has tools turned on for this session
+  //      (`hecateChatToolsEnabled`).
+  // `chatTarget === "model"` is a legacy storage value that older
+  // installs may still hold; the slice migrates those entries to
+  // `chatToolsEnabledBySessionID[id] = false` on mount, so this
+  // expression doesn't have to special-case the old encoding.
   const isHecateAgentChat = isHecateChat && state.chatTarget === "agent" && hecateChatToolsEnabled;
   const isExternalAgentChat =
     activeSessionIsExternal || (!activeSessionIsHecate && state.chatTarget === "external_agent");

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -369,9 +369,9 @@ describe("useRuntimeConsole", () => {
     });
     expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSessionID).toBe("chat_direct");
-    // Post-toggle-decoupling: a tools-off Hecate chat lives on chatTarget
-    // "agent" with a per-session tools-disabled override, not on the
-    // legacy chatTarget "model" discriminant.
+    // A tools-off Hecate chat resolves to chatTarget "agent" with a
+    // per-session tools-disabled override on chatToolsEnabledBySessionID
+    // — the two-axis encoding the slice persists today.
     expect(result.current.state.chatTarget).toBe("agent");
     expect(result.current.state.chatToolsEnabledBySessionID.get("chat_direct")).toBe(false);
   });
@@ -1077,9 +1077,9 @@ describe("useRuntimeConsole", () => {
     });
     expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSessionID).toBe("chat_direct_tools_unavailable");
-    // Post-toggle-decoupling: chatTarget stays "agent"; the
-    // tools-off intent (auto-downgraded here because the model has no
-    // tool calling) is recorded on the per-session map.
+    // chatTarget stays "agent"; the tools-off intent (auto-downgraded
+    // here because the model has no tool calling) is recorded on the
+    // per-session map.
     expect(result.current.state.chatTarget).toBe("agent");
     expect(
       result.current.state.chatToolsEnabledBySessionID.get("chat_direct_tools_unavailable"),


### PR DESCRIPTION
## Summary

Comment-only cleanup. Five long-lived comments across the chat slice, derived hooks, ChatView, and the runtime-console composition tests were narrating the code as a delta from a prior state (`pre-toggle-split`, `post-toggle-decoupling`, etc.). Rewritten to describe what the code does today.

The migration story belongs in commit history — keeping it in long-lived comments bit-rots them and confuses readers who never knew there was a "before". Same spirit as the project rule against plan / phase / release labels in repo-observable text.

## Files touched

- `ui/src/app/state/chat.tsx` — one-shot migration comment
- `ui/src/app/state/derived.ts` — `useChatToolsEnabled` resolution order
- `ui/src/features/chats/ChatView.tsx` — `isHecateAgentChat` derivation rationale
- `ui/src/test/runtime-console-composition.test.tsx` — two assertion comments

## Verification

- [x] `bun run typecheck` clean
- [x] `bun run test` 1145 / 1145 pass
- [x] `bun run format:check` clean

## Diff stat

```
4 files changed, 30 insertions(+), 32 deletions(-)
```