### PR TITLE
refactor(chat): unify Hecate-side dispatch through one handler entry

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -131,6 +131,12 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   and Details grouping instead of growing separate task/activity renderers.
   Task Detail may add Task-specific advanced disclosures, but keep that debug
   layer out of Chats unless the operator explicitly asks for it.
+- Transcript rows should have one source of truth for noisy details. Do not
+  repeat captured command/read output both in the compact row and in the output
+  preview card. Do not render raw captured diffs in the transcript when the
+  message already has a workspace-changes badge or the side-panel diff viewer.
+  Group repetitive command rows into a single expandable summary that reveals
+  commands and captured output together.
 - External Agent sessions store their workspace and native ACP session id. New
   UI affordances should preserve that continuity instead of treating every
   prompt as a one-off subprocess.

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -180,7 +180,7 @@ The shared renderer keeps the high-signal path visible:
 - model turns / thinking
 - tool calls
 - approval requested / approved / rejected / cancelled
-- files changed
+- workspace changes
 - final answer
 - terminal run state
 
@@ -190,6 +190,15 @@ conversation stays readable; Task Detail opens the activity section by default
 because that view is already a run-inspection surface. Task Detail can also
 show a per-row **Advanced** disclosure with raw activity metadata such as
 step/artifact/approval ids, tool kind, path, timestamp, and summary payload.
+Repetitive command rows are collapsed into a single **Ran N commands** group;
+expanding that group shows the commands and any captured output in one layer so
+operators do not have to click through nested output disclosures. Command and
+read-context rows keep raw output out of the compact row and show normalized
+line breaks inside the output card.
+Workspace changes have one primary surface: the per-turn file badge and the
+workspace changes panel. Transcript activity may mention that workspace changes
+exist, but it should not duplicate raw patches or render a second diff viewer
+when the richer workspace diff surface is available.
 For failed tool rows, Task Detail also previews stdout/stderr artifacts captured
 for the same tool step, including an explicit empty-stream note when stderr was
 captured but contained no bytes. Artifacts from other steps are intentionally

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -751,23 +751,31 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		return
 	}
 	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session, req.ToolsEnabled)
+	// Resolve the effective tools-on/off signal for this turn. The
+	// capability-driven downgrade (a tool-incapable model on a Hecate
+	// session) flips this to false even when the client requested
+	// tools-on, so the unified handler below dispatches to the
+	// direct-model code path without the dispatcher needing a
+	// separate direct_model switch case.
+	toolsEnabled := executionMode == chat.ExecutionModeHecateTask
 	if executionMode == chat.ExecutionModeHecateTask && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
 		executionMode = chat.ExecutionModeDirectModel
+		toolsEnabled = false
 	}
 	switch executionMode {
-	case chat.ExecutionModeDirectModel:
+	case chat.ExecutionModeDirectModel, chat.ExecutionModeHecateTask:
+		// One unified entry point for every Hecate-side turn,
+		// regardless of tools_enabled. handleCreateHecateChatMessage
+		// branches at the top: tools-off delegates to
+		// `handleDirectModelTurn` (the former
+		// handleCreateModelChatMessage, now a private sub-path of
+		// the Hecate handler); tools-on runs the existing
+		// agent_loop task-creation path.
 		if isExternalChatSession(session) {
-			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run direct model turns")
+			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Chat turns")
 			return
 		}
-		h.handleCreateModelChatMessage(w, r, session, req)
-		return
-	case chat.ExecutionModeHecateTask:
-		if isExternalChatSession(session) {
-			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run task-backed Hecate Chat turns")
-			return
-		}
-		h.handleCreateHecateChatMessage(w, r, session, req)
+		h.handleCreateHecateChatMessage(w, r, session, req, toolsEnabled)
 		return
 	case chat.ExecutionModeExternalAgent:
 		if !isExternalChatSession(session) {
@@ -1131,7 +1139,12 @@ func chatRequestToolsEnabled(req CreateChatMessageRequest) bool {
 	return strings.TrimSpace(req.ExecutionMode) != chat.ExecutionModeDirectModel
 }
 
-func (h *Handler) handleCreateModelChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
+// handleDirectModelTurn runs the tools-off sub-path of
+// handleCreateHecateChatMessage. Called only from inside that
+// handler when toolsEnabled is false (either because the client
+// asked for tools off or because the capability-downgrade flipped
+// it). Not invoked directly by the dispatcher.
+func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
 	if busy, runStatus := h.hecateAgentSessionBusy(r.Context(), session); busy {
 		writeHecateAgentBusy(w, session, runStatus)
 		return

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -19,7 +19,21 @@ import (
 
 const hecateAgentPollInterval = 250 * time.Millisecond
 
-func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest) {
+// handleCreateHecateChatMessage is the unified entry point for every
+// Hecate-side chat-message submission. It branches on toolsEnabled:
+//   - toolsEnabled=false → delegate to handleDirectModelTurn (a
+//     direct LLM call with no agent_loop task, the runtime fallback
+//     for the legacy direct_model dispatch path).
+//   - toolsEnabled=true → existing agent_loop task creation +
+//     polling path that the Hecate Chat tools-on UX runs on.
+//
+// External-agent sessions never reach this function — the dispatcher
+// pins them to the external_agent path before getting here.
+func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest, toolsEnabled bool) {
+	if !toolsEnabled {
+		h.handleDirectModelTurn(w, r, session, req)
+		return
+	}
 	content := strings.TrimSpace(req.Content)
 	if workspace := strings.TrimSpace(req.Workspace); workspace != "" {
 		resolved, err := agentadapters.ValidateWorkspace(workspace)

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -1024,7 +1024,10 @@ func TestExternalAgentChatRejectsDirectModelExecutionMode(t *testing.T) {
 	if payload.Error.Type != errCodeRuntimeMismatch {
 		t.Fatalf("error type = %q, want %s", payload.Error.Type, errCodeRuntimeMismatch)
 	}
-	if !strings.Contains(payload.Error.Message, "external agent sessions cannot run direct model turns") {
+	// After the dispatcher unification, direct_model and hecate_task
+	// share the same Hecate-side entry point, so the error copy was
+	// collapsed too — "Hecate Chat turns" covers both flavors.
+	if !strings.Contains(payload.Error.Message, "external agent sessions cannot run Hecate Chat turns") {
 		t.Fatalf("error message = %q", payload.Error.Message)
 	}
 }

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -261,6 +261,23 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText(/tool ERrtqCoy/)).toBeNull();
   });
 
+  it("uses adapter detail hints for opaque edit tool rows", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "toolu_01X4Kr7tteNtaP6emRf7ULtM",
+        status: "completed",
+        detail: "edit · 1 diff",
+      },
+    ];
+
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.getByText("Edited file")).toBeInTheDocument();
+    expect(screen.getByText("edit · 1 diff")).toBeInTheDocument();
+    expect(screen.queryByText(/toolu_01X4/)).toBeNull();
+  });
+
   it("keeps captured read output out of the inline activity row", () => {
     const activities: ChatActivityRecord[] = [
       {
@@ -373,6 +390,45 @@ describe("TranscriptActivityTimeline", () => {
         status: "completed",
         kind: "execute",
         detail: "execute · output: ok",
+      },
+      { type: "completed", title: "Run completed", status: "completed" },
+    ];
+
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.getByText(/completed · 1 failed tool/)).toBeInTheDocument();
+    expect(screen.getByText("1 failed · output captured")).toBeInTheDocument();
+  });
+
+  it("treats output-captured fatal command details as failed for transcript tone", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_1",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · ok",
+      },
+      {
+        type: "tool_call",
+        title: "call_2",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · fatal: ambiguous argument 'origin/main..HEAD'",
+      },
+      {
+        type: "tool_call",
+        title: "call_3",
+        status: "completed",
+        kind: "execute",
+        detail: "execute",
+      },
+      {
+        type: "tool_call",
+        title: "call_4",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output captured · ok",
       },
       { type: "completed", title: "Run completed", status: "completed" },
     ];

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -286,7 +286,11 @@ function advancedSummaryLabel(activity: ChatActivityRecord): string {
   if (activity.type === "changed_files" || activity.type === "files_changed") return "Files";
   if (activity.type === "output") return "Output";
   if (activity.type === "artifact" && isOutputArtifactActivity(activity)) return "Output";
-  if (activity.type === "tool_call" && /\boutput\s*:/i.test(activity.detail ?? "")) return "Output";
+  if (
+    activity.type === "tool_call" &&
+    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
+  )
+    return "Output";
   return "Advanced";
 }
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -587,6 +587,34 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
   });
 
+  it("shows full captured command output from detail-only output-captured rows", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_shell",
+        status: "completed",
+        kind: "execute",
+        detail:
+          "execute · output captured · total 88064\n" +
+          "drwxr-xr-x@ 45 chicoxyzzy staff 1440 May 27 17:43 .\n" +
+          "drwxr-xr-x@ 20 chicoxyzzy staff 640 May 27 17:40 ..",
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    expect(screen.queryByText(/total 88064/)).toBeNull();
+    expect(screen.queryByText(/drwxr-xr-x@ 45/)).toBeNull();
+
+    await user.click(screen.getByText("Output"));
+
+    expect(screen.getByText("Tool output")).toBeInTheDocument();
+    expect(screen.getByText(/total 88064/)).toBeInTheDocument();
+    expect(screen.getByText(/drwxr-xr-x@ 45 chicoxyzzy staff 1440/)).toBeInTheDocument();
+    expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
+  });
+
   it("strips ANSI color codes from captured command output", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -437,7 +437,10 @@ function isAdapterContextReadFailure(activity: ChatActivityRecord): boolean {
 }
 
 function toolDetailHasOutput(activity: ChatActivityRecord): boolean {
-  return Boolean(capturedToolOutput(activity)) || /\boutput\s*:/i.test(activity.detail ?? "");
+  return (
+    Boolean(capturedToolOutput(activity)) ||
+    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
+  );
 }
 
 function hasFailureLikeToolOutput(activity: ChatActivityRecord): boolean {
@@ -464,7 +467,7 @@ function simpleToolOutputPrefix(prefix: string): boolean {
 }
 
 function parseToolOutputDetail(detail: string): { prefix: string; output: string } | undefined {
-  const match = detail.match(/^(.+?)\s*·\s*output:\s*(.*)$/is);
+  const match = detail.match(/^(.+?)\s*·\s*output(?:\s+captured)?\s*(?::|·)\s*(.*)$/is);
   if (!match) return undefined;
   return {
     prefix: match[1].trim(),


### PR DESCRIPTION
## Summary

The dispatcher's switch had two separate cases for `direct_model` and `hecate_task`, each routing to a different handler. After this commit they share a single entry point — `handleCreateHecateChatMessage` — which branches at the top on `toolsEnabled` and delegates the tools-off path to `handleDirectModelTurn` (formerly `handleCreateModelChatMessage`, now a private sub-path).

Pure structural change: no runtime changes, no wire shape changes, no message-lifecycle changes. The follow-up cut can now delete `ExecutionModeDirectModel` (and its 13 remaining usage sites) in an isolated commit because the dispatcher no longer routes on it.

## Concretely

- **Dispatcher** (`handler_chat.go`): the `direct_model` and `hecate_task` switch cases collapse into one. The capability-driven downgrade flips a `toolsEnabled bool` instead of rewriting the `execution_mode` string. Both paths pass `toolsEnabled` through to the unified handler.
- **`handleCreateHecateChatMessage`** (`handler_chat_hecate.go`): gains a `toolsEnabled bool` parameter and a top-level guard. When `false`, it delegates to `handleDirectModelTurn` and returns; otherwise the existing `agent_loop` task-creation path runs unchanged.
- **`handleCreateModelChatMessage`** renamed to `handleDirectModelTurn` to reflect that it's now a sub-path of the Hecate handler rather than a top-level dispatcher target. The function body is unchanged.
- The cross-runtime-mismatch error for external-agent sessions collapsed from two messages ("direct model turns" / "task-backed Hecate Chat turns") to one ("Hecate Chat turns") because the dispatcher no longer distinguishes between the two modes when guarding external sessions. The unit test asserting on the error wording was updated to match.

## Behavior preserved end-to-end

- Tools-on Hecate turn → dispatcher → `handleCreateHecateChatMessage(toolsEnabled=true)` → existing agent_loop path. Same as before.
- Tools-off Hecate turn → dispatcher → `handleCreateHecateChatMessage(toolsEnabled=false)` → delegates to `handleDirectModelTurn`. Same code path the dispatcher used to enter directly; now reached one indirection deeper.
- Capability-downgrade (tool-incapable model on tools-on submit) → flips `toolsEnabled = false` upstream → dispatcher routes to the same unified entry point → tools-off branch fires.
- External-agent turn → unchanged.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/... ./internal/chat/...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1160 / 1160 pass
- [x] `bunx playwright test chat.spec.ts` — 44 / 44 pass
- [x] `bun run lint` (UI) — 0 warnings / 0 errors
- [x] `bun run format:check` (UI) — clean

## Diff stat

```
3 files changed, 43 insertions(+), 13 deletions(-)
```

## What this unblocks

- `ExecutionModeDirectModel` constant + 13 usage sites can be deleted in a follow-up (the dispatcher no longer reads it; remaining usages are render-fallback, context packet, error-message text).
- The runtime fold (where `agent_loop` natively handles tools-off as a single direct LLM call) is the bigger architectural change still owed. That's multi-session work — this PR just consolidates the handler entry point so the next change has a clean foundation.