### PR TITLE
ci: split Go test checks by platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,21 +164,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-  test-go:
-    name: Go tests (${{ matrix.name }})
+  test-go-linux-race:
+    name: Go tests (Linux race)
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux race
-            os: ubuntu-latest
-            command: go test -race -timeout 10m ./...
-          - name: Windows bootstrap
-            os: windows-latest
-            command: go test ./internal/bootstrap
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -188,7 +178,39 @@ jobs:
           cache: true
 
       - name: Test
-        run: ${{ matrix.command }}
+        run: go test -race -timeout 10m ./...
+
+  test-go-windows-bootstrap:
+    name: Go tests (Windows bootstrap)
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test
+        run: go test ./internal/bootstrap
+
+  test-go-macos-bootstrap:
+    name: Go tests (macOS bootstrap)
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test
+        run: go test ./internal/bootstrap
 
   build-hecate:
     name: Build hecate
@@ -451,7 +473,9 @@ jobs:
       - changes
       - test-tauri-rust
       - lint-go
-      - test-go
+      - test-go-linux-race
+      - test-go-windows-bootstrap
+      - test-go-macos-bootstrap
       - build-hecate
       - e2e
       - e2e-ollama
@@ -471,7 +495,9 @@ jobs:
       ) &&
       contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
       contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.test-go.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-linux-race.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-windows-bootstrap.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-macos-bootstrap.result) &&
       contains(fromJSON('["success","skipped"]'), needs.build-hecate.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e.result) &&
       contains(fromJSON('["success","skipped"]'), needs.e2e-ollama.result) &&


### PR DESCRIPTION
## Summary

- Replace the dynamic Go test matrix check name with static platform-specific jobs.
- Keep the existing Linux race and Windows bootstrap coverage with byte-identical check names: `Go tests (Linux race)` and `Go tests (Windows bootstrap)`.
- Add a cheap `Go tests (macOS bootstrap)` check without expanding regular PRs into full macOS runtime or Tauri packaging work.
- Update the Tauri desktop bundle gate so expensive packaging still waits for every cheap platform check when desktop builds are relevant.

## Why

When the old matrix job was skipped, GitHub could not expand `Go tests (${{ matrix.name }})`, so it rendered the literal expression instead of the concrete check name. That was not just cosmetic: required status checks are keyed by check name, so a protected check such as `Go tests (Linux race)` could fail to report on skipped non-Go PRs and leave a PR stuck waiting for a check that never materialized.

Static jobs always report stable names in both run and skip paths. Existing required-check names for Linux race and Windows bootstrap remain unchanged, while macOS bootstrap is intentionally a new optional check until branch protection is updated.

## CI shape

- `Go tests (Linux race)` keeps the full `go test -race -timeout 10m ./...` coverage on Ubuntu.
- `Go tests (Windows bootstrap)` keeps the focused Windows bootstrap smoke.
- `Go tests (macOS bootstrap)` adds the same focused bootstrap smoke on macOS, the primary desktop development target.
- The Tauri desktop matrix still runs only after cheaper checks pass and only for desktop/workflow-relevant changes.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "workflow yaml ok"'`
- `actionlint .github/workflows/test.yml`
- `GOCACHE="$PWD/.gocache" go test ./internal/bootstrap`
