### PR TITLE
refactor(chat): remove direct model execution mode

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -98,8 +98,8 @@ focused on request setup, polling, and cancellation.
 Chat sessions separate ownership from turn execution:
 
 1. `agent_id="hecate"` owns built-in Hecate Chat sessions. Each turn chooses
-   `execution_mode="direct_model"` for a plain gateway/router call or
-   `execution_mode="hecate_task"` for task-backed tools.
+   `execution_mode="hecate_task"`. `tools_enabled=false` records a plain
+   gateway/router call; `tools_enabled=true` records a task-backed tools turn.
 2. `agent_id` values such as `codex`, `claude_code`, or `cursor_agent` own
    External Agent sessions. Their turns use `execution_mode="external_agent"`
    and point at one supervised adapter session.

--- a/docs/chat-sessions.md
+++ b/docs/chat-sessions.md
@@ -115,10 +115,7 @@ the tools-on/off axis is recorded on each message's `tools_enabled` boolean
 instead of split across two execution-mode values:
 
 - **Model** segments (`tools_enabled=false`) call the gateway/router directly
-  and store user/assistant messages without creating Tasks. Older clients may
-  still send `execution_mode="direct_model"` on the wire; the gateway folds
-  the legacy literal into the unified `hecate_task` write with
-  `tools_enabled=false` so reads against either shape behave the same.
+  and store user/assistant messages without creating Tasks.
 - **Task-backed Hecate Chat** segments map a tools-on stretch of a chat to one
   visible `agent_loop` task. The first tool-enabled prompt creates the task;
   follow-up prompts continue the latest terminal run when the previous segment

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -150,7 +150,7 @@ type ContextPacket struct {
     SourcePreset string
     Provider    string
     Model       string
-    ExecutionMode string // direct_model | hecate_task | external_agent
+    ExecutionMode string // hecate_task | external_agent
     Items       []ContextItem
 }
 

--- a/docs/rfcs/hecate-chat-model-capabilities.md
+++ b/docs/rfcs/hecate-chat-model-capabilities.md
@@ -144,7 +144,7 @@ records the execution mode that produced that turn:
 
 ```ts
 type ChatAgentID = "hecate" | "codex" | "claude_code" | "cursor_agent" | string;
-type ChatExecutionMode = "direct_model" | "hecate_task" | "external_agent";
+type ChatExecutionMode = "hecate_task" | "external_agent";
 ```
 
 Hecate Chat sessions also store:
@@ -442,9 +442,9 @@ Done in the core bridge:
   chat banner while Tasks remains canonical
 - streamed assistant text from the backing task updates the chat transcript
   before the run reaches a terminal state when the provider route supports SSE
-- direct model turns and Hecate Agent turns share one Agent Chat transcript
-  using `execution_mode="direct_model"` / `execution_mode="hecate_task"`
-  message snapshots
+- tools-off direct model turns and Hecate Agent turns share one Agent Chat
+  transcript using `execution_mode="hecate_task"` with `tools_enabled=false`
+  or `tools_enabled=true` message snapshots
 - turning tools back on after a direct model segment creates a new task-backed
   segment in the same transcript
 - Hecate Chat queues prompts locally while the active task-backed segment is

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1180,14 +1180,10 @@ chooses the chat owner:
   `execution_mode="hecate_task"` and `tools_enabled` to choose between a normal
   provider/model call (`tools_enabled=false`) and a visible `agent_loop` task
   with Hecate tools, task approvals, artifacts, and OTel
-  (`tools_enabled=true`). The legacy `execution_mode="direct_model"` literal is
-  still accepted as a back-compat input (older clients send it instead of
-  setting `tools_enabled=false`); the gateway folds it into the unified
-  hecate-task dispatch and records `tools_enabled=false` on the persisted
-  message. Hecate Chat sessions may opt into RTK command-output compaction with
-  `rtk_enabled=true`; shell and git tool calls then launch as `rtk sh -lc
-<command>` while keeping Hecate approvals, policy validation, sandboxing,
-  limits, and timeouts in place.
+  (`tools_enabled=true`). Hecate Chat sessions may opt into
+  RTK command-output compaction with `rtk_enabled=true`; shell and git tool
+  calls then launch as `rtk sh -lc <command>` while keeping Hecate approvals,
+  policy validation, sandboxing, limits, and timeouts in place.
 - `agent_id="codex"`, `"claude_code"`, `"cursor_agent"`, `"grok_build"`, or another
   registered adapter id — the external adapter owns the native session while
   Hecate supervises lifecycle, transcript, diagnostics, and external-agent
@@ -1293,8 +1289,7 @@ Creates a chat session. `agent_id` chooses the session owner:
 - `hecate` (default) creates a Hecate Chat. Subsequent turns send
   `execution_mode="hecate_task"` with `tools_enabled` set per turn
   (`tools_enabled=true` for tool-backed runs, `tools_enabled=false` for
-  direct model chat). Legacy clients sending `execution_mode="direct_model"`
-  still work; the gateway treats it as a tools-off hecate-task turn.
+  direct model chat).
 - Any registered external-agent id, such as `codex`, `claude_code`,
   `cursor_agent`, or `grok_build`, creates an External Agent chat and requires
   `workspace`.
@@ -1519,15 +1514,12 @@ the user message and assistant output.
 
 - `execution_mode` — `hecate_task` or `external_agent`. Hecate Chat sessions
   use `hecate_task` (tools-on/off is set separately via `tools_enabled`);
-  External Agent sessions always use `external_agent`. The legacy
-  `direct_model` literal is still accepted as a back-compat input — the
-  gateway normalizes it to `hecate_task` with `tools_enabled=false`.
+  External Agent sessions always use `external_agent`.
 - `tools_enabled` (boolean) — per-turn tools-on/off signal for Hecate Chat
   sessions. `true` opts into the tool-backed `agent_loop` path; `false`
   dispatches the prompt directly to the selected model without creating a
-  task. When omitted, the gateway derives the value from `execution_mode`
-  (legacy `direct_model` → `false`; `hecate_task` → `true`; both omitted →
-  `false`, preserving the pre-`tools_enabled` default).
+  task. When omitted, Hecate treats Hecate-owned turns as tools-on unless model
+  capabilities require a tools-off direct model fallback.
 - `provider` / `model` — used for tools-off turns and new task-backed
   Hecate Chat segments. Existing task-backed segments continue with their
   saved model snapshot until the operator turns tools off or starts a new
@@ -1695,7 +1687,7 @@ Chat execution errors:
 | `400`  | `chat.workspace_required`        | Task-backed Hecate Chat turns and External Agent sessions need a selected workspace path before the first turn.                                                                             |
 | `400`  | `chat.model_required`            | Hecate Chat needs an explicit selected model before direct model or task-backed turns, or an External Agent adapter requires a launch model before session start.                           |
 | `400`  | `chat.agent_id_invalid`          | The requested session owner is not `hecate` and does not match a registered external-agent adapter.                                                                                         |
-| `400`  | `chat.execution_mode_invalid`    | The requested turn execution mode is not one of `hecate_task` or `external_agent` (legacy `direct_model` is also accepted and normalized to `hecate_task`).                                 |
+| `400`  | `chat.execution_mode_invalid`    | The requested turn execution mode is not one of `hecate_task` or `external_agent`.                                                                                                          |
 | `400`  | `chat.runtime_mismatch`          | The request tried to run a turn through a runtime that does not match the existing session type.                                                                                            |
 | `400`  | `chat.adapter_not_found`         | The selected external-agent adapter is not registered.                                                                                                                                      |
 | `409`  | `chat.agent_session_busy`        | The backing task run is queued, running, or awaiting approval. Resolve/cancel the active run before sending another prompt, even for tools-off turns in the same Hecate Chat session.       |

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -41,6 +41,8 @@ var (
 	buildOnce    sync.Once
 	builtBinPath string
 	builtBinErr  error
+	e2ePortMu    sync.Mutex
+	e2ePorts     = map[int]struct{}{}
 )
 
 const gatewayStartupTimeout = 30 * time.Second
@@ -129,36 +131,51 @@ func gatewayServer(t *testing.T, extraEnv ...string) string {
 	t.Helper()
 
 	bin := hecateBinary(t)
-	port := freePort(t)
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	baseURL := "http://" + addr
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		port := freePort(t)
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+		baseURL := "http://" + addr
 
-	// HECATE_DATA_DIR points at a per-test temp dir so any state file the
-	// runtime touches (bootstrap, control plane) lands under the test's
-	// own filesystem and gets cleaned up automatically.
-	env := append(os.Environ(),
-		"HECATE_ADDRESS="+addr,
-		"HECATE_DATA_DIR="+t.TempDir(),
-	)
-	env = append(env, extraEnv...)
-	env = append(env, autoPreconfiguredEnv(extraEnv)...)
+		// HECATE_DATA_DIR points at a per-test temp dir so any state file the
+		// runtime touches (bootstrap, control plane) lands under the test's
+		// own filesystem and gets cleaned up automatically.
+		env := append(os.Environ(),
+			"HECATE_ADDRESS="+addr,
+			"HECATE_DATA_DIR="+t.TempDir(),
+		)
+		env = append(env, extraEnv...)
+		env = append(env, autoPreconfiguredEnv(extraEnv)...)
 
-	cmd := exec.Command(bin, "serve")
-	cmd.Env = env
-	output := newTailBuffer(64 * 1024)
-	cmd.Stdout = output
-	cmd.Stderr = output
+		cmd := exec.Command(bin, "serve")
+		cmd.Env = env
+		output := newTailBuffer(64 * 1024)
+		cmd.Stdout = output
+		cmd.Stderr = output
 
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start gateway: %v", err)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start gateway: %v", err)
+		}
+		if err := waitHealthyProcessResult(baseURL, gatewayStartupTimeout, cmd, output); err != nil {
+			lastErr = err
+			if gatewayListenAddressInUse(output.String()) {
+				t.Logf("retrying gateway startup after listen-address collision on %s", addr)
+				continue
+			}
+			t.Fatalf("%v\n--- gateway output tail ---\n%s", err, output.String())
+		}
+
+		t.Cleanup(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+		return baseURL
 	}
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
-
-	waitHealthyProcess(t, baseURL, gatewayStartupTimeout, cmd, output)
-	return baseURL
+	if lastErr != nil {
+		t.Fatalf("start gateway after listen-address retries: %v", lastErr)
+	}
+	t.Fatal("start gateway after listen-address retries: exhausted attempts")
+	return ""
 }
 
 // autoPreconfiguredEnv scans extraEnv for PROVIDER_<NAME>_<FIELD>
@@ -211,6 +228,15 @@ func waitHealthyProcess(t *testing.T, baseURL string, timeout time.Duration, cmd
 
 func waitHealthyWithDiagnostics(t *testing.T, baseURL string, timeout time.Duration, cmd *exec.Cmd, output *tailBuffer) {
 	t.Helper()
+	if err := waitHealthyProcessResult(baseURL, timeout, cmd, output); err != nil {
+		if output != nil {
+			t.Fatalf("%v\n--- gateway output tail ---\n%s", err, output.String())
+		}
+		t.Fatal(err)
+	}
+}
+
+func waitHealthyProcessResult(baseURL string, timeout time.Duration, cmd *exec.Cmd, output *tailBuffer) error {
 	deadline := time.Now().Add(timeout)
 	lastProbe := "not attempted"
 	client := &http.Client{Timeout: time.Second}
@@ -218,7 +244,7 @@ func waitHealthyWithDiagnostics(t *testing.T, baseURL string, timeout time.Durat
 		resp, err := client.Get(baseURL + "/healthz") //nolint:noctx
 		if err == nil && resp.StatusCode == http.StatusOK {
 			resp.Body.Close()
-			return
+			return nil
 		}
 		if err != nil {
 			lastProbe = err.Error()
@@ -228,6 +254,10 @@ func waitHealthyWithDiagnostics(t *testing.T, baseURL string, timeout time.Durat
 		if resp != nil {
 			resp.Body.Close()
 		}
+		if output != nil && gatewayListenAddressInUse(output.String()) {
+			lastProbe += "; process output: listen address in use"
+			break
+		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	if cmd != nil && cmd.Process != nil {
@@ -236,22 +266,36 @@ func waitHealthyWithDiagnostics(t *testing.T, baseURL string, timeout time.Durat
 			lastProbe += "; process wait: " + err.Error()
 		}
 	}
-	if output != nil {
-		t.Fatalf("gateway at %s never became healthy within %s (last probe: %s)\n--- gateway output tail ---\n%s", baseURL, timeout, lastProbe, output.String())
-	}
-	t.Fatalf("gateway at %s never became healthy within %s (last probe: %s)", baseURL, timeout, lastProbe)
+	return fmt.Errorf("gateway at %s never became healthy within %s (last probe: %s)", baseURL, timeout, lastProbe)
+}
+
+func gatewayListenAddressInUse(output string) bool {
+	return strings.Contains(output, "gateway listen failed") &&
+		strings.Contains(output, "bind: address already in use")
 }
 
 // freePort asks the OS for an available TCP port.
 func freePort(t *testing.T) int {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("freePort: %v", err)
+	for attempt := 0; attempt < 100; attempt++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("freePort: %v", err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		e2ePortMu.Lock()
+		_, used := e2ePorts[port]
+		if !used {
+			e2ePorts[port] = struct{}{}
+		}
+		e2ePortMu.Unlock()
+		ln.Close()
+		if !used {
+			return port
+		}
 	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
-	return port
+	t.Fatal("freePort: exhausted reserved port attempts")
+	return 0
 }
 
 // ─── HTTP helpers ────────────────────────────────────────────────────────────

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -750,16 +750,13 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		})
 		return
 	}
-	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session, req.ToolsEnabled)
-	// Resolve the effective tools-on/off signal for this turn from
-	// either the new `tools_enabled` field or the legacy
-	// `execution_mode = "direct_model"` literal. The capability-
-	// driven downgrade (a tool-incapable model on a Hecate session)
-	// flips this to false even when the client requested tools-on,
-	// so the unified handler routes the turn to the direct-model
-	// code path without the dispatcher needing a separate
-	// direct_model switch case.
-	toolsEnabled := chatRequestToolsEnabled(req)
+	executionMode := normalizeChatExecutionMode(req.ExecutionMode, session)
+	toolsEnabled := true
+	if req.ToolsEnabled != nil {
+		toolsEnabled = *req.ToolsEnabled
+	}
+	// Capability-driven downgrade lets a Hecate turn with tools on fall
+	// back to the direct model path without changing its runtime owner.
 	if toolsEnabled && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
 		toolsEnabled = false
 	}
@@ -768,14 +765,8 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		// One unified entry point for every Hecate-side turn,
 		// regardless of tools_enabled. handleCreateHecateChatMessage
 		// branches at the top: tools-off delegates to
-		// `handleDirectModelTurn` (the former
-		// handleCreateModelChatMessage, now a private sub-path of
-		// the Hecate handler); tools-on runs the existing
-		// agent_loop task-creation path. The legacy
-		// `execution_mode = "direct_model"` literal that older
-		// clients still send normalizes to `hecate_task` inside
-		// `normalizeChatExecutionMode`, so it falls into this case
-		// the same way an explicit hecate_task would.
+		// `handleDirectModelTurn`; tools-on runs the existing
+		// agent_loop task-creation path.
 		if isExternalChatSession(session) {
 			writeAgentChatRuntimeMismatch(w, "external agent sessions cannot run Hecate Chat turns")
 			return
@@ -1098,35 +1089,10 @@ func (h *Handler) hecateTaskShouldFallbackToDirectModel(ctx context.Context, ses
 	return !modelcaps.ToolCapable(caps)
 }
 
-// normalizeChatExecutionMode resolves the execution mode the handler
-// should dispatch on. The explicit `execution_mode` field on the
-// request still wins when set — older clients send the legacy
-// `direct_model` literal directly and the dispatcher's switch case
-// accepts it. When it's empty:
-//
-//   - External-agent sessions always dispatch as `external_agent`
-//     (agent_id pins the session kind regardless of any per-turn
-//     flag the client may have sent).
-//   - Every Hecate-side turn (tools on or off) normalizes to
-//     `hecate_task`. The tools-on/off axis lives on `req.ToolsEnabled`
-//     now; the dispatcher reads it separately and the unified handler
-//     branches on it.
-//
-// Returns ExecutionModeHecateTask for Hecate sessions even when the
-// client sent neither field, which matches the pre-tools_enabled
-// default behavior (the no-tools fallback) once tools-off becomes a
-// boolean flag rather than its own execution mode.
-func normalizeChatExecutionMode(mode string, session chat.Session, _ *bool) string {
+// normalizeChatExecutionMode resolves the runtime owner for this turn.
+// Tools-on/off is tracked separately via tools_enabled.
+func normalizeChatExecutionMode(mode string, session chat.Session) string {
 	mode = strings.TrimSpace(mode)
-	// Legacy: older clients send `direct_model` as the execution
-	// mode for tools-off turns. Internally every Hecate-side turn is
-	// `hecate_task` now; the tools-off intent is recovered separately
-	// by chatRequestToolsEnabled. Normalize the legacy literal so
-	// the dispatcher's switch only has to know about the two
-	// remaining execution modes.
-	if mode == chat.LegacyExecutionModeDirectModel {
-		return chat.ExecutionModeHecateTask
-	}
 	if mode != "" {
 		return mode
 	}
@@ -1134,45 +1100,6 @@ func normalizeChatExecutionMode(mode string, session chat.Session, _ *bool) stri
 		return chat.ExecutionModeExternalAgent
 	}
 	return chat.ExecutionModeHecateTask
-}
-
-// chatRequestToolsEnabled returns the per-turn tools-on/off signal
-// the handler should dispatch + persist for this submission. The
-// dedicated `tools_enabled` field wins when set; otherwise the value
-// is derived from the explicit execution_mode literal so older
-// clients continue to behave unchanged:
-//
-//   - explicit `tools_enabled` → use it verbatim.
-//   - "hecate_task" execution_mode → tools on (an opt-in to the
-//     agent path).
-//   - legacy "direct_model" execution_mode → tools off.
-//   - both empty → tools off, matching the pre-tools_enabled wire
-//     contract where an unspecified turn defaulted to the model-chat
-//     path. Newer clients should set `tools_enabled` explicitly.
-//   - external_agent → tools_enabled is irrelevant on that dispatch
-//     path; this function still returns a value but the dispatcher
-//     never reads it for external sessions.
-//
-// The capability-driven downgrade in the dispatcher (a tool-incapable
-// model on a hecate_task turn) flips this to false too, so the
-// persisted Message always reflects what actually ran rather than
-// what the client originally requested.
-func chatRequestToolsEnabled(req CreateChatMessageRequest) bool {
-	if req.ToolsEnabled != nil {
-		return *req.ToolsEnabled
-	}
-	switch strings.TrimSpace(req.ExecutionMode) {
-	case chat.ExecutionModeHecateTask:
-		return true
-	case chat.LegacyExecutionModeDirectModel, "":
-		return false
-	default:
-		// external_agent or any other value — return the safe
-		// default. External-agent dispatch ignores this anyway, and
-		// an unknown execution_mode hits writeChatExecutionModeInvalid
-		// before reaching the tools_enabled-driven branches.
-		return false
-	}
 }
 
 // handleDirectModelTurn runs the tools-off sub-path of
@@ -1221,22 +1148,22 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 
 	segmentID := modelSegmentID(session, provider, model)
 	updated, err := h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
-		ID: newChatID("msg"),
-		// Persist every Hecate-side turn as `hecate_task`, regardless
-		// of tools state. The tools-off discriminant lives entirely
-		// on `ToolsEnabled` now; the legacy `direct_model` literal is
-		// no longer written. Reads of older rows still see the legacy
-		// value until the sqlite migration in internal/chat/sqlite.go
-		// backfills them to `hecate_task` on boot.
+		ID:            newChatID("msg"),
 		ExecutionMode: chat.ExecutionModeHecateTask,
-		ToolsEnabled:  false,
-		SegmentID:     segmentID,
-		Provider:      provider,
-		Model:         model,
-		Capabilities:  caps,
-		Role:          "user",
-		Content:       content,
-		CreatedAt:     startedAt,
+		// The model-chat handler dispatches when the operator submitted
+		// with tools off (or when the runtime downgraded a hecate_task
+		// turn because the model can't run tools). Either way, the
+		// persisted Message records ToolsEnabled=false so a future
+		// read against this row recovers the original intent without
+		// having to parse the execution_mode string.
+		ToolsEnabled: false,
+		SegmentID:    segmentID,
+		Provider:     provider,
+		Model:        model,
+		Capabilities: caps,
+		Role:         "user",
+		Content:      content,
+		CreatedAt:    startedAt,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -1369,14 +1296,7 @@ func agentChatModelHistory(session chat.Session, systemPrompt, content string) [
 func modelSegmentID(session chat.Session, provider, model string) string {
 	for i := len(session.Messages) - 1; i >= 0; i-- {
 		message := session.Messages[i]
-		// A direct-model run continues into the same segment as the
-		// previous direct-model turn for the same provider/model pair.
-		// Today such turns persist as `hecate_task` + `tools_enabled =
-		// false`; older rows still on the legacy `direct_model` literal
-		// also count until the sqlite migration sweeps them. Anything
-		// else (a tools-on hecate_task turn, an external_agent turn)
-		// breaks the segment run.
-		if !messageIsDirectModelTurn(message) {
+		if message.ExecutionMode != chat.ExecutionModeHecateTask || message.ToolsEnabled {
 			break
 		}
 		if message.Provider == provider && message.Model == model && message.SegmentID != "" {
@@ -1384,18 +1304,6 @@ func modelSegmentID(session chat.Session, provider, model string) string {
 		}
 	}
 	return newChatID("segment")
-}
-
-// messageIsDirectModelTurn reports whether the persisted message
-// represents a Hecate-side turn that ran without tools. Recognizes
-// both the new wire shape (execution_mode=hecate_task + tools_enabled
-// =false) and the legacy direct_model literal that pre-migration
-// rows still carry.
-func messageIsDirectModelTurn(message chat.Message) bool {
-	if message.ExecutionMode == chat.LegacyExecutionModeDirectModel {
-		return true
-	}
-	return message.ExecutionMode == chat.ExecutionModeHecateTask && !message.ToolsEnabled
 }
 
 func isTerminalAgentChatStatus(status string) bool {

--- a/internal/api/handler_chat_dispatch_test.go
+++ b/internal/api/handler_chat_dispatch_test.go
@@ -6,88 +6,26 @@ import (
 	"github.com/hecatehq/hecate/internal/chat"
 )
 
-// boolPtr is a tiny helper for the tools_enabled tri-state on
-// CreateChatMessageRequest. A `*bool` field uses nil to mean "the
-// client did not send this", which is what `chatRequestToolsEnabled`
-// falls back on; non-nil values pin the tools state.
-func boolPtr(b bool) *bool { return &b }
-
-func TestNormalizeChatExecutionMode_ExplicitModeWinsOverSessionShape(t *testing.T) {
-	// When the client sends `execution_mode` explicitly, the dispatcher
-	// uses it verbatim (except for the legacy direct_model literal
-	// which normalizes to hecate_task — covered in its own test
-	// below). The tools_enabled argument is unused by the function
-	// today; the dispatcher reads tools_enabled separately via
-	// chatRequestToolsEnabled.
+func TestNormalizeChatExecutionMode_ExplicitModeWins(t *testing.T) {
 	session := chat.Session{AgentID: chat.DefaultAgentID}
-	if got := normalizeChatExecutionMode(chat.ExecutionModeHecateTask, session, boolPtr(false)); got != chat.ExecutionModeHecateTask {
+	if got := normalizeChatExecutionMode(chat.ExecutionModeHecateTask, session); got != chat.ExecutionModeHecateTask {
 		t.Errorf("explicit hecate_task: got %q, want hecate_task", got)
 	}
-	if got := normalizeChatExecutionMode(chat.ExecutionModeExternalAgent, session, boolPtr(true)); got != chat.ExecutionModeExternalAgent {
+	if got := normalizeChatExecutionMode(chat.ExecutionModeExternalAgent, session); got != chat.ExecutionModeExternalAgent {
 		t.Errorf("explicit external_agent: got %q, want external_agent", got)
 	}
 }
 
-func TestNormalizeChatExecutionMode_LegacyDirectModelNormalizesToHecateTask(t *testing.T) {
-	// Older clients still send execution_mode="direct_model" for what
-	// is now a Hecate-task turn with tools off. The dispatcher's
-	// switch only knows hecate_task and external_agent, so the
-	// normalize step folds the legacy literal forward. The tools-off
-	// intent is recovered separately by chatRequestToolsEnabled.
-	session := chat.Session{AgentID: chat.DefaultAgentID}
-	if got := normalizeChatExecutionMode(chat.LegacyExecutionModeDirectModel, session, nil); got != chat.ExecutionModeHecateTask {
-		t.Errorf("legacy direct_model: got %q, want hecate_task", got)
-	}
-}
-
 func TestNormalizeChatExecutionMode_ExternalSessionPinsExternalAgent(t *testing.T) {
-	// When the session itself is external (agent_id != "hecate"), the
-	// dispatcher pins external_agent. Agent identity is the source
-	// of truth here.
 	session := chat.Session{AgentID: "claude_code"}
-	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeExternalAgent {
+	if got := normalizeChatExecutionMode("", session); got != chat.ExecutionModeExternalAgent {
 		t.Errorf("external session + no signals: got %q, want external_agent", got)
 	}
 }
 
 func TestNormalizeChatExecutionMode_HecateSessionDefaultsToHecateTask(t *testing.T) {
-	// Every Hecate-side turn — tools-on or tools-off — now normalizes
-	// to hecate_task. The tools-on/off axis lives on the per-message
-	// ToolsEnabled boolean, not on execution_mode.
 	session := chat.Session{AgentID: chat.DefaultAgentID}
-	if got := normalizeChatExecutionMode("", session, nil); got != chat.ExecutionModeHecateTask {
+	if got := normalizeChatExecutionMode("", session); got != chat.ExecutionModeHecateTask {
 		t.Errorf("hecate session + no signals: got %q, want hecate_task", got)
-	}
-	if got := normalizeChatExecutionMode("", session, boolPtr(true)); got != chat.ExecutionModeHecateTask {
-		t.Errorf("hecate session + tools_enabled=true: got %q, want hecate_task", got)
-	}
-	if got := normalizeChatExecutionMode("", session, boolPtr(false)); got != chat.ExecutionModeHecateTask {
-		t.Errorf("hecate session + tools_enabled=false: got %q, want hecate_task", got)
-	}
-}
-
-func TestChatRequestToolsEnabled_PreservesLegacyDirectModelAsToolsOff(t *testing.T) {
-	// The legacy execution_mode="direct_model" literal still encodes
-	// tools-off intent for older clients. chatRequestToolsEnabled
-	// (the helper the dispatcher uses to derive the per-turn tools
-	// state) must recognize it so the resulting Message.ToolsEnabled
-	// matches what the client meant.
-	cases := []struct {
-		name string
-		req  CreateChatMessageRequest
-		want bool
-	}{
-		{"explicit tools_enabled=true wins", CreateChatMessageRequest{ToolsEnabled: boolPtr(true), ExecutionMode: chat.LegacyExecutionModeDirectModel}, true},
-		{"explicit tools_enabled=false wins", CreateChatMessageRequest{ToolsEnabled: boolPtr(false), ExecutionMode: chat.ExecutionModeHecateTask}, false},
-		{"legacy direct_model → tools off", CreateChatMessageRequest{ExecutionMode: chat.LegacyExecutionModeDirectModel}, false},
-		{"hecate_task → tools on", CreateChatMessageRequest{ExecutionMode: chat.ExecutionModeHecateTask}, true},
-		{"unset → tools off (preserves pre-tools_enabled default)", CreateChatMessageRequest{}, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := chatRequestToolsEnabled(tc.req); got != tc.want {
-				t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/api/handler_chat_errors.go
+++ b/internal/api/handler_chat_errors.go
@@ -91,9 +91,9 @@ func writeChatAgentIDInvalid(w http.ResponseWriter) {
 }
 
 func writeChatExecutionModeInvalid(w http.ResponseWriter) {
-	WriteErrorDetails(w, http.StatusBadRequest, errCodeExecutionModeInvalid, "execution_mode must be direct_model, hecate_task, or external_agent", ErrorDetails{
+	WriteErrorDetails(w, http.StatusBadRequest, errCodeExecutionModeInvalid, "execution_mode must be hecate_task or external_agent", ErrorDetails{
 		UserMessage:    "This chat mode is not supported by the current API.",
-		OperatorAction: "Use one of: direct_model, hecate_task, or external_agent.",
+		OperatorAction: "Use one of: hecate_task or external_agent.",
 	})
 }
 

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -22,8 +22,7 @@ const hecateAgentPollInterval = 250 * time.Millisecond
 // handleCreateHecateChatMessage is the unified entry point for every
 // Hecate-side chat-message submission. It branches on toolsEnabled:
 //   - toolsEnabled=false → delegate to handleDirectModelTurn (a
-//     direct LLM call with no agent_loop task, the runtime fallback
-//     for the legacy direct_model dispatch path).
+//     direct LLM call with no agent_loop task).
 //   - toolsEnabled=true → existing agent_loop task creation +
 //     polling path that the Hecate Chat tools-on UX runs on.
 //
@@ -377,10 +376,9 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		}
 		// Post-unification: every Hecate-side message persists as
 		// `hecate_task`; the tools-on/off discriminant lives on the
-		// per-message ToolsEnabled boolean. A direct-model turn
-		// (ToolsEnabled=false) AND the legacy direct_model literal
-		// both break the running tool-task segment — the new turn
-		// gets its own backing task.
+		// per-message ToolsEnabled boolean. A tools-off turn breaks
+		// the running tool-task segment, so the next tools-on turn gets
+		// its own backing task.
 		if !isHecateTaskToolsOnMessage(message) {
 			return true
 		}
@@ -400,9 +398,6 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 // agent_loop runtime with tools. Used by segment continuation logic
 // to detect when a turn breaks a running tool-task segment.
 func isHecateTaskToolsOnMessage(message chat.Message) bool {
-	if message.ExecutionMode == chat.LegacyExecutionModeDirectModel {
-		return false
-	}
 	if message.ExecutionMode != chat.ExecutionModeHecateTask {
 		return false
 	}

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -435,19 +435,16 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	}
 
 	modelTurn := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
+		`{"execution_mode":"hecate_task","tools_enabled":false,"provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
 	if len(modelTurn.Data.Messages) != 2 {
 		t.Fatalf("model messages = %d, want 2", len(modelTurn.Data.Messages))
 	}
 	modelAssistant := modelTurn.Data.Messages[1]
-	// Post-unification: every Hecate-side message persists as
-	// `hecate_task`. The tools-off discriminant lives on the
-	// per-message ToolsEnabled boolean asserted below.
 	if modelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
 		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
 	if modelAssistant.ToolsEnabled {
-		t.Errorf("model assistant tools_enabled = true, want false (direct_model dispatch records tools-off)")
+		t.Errorf("model assistant tools_enabled = true, want false (hecate_task dispatch records tools-off)")
 	}
 	if !strings.Contains(modelAssistant.Content, "Segment answer") {
 		t.Fatalf("model assistant content = %q", modelAssistant.Content)
@@ -468,7 +465,7 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	}
 
 	secondModel := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
+		`{"execution_mode":"hecate_task","tools_enabled":false,"provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
 	if secondModel.Data.TaskID != firstTaskID {
 		t.Fatalf("model segment should preserve latest task pointer, got %q want %q", secondModel.Data.TaskID, firstTaskID)
 	}
@@ -560,7 +557,7 @@ func TestHecateAgentNewSegmentLivePlaceholderDoesNotBorrowPreviousTask(t *testin
 		t.Fatalf("first tools turn task_id is empty: %+v", firstTools.Data)
 	}
 	secondModel := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
+		`{"execution_mode":"hecate_task","tools_enabled":false,"provider":"openai","model":"gpt-4o-mini","content":"back to direct chat"}`)
 	if secondModel.Data.TaskID != firstTaskID {
 		t.Fatalf("direct model segment should preserve latest task pointer on the session, got %q want %q", secondModel.Data.TaskID, firstTaskID)
 	}
@@ -1023,7 +1020,7 @@ func TestExternalAgentChatRejectsDirectModelExecutionMode(t *testing.T) {
 	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
 		fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, workspace))
 	recorder := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
-		`{"execution_mode":"direct_model","provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
+		`{"execution_mode":"hecate_task","tools_enabled":false,"provider":"openai","model":"gpt-4o-mini","content":"answer directly"}`)
 	payload := decodeRecorder[struct {
 		Error struct {
 			Type    string `json:"type"`
@@ -1033,9 +1030,6 @@ func TestExternalAgentChatRejectsDirectModelExecutionMode(t *testing.T) {
 	if payload.Error.Type != errCodeRuntimeMismatch {
 		t.Fatalf("error type = %q, want %s", payload.Error.Type, errCodeRuntimeMismatch)
 	}
-	// After the dispatcher unification, direct_model and hecate_task
-	// share the same Hecate-side entry point, so the error copy was
-	// collapsed too — "Hecate Chat turns" covers both flavors.
 	if !strings.Contains(payload.Error.Message, "external agent sessions cannot run Hecate Chat turns") {
 		t.Fatalf("error message = %q", payload.Error.Message)
 	}
@@ -1171,7 +1165,7 @@ func TestHecateChatRejectsDirectModelTurnWhileBackingRunBusy(t *testing.T) {
 	}
 
 	recorder := client.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/chat/sessions/"+session.ID+"/messages",
-		`{"execution_mode":"direct_model","content":"answer directly","model":"gpt-4o-mini"}`)
+		`{"execution_mode":"hecate_task","tools_enabled":false,"content":"answer directly","model":"gpt-4o-mini"}`)
 	payload := decodeRecorder[struct {
 		Error struct {
 			Type        string `json:"type"`

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -172,6 +172,7 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 				item: ChatSegmentItem{
 					ID:            segmentID,
 					ExecutionMode: firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session)),
+					ToolsEnabled:  message.ToolsEnabled,
 					Provider:      firstNonEmpty(message.Provider, session.Provider),
 					Model:         firstNonEmpty(message.Model, session.Model),
 					TaskID:        message.TaskID,
@@ -183,6 +184,9 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 		builder.item.MessageCount++
 		if builder.item.ExecutionMode == "" {
 			builder.item.ExecutionMode = firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
+		}
+		if message.ToolsEnabled {
+			builder.item.ToolsEnabled = true
 		}
 		if builder.item.Provider == "" {
 			builder.item.Provider = message.Provider

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -597,21 +597,13 @@ type CreateChatSessionRequest struct {
 
 type CreateChatMessageRequest struct {
 	Content string `json:"content"`
-	// ExecutionMode is the legacy per-turn dispatch discriminant.
-	// Today it carries one of "direct_model", "hecate_task", or
-	// "external_agent"; the model-chat direct_model path is being
-	// retired in favor of ToolsEnabled=false on a hecate_task turn.
-	// Reads still accept the legacy value for back-compat; the
-	// handler derives a ToolsEnabled signal from it when the explicit
-	// field is missing (see `chatRequestToolsEnabled`).
+	// ExecutionMode identifies the runtime owner for this turn:
+	// "hecate_task" or "external_agent". Tools-off Hecate turns still
+	// use "hecate_task" and carry ToolsEnabled=false.
 	ExecutionMode string `json:"execution_mode,omitempty"`
 	// ToolsEnabled is the per-turn tools-on/off signal. Pointer so the
-	// handler can distinguish "explicit false" from "not specified" —
-	// when nil, the handler derives the value from ExecutionMode so
-	// existing clients continue to work unchanged. New clients should
-	// set this field directly and leave ExecutionMode empty (the
-	// session's agent_id already encodes the broad agent-vs-external
-	// dispatch); the handler will route to the same destination.
+	// handler can distinguish "explicit false" from "not specified".
+	// When nil, Hecate defaults to tools on.
 	ToolsEnabled *bool  `json:"tools_enabled,omitempty"`
 	Provider     string `json:"provider,omitempty"`
 	Model        string `json:"model,omitempty"`
@@ -683,6 +675,7 @@ type ChatSessionItem struct {
 type ChatSegmentItem struct {
 	ID            string `json:"id"`
 	ExecutionMode string `json:"execution_mode"`
+	ToolsEnabled  bool   `json:"tools_enabled"`
 	Provider      string `json:"provider,omitempty"`
 	Model         string `json:"model,omitempty"`
 	TaskID        string `json:"task_id,omitempty"`

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -200,7 +200,7 @@ func defaultErrorAction(code string) string {
 	case errCodeModelRequired:
 		return "Use the model picker in the chat header, or add a provider that reports at least one model."
 	case errCodeAgentIDInvalid, errCodeExecutionModeInvalid:
-		return "Use agent_id hecate or a registered external agent id. For execution_mode, use direct_model, hecate_task, or external_agent."
+		return "Use agent_id hecate or a registered external agent id. For execution_mode, use hecate_task or external_agent."
 	case errCodeRuntimeMismatch:
 		return "Start a new chat or switch back to the runtime that created this session."
 	case errCodeAgentAdapterNotFound:

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2104,7 +2104,7 @@ func TestAgentChatCreateAllowsEmptyHecateShellAndRequiresModelOnSend(t *testing.
 		t.Fatalf("model = %q, want empty shell model", created.Data.Model)
 	}
 
-	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`)
+	rec := client.mustRequestStatus(http.StatusBadRequest, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello","tools_enabled":false}`)
 	payload := decodeRecorder[struct {
 		Error struct {
 			Type           string `json:"type"`

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -537,13 +537,8 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		{name: "execution_mode", definition: "TEXT NOT NULL DEFAULT ''"},
 		// Boolean stored as INTEGER (0/1). DEFAULT 1 so existing rows
 		// land on "tools on" — the agent path is the safe assumption.
-		// The legacy execution_mode='direct_model' rows get backfilled
-		// to 0 by the dedicated migration below, since those rows
-		// explicitly recorded a tools-off intent before tools-off had
-		// its own column. The handler layer treats this column as the
-		// source of truth going forward; execution_mode stays for
-		// segment routing (hecate_task vs external_agent) and
-		// backwards-compat reads.
+		// Tools-off direct model turns are represented as hecate_task
+		// messages with tools_enabled=0.
 		{name: "tools_enabled", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{name: "segment_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "task_id", definition: "TEXT NOT NULL DEFAULT ''"},
@@ -567,41 +562,6 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		if err := s.ensureMessageColumn(ctx, column.name, column.definition); err != nil {
 			return err
 		}
-	}
-
-	// Backfill `tools_enabled = 0` for rows that recorded the legacy
-	// `execution_mode = 'direct_model'` value. That literal predates
-	// the dedicated tools-enabled column and is the single signal in
-	// older data that the user submitted with tools off. The UPDATE
-	// is idempotent and runs every boot; once every direct_model row
-	// has been touched the WHERE clause selects nothing on
-	// subsequent boots.
-	if _, err := s.client.DB().ExecContext(
-		ctx,
-		fmt.Sprintf(
-			`UPDATE %s SET tools_enabled = 0 WHERE execution_mode = 'direct_model' AND tools_enabled = 1`,
-			s.messagesTable,
-		),
-	); err != nil {
-		return fmt.Errorf("backfill sqlite agent chat tools_enabled: %w", err)
-	}
-
-	// Migrate execution_mode='direct_model' rows to 'hecate_task'.
-	// Every Hecate-side turn now persists as hecate_task; the
-	// tools-off intent is recorded on the tools_enabled column above
-	// (already backfilled by the previous statement). The two
-	// migrations together preserve the original turn semantics
-	// without leaving the legacy literal as a parallel discriminant
-	// that handler code would have to keep checking. Idempotent —
-	// re-runs select nothing once the column is fully migrated.
-	if _, err := s.client.DB().ExecContext(
-		ctx,
-		fmt.Sprintf(
-			`UPDATE %s SET execution_mode = 'hecate_task' WHERE execution_mode = 'direct_model'`,
-			s.messagesTable,
-		),
-	); err != nil {
-		return fmt.Errorf("backfill sqlite agent chat execution_mode: %w", err)
 	}
 
 	messagesIndex := strings.Trim(s.messagesTable, `"`) + "_session_seq_idx"

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/hecatehq/hecate/internal/storage"
 )
@@ -32,75 +31,6 @@ func TestSQLiteStoreConformance(t *testing.T) {
 	RunConformanceTests(t, "SQLiteStore", func(t *testing.T) Store {
 		return newSQLiteTestStore(t)
 	})
-}
-
-func TestSQLiteStoreBackfillsToolsEnabledForLegacyDirectModelRows(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "chat.db")
-	client, err := storage.NewSQLiteClient(context.Background(), storage.SQLiteConfig{
-		Path:        path,
-		TablePrefix: "test",
-	})
-	if err != nil {
-		t.Fatalf("NewSQLiteClient: %v", err)
-	}
-	t.Cleanup(func() { _ = client.Close() })
-
-	store, err := NewSQLiteStore(context.Background(), client)
-	if err != nil {
-		t.Fatalf("NewSQLiteStore: %v", err)
-	}
-	if _, err := store.Create(context.Background(), Session{
-		ID:      "chat_legacy_direct",
-		AgentID: DefaultAgentID,
-	}); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	// Simulate a pre-migration row: legacy `execution_mode='direct_model'`
-	// with the default column value (tools_enabled=1, "tools on"). The
-	// real backfill target is upgraded installs whose existing rows
-	// land on the column default after `ALTER TABLE ADD COLUMN`.
-	if _, err := client.DB().ExecContext(
-		context.Background(),
-		`INSERT INTO `+client.TableName("chat_messages")+`
-		     (id, session_id, sequence, execution_mode, tools_enabled, role, content,
-		      agent_id, agent_name, status, exit_code, cost_mode,
-		      workspace, diff_stat, diff, created_at)
-		 VALUES ('msg_legacy', 'chat_legacy_direct', 99, 'direct_model', 1, 'user', 'legacy tools-off turn',
-		         'hecate', '', '', 0, '',
-		         '', '', '', ?)`,
-		time.Now().UTC().Format(time.RFC3339Nano),
-	); err != nil {
-		t.Fatalf("raw INSERT legacy row: %v", err)
-	}
-
-	// Re-running the migration (idempotent) flips tools_enabled to 0
-	// for any direct_model row that still landed on the column
-	// default, and rewrites execution_mode from 'direct_model' to
-	// 'hecate_task' so the handler-side reads only have to know
-	// about one Hecate-side mode going forward.
-	if _, err := NewSQLiteStore(context.Background(), client); err != nil {
-		t.Fatalf("re-open SQLiteStore: %v", err)
-	}
-
-	session, ok, err := store.Get(context.Background(), "chat_legacy_direct")
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if !ok {
-		t.Fatal("Get: ok = false")
-	}
-	if len(session.Messages) != 1 {
-		t.Fatalf("len(Messages) = %d, want 1", len(session.Messages))
-	}
-	if session.Messages[0].ToolsEnabled {
-		t.Errorf("legacy direct_model row ToolsEnabled = true, want false (tools_enabled backfill missed)")
-	}
-	if got := session.Messages[0].ExecutionMode; got != ExecutionModeHecateTask {
-		t.Errorf("legacy direct_model row ExecutionMode = %q, want %q (execution_mode backfill missed)", got, ExecutionModeHecateTask)
-	}
 }
 
 func TestSQLiteStorePersistsAcrossInstances(t *testing.T) {

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -46,11 +46,7 @@ type Message struct {
 	// ToolsEnabled records whether the user submitted this turn with
 	// tools on. Independent of ExecutionMode: a Hecate-task turn with
 	// ToolsEnabled=false dispatches directly to the model without
-	// creating an agent_loop task, replacing the legacy
-	// ExecutionMode="direct_model" encoding. Reads against existing
-	// rows that predate this field default to true; the sqlite
-	// migration backfills false for rows that still carry the legacy
-	// "direct_model" execution_mode value.
+	// creating an agent_loop task.
 	ToolsEnabled    bool
 	SegmentID       string
 	TaskID          string
@@ -421,15 +417,6 @@ const (
 	ExecutionModeExternalAgent = "external_agent"
 )
 
-// LegacyExecutionModeDirectModel is the wire literal older clients
-// may still send and older persisted rows may still carry for what
-// is conceptually now a Hecate-task turn with tools off. Kept as a
-// named back-compat constant rather than scattered string literals
-// so the cleanup landing site is obvious — once every reachable
-// install has migrated to writing `hecate_task` + `tools_enabled =
-// false`, this constant + its readers can be deleted in one diff.
-const LegacyExecutionModeDirectModel = "direct_model"
-
 func hydrateMessageRuntimeFromSession(message *Message, session Session) {
 	if message.ExecutionMode == "" {
 		message.ExecutionMode = defaultMessageExecutionMode(session)
@@ -472,11 +459,5 @@ func defaultMessageExecutionMode(session Session) string {
 	if session.AgentID != "" && session.AgentID != DefaultAgentID {
 		return ExecutionModeExternalAgent
 	}
-	// Every Hecate-side session now uses `hecate_task` as the
-	// execution mode regardless of whether a backing task exists.
-	// Tools-on/off is recorded separately on `Message.ToolsEnabled`;
-	// the legacy `direct_model` value is only present on rows that
-	// predate the unification and gets folded into `hecate_task` by
-	// the sqlite migration in internal/chat/sqlite.go.
 	return ExecutionModeHecateTask
 }

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -628,7 +628,7 @@ function docsHecateToolsFallbackSession() {
       {
         id: "hecate-tools-fallback-user-1",
         runtime_kind: "model",
-        execution_mode: "direct_model",
+        execution_mode: "hecate_task", tools_enabled: false,
         segment_id: "model:smollm-joke",
         role: "user",
         content: "tell a short terminal joke",
@@ -639,7 +639,7 @@ function docsHecateToolsFallbackSession() {
       {
         id: "hecate-tools-fallback-assistant-1",
         runtime_kind: "model",
-        execution_mode: "direct_model",
+        execution_mode: "hecate_task", tools_enabled: false,
         segment_id: "model:smollm-joke",
         role: "assistant",
         content:
@@ -1613,7 +1613,7 @@ async function addProvider(params: {
   console.log(`  added provider ${params.name} (${params.kind})`);
 }
 
-// seedChatSessions creates a few direct model sessions through Hecate's
+// seedChatSessions creates a few Hecate-owned sessions through the local
 // API. The first session optionally gets a real completion so the
 // observability screenshot has a trace row to open; the main Chats
 // screenshot below is fixture-backed so it stays stable without Ollama.
@@ -1737,7 +1737,8 @@ async function main() {
   await clearAndNavigate(page);
   await page.evaluate((workspaceKey) => {
     window.localStorage.setItem(workspaceKey, "chats");
-    window.localStorage.setItem("hecate.chatTarget", "model");
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.agentWorkspace", "/Users/alice/dev/hecate");
   }, WORKSPACE_KEY);
   await page.reload();

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1759,6 +1759,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       {
         id: `msg-user-${turn}`,
         execution_mode: executionMode,
+        tools_enabled: isHecateAgent,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         provider: body.provider || "",
@@ -1770,6 +1771,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       {
         id: `msg-assistant-${turn}`,
         execution_mode: executionMode,
+        tools_enabled: isHecateAgent,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
         task_id: isHecateAgent ? taskID : undefined,
         run_id: isHecateAgent ? runID : undefined,

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1339,17 +1339,19 @@ test("Hecate Chat sends direct model turns when selected model lacks tools", asy
           model: "smollm2:135m",
           status: "completed",
           message_count: 2,
-          messages: [
-            {
-              id: "direct-user-e2e",
-              execution_mode: "direct_model",
-              role: "user",
+	          messages: [
+	            {
+	              id: "direct-user-e2e",
+	              execution_mode: "hecate_task",
+	              tools_enabled: false,
+	              role: "user",
               content: "tell a tiny joke",
               created_at: "2026-05-14T12:00:00Z",
             },
-            {
-              id: "direct-assistant-e2e",
-              execution_mode: "direct_model",
+	            {
+	              id: "direct-assistant-e2e",
+	              execution_mode: "hecate_task",
+	              tools_enabled: false,
               role: "assistant",
               content: "Direct response to: tell a tiny joke",
               status: "completed",
@@ -1737,18 +1739,13 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     const body = await route.request().postDataJSON();
     submittedTurns.push(body);
     const turn = submittedTurns.length;
-    // Mirror the backend's `normalizeChatExecutionMode` derivation:
-    // explicit execution_mode wins; otherwise derive from
-    // tools_enabled (true → hecate_task, false/undefined →
-    // direct_model). The UI sends tools_enabled for Hecate-side
-    // turns and omits execution_mode.
-    const executionMode =
-      body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model");
-    const isHecateAgent = executionMode === "hecate_task";
-    const agentTurn = submittedTurns.filter(
-      (t) =>
-        (t.execution_mode || (t.tools_enabled ? "hecate_task" : "direct_model")) === "hecate_task",
-    ).length;
+	    // Hecate-owned turns always use hecate_task; tools_enabled carries
+	    // the task-runtime vs direct-provider axis.
+	    const executionMode = body.execution_mode || "hecate_task";
+	    const isHecateAgent = executionMode === "hecate_task" && body.tools_enabled !== false;
+	    const agentTurn = submittedTurns.filter(
+	      (t) => (t.execution_mode || "hecate_task") === "hecate_task" && t.tools_enabled !== false,
+	    ).length;
     const taskID = isHecateAgent ? `task-tools-${agentTurn}` : "";
     const runID = isHecateAgent ? `run-tools-${agentTurn}` : "";
     const firstTaskNeedsApproval = isHecateAgent && agentTurn === 1 && !taskApprovalResolved;
@@ -2024,11 +2021,8 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
       messages: [
         {
           id: "msg-user-direct",
-          // Backend response carries execution_mode regardless of
-          // what the client sent — derive it from the request the
-          // same way `normalizeChatExecutionMode` does.
-          execution_mode:
-            body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model"),
+	          execution_mode: body.execution_mode || "hecate_task",
+	          tools_enabled: body.tools_enabled !== false,
           provider: body.provider || "",
           model: body.model,
           role: "user",
@@ -2037,8 +2031,8 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
         },
         {
           id: "msg-assistant-direct",
-          execution_mode:
-            body.execution_mode || (body.tools_enabled ? "hecate_task" : "direct_model"),
+	          execution_mode: body.execution_mode || "hecate_task",
+	          tools_enabled: body.tools_enabled !== false,
           provider: body.provider || "",
           model: body.model,
           role: "assistant",
@@ -2125,9 +2119,10 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     status: "running",
     message_count: 2,
     segments: [
-      {
-        id: "model:first",
-        execution_mode: "direct_model",
+	      {
+	        id: "model:first",
+	        execution_mode: "hecate_task",
+	        tools_enabled: false,
         provider: "lmstudio",
         model: "qwen2.5",
         status: "completed",
@@ -2630,8 +2625,8 @@ test("selected-model readiness can switch to the backend-suggested fallback mode
       }),
     }),
   );
-  await page.addInitScript(() => {
-    window.localStorage.setItem("hecate.chatTarget", "model");
+	  await page.addInitScript(() => {
+	    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.providerFilter", "auto");
     window.localStorage.setItem("hecate.model", "claude-sonnet-4-6");
     window.localStorage.setItem("hecate.project", "proj_e2e");

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1339,19 +1339,19 @@ test("Hecate Chat sends direct model turns when selected model lacks tools", asy
           model: "smollm2:135m",
           status: "completed",
           message_count: 2,
-	          messages: [
-	            {
-	              id: "direct-user-e2e",
-	              execution_mode: "hecate_task",
-	              tools_enabled: false,
-	              role: "user",
+          messages: [
+            {
+              id: "direct-user-e2e",
+              execution_mode: "hecate_task",
+              tools_enabled: false,
+              role: "user",
               content: "tell a tiny joke",
               created_at: "2026-05-14T12:00:00Z",
             },
-	            {
-	              id: "direct-assistant-e2e",
-	              execution_mode: "hecate_task",
-	              tools_enabled: false,
+            {
+              id: "direct-assistant-e2e",
+              execution_mode: "hecate_task",
+              tools_enabled: false,
               role: "assistant",
               content: "Direct response to: tell a tiny joke",
               status: "completed",
@@ -1739,13 +1739,13 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
     const body = await route.request().postDataJSON();
     submittedTurns.push(body);
     const turn = submittedTurns.length;
-	    // Hecate-owned turns always use hecate_task; tools_enabled carries
-	    // the task-runtime vs direct-provider axis.
-	    const executionMode = body.execution_mode || "hecate_task";
-	    const isHecateAgent = executionMode === "hecate_task" && body.tools_enabled !== false;
-	    const agentTurn = submittedTurns.filter(
-	      (t) => (t.execution_mode || "hecate_task") === "hecate_task" && t.tools_enabled !== false,
-	    ).length;
+    // Hecate-owned turns always use hecate_task; tools_enabled carries
+    // the task-runtime vs direct-provider axis.
+    const executionMode = body.execution_mode || "hecate_task";
+    const isHecateAgent = executionMode === "hecate_task" && body.tools_enabled !== false;
+    const agentTurn = submittedTurns.filter(
+      (t) => (t.execution_mode || "hecate_task") === "hecate_task" && t.tools_enabled !== false,
+    ).length;
     const taskID = isHecateAgent ? `task-tools-${agentTurn}` : "";
     const runID = isHecateAgent ? `run-tools-${agentTurn}` : "";
     const firstTaskNeedsApproval = isHecateAgent && agentTurn === 1 && !taskApprovalResolved;
@@ -2021,8 +2021,8 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
       messages: [
         {
           id: "msg-user-direct",
-	          execution_mode: body.execution_mode || "hecate_task",
-	          tools_enabled: body.tools_enabled !== false,
+          execution_mode: body.execution_mode || "hecate_task",
+          tools_enabled: body.tools_enabled !== false,
           provider: body.provider || "",
           model: body.model,
           role: "user",
@@ -2031,8 +2031,8 @@ test("Hecate Chat falls back to direct chat when the selected model has no tools
         },
         {
           id: "msg-assistant-direct",
-	          execution_mode: body.execution_mode || "hecate_task",
-	          tools_enabled: body.tools_enabled !== false,
+          execution_mode: body.execution_mode || "hecate_task",
+          tools_enabled: body.tools_enabled !== false,
           provider: body.provider || "",
           model: body.model,
           role: "assistant",
@@ -2119,10 +2119,10 @@ test("Hecate Chat rehydrates an active task and blocks direct sends after refres
     status: "running",
     message_count: 2,
     segments: [
-	      {
-	        id: "model:first",
-	        execution_mode: "hecate_task",
-	        tools_enabled: false,
+      {
+        id: "model:first",
+        execution_mode: "hecate_task",
+        tools_enabled: false,
         provider: "lmstudio",
         model: "qwen2.5",
         status: "completed",
@@ -2625,8 +2625,8 @@ test("selected-model readiness can switch to the backend-suggested fallback mode
       }),
     }),
   );
-	  await page.addInitScript(() => {
-	    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     window.localStorage.setItem("hecate.providerFilter", "auto");
     window.localStorage.setItem("hecate.model", "claude-sonnet-4-6");
     window.localStorage.setItem("hecate.project", "proj_e2e");

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -616,7 +616,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       const content = String(body.content || "");
       const executionMode =
         body.execution_mode ||
-        (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "direct_model");
+        (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
+      const toolsEnabled = executionMode === "external_agent" ? undefined : body.tools_enabled !== false;
       const sequence = chatSequence;
       const segmentID = `segment-${sequence}`;
       const isExternal = executionMode === "external_agent";
@@ -640,18 +641,19 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           id: `agent-msg-user-${sequence}`,
           execution_mode: executionMode,
           segment_id: isExternal ? segmentID : undefined,
-          role: "user",
-          content,
-          created_at: now(),
+	          role: "user",
+	          content,
+	          tools_enabled: toolsEnabled,
+	          created_at: now(),
         },
         {
           id: `agent-msg-assistant-${sequence}`,
           execution_mode: executionMode,
           segment_id: isExternal ? segmentID : undefined,
-          role: "assistant",
-          content:
-            executionMode === "direct_model"
-              ? `Direct response to: ${content}`
+	          role: "assistant",
+	          content:
+	            executionMode === "hecate_task" && toolsEnabled === false
+	              ? `Direct response to: ${content}`
               : keepRunning
                 ? "I'll inspect that now."
                 : `Agent response to: ${content}`,
@@ -707,7 +709,11 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           provider: body.provider || session.provider,
           model: body.model || session.model,
           workspace: session.workspace,
-          run_id: executionMode === "direct_model" ? `model_run_${sequence}` : `run_${sequence}`,
+          tools_enabled: toolsEnabled,
+          run_id:
+            executionMode === "hecate_task" && toolsEnabled === false
+              ? `model_run_${sequence}`
+              : `run_${sequence}`,
           request_id: `req_${sequence}`,
           trace_id: `trace_${sequence}`,
           cost_mode: executionMode === "external_agent" ? "external" : "hecate",

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -617,7 +617,8 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
       const executionMode =
         body.execution_mode ||
         (session.agent_id && session.agent_id !== "hecate" ? "external_agent" : "hecate_task");
-      const toolsEnabled = executionMode === "external_agent" ? undefined : body.tools_enabled !== false;
+      const toolsEnabled =
+        executionMode === "external_agent" ? undefined : body.tools_enabled !== false;
       const sequence = chatSequence;
       const segmentID = `segment-${sequence}`;
       const isExternal = executionMode === "external_agent";
@@ -641,19 +642,19 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
           id: `agent-msg-user-${sequence}`,
           execution_mode: executionMode,
           segment_id: isExternal ? segmentID : undefined,
-	          role: "user",
-	          content,
-	          tools_enabled: toolsEnabled,
-	          created_at: now(),
+          role: "user",
+          content,
+          tools_enabled: toolsEnabled,
+          created_at: now(),
         },
         {
           id: `agent-msg-assistant-${sequence}`,
           execution_mode: executionMode,
           segment_id: isExternal ? segmentID : undefined,
-	          role: "assistant",
-	          content:
-	            executionMode === "hecate_task" && toolsEnabled === false
-	              ? `Direct response to: ${content}`
+          role: "assistant",
+          content:
+            executionMode === "hecate_task" && toolsEnabled === false
+              ? `Direct response to: ${content}`
               : keepRunning
                 ? "I'll inspect that now."
                 : `Agent response to: ${content}`,

--- a/ui/src/app/state/_shared.test.ts
+++ b/ui/src/app/state/_shared.test.ts
@@ -12,14 +12,15 @@ import {
 describe("parseQueuedChatMessageList", () => {
   it("keeps valid queued chat messages", () => {
     expect(
-      parseQueuedChatMessageList([
-        {
-          id: "queued-1",
-          session_id: "chat-1",
-          content: "continue",
-          execution_mode: "direct_model",
-          provider_filter: "auto",
-          model: "gpt-4o-mini",
+	      parseQueuedChatMessageList([
+	        {
+	          id: "queued-1",
+	          session_id: "chat-1",
+	          content: "continue",
+	          execution_mode: "hecate_task",
+	          tools_enabled: false,
+	          provider_filter: "auto",
+	          model: "gpt-4o-mini",
           workspace: "/tmp/hecate",
           system_prompt: "Be concise.",
           agent_id: "hecate",
@@ -28,11 +29,12 @@ describe("parseQueuedChatMessageList", () => {
       ]),
     ).toEqual([
       {
-        id: "queued-1",
-        session_id: "chat-1",
-        content: "continue",
-        execution_mode: "direct_model",
-        provider_filter: "auto",
+	        id: "queued-1",
+	        session_id: "chat-1",
+	        content: "continue",
+	        execution_mode: "hecate_task",
+	        tools_enabled: false,
+	        provider_filter: "auto",
         model: "gpt-4o-mini",
         workspace: "/tmp/hecate",
         system_prompt: "Be concise.",
@@ -73,19 +75,11 @@ describe("parseStoredChatTarget", () => {
     expect(parseStoredChatTarget("external_agent")).toBe("external_agent");
   });
 
-  it("coerces the legacy 'model' literal forward to 'agent'", () => {
-    // Older installs encoded "tools off for new chats" as
-    // hecate.chatTarget = "model". The tools-off intent is recovered
-    // separately by the per-session chat-tools-enabled migration; the
-    // top-level discriminant should land on the safe default rather
-    // than wipe.
-    expect(parseStoredChatTarget("model")).toBe("agent");
-  });
-
   it("returns null for unknown values so usePersistedState wipes the key", () => {
     expect(parseStoredChatTarget("")).toBeNull();
     expect(parseStoredChatTarget("garbage")).toBeNull();
     expect(parseStoredChatTarget("AGENT")).toBeNull();
+    expect(parseStoredChatTarget("model")).toBeNull();
   });
 });
 
@@ -93,9 +87,6 @@ describe("normalizeStoredChatTarget", () => {
   it("preserves external_agent and coerces everything else to agent", () => {
     expect(normalizeStoredChatTarget("agent")).toBe("agent");
     expect(normalizeStoredChatTarget("external_agent")).toBe("external_agent");
-    // Coercive normalizer — used by code paths where the wider type
-    // has already vouched for the input. The legacy "model" literal
-    // and unknown values land on the safe default.
     expect(normalizeStoredChatTarget("model")).toBe("agent");
     expect(normalizeStoredChatTarget("garbage")).toBe("agent");
     expect(normalizeStoredChatTarget("")).toBe("agent");
@@ -103,20 +94,15 @@ describe("normalizeStoredChatTarget", () => {
 });
 
 describe("normalizeStoredHecateChatTarget", () => {
-  it("coerces 'agent' and the legacy 'model' literal to 'agent'", () => {
+  it("preserves only the current Hecate target", () => {
     expect(normalizeStoredHecateChatTarget("agent")).toBe("agent");
-    // Persisted `chatTargetBySessionID` entries from earlier installs
-    // may still carry `"model"` for sessions that were tools-off.
-    // Map those to "agent" so the per-session map stays well-typed;
-    // the original tools-off intent is recovered separately by the
-    // chat-slice migration that reads raw localStorage.
-    expect(normalizeStoredHecateChatTarget("model")).toBe("agent");
   });
 
   it("returns the empty string for unknown values so the entry is dropped", () => {
     expect(normalizeStoredHecateChatTarget("")).toBe("");
     expect(normalizeStoredHecateChatTarget("external_agent")).toBe("");
     expect(normalizeStoredHecateChatTarget("garbage")).toBe("");
+    expect(normalizeStoredHecateChatTarget("model")).toBe("");
   });
 });
 
@@ -131,13 +117,8 @@ describe("chatTargetToExecutionMode", () => {
 });
 
 describe("executionModeToChatTarget", () => {
-  it("collapses the agent-side execution modes back to 'agent'", () => {
-    // Both tools-on (hecate_task) and the tools-off / capability-
-    // downgrade runtime fallback (direct_model) resolve to the same
-    // user-target value: "agent". The tools-on/off axis lives on the
-    // separate chatToolsEnabledBySessionID map.
+  it("maps hecate_task back to agent", () => {
     expect(executionModeToChatTarget("hecate_task")).toBe("agent");
-    expect(executionModeToChatTarget("direct_model")).toBe("agent");
   });
 
   it("maps external_agent to external_agent", () => {

--- a/ui/src/app/state/_shared.test.ts
+++ b/ui/src/app/state/_shared.test.ts
@@ -12,15 +12,15 @@ import {
 describe("parseQueuedChatMessageList", () => {
   it("keeps valid queued chat messages", () => {
     expect(
-	      parseQueuedChatMessageList([
-	        {
-	          id: "queued-1",
-	          session_id: "chat-1",
-	          content: "continue",
-	          execution_mode: "hecate_task",
-	          tools_enabled: false,
-	          provider_filter: "auto",
-	          model: "gpt-4o-mini",
+      parseQueuedChatMessageList([
+        {
+          id: "queued-1",
+          session_id: "chat-1",
+          content: "continue",
+          execution_mode: "hecate_task",
+          tools_enabled: false,
+          provider_filter: "auto",
+          model: "gpt-4o-mini",
           workspace: "/tmp/hecate",
           system_prompt: "Be concise.",
           agent_id: "hecate",
@@ -29,12 +29,12 @@ describe("parseQueuedChatMessageList", () => {
       ]),
     ).toEqual([
       {
-	        id: "queued-1",
-	        session_id: "chat-1",
-	        content: "continue",
-	        execution_mode: "hecate_task",
-	        tools_enabled: false,
-	        provider_filter: "auto",
+        id: "queued-1",
+        session_id: "chat-1",
+        content: "continue",
+        execution_mode: "hecate_task",
+        tools_enabled: false,
+        provider_filter: "auto",
         model: "gpt-4o-mini",
         workspace: "/tmp/hecate",
         system_prompt: "Be concise.",

--- a/ui/src/app/state/_shared.ts
+++ b/ui/src/app/state/_shared.ts
@@ -27,17 +27,16 @@ export type ChatTarget = "agent" | "external_agent";
 // Collapses to "agent" — could be inlined, but the named type signals
 // intent at use sites that operate only on the Hecate-targeted slice.
 export type HecateChatTarget = "agent";
-// ChatExecutionMode is the runtime mode the gateway dispatches a turn
-// through. Independent of ChatTarget: a Hecate-targeted chat can still
-// run as `direct_model` when the user has tools off or the chosen model
-// lacks tool calling.
-export type ChatExecutionMode = "direct_model" | "hecate_task" | "external_agent";
+// ChatExecutionMode is the runtime owner category. Hecate-owned turns
+// always use hecate_task; tools on/off is carried separately.
+export type ChatExecutionMode = "hecate_task" | "external_agent";
 
 export type QueuedChatMessage = {
   id: string;
   session_id: string;
   content: string;
   execution_mode: ChatExecutionMode;
+  tools_enabled: boolean;
   provider_filter: ProviderFilter;
   model: string;
   workspace: string;
@@ -68,9 +67,6 @@ export function chatTargetToExecutionMode(target: ChatTarget): ChatExecutionMode
 export function executionModeToChatTarget(mode: string): ChatTarget | "" {
   switch (mode) {
     case "hecate_task":
-    case "direct_model":
-      // `direct_model` runs route through the agent path with tools
-      // off; from the user-target perspective they're still "agent".
       return "agent";
     case "external_agent":
       return "external_agent";
@@ -85,25 +81,14 @@ export function executionModeToChatTarget(mode: string): ChatTarget | "" {
 // and the hook falls back to the explicit "agent" default rather
 // than silently coercing the bad value and re-persisting it.
 //
-// The legacy "model" value (older installs encoded "tools off" as
-// chatTarget "model") coerces to "agent" so the user's existing
-// localStorage doesn't get wiped on the first read after upgrade. The
-// tools-off intent is recovered from `hecate.chatTargetBySessionID` by
-// the migration in the chat slice; there's nothing useful left on the
-// top-level chatTarget key for the legacy value to carry.
 export function parseStoredChatTarget(raw: string): ChatTarget | null {
   if (raw === "agent" || raw === "external_agent") return raw;
-  if (raw === "model") return "agent";
   return null;
 }
 
 // Single-value collapse: HecateChatTarget only has "agent" today.
-// Accepts the legacy "model" too so the parseChatTargetsBySessionID
-// migration can fold a pre-upgrade per-session map without losing
-// entries — the value's tools-off semantic is recovered separately by
-// the migration in the chat slice.
 export function normalizeStoredHecateChatTarget(value: string): HecateChatTarget | "" {
-  return value === "agent" || value === "model" ? "agent" : "";
+  return value === "agent" ? "agent" : "";
 }
 
 // Structural guard for the queued-chat-messages localStorage payload.
@@ -123,9 +108,7 @@ export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[]
     const content = typeof item.content === "string" ? item.content : "";
     if (!id || !sessionID || !content.trim()) return [];
     const executionMode =
-      item.execution_mode === "direct_model" ||
-      item.execution_mode === "hecate_task" ||
-      item.execution_mode === "external_agent"
+      item.execution_mode === "hecate_task" || item.execution_mode === "external_agent"
         ? item.execution_mode
         : "";
     if (!executionMode) return [];
@@ -135,6 +118,7 @@ export function parseQueuedChatMessageList(parsed: unknown): QueuedChatMessage[]
         session_id: sessionID,
         content,
         execution_mode: executionMode,
+        tools_enabled: typeof item.tools_enabled === "boolean" ? item.tools_enabled : true,
         provider_filter:
           typeof item.provider_filter === "string"
             ? (item.provider_filter as ProviderFilter)

--- a/ui/src/app/state/chat.tsx
+++ b/ui/src/app/state/chat.tsx
@@ -77,12 +77,9 @@ export type ChatState = {
   // map nor a derived signal exists. Persisted under
   // `hecate.chatToolsEnabled`.
   defaultChatToolsEnabled: boolean;
-  // Per-session tools-enabled override. Mirrors `chatTargetBySessionID`
-  // shape; a missing entry falls back to `defaultChatToolsEnabled`.
-  // Populated by the user toggling the tools pill in ChatSettingsPanel.
-  // Migrated automatically on slice mount from any legacy
-  // `chatTargetBySessionID` entry set to "model" (those map to
-  // tools-off in the new model). Persisted under
+  // Per-session tools-enabled override. A missing entry falls back to
+  // `defaultChatToolsEnabled`. Populated by the user toggling the tools
+  // pill in ChatSettingsPanel. Persisted under
   // `hecate.chatToolsEnabledBySessionID`.
   chatToolsEnabledBySessionID: Map<string, boolean>;
   agentAdapterID: string;
@@ -195,48 +192,6 @@ export function ChatProvider({
     initialState?.chatToolsEnabledBySessionID ?? new Map(),
     { serialize: serializeChatToolsEnabledBySessionID },
   );
-  // One-shot back-compat migration: the per-session map
-  // `hecate.chatTargetBySessionID` once encoded "tools off for this
-  // session" as `{[sid]: "model"}` for entries without their own
-  // chatToolsEnabled override. The parser at slice-mount coerces those
-  // "model" values to "agent" before they reach this hook, so we read
-  // the raw localStorage payload directly to recover the tools-off
-  // intent for any session that was tools-off pre-upgrade. Explicit
-  // `chatToolsEnabledBySessionID` entries the user already wrote are
-  // left alone — the migration only adds entries, never overrides.
-  const toolsEnabledMigrationRanRef = useRef(false);
-  useEffect(() => {
-    if (toolsEnabledMigrationRanRef.current) return;
-    toolsEnabledMigrationRanRef.current = true;
-    let raw: string | null = null;
-    try {
-      raw = window.localStorage?.getItem("hecate.chatTargetBySessionID") ?? null;
-    } catch {
-      return;
-    }
-    if (!raw) return;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      return;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
-    let touched = false;
-    const merged = new Map(chatToolsEnabledBySessionID);
-    for (const [sessionID, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (value === "model" && !merged.has(sessionID)) {
-        merged.set(sessionID, false);
-        touched = true;
-      }
-    }
-    if (touched) {
-      setChatToolsEnabledBySessionID(merged);
-    }
-    // Intentional one-shot: subsequent updates to either map are user
-    // edits we don't want to re-migrate against.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   const [agentAdapterID, setAgentAdapterID] = usePersistedState(
     "hecate.agentAdapterID",
     parseStoredString,

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -132,23 +132,19 @@ function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null)
     return { provider: "", model: "" };
   }
   const segments = [...(session.segments ?? [])].reverse();
-  const segment = segments.find(
-    (item) => item.execution_mode === "hecate_task" || item.execution_mode === "direct_model",
-  );
+  const segment = segments.find((item) => item.execution_mode === "hecate_task");
   if (segment?.provider || segment?.model) {
     return { provider: segment.provider ?? "", model: segment.model ?? "" };
   }
   const messages = [...(session.messages ?? [])].reverse();
-  const message = messages.find(
-    (item) => item.execution_mode === "hecate_task" || item.execution_mode === "direct_model",
-  );
+  const message = messages.find((item) => item.execution_mode === "hecate_task");
   if (message?.provider || message?.model) {
     return { provider: message.provider ?? "", model: message.model ?? "" };
   }
   return { provider: session.provider ?? "", model: session.model ?? "" };
 }
 
-function effectiveHecateExecutionMode({
+function effectiveHecateToolsEnabled({
   requested,
   models,
   providerFilter,
@@ -159,18 +155,11 @@ function effectiveHecateExecutionMode({
   models: ModelRecord[];
   providerFilter: ProviderFilter;
   model: string;
-  // User intent: false means the operator explicitly toggled tools off
-  // for this Hecate-targeted chat, so downgrade the execution mode to
-  // direct_model regardless of model capability. Independent of the
-  // capability-derived downgrade below, which handles the case where
-  // the model itself doesn't support tool calling.
   toolsEnabled: boolean;
-}): ChatExecutionMode {
-  if (requested !== "hecate_task") return requested;
-  if (!toolsEnabled) return "direct_model";
-  return modelSelectionHasNoToolCalling({ models, providerFilter, model })
-    ? "direct_model"
-    : requested;
+}): boolean {
+  if (requested !== "hecate_task") return true;
+  if (!toolsEnabled) return false;
+  return !modelSelectionHasNoToolCalling({ models, providerFilter, model });
 }
 
 function modelAvailableForProviderFilter(
@@ -466,12 +455,14 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     content: string,
     executionMode: ChatExecutionMode,
     sessionID: string,
+    toolsEnabled: boolean,
   ): QueuedChatMessage {
     return {
       id: `queued-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       session_id: sessionID,
       content,
       execution_mode: executionMode,
+      tools_enabled: toolsEnabled,
       provider_filter: providerFilter,
       model,
       workspace: workspaceForActiveTurn(),
@@ -481,10 +472,15 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     };
   }
 
-  function queueChatMessage(content: string, executionMode: ChatExecutionMode, sessionID: string) {
+  function queueChatMessage(
+    content: string,
+    executionMode: ChatExecutionMode,
+    sessionID: string,
+    toolsEnabled: boolean,
+  ) {
     setQueuedChatMessages((current) => [
       ...current,
-      buildQueuedChatMessage(content, executionMode, sessionID),
+      buildQueuedChatMessage(content, executionMode, sessionID, toolsEnabled),
     ]);
     setMessage("");
   }
@@ -527,37 +523,33 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const turnModel = queued?.model ?? model;
     const requestedExecutionMode =
       queued?.execution_mode ?? chatTargetToExecutionMode(params.chatTarget);
-    // Resolve tools-enabled against the *active* session, not the
-    // queued message's pinned session: queued messages reuse the
-    // execution_mode they were enqueued with, so the toolsEnabled
-    // signal only affects fresh-from-the-composer turns.
-    const turnToolsEnabled = queued
-      ? requestedExecutionMode !== "direct_model"
-      : resolveToolsEnabled(activeChatSessionID);
-    const turnExecutionMode = effectiveHecateExecutionMode({
-      requested: requestedExecutionMode,
-      models,
-      providerFilter: turnProviderFilter,
-      model: turnModel,
-      toolsEnabled: turnToolsEnabled,
-    });
+    const requestedToolsEnabled = queued?.tools_enabled ?? resolveToolsEnabled(activeChatSessionID);
+    const isExternalAgent = requestedExecutionMode === "external_agent";
+    const turnToolsEnabled = isExternalAgent
+      ? true
+      : effectiveHecateToolsEnabled({
+          requested: requestedExecutionMode,
+          models,
+          providerFilter: turnProviderFilter,
+          model: turnModel,
+          toolsEnabled: requestedToolsEnabled,
+        });
+    const turnExecutionMode = requestedExecutionMode;
+    const isDirectModelTurn = !isExternalAgent && !turnToolsEnabled;
     if (!queued && activeChatSessionID && chatSessionIsBusy(activeChatSession)) {
-      queueChatMessage(content, turnExecutionMode, activeChatSessionID);
+      queueChatMessage(content, turnExecutionMode, activeChatSessionID, turnToolsEnabled);
       return;
     }
-
     setChatLoading(true);
     clearChatErrorState();
     setRuntimeHeaders(null);
-    const isExternalAgent = turnExecutionMode === "external_agent";
-    const isModelTurn = turnExecutionMode === "direct_model";
     let turnWorkspace = queued?.workspace ?? workspaceForActiveTurn();
     const turnSystemPrompt = queued?.system_prompt ?? systemPrompt;
     const turnAgentID = queued?.agent_id ?? agentAdapterID;
     setStreamingContent(
       isExternalAgent
         ? "Starting external agent..."
-        : isModelTurn
+        : isDirectModelTurn
           ? "Waiting for model output..."
           : "Starting Hecate Chat tools...",
     );
@@ -586,7 +578,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         }
       }
       turnWorkspace = turnWorkspace || sessionForSubmit?.workspace?.trim() || "";
-      if (!isModelTurn && !turnWorkspace) {
+      if (!isDirectModelTurn && !turnWorkspace) {
         setChatErrorState(chatWorkspaceRequiredError());
         return;
       }
@@ -611,8 +603,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
                 model: turnModel,
               }
             : {}),
-          ...(!isModelTurn ? { workspace: turnWorkspace } : {}),
-          ...(!isExternalAgent ? { rtk_enabled: hecateRTKEnabled } : {}),
+          ...(!isDirectModelTurn ? { workspace: turnWorkspace } : {}),
+          ...(!isExternalAgent && turnToolsEnabled ? { rtk_enabled: hecateRTKEnabled } : {}),
           ...(isExternalAgent && configOptions.length > 0 ? { config_options: configOptions } : {}),
         });
         sessionID = created.data.id;
@@ -620,14 +612,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         applyChatSession(created.data);
       }
       if (!isExternalAgent && sessionID) {
-        // Pin the session target to "agent" (the user-target perspective)
-        // regardless of whether this turn ran with tools on or off. The
-        // tools state lives in chatToolsEnabledBySessionID now — mirror
-        // the just-resolved turn into it so a fresh client opening this
-        // session resumes with the same toggle position the user had
-        // when they submitted. Without the toolsEnabled mirror, only
-        // the in-memory toggle state is correct; localStorage would
-        // miss the most recent turn's intent.
         const sid = sessionID;
         setChatTargetBySessionID((current) => {
           const next = new Map(current);
@@ -636,7 +620,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         });
         setChatToolsEnabledBySessionID((current) => {
           const next = new Map(current);
-          next.set(sid, turnExecutionMode === "hecate_task");
+          next.set(sid, turnToolsEnabled);
           return next;
         });
       }
@@ -652,6 +636,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
                 {
                   id: `pending-agent-user-${Date.now()}`,
                   execution_mode: turnExecutionMode,
+                  tools_enabled: !isExternalAgent ? turnToolsEnabled : undefined,
                   provider: !isExternalAgent
                     ? turnProviderFilter === "auto"
                       ? ""
@@ -682,7 +667,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
                   last.content ||
                     (isExternalAgent
                       ? "External agent is running..."
-                      : isModelTurn
+                      : isDirectModelTurn
                         ? "Model is responding..."
                         : "Hecate Chat tools are running..."),
                 );
@@ -709,20 +694,14 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       });
       const updated = await createChatMessageRequest(sessionID, {
         content: pendingContent,
-        // External-agent turns continue to send the literal
-        // execution_mode — the backend dispatch on that path is
-        // unchanged. Hecate-side turns send `tools_enabled` instead
-        // and let the backend derive the execution mode; the model
-        // path eventually folds into the task path and dispatch
-        // there will route on the boolean directly.
         ...(isExternalAgent
           ? { execution_mode: turnExecutionMode }
-          : { tools_enabled: turnExecutionMode === "hecate_task" }),
+          : { tools_enabled: turnToolsEnabled }),
         ...(!isExternalAgent
           ? { provider: turnProviderFilter === "auto" ? "" : turnProviderFilter, model: turnModel }
           : {}),
         ...(!isExternalAgent ? { system_prompt: turnSystemPrompt } : {}),
-        ...(turnExecutionMode === "hecate_task" ? { workspace: turnWorkspace } : {}),
+        ...(!isExternalAgent && turnToolsEnabled ? { workspace: turnWorkspace } : {}),
       });
       applyChatSession(updated.data);
     } catch (submitError) {
@@ -864,7 +843,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
     const requestedChatTarget = requestedAgentID === "hecate" ? "agent" : defaultChatTarget;
     const requestedExecutionMode = chatTargetToExecutionMode(requestedChatTarget);
-    const executionMode = effectiveHecateExecutionMode({
+    const toolsEnabled = effectiveHecateToolsEnabled({
       requested: requestedExecutionMode,
       models,
       providerFilter,
@@ -875,21 +854,16 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       // contribute.
       toolsEnabled: defaultChatToolsEnabled,
     });
-    // The Hecate-routing availability check matters only when the turn
-    // will actually run as a Hecate task: an unroutable model on the
-    // hecate_task path falls back to "" so the gateway picks a routable
-    // default. When the effective mode downgrades to direct_model
-    // (toolsEnabled off or model lacks tool calling), the turn
-    // dispatches straight to the named provider — keep what the user
-    // picked even if it isn't in the Hecate-routing catalog.
+    // The Hecate-routing availability check matters only when tools are
+    // enabled: an unroutable model falls back to "" so the gateway picks
+    // a routable default. Tools-off chat is still a Hecate-owned session,
+    // but it dispatches directly to the selected model.
     const requestedModel =
-      executionMode === "hecate_task" &&
-      model &&
-      !modelAvailableForProviderFilter(models, providerFilter, model)
+      toolsEnabled && model && !modelAvailableForProviderFilter(models, providerFilter, model)
         ? ""
         : model;
     const workspace = workspaceForNewChat(createProjectID);
-    if (executionMode === "hecate_task" && !workspace) {
+    if (toolsEnabled && !workspace) {
       setChatErrorState(chatWorkspaceRequiredError());
       setActiveChatSessionID("");
       setActiveChatSession(null);
@@ -903,8 +877,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         agent_id: "hecate",
         provider: providerFilter === "auto" ? "" : providerFilter,
         model: requestedModel,
-        ...(workspace ? { workspace } : {}),
-        ...(executionMode === "hecate_task" ? { rtk_enabled: hecateRTKEnabled } : {}),
+        ...(toolsEnabled && workspace ? { workspace } : {}),
+        ...(toolsEnabled ? { rtk_enabled: hecateRTKEnabled } : {}),
       });
       setActiveChatSessionID(created.data.id);
       // Same per-session pinning as the submit path: chatTarget stays
@@ -918,7 +892,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       });
       setChatToolsEnabledBySessionID((current) => {
         const next = new Map(current);
-        next.set(created.data.id, executionMode === "hecate_task");
+        next.set(created.data.id, toolsEnabled);
         return next;
       });
       applyChatSession(created.data);

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -41,7 +41,7 @@ function sessionHasActiveHecateTaskSegment(session: ChatSessionRecord | null): b
 // chatTarget gates several views' route/copy decisions. The active
 // agent-chat session forces a target via its agent_id
 // shape; the per-session map override (used by Hecate Chat to flip
-// between agent and direct model) and the default target take effect
+// tools on/off) and the default target take effect
 // only when nothing in the session pins the target.
 export function useChatTarget(): ChatTarget {
   const { state } = useChat();
@@ -76,14 +76,10 @@ export function useChatTarget(): ChatTarget {
 // callers should gate the call site on `chatTarget === "agent"` before
 // using the result to drive UI state.
 //
-// `chatTargetBySessionID[id] === "model"` is a legacy storage value
-// migrated forward to `chatToolsEnabledBySessionID[id] = false` at
-// slice mount (see chat.tsx), so this hook never has to look at
-// chatTarget for back-compat. Deliberately no derivation from the
-// session's message-tail `execution_mode`: the latest completed turn's
-// mode could have been a capability-driven downgrade rather than user
-// intent, and confusing those would silently flip the toggle state on
-// session resume.
+// Deliberately no derivation from the session's message-tail
+// `tools_enabled`: the latest completed turn may have been a
+// capability-driven fallback rather than user intent, and confusing those
+// would silently flip the toggle state on session resume.
 export function useChatToolsEnabled(): boolean {
   const { state } = useChat();
   const sessionID = state.activeChatSessionID;

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -4,7 +4,7 @@ import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useProjects } from "../../app/state/projects";
 import { useChatActions } from "../../app/state/coordinators/chat";
-import { useNewChatAgentID, useChatTarget } from "../../app/state/derived";
+import { useNewChatAgentID, useChatTarget, useChatToolsEnabled } from "../../app/state/derived";
 import { useWiredSettingsActions } from "../../app/state/coordinators/wired";
 import { formatAbsoluteTime } from "../../lib/format";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
@@ -59,6 +59,7 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
   const providersAndModels = useProvidersAndModels();
   const projects = useProjects();
   const chatTarget = useChatTarget();
+  const chatToolsEnabled = useChatToolsEnabled();
   const { actions: settingsActions } = useWiredSettingsActions();
   const chatActions = useChatActions({
     chatTarget,
@@ -110,7 +111,8 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
   const workspaceForNewChat = projects.activeProjectID
     ? selectedProjectWorkspace
     : chat.state.agentWorkspace.trim();
-  const selectedNewChatUsesWorkspace = newChatAgentID !== "hecate" || chatTarget === "agent";
+  const selectedNewChatUsesWorkspace =
+    newChatAgentID !== "hecate" || (chatTarget === "agent" && chatToolsEnabled);
   const workspaceRequiredForNewChat =
     isAgentChat && selectedNewChatUsesWorkspace && !workspaceForNewChat;
 

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -25,6 +25,7 @@ import {
 export type VisibleChatMessage = {
   id: string;
   execution_mode?: string;
+  tools_enabled?: boolean;
   segment_id?: string;
   task_id?: string;
   run_id?: string;
@@ -501,6 +502,7 @@ function buildVisibleMessage(m: ChatMessageRecord, id: string): VisibleChatMessa
   return {
     id,
     execution_mode: m.execution_mode,
+    tools_enabled: m.tools_enabled,
     segment_id: m.segment_id,
     task_id: m.task_id,
     run_id: m.run_id,
@@ -537,7 +539,8 @@ function fallbackSegmentID(message: VisibleChatMessage): string {
 function segmentFromMessage(message: VisibleChatMessage, segmentID: string): ChatSegmentRecord {
   return {
     id: segmentID,
-    execution_mode: message.execution_mode || "direct_model",
+    execution_mode: message.execution_mode || "hecate_task",
+    tools_enabled: message.tools_enabled,
     provider: message.provider,
     model: message.model,
     task_id: message.task_id,
@@ -645,6 +648,16 @@ function describeChatSegment(segment: ChatSegmentRecord): {
   const provider = segment.provider && segment.provider !== "auto" ? segment.provider : "";
   switch (segment.execution_mode) {
     case "hecate_task": {
+      if (segment.tools_enabled === false) {
+        const meta = [provider, "direct model chat"].filter(Boolean).join(" · ");
+        return {
+          kicker: "Tools off",
+          title: model,
+          meta,
+          label: `Tools off segment using ${model}`,
+          tone: "off",
+        };
+      }
       const meta = [
         provider,
         segment.task_id ? formatTaskLinkLabel(segment.task_id) : "",
@@ -673,13 +686,13 @@ function describeChatSegment(segment: ChatSegmentRecord): {
       };
     }
     default: {
-      const meta = [provider, "direct model chat"].filter(Boolean).join(" · ");
+      const meta = [provider, segment.status].filter(Boolean).join(" · ");
       return {
-        kicker: "Tools off",
+        kicker: "Chat",
         title: model,
         meta,
-        label: `Tools off segment using ${model}`,
-        tone: "off",
+        label: `Chat segment using ${model}`,
+        tone: "external",
       };
     }
   }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -67,7 +67,9 @@ function setup(stateOverrides: Record<string, any> = {}, actionOverrides = {}) {
           agent_id: isExternalChat ? agentID : "hecate",
           driver_kind: isExternalChat ? "acp" : undefined,
           execution_mode: isExternalChat ? "external_agent" : "hecate_task",
-          tools_enabled: isExternalChat ? undefined : stateOverrides.defaultChatToolsEnabled !== false,
+          tools_enabled: isExternalChat
+            ? undefined
+            : stateOverrides.defaultChatToolsEnabled !== false,
           title: "New chat",
           provider: isExternalChat ? undefined : provider,
           model: isExternalChat ? undefined : model,
@@ -351,7 +353,8 @@ describe("ChatView input", () => {
     const createChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         agentWorkspace: "",
         activeChatSessionID: "",
         activeChatSession: null,
@@ -817,7 +820,11 @@ describe("ChatView input", () => {
   });
 
   it("enables the send button when message has content", () => {
-    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, message: "hello" });
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
+      message: "hello",
+    });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(false);
@@ -825,7 +832,8 @@ describe("ChatView input", () => {
 
   it("keeps Hecate Chat composer editable but blocks send until a model is selected", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       model: "",
       message: "hello",
     });
@@ -840,7 +848,8 @@ describe("ChatView input", () => {
 
   it("keeps model composer editable but blocks send when no provider is configured", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       message: "hello",
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
@@ -866,7 +875,8 @@ describe("ChatView input", () => {
 
   it("blocks sending when the selected model is not discovered by the selected provider", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       model: "llama3.1:8b",
       message: "hello",
@@ -945,7 +955,8 @@ describe("ChatView input", () => {
   it("shows stale selected-model readiness on existing transcripts", async () => {
     const onNavigate = vi.fn();
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       model: "llama3.1:8b",
       message: "hello",
@@ -953,7 +964,8 @@ describe("ChatView input", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Existing chat",
-        execution_mode: "hecate_task", tools_enabled: false,
+        execution_mode: "hecate_task",
+        tools_enabled: false,
         status: "completed",
         provider: "ollama",
         model: "llama3.1:8b",
@@ -962,7 +974,8 @@ describe("ChatView input", () => {
             id: "m1",
             role: "user",
             content: "hi",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             created_at: "2026-04-20T00:00:00Z",
           },
         ],
@@ -1019,7 +1032,8 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         providerFilter: "anthropic",
         model: "claude-sonnet-4-6",
         message: "hello",
@@ -1076,7 +1090,8 @@ describe("ChatView input", () => {
   it("opens Connections from the model empty state", async () => {
     const onNavigate = vi.fn();
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
         {
@@ -1100,7 +1115,8 @@ describe("ChatView input", () => {
 
   it("keeps configured-provider model discovery repair compact in the empty state", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       settingsConfig: {
         backend: "memory",
@@ -1210,7 +1226,8 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1320,7 +1337,8 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1492,7 +1510,8 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1588,7 +1607,8 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1636,7 +1656,8 @@ describe("ChatView input", () => {
 
   it("shows a first-run setup state when providers and agents are unavailable", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       message: "hello",
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
@@ -1907,7 +1928,8 @@ describe("ChatView input", () => {
     const setModel = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         message: "continue",
         providerFilter: "ollama",
         model: "smollm2:135m",
@@ -2153,7 +2175,8 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        execution_mode: "hecate_task", tools_enabled: false,
+        execution_mode: "hecate_task",
+        tools_enabled: false,
         title: "Mixed chat",
         provider: "ollama",
         model: "smollm2:135m",
@@ -2162,7 +2185,8 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2432,7 +2456,8 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        execution_mode: "hecate_task", tools_enabled: false,
+        execution_mode: "hecate_task",
+        tools_enabled: false,
         title: "Mixed chat",
         task_id: "task_latest",
         latest_run_id: "run_latest",
@@ -2443,7 +2468,8 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:direct",
             role: "user",
             content: "tell a joke",
@@ -2451,7 +2477,8 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:direct",
             run_id: "model_run_1",
             trace_id: "trace_1",
@@ -2488,7 +2515,8 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2506,7 +2534,8 @@ describe("ChatView input", () => {
           },
           {
             id: "model:second",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2516,7 +2545,8 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:first",
             role: "user",
             content: "answer directly",
@@ -2524,7 +2554,8 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:first",
             role: "assistant",
             content: "Direct answer.",
@@ -2555,7 +2586,8 @@ describe("ChatView input", () => {
           },
           {
             id: "m5",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:second",
             role: "user",
             content: "back to direct",
@@ -2563,7 +2595,8 @@ describe("ChatView input", () => {
           },
           {
             id: "m6",
-            execution_mode: "hecate_task", tools_enabled: false,
+            execution_mode: "hecate_task",
+            tools_enabled: false,
             segment_id: "model:second",
             role: "assistant",
             content: "Direct again.",
@@ -2788,7 +2821,10 @@ describe("ChatView input", () => {
   it("calls setMessage as user types", async () => {
     const setMessage = vi.fn();
     // Start with empty message so the assertion sees only what we typed.
-    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, message: "" }, { setMessage });
+    const { state, actions } = setup(
+      { chatTarget: "agent", defaultChatToolsEnabled: false, message: "" },
+      { setMessage },
+    );
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     const ta = screen.getByPlaceholderText(/Message/i) as HTMLTextAreaElement;
     const user = userEvent.setup();
@@ -2800,7 +2836,8 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         message: "",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2858,7 +2895,8 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         message: "line one\nline two",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2889,7 +2927,8 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         message: "pending question",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2950,14 +2989,19 @@ describe("ChatView chats sidebar", () => {
   }
 
   it("shows 'No chats yet' when chatSessions is empty", () => {
-    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, chatSessions: [] });
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
+      chatSessions: [],
+    });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/No chats yet/i)).toBeTruthy();
   });
 
   it("renders one row per chat with title", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
@@ -2984,12 +3028,14 @@ describe("ChatView chats sidebar", () => {
 
   it("filters chat history by title and route metadata", async () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
           title: "Budget check",
-          execution_mode: "hecate_task", tools_enabled: false,
+          execution_mode: "hecate_task",
+          tools_enabled: false,
           status: "completed",
           provider: "anthropic",
           message_count: 4,
@@ -2998,7 +3044,8 @@ describe("ChatView chats sidebar", () => {
         {
           id: "s2",
           title: "Release notes cleanup",
-          execution_mode: "hecate_task", tools_enabled: false,
+          execution_mode: "hecate_task",
+          tools_enabled: false,
           status: "completed",
           provider: "openai",
           message_count: 2,
@@ -3075,7 +3122,8 @@ describe("ChatView chats sidebar", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -3092,7 +3140,8 @@ describe("ChatView chats sidebar", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -4489,7 +4538,8 @@ describe("ChatView external-agent target", () => {
 describe("ChatView model target", () => {
   it("announces markdown task-list checkbox state", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       activeChatSessionID: "s1",
       activeChatSession: {
         id: "s1",
@@ -4509,7 +4559,8 @@ describe("ChatView model target", () => {
     const setModel = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         providerFilter: "openai",
         model: "gpt-4o-mini",
         activeChatSessionID: "s1",
@@ -4759,7 +4810,8 @@ describe("ChatView error display", () => {
 describe("ChatView session title", () => {
   it("shows the chat empty state without composer when no chat is selected", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       chatSessions: [],
       activeChatSessionID: "",
       activeChatSession: null,
@@ -4775,7 +4827,8 @@ describe("ChatView session title", () => {
 
   it("shows a passive new-chat canvas when chat history exists but none is active", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
@@ -4822,7 +4875,8 @@ describe("ChatView session title", () => {
 
   it("shows the active session's title", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       activeChatSession: {
         id: "s1",
         title: "Hello world",
@@ -4895,7 +4949,8 @@ describe("ChatView New chat button", () => {
       activeChatSession: {
         id: "chat_new",
         agent_id: "hecate",
-        execution_mode: "hecate_task", tools_enabled: false,
+        execution_mode: "hecate_task",
+        tools_enabled: false,
         title: "New chat",
         provider: "openai",
         model: "gpt-4o-mini",
@@ -4920,7 +4975,8 @@ describe("ChatView session focus", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s2", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -4949,7 +5005,11 @@ describe("ChatView session focus", () => {
   it("does NOT focus the textarea when activeChatSessionID changes from data-load", async () => {
     // Initial-load and API-driven session arrivals must not steal
     // focus — page-level shortcuts depend on it. Asserts the negative.
-    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, activeChatSessionID: "" });
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
+      activeChatSessionID: "",
+    });
     const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     const searchInput = screen.getByRole("textbox", { name: "Search chats" });
     searchInput.focus();
@@ -4966,7 +5026,8 @@ describe("ChatView history pagination", () => {
     const loadMoreChatSessions = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         chatSessionsHasMore: true,
         chatSessions: [
           { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
@@ -4984,7 +5045,8 @@ describe("ChatView history pagination", () => {
     const loadMoreChatSessions = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "agent", defaultChatToolsEnabled: false,
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
         chatSessionsHasMore: true,
         chatSessions: [
           { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
@@ -5026,7 +5088,8 @@ describe("ChatView agent approvals", () => {
 
   it("hides the auto-mode banner when in model chat target (it's an agent-only concern)", () => {
     const { state, actions } = setup({
-      chatTarget: "agent", defaultChatToolsEnabled: false,
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
       agentAdapterApprovalMode: "auto",
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -66,11 +66,8 @@ function setup(stateOverrides: Record<string, any> = {}, actionOverrides = {}) {
           id: activeChatSessionID,
           agent_id: isExternalChat ? agentID : "hecate",
           driver_kind: isExternalChat ? "acp" : undefined,
-          execution_mode: isExternalChat
-            ? "external_agent"
-            : chatTarget === "agent"
-              ? "hecate_task"
-              : "hecate_direct",
+          execution_mode: isExternalChat ? "external_agent" : "hecate_task",
+          tools_enabled: isExternalChat ? undefined : stateOverrides.defaultChatToolsEnabled !== false,
           title: "New chat",
           provider: isExternalChat ? undefined : provider,
           model: isExternalChat ? undefined : model,
@@ -354,7 +351,7 @@ describe("ChatView input", () => {
     const createChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         agentWorkspace: "",
         activeChatSessionID: "",
         activeChatSession: null,
@@ -820,7 +817,7 @@ describe("ChatView input", () => {
   });
 
   it("enables the send button when message has content", () => {
-    const { state, actions } = setup({ chatTarget: "model", message: "hello" });
+    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, message: "hello" });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     const send = document.querySelector("button[type='submit']") as HTMLButtonElement;
     expect(send.disabled).toBe(false);
@@ -828,7 +825,7 @@ describe("ChatView input", () => {
 
   it("keeps Hecate Chat composer editable but blocks send until a model is selected", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       model: "",
       message: "hello",
     });
@@ -843,7 +840,7 @@ describe("ChatView input", () => {
 
   it("keeps model composer editable but blocks send when no provider is configured", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       message: "hello",
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
@@ -869,7 +866,7 @@ describe("ChatView input", () => {
 
   it("blocks sending when the selected model is not discovered by the selected provider", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       model: "llama3.1:8b",
       message: "hello",
@@ -948,7 +945,7 @@ describe("ChatView input", () => {
   it("shows stale selected-model readiness on existing transcripts", async () => {
     const onNavigate = vi.fn();
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       model: "llama3.1:8b",
       message: "hello",
@@ -956,7 +953,7 @@ describe("ChatView input", () => {
       activeChatSession: {
         id: "chat_1",
         title: "Existing chat",
-        execution_mode: "direct_model",
+        execution_mode: "hecate_task", tools_enabled: false,
         status: "completed",
         provider: "ollama",
         model: "llama3.1:8b",
@@ -965,7 +962,7 @@ describe("ChatView input", () => {
             id: "m1",
             role: "user",
             content: "hi",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             created_at: "2026-04-20T00:00:00Z",
           },
         ],
@@ -1022,7 +1019,7 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         providerFilter: "anthropic",
         model: "claude-sonnet-4-6",
         message: "hello",
@@ -1079,7 +1076,7 @@ describe("ChatView input", () => {
   it("opens Connections from the model empty state", async () => {
     const onNavigate = vi.fn();
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
         {
@@ -1103,7 +1100,7 @@ describe("ChatView input", () => {
 
   it("keeps configured-provider model discovery repair compact in the empty state", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       providerFilter: "ollama",
       settingsConfig: {
         backend: "memory",
@@ -1213,7 +1210,7 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1323,7 +1320,7 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1495,7 +1492,7 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1591,7 +1588,7 @@ describe("ChatView input", () => {
     const setProviderFilter = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
         providerPresets: [
           {
@@ -1639,7 +1636,7 @@ describe("ChatView input", () => {
 
   it("shows a first-run setup state when providers and agents are unavailable", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       message: "hello",
       settingsConfig: { backend: "memory", providers: [], policy_rules: [], events: [] },
       agentAdapters: [
@@ -1910,7 +1907,7 @@ describe("ChatView input", () => {
     const setModel = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         message: "continue",
         providerFilter: "ollama",
         model: "smollm2:135m",
@@ -2156,7 +2153,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        execution_mode: "direct_model",
+        execution_mode: "hecate_task", tools_enabled: false,
         title: "Mixed chat",
         provider: "ollama",
         model: "smollm2:135m",
@@ -2165,7 +2162,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2435,7 +2432,7 @@ describe("ChatView input", () => {
       activeChatSessionID: "chat_1",
       activeChatSession: {
         id: "chat_1",
-        execution_mode: "direct_model",
+        execution_mode: "hecate_task", tools_enabled: false,
         title: "Mixed chat",
         task_id: "task_latest",
         latest_run_id: "run_latest",
@@ -2446,7 +2443,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:direct",
             role: "user",
             content: "tell a joke",
@@ -2454,7 +2451,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:direct",
             run_id: "model_run_1",
             trace_id: "trace_1",
@@ -2491,7 +2488,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2509,7 +2506,7 @@ describe("ChatView input", () => {
           },
           {
             id: "model:second",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             provider: "ollama",
             model: "smollm2:135m",
             status: "completed",
@@ -2519,7 +2516,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:first",
             role: "user",
             content: "answer directly",
@@ -2527,7 +2524,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:first",
             role: "assistant",
             content: "Direct answer.",
@@ -2558,7 +2555,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m5",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:second",
             role: "user",
             content: "back to direct",
@@ -2566,7 +2563,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m6",
-            execution_mode: "direct_model",
+            execution_mode: "hecate_task", tools_enabled: false,
             segment_id: "model:second",
             role: "assistant",
             content: "Direct again.",
@@ -2791,7 +2788,7 @@ describe("ChatView input", () => {
   it("calls setMessage as user types", async () => {
     const setMessage = vi.fn();
     // Start with empty message so the assertion sees only what we typed.
-    const { state, actions } = setup({ chatTarget: "model", message: "" }, { setMessage });
+    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, message: "" }, { setMessage });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     const ta = screen.getByPlaceholderText(/Message/i) as HTMLTextAreaElement;
     const user = userEvent.setup();
@@ -2803,7 +2800,7 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         message: "",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2861,7 +2858,7 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         message: "line one\nline two",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2892,7 +2889,7 @@ describe("ChatView input", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         message: "pending question",
         activeChatSessionID: "chat_history",
         activeChatSession: {
@@ -2953,14 +2950,14 @@ describe("ChatView chats sidebar", () => {
   }
 
   it("shows 'No chats yet' when chatSessions is empty", () => {
-    const { state, actions } = setup({ chatTarget: "model", chatSessions: [] });
+    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, chatSessions: [] });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/No chats yet/i)).toBeTruthy();
   });
 
   it("renders one row per chat with title", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
@@ -2987,12 +2984,12 @@ describe("ChatView chats sidebar", () => {
 
   it("filters chat history by title and route metadata", async () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
           title: "Budget check",
-          execution_mode: "direct_model",
+          execution_mode: "hecate_task", tools_enabled: false,
           status: "completed",
           provider: "anthropic",
           message_count: 4,
@@ -3001,7 +2998,7 @@ describe("ChatView chats sidebar", () => {
         {
           id: "s2",
           title: "Release notes cleanup",
-          execution_mode: "direct_model",
+          execution_mode: "hecate_task", tools_enabled: false,
           status: "completed",
           provider: "openai",
           message_count: 2,
@@ -3078,7 +3075,7 @@ describe("ChatView chats sidebar", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -3095,7 +3092,7 @@ describe("ChatView chats sidebar", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s1", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -3119,7 +3116,7 @@ describe("ChatView external-agent target", () => {
     const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     expect(screen.getByText(/External agents run as your OS user/)).toBeTruthy();
 
-    const modelState = setup({ chatTarget: "model" }).state;
+    const modelState = setup({ chatTarget: "agent", defaultChatToolsEnabled: false }).state;
     rerender(withRuntimeConsole(<ChatView />, { state: modelState, actions }));
     expect(screen.queryByText(/External agents run as your OS user/)).toBeNull();
   });
@@ -4492,7 +4489,7 @@ describe("ChatView external-agent target", () => {
 describe("ChatView model target", () => {
   it("announces markdown task-list checkbox state", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       activeChatSessionID: "s1",
       activeChatSession: {
         id: "s1",
@@ -4512,7 +4509,7 @@ describe("ChatView model target", () => {
     const setModel = vi.fn();
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         providerFilter: "openai",
         model: "gpt-4o-mini",
         activeChatSessionID: "s1",
@@ -4762,7 +4759,7 @@ describe("ChatView error display", () => {
 describe("ChatView session title", () => {
   it("shows the chat empty state without composer when no chat is selected", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       chatSessions: [],
       activeChatSessionID: "",
       activeChatSession: null,
@@ -4778,7 +4775,7 @@ describe("ChatView session title", () => {
 
   it("shows a passive new-chat canvas when chat history exists but none is active", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       chatSessions: [
         {
           id: "s1",
@@ -4825,7 +4822,7 @@ describe("ChatView session title", () => {
 
   it("shows the active session's title", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       activeChatSession: {
         id: "s1",
         title: "Hello world",
@@ -4898,7 +4895,7 @@ describe("ChatView New chat button", () => {
       activeChatSession: {
         id: "chat_new",
         agent_id: "hecate",
-        execution_mode: "hecate_direct",
+        execution_mode: "hecate_task", tools_enabled: false,
         title: "New chat",
         provider: "openai",
         model: "gpt-4o-mini",
@@ -4923,7 +4920,7 @@ describe("ChatView session focus", () => {
     const selectChatSession = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         chatSessions: [
           { id: "s2", title: "Pick me", message_count: 0, provider_call_count: 0 } as any,
         ],
@@ -4952,7 +4949,7 @@ describe("ChatView session focus", () => {
   it("does NOT focus the textarea when activeChatSessionID changes from data-load", async () => {
     // Initial-load and API-driven session arrivals must not steal
     // focus — page-level shortcuts depend on it. Asserts the negative.
-    const { state, actions } = setup({ chatTarget: "model", activeChatSessionID: "" });
+    const { state, actions } = setup({ chatTarget: "agent", defaultChatToolsEnabled: false, activeChatSessionID: "" });
     const { rerender } = render(withRuntimeConsole(<ChatView />, { state, actions }));
     const searchInput = screen.getByRole("textbox", { name: "Search chats" });
     searchInput.focus();
@@ -4969,7 +4966,7 @@ describe("ChatView history pagination", () => {
     const loadMoreChatSessions = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         chatSessionsHasMore: true,
         chatSessions: [
           { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
@@ -4987,7 +4984,7 @@ describe("ChatView history pagination", () => {
     const loadMoreChatSessions = vi.fn(async () => undefined);
     const { state, actions } = setup(
       {
-        chatTarget: "model",
+        chatTarget: "agent", defaultChatToolsEnabled: false,
         chatSessionsHasMore: true,
         chatSessions: [
           { id: "s1", title: "First page", message_count: 1, provider_call_count: 1 } as any,
@@ -5029,7 +5026,7 @@ describe("ChatView agent approvals", () => {
 
   it("hides the auto-mode banner when in model chat target (it's an agent-only concern)", () => {
     const { state, actions } = setup({
-      chatTarget: "model",
+      chatTarget: "agent", defaultChatToolsEnabled: false,
       agentAdapterApprovalMode: "auto",
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -199,10 +199,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   //   2. The session is on a Hecate-shaped path overall (`isHecateChat`).
   //   3. The user has tools turned on for this session
   //      (`hecateChatToolsEnabled`).
-  // `chatTarget === "model"` is a legacy storage value that older
-  // installs may still hold; the slice migrates those entries to
-  // `chatToolsEnabledBySessionID[id] = false` on mount, so this
-  // expression doesn't have to special-case the old encoding.
   const isHecateAgentChat = isHecateChat && state.chatTarget === "agent" && hecateChatToolsEnabled;
   const isExternalAgentChat =
     activeSessionIsExternal || (!activeSessionIsHecate && state.chatTarget === "external_agent");
@@ -414,8 +410,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const chatSettingsPanelOpen = selectedChatReady && isAgentChat && chatSettingsOpen;
   const rightPanelOpen = chatSettingsPanelOpen || workspaceChangesPanelOpen;
   const rightPanelLabel = chatSettingsPanelOpen ? "Chat settings panel" : "Workspace changes panel";
-  const chatSetupRepairTarget =
-    isHecateAgentChat && hecateAgentToolsDisabledForModel ? "model" : state.chatTarget;
+  const chatSetupRepairTarget = state.chatTarget;
   const hecateChatModelReady =
     isHecateAgentChat && hecateAgentModelLocked
       ? Boolean(hecateChatModelValue)
@@ -442,6 +437,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     state.message.trim() === "";
   const chatSetupRepair = resolveChatSetupRepairState({
     target: chatSetupRepairTarget,
+    workspaceRequired: isExternalAgentChat || hecateTaskToolsAvailable,
     hasConfiguredProviders,
     modelRouteUnavailable,
     selectedModelIssue,

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -961,8 +961,6 @@ function contextPacketEmpty(packet: ChatContextPacketRecord): boolean {
 
 function humanExecutionMode(mode: string): string {
   switch (mode) {
-    case "direct_model":
-      return "Direct model chat";
     case "external_agent":
       return "External agent";
     case "hecate_task":

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -160,16 +160,12 @@ export type CreateChatSessionPayload = {
 
 export type CreateChatMessagePayload = {
   content: string;
-  // execution_mode stays on the wire so external-agent dispatch
-  // continues to send the literal explicitly. For Hecate-side turns
-  // the UI now prefers `tools_enabled` and omits `execution_mode`;
-  // the backend derives the dispatch from the boolean when the
-  // legacy field is empty.
-  execution_mode?: "external_agent" | "hecate_task" | "direct_model";
-  // tools_enabled is the per-turn tools-on/off signal. Backend
-  // dispatch routes hecate_task vs direct_model on this boolean when
-  // execution_mode is absent (the new wire shape for Hecate-side
-  // turns). External-agent turns don't use it — agent_id pins the
+  // External-agent turns send the literal mode. Hecate-owned turns use
+  // hecate_task and carry direct-model vs tool-runtime intent through
+  // tools_enabled.
+  execution_mode?: "external_agent" | "hecate_task";
+  // tools_enabled is the per-turn tools-on/off signal for Hecate-owned
+  // turns. External-agent turns don't use it — agent_id pins the
   // dispatch and the agent owns its own tools.
   tools_enabled?: boolean;
   provider?: string;

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -20,7 +20,8 @@ describe("resolveChatSetupRepairState", () => {
   it("points chats without configured providers to Connections", () => {
     const repair = resolveChatSetupRepairState({
       ...base,
-      target: "model",
+      target: "agent",
+      workspaceRequired: false,
       hasConfiguredProviders: false,
       modelRouteUnavailable: true,
     });
@@ -36,7 +37,8 @@ describe("resolveChatSetupRepairState", () => {
   it("explains that configured providers may need refresh or loaded models", () => {
     const repair = resolveChatSetupRepairState({
       ...base,
-      target: "model",
+      target: "agent",
+      workspaceRequired: false,
       modelRouteUnavailable: true,
     });
 

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -2,7 +2,7 @@ import type { SelectedModelIssue } from "./provider-issues";
 import type { ModelRecord } from "../types/model";
 import type { ProviderFilter } from "../types/provider";
 
-export type ChatSetupTarget = "model" | "agent" | "external_agent";
+export type ChatSetupTarget = "agent" | "external_agent";
 
 export type ChatSetupRepairKind =
   | "no_provider"
@@ -34,6 +34,7 @@ export function resolveChatSetupRepairState({
   modelRouteUnavailable,
   selectedModelIssue,
   workspace,
+  workspaceRequired,
   selectedAgentID,
   selectedAgentName,
   selectedAgentAvailable,
@@ -45,6 +46,7 @@ export function resolveChatSetupRepairState({
   modelRouteUnavailable: boolean;
   selectedModelIssue: SelectedModelIssue | null;
   workspace: string;
+  workspaceRequired?: boolean;
   selectedAgentID?: string;
   selectedAgentName?: string;
   selectedAgentAvailable: boolean;
@@ -82,7 +84,9 @@ export function resolveChatSetupRepairState({
     return null;
   }
 
-  if (target === "agent" && hasConfiguredProviders && !workspace.trim()) {
+  const shouldRequireWorkspace = workspaceRequired ?? target === "agent";
+
+  if (target === "agent" && shouldRequireWorkspace && hasConfiguredProviders && !workspace.trim()) {
     return workspaceRepair();
   }
 
@@ -113,7 +117,7 @@ export function resolveChatSetupRepairState({
     };
   }
 
-  if (target === "agent" && !workspace.trim()) {
+  if (target === "agent" && shouldRequireWorkspace && !workspace.trim()) {
     return workspaceRepair();
   }
 

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -688,8 +688,8 @@ describe("useRuntimeConsole", () => {
       agent_id: "hecate",
       model: "gpt-4o-mini",
       project_id: "proj_1",
-      workspace: "/tmp/hecate-project",
     });
+    expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
 
@@ -752,13 +752,12 @@ describe("useRuntimeConsole", () => {
 
     expect(createBody).toMatchObject({
       agent_id: "hecate",
-      // Tools-off Hecate creation dispatches as direct_model straight
-      // to the named provider, so the user's chosen model is kept
-      // even when it isn't in the Hecate-routing catalog.
+      // Tools-off Hecate creation keeps execution_mode as hecate_task
+      // and records the direct provider call with tools_enabled=false.
       model: "gpt-4o-mini",
-      workspace: "/tmp/hecate",
       project_id: "proj_1",
     });
+    expect(createBody).not.toHaveProperty("workspace");
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
 
@@ -2787,7 +2786,7 @@ describe("useRuntimeConsole", () => {
                 segments: [
                   {
                     id: "model:first",
-                    execution_mode: "direct_model",
+                    execution_mode: "hecate_task", tools_enabled: false,
                     provider: "ollama",
                     model: "smollm2:135m",
                     status: "completed",

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -2786,7 +2786,8 @@ describe("useRuntimeConsole", () => {
                 segments: [
                   {
                     id: "model:first",
-                    execution_mode: "hecate_task", tools_enabled: false,
+                    execution_mode: "hecate_task",
+                    tools_enabled: false,
                     provider: "ollama",
                     model: "smollm2:135m",
                     status: "completed",

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -41,17 +41,9 @@ export type ChatSessionSummaryRecord = {
 
 export type ChatMessageRecord = {
   id: string;
-  execution_mode?: "external_agent" | "hecate_task" | "direct_model" | string;
+  execution_mode?: "external_agent" | "hecate_task" | string;
   // tools_enabled is the per-turn tools-on/off signal the gateway
-  // recorded when this message was appended. Optional so older
-  // backends that predate the field can be tolerated; consumers
-  // should treat `undefined` as "no signal — assume tools on" (the
-  // agent path is the safe default). Today the UI doesn't derive
-  // tools-toggle state from message history (see `useChatToolsEnabled`
-  // in `app/state/derived.ts`) so this field is informational on the
-  // client side; once the backend dispatch routes on tools_enabled
-  // instead of execution_mode the field becomes the canonical wire
-  // signal.
+  // recorded when this message was appended.
   tools_enabled?: boolean;
   segment_id?: string;
   task_id?: string;
@@ -106,7 +98,8 @@ export type ChatContextSourceRecord = {
 
 export type ChatSegmentRecord = {
   id: string;
-  execution_mode: "external_agent" | "hecate_task" | "direct_model" | string;
+  execution_mode: "external_agent" | "hecate_task" | string;
+  tools_enabled?: boolean;
   provider?: string;
   model?: string;
   task_id?: string;


### PR DESCRIPTION
## Summary

- remove `direct_model` from the chat execution-mode model
- represent plain provider/model chat as `execution_mode="hecate_task"` with `tools_enabled=false`
- keep task-backed Hecate turns as `execution_mode="hecate_task"` with `tools_enabled=true`, and external agents as `external_agent`
- update backend routing, chat storage defaults, UI state, E2E fixtures, screenshot setup, and docs

## Breaking change

This intentionally removes the legacy `direct_model` execution mode. Alpha clients and fixtures should use `hecate_task` plus `tools_enabled=false` for direct model chat.

## Verification

- `GOCACHE="$PWD/.gocache" go test ./internal/chat ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`
