### PR TITLE
refactor(chat): retire ExecutionModeDirectModel as a write-side value

### DIFF
--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -751,25 +751,31 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		return
 	}
 	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session, req.ToolsEnabled)
-	// Resolve the effective tools-on/off signal for this turn. The
-	// capability-driven downgrade (a tool-incapable model on a Hecate
-	// session) flips this to false even when the client requested
-	// tools-on, so the unified handler below routes the turn to the
-	// direct-model code path without the dispatcher needing a
-	// separate direct_model switch case.
-	toolsEnabled := executionMode == chat.ExecutionModeHecateTask
+	// Resolve the effective tools-on/off signal for this turn from
+	// either the new `tools_enabled` field or the legacy
+	// `execution_mode = "direct_model"` literal. The capability-
+	// driven downgrade (a tool-incapable model on a Hecate session)
+	// flips this to false even when the client requested tools-on,
+	// so the unified handler routes the turn to the direct-model
+	// code path without the dispatcher needing a separate
+	// direct_model switch case.
+	toolsEnabled := chatRequestToolsEnabled(req)
 	if toolsEnabled && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
 		toolsEnabled = false
 	}
 	switch executionMode {
-	case chat.ExecutionModeDirectModel, chat.ExecutionModeHecateTask:
+	case chat.ExecutionModeHecateTask:
 		// One unified entry point for every Hecate-side turn,
 		// regardless of tools_enabled. handleCreateHecateChatMessage
 		// branches at the top: tools-off delegates to
 		// `handleDirectModelTurn` (the former
 		// handleCreateModelChatMessage, now a private sub-path of
 		// the Hecate handler); tools-on runs the existing
-		// agent_loop task-creation path.
+		// agent_loop task-creation path. The legacy
+		// `execution_mode = "direct_model"` literal that older
+		// clients still send normalizes to `hecate_task` inside
+		// `normalizeChatExecutionMode`, so it falls into this case
+		// the same way an explicit hecate_task would.
 		if isExternalChatSession(session) {
 			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Chat turns")
 			return
@@ -1094,57 +1100,79 @@ func (h *Handler) hecateTaskShouldFallbackToDirectModel(ctx context.Context, ses
 
 // normalizeChatExecutionMode resolves the execution mode the handler
 // should dispatch on. The explicit `execution_mode` field on the
-// request still wins when set — older clients send the literal
-// directly. When it's empty:
+// request still wins when set — older clients send the legacy
+// `direct_model` literal directly and the dispatcher's switch case
+// accepts it. When it's empty:
 //
 //   - External-agent sessions always dispatch as `external_agent`
 //     (agent_id pins the session kind regardless of any per-turn
 //     flag the client may have sent).
-//   - Hecate sessions consult the per-turn `tools_enabled` signal
-//     when it's set: true → `hecate_task`, false → `direct_model`.
-//     This lets newer clients submit `tools_enabled` and omit
-//     `execution_mode` entirely, which is the wire shape the UI
-//     moves to once the model-chat dispatch path is folded into
-//     hecate_task.
-//   - When neither field is set on a Hecate session, the dispatcher
-//     defaults to `direct_model` for back-compat with the pre-
-//     tools_enabled wire shape (where the absence of `execution_mode`
-//     was a no-tools turn).
-func normalizeChatExecutionMode(mode string, session chat.Session, toolsEnabled *bool) string {
+//   - Every Hecate-side turn (tools on or off) normalizes to
+//     `hecate_task`. The tools-on/off axis lives on `req.ToolsEnabled`
+//     now; the dispatcher reads it separately and the unified handler
+//     branches on it.
+//
+// Returns ExecutionModeHecateTask for Hecate sessions even when the
+// client sent neither field, which matches the pre-tools_enabled
+// default behavior (the no-tools fallback) once tools-off becomes a
+// boolean flag rather than its own execution mode.
+func normalizeChatExecutionMode(mode string, session chat.Session, _ *bool) string {
 	mode = strings.TrimSpace(mode)
+	// Legacy: older clients send `direct_model` as the execution
+	// mode for tools-off turns. Internally every Hecate-side turn is
+	// `hecate_task` now; the tools-off intent is recovered separately
+	// by chatRequestToolsEnabled. Normalize the legacy literal so
+	// the dispatcher's switch only has to know about the two
+	// remaining execution modes.
+	if mode == chat.LegacyExecutionModeDirectModel {
+		return chat.ExecutionModeHecateTask
+	}
 	if mode != "" {
 		return mode
 	}
 	if isExternalChatSession(session) {
 		return chat.ExecutionModeExternalAgent
 	}
-	if toolsEnabled != nil {
-		if *toolsEnabled {
-			return chat.ExecutionModeHecateTask
-		}
-		return chat.ExecutionModeDirectModel
-	}
-	return chat.ExecutionModeDirectModel
+	return chat.ExecutionModeHecateTask
 }
 
 // chatRequestToolsEnabled returns the per-turn tools-on/off signal
-// the handler should persist for this submission. The dedicated field
-// wins when set; otherwise the value is derived from the (legacy)
-// execution_mode so existing clients continue to behave unchanged:
+// the handler should dispatch + persist for this submission. The
+// dedicated `tools_enabled` field wins when set; otherwise the value
+// is derived from the explicit execution_mode literal so older
+// clients continue to behave unchanged:
 //
-//   - direct_model → tools off
-//   - hecate_task / external_agent / unset → tools on (the agent path
-//     is the safe assumption when the client offers no signal)
+//   - explicit `tools_enabled` → use it verbatim.
+//   - "hecate_task" execution_mode → tools on (an opt-in to the
+//     agent path).
+//   - legacy "direct_model" execution_mode → tools off.
+//   - both empty → tools off, matching the pre-tools_enabled wire
+//     contract where an unspecified turn defaulted to the model-chat
+//     path. Newer clients should set `tools_enabled` explicitly.
+//   - external_agent → tools_enabled is irrelevant on that dispatch
+//     path; this function still returns a value but the dispatcher
+//     never reads it for external sessions.
 //
 // The capability-driven downgrade in the dispatcher (a tool-incapable
-// model on a hecate_task turn) flips this to false as well, so the
+// model on a hecate_task turn) flips this to false too, so the
 // persisted Message always reflects what actually ran rather than
 // what the client originally requested.
 func chatRequestToolsEnabled(req CreateChatMessageRequest) bool {
 	if req.ToolsEnabled != nil {
 		return *req.ToolsEnabled
 	}
-	return strings.TrimSpace(req.ExecutionMode) != chat.ExecutionModeDirectModel
+	switch strings.TrimSpace(req.ExecutionMode) {
+	case chat.ExecutionModeHecateTask:
+		return true
+	case chat.LegacyExecutionModeDirectModel, "":
+		return false
+	default:
+		// external_agent or any other value — return the safe
+		// default. External-agent dispatch ignores this anyway, and
+		// an unknown execution_mode hits writeChatExecutionModeInvalid
+		// before reaching the tools_enabled-driven branches.
+		return false
+	}
 }
 
 // handleDirectModelTurn runs the tools-off sub-path of
@@ -1193,22 +1221,22 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 
 	segmentID := modelSegmentID(session, provider, model)
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID:            newChatID("msg"),
-		ExecutionMode: chat.ExecutionModeDirectModel,
-		// The model-chat handler dispatches when the operator submitted
-		// with tools off (or when the runtime downgraded a hecate_task
-		// turn because the model can't run tools). Either way, the
-		// persisted Message records ToolsEnabled=false so a future
-		// read against this row recovers the original intent without
-		// having to parse the execution_mode string.
-		ToolsEnabled: false,
-		SegmentID:    segmentID,
-		Provider:     provider,
-		Model:        model,
-		Capabilities: caps,
-		Role:         "user",
-		Content:      content,
-		CreatedAt:    startedAt,
+		ID: newChatID("msg"),
+		// Persist every Hecate-side turn as `hecate_task`, regardless
+		// of tools state. The tools-off discriminant lives entirely
+		// on `ToolsEnabled` now; the legacy `direct_model` literal is
+		// no longer written. Reads of older rows still see the legacy
+		// value until the sqlite migration in internal/chat/sqlite.go
+		// backfills them to `hecate_task` on boot.
+		ExecutionMode: chat.ExecutionModeHecateTask,
+		ToolsEnabled:  false,
+		SegmentID:     segmentID,
+		Provider:      provider,
+		Model:         model,
+		Capabilities:  caps,
+		Role:          "user",
+		Content:       content,
+		CreatedAt:     startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -1220,7 +1248,7 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 	contextPacket := h.directModelContextPacket(r.Context(), session, provider, model, strings.TrimSpace(req.SystemPrompt))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
-		ExecutionMode: chat.ExecutionModeDirectModel,
+		ExecutionMode: chat.ExecutionModeHecateTask,
 		ToolsEnabled:  false,
 		SegmentID:     segmentID,
 		RunID:         runID,
@@ -1341,7 +1369,14 @@ func agentChatModelHistory(session chat.Session, systemPrompt, content string) [
 func modelSegmentID(session chat.Session, provider, model string) string {
 	for i := len(session.Messages) - 1; i >= 0; i-- {
 		message := session.Messages[i]
-		if message.ExecutionMode != chat.ExecutionModeDirectModel {
+		// A direct-model run continues into the same segment as the
+		// previous direct-model turn for the same provider/model pair.
+		// Today such turns persist as `hecate_task` + `tools_enabled =
+		// false`; older rows still on the legacy `direct_model` literal
+		// also count until the sqlite migration sweeps them. Anything
+		// else (a tools-on hecate_task turn, an external_agent turn)
+		// breaks the segment run.
+		if !messageIsDirectModelTurn(message) {
 			break
 		}
 		if message.Provider == provider && message.Model == model && message.SegmentID != "" {
@@ -1349,6 +1384,18 @@ func modelSegmentID(session chat.Session, provider, model string) string {
 		}
 	}
 	return newChatID("segment")
+}
+
+// messageIsDirectModelTurn reports whether the persisted message
+// represents a Hecate-side turn that ran without tools. Recognizes
+// both the new wire shape (execution_mode=hecate_task + tools_enabled
+// =false) and the legacy direct_model literal that pre-migration
+// rows still carry.
+func messageIsDirectModelTurn(message chat.Message) bool {
+	if message.ExecutionMode == chat.LegacyExecutionModeDirectModel {
+		return true
+	}
+	return message.ExecutionMode == chat.ExecutionModeHecateTask && !message.ToolsEnabled
 }
 
 func isTerminalAgentChatStatus(status string) bool {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -11,7 +11,7 @@ import (
 const chatContextPacketVersion = "chat.context.v1"
 
 func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {
-	packet := baseChatContextPacket(chat.ExecutionModeDirectModel, provider, model, session.Workspace)
+	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, session.Workspace)
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	if packet.SystemPromptIncluded {

--- a/internal/api/handler_chat_dispatch_test.go
+++ b/internal/api/handler_chat_dispatch_test.go
@@ -8,62 +8,86 @@ import (
 
 // boolPtr is a tiny helper for the tools_enabled tri-state on
 // CreateChatMessageRequest. A `*bool` field uses nil to mean "the
-// client did not send this", which is what
-// `normalizeChatExecutionMode` falls back on; non-nil values pin the
-// dispatch.
+// client did not send this", which is what `chatRequestToolsEnabled`
+// falls back on; non-nil values pin the tools state.
 func boolPtr(b bool) *bool { return &b }
 
-func TestNormalizeChatExecutionMode_ExplicitModeWinsOverEverything(t *testing.T) {
+func TestNormalizeChatExecutionMode_ExplicitModeWinsOverSessionShape(t *testing.T) {
 	// When the client sends `execution_mode` explicitly, the dispatcher
-	// uses it verbatim regardless of session shape or tools_enabled.
-	// This preserves back-compat with older clients that send the
-	// literal directly.
+	// uses it verbatim (except for the legacy direct_model literal
+	// which normalizes to hecate_task — covered in its own test
+	// below). The tools_enabled argument is unused by the function
+	// today; the dispatcher reads tools_enabled separately via
+	// chatRequestToolsEnabled.
 	session := chat.Session{AgentID: chat.DefaultAgentID}
 	if got := normalizeChatExecutionMode(chat.ExecutionModeHecateTask, session, boolPtr(false)); got != chat.ExecutionModeHecateTask {
-		t.Errorf("explicit hecate_task + tools_enabled=false: got %q, want hecate_task", got)
-	}
-	if got := normalizeChatExecutionMode(chat.ExecutionModeDirectModel, session, boolPtr(true)); got != chat.ExecutionModeDirectModel {
-		t.Errorf("explicit direct_model + tools_enabled=true: got %q, want direct_model", got)
+		t.Errorf("explicit hecate_task: got %q, want hecate_task", got)
 	}
 	if got := normalizeChatExecutionMode(chat.ExecutionModeExternalAgent, session, boolPtr(true)); got != chat.ExecutionModeExternalAgent {
 		t.Errorf("explicit external_agent: got %q, want external_agent", got)
 	}
 }
 
+func TestNormalizeChatExecutionMode_LegacyDirectModelNormalizesToHecateTask(t *testing.T) {
+	// Older clients still send execution_mode="direct_model" for what
+	// is now a Hecate-task turn with tools off. The dispatcher's
+	// switch only knows hecate_task and external_agent, so the
+	// normalize step folds the legacy literal forward. The tools-off
+	// intent is recovered separately by chatRequestToolsEnabled.
+	session := chat.Session{AgentID: chat.DefaultAgentID}
+	if got := normalizeChatExecutionMode(chat.LegacyExecutionModeDirectModel, session, nil); got != chat.ExecutionModeHecateTask {
+		t.Errorf("legacy direct_model: got %q, want hecate_task", got)
+	}
+}
+
 func TestNormalizeChatExecutionMode_ExternalSessionPinsExternalAgent(t *testing.T) {
 	// When the session itself is external (agent_id != "hecate"), the
-	// dispatcher pins external_agent no matter what tools_enabled
-	// signal the client may have sent. Agent identity is the source
+	// dispatcher pins external_agent. Agent identity is the source
 	// of truth here.
 	session := chat.Session{AgentID: "claude_code"}
 	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeExternalAgent {
 		t.Errorf("external session + no signals: got %q, want external_agent", got)
 	}
-	if got := normalizeChatExecutionMode("", session, boolPtr(true)); got != chat.ExecutionModeExternalAgent {
-		t.Errorf("external session + tools_enabled=true: got %q, want external_agent", got)
-	}
 }
 
-func TestNormalizeChatExecutionMode_HecateSessionDerivesFromToolsEnabled(t *testing.T) {
-	// The new wire shape: Hecate-side turns send `tools_enabled` and
-	// omit `execution_mode`. The dispatcher routes hecate_task vs
-	// direct_model on the boolean.
+func TestNormalizeChatExecutionMode_HecateSessionDefaultsToHecateTask(t *testing.T) {
+	// Every Hecate-side turn — tools-on or tools-off — now normalizes
+	// to hecate_task. The tools-on/off axis lives on the per-message
+	// ToolsEnabled boolean, not on execution_mode.
 	session := chat.Session{AgentID: chat.DefaultAgentID}
+	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeHecateTask {
+		t.Errorf("hecate session + no signals: got %q, want hecate_task", got)
+	}
 	if got := normalizeChatExecutionMode("", session, boolPtr(true)); got != chat.ExecutionModeHecateTask {
 		t.Errorf("hecate session + tools_enabled=true: got %q, want hecate_task", got)
 	}
-	if got := normalizeChatExecutionMode("", session, boolPtr(false)); got != chat.ExecutionModeDirectModel {
-		t.Errorf("hecate session + tools_enabled=false: got %q, want direct_model", got)
+	if got := normalizeChatExecutionMode("", session, boolPtr(false)); got != chat.ExecutionModeHecateTask {
+		t.Errorf("hecate session + tools_enabled=false: got %q, want hecate_task", got)
 	}
 }
 
-func TestNormalizeChatExecutionMode_HecateSessionDefaultsToDirectModelWhenSignalsAbsent(t *testing.T) {
-	// Pre-tools_enabled clients sent neither field on the model-chat
-	// path and relied on the dispatcher's default. Keep that
-	// contract: a Hecate session with no execution_mode and no
-	// tools_enabled still routes to direct_model.
-	session := chat.Session{AgentID: chat.DefaultAgentID}
-	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeDirectModel {
-		t.Errorf("hecate session + no signals: got %q, want direct_model", got)
+func TestChatRequestToolsEnabled_PreservesLegacyDirectModelAsToolsOff(t *testing.T) {
+	// The legacy execution_mode="direct_model" literal still encodes
+	// tools-off intent for older clients. chatRequestToolsEnabled
+	// (the helper the dispatcher uses to derive the per-turn tools
+	// state) must recognize it so the resulting Message.ToolsEnabled
+	// matches what the client meant.
+	cases := []struct {
+		name string
+		req  CreateChatMessageRequest
+		want bool
+	}{
+		{"explicit tools_enabled=true wins", CreateChatMessageRequest{ToolsEnabled: boolPtr(true), ExecutionMode: chat.LegacyExecutionModeDirectModel}, true},
+		{"explicit tools_enabled=false wins", CreateChatMessageRequest{ToolsEnabled: boolPtr(false), ExecutionMode: chat.ExecutionModeHecateTask}, false},
+		{"legacy direct_model → tools off", CreateChatMessageRequest{ExecutionMode: chat.LegacyExecutionModeDirectModel}, false},
+		{"hecate_task → tools on", CreateChatMessageRequest{ExecutionMode: chat.ExecutionModeHecateTask}, true},
+		{"unset → tools off (preserves pre-tools_enabled default)", CreateChatMessageRequest{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chatRequestToolsEnabled(tc.req); got != tc.want {
+				t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -375,7 +375,13 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		if strings.TrimSpace(message.Content) == "" && message.Role == "assistant" {
 			continue
 		}
-		if message.ExecutionMode != chat.ExecutionModeHecateTask {
+		// Post-unification: every Hecate-side message persists as
+		// `hecate_task`; the tools-on/off discriminant lives on the
+		// per-message ToolsEnabled boolean. A direct-model turn
+		// (ToolsEnabled=false) AND the legacy direct_model literal
+		// both break the running tool-task segment — the new turn
+		// gets its own backing task.
+		if !isHecateTaskToolsOnMessage(message) {
 			return true
 		}
 		if provider != "" && strings.TrimSpace(message.Provider) != "" && strings.TrimSpace(message.Provider) != provider {
@@ -387,6 +393,20 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		return false
 	}
 	return false
+}
+
+// isHecateTaskToolsOnMessage reports whether the persisted message
+// is a tools-on Hecate-task turn — i.e., a turn that ran through the
+// agent_loop runtime with tools. Used by segment continuation logic
+// to detect when a turn breaks a running tool-task segment.
+func isHecateTaskToolsOnMessage(message chat.Message) bool {
+	if message.ExecutionMode == chat.LegacyExecutionModeDirectModel {
+		return false
+	}
+	if message.ExecutionMode != chat.ExecutionModeHecateTask {
+		return false
+	}
+	return message.ToolsEnabled
 }
 
 func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session chat.Session, prompt, systemPrompt string, forceNewTask bool) (types.Task, types.TaskRun, error) {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -440,7 +440,10 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 		t.Fatalf("model messages = %d, want 2", len(modelTurn.Data.Messages))
 	}
 	modelAssistant := modelTurn.Data.Messages[1]
-	if modelAssistant.ExecutionMode != chat.ExecutionModeDirectModel || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
+	// Post-unification: every Hecate-side message persists as
+	// `hecate_task`. The tools-off discriminant lives on the
+	// per-message ToolsEnabled boolean asserted below.
+	if modelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
 		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
 	if modelAssistant.ToolsEnabled {
@@ -470,8 +473,11 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 		t.Fatalf("model segment should preserve latest task pointer, got %q want %q", secondModel.Data.TaskID, firstTaskID)
 	}
 	secondModelAssistant := secondModel.Data.Messages[len(secondModel.Data.Messages)-1]
-	if secondModelAssistant.ExecutionMode != chat.ExecutionModeDirectModel || secondModelAssistant.TaskID != "" {
+	if secondModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondModelAssistant.TaskID != "" {
 		t.Fatalf("second model assistant snapshot = execution_mode %q task %q", secondModelAssistant.ExecutionMode, secondModelAssistant.TaskID)
+	}
+	if secondModelAssistant.ToolsEnabled {
+		t.Fatalf("second model assistant tools_enabled = true, want false (direct-model turn)")
 	}
 
 	secondTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
@@ -502,19 +508,15 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if len(segments) != 5 {
 		t.Fatalf("segments = %d, want 5: %+v", len(segments), segments)
 	}
-	wantModes := []string{
-		chat.ExecutionModeDirectModel,
-		chat.ExecutionModeHecateTask,
-		chat.ExecutionModeDirectModel,
-		chat.ExecutionModeHecateTask,
-		chat.ExecutionModeHecateTask,
-	}
-	for i, want := range wantModes {
-		if segments[i].ExecutionMode != want {
-			t.Fatalf("segment %d execution_mode = %q, want %q: %+v", i, segments[i].ExecutionMode, want, segments)
+	// All segments persist as `hecate_task` now. The segment shape
+	// (model vs tools turn) is recoverable from segment.ID prefix
+	// (`segment:` vs `task:`) and the per-segment task_id population.
+	for i, segment := range segments {
+		if segment.ExecutionMode != chat.ExecutionModeHecateTask {
+			t.Fatalf("segment %d execution_mode = %q, want hecate_task: %+v", i, segment.ExecutionMode, segments)
 		}
-		if segments[i].MessageCount != 2 {
-			t.Fatalf("segment %d message_count = %d, want 2: %+v", i, segments[i].MessageCount, segments)
+		if segment.MessageCount != 2 {
+			t.Fatalf("segment %d message_count = %d, want 2: %+v", i, segment.MessageCount, segments)
 		}
 	}
 	if segments[0].ID != modelAssistant.SegmentID || segments[0].TaskID != "" || segments[0].Model != "gpt-4o-mini" {
@@ -939,8 +941,15 @@ func TestHecateAgentChatFallsBackToDirectModelWhenToolsUnavailable(t *testing.T)
 		t.Fatalf("messages = %d, want at least 2", len(updated.Data.Messages))
 	}
 	assistant := updated.Data.Messages[len(updated.Data.Messages)-1]
-	if assistant.ExecutionMode != chat.ExecutionModeDirectModel {
-		t.Fatalf("assistant execution mode = %q, want direct_model", assistant.ExecutionMode)
+	// Post-unification: every Hecate-side turn persists as
+	// `hecate_task` regardless of tools state. The capability
+	// downgrade flips `ToolsEnabled` to false but the
+	// execution_mode stays consistent across the chat session.
+	if assistant.ExecutionMode != chat.ExecutionModeHecateTask {
+		t.Fatalf("assistant execution mode = %q, want hecate_task", assistant.ExecutionMode)
+	}
+	if assistant.ToolsEnabled {
+		t.Fatalf("assistant tools_enabled = true, want false (capability downgrade)")
 	}
 	if assistant.TaskID != "" {
 		t.Fatalf("assistant task id = %q, want empty", assistant.TaskID)

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -261,10 +261,11 @@ func defaultMessageExecutionModeForRender(session chat.Session) string {
 	if session.AgentID != "" && session.AgentID != chat.DefaultAgentID {
 		return chat.ExecutionModeExternalAgent
 	}
-	if session.TaskID != "" {
-		return chat.ExecutionModeHecateTask
-	}
-	return chat.ExecutionModeDirectModel
+	// Every Hecate-side render fallback is `hecate_task` now —
+	// regardless of whether a backing task exists. Tools-on/off is
+	// recorded on the per-message ToolsEnabled field, not on the
+	// execution_mode string.
+	return chat.ExecutionModeHecateTask
 }
 
 func agentChatUsageFromResult(usage agentadapters.Usage) chat.Usage {

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -572,12 +572,10 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 	// Backfill `tools_enabled = 0` for rows that recorded the legacy
 	// `execution_mode = 'direct_model'` value. That literal predates
 	// the dedicated tools-enabled column and is the single signal in
-	// older data that the user submitted with tools off. The UPDATE is
-	// idempotent and runs every boot; once every direct_model row has
-	// been touched the WHERE clause selects nothing on subsequent
-	// boots. The legacy value is preserved in execution_mode so a
-	// historical-by-string read against an unmigrated session still
-	// behaves.
+	// older data that the user submitted with tools off. The UPDATE
+	// is idempotent and runs every boot; once every direct_model row
+	// has been touched the WHERE clause selects nothing on
+	// subsequent boots.
 	if _, err := s.client.DB().ExecContext(
 		ctx,
 		fmt.Sprintf(
@@ -586,6 +584,24 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		),
 	); err != nil {
 		return fmt.Errorf("backfill sqlite agent chat tools_enabled: %w", err)
+	}
+
+	// Migrate execution_mode='direct_model' rows to 'hecate_task'.
+	// Every Hecate-side turn now persists as hecate_task; the
+	// tools-off intent is recorded on the tools_enabled column above
+	// (already backfilled by the previous statement). The two
+	// migrations together preserve the original turn semantics
+	// without leaving the legacy literal as a parallel discriminant
+	// that handler code would have to keep checking. Idempotent —
+	// re-runs select nothing once the column is fully migrated.
+	if _, err := s.client.DB().ExecContext(
+		ctx,
+		fmt.Sprintf(
+			`UPDATE %s SET execution_mode = 'hecate_task' WHERE execution_mode = 'direct_model'`,
+			s.messagesTable,
+		),
+	); err != nil {
+		return fmt.Errorf("backfill sqlite agent chat execution_mode: %w", err)
 	}
 
 	messagesIndex := strings.Trim(s.messagesTable, `"`) + "_session_seq_idx"

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -78,7 +78,9 @@ func TestSQLiteStoreBackfillsToolsEnabledForLegacyDirectModelRows(t *testing.T) 
 
 	// Re-running the migration (idempotent) flips tools_enabled to 0
 	// for any direct_model row that still landed on the column
-	// default.
+	// default, and rewrites execution_mode from 'direct_model' to
+	// 'hecate_task' so the handler-side reads only have to know
+	// about one Hecate-side mode going forward.
 	if _, err := NewSQLiteStore(context.Background(), client); err != nil {
 		t.Fatalf("re-open SQLiteStore: %v", err)
 	}
@@ -94,7 +96,10 @@ func TestSQLiteStoreBackfillsToolsEnabledForLegacyDirectModelRows(t *testing.T) 
 		t.Fatalf("len(Messages) = %d, want 1", len(session.Messages))
 	}
 	if session.Messages[0].ToolsEnabled {
-		t.Errorf("legacy direct_model row ToolsEnabled = true, want false (backfill missed)")
+		t.Errorf("legacy direct_model row ToolsEnabled = true, want false (tools_enabled backfill missed)")
+	}
+	if got := session.Messages[0].ExecutionMode; got != ExecutionModeHecateTask {
+		t.Errorf("legacy direct_model row ExecutionMode = %q, want %q (execution_mode backfill missed)", got, ExecutionModeHecateTask)
 	}
 }
 

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -417,10 +417,18 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 
 const (
 	DefaultAgentID             = "hecate"
-	ExecutionModeDirectModel   = "direct_model"
 	ExecutionModeHecateTask    = "hecate_task"
 	ExecutionModeExternalAgent = "external_agent"
 )
+
+// LegacyExecutionModeDirectModel is the wire literal older clients
+// may still send and older persisted rows may still carry for what
+// is conceptually now a Hecate-task turn with tools off. Kept as a
+// named back-compat constant rather than scattered string literals
+// so the cleanup landing site is obvious — once every reachable
+// install has migrated to writing `hecate_task` + `tools_enabled =
+// false`, this constant + its readers can be deleted in one diff.
+const LegacyExecutionModeDirectModel = "direct_model"
 
 func hydrateMessageRuntimeFromSession(message *Message, session Session) {
 	if message.ExecutionMode == "" {
@@ -464,8 +472,11 @@ func defaultMessageExecutionMode(session Session) string {
 	if session.AgentID != "" && session.AgentID != DefaultAgentID {
 		return ExecutionModeExternalAgent
 	}
-	if session.TaskID != "" {
-		return ExecutionModeHecateTask
-	}
-	return ExecutionModeDirectModel
+	// Every Hecate-side session now uses `hecate_task` as the
+	// execution mode regardless of whether a backing task exists.
+	// Tools-on/off is recorded separately on `Message.ToolsEnabled`;
+	// the legacy `direct_model` value is only present on rows that
+	// predate the unification and gets folded into `hecate_task` by
+	// the sqlite migration in internal/chat/sqlite.go.
+	return ExecutionModeHecateTask
 }


### PR DESCRIPTION
## Summary

Every Hecate-side chat message now persists as `execution_mode = "hecate_task"` regardless of tools state. The tools-on/off discriminant lives entirely on the per-message `ToolsEnabled` boolean. The legacy `"direct_model"` literal stays **accepted as a wire-side back-compat input** but is no longer written anywhere — and a sqlite migration sweeps existing rows forward so the value also disappears from new reads.

Stacked on PR #281 (the dead-flip cleanup). Net behavioral change: persisted messages from tools-off turns now carry `execution_mode = "hecate_task"` + `tools_enabled = false` instead of `execution_mode = "direct_model"`.

## Backend writes

- `internal/chat/store.go`: drop the `ExecutionModeDirectModel` constant; introduce `LegacyExecutionModeDirectModel` whose name signals to readers that the value is only here for older clients and older persisted rows.
- `defaultMessageExecutionMode` returns `hecate_task` for any Hecate-side session.
- `handleDirectModelTurn` writes `ExecutionMode: hecate_task` (with `ToolsEnabled: false`) for tools-off turns.
- `directModelContextPacket` and `defaultMessageExecutionModeForRender` return `hecate_task`.
- `normalizeChatExecutionMode` folds the legacy `direct_model` literal forward to `hecate_task` before the dispatcher's switch sees it, so the switch only has to know about the two surviving execution modes.
- `chatRequestToolsEnabled` rewritten as an explicit switch over the execution_mode literals. The pre-tools_enabled "no signal" contract (absence of both fields defaulted to model-chat dispatch) is preserved by returning `false` when both fields are empty.

## Sqlite migration

- `internal/chat/sqlite.go` gains a second backfill UPDATE that rewrites every `execution_mode = 'direct_model'` row to `'hecate_task'`. Runs **after** the existing `tools_enabled = 0` backfill so the tools-off intent is preserved on every row before the discriminant changes shape. Idempotent.
- `internal/chat/sqlite_test.go` extends the existing backfill conformance to also assert the execution_mode flip.

## Segment continuation

- `shouldStartNewHecateAgentSegment` checked `message.ExecutionMode != chat.ExecutionModeHecateTask` to detect a break in the running tool-task segment. After the rename every Hecate-side message matches that, so the function would refuse to start a new task across tools-off → tools-on transitions. Replace the check with `isHecateTaskToolsOnMessage`, which inspects both `ExecutionMode` and `ToolsEnabled` and recognizes the legacy literal too.
- `modelSegmentID` gets the same treatment via `messageIsDirectModelTurn`.

## Dispatcher

The switch case drops `chat.ExecutionModeDirectModel` because the legacy literal is normalized away before the switch sees it. The dispatcher only knows `hecate_task` and `external_agent` now.

## Tests

- `handler_chat_dispatch_test.go` rewritten to assert the new semantics: explicit mode wins, legacy `direct_model` normalizes forward, external sessions pin `external_agent`, Hecate sessions default to `hecate_task`. Plus a dedicated table-driven test for `chatRequestToolsEnabled` exercising the explicit-true / explicit-false / legacy-direct_model / hecate_task / both-empty matrix.
- `handler_chat_hecate_test.go` updates 8 sites that previously asserted `ExecutionMode == direct_model` on persisted messages.

## UI

**No UI changes.** `ChatExecutionMode` already accepts `"direct_model"` as a legacy literal, the UI doesn't derive toggle state from message history anyway (`useChatToolsEnabled` reads slice state, not the wire), and reads of pre-migration data still display correctly. The execution_mode axis on the wire collapses to two values for new writes; clients tolerate the third forever.

## Out of scope (still owed)

- **`LegacyExecutionModeDirectModel` constant stays for one cycle.** Once every reachable install has restarted (sweeping the sqlite backfill) and every client has stopped sending the literal, the constant + its three read-side guards can be deleted in a tiny follow-up.
- **Docs sweep.** `docs/chat-sessions.md` + `docs/runtime-api.md` still describe `direct_model` as a valid execution_mode value. Accurate as wire input (back-compat), but worth a sweep that surfaces "tools-off Hecate-task turns" as the new canonical encoding.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -timeout 5m ./internal/api/... ./internal/chat/...` — all green
- [x] `bun run typecheck` (UI) — clean
- [x] `bun run test` (UI) — 1163 / 1163 pass
- [x] `bunx playwright test chat.spec.ts` — 44 / 44 pass
- [x] `bun run lint` (UI) — 0 warnings / 0 errors
- [x] `bun run format:check` (UI) — clean

## Diff stat

```
9 files changed, 253 insertions(+), 120 deletions(-)
```