### PR TITLE
test(security): cover exposed runtime token guards

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,6 +11,21 @@ the `x-api-key` header. It is a local deployment guard, not user management;
 keep using a reverse proxy, firewall, VPN, or equivalent control for anything
 reachable beyond your own machine.
 
+Minimum exposed-instance guardrail set:
+
+```bash
+HECATE_ADDRESS=0.0.0.0:8765
+HECATE_ALLOW_NON_LOOPBACK_BIND=1
+HECATE_ALLOWED_ORIGINS=https://hecate.example.com
+HECATE_RUNTIME_TOKEN=replace-with-at-least-24-random-characters
+HECATE_INFERENCE_TOKEN=replace-with-at-least-24-random-characters
+```
+
+Use `HECATE_RUNTIME_TOKEN` for Hecate-native clients such as the operator UI,
+MCP tools, and chat/task control-plane calls. Use `HECATE_INFERENCE_TOKEN` for
+OpenAI- or Anthropic-shaped SDK clients pointed at `/v1/*`. Keep `/healthz`
+private to the host, load balancer, or orchestrator health check.
+
 ## Contents
 
 - [Image pinning](#image-pinning)

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -273,6 +273,22 @@ func postJSON(t *testing.T, url, body string, headers map[string]string) *http.R
 	return resp
 }
 
+func getWithHeaders(t *testing.T, url string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
 func getJSON[T any](t *testing.T, url string) T {
 	t.Helper()
 	resp, err := http.Get(url) //nolint:noctx
@@ -429,6 +445,74 @@ func TestGatewayNoProviderConfiguredReturns502(t *testing.T) {
 	if resp.StatusCode == http.StatusOK {
 		t.Fatalf("expected non-200 with no provider configured, got 200")
 	}
+}
+
+func TestGatewayRuntimeAndInferenceTokensProtectExposedSurfaces(t *testing.T) {
+	t.Parallel()
+
+	const (
+		runtimeToken   = "local-runtime-token-123456"
+		inferenceToken = "local-inference-token-123456"
+	)
+	fakeResp := `{"id":"chatcmpl-auth-e2e","object":"chat.completion","created":1700000000,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"auth ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`
+	upstream := fakeOpenAIServer(t, "/v1/chat/completions", fakeResp, false)
+
+	base := gatewayServer(t,
+		"HECATE_RUNTIME_TOKEN="+runtimeToken,
+		"HECATE_INFERENCE_TOKEN="+inferenceToken,
+		"PROVIDER_FAKE_API_KEY=dummy",
+		"PROVIDER_FAKE_BASE_URL="+upstream,
+		"PROVIDER_FAKE_KIND=local",
+	)
+
+	resp := getWithHeaders(t, base+"/healthz", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	resp = getWithHeaders(t, base+"/hecate/v1/whoami", nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET /hecate/v1/whoami without runtime token status = %d, want 401", resp.StatusCode)
+	}
+	_ = readBody(t, resp)
+
+	resp = getWithHeaders(t, base+"/hecate/v1/whoami", map[string]string{
+		"X-Hecate-Runtime-Token": runtimeToken,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /hecate/v1/whoami with runtime token status = %d, want 200; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+
+	resp = getWithHeaders(t, base+"/v1/models", nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET /v1/models without inference token status = %d, want 401", resp.StatusCode)
+	}
+	_ = readBody(t, resp)
+
+	resp = getWithHeaders(t, base+"/v1/models", map[string]string{
+		"x-api-key": inferenceToken,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/models with inference token status = %d, want 200; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`
+	resp = postJSON(t, base+"/v1/chat/completions", body, nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("POST /v1/chat/completions without inference token status = %d, want 401", resp.StatusCode)
+	}
+	_ = readBody(t, resp)
+
+	resp = postJSON(t, base+"/v1/chat/completions", body, map[string]string{
+		"Authorization": "Bearer " + inferenceToken,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /v1/chat/completions with inference token status = %d, want 200; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
 }
 
 func TestEnvExampleDoesNotExposeAgentAdapterFixtureOverrides(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a real-binary e2e regression for the exposed-instance token story and documents the minimum exposed-instance guardrail set.

- boots `hecate serve` with both `HECATE_RUNTIME_TOKEN` and `HECATE_INFERENCE_TOKEN`
- verifies `/healthz` stays open
- verifies `/hecate/v1/whoami` rejects without the runtime token and succeeds with it
- verifies `/v1/models` and `/v1/chat/completions` reject without the inference token and succeed with `x-api-key` / `Authorization: Bearer ...`
- adds a deployment snippet showing the expected non-loopback bind, allowed origin, runtime token, and inference token combination

## Verification

- `GOCACHE="$PWD/.gocache" go test -tags e2e ./e2e -run TestGatewayRuntimeAndInferenceTokensProtectExposedSurfaces -count=1 -v`
- `GOCACHE="$PWD/.gocache" go test -tags e2e ./e2e -count=1`
- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/config`
- `./ui/node_modules/.bin/oxfmt --check docs/deployment.md`
- `git diff --check -- docs/deployment.md e2e/gateway_test.go`

Note: local unstaged `ui/e2e/chat.spec.ts` changes were present before this commit and are not part of this PR.