### PR TITLE
fix(ui): improve transcript workspace changes

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -2929,7 +2929,9 @@ test("workspace changes review inspects and discards a current file", async ({ p
     });
   });
 
+  let readmeFileDiffRequests = 0;
   await page.route("/hecate/v1/chat/sessions/a-diff-1/workspace-diff/files/README.md", (route) => {
+    readmeFileDiffRequests += 1;
     void route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -2969,15 +2971,19 @@ test("workspace changes review inspects and discards a current file", async ({ p
   await page.waitForSelector(".hecate-activitybar");
 
   await expect(page.getByText("Updated the docs.")).toBeVisible();
-  await expect(page.getByText("Workspace changes")).toBeVisible();
-  await page.getByRole("button", { name: "Workspace changes" }).click();
+  const workspaceChangesButton = page.getByRole("button", { name: "Workspace changes" });
+  await expect(workspaceChangesButton).toBeVisible();
+  await workspaceChangesButton.click();
   const workspaceChangesPanel = page.getByLabel("Workspace changes panel");
   await expect(
     workspaceChangesPanel.getByText("2 files changed, 6 insertions(+), 1 deletion(-)").first(),
   ).toBeVisible();
 
   await expect(page.getByRole("button", { name: "Hide diff README.md" })).toBeVisible();
-  await expect(workspaceChangesPanel).toContainText("current line");
+  await expect.poll(() => readmeFileDiffRequests).toBeGreaterThan(0);
+  const readmeDiffPreview = workspaceChangesPanel.getByTestId("workspace-file-diff-preview");
+  await expect(readmeDiffPreview).toBeVisible();
+  await expect(readmeDiffPreview.getByTestId("diff-viewer")).toBeAttached();
 
   await page.getByRole("button", { name: "Discard README.md" }).click();
   await expect(page.getByRole("button", { name: "Confirm discard README.md" })).toBeVisible();

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3319,7 +3319,7 @@ describe("ChatView external-agent target", () => {
       "title",
       "Workspace changes · 2 files changed, 10 insertions(+), 4 deletions(-)",
     );
-    expect(screen.getByText("2 files changed, 10 insertions(+), 4 deletions(-)")).toBeTruthy();
+    expect(screen.queryByText("2 files changed, 10 insertions(+), 4 deletions(-)")).toBeNull();
     expect(screen.getByText("raw agent output · 1 line")).toBeTruthy();
     expect(screen.getAllByText("completed").length).toBeGreaterThan(0);
     const user = userEvent.setup();

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -276,12 +276,12 @@ describe("TranscriptActivityTimeline", () => {
     render(<TranscriptActivityTimeline activities={activities} />);
 
     expect(screen.getByText("Read context")).toBeInTheDocument();
-    expect(screen.getByText("read · output captured")).toBeInTheDocument();
+    expect(screen.queryByText("read · output captured")).toBeNull();
     expect(screen.queryByText(/h1 align/)).toBeNull();
     expect(screen.queryByText(/docs\/assets\/logo/)).toBeNull();
   });
 
-  it("summarizes noisy generic command activity while showing child output inline", async () => {
+  it("summarizes noisy generic command activity without expanding every output card", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [
       {
@@ -334,10 +334,14 @@ describe("TranscriptActivityTimeline", () => {
     await user.click(screen.getByText("Commands"));
 
     expect(screen.getAllByText("Ran command")).toHaveLength(4);
-    expect(screen.queryByText(/output captured · commit abc123/)).toBeNull();
+    expect(screen.queryByText(/commit abc123/)).toBeNull();
+    expect(screen.queryByText("Tool output for call_1")).toBeNull();
+    expect(screen.queryByText("Tool output for call_4")).toBeNull();
+
+    await user.click(screen.getAllByText("Output")[0]);
+
     expect(screen.getByText("Tool output for call_1")).toBeInTheDocument();
-    expect(screen.getByText("Tool output for call_4")).toBeInTheDocument();
-    expect(screen.queryByText(/^Output$/)).toBeNull();
+    expect(screen.queryByText("Tool output for call_4")).toBeNull();
   });
 
   it("treats completed commands with fatal output as failed for transcript tone", () => {
@@ -421,7 +425,7 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText(/cancelled · 2 interrupted tools/)).toBeInTheDocument();
   });
 
-  it("includes workspace changes in the summary and expanded activity list when diffStat is supplied", () => {
+  it("includes workspace changes in the summary without duplicating a timeline row", () => {
     const activities: ChatActivityRecord[] = [
       { type: "tool_call", title: "read_file", status: "completed" },
     ];
@@ -432,8 +436,8 @@ describe("TranscriptActivityTimeline", () => {
       />,
     );
     expect(screen.getByText(/workspace changes/)).toBeInTheDocument();
-    expect(screen.getByText("Workspace changes")).toBeInTheDocument();
-    expect(screen.getByText("1 file changed, 2 insertions(+), 1 deletion(-)")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace changes")).toBeNull();
+    expect(screen.queryByText("1 file changed, 2 insertions(+), 1 deletion(-)")).toBeNull();
   });
 
   it("does not duplicate backend files_changed rows when diffStat is supplied", () => {
@@ -453,10 +457,8 @@ describe("TranscriptActivityTimeline", () => {
       />,
     );
 
-    expect(screen.getAllByText("Workspace changes")).toHaveLength(1);
-    expect(screen.getAllByText("2 files changed, 72 insertions(+), 3 deletions(-)")).toHaveLength(
-      1,
-    );
+    expect(screen.queryByText("Workspace changes")).toBeNull();
+    expect(screen.queryByText("2 files changed, 72 insertions(+), 3 deletions(-)")).toBeNull();
   });
 
   it("hides the 'started' activity when a terminal activity has appeared", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -10,7 +10,6 @@ import {
   compactAgentActivities,
   compactDetailActivities,
   detailSummaryLabel,
-  fileChangesActivity,
   formatDiffStatSummary,
   isActiveAgentActivity,
   isOutputArtifactActivity,
@@ -111,7 +110,7 @@ export function TranscriptActivityTimeline({
 }) {
   const visible = orderVisibleActivities(compactAgentActivities(activities, Boolean(diffStat)));
   const details = orderVisibleActivities(compactDetailActivities(activities, Boolean(diffStat)));
-  const primaryRaw = diffStat ? [...visible, fileChangesActivity(diffStat)] : visible;
+  const primaryRaw = visible;
   const primary = summarizeTimelineActivities(primaryRaw);
   const terminal = terminalAgentActivity(activities);
   const hasRunning = !terminal && activities.some(isActiveAgentActivity);
@@ -297,7 +296,6 @@ function TimelineActivityLine({
                     key={child.id || `child-${child.type}-${child.created_at ?? index}`}
                     activity={child}
                     renderAdvancedActivity={renderAdvancedActivity}
-                    inlineAdvanced={activity.type === "tool_group"}
                   />
                 ))}
               </div>

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -217,11 +217,9 @@ export function TranscriptActivityTimeline({
 function TimelineActivityLine({
   activity,
   renderAdvancedActivity,
-  inlineAdvanced = false,
 }: {
   activity: ChatActivityRecord;
   renderAdvancedActivity?: (activity: ChatActivityRecord) => ReactNode;
-  inlineAdvanced?: boolean;
 }) {
   const children = activity.children ?? [];
   const advancedContent = renderAdvancedActivity?.(activity);
@@ -232,33 +230,11 @@ function TimelineActivityLine({
       <ActivityLine
         activity={activity}
         prefix={activityLinePrefix(activity)}
-        hideDetail={inlineAdvanced && Boolean(advancedContent)}
       />
     );
   const hasAdvanced = children.length > 0 || Boolean(advancedContent);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   if (!hasAdvanced) return line;
-
-  if (inlineAdvanced) {
-    return (
-      <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
-        {line}
-        {children.length > 0 && (
-          <div style={{ display: "grid", gap: 5, marginLeft: 15 }}>
-            {children.map((child, index) => (
-              <TimelineActivityLine
-                key={child.id || `child-${child.type}-${child.created_at ?? index}`}
-                activity={child}
-                renderAdvancedActivity={renderAdvancedActivity}
-                inlineAdvanced
-              />
-            ))}
-          </div>
-        )}
-        {advancedContent && <div style={{ marginLeft: 15 }}>{advancedContent}</div>}
-      </div>
-    );
-  }
 
   return (
     <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
@@ -362,14 +338,9 @@ function PlanActivityLine({ activity }: { activity: ChatActivityRecord }) {
   );
 }
 
-function ActivityLine({
-  activity,
-  prefix,
-  hideDetail = false,
-}: {
+function ActivityLine({ activity, prefix }: {
   activity: ChatActivityRecord;
   prefix?: string;
-  hideDetail?: boolean;
 }) {
   const display = activityDisplay(activity);
   const status = activityEffectiveStatus(activity);
@@ -406,7 +377,7 @@ function ActivityLine({
       >
         {display.title}
       </span>
-      {display.detail && !hideDetail && (
+      {display.detail && (
         <span
           style={{
             fontSize: 11,

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -227,10 +227,7 @@ function TimelineActivityLine({
     activity.type === "plan" ? (
       <PlanActivityLine activity={activity} />
     ) : (
-      <ActivityLine
-        activity={activity}
-        prefix={activityLinePrefix(activity)}
-      />
+      <ActivityLine activity={activity} prefix={activityLinePrefix(activity)} />
     );
   const hasAdvanced = children.length > 0 || Boolean(advancedContent);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -338,10 +335,7 @@ function PlanActivityLine({ activity }: { activity: ChatActivityRecord }) {
   );
 }
 
-function ActivityLine({ activity, prefix }: {
-  activity: ChatActivityRecord;
-  prefix?: string;
-}) {
+function ActivityLine({ activity, prefix }: { activity: ChatActivityRecord; prefix?: string }) {
   const display = activityDisplay(activity);
   const status = activityEffectiveStatus(activity);
   return (

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -587,6 +587,28 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
   });
 
+  it("strips ANSI color codes from captured command output", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_shell",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output: done",
+        artifact_preview: `${String.fromCharCode(27)}[31mfailed${String.fromCharCode(27)}[0m\nnext line`,
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    await user.click(screen.getByText("Output"));
+
+    const output = screen.getByText(/failed/);
+    expect(output.textContent).toContain("failed\nnext line");
+    expect(output.textContent).not.toContain(String.fromCharCode(27));
+  });
+
   it("renders arrow-separated read-context output with real line breaks", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -548,7 +548,7 @@ describe("TranscriptMessageRow", () => {
 
     render(<TranscriptMessageRow {...baseProps} activities={activities} />);
 
-    expect(screen.getByText("read · output captured")).toBeInTheDocument();
+    expect(screen.queryByText("read · output captured")).toBeNull();
     expect(screen.queryByText(/import foo/)).toBeNull();
 
     await user.click(screen.getByText("Output"));
@@ -577,7 +577,7 @@ describe("TranscriptMessageRow", () => {
 
     render(<TranscriptMessageRow {...baseProps} activities={activities} />);
 
-    expect(screen.getByText("execute · output captured")).toBeInTheDocument();
+    expect(screen.queryByText("execute · output captured")).toBeNull();
     expect(screen.queryByText(/total 88064/)).toBeNull();
 
     await user.click(screen.getByText("Output"));
@@ -604,9 +604,60 @@ describe("TranscriptMessageRow", () => {
 
     await user.click(screen.getByText("Output"));
 
-    expect(screen.getByText(/import \{ parsePatchFiles \}/)).toBeInTheDocument();
-    expect(screen.getByText(/import \{ FileDiff \}/)).toBeInTheDocument();
-    expect(screen.queryByText(/1 │/)).toBeNull();
+    const output = screen.getByText(/import \{ parsePatchFiles \}/);
+    expect(output.textContent).toContain(
+      'import { parsePatchFiles } from "@pierre/diffs";\nimport { FileDiff } from "@pierre/diffs/react";',
+    );
+    expect(output).not.toHaveTextContent(/1(?:>|→|\|)/);
+  });
+
+  it("renders pipe-separated read-context output with real line breaks", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_read",
+        status: "completed",
+        kind: "read",
+        detail:
+          'read · output: 1 | <h1 align="center"> 2 | <img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png">',
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    await user.click(screen.getByText("Output"));
+
+    const output = screen.getByText(/<h1 align="center">/);
+    expect(output.textContent).toContain(
+      '<h1 align="center">\n<img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png">',
+    );
+    expect(output).not.toHaveTextContent(/\d+\s*\|/);
+  });
+
+  it("does not duplicate captured diffs when the workspace-changes chip is available", () => {
+    const diff = [
+      "diff --git a/README.md b/README.md",
+      "index 1111111..2222222 100644",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -1 +1,2 @@",
+      " # Hecate",
+      "+Local runtime console",
+    ].join("\n");
+
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        diff={diff}
+        diffStat="README.md | 1 +\n1 file changed, 1 insertion(+)"
+        changedFilesLink={{ label: "1 file", onClick: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Open 1 file" })).toBeInTheDocument();
+    expect(screen.queryByText(/workspace changes · 1 file changed/)).toBeNull();
+    expect(screen.queryByTestId("diff-viewer")).toBeNull();
   });
 
   it("shows the rich diff viewer for file-change activity when a patch is captured", async () => {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -116,6 +116,7 @@ export function TranscriptMessageRow({
   const showCapturedDiff =
     isAssistant &&
     Boolean(diffStat?.trim() || diff?.trim()) &&
+    !changedFilesLink &&
     !(visibleActivities ?? []).some(isFilesChangedActivity);
 
   return (
@@ -430,11 +431,16 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
 }
 
 function normalizeToolOutputPreview(output: string): string {
-  return output
-    .replace(/\s*(\d+)\s*(?:>|→)/g, (_match, _line: string, offset: number) =>
-      offset === 0 ? "" : "\n",
-    )
+  return stripAnsi(output)
+    .replace(/\r\n/g, "\n")
+    .replace(/(?:^|\n)[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
+    .replace(/[ \t]+\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/g, "");
 }
 
 function CapturedDiffDetails({ diffStat, diff }: { diffStat?: string; diff?: string }) {

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -15,6 +15,8 @@ import { DiffStatList, TranscriptActivityTimeline } from "./TranscriptActivityTi
 import { TranscriptMarkdown } from "./TranscriptMarkdown";
 import { capturedToolOutput } from "./transcriptActivityHelpers";
 
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
 export function TranscriptMessageRow({
   id,
   role,
@@ -440,7 +442,7 @@ function normalizeToolOutputPreview(output: string): string {
 }
 
 function stripAnsi(value: string): string {
-  return value.replace(/\u001b\[[0-9;]*m/g, "");
+  return value.replace(ANSI_ESCAPE_PATTERN, "");
 }
 
 function CapturedDiffDetails({ diffStat, diff }: { diffStat?: string; diff?: string }) {

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -11,7 +11,6 @@ import {
   compactDetailActivities,
   capturedToolOutput,
   detailSummaryLabel,
-  fileChangesActivity,
   formatDiffStatSummary,
   isActiveAgentActivity,
   isOutputArtifactActivity,
@@ -81,17 +80,6 @@ describe("parseDiffStatRows", () => {
 
   it("trims path and change whitespace", () => {
     expect(parseDiffStatRows("  foo.ts  |  3 +-  ")).toEqual([{ path: "foo.ts", change: "3 +-" }]);
-  });
-});
-
-describe("fileChangesActivity", () => {
-  it("packages a diffStat into a synthetic files_changed activity", () => {
-    const built = fileChangesActivity("foo.ts | 3 +-\n1 file changed");
-    expect(built.id).toBe("hecate-agent:files-changed");
-    expect(built.type).toBe("files_changed");
-    expect(built.status).toBe("completed");
-    expect(built.title).toBe("Workspace changes");
-    expect(built.detail).toMatch(/^1 file changed/);
   });
 });
 
@@ -326,7 +314,7 @@ describe("activityDisplay", () => {
       ),
     ).toEqual({
       title: "Ran command",
-      detail: "execute · output captured",
+      detail: undefined,
     });
   });
 

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -14,16 +14,6 @@ export function formatDiffStatSummary(diffStat: string): string {
   return compactInlineDetail(lines[0] || "");
 }
 
-export function fileChangesActivity(diffStat: string): ChatActivityRecord {
-  return {
-    id: "hecate-agent:files-changed",
-    type: "files_changed",
-    status: "completed",
-    title: "Workspace changes",
-    detail: formatDiffStatSummary(diffStat),
-  };
-}
-
 export function parseDiffStatRows(diffStat: string): Array<{ path: string; change: string }> {
   return diffStat
     .split(/\\n|\r?\n/)
@@ -397,10 +387,10 @@ function toolActivityDetail(
 export function capturedToolOutput(activity: ChatActivityRecord): string | undefined {
   if (activity.type !== "tool_call") return undefined;
   const preview = activity.artifact_preview?.trimEnd();
-  if (preview) return preview;
   const detail = activity.detail?.trim();
-  if (!detail) return undefined;
-  return parseToolOutputDetail(detail)?.output;
+  const parsed = detail ? parseToolOutputDetail(detail)?.output : undefined;
+  if (preview && parsed) return parsed.length > preview.length ? parsed : preview;
+  return preview || parsed;
 }
 
 function isThinkingToolActivity(activity: ChatActivityRecord): boolean {
@@ -447,26 +437,30 @@ function isAdapterContextReadFailure(activity: ChatActivityRecord): boolean {
 }
 
 function toolDetailHasOutput(activity: ChatActivityRecord): boolean {
-  return /\boutput\s*:/i.test(activity.detail ?? "");
+  return Boolean(capturedToolOutput(activity)) || /\boutput\s*:/i.test(activity.detail ?? "");
 }
 
 function hasFailureLikeToolOutput(activity: ChatActivityRecord): boolean {
   if (activity.type !== "tool_call") return false;
-  const output = capturedToolOutput(activity) ?? "";
+  const output = capturedToolOutput(activity) ?? activity.detail ?? "";
   // Some ACP adapters report the tool call as completed even when the
   // command itself printed a fatal error. Keep this inference narrow:
   // it is a UI tone, not a persisted status rewrite.
   return /(^|\s)(fatal|panic):/i.test(output) || /\bexit(?:ed)?\s+code\s+[1-9]\d*/i.test(output);
 }
 
-function compactToolOutputDetail(detail: string): string {
+function compactToolOutputDetail(detail: string): string | undefined {
   const parsed = parseToolOutputDetail(detail);
   if (!parsed) return detail;
 
   const { prefix, output } = parsed;
   if (/^failed to read file:/i.test(output)) return `${prefix} · read failed`;
   if (/^cannot read binary file:/i.test(output)) return `${prefix} · binary file skipped`;
-  return `${prefix} · output captured`;
+  return simpleToolOutputPrefix(prefix) ? undefined : prefix;
+}
+
+function simpleToolOutputPrefix(prefix: string): boolean {
+  return /^(execute|read|write|edit|command|shell)$/i.test(prefix.trim());
 }
 
 function parseToolOutputDetail(detail: string): { prefix: string; output: string } | undefined {


### PR DESCRIPTION
## Summary
- remove duplicated Workspace changes rows when the header file chip already links to the workspace-diff panel
- keep noisy command groups compact while allowing commands and individual outputs to be expanded on demand
- make read/tool output previews more readable by normalizing ACP line markers, stripping ANSI color codes, and preferring full captured previews over shortened inline details
- keep captured diffs out of the transcript when the workspace changes chip/right panel is available

## Tests
- `cd ui && bun run typecheck`
- `cd ui && bun run test`