### PR TITLE
Improve transcript command readability

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -131,6 +131,12 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   and Details grouping instead of growing separate task/activity renderers.
   Task Detail may add Task-specific advanced disclosures, but keep that debug
   layer out of Chats unless the operator explicitly asks for it.
+- Transcript rows should have one source of truth for noisy details. Do not
+  repeat captured command/read output both in the compact row and in the output
+  preview card. Do not render raw captured diffs in the transcript when the
+  message already has a workspace-changes badge or the side-panel diff viewer.
+  Group repetitive command rows into a single expandable summary that reveals
+  commands and captured output together.
 - External Agent sessions store their workspace and native ACP session id. New
   UI affordances should preserve that continuity instead of treating every
   prompt as a one-off subprocess.

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -180,7 +180,7 @@ The shared renderer keeps the high-signal path visible:
 - model turns / thinking
 - tool calls
 - approval requested / approved / rejected / cancelled
-- files changed
+- workspace changes
 - final answer
 - terminal run state
 
@@ -190,6 +190,15 @@ conversation stays readable; Task Detail opens the activity section by default
 because that view is already a run-inspection surface. Task Detail can also
 show a per-row **Advanced** disclosure with raw activity metadata such as
 step/artifact/approval ids, tool kind, path, timestamp, and summary payload.
+Repetitive command rows are collapsed into a single **Ran N commands** group;
+expanding that group shows the commands and any captured output in one layer so
+operators do not have to click through nested output disclosures. Command and
+read-context rows keep raw output out of the compact row and show normalized
+line breaks inside the output card.
+Workspace changes have one primary surface: the per-turn file badge and the
+workspace changes panel. Transcript activity may mention that workspace changes
+exist, but it should not duplicate raw patches or render a second diff viewer
+when the richer workspace diff surface is available.
 For failed tool rows, Task Detail also previews stdout/stderr artifacts captured
 for the same tool step, including an explicit empty-stream note when stderr was
 captured but contained no bytes. Artifacts from other steps are intentionally

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -281,7 +281,7 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText(/docs\/assets\/logo/)).toBeNull();
   });
 
-  it("summarizes noisy generic command activity without expanding every output card", async () => {
+  it("summarizes noisy generic command activity and reveals command details together", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [
       {
@@ -335,13 +335,9 @@ describe("TranscriptActivityTimeline", () => {
 
     expect(screen.getAllByText("Ran command")).toHaveLength(4);
     expect(screen.queryByText(/commit abc123/)).toBeNull();
-    expect(screen.queryByText("Tool output for call_1")).toBeNull();
-    expect(screen.queryByText("Tool output for call_4")).toBeNull();
-
-    await user.click(screen.getAllByText("Output")[0]);
-
     expect(screen.getByText("Tool output for call_1")).toBeInTheDocument();
-    expect(screen.queryByText("Tool output for call_4")).toBeNull();
+    expect(screen.getByText("Tool output for call_4")).toBeInTheDocument();
+    expect(screen.queryByText("Output")).toBeNull();
   });
 
   it("treats completed commands with fatal output as failed for transcript tone", () => {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -261,6 +261,23 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText(/tool ERrtqCoy/)).toBeNull();
   });
 
+  it("uses adapter detail hints for opaque edit tool rows", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "toolu_01X4Kr7tteNtaP6emRf7ULtM",
+        status: "completed",
+        detail: "edit · 1 diff",
+      },
+    ];
+
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.getByText("Edited file")).toBeInTheDocument();
+    expect(screen.getByText("edit · 1 diff")).toBeInTheDocument();
+    expect(screen.queryByText(/toolu_01X4/)).toBeNull();
+  });
+
   it("keeps captured read output out of the inline activity row", () => {
     const activities: ChatActivityRecord[] = [
       {
@@ -369,6 +386,45 @@ describe("TranscriptActivityTimeline", () => {
         status: "completed",
         kind: "execute",
         detail: "execute · output: ok",
+      },
+      { type: "completed", title: "Run completed", status: "completed" },
+    ];
+
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.getByText(/completed · 1 failed tool/)).toBeInTheDocument();
+    expect(screen.getByText("1 failed · output captured")).toBeInTheDocument();
+  });
+
+  it("treats output-captured fatal command details as failed for transcript tone", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_1",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · ok",
+      },
+      {
+        type: "tool_call",
+        title: "call_2",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · fatal: ambiguous argument 'origin/main..HEAD'",
+      },
+      {
+        type: "tool_call",
+        title: "call_3",
+        status: "completed",
+        kind: "execute",
+        detail: "execute",
+      },
+      {
+        type: "tool_call",
+        title: "call_4",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · ok",
       },
       { type: "completed", title: "Run completed", status: "completed" },
     ];

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -262,7 +262,12 @@ function TimelineActivityLine({
               background: "var(--bg1)",
             }}
           >
-            {children.length > 0 && (
+            {activity.type === "tool_group" && children.length > 0 ? (
+              <CommandGroupActivities
+                activities={children}
+                renderAdvancedActivity={renderAdvancedActivity}
+              />
+            ) : children.length > 0 ? (
               <div style={{ display: "grid", gap: 5 }}>
                 {children.map((child, index) => (
                   <TimelineActivityLine
@@ -272,11 +277,43 @@ function TimelineActivityLine({
                   />
                 ))}
               </div>
-            )}
+            ) : null}
             {advancedContent}
           </div>
         )}
       </details>
+    </div>
+  );
+}
+
+function CommandGroupActivities({
+  activities,
+  renderAdvancedActivity,
+}: {
+  activities: ChatActivityRecord[];
+  renderAdvancedActivity?: (activity: ChatActivityRecord) => ReactNode;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {activities.map((activity, index) => {
+        const advancedContent = renderAdvancedActivity?.(activity);
+        const line =
+          activity.type === "plan" ? (
+            <PlanActivityLine activity={activity} />
+          ) : (
+            <ActivityLine activity={activity} prefix={activityLinePrefix(activity)} />
+          );
+
+        return (
+          <div
+            key={activity.id || `command-${activity.type}-${activity.created_at ?? index}`}
+            style={{ display: "grid", gap: 5, minWidth: 0 }}
+          >
+            {line}
+            {advancedContent && <div style={{ marginLeft: 15 }}>{advancedContent}</div>}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -286,7 +323,11 @@ function advancedSummaryLabel(activity: ChatActivityRecord): string {
   if (activity.type === "changed_files" || activity.type === "files_changed") return "Files";
   if (activity.type === "output") return "Output";
   if (activity.type === "artifact" && isOutputArtifactActivity(activity)) return "Output";
-  if (activity.type === "tool_call" && /\boutput\s*:/i.test(activity.detail ?? "")) return "Output";
+  if (
+    activity.type === "tool_call" &&
+    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
+  )
+    return "Output";
   return "Advanced";
 }
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -587,6 +587,34 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
   });
 
+  it("shows full captured command output from detail-only output-captured rows", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_shell",
+        status: "completed",
+        kind: "execute",
+        detail:
+          "execute · output captured · total 88064\n" +
+          "drwxr-xr-x@ 45 chicoxyzzy staff 1440 May 27 17:43 .\n" +
+          "drwxr-xr-x@ 20 chicoxyzzy staff 640 May 27 17:40 ..",
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    expect(screen.queryByText(/total 88064/)).toBeNull();
+    expect(screen.queryByText(/drwxr-xr-x@ 45/)).toBeNull();
+
+    await user.click(screen.getByText("Output"));
+
+    expect(screen.getByText("Tool output")).toBeInTheDocument();
+    expect(screen.getByText(/total 88064/)).toBeInTheDocument();
+    expect(screen.getByText(/drwxr-xr-x@ 45 chicoxyzzy staff 1440/)).toBeInTheDocument();
+    expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
+  });
+
   it("strips ANSI color codes from captured command output", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -433,10 +433,13 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
 }
 
 function normalizeToolOutputPreview(output: string): string {
-  return stripAnsi(output)
+  const withoutAnsi = stripAnsi(output)
     .replace(/\r\n/g, "\n")
-    .replace(/(?:^|\n)[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
-    .replace(/[ \t]+\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
+    .replace(/\r/g, "\n");
+
+  return withoutAnsi
+    .replace(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
+    .replace(/^\n+/, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -433,9 +433,7 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
 }
 
 function normalizeToolOutputPreview(output: string): string {
-  const withoutAnsi = stripAnsi(output)
-    .replace(/\r\n/g, "\n")
-    .replace(/\r/g, "\n");
+  const withoutAnsi = stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
   return withoutAnsi
     .replace(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -318,6 +318,37 @@ describe("activityDisplay", () => {
     });
   });
 
+  it("keeps output-captured command details out of the compact activity row", () => {
+    const command = activity({
+      type: "tool_call",
+      title: "call_shell",
+      status: "completed",
+      kind: "execute",
+      detail: "execute · output captured · total 88064 drwxr-xr-x@ 45 chicoxyzzy staff",
+    });
+
+    expect(activityDisplay(command)).toEqual({
+      title: "Ran command",
+      detail: undefined,
+    });
+    expect(capturedToolOutput(command)).toBe("total 88064 drwxr-xr-x@ 45 chicoxyzzy staff");
+  });
+
+  it("uses adapter detail hints to humanize opaque external-agent tool ids", () => {
+    expect(
+      activityDisplay(
+        activity({
+          type: "tool_call",
+          title: "toolu_01X4Kr7tteNtaP6emRf7ULtM",
+          detail: "edit · 1 diff",
+        }),
+      ),
+    ).toEqual({
+      title: "Edited file",
+      detail: "edit · 1 diff",
+    });
+  });
+
   it("renders the model-turn summary for collapsed model_turns rows", () => {
     expect(
       activityDisplay(

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -327,13 +327,14 @@ function toolActivityTitle(activity: ChatActivityRecord): string {
 
   const raw = stripStatusSuffix(activity.title || activity.kind || "tool").trim();
   const normalized = raw.toLowerCase();
-  const kind = (activity.kind || activity.detail || "").trim().toLowerCase();
+  const normalizedKind = (activity.kind || "").trim().toLowerCase();
+  const toolHint = `${activity.kind ?? ""} ${activity.detail ?? ""}`.trim().toLowerCase();
 
   if (opaqueToolCallID(raw)) {
-    if (kind.includes("execute") || kind.includes("command") || kind.includes("shell"))
+    if (toolHint.includes("execute") || toolHint.includes("command") || toolHint.includes("shell"))
       return "Ran command";
-    if (kind.includes("read")) return "Read context";
-    if (kind.includes("edit") || kind.includes("write")) return "Edited file";
+    if (toolHint.includes("read")) return "Read context";
+    if (toolHint.includes("edit") || toolHint.includes("write")) return "Edited file";
     return "Used tool";
   }
 
@@ -361,10 +362,15 @@ function toolActivityTitle(activity: ChatActivityRecord): string {
     return `Ran ${execMatch[1].replaceAll("_", " ")}`;
   }
 
-  if (kind === "execute" || kind === "command") {
+  if (
+    normalizedKind === "execute" ||
+    normalizedKind === "command" ||
+    /^execute(?:\s|·|$)/.test(toolHint) ||
+    /^command(?:\s|·|$)/.test(toolHint)
+  ) {
     return "Ran command";
   }
-  if (kind === "read") {
+  if (normalizedKind === "read" || /^read(?:\s|·|$)/.test(toolHint)) {
     return "Read context";
   }
 
@@ -399,7 +405,8 @@ function isThinkingToolActivity(activity: ChatActivityRecord): boolean {
   const title = stripStatusSuffix(activity.title || "")
     .trim()
     .toLowerCase();
-  return kind === "think" || title === "think";
+  const detail = (activity.detail || "").trim().toLowerCase();
+  return kind === "think" || title === "think" || /^think(?:\s|·|$)/.test(detail);
 }
 
 function modelTurnDetail(activity: ChatActivityRecord): string {
@@ -437,7 +444,10 @@ function isAdapterContextReadFailure(activity: ChatActivityRecord): boolean {
 }
 
 function toolDetailHasOutput(activity: ChatActivityRecord): boolean {
-  return Boolean(capturedToolOutput(activity)) || /\boutput\s*:/i.test(activity.detail ?? "");
+  return (
+    Boolean(capturedToolOutput(activity)) ||
+    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
+  );
 }
 
 function hasFailureLikeToolOutput(activity: ChatActivityRecord): boolean {
@@ -464,7 +474,7 @@ function simpleToolOutputPrefix(prefix: string): boolean {
 }
 
 function parseToolOutputDetail(detail: string): { prefix: string; output: string } | undefined {
-  const match = detail.match(/^(.+?)\s*·\s*output:\s*(.*)$/is);
+  const match = detail.match(/^(.+?)\s*·\s*output(?:\s+captured)?\s*(?::|·)\s*(.*)$/is);
   if (!match) return undefined;
   return {
     prefix: match[1].trim(),


### PR DESCRIPTION
## Summary

- Make noisy command groups expand into a readable command list with output previews visible in one layer.
- Parse both `output:` and `output captured` tool details so rows do not duplicate noisy output snippets.
- Improve external-agent tool labeling from adapter hints, including opaque edit/think tool ids.
- Preserve readable line breaks in captured read/command output previews.
- Document transcript readability guardrails and cover the edge cases that regressed in review.

## Validation

- `cd ui && bun run format:check`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- TranscriptActivityTimeline transcriptActivityHelpers TranscriptMessageRow`
- `cd ui && bun run test`
- `cd ui && bun run lint`
- `just docs-format-check`
