### PR TITLE
refactor(chat): narrow ChatTarget to agent | external_agent

### DIFF
--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -132,7 +132,7 @@ describe("ConsoleShell titlebar", () => {
 describe("ConsoleShell navigation", () => {
   it("keeps Chats available when no providers are configured", async () => {
     const state = createRuntimeConsoleFixture({
-      chatTarget: "model",
+      chatTarget: "agent",
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
     });
     render(
@@ -234,23 +234,6 @@ describe("ConsoleShell navigation", () => {
     );
 
     expect(screen.getByText("context 79% left")).toBeInTheDocument();
-  });
-
-  it("does not show agent workspace details while chatting with models", () => {
-    const state = createRuntimeConsoleFixture({
-      chatTarget: "model",
-      agentWorkspace: "/Users/alice/dev/hecate",
-      agentWorkspaceBranch: "main",
-    });
-    render(
-      withRuntimeConsole(<ConsoleShell activeWorkspace="chats" onSelectWorkspace={() => {}} />, {
-        state,
-        actions: createRuntimeConsoleActions(),
-      }),
-    );
-
-    expect(screen.queryByText("/Users/alice/dev/hecate")).toBeNull();
-    expect(screen.queryByText("git:main")).toBeNull();
   });
 
   it("keeps No project as the default chat-sidebar project context", () => {

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -426,7 +426,7 @@ function AuthenticatedShell({
             </>
           );
         })()}
-        {activeWorkspace === "chats" && chatTarget !== "model" && agentWorkspace && (
+        {activeWorkspace === "chats" && agentWorkspace && (
           <>
             <span className="hecate-statusbar__sep">|</span>
             <span className="hecate-statusbar__path" title={agentWorkspace}>

--- a/ui/src/app/state/_shared.test.ts
+++ b/ui/src/app/state/_shared.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { parseQueuedChatMessageList } from "./_shared";
+import {
+  chatTargetToExecutionMode,
+  executionModeToChatTarget,
+  normalizeStoredChatTarget,
+  normalizeStoredHecateChatTarget,
+  parseQueuedChatMessageList,
+  parseStoredChatTarget,
+} from "./_shared";
 
 describe("parseQueuedChatMessageList", () => {
   it("keeps valid queued chat messages", () => {
@@ -57,5 +64,89 @@ describe("parseQueuedChatMessageList", () => {
         execution_mode: "hecate_task",
       }),
     ]);
+  });
+});
+
+describe("parseStoredChatTarget", () => {
+  it("accepts the two current discriminant values", () => {
+    expect(parseStoredChatTarget("agent")).toBe("agent");
+    expect(parseStoredChatTarget("external_agent")).toBe("external_agent");
+  });
+
+  it("coerces the legacy 'model' literal forward to 'agent'", () => {
+    // Older installs encoded "tools off for new chats" as
+    // hecate.chatTarget = "model". The tools-off intent is recovered
+    // separately by the per-session chat-tools-enabled migration; the
+    // top-level discriminant should land on the safe default rather
+    // than wipe.
+    expect(parseStoredChatTarget("model")).toBe("agent");
+  });
+
+  it("returns null for unknown values so usePersistedState wipes the key", () => {
+    expect(parseStoredChatTarget("")).toBeNull();
+    expect(parseStoredChatTarget("garbage")).toBeNull();
+    expect(parseStoredChatTarget("AGENT")).toBeNull();
+  });
+});
+
+describe("normalizeStoredChatTarget", () => {
+  it("preserves external_agent and coerces everything else to agent", () => {
+    expect(normalizeStoredChatTarget("agent")).toBe("agent");
+    expect(normalizeStoredChatTarget("external_agent")).toBe("external_agent");
+    // Coercive normalizer — used by code paths where the wider type
+    // has already vouched for the input. The legacy "model" literal
+    // and unknown values land on the safe default.
+    expect(normalizeStoredChatTarget("model")).toBe("agent");
+    expect(normalizeStoredChatTarget("garbage")).toBe("agent");
+    expect(normalizeStoredChatTarget("")).toBe("agent");
+  });
+});
+
+describe("normalizeStoredHecateChatTarget", () => {
+  it("coerces 'agent' and the legacy 'model' literal to 'agent'", () => {
+    expect(normalizeStoredHecateChatTarget("agent")).toBe("agent");
+    // Persisted `chatTargetBySessionID` entries from earlier installs
+    // may still carry `"model"` for sessions that were tools-off.
+    // Map those to "agent" so the per-session map stays well-typed;
+    // the original tools-off intent is recovered separately by the
+    // chat-slice migration that reads raw localStorage.
+    expect(normalizeStoredHecateChatTarget("model")).toBe("agent");
+  });
+
+  it("returns the empty string for unknown values so the entry is dropped", () => {
+    expect(normalizeStoredHecateChatTarget("")).toBe("");
+    expect(normalizeStoredHecateChatTarget("external_agent")).toBe("");
+    expect(normalizeStoredHecateChatTarget("garbage")).toBe("");
+  });
+});
+
+describe("chatTargetToExecutionMode", () => {
+  it("maps agent to hecate_task", () => {
+    expect(chatTargetToExecutionMode("agent")).toBe("hecate_task");
+  });
+
+  it("maps external_agent to external_agent", () => {
+    expect(chatTargetToExecutionMode("external_agent")).toBe("external_agent");
+  });
+});
+
+describe("executionModeToChatTarget", () => {
+  it("collapses the agent-side execution modes back to 'agent'", () => {
+    // Both tools-on (hecate_task) and the tools-off / capability-
+    // downgrade runtime fallback (direct_model) resolve to the same
+    // user-target value: "agent". The tools-on/off axis lives on the
+    // separate chatToolsEnabledBySessionID map.
+    expect(executionModeToChatTarget("hecate_task")).toBe("agent");
+    expect(executionModeToChatTarget("direct_model")).toBe("agent");
+  });
+
+  it("maps external_agent to external_agent", () => {
+    expect(executionModeToChatTarget("external_agent")).toBe("external_agent");
+  });
+
+  it("returns the empty string for unknown modes", () => {
+    expect(executionModeToChatTarget("")).toBe("");
+    expect(executionModeToChatTarget("garbage")).toBe("");
+    expect(executionModeToChatTarget("model")).toBe("");
   });
 });

--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -16,8 +16,21 @@
 
 import type { ProviderFilter } from "../../types/provider";
 
-export type ChatTarget = "model" | "agent" | "external_agent";
-export type HecateChatTarget = "model" | "agent";
+// ChatTarget discriminates where a new chat dispatches to. Two values:
+// the local Hecate agent ("agent") or one of the external coding agents
+// (Codex, Claude Code, Cursor Agent, Grok Build — all "external_agent").
+// Tools on/off within an agent chat is a separate axis carried on
+// `chatToolsEnabledBySessionID` / `defaultChatToolsEnabled`.
+export type ChatTarget = "agent" | "external_agent";
+// HecateChatTarget kept as a single-value alias so call sites that
+// specifically require the non-external branch read self-documenting.
+// Collapses to "agent" — could be inlined, but the named type signals
+// intent at use sites that operate only on the Hecate-targeted slice.
+export type HecateChatTarget = "agent";
+// ChatExecutionMode is the runtime mode the gateway dispatches a turn
+// through. Independent of ChatTarget: a Hecate-targeted chat can still
+// run as `direct_model` when the user has tools off or the chosen model
+// lacks tool calling.
 export type ChatExecutionMode = "direct_model" | "hecate_task" | "external_agent";
 
 export type QueuedChatMessage = {
@@ -38,23 +51,13 @@ export const queuedChatMessagesStorageKey = "hecate.queuedChatMessages";
 // Coercive normalizer — drops unknown values onto the safe default
 // rather than rejecting them. Used by code paths where the wider
 // type system has already vouched for the input. For localStorage
-// reads use the strict `parseStoredChatTarget` below so corrupt keys
-// get wiped.
+// reads use the strict `parseStoredChatTarget` below.
 export function normalizeStoredChatTarget(value: string): ChatTarget {
-  switch (value) {
-    case "model":
-    case "agent":
-    case "external_agent":
-      return value;
-    default:
-      return "agent";
-  }
+  return value === "external_agent" ? "external_agent" : "agent";
 }
 
 export function chatTargetToExecutionMode(target: ChatTarget): ChatExecutionMode {
   switch (target) {
-    case "model":
-      return "direct_model";
     case "agent":
       return "hecate_task";
     case "external_agent":
@@ -64,9 +67,10 @@ export function chatTargetToExecutionMode(target: ChatTarget): ChatExecutionMode
 
 export function executionModeToChatTarget(mode: string): ChatTarget | "" {
   switch (mode) {
-    case "direct_model":
-      return "model";
     case "hecate_task":
+    case "direct_model":
+      // `direct_model` runs route through the agent path with tools
+      // off; from the user-target perspective they're still "agent".
       return "agent";
     case "external_agent":
       return "external_agent";
@@ -80,21 +84,26 @@ export function executionModeToChatTarget(mode: string): ChatTarget | "" {
 // shape-drift fallback" — return null so a corrupt key gets wiped
 // and the hook falls back to the explicit "agent" default rather
 // than silently coercing the bad value and re-persisting it.
-// normalizeStoredChatTarget (above) keeps its coercive behaviour
-// for non-storage sources where the wider type system has already
-// vouched for the input.
+//
+// The legacy "model" value (older installs encoded "tools off" as
+// chatTarget "model") coerces to "agent" so the user's existing
+// localStorage doesn't get wiped on the first read after upgrade. The
+// tools-off intent is recovered from `hecate.chatTargetBySessionID` by
+// the migration in the chat slice; there's nothing useful left on the
+// top-level chatTarget key for the legacy value to carry.
 export function parseStoredChatTarget(raw: string): ChatTarget | null {
-  return raw === "model" || raw === "agent" || raw === "external_agent" ? raw : null;
+  if (raw === "agent" || raw === "external_agent") return raw;
+  if (raw === "model") return "agent";
+  return null;
 }
 
+// Single-value collapse: HecateChatTarget only has "agent" today.
+// Accepts the legacy "model" too so the parseChatTargetsBySessionID
+// migration can fold a pre-upgrade per-session map without losing
+// entries — the value's tools-off semantic is recovered separately by
+// the migration in the chat slice.
 export function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
-  switch (value) {
-    case "model":
-    case "agent":
-      return value;
-    default:
-      return "";
-  }
+  return value === "agent" || value === "model" ? "agent" : "";
 }
 
 // Structural guard for the queued-chat-messages localStorage payload.

--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -195,20 +195,37 @@ export function ChatProvider({
     initialState?.chatToolsEnabledBySessionID ?? new Map(),
     { serialize: serializeChatToolsEnabledBySessionID },
   );
-  // One-shot migration from the legacy storage key
-  // `chatTargetBySessionID`: any entry with value "model" used to
-  // encode "tools off for this session" and now lives on
-  // `chatToolsEnabledBySessionID[X] = false`. Run once on mount;
-  // explicit toolsEnabled entries the user already wrote are left
-  // alone — the migration only adds entries, never overrides.
+  // One-shot back-compat migration: the per-session map
+  // `hecate.chatTargetBySessionID` once encoded "tools off for this
+  // session" as `{[sid]: "model"}` for entries without their own
+  // chatToolsEnabled override. The parser at slice-mount coerces those
+  // "model" values to "agent" before they reach this hook, so we read
+  // the raw localStorage payload directly to recover the tools-off
+  // intent for any session that was tools-off pre-upgrade. Explicit
+  // `chatToolsEnabledBySessionID` entries the user already wrote are
+  // left alone — the migration only adds entries, never overrides.
   const toolsEnabledMigrationRanRef = useRef(false);
   useEffect(() => {
     if (toolsEnabledMigrationRanRef.current) return;
     toolsEnabledMigrationRanRef.current = true;
+    let raw: string | null = null;
+    try {
+      raw = window.localStorage?.getItem("hecate.chatTargetBySessionID") ?? null;
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
     let touched = false;
     const merged = new Map(chatToolsEnabledBySessionID);
-    for (const [sessionID, target] of chatTargetBySessionID) {
-      if (target === "model" && !merged.has(sessionID)) {
+    for (const [sessionID, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (value === "model" && !merged.has(sessionID)) {
         merged.set(sessionID, false);
         touched = true;
       }

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -856,23 +856,30 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
     const requestedChatTarget = requestedAgentID === "hecate" ? "agent" : defaultChatTarget;
     const requestedExecutionMode = chatTargetToExecutionMode(requestedChatTarget);
-    const requestedModel =
-      requestedExecutionMode === "hecate_task" &&
-      model &&
-      !modelAvailableForProviderFilter(models, providerFilter, model)
-        ? ""
-        : model;
     const executionMode = effectiveHecateExecutionMode({
       requested: requestedExecutionMode,
       models,
       providerFilter,
-      model: requestedModel,
+      model,
       // No active session yet — fall back to the user default. The
       // composer hasn't had a chance to call setChatToolsEnabled
       // against the new session ID, so the per-session map can't
       // contribute.
       toolsEnabled: defaultChatToolsEnabled,
     });
+    // The Hecate-routing availability check matters only when the turn
+    // will actually run as a Hecate task: an unroutable model on the
+    // hecate_task path falls back to "" so the gateway picks a routable
+    // default. When the effective mode downgrades to direct_model
+    // (toolsEnabled off or model lacks tool calling), the turn
+    // dispatches straight to the named provider — keep what the user
+    // picked even if it isn't in the Hecate-routing catalog.
+    const requestedModel =
+      executionMode === "hecate_task" &&
+      model &&
+      !modelAvailableForProviderFilter(models, providerFilter, model)
+        ? ""
+        : model;
     const workspace = workspaceForNewChat(createProjectID);
     if (executionMode === "hecate_task" && !workspace) {
       setChatErrorState(chatWorkspaceRequiredError());

--- a/ui/src/app/state/coordinators/overrides.tsx
+++ b/ui/src/app/state/coordinators/overrides.tsx
@@ -44,7 +44,7 @@ export type CoordinatorOverrides = {
   // precomputed values; per-view tests still set them directly and
   // expect those values to win regardless of what the derivation
   // hooks would compute from slice state. Production never sets.
-  derivedChatTarget?: "model" | "agent" | "external_agent";
+  derivedChatTarget?: "agent" | "external_agent";
   derivedNewChatAgentID?: string;
 };
 

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -14,30 +14,13 @@ import { CoordinatorOverridesContext } from "./coordinators/overrides";
 import { useProvidersAndModels } from "./providersAndModels";
 import { useRuntime } from "./runtime";
 import { deriveSessionState, type SessionState } from "../runtimeConsoleDashboard";
-import {
-  type ChatTarget,
-  type HecateChatTarget,
-  executionModeToChatTarget,
-  normalizeStoredHecateChatTarget,
-} from "./_shared";
+import { type ChatTarget } from "./_shared";
 import type { ChatSessionRecord } from "../../types/chat";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderRecord } from "../../types/provider";
 
 function chatSessionIsExternal(session: ChatSessionRecord | null): boolean {
   return Boolean(session?.agent_id && session.agent_id !== "hecate");
-}
-
-function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): HecateChatTarget {
-  if (!session) return "agent";
-  const messages = session.messages ?? [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const target = normalizeStoredHecateChatTarget(
-      executionModeToChatTarget(messages[i]?.execution_mode ?? ""),
-    );
-    if (target) return target;
-  }
-  return "agent";
 }
 
 function hecateTaskStatusIsActive(status?: string): boolean {
@@ -69,11 +52,7 @@ export function useChatTarget(): ChatTarget {
   if (overrides?.derivedChatTarget) return overrides.derivedChatTarget;
   if (state.activeChatSessionID && state.activeChatSession) {
     if (chatSessionIsExternal(state.activeChatSession)) return "external_agent";
-    if (sessionHasActiveHecateTaskSegment(state.activeChatSession)) return "agent";
-    return (
-      state.chatTargetBySessionID.get(state.activeChatSessionID) ??
-      deriveHecateChatTargetFromSession(state.activeChatSession)
-    );
+    return "agent";
   }
   return state.defaultChatTarget;
 }

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -32,7 +32,7 @@ type Props = {
   onOpenAgentSetup: () => void;
   onQuickAddLocalProviders: (providers: LocalProviderDiscoveryRecord[]) => void;
   onRefreshQuickLocalProviders: () => void;
-  onSwitchTarget: (target: "model" | "agent" | "external_agent") => void;
+  onSwitchTarget: (target: "agent" | "external_agent") => void;
   rtkAvailable: boolean;
   rtkPath: string;
   rtkEnabled: boolean;
@@ -222,15 +222,6 @@ export function ChatEmptyState({
               type="button"
             >
               <Icon d={Icons.terminal} size={13} /> Use agent
-            </button>
-          )}
-          {!modelRouteUnavailable && isAgentChat && (
-            <button
-              className="btn btn-ghost btn-sm"
-              onClick={() => onSwitchTarget("model")}
-              type="button"
-            >
-              <Icon d={Icons.model} size={13} /> Use model
             </button>
           )}
         </div>

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2106,7 +2106,10 @@ describe("ChatView input", () => {
     expectBefore(screen.getByLabelText("Message"), activeRunStatus);
 
     rerender(
-      withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }),
+      withRuntimeConsole(<ChatView />, {
+        state: { ...state, defaultChatToolsEnabled: false },
+        actions,
+      }),
     );
     expect(document.querySelector('[aria-label="Fixed provider: Ollama"]')).toBeTruthy();
     expect(document.querySelector('[aria-label="Fixed model: qwen2.5-coder"]')).toBeTruthy();
@@ -2291,7 +2294,10 @@ describe("ChatView input", () => {
     expect(screen.getByText(/Tools use task approvals and per-call sandboxing/)).toBeTruthy();
 
     rerender(
-      withRuntimeConsole(<ChatView />, { state: { ...state, chatTarget: "model" }, actions }),
+      withRuntimeConsole(<ChatView />, {
+        state: { ...state, defaultChatToolsEnabled: false },
+        actions,
+      }),
     );
     expect(screen.queryByText(/Tools use task approvals and per-call sandboxing/)).toBeNull();
   });

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -186,8 +186,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   );
   const activeSessionIsHecate = Boolean(state.activeChatSession && !activeSessionIsExternal);
   const isHecateChat =
-    activeSessionIsHecate ||
-    (!activeSessionIsExternal && (state.chatTarget === "agent" || state.chatTarget === "model"));
+    activeSessionIsHecate || (!activeSessionIsExternal && state.chatTarget === "agent");
   const isAgentChat = isHecateChat || state.chatTarget === "external_agent";
   // "Hecate-agent chat" semantically means: the user wants the *next
   // turn* to run through the Hecate agent path with tools enabled.

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -186,11 +186,12 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatTarget).toBe("agent");
   });
 
-  it("preserves the saved chat target preference", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+  it("preserves the saved tools-enabled preference", async () => {
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
-    expect(result.current.state.chatTarget).toBe("model");
+    expect(result.current.state.chatTarget).toBe("agent");
+    expect(result.current.state.defaultChatToolsEnabled).toBe(false);
   });
 
   it("drops stale persisted provider and model selections when only a catalog preset remains", async () => {
@@ -269,7 +270,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("keeps expected Hecate chat setup route failures out of the global notice", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.providerFilter", "ollama");
     window.localStorage.setItem("hecate.model", "ministral-3:latest");
     fetchMock.mockImplementation(
@@ -330,7 +331,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("keeps a newly created tools-off Hecate chat in direct model mode", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     let createBody: any = null;
     fetchMock.mockImplementation(
@@ -507,7 +508,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("creates a Hecate chat session from the default model when no model is preselected", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.agentWorkspace", "/tmp/hecate");
     let createBody: any = null;
     fetchMock.mockImplementation(
@@ -626,7 +627,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("creates new chat sessions in the active project", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     window.localStorage.setItem("hecate.project", "proj_1");
     const project: ProjectRecord = {
@@ -693,7 +694,7 @@ describe("useRuntimeConsole", () => {
   });
 
   it("honors an explicit project scope when creating a Hecate chat", async () => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     const project: ProjectRecord = {
       id: "proj_1",
@@ -751,7 +752,10 @@ describe("useRuntimeConsole", () => {
 
     expect(createBody).toMatchObject({
       agent_id: "hecate",
-      model: "",
+      // Tools-off Hecate creation dispatches as direct_model straight
+      // to the named provider, so the user's chosen model is kept
+      // even when it isn't in the Hecate-routing catalog.
+      model: "gpt-4o-mini",
       workspace: "/tmp/hecate",
       project_id: "proj_1",
     });
@@ -1775,10 +1779,6 @@ describe("useRuntimeConsole", () => {
 
   // ─── Hecate Chat session actions ───────────────────────────────────────────
   describe("Hecate Chat session actions", () => {
-    beforeEach(() => {
-      window.localStorage.setItem("hecate.chatTarget", "model");
-    });
-
     function withSessions(
       sessions: Array<{ id: string; title: string }>,
       routes: Record<string, () => Response> = {},
@@ -2721,23 +2721,27 @@ describe("useRuntimeConsole", () => {
       });
       await waitFor(() => expect(result.current.state.activeChatSession?.id).toBe("chat_a"));
       expect(result.current.state.chatTarget).toBe("agent");
+      expect(result.current.state.chatToolsEnabledBySessionID.get("chat_a")).toBeUndefined();
 
       act(() => {
-        result.current.actions.setChatTarget("model");
+        result.current.actions.setChatToolsEnabled(false);
       });
-      expect(result.current.state.chatTarget).toBe("model");
+      expect(result.current.state.chatToolsEnabledBySessionID.get("chat_a")).toBe(false);
 
       await act(async () => {
         await result.current.actions.selectChatSession("chat_b");
       });
       await waitFor(() => expect(result.current.state.activeChatSession?.id).toBe("chat_b"));
-      expect(result.current.state.chatTarget).toBe("agent");
+      // chat_b has no per-session override yet, so it falls back to the
+      // user default — the per-session pin on chat_a doesn't bleed.
+      expect(result.current.state.chatToolsEnabledBySessionID.get("chat_b")).toBeUndefined();
 
       await act(async () => {
         await result.current.actions.selectChatSession("chat_a");
       });
       await waitFor(() => expect(result.current.state.activeChatSession?.id).toBe("chat_a"));
-      expect(result.current.state.chatTarget).toBe("model");
+      // chat_a remembers its tools-off pin across the switch.
+      expect(result.current.state.chatToolsEnabledBySessionID.get("chat_a")).toBe(false);
     });
 
     it("restores provider and model from the latest Hecate chat segment on selection", async () => {

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -8,12 +8,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 
-import {
-  type ChatTarget,
-  type HecateChatTarget,
-  executionModeToChatTarget,
-  normalizeStoredHecateChatTarget,
-} from "../app/state/_shared";
+import { type ChatTarget } from "../app/state/_shared";
 import { buildLocalProviderIssue } from "../lib/provider-issues";
 import type { LocalProviderIssue } from "../lib/provider-issues";
 import { filterModelsByKind, filterModelsByProvider } from "../lib/runtime-utils";
@@ -55,33 +50,6 @@ function chatSessionIsBusy(session: ChatSessionRecord | null): boolean {
   return (session.messages ?? []).some(
     (message) => message.role === "assistant" && busy(message.status),
   );
-}
-
-function hecateTaskStatusIsActive(status?: string): boolean {
-  return status === "queued" || status === "running" || status === "awaiting_approval";
-}
-
-function sessionHasActiveHecateTaskSegment(session: ChatSessionRecord | null): boolean {
-  if (!session) return false;
-  if (session.task_id && hecateTaskStatusIsActive(session.status)) return true;
-  return (session.segments ?? []).some(
-    (segment) =>
-      segment.execution_mode === "hecate_task" &&
-      Boolean(segment.task_id) &&
-      hecateTaskStatusIsActive(segment.status),
-  );
-}
-
-function deriveHecateChatTargetFromSession(session: ChatSessionRecord | null): HecateChatTarget {
-  if (!session) return "agent";
-  const messages = session.messages ?? [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const target = normalizeStoredHecateChatTarget(
-      executionModeToChatTarget(messages[i]?.execution_mode ?? ""),
-    );
-    if (target) return target;
-  }
-  return "agent";
 }
 
 export { humanizeChatError };
@@ -214,10 +182,7 @@ export function useRuntimeConsole() {
     activeChatSessionID && activeChatSession
       ? chatSessionIsExternal(activeChatSession)
         ? "external_agent"
-        : sessionHasActiveHecateTaskSegment(activeChatSession)
-          ? "agent"
-          : (chatTargetBySessionID.get(activeChatSessionID) ??
-            deriveHecateChatTargetFromSession(activeChatSession))
+        : "agent"
       : defaultChatTarget;
 
   // Forward-dependency ref. The cycle is dashboard.loadDashboard


### PR DESCRIPTION
## Summary

Drops the dead `"model"` member of `ChatTarget`. The toggle for tools-on/off moved to its own slice field; the three-value union and its scattered dead-code branches were carrying no remaining behavior. Pure delete-positive PR (+113 / −153) plus a couple of small back-compat seams.

## Type changes (`app/state/_shared.ts`)

- `ChatTarget` is now `"agent" | "external_agent"`.
- `HecateChatTarget` collapses to a single-value alias (`"agent"`) — kept as a named type so call sites that specifically address the non-external branch read self-documenting.
- `chatTargetToExecutionMode` drops the `"model"` case.
- `executionModeToChatTarget` keeps the `direct_model` → `"agent"` mapping (the runtime fallback execution mode still surfaces this).
- `parseStoredChatTarget` and `normalizeStoredHecateChatTarget` coerce the legacy `"model"` literal to `"agent"` at read time so an upgrade doesn't wipe the user's persisted chatTarget.

## Dead-code removal

- `AppShell.tsx` drops the `chatTarget !== "model"` guard on the workspace status pill — always true now.
- `ChatView.tsx` drops the `chatTarget === "model"` branch of `isHecateChat`.
- `ChatEmptyState.tsx` drops the "Use model" button. The user expresses tools-off in the chat-settings panel after the chat starts, not as a sibling of "Use agent" in the empty state.
- `derived.ts` collapses `useChatTarget`: an active Hecate session always returns `"agent"`, and the `deriveHecateChatTargetFromSession` helper is removed (it always returned `"agent"` after the toggle decoupling).
- The duplicate helpers in the test composer get the same treatment.

## Back-compat migration (`app/state/chat.tsx`)

The one-shot migration that lifted legacy `chatTargetBySessionID[id] === "model"` entries into `chatToolsEnabledBySessionID[id] = false` now reads raw `localStorage`. The parser coerces `"model"` to `"agent"` before the typed map reaches this hook, so the typed map can no longer carry the legacy signal; reading the raw JSON before parsing recovers the user's tools-off intent for any session that was tools-off pre-upgrade.

## Coordinator routing-check fix (`app/state/coordinators/chat.ts`)

The `requestedModel` availability check used to evaluate against the *requested* execution mode, which (after the chat-target narrowing) is always `hecate_task` — meaning a tools-off chat-create would drop an otherwise-fine model just because Hecate-routing didn't know about it. Re-order: compute the *effective* execution mode first (which the toolsEnabled downgrade may have flipped to `direct_model`), then run the availability check only when the turn actually dispatches as `hecate_task`. Direct-model turns bypass Hecate routing, so an unknown-by-Hecate model is fine.

## Test updates

- The seven sites in `runtime-console-composition.test.tsx` that set `localStorage.hecate.chatTarget = "model"` (legacy tools-off encoding) now write `hecate.chatToolsEnabled = "false"` directly.
- The "preserves the saved chat target preference" test renames to "preserves the saved tools-enabled preference" and asserts the new state field directly.
- The Hecate-session-actions describe block drops its `beforeEach` that pinned tools off — the tests inside exercise active-session paths where tools-off bleeds into the submit's execution mode and the asserted behavior is task-backed.
- The session-switch test that walked `chatTarget` between sessions now walks `chatToolsEnabledBySessionID` instead.
- The "honors an explicit project scope when creating a Hecate chat" test now expects `model: "gpt-4o-mini"` instead of `""`. The old expectation was an artifact of the routing-check firing on a tools-off flow; the corrected coordinator skips the check on direct-model dispatch, so the user-chosen model is kept.
- The AppShell test "does not show agent workspace details while chatting with models" is deleted: with `"model"` gone, there's no state in which the workspace pill should be hidden while inside a Hecate chat.

## Verification

- [x] `bun run typecheck` clean
- [x] `bun run test` 1144 / 1144 pass
- [x] `bun run lint` 0 warnings / 0 errors
- [x] `bun run format:check` clean

## Diff stat

```
12 files changed, 113 insertions(+), 153 deletions(-)
```

## Follow-up

Backend handler + sqlite migration to retire the `/hecate/v1/chat/sessions` REST surface entirely is the next pure-delete pass.