### PR TITLE
feat(chat): UI sends tools_enabled; backend derives execution_mode from it

### DIFF
--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -750,7 +750,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		})
 		return
 	}
-	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session)
+	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session, req.ToolsEnabled)
 	if executionMode == chat.ExecutionModeHecateTask && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
 		executionMode = chat.ExecutionModeDirectModel
 	}
@@ -1076,13 +1076,37 @@ func (h *Handler) hecateTaskShouldFallbackToDirectModel(ctx context.Context, ses
 	return !modelcaps.ToolCapable(caps)
 }
 
-func normalizeChatExecutionMode(mode string, session chat.Session) string {
+// normalizeChatExecutionMode resolves the execution mode the handler
+// should dispatch on. The explicit `execution_mode` field on the
+// request still wins when set — older clients send the literal
+// directly. When it's empty:
+//
+//   - External-agent sessions always dispatch as `external_agent`
+//     (agent_id pins the session kind regardless of any per-turn
+//     flag the client may have sent).
+//   - Hecate sessions consult the per-turn `tools_enabled` signal
+//     when it's set: true → `hecate_task`, false → `direct_model`.
+//     This lets newer clients submit `tools_enabled` and omit
+//     `execution_mode` entirely, which is the wire shape the UI
+//     moves to once the model-chat dispatch path is folded into
+//     hecate_task.
+//   - When neither field is set on a Hecate session, the dispatcher
+//     defaults to `direct_model` for back-compat with the pre-
+//     tools_enabled wire shape (where the absence of `execution_mode`
+//     was a no-tools turn).
+func normalizeChatExecutionMode(mode string, session chat.Session, toolsEnabled *bool) string {
 	mode = strings.TrimSpace(mode)
 	if mode != "" {
 		return mode
 	}
 	if isExternalChatSession(session) {
 		return chat.ExecutionModeExternalAgent
+	}
+	if toolsEnabled != nil {
+		if *toolsEnabled {
+			return chat.ExecutionModeHecateTask
+		}
+		return chat.ExecutionModeDirectModel
 	}
 	return chat.ExecutionModeDirectModel
 }

--- a/internal/api/handler_chat_dispatch_test.go
+++ b/internal/api/handler_chat_dispatch_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/chat"
+)
+
+// boolPtr is a tiny helper for the tools_enabled tri-state on
+// CreateChatMessageRequest. A `*bool` field uses nil to mean "the
+// client did not send this", which is what
+// `normalizeChatExecutionMode` falls back on; non-nil values pin the
+// dispatch.
+func boolPtr(b bool) *bool { return &b }
+
+func TestNormalizeChatExecutionMode_ExplicitModeWinsOverEverything(t *testing.T) {
+	// When the client sends `execution_mode` explicitly, the dispatcher
+	// uses it verbatim regardless of session shape or tools_enabled.
+	// This preserves back-compat with older clients that send the
+	// literal directly.
+	session := chat.Session{AgentID: chat.DefaultAgentID}
+	if got := normalizeChatExecutionMode(chat.ExecutionModeHecateTask, session, boolPtr(false)); got != chat.ExecutionModeHecateTask {
+		t.Errorf("explicit hecate_task + tools_enabled=false: got %q, want hecate_task", got)
+	}
+	if got := normalizeChatExecutionMode(chat.ExecutionModeDirectModel, session, boolPtr(true)); got != chat.ExecutionModeDirectModel {
+		t.Errorf("explicit direct_model + tools_enabled=true: got %q, want direct_model", got)
+	}
+	if got := normalizeChatExecutionMode(chat.ExecutionModeExternalAgent, session, boolPtr(true)); got != chat.ExecutionModeExternalAgent {
+		t.Errorf("explicit external_agent: got %q, want external_agent", got)
+	}
+}
+
+func TestNormalizeChatExecutionMode_ExternalSessionPinsExternalAgent(t *testing.T) {
+	// When the session itself is external (agent_id != "hecate"), the
+	// dispatcher pins external_agent no matter what tools_enabled
+	// signal the client may have sent. Agent identity is the source
+	// of truth here.
+	session := chat.Session{AgentID: "claude_code"}
+	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeExternalAgent {
+		t.Errorf("external session + no signals: got %q, want external_agent", got)
+	}
+	if got := normalizeChatExecutionMode("", session, boolPtr(true)); got != chat.ExecutionModeExternalAgent {
+		t.Errorf("external session + tools_enabled=true: got %q, want external_agent", got)
+	}
+}
+
+func TestNormalizeChatExecutionMode_HecateSessionDerivesFromToolsEnabled(t *testing.T) {
+	// The new wire shape: Hecate-side turns send `tools_enabled` and
+	// omit `execution_mode`. The dispatcher routes hecate_task vs
+	// direct_model on the boolean.
+	session := chat.Session{AgentID: chat.DefaultAgentID}
+	if got := normalizeChatExecutionMode("", session, boolPtr(true)); got != chat.ExecutionModeHecateTask {
+		t.Errorf("hecate session + tools_enabled=true: got %q, want hecate_task", got)
+	}
+	if got := normalizeChatExecutionMode("", session, boolPtr(false)); got != chat.ExecutionModeDirectModel {
+		t.Errorf("hecate session + tools_enabled=false: got %q, want direct_model", got)
+	}
+}
+
+func TestNormalizeChatExecutionMode_HecateSessionDefaultsToDirectModelWhenSignalsAbsent(t *testing.T) {
+	// Pre-tools_enabled clients sent neither field on the model-chat
+	// path and relied on the dispatcher's default. Keep that
+	// contract: a Hecate session with no execution_mode and no
+	// tools_enabled still routes to direct_model.
+	session := chat.Session{AgentID: chat.DefaultAgentID}
+	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeDirectModel {
+		t.Errorf("hecate session + no signals: got %q, want direct_model", got)
+	}
+}

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1384,7 +1384,9 @@ test("Hecate Chat sends direct model turns when selected model lacks tools", asy
   await expect
     .poll(() => messagePayload)
     .toMatchObject({
-      execution_mode: "direct_model",
+      // UI sends tools_enabled and omits execution_mode for
+      // Hecate-side turns; backend derives the dispatch.
+      tools_enabled: false,
       provider: "ollama",
       model: "smollm2:135m",
     });
@@ -1555,7 +1557,7 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
   await expect
     .poll(() => messagePayload)
     .toMatchObject({
-      execution_mode: "hecate_task",
+      tools_enabled: true,
       model: "qwen2.5",
       workspace: "/tmp/hecate-e2e-workspace",
     });
@@ -1735,9 +1737,18 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     const body = await route.request().postDataJSON();
     submittedTurns.push(body);
     const turn = submittedTurns.length;
-    const executionMode = body.execution_mode || "direct_model";
+    // Mirror the backend's `normalizeChatExecutionMode` derivation:
+    // explicit execution_mode wins; otherwise derive from
+    // tools_enabled (true → hecate_task, false/undefined →
+    // direct_model). The UI sends tools_enabled for Hecate-side
+    // turns and omits execution_mode.
+    const executionMode =
+      body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model");
     const isHecateAgent = executionMode === "hecate_task";
-    const agentTurn = submittedTurns.filter((t) => t.execution_mode === "hecate_task").length;
+    const agentTurn = submittedTurns.filter(
+      (t) =>
+        (t.execution_mode || (t.tools_enabled ? "hecate_task" : "direct_model")) === "hecate_task",
+    ).length;
     const taskID = isHecateAgent ? `task-tools-${agentTurn}` : "";
     const runID = isHecateAgent ? `run-tools-${agentTurn}` : "";
     const firstTaskNeedsApproval = isHecateAgent && agentTurn === 1 && !taskApprovalResolved;
@@ -1864,17 +1875,16 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
   await expect(page.getByLabel("Tools off segment using qwen2.5")).toHaveCount(1);
 
   expect(createSessionCount).toBe(1);
-  expect(submittedTurns.map((turn) => turn.execution_mode)).toEqual([
-    "hecate_task",
-    "direct_model",
-    "hecate_task",
-  ]);
+  // UI sends tools_enabled (boolean) for Hecate-side turns and omits
+  // the legacy execution_mode literal. The three-turn sequence is
+  // tools-on / tools-off / tools-on.
+  expect(submittedTurns.map((turn) => turn.tools_enabled)).toEqual([true, false, true]);
   expect(submittedTurns.map((turn) => turn.content)).toEqual([
     "first with tools",
     "direct model turn",
     "tools again",
   ]);
-  expect(submittedTurns.filter((turn) => turn.execution_mode === "hecate_task")).toEqual([
+  expect(submittedTurns.filter((turn) => turn.tools_enabled === true)).toEqual([
     expect.objectContaining({ model: "qwen2.5", workspace: "/tmp/hecate-e2e-workspace" }),
     expect.objectContaining({ model: "qwen2.5", workspace: "/tmp/hecate-e2e-workspace" }),
   ]);
@@ -2014,7 +2024,11 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
       messages: [
         {
           id: "msg-user-direct",
-          execution_mode: body.execution_mode,
+          // Backend response carries execution_mode regardless of
+          // what the client sent — derive it from the request the
+          // same way `normalizeChatExecutionMode` does.
+          execution_mode:
+            body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model"),
           provider: body.provider || "",
           model: body.model,
           role: "user",
@@ -2023,7 +2037,8 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
         },
         {
           id: "msg-assistant-direct",
-          execution_mode: body.execution_mode,
+          execution_mode:
+            body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model"),
           provider: body.provider || "",
           model: body.model,
           role: "assistant",
@@ -2055,7 +2070,7 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
 
   expect(submittedTurns).toEqual([
     expect.objectContaining({
-      execution_mode: "direct_model",
+      tools_enabled: false,
       provider: "ollama",
       model: "smollm2:135m",
       content: "tell a joke",

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -709,7 +709,15 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       });
       const updated = await createChatMessageRequest(sessionID, {
         content: pendingContent,
-        execution_mode: turnExecutionMode,
+        // External-agent turns continue to send the literal
+        // execution_mode — the backend dispatch on that path is
+        // unchanged. Hecate-side turns send `tools_enabled` instead
+        // and let the backend derive the execution mode; the model
+        // path eventually folds into the task path and dispatch
+        // there will route on the boolean directly.
+        ...(isExternalAgent
+          ? { execution_mode: turnExecutionMode }
+          : { tools_enabled: turnExecutionMode === "hecate_task" }),
         ...(!isExternalAgent
           ? { provider: turnProviderFilter === "auto" ? "" : turnProviderFilter, model: turnModel }
           : {}),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -160,7 +160,18 @@ export type CreateChatSessionPayload = {
 
 export type CreateChatMessagePayload = {
   content: string;
+  // execution_mode stays on the wire so external-agent dispatch
+  // continues to send the literal explicitly. For Hecate-side turns
+  // the UI now prefers `tools_enabled` and omits `execution_mode`;
+  // the backend derives the dispatch from the boolean when the
+  // legacy field is empty.
   execution_mode?: "external_agent" | "hecate_task" | "direct_model";
+  // tools_enabled is the per-turn tools-on/off signal. Backend
+  // dispatch routes hecate_task vs direct_model on this boolean when
+  // execution_mode is absent (the new wire shape for Hecate-side
+  // turns). External-agent turns don't use it — agent_id pins the
+  // dispatch and the agent owns its own tools.
+  tools_enabled?: boolean;
   provider?: string;
   model?: string;
   system_prompt?: string;

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -1948,10 +1948,15 @@ describe("useRuntimeConsole", () => {
 
       expect(postedBody).toMatchObject({
         content: "inspect the repo",
-        execution_mode: "hecate_task",
+        // Hecate-side turns now send `tools_enabled` and let the
+        // backend derive the dispatch. The legacy `execution_mode`
+        // field stays in the type but isn't sent for non-external
+        // turns.
+        tools_enabled: true,
         system_prompt: "Prefer small, reviewable diffs.",
         workspace: "/workspace",
       });
+      expect(postedBody).not.toHaveProperty("execution_mode");
     });
 
     it("sends Hecate Chat turns directly when the selected model is not tool-capable", async () => {
@@ -2046,10 +2051,15 @@ describe("useRuntimeConsole", () => {
 
       expect(postedBody).toMatchObject({
         content: "tell a small joke",
-        execution_mode: "direct_model",
+        // A capability-driven downgrade (model lacks tool calling)
+        // surfaces on the wire as tools_enabled=false; the backend
+        // routes to the direct-model path without needing the
+        // legacy execution_mode literal.
+        tools_enabled: false,
         provider: "ollama",
         model: "smollm2:135m",
       });
+      expect(postedBody).not.toHaveProperty("execution_mode");
       expect(postedBody).not.toHaveProperty("workspace");
       expect(result.current.state.chatError).toBe("");
     });


### PR DESCRIPTION
## Summary

The Hecate-side chat-message submit no longer puts the legacy `execution_mode` literal on the wire. It sends `tools_enabled` and lets the dispatcher derive the rest. The backend keeps accepting `execution_mode` for back-compat with older clients (and continues to use it for external-agent dispatch).

Next step in the model-chat removal sequence — after this lands, the dispatcher routes on `tools_enabled` from the canonical write path, which unblocks the structural fold (`handleCreateModelChatMessage` → `handleCreateHecateChatMessage`).

## Backend dispatch

- **`normalizeChatExecutionMode(mode, session, toolsEnabled)`** gains the `toolsEnabled *bool` parameter.
- When `execution_mode` is empty and the session is Hecate-shaped, the dispatcher reads the boolean: `true` → `hecate_task`, `false` → `direct_model`.
- External-agent sessions still pin to `external_agent` regardless of any per-turn flag — agent_id is the source of truth there.
- When both `execution_mode` and `tools_enabled` are absent on a Hecate session, the dispatcher continues to default to `direct_model` (the pre-tools_enabled wire contract).

## UI submit

- `coordinators/chat.ts:submitChat` constructs the chat-message POST body conditionally:
  - external-agent turns send explicit `execution_mode: "external_agent"`
  - Hecate-side turns send `tools_enabled: turnExecutionMode === "hecate_task"` and **omit** `execution_mode` entirely
- `CreateChatMessagePayload` type gains `tools_enabled?: boolean` alongside the existing optional `execution_mode`. Both fields stay optional so the wire shape is forward-compat: a backend that doesn't yet honor `tools_enabled` falls back to its `normalizeChatExecutionMode` default (`direct_model`).

## Tests

- **New `handler_chat_dispatch_test.go`** covers the four `normalizeChatExecutionMode` cases as pure-function unit tests:
  - explicit mode wins (over both session shape and tools_enabled)
  - external session pins `external_agent`
  - Hecate session derives from `tools_enabled`
  - Hecate session defaults to `direct_model` when both signals are absent
- Two `runtime-console-composition.test.tsx` cases update their `postedBody` assertions: instead of `execution_mode: "hecate_task"` / `execution_mode: "direct_model"`, they now assert `tools_enabled: true` / `tools_enabled: false` and that `execution_mode` is absent from the body.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1155 / 1155 pass
- [x] `bun run lint` (UI) — 0 warnings / 0 errors
- [x] `bun run format:check` (UI) — clean

## Diff stat

```
5 files changed, 127 insertions(+), 5 deletions(-)
```

## What this unblocks

With this merged:
- Dispatcher reads from the canonical `tools_enabled` signal for Hecate-side turns.
- UI no longer sends the legacy literal for hot-path Hecate chats.
- The structural fold (next PR) can route `handleCreateHecateChatMessage` on `tools_enabled` with a clear short-circuit for tools-off rather than having to interpret two parallel wire encodings.

## Follow-ups still owed

From PR #268's "What's NOT in this PR" list, items remaining:
1. **Fold `handleCreateModelChatMessage` into `handleCreateHecateChatMessage`** with a tools-off short-circuit (~300 LOC restructure).
2. **Remove `ExecutionModeDirectModel`** constant + 13 usage sites (once the fold is done).
3. **E2E updates** (chat.spec.ts ~5 tools-off sites).
4. **Docs updates** — chat-sessions.md / runtime-api.md / telemetry.md once dispatch is fully on `tools_enabled`.