### PR TITLE
test(security): cover messages inference token e2e

### DIFF
--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -513,6 +513,24 @@ func TestGatewayRuntimeAndInferenceTokensProtectExposedSurfaces(t *testing.T) {
 		t.Fatalf("POST /v1/chat/completions with inference token status = %d, want 200; body=%s", resp.StatusCode, readBody(t, resp))
 	}
 	resp.Body.Close()
+
+	messagesBody := `{"model":"claude-sonnet-4-20250514","max_tokens":128,"messages":[{"role":"user","content":"hello"}]}`
+	resp = postJSON(t, base+"/v1/messages", messagesBody, map[string]string{
+		"anthropic-version": "2023-06-01",
+	})
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("POST /v1/messages without inference token status = %d, want 401", resp.StatusCode)
+	}
+	_ = readBody(t, resp)
+
+	resp = postJSON(t, base+"/v1/messages", messagesBody, map[string]string{
+		"anthropic-version": "2023-06-01",
+		"x-api-key":         inferenceToken,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /v1/messages with inference token status = %d, want 200; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
 }
 
 func TestEnvExampleDoesNotExposeAgentAdapterFixtureOverrides(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes the exposed-instance token e2e matrix from #271 by adding the Anthropic-shaped `/v1/messages` route.

- verifies `POST /v1/messages` rejects without `HECATE_INFERENCE_TOKEN` credentials
- verifies `POST /v1/messages` succeeds with `x-api-key` and the configured inference token
- keeps the existing `/healthz`, `/hecate/v1/whoami`, `/v1/models`, and `/v1/chat/completions` assertions intact

## Verification

- `GOCACHE="$PWD/.gocache" go test -tags e2e ./e2e -run TestGatewayRuntimeAndInferenceTokensProtectExposedSurfaces -count=1 -v`
- `GOCACHE="$PWD/.gocache" go test -tags e2e ./e2e -run TestGatewayRuntimeAndInferenceTokensProtectExposedSurfaces -count=1`
- `git diff --check -- e2e/gateway_test.go`

## Dependabot triage

The remaining moderate alert is `GHSA-wrw7-89jp-8q8g` for Rust `glib` in `tauri/src-tauri/Cargo.lock`. It is pulled through the Tauri Linux GTK stack (`tauri -> gtk v0.18.2 -> glib v0.18.5`). The patched line starts at `glib 0.20.0`, but `gtk v0.18.2` requires `glib ^0.18`, so `cargo update -p glib --precise 0.20.0 --dry-run` cannot resolve. `cargo update -p tauri --dry-run` reports no compatible update. This needs an upstream Tauri/GTK stack movement rather than a safe direct lockfile bump.