### PR TITLE
chore(chat): drop dead executionMode flip in the capability-downgrade

### DIFF
--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -754,12 +754,11 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	// Resolve the effective tools-on/off signal for this turn. The
 	// capability-driven downgrade (a tool-incapable model on a Hecate
 	// session) flips this to false even when the client requested
-	// tools-on, so the unified handler below dispatches to the
+	// tools-on, so the unified handler below routes the turn to the
 	// direct-model code path without the dispatcher needing a
 	// separate direct_model switch case.
 	toolsEnabled := executionMode == chat.ExecutionModeHecateTask
-	if executionMode == chat.ExecutionModeHecateTask && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
-		executionMode = chat.ExecutionModeDirectModel
+	if toolsEnabled && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
 		toolsEnabled = false
 	}
 	switch executionMode {


### PR DESCRIPTION
## Summary

After PR #278's dispatcher unification, the switch case treats `direct_model` and `hecate_task` as the same target (the unified `handleCreateHecateChatMessage` entry point that branches on `toolsEnabled`). The capability-downgrade block previously wrote both:

```go
if executionMode == chat.ExecutionModeHecateTask && ... {
    executionMode = chat.ExecutionModeDirectModel  // dead
    toolsEnabled = false
}
```

The `toolsEnabled` flip is the only signal the unified handler now reads — the `executionMode` write doesn't change which case fires (both literals match the same case) and isn't consulted downstream. This PR drops the dead write. The conditional also uses `toolsEnabled` directly instead of re-checking the executionMode literal, since they're equivalent at that point.

## Diff stat

```
1 file changed, 2 insertions(+), 3 deletions(-)
```

Pure dead-code cleanup enabled by #278's unification. No behavior change.

## What's NOT in this PR

`ExecutionModeDirectModel` constant + 11 remaining usage sites are still load-bearing:

- `normalizeChatExecutionMode` returns it
- `chatRequestToolsEnabled` compares against it  
- `handleDirectModelTurn` writes it to `message.ExecutionMode`
- `chat/store.go` `defaultMessageExecutionMode` returns it
- `handler_chat_render.go` render fallback
- `handler_chat_context.go` context packet builder
- A handful of test sites

A real removal there requires a sqlite write-side migration (stop persisting the literal in `execution_mode` columns; backfill old rows to `hecate_task` + `tools_enabled=false`). Separate cut, roughly ~300 LOC. My PR #278 commit message overpromised on this — apologies for the imprecision. This PR delivers the truly-pure-delete subset; the constant removal stays as a tracked follow-up with realistic scope.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1163 / 1163 pass
- [x] `bunx playwright test chat.spec.ts` — 44 / 44 pass
- [x] `bun run format:check` (UI) — clean