### PR TITLE
feat(chat): expose tools_enabled on the chat-message response DTO

### DIFF
--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -443,6 +443,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if modelAssistant.ExecutionMode != chat.ExecutionModeDirectModel || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
 		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
+	if modelAssistant.ToolsEnabled {
+		t.Errorf("model assistant tools_enabled = true, want false (direct_model dispatch records tools-off)")
+	}
 	if !strings.Contains(modelAssistant.Content, "Segment answer") {
 		t.Fatalf("model assistant content = %q", modelAssistant.Content)
 	}
@@ -456,6 +459,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	toolsAssistant := toolsTurn.Data.Messages[len(toolsTurn.Data.Messages)-1]
 	if toolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || toolsAssistant.TaskID != firstTaskID || toolsAssistant.SegmentID != "task:"+firstTaskID {
 		t.Fatalf("tools assistant snapshot = execution_mode %q task %q segment %q", toolsAssistant.ExecutionMode, toolsAssistant.TaskID, toolsAssistant.SegmentID)
+	}
+	if !toolsAssistant.ToolsEnabled {
+		t.Errorf("tools assistant tools_enabled = false, want true (hecate_task dispatch records tools-on)")
 	}
 
 	secondModel := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -59,6 +59,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 		messages = append(messages, ChatMessageItem{
 			ID:              message.ID,
 			ExecutionMode:   message.ExecutionMode,
+			ToolsEnabled:    message.ToolsEnabled,
 			SegmentID:       message.SegmentID,
 			TaskID:          message.TaskID,
 			RunID:           message.RunID,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -695,8 +695,16 @@ type ChatSegmentItem struct {
 }
 
 type ChatMessageItem struct {
-	ID              string                  `json:"id"`
-	ExecutionMode   string                  `json:"execution_mode,omitempty"`
+	ID            string `json:"id"`
+	ExecutionMode string `json:"execution_mode,omitempty"`
+	// ToolsEnabled is the per-turn tools-on/off signal the gateway
+	// recorded when this message was appended. Always present on the
+	// wire (no `omitempty`) so `false` is a meaningful "tools were
+	// off" and not indistinguishable from "the field is absent."
+	// Clients that talk to a backend predating this field should
+	// treat it as `true` by default — the agent path is the safe
+	// assumption when no signal is present.
+	ToolsEnabled    bool                    `json:"tools_enabled"`
 	SegmentID       string                  `json:"segment_id,omitempty"`
 	TaskID          string                  `json:"task_id,omitempty"`
 	RunID           string                  `json:"run_id,omitempty"`

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -42,6 +42,17 @@ export type ChatSessionSummaryRecord = {
 export type ChatMessageRecord = {
   id: string;
   execution_mode?: "external_agent" | "hecate_task" | "direct_model" | string;
+  // tools_enabled is the per-turn tools-on/off signal the gateway
+  // recorded when this message was appended. Optional so older
+  // backends that predate the field can be tolerated; consumers
+  // should treat `undefined` as "no signal — assume tools on" (the
+  // agent path is the safe default). Today the UI doesn't derive
+  // tools-toggle state from message history (see `useChatToolsEnabled`
+  // in `app/state/derived.ts`) so this field is informational on the
+  // client side; once the backend dispatch routes on tools_enabled
+  // instead of execution_mode the field becomes the canonical wire
+  // signal.
+  tools_enabled?: boolean;
   segment_id?: string;
   task_id?: string;
   run_id?: string;


### PR DESCRIPTION
## Summary

Closes the read-side gap flagged on PR #268: `Message.ToolsEnabled` is persisted today and the write path sets it correctly, but no chat-session response DTO surfaced it, so clients could not read the per-message value back.

This PR surfaces the field on `ChatMessageItem` (the wire DTO) and on `ChatMessageRecord` (the UI type) so every chat-message response carries it for every turn the gateway recorded.

## Wire

- **`ChatMessageItem.ToolsEnabled bool`** with `json:"tools_enabled"`. No `omitempty` — a `false` is meaningful "tools were off" and shouldn't be indistinguishable from an absent field.
- DTO docs note: clients talking to backends predating this field should treat its absence as `true` (the agent path is the safe default).
- `renderChatSession` maps `message.ToolsEnabled` straight through. Agent-path turns surface `true`, direct-model turns surface `false`, external-agent rows surface the zero value (the field doesn't apply when the agent owns its own tools).

## UI type

- **`ChatMessageRecord.tools_enabled?: boolean`** mirrors the wire shape. Optional so older backends are tolerated.
- The TS type comment explicitly notes the UI does **not** currently derive toggle state from message history (see `useChatToolsEnabled` in `app/state/derived.ts`); the field is informational on the client for now. It becomes the canonical wire signal once the backend dispatch routes on `tools_enabled` instead of `execution_mode` in the follow-up fold cut.

## Test

The existing `TestHecateChatCanSwitchBetweenModelAndToolsSegments` already exercises both dispatch paths back-to-back, so it's the natural place to assert the round-trip:

- direct-model assistant must surface `tools_enabled = false`
- hecate-task assistant must surface `tools_enabled = true`

No new test boilerplate; two single-line assertions in the right spots.

## What this unblocks

This is the third item from PR #268's "What's NOT in this PR" list. With it landed:

- The fold step (`handleCreateModelChatMessage` → `handleCreateHecateChatMessage` with tools-off short-circuit) can use `tools_enabled` as the canonical dispatch signal, knowing clients can read it back from response DTOs.
- The UI can start deriving toggle state from message history if/when that becomes desirable (it deliberately doesn't today, per `useChatToolsEnabled`).

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1155 / 1155 pass
- [x] `bun run lint` (UI) — 0 warnings / 0 errors
- [x] `bun run format:check` (UI) — clean

## Diff stat

```
4 files changed, 28 insertions(+), 2 deletions(-)
```