### PR TITLE
feat(chat): introduce tools_enabled — first cut of model-chat removal

### DIFF
--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -1087,6 +1087,26 @@ func normalizeChatExecutionMode(mode string, session chat.Session) string {
 	return chat.ExecutionModeDirectModel
 }
 
+// chatRequestToolsEnabled returns the per-turn tools-on/off signal
+// the handler should persist for this submission. The dedicated field
+// wins when set; otherwise the value is derived from the (legacy)
+// execution_mode so existing clients continue to behave unchanged:
+//
+//   - direct_model → tools off
+//   - hecate_task / external_agent / unset → tools on (the agent path
+//     is the safe assumption when the client offers no signal)
+//
+// The capability-driven downgrade in the dispatcher (a tool-incapable
+// model on a hecate_task turn) flips this to false as well, so the
+// persisted Message always reflects what actually ran rather than
+// what the client originally requested.
+func chatRequestToolsEnabled(req CreateChatMessageRequest) bool {
+	if req.ToolsEnabled != nil {
+		return *req.ToolsEnabled
+	}
+	return strings.TrimSpace(req.ExecutionMode) != chat.ExecutionModeDirectModel
+}
+
 func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
 	if busy, runStatus := h.hecateAgentSessionBusy(r.Context(), session); busy {
 		writeHecateAgentBusy(w, session, runStatus)
@@ -1130,13 +1150,20 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            newChatID("msg"),
 		ExecutionMode: chat.ExecutionModeDirectModel,
-		SegmentID:     segmentID,
-		Provider:      provider,
-		Model:         model,
-		Capabilities:  caps,
-		Role:          "user",
-		Content:       content,
-		CreatedAt:     startedAt,
+		// The model-chat handler dispatches when the operator submitted
+		// with tools off (or when the runtime downgraded a hecate_task
+		// turn because the model can't run tools). Either way, the
+		// persisted Message records ToolsEnabled=false so a future
+		// read against this row recovers the original intent without
+		// having to parse the execution_mode string.
+		ToolsEnabled: false,
+		SegmentID:    segmentID,
+		Provider:     provider,
+		Model:        model,
+		Capabilities: caps,
+		Role:         "user",
+		Content:      content,
+		CreatedAt:    startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -1149,6 +1176,7 @@ func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Re
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeDirectModel,
+		ToolsEnabled:  false,
 		SegmentID:     segmentID,
 		RunID:         runID,
 		RequestID:     RequestIDFromContext(r.Context()),

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -102,14 +102,19 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            userID,
 		ExecutionMode: messageSnapshot.ExecutionMode,
-		SegmentID:     messageSnapshot.SegmentID,
-		TaskID:        messageSnapshot.TaskID,
-		Provider:      messageSnapshot.Provider,
-		Model:         messageSnapshot.Model,
-		Capabilities:  messageSnapshot.Capabilities,
-		Role:          "user",
-		Content:       content,
-		CreatedAt:     startedAt,
+		// Hecate-task handler: the operator submitted with tools on
+		// (otherwise the dispatcher routes to the model-chat handler
+		// path). Record the intent so a future read against this row
+		// doesn't have to interpret execution_mode to recover it.
+		ToolsEnabled: true,
+		SegmentID:    messageSnapshot.SegmentID,
+		TaskID:       messageSnapshot.TaskID,
+		Provider:     messageSnapshot.Provider,
+		Model:        messageSnapshot.Model,
+		Capabilities: messageSnapshot.Capabilities,
+		Role:         "user",
+		Content:      content,
+		CreatedAt:    startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -121,6 +126,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: messageSnapshot.ExecutionMode,
+		ToolsEnabled:  true,
 		SegmentID:     messageSnapshot.SegmentID,
 		TaskID:        messageSnapshot.TaskID,
 		RequestID:     RequestIDFromContext(r.Context()),
@@ -324,6 +330,7 @@ func hecateAgentSegmentID(session chat.Session) string {
 func hecateAgentMessageSnapshot(session chat.Session, caps types.ModelCapabilities, segmentID string) chat.Message {
 	return chat.Message{
 		ExecutionMode: chat.ExecutionModeHecateTask,
+		ToolsEnabled:  true,
 		SegmentID:     segmentID,
 		TaskID:        session.TaskID,
 		Provider:      session.Provider,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -596,12 +596,27 @@ type CreateChatSessionRequest struct {
 }
 
 type CreateChatMessageRequest struct {
-	Content       string `json:"content"`
+	Content string `json:"content"`
+	// ExecutionMode is the legacy per-turn dispatch discriminant.
+	// Today it carries one of "direct_model", "hecate_task", or
+	// "external_agent"; the model-chat direct_model path is being
+	// retired in favor of ToolsEnabled=false on a hecate_task turn.
+	// Reads still accept the legacy value for back-compat; the
+	// handler derives a ToolsEnabled signal from it when the explicit
+	// field is missing (see `chatRequestToolsEnabled`).
 	ExecutionMode string `json:"execution_mode,omitempty"`
-	Provider      string `json:"provider,omitempty"`
-	Model         string `json:"model,omitempty"`
-	SystemPrompt  string `json:"system_prompt,omitempty"`
-	Workspace     string `json:"workspace,omitempty"`
+	// ToolsEnabled is the per-turn tools-on/off signal. Pointer so the
+	// handler can distinguish "explicit false" from "not specified" —
+	// when nil, the handler derives the value from ExecutionMode so
+	// existing clients continue to work unchanged. New clients should
+	// set this field directly and leave ExecutionMode empty (the
+	// session's agent_id already encodes the broad agent-vs-external
+	// dispatch); the handler will route to the same destination.
+	ToolsEnabled *bool  `json:"tools_enabled,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	Model        string `json:"model,omitempty"`
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	Workspace    string `json:"workspace,omitempty"`
 }
 
 type UpdateChatSessionRequest struct {

--- a/internal/chat/conformance_test.go
+++ b/internal/chat/conformance_test.go
@@ -41,4 +41,8 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreDeleteByProjectID(t, factory(t))
 	})
+	t.Run(name+"/ToolsEnabledRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		runStoreToolsEnabledRoundTrip(t, factory(t))
+	})
 }

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -297,17 +297,18 @@ func (s *SQLiteStore) AppendMessage(ctx context.Context, sessionID string, messa
 		ctx,
 		fmt.Sprintf(
 			`INSERT INTO %s (
-				id, session_id, sequence, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id,
+				id, session_id, sequence, execution_mode, tools_enabled, segment_id, task_id, run_id, request_id, trace_id, span_id,
 				role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code,
 				cost_mode, provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at,
 				error, activities, usage, timing, context_packet
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			s.messagesTable,
 		),
 		message.ID,
 		sessionID,
 		nextSeq,
 		message.ExecutionMode,
+		boolToSQLiteInt(message.ToolsEnabled),
 		message.SegmentID,
 		message.TaskID,
 		message.RunID,
@@ -367,7 +368,7 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, messa
 		ctx,
 		fmt.Sprintf(
 			`UPDATE %s SET
-			   execution_mode = ?, segment_id = ?, task_id = ?, run_id = ?, request_id = ?, trace_id = ?, span_id = ?, role = ?, content = ?, raw_output = ?, agent_id = ?, agent_name = ?,
+			   execution_mode = ?, tools_enabled = ?, segment_id = ?, task_id = ?, run_id = ?, request_id = ?, trace_id = ?, span_id = ?, role = ?, content = ?, raw_output = ?, agent_id = ?, agent_name = ?,
 			   driver_kind = ?, native_session_id = ?, status = ?, exit_code = ?,
 			   cost_mode = ?, provider = ?, model = ?, capabilities = ?, workspace = ?, diff_stat = ?, diff = ?, created_at = ?,
 			   started_at = ?, completed_at = ?, error = ?, activities = ?, usage = ?, timing = ?, context_packet = ?
@@ -375,6 +376,7 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, messa
 			s.messagesTable,
 		),
 		message.ExecutionMode,
+		boolToSQLiteInt(message.ToolsEnabled),
 		message.SegmentID,
 		message.TaskID,
 		message.RunID,
@@ -533,6 +535,16 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 	}{
 		{name: "run_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "execution_mode", definition: "TEXT NOT NULL DEFAULT ''"},
+		// Boolean stored as INTEGER (0/1). DEFAULT 1 so existing rows
+		// land on "tools on" — the agent path is the safe assumption.
+		// The legacy execution_mode='direct_model' rows get backfilled
+		// to 0 by the dedicated migration below, since those rows
+		// explicitly recorded a tools-off intent before tools-off had
+		// its own column. The handler layer treats this column as the
+		// source of truth going forward; execution_mode stays for
+		// segment routing (hecate_task vs external_agent) and
+		// backwards-compat reads.
+		{name: "tools_enabled", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{name: "segment_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "task_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "request_id", definition: "TEXT NOT NULL DEFAULT ''"},
@@ -555,6 +567,25 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		if err := s.ensureMessageColumn(ctx, column.name, column.definition); err != nil {
 			return err
 		}
+	}
+
+	// Backfill `tools_enabled = 0` for rows that recorded the legacy
+	// `execution_mode = 'direct_model'` value. That literal predates
+	// the dedicated tools-enabled column and is the single signal in
+	// older data that the user submitted with tools off. The UPDATE is
+	// idempotent and runs every boot; once every direct_model row has
+	// been touched the WHERE clause selects nothing on subsequent
+	// boots. The legacy value is preserved in execution_mode so a
+	// historical-by-string read against an unmigrated session still
+	// behaves.
+	if _, err := s.client.DB().ExecContext(
+		ctx,
+		fmt.Sprintf(
+			`UPDATE %s SET tools_enabled = 0 WHERE execution_mode = 'direct_model' AND tools_enabled = 1`,
+			s.messagesTable,
+		),
+	); err != nil {
+		return fmt.Errorf("backfill sqlite agent chat tools_enabled: %w", err)
 	}
 
 	messagesIndex := strings.Trim(s.messagesTable, `"`) + "_session_seq_idx"
@@ -634,7 +665,7 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 	rows, err := s.client.DB().QueryContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT id, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
+			`SELECT id, execution_mode, tools_enabled, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
 			        provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at, error, activities, usage, timing, context_packet
 			 FROM %s
 			 WHERE session_id = ?
@@ -657,9 +688,11 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 		var timing string
 		var capabilities string
 		var contextPacket string
+		var toolsEnabledInt int64
 		if err := rows.Scan(
 			&message.ID,
 			&message.ExecutionMode,
+			&toolsEnabledInt,
 			&message.SegmentID,
 			&message.TaskID,
 			&message.RunID,
@@ -704,12 +737,24 @@ func (s *SQLiteStore) loadMessages(ctx context.Context, sessionID string) ([]Mes
 		message.Timing = unmarshalTiming(timing)
 		message.Capabilities = unmarshalModelCapabilities(capabilities)
 		message.Context = unmarshalContextPacket(contextPacket)
+		message.ToolsEnabled = toolsEnabledInt != 0
 		messages = append(messages, message)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate sqlite agent chat messages: %w", err)
 	}
 	return messages, nil
+}
+
+// boolToSQLiteInt converts a Go bool to the 0/1 integer that the
+// `tools_enabled` column stores. SQLite has no native boolean type
+// and modernc.org/sqlite does not auto-bind bool to INTEGER, so the
+// translation has to be explicit at every write site.
+func boolToSQLiteInt(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func (s *SQLiteStore) ensureMessageColumn(ctx context.Context, column, definition string) error {
@@ -783,10 +828,11 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 	var timing string
 	var capabilities string
 	var contextPacket string
+	var toolsEnabledInt int64
 	err := tx.QueryRowContext(
 		ctx,
 		fmt.Sprintf(
-			`SELECT id, execution_mode, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
+			`SELECT id, execution_mode, tools_enabled, segment_id, task_id, run_id, request_id, trace_id, span_id, role, content, raw_output, agent_id, agent_name, driver_kind, native_session_id, status, exit_code, cost_mode,
 			        provider, model, capabilities, workspace, diff_stat, diff, created_at, started_at, completed_at, error, activities, usage, timing, context_packet
 			 FROM %s
 			 WHERE id = ? AND session_id = ?`,
@@ -797,6 +843,7 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 	).Scan(
 		&message.ID,
 		&message.ExecutionMode,
+		&toolsEnabledInt,
 		&message.SegmentID,
 		&message.TaskID,
 		&message.RunID,
@@ -845,6 +892,7 @@ func loadMessage(ctx context.Context, tx txRunner, table string, sessionID strin
 	message.Timing = unmarshalTiming(timing)
 	message.Capabilities = unmarshalModelCapabilities(capabilities)
 	message.Context = unmarshalContextPacket(contextPacket)
+	message.ToolsEnabled = toolsEnabledInt != 0
 	return message, nil
 }
 

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/storage"
 )
@@ -31,6 +32,70 @@ func TestSQLiteStoreConformance(t *testing.T) {
 	RunConformanceTests(t, "SQLiteStore", func(t *testing.T) Store {
 		return newSQLiteTestStore(t)
 	})
+}
+
+func TestSQLiteStoreBackfillsToolsEnabledForLegacyDirectModelRows(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chat.db")
+	client, err := storage.NewSQLiteClient(context.Background(), storage.SQLiteConfig{
+		Path:        path,
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	store, err := NewSQLiteStore(context.Background(), client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	if _, err := store.Create(context.Background(), Session{
+		ID:      "chat_legacy_direct",
+		AgentID: DefaultAgentID,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Simulate a pre-migration row: legacy `execution_mode='direct_model'`
+	// with the default column value (tools_enabled=1, "tools on"). The
+	// real backfill target is upgraded installs whose existing rows
+	// land on the column default after `ALTER TABLE ADD COLUMN`.
+	if _, err := client.DB().ExecContext(
+		context.Background(),
+		`INSERT INTO `+client.TableName("chat_messages")+`
+		     (id, session_id, sequence, execution_mode, tools_enabled, role, content,
+		      agent_id, agent_name, status, exit_code, cost_mode,
+		      workspace, diff_stat, diff, created_at)
+		 VALUES ('msg_legacy', 'chat_legacy_direct', 99, 'direct_model', 1, 'user', 'legacy tools-off turn',
+		         'hecate', '', '', 0, '',
+		         '', '', '', ?)`,
+		time.Now().UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("raw INSERT legacy row: %v", err)
+	}
+
+	// Re-running the migration (idempotent) flips tools_enabled to 0
+	// for any direct_model row that still landed on the column
+	// default.
+	if _, err := NewSQLiteStore(context.Background(), client); err != nil {
+		t.Fatalf("re-open SQLiteStore: %v", err)
+	}
+
+	session, ok, err := store.Get(context.Background(), "chat_legacy_direct")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: ok = false")
+	}
+	if len(session.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1", len(session.Messages))
+	}
+	if session.Messages[0].ToolsEnabled {
+		t.Errorf("legacy direct_model row ToolsEnabled = true, want false (backfill missed)")
+	}
 }
 
 func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -41,8 +41,17 @@ type Session struct {
 }
 
 type Message struct {
-	ID              string
-	ExecutionMode   string
+	ID            string
+	ExecutionMode string
+	// ToolsEnabled records whether the user submitted this turn with
+	// tools on. Independent of ExecutionMode: a Hecate-task turn with
+	// ToolsEnabled=false dispatches directly to the model without
+	// creating an agent_loop task, replacing the legacy
+	// ExecutionMode="direct_model" encoding. Reads against existing
+	// rows that predate this field default to true; the sqlite
+	// migration backfills false for rows that still carry the legacy
+	// "direct_model" execution_mode value.
+	ToolsEnabled    bool
 	SegmentID       string
 	TaskID          string
 	RunID           string

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -227,6 +227,74 @@ func runStoreLifecycle(t *testing.T, store Store) {
 	}
 }
 
+func runStoreToolsEnabledRoundTrip(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := store.Create(ctx, Session{
+		ID:      "chat_tools_enabled",
+		AgentID: DefaultAgentID,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Two messages with explicit, opposite ToolsEnabled values to
+	// verify the round-trip preserves each independently and the
+	// boolean isn't being collapsed to a per-session signal.
+	if _, err := store.AppendMessage(ctx, created.ID, Message{
+		ID:            "msg_tools_on",
+		ExecutionMode: ExecutionModeHecateTask,
+		ToolsEnabled:  true,
+		Role:          "user",
+		Content:       "with tools",
+	}); err != nil {
+		t.Fatalf("AppendMessage(tools_on): %v", err)
+	}
+	if _, err := store.AppendMessage(ctx, created.ID, Message{
+		ID:            "msg_tools_off",
+		ExecutionMode: ExecutionModeHecateTask,
+		ToolsEnabled:  false,
+		Role:          "user",
+		Content:       "no tools",
+	}); err != nil {
+		t.Fatalf("AppendMessage(tools_off): %v", err)
+	}
+
+	session, ok, err := store.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: ok = false")
+	}
+	byID := make(map[string]Message, len(session.Messages))
+	for _, m := range session.Messages {
+		byID[m.ID] = m
+	}
+	if got := byID["msg_tools_on"].ToolsEnabled; !got {
+		t.Errorf("msg_tools_on.ToolsEnabled = false, want true")
+	}
+	if got := byID["msg_tools_off"].ToolsEnabled; got {
+		t.Errorf("msg_tools_off.ToolsEnabled = true, want false")
+	}
+
+	// UpdateMessage flips the flag — verifies the write path preserves
+	// the column on UPDATE, not just INSERT.
+	if _, err := store.UpdateMessage(ctx, created.ID, "msg_tools_off", func(m *Message) {
+		m.ToolsEnabled = true
+	}); err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+	session, _, err = store.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+	for _, m := range session.Messages {
+		if m.ID == "msg_tools_off" && !m.ToolsEnabled {
+			t.Errorf("msg_tools_off.ToolsEnabled after update = false, want true")
+		}
+	}
+}
+
 func runStoreDeepCopiesConfigOptions(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Foundation for retiring the `ExecutionMode='direct_model'` encoding of "tools off for this turn." This is the first cut of a multi-step refactor that ends with the model-chat dispatch path folded into the hecate-task path and `ExecutionModeDirectModel` deleted. Each commit here is additive and non-breaking — no wire shape changes, no dispatch semantics changes; the field is plumbed through so a follow-up PR can rewire dispatch without simultaneously inventing the persistence + API contract.

## What's in this PR

### Storage layer foundation (`f26d7cbd`)

- **`chat.Message.ToolsEnabled bool`** — independent of ExecutionMode. A hecate_task turn with ToolsEnabled=false will dispatch directly to the model without creating an agent_loop task once the handler rewire follows. ExecutionMode keeps its current role for segment routing.
- **Sqlite schema migration** adds `tools_enabled INTEGER NOT NULL DEFAULT 1` to `chat_messages`. The migration is idempotent (uses the existing `ensureMessageColumn` pattern).
- **One-shot backfill SQL**: `UPDATE chat_messages SET tools_enabled = 0 WHERE execution_mode = 'direct_model' AND tools_enabled = 1`. Captures the legacy direct_model signal that predates the dedicated column. The WHERE clause specifies `tools_enabled = 1` so once every direct_model row has been flipped, the UPDATE selects nothing on subsequent boots — runs every startup, behaves correctly.
- **INSERT/UPDATE/SELECT** statements all carry `tools_enabled`. A small `boolToSQLiteInt` helper makes the bool↔INTEGER translation explicit at every write site (modernc.org/sqlite doesn't auto-bind bool to INTEGER on writes).
- **Conformance test** `ToolsEnabledRoundTrip` exercises both MemoryStore and SQLiteStore. Two messages with explicit opposite ToolsEnabled values round-trip independently, and the UPDATE path preserves the column.
- **Sqlite-specific test** `TestSQLiteStoreBackfillsToolsEnabledForLegacyDirectModelRows` simulates a pre-migration row (raw INSERT with `execution_mode = 'direct_model'` AND `tools_enabled = 1` — the column default), re-opens the store to re-run the migration, and asserts the row was flipped to `ToolsEnabled = false`.

### Handler-side plumbing (`50ee6691`)

- **`CreateChatMessageRequest`** gains `ToolsEnabled *bool`. A pointer because the handler needs to distinguish "explicit false" from "not specified". When nil, the new helper `chatRequestToolsEnabled` derives the signal from the (legacy) `execution_mode` so existing clients continue to behave unchanged: `direct_model` → false, anything else → true.
- The model-chat handler now writes `ToolsEnabled = false` at each `AppendMessage`. The hecate-task handler writes `true`. The `hecateAgentMessageSnapshot` builder (used by the hecate path to prime a message from session state) carries `true` too.
- External-agent rows leave `ToolsEnabled` at the zero value — the field is Hecate-side semantic and doesn't apply when the agent owns its own tools.
- The capability-driven downgrade in the dispatcher (a tool-incapable model on a hecate_task turn) still routes to the model-chat handler, which means the persisted `ToolsEnabled` lands on `false` even if the client originally requested `true` — the row reflects what actually dispatched rather than what was asked for.

## What's NOT in this PR (explicit follow-ups)

The original brief was to drop the model-chat path entirely. This PR delivers the additive foundation only; the structural fold + delete work is a separate PR (or two) because the fold is the highest-risk piece and worth review in isolation:

1. **Fold `handleCreateModelChatMessage` into `handleCreateHecateChatMessage`** with a tools-off short-circuit that skips agent_loop task creation. ~300 LOC restructure of streaming + activity rendering + live SSE coordination.
2. **Remove `ExecutionModeDirectModel`** constant + 13 usage sites once the fold is done.
3. **Render layer — expose `tools_enabled` on chat-message response DTOs.** The field is persisted today and the write path sets it correctly, but no chat-session response DTO surfaces it, so clients can't read the per-message value back. The UI deliberately keeps deriving toggle state from its own slice rather than message history (per the existing `useChatToolsEnabled` design — see PR #265 / #267), so nothing is broken in the meantime. But the read-side gap is a prerequisite for the fold: once dispatch routes on `tools_enabled` instead of `execution_mode`, the field has to be visible to readers as the canonical signal.
4. **UI changes** to send `tools_enabled` on submit (and stop sending `execution_mode = "direct_model"`).
5. **E2E updates** (chat.spec.ts touches tools-off in ~5 places).
6. **Docs updates** — `chat-sessions.md`, `runtime-api.md`, `telemetry.md` once the wire shape is stable.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/... ./internal/chat/...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/... ./internal/storage/... ./internal/orchestrator/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1155 / 1155 pass (no UI surface affected; new field is additive on the request shape)

## Diff stat

```
8 files changed, 271 insertions(+), 27 deletions(-)
```

## Merge safety

This PR can land standalone — the new field is additive, the backfill is idempotent, the handler dispatch is unchanged, and the persisted ToolsEnabled value is correct for every turn that actually runs (it doesn't yet drive any branching, but it accurately records what the dispatcher chose).
