### PR TITLE
fix(ui): reduce transcript workspace noise

### DIFF
--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -685,6 +685,27 @@ describe("TranscriptMessageRow", () => {
     expect(output).not.toHaveTextContent(/\d+\s*\|/);
   });
 
+  it("strips right-aligned line gutters from read-context output", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_read",
+        status: "completed",
+        kind: "read",
+        detail: "read · output:   41 | function run() {\n  42 |   return true;\n  43 | }",
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    await user.click(screen.getByText("Output"));
+
+    const output = screen.getByText(/function run/);
+    expect(output.textContent).toContain("function run() {\nreturn true;\n}");
+    expect(output).not.toHaveTextContent(/\d+\s*\|/);
+  });
+
   it("does not duplicate captured diffs when the workspace-changes chip is available", () => {
     const diff = [
       "diff --git a/README.md b/README.md",
@@ -708,6 +729,30 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByRole("button", { name: "Open 1 file" })).toBeInTheDocument();
     expect(screen.queryByText(/workspace changes · 1 file changed/)).toBeNull();
     expect(screen.queryByTestId("diff-viewer")).toBeNull();
+  });
+
+  it("hides backend changed-files activity rows when the workspace-changes chip is available", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "files_changed",
+        title: "Workspace changes",
+        status: "completed",
+        detail: "README.md | 1 +\n1 file changed, 1 insertion(+)",
+      },
+    ];
+
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        activities={activities}
+        diffStat="README.md | 1 +\n1 file changed, 1 insertion(+)"
+        changedFilesLink={{ label: "1 file", onClick: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Open 1 file" })).toBeInTheDocument();
+    expect(screen.queryByText("Workspace changes")).toBeNull();
+    expect(screen.queryByText("Files")).toBeNull();
   });
 
   it("shows the rich diff viewer for file-change activity when a patch is captured", async () => {
@@ -740,9 +785,9 @@ describe("TranscriptMessageRow", () => {
       />,
     );
 
-    const filesSummary = screen.getByText("Files");
-    expect(filesSummary.tagName).toBe("SUMMARY");
-    await user.click(filesSummary);
+    const changesSummary = screen.getByText(/^workspace changes/);
+    expect(changesSummary.tagName).toBe("SUMMARY");
+    await user.click(changesSummary);
 
     expect(screen.getByTestId("diff-viewer")).toBeInTheDocument();
   });

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -103,6 +103,12 @@ export function TranscriptMessageRow({
           if ((failed || cancelled) && isTerminalSessionMetadata(activity)) return false;
           if ((failed || cancelled) && isStaleTerminalPlaceholder(activity)) return false;
           if (failed && duplicatesFailureNotice(activity, error || content)) return false;
+          if (
+            isFilesChangedActivity(activity) &&
+            (changedFilesLink || diffStat?.trim() || diff?.trim())
+          ) {
+            return false;
+          }
           return true;
         })
       : activities;
@@ -435,11 +441,22 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
 function normalizeToolOutputPreview(output: string): string {
   const withoutAnsi = stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
-  return withoutAnsi
-    .replace(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\|)\s*/g, "\n")
+  return stripLineNumberGutters(withoutAnsi)
     .replace(/^\n+/, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+function stripLineNumberGutters(output: string): string {
+  if (!looksLikeLineNumberGutter(output)) return output;
+  return output
+    .replace(/(^|\n)[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/g, "$1")
+    .replace(/[ \t]+\d{1,6}\s*(?:>|→|\|)\s*/g, "\n");
+}
+
+function looksLikeLineNumberGutter(output: string): boolean {
+  const matches = output.match(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\|)\s*/g) ?? [];
+  return matches.length > 1 || /^[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/.test(output);
 }
 
 function stripAnsi(value: string): string {

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -334,6 +334,22 @@ describe("activityDisplay", () => {
     expect(capturedToolOutput(command)).toBe("total 88064 drwxr-xr-x@ 45 chicoxyzzy staff");
   });
 
+  it("keeps output-captured command details out of the compact row without a separator", () => {
+    const command = activity({
+      type: "tool_call",
+      title: "call_shell",
+      status: "completed",
+      kind: "execute",
+      detail: "execute · output captured total 88064 drwxr-xr-x@ 45 chicoxyzzy staff",
+    });
+
+    expect(activityDisplay(command)).toEqual({
+      title: "Ran command",
+      detail: undefined,
+    });
+    expect(capturedToolOutput(command)).toBe("total 88064 drwxr-xr-x@ 45 chicoxyzzy staff");
+  });
+
   it("uses adapter detail hints to humanize opaque external-agent tool ids", () => {
     expect(
       activityDisplay(
@@ -346,6 +362,21 @@ describe("activityDisplay", () => {
     ).toEqual({
       title: "Edited file",
       detail: "edit · 1 diff",
+    });
+  });
+
+  it("humanizes edit-like tool kinds even when the title is opaque", () => {
+    expect(
+      activityDisplay(
+        activity({
+          type: "tool_call",
+          title: "toolu_01BZs1wuiXD65ZLAfKxhCebd",
+          kind: "write",
+        }),
+      ),
+    ).toEqual({
+      title: "Edited file",
+      detail: "edit · tool 01BZs1wu",
     });
   });
 

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -373,6 +373,14 @@ function toolActivityTitle(activity: ChatActivityRecord): string {
   if (normalizedKind === "read" || /^read(?:\s|·|$)/.test(toolHint)) {
     return "Read context";
   }
+  if (
+    normalizedKind === "edit" ||
+    normalizedKind === "write" ||
+    /^edit(?:\s|·|$)/.test(toolHint) ||
+    /^write(?:\s|·|$)/.test(toolHint)
+  ) {
+    return "Edited file";
+  }
 
   return raw;
 }
@@ -474,7 +482,7 @@ function simpleToolOutputPrefix(prefix: string): boolean {
 }
 
 function parseToolOutputDetail(detail: string): { prefix: string; output: string } | undefined {
-  const match = detail.match(/^(.+?)\s*·\s*output(?:\s+captured)?\s*(?::|·)\s*(.*)$/is);
+  const match = detail.match(/^(.+?)\s*·\s*output(?:\s+captured)?(?:\s*(?::|·)\s*|\s+)(.+)$/is);
   if (!match) return undefined;
   return {
     prefix: match[1].trim(),


### PR DESCRIPTION
## Summary

- Hide backend changed-files activity rows when the workspace-changes chip/diff surface is already present.
- Keep captured command/read output out of compact transcript rows and reveal it in the output preview instead.
- Improve read-context output previews by stripping line-number gutters more reliably.
- Humanize opaque edit/write tool calls as file edits.

## Validation

- `cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx src/features/transcript/transcriptActivityHelpers.test.ts`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
