### PR TITLE
fix(chat): flush buffered stream activity on cancel

### DIFF
--- a/internal/api/chat_stream_coalesce.go
+++ b/internal/api/chat_stream_coalesce.go
@@ -22,18 +22,21 @@ const agentChatStreamCoalesceInterval = 50 * time.Millisecond
 // output + activity callbacks into at most one persist+publish per
 // interval, on the leading edge: the first update after an idle gap
 // flushes immediately (responsive), and bursts within the window are
-// held and folded into the next flush (or into close's trailing
-// flush).
+// held and folded into the next flush — a later callback, the trailing
+// timer, or close's final flush, whichever comes first.
 //
 // Correctness rests on the adapter contract that OnOutput/OnActivity
 // fire only while RunRequest is executing, from the adapter's single
 // reader goroutine, and that the handler calls close() after Run
-// returns — i.e. once no further callbacks can arrive. Under that
-// contract flushes never overlap, so there is deliberately no
-// background timer goroutine that could race the post-run finalize;
-// the trailing flush is close's job. The mutex still guards the
-// pending state so the type stays correct if an adapter ever calls
-// back from multiple goroutines.
+// returns — i.e. once no further callbacks can arrive. A trailing timer
+// flushes a burst the window held when no later callback arrives to
+// flush it, so a sparse stream can't hide an activity or partial output
+// for the length of a tool/run pause. The flush runs under c.mu, so
+// close() (which also takes c.mu) can neither overlap an in-flight
+// trailing flush nor race a late timer fire: a timer that fires after
+// close observes closed and is a no-op, leaving the post-run finalize
+// the sole owner of terminal state. The mutex also keeps the type
+// correct if an adapter ever calls back from multiple goroutines.
 //
 // Output is last-write-wins: each OnOutput carries the full
 // accumulated transcript, so a dropped intermediate snapshot is
@@ -50,6 +53,11 @@ type chatStreamCoalescer struct {
 	// uses time.Now. Tests override it to drive the window
 	// deterministically without real sleeps.
 	clock func() time.Time
+	// afterFunc schedules the trailing flush; production wraps
+	// time.AfterFunc. Tests override it to fire the timer on demand
+	// instead of waiting real time. The returned func stops the timer
+	// and reports whether it cancelled before firing.
+	afterFunc func(d time.Duration, fn func()) func() bool
 
 	mu          sync.Mutex
 	lastFlush   time.Time
@@ -57,62 +65,133 @@ type chatStreamCoalescer struct {
 	haveContent bool
 	content     string
 	activities  []agentadapters.Activity
+	// stopTimer cancels the pending trailing flush; non-nil exactly
+	// while a trailing timer is armed.
+	stopTimer func() bool
 }
 
 func newChatStreamCoalescer(interval time.Duration, flush func(content string, haveContent bool, activities []agentadapters.Activity)) *chatStreamCoalescer {
-	return &chatStreamCoalescer{flush: flush, interval: interval, clock: time.Now}
+	return &chatStreamCoalescer{
+		flush:    flush,
+		interval: interval,
+		clock:    time.Now,
+		afterFunc: func(d time.Duration, fn func()) func() bool {
+			return time.AfterFunc(d, fn).Stop
+		},
+	}
 }
 
 // output records the latest full transcript snapshot and flushes when
-// the coalesce window has elapsed since the last flush.
+// the coalesce window has elapsed since the last flush, else arms the
+// trailing timer so the held snapshot flushes when the window closes.
 func (c *chatStreamCoalescer) output(display string) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
 	c.content = display
 	c.haveContent = true
 	c.maybeFlushLocked()
 }
 
 // activity buffers a streamed activity record and flushes when the
-// coalesce window has elapsed since the last flush.
+// coalesce window has elapsed since the last flush, else arms the
+// trailing timer so the buffered batch flushes when the window closes.
 func (c *chatStreamCoalescer) activity(act agentadapters.Activity) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
 	c.activities = append(c.activities, act)
 	c.maybeFlushLocked()
 }
 
 // maybeFlushLocked flushes the pending batch when the coalesce window
-// has elapsed. It is called with c.mu held and always releases the
-// lock before returning — the flush callback performs IO (SQLite
-// write + SSE publish) and must not run under the lock.
+// has elapsed, otherwise arms a trailing timer so a quiet burst still
+// flushes when the window closes. Caller holds c.mu and has checked
+// !closed.
 func (c *chatStreamCoalescer) maybeFlushLocked() {
-	if c.closed {
-		c.mu.Unlock()
-		return
-	}
 	now := c.clock()
 	if !c.lastFlush.IsZero() && now.Sub(c.lastFlush) < c.interval {
-		c.mu.Unlock()
+		c.scheduleTrailingLocked(now)
 		return
 	}
+	c.flushLocked(now)
+}
+
+// scheduleTrailingLocked arms a one-shot timer to flush the held batch
+// when the current window closes, unless one is already armed. The
+// window is anchored to lastFlush, so every callback held in the same
+// window targets the same deadline and the first one's timer stands.
+// Caller holds c.mu.
+func (c *chatStreamCoalescer) scheduleTrailingLocked(now time.Time) {
+	if c.stopTimer != nil {
+		return
+	}
+	delay := c.interval - now.Sub(c.lastFlush)
+	if delay < 0 {
+		delay = 0
+	}
+	c.stopTimer = c.afterFunc(delay, c.trailingFlush)
+}
+
+// stopTimerLocked cancels a pending trailing timer if one is armed.
+// Caller holds c.mu.
+func (c *chatStreamCoalescer) stopTimerLocked() {
+	if c.stopTimer != nil {
+		c.stopTimer()
+		c.stopTimer = nil
+	}
+}
+
+// flushLocked sends the pending batch to the flush callback and records
+// the flush time. The callback runs under c.mu by design: the adapter's
+// single reader drives leading-edge flushes synchronously, and running
+// the trailing-timer flush under the lock lets close() serialize with
+// it — close takes c.mu, so it can't overlap an in-flight flush, and a
+// timer that fires after close sees closed and bails. Caller holds c.mu
+// and has checked !closed.
+func (c *chatStreamCoalescer) flushLocked(now time.Time) {
+	c.stopTimerLocked()
 	c.lastFlush = now
 	content, haveContent, activities := c.takePendingLocked()
-	c.mu.Unlock()
 	c.flush(content, haveContent, activities)
 }
 
-// close flushes any remaining pending batch and blocks further
-// flushes. The handler calls it after Run returns and before writing
-// the terminal message state, so buffered activities are persisted
-// ahead of the finalize that appends terminal rows.
+// trailingFlush is the timer callback. The timer that scheduled it has
+// fired, so it clears stopTimer; if the coalescer closed or nothing is
+// pending in the meantime it is a no-op, keeping close() and the
+// post-run finalize the sole owners of terminal state.
+func (c *chatStreamCoalescer) trailingFlush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopTimer = nil
+	if c.closed {
+		return
+	}
+	if !c.haveContent && len(c.activities) == 0 {
+		return
+	}
+	c.flushLocked(c.clock())
+}
+
+// close cancels any pending trailing timer, flushes the remaining
+// batch, and blocks further flushes. The handler calls it after Run
+// returns and before writing the terminal message state, so buffered
+// activities are persisted ahead of the finalize that appends terminal
+// rows. Taking c.mu here is what serializes close with an in-flight or
+// late trailing flush.
 func (c *chatStreamCoalescer) close() {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed {
-		c.mu.Unlock()
 		return
 	}
 	c.closed = true
+	c.stopTimerLocked()
 	content, haveContent, activities := c.takePendingLocked()
-	c.mu.Unlock()
 	if haveContent || len(activities) > 0 {
 		c.flush(content, haveContent, activities)
 	}

--- a/internal/api/chat_stream_coalesce_test.go
+++ b/internal/api/chat_stream_coalesce_test.go
@@ -13,20 +13,42 @@ type coalesceFlush struct {
 	activities  []agentadapters.Activity
 }
 
-// newTestCoalescer wires a coalescer to a fake clock the test drives
-// by reassigning *now, plus a recorder capturing every flush.
-func newTestCoalescer(interval time.Duration) (*chatStreamCoalescer, *[]coalesceFlush, *time.Time) {
+// newTestCoalescer wires a coalescer to a fake clock the test drives by
+// reassigning *now and a fake trailing timer the test fires via the
+// returned func, plus a recorder capturing every flush. The coalescer
+// arms at most one trailing timer at a time, so the fake holds a single
+// pending callback; firing or cancelling it clears the slot.
+func newTestCoalescer(interval time.Duration) (*chatStreamCoalescer, *[]coalesceFlush, *time.Time, func()) {
 	var flushes []coalesceFlush
 	now := time.Unix(0, 0)
 	c := newChatStreamCoalescer(interval, func(content string, haveContent bool, activities []agentadapters.Activity) {
 		flushes = append(flushes, coalesceFlush{content: content, haveContent: haveContent, activities: activities})
 	})
 	c.clock = func() time.Time { return now }
-	return c, &flushes, &now
+
+	var pending func()
+	c.afterFunc = func(_ time.Duration, fn func()) func() bool {
+		pending = fn
+		return func() bool {
+			if pending == nil {
+				return false
+			}
+			pending = nil
+			return true
+		}
+	}
+	fireTimer := func() {
+		fn := pending
+		pending = nil
+		if fn != nil {
+			fn()
+		}
+	}
+	return c, &flushes, &now, fireTimer
 }
 
 func TestChatStreamCoalescerLeadingEdgeFlushesFirstUpdate(t *testing.T) {
-	c, flushes, _ := newTestCoalescer(50 * time.Millisecond)
+	c, flushes, _, _ := newTestCoalescer(50 * time.Millisecond)
 
 	c.output("hello")
 
@@ -39,7 +61,7 @@ func TestChatStreamCoalescerLeadingEdgeFlushesFirstUpdate(t *testing.T) {
 }
 
 func TestChatStreamCoalescerHoldsBurstAndKeepsLatestContent(t *testing.T) {
-	c, flushes, now := newTestCoalescer(50 * time.Millisecond)
+	c, flushes, now, _ := newTestCoalescer(50 * time.Millisecond)
 
 	c.output("a") // leading-edge flush at t=0
 	*now = now.Add(10 * time.Millisecond)
@@ -65,7 +87,7 @@ func TestChatStreamCoalescerHoldsBurstAndKeepsLatestContent(t *testing.T) {
 }
 
 func TestChatStreamCoalescerBuffersActivitiesInOrder(t *testing.T) {
-	c, flushes, now := newTestCoalescer(50 * time.Millisecond)
+	c, flushes, now, _ := newTestCoalescer(50 * time.Millisecond)
 
 	c.output("a") // leading-edge flush; arms the window
 	*now = now.Add(5 * time.Millisecond)
@@ -89,8 +111,34 @@ func TestChatStreamCoalescerBuffersActivitiesInOrder(t *testing.T) {
 	}
 }
 
+func TestChatStreamCoalescerTrailingTimerFlushesQuietBurst(t *testing.T) {
+	c, flushes, now, fireTimer := newTestCoalescer(50 * time.Millisecond)
+
+	c.output("a") // leading-edge flush at t=0; arms the window
+	*now = now.Add(10 * time.Millisecond)
+	c.activity(agentadapters.Activity{ID: "act-1"}) // held within window
+
+	// No later callback arrives. Without a trailing timer this activity
+	// would stay hidden until close(); the timer fires when the window
+	// closes and flushes it.
+	if len(*flushes) != 1 {
+		t.Fatalf("within-window activity: got %d flushes, want 1", len(*flushes))
+	}
+
+	*now = now.Add(40 * time.Millisecond) // window closed: t=50
+	fireTimer()
+
+	if len(*flushes) != 2 {
+		t.Fatalf("after trailing timer: got %d flushes, want 2", len(*flushes))
+	}
+	got := (*flushes)[1].activities
+	if len(got) != 1 || got[0].ID != "act-1" {
+		t.Fatalf("trailing flush activities = %+v, want [act-1]", got)
+	}
+}
+
 func TestChatStreamCoalescerCloseFlushesPendingThenStops(t *testing.T) {
-	c, flushes, now := newTestCoalescer(50 * time.Millisecond)
+	c, flushes, now, _ := newTestCoalescer(50 * time.Millisecond)
 
 	c.output("a") // leading-edge flush
 	*now = now.Add(10 * time.Millisecond)
@@ -114,8 +162,31 @@ func TestChatStreamCoalescerCloseFlushesPendingThenStops(t *testing.T) {
 	}
 }
 
+func TestChatStreamCoalescerCloseCancelsPendingTrailingTimer(t *testing.T) {
+	c, flushes, now, fireTimer := newTestCoalescer(50 * time.Millisecond)
+
+	c.output("a") // leading-edge flush at t=0
+	*now = now.Add(10 * time.Millisecond)
+	c.output("ab") // held within window; arms the trailing timer
+
+	c.close() // flushes the pending batch and cancels the timer
+	if len(*flushes) != 2 {
+		t.Fatalf("close with pending: got %d flushes, want 2", len(*flushes))
+	}
+	if got := (*flushes)[1].content; got != "ab" {
+		t.Fatalf("close flush content = %q, want %q", got, "ab")
+	}
+
+	// The cancelled timer firing late must not flush — close() and the
+	// finalize own terminal state.
+	fireTimer()
+	if len(*flushes) != 2 {
+		t.Fatalf("fired cancelled timer: got %d flushes, want 2 (no-op)", len(*flushes))
+	}
+}
+
 func TestChatStreamCoalescerCloseWithoutPendingIsNoOp(t *testing.T) {
-	c, flushes, now := newTestCoalescer(50 * time.Millisecond)
+	c, flushes, now, _ := newTestCoalescer(50 * time.Millisecond)
 
 	c.output("a") // leading-edge flush consumes the pending content
 	c.close()     // nothing pending -> no extra flush

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -869,8 +869,17 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	// last-write-wins (the full accumulated transcript); activities are
 	// applied in arrival order via the same per-record merge the
 	// adapter callbacks used to do inline.
+	//
+	// It persists under r.Context(), not runCtx: the trailing flush
+	// (from the coalescer's timer or close()) can run as Run is
+	// returning, so on cancel/deadline paths runCtx is already done and
+	// persisting under it would silently drop the final buffered batch.
+	// The terminal finalize below recovers content (it re-sets
+	// message.Content from result.Output) but only appends activity
+	// rows, so a dropped activity batch would be lost for good.
+	// r.Context() matches that finalize and outlives run cancellation.
 	streamFlush := func(display string, haveContent bool, activities []agentadapters.Activity) {
-		updated, updateErr := h.agentChat.UpdateMessage(runCtx, session.ID, assistantID, func(message *chat.Message) {
+		updated, updateErr := h.agentChat.UpdateMessage(r.Context(), session.ID, assistantID, func(message *chat.Message) {
 			if haveContent {
 				message.Content = display
 				if strings.TrimSpace(display) != "" && !outputSeen {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2549,6 +2549,11 @@ type fakeAgentChatRunner struct {
 	closedSessions     []string
 	closeErr           error
 	configOptions      []agentcontrols.ConfigOption
+	// activitiesAfterCancel are emitted via OnActivity after ctx is
+	// cancelled (waitForCancel only), so they sit in the stream
+	// coalescer when the run returns and exercise the trailing
+	// flush/finalize persistence path under an already-done runCtx.
+	activitiesAfterCancel []agentadapters.Activity
 }
 
 func (r *fakeAgentChatRunner) PrepareSession(ctx context.Context, req agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error) {
@@ -2609,6 +2614,11 @@ func (r *fakeAgentChatRunner) Run(ctx context.Context, req agentadapters.RunRequ
 		}
 		output += "started\n"
 		<-ctx.Done()
+		for _, activity := range r.activitiesAfterCancel {
+			if req.OnActivity != nil {
+				req.OnActivity(activity)
+			}
+		}
 		return r.result(req, output, started, 1), context.Canceled
 	}
 	if req.OnOutput != nil && r.output != "" {
@@ -3138,6 +3148,87 @@ func TestAgentChatCancelsExternalAdapter(t *testing.T) {
 		}
 		if assistant.Error != "" {
 			t.Fatalf("assistant error = %q, want empty cancellation detail", assistant.Error)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for cancelled message POST")
+	}
+}
+
+// cancelAwareChatStore wraps a chat.Store so UpdateMessage fails when
+// its context is already cancelled, the way the production SQLite store
+// does (it runs the write under ctx). The in-memory test store ignores
+// ctx, so without this wrapper a flush under an already-cancelled
+// runCtx would silently succeed and hide the persistence-context
+// regression this test guards.
+type cancelAwareChatStore struct {
+	chat.Store
+}
+
+func (s cancelAwareChatStore) UpdateMessage(ctx context.Context, sessionID, messageID string, update func(*chat.Message)) (chat.Session, error) {
+	if err := ctx.Err(); err != nil {
+		return chat.Session{}, err
+	}
+	return s.Store.UpdateMessage(ctx, sessionID, messageID, update)
+}
+
+func TestAgentChatPersistsCoalescedActivityWhenRunCancelled(t *testing.T) {
+	dir := t.TempDir()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	// Honor ctx on writes so the post-cancel flush fails on an
+	// already-cancelled runCtx, as it would against SQLite.
+	apiHandler.SetAgentChatStore(cancelAwareChatStore{Store: chat.NewMemoryStore()})
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{
+		waitForCancel: true,
+		// Emitted after ctx.Done(): the coalescer buffers this activity
+		// and only flushes it once the run has returned, when runCtx is
+		// already cancelled. It must persist under a context that
+		// outlives the run cancel, not be dropped before the finalize
+		// (which only appends terminal rows and would not restore it).
+		activitiesAfterCancel: []agentadapters.Activity{
+			{ID: "tool:held", Type: "tool_call", Status: "completed", Kind: "execute", Title: "held tool"},
+		},
+	})
+	handler := NewServer(logger, apiHandler)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	created := requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
+	done := make(chan ChatSessionResponse, 1)
+	go func() {
+		done <- requestJSONToURL[ChatSessionResponse](t, http.MethodPost, server.URL+"/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"please wait"}`)
+	}()
+
+	waitForAgentChatStatus(t, server.URL, created.Data.ID, "running")
+	cancelResp := postJSONToURL(t, server.URL+"/hecate/v1/chat/sessions/"+created.Data.ID+"/cancel", `{}`)
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(cancelResp.Body)
+		t.Fatalf("cancel status = %d, want 202, body=%s", cancelResp.StatusCode, string(body))
+	}
+
+	select {
+	case updated := <-done:
+		if got := updated.Data.Status; got != "cancelled" {
+			t.Fatalf("final status = %q, want cancelled", got)
+		}
+		assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
+		if assistant.Status != "cancelled" {
+			t.Fatalf("assistant status = %q, want cancelled", assistant.Status)
+		}
+		found := false
+		for _, activity := range assistant.Activities {
+			if activity.ID != "tool:held" {
+				continue
+			}
+			found = true
+			if activity.Status != "completed" || activity.Title != "held tool" {
+				t.Fatalf("held activity = %#v, want completed 'held tool'", activity)
+			}
+		}
+		if !found {
+			t.Fatalf("coalesced activity dropped on cancel; activities = %#v", assistant.Activities)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatalf("timed out waiting for cancelled message POST")

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -523,6 +523,8 @@ function buildVisibleMessage(m: ChatMessageRecord, id: string): VisibleChatMessa
     usage: m.usage,
     duration_ms: m.duration_ms,
     error: m.error,
+    timing: m.timing,
+    context_packet: m.context_packet,
   };
 }
 

--- a/ui/src/features/chats/projectVisibleMessage.test.ts
+++ b/ui/src/features/chats/projectVisibleMessage.test.ts
@@ -53,4 +53,18 @@ describe("projectVisibleMessage", () => {
     // fresh object every call and are never cached.
     expect(first).not.toBe(second);
   });
+
+  it("projects timing and context_packet for the inspector", () => {
+    const timing = { total_ms: 1200, bottleneck: "model" };
+    const context_packet = { provider: "anthropic", model: "claude", message_count: 3 };
+    const m = message("m1", "hello", { timing, context_packet });
+
+    const visible = projectVisibleMessage(m, 0);
+
+    // ChatTranscriptRow forwards these into the timing/context inspector
+    // for assistant rows; omitting them from the projection silently
+    // dropped that data from reconciled snapshots.
+    expect(visible.timing).toBe(timing);
+    expect(visible.context_packet).toBe(context_packet);
+  });
 });


### PR DESCRIPTION
## Summary
- add a trailing flush timer to the chat stream coalescer so quiet bursts are persisted before finalization
- persist buffered activity under the request context on cancellation so final adapter activity is not dropped
- keep timing and context packet data in the visible message projection used by the transcript inspector

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate-ui-perf/.gocache" go test ./internal/api
- cd ui && bun run typecheck
- cd ui && bun run test -- projectVisibleMessage