### PR TITLE
chore(agent): add Copilot instruction adapters

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Hecate Copilot Instructions
+
+Hecate is an open-source local AI runtime console. It routes OpenAI- and
+Anthropic-shaped traffic to upstream providers, runs queued `agent_loop` tasks
+behind policy and approval gates, supervises ACP coding agents, and emits
+OpenTelemetry traces.
+
+This file is a GitHub Copilot adapter shim. The canonical provider-neutral
+guidance lives in `AGENTS.md` and `docs-ai/`; read those before changing code.
+Do not copy long-form rules into this file.
+
+Universal rules:
+
+- Keep changes scoped to the user request and the existing architecture.
+- Follow `docs-ai/core/engineering-standards.md` and
+  `docs-ai/core/workflow.md`.
+- Use the relevant `docs-ai/skills/*/SKILL.md` for the area being changed.
+- Do not create Claude-, Cursor-, Codex-, or Copilot-specific copies of shared
+  guidance.
+- Do not auto-commit. Suggest a Conventional Commit message when useful.
+- Report the verification you ran, and call out anything you could not run.
+
+Verification starts at `docs-ai/core/verification.md`. Common gates:
+
+- Backend/runtime: focused `go test`, then `go test -race -timeout 10m ./...`
+  or `just test-race` for broad runtime changes.
+- E2E: `go test -tags e2e ./e2e/...`.
+- UI: `cd ui && bun run typecheck && bun run test`; never use `bun test`.
+- Agent docs: `just agent-docs-check`, `just docs-format-check`, and
+  `just check-links` when links change.

--- a/.github/instructions/agent-docs.instructions.md
+++ b/.github/instructions/agent-docs.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "AGENTS.md,CLAUDE.md,docs-ai/**,.github/copilot-instructions.md,.github/instructions/**"
+---
+
+# Agent Guidance Docs
+
+Agent guidance is provider-neutral. Keep `docs-ai/` as the source of truth and
+use adapter files only to help a specific product discover that guidance.
+
+Before editing this area, read:
+
+- `docs-ai/core/agent-guidance.md`
+- `docs-ai/README.md`
+- `docs-ai/skills/README.md`
+
+Rules:
+
+- Do not add tracked `.claude/` or `.cursor/` guidance.
+- Keep `CLAUDE.md` as the compatibility shim importing `AGENTS.md`.
+- Keep GitHub Copilot files short; they must point to `docs-ai/` rather than
+  duplicating canonical skills or workflow rules.
+- When adding, moving, or deleting a skill, update `docs-ai/skills/README.md`.
+- Run `just agent-docs-check`, `just docs-format-check`, and `just check-links`
+  when links change.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: "cmd/**/*.go,internal/**/*.go,pkg/**/*.go,e2e/**/*.go,go.mod,go.sum"
+---
+
+# Backend Runtime
+
+For Go backend/runtime work, read `AGENTS.md` plus
+`docs-ai/skills/backend/SKILL.md`. Use `docs-ai/core/verification.md` for the
+verification ladder.
+
+High-signal rules:
+
+- Workspace-bound file/search/write behavior goes through WorkspaceFS;
+  subprocesses go through ProcessRunner, GitRunner, or the sandbox seams.
+- Mirror persisted behavior across memory and sqlite backends.
+- Run events are append-only and use the runtime event seams; document new event
+  types in `docs/events.md`.
+- Store money as `int64` micro-USD, never floats.
+- Add OTel spans/attributes for new request or runtime paths.
+- Do not introduce auth, tenant, or remote-multi-user assumptions; Hecate is a
+  local operator console.
+- Add unit tests and e2e tests for backend behavior changes.

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "internal/providers/**,internal/api/openai.go,internal/api/anthropic.go,internal/api/handler_messages.go,pkg/types/chat.go"
+---
+
+# Provider Boundary
+
+For provider work, read `internal/providers/AGENTS.md` and
+`docs-ai/skills/providers/SKILL.md` before editing.
+
+High-signal rules:
+
+- The API-side uppercase structs and provider-side lowercase structs are
+  intentionally duplicated. Do not unify them.
+- When adding a passthrough field, mirror the full chain across public types,
+  API structs, provider structs, both `Chat` and `ChatStream`, and tests.
+- Translate or explicitly drop unsupported cross-provider fields.
+- Seed capability caches in provider tests when discovery is not the behavior
+  under test.
+- Streaming paths need dedicated tests; non-stream tests do not prove streaming
+  wire plumbing works.

--- a/.github/instructions/tauri.instructions.md
+++ b/.github/instructions/tauri.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "tauri/**,scripts/stamp-version.ts,scripts/release.ts,docs/desktop-app.md"
+---
+
+# Tauri Desktop App
+
+For desktop work, read `docs-ai/skills/tauri/SKILL.md` before editing.
+
+High-signal rules:
+
+- The desktop app wraps the Go `hecate` sidecar and loads the embedded React UI
+  over loopback.
+- Keep sidecar naming, permissions, schemas, and version stamping in sync.
+- Do not bypass the sidecar lifecycle helpers or silently change startup/port
+  behavior.
+- Run the Rust/Tauri verification called for by the touched area, and report
+  any platform-specific checks you could not run.

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "ui/**"
+---
+
+# Operator UI
+
+For UI work, read `ui/AGENTS.md` and `docs-ai/skills/ui/SKILL.md` before
+editing.
+
+High-signal rules:
+
+- Build for an operator console: dense, calm, scannable workflows over
+  marketing-style composition.
+- Reuse existing primitives, design tokens, API helpers, and test setup.
+- Keep TypeScript mirrors in sync with Go API response shapes.
+- Hecate-native endpoints use `{object, data}` envelopes; UI clients should
+  read `payload.data`.
+- Verify with `cd ui && bun run typecheck && bun run test`; never use
+  `bun test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,15 @@ guidance live in [`docs-ai/`](docs-ai/README.md).
 
 ## Where guidance lives
 
-| Surface                                                               | What it carries                                                                                                                      |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`docs-ai/`](docs-ai/README.md)                                       | Canonical provider-neutral agent guidance — project context, conventions, workflow, verification, task shapes, area + posture skills |
-| `AGENTS.md` (this) and `ui/AGENTS.md`, `internal/providers/AGENTS.md` | Codebase map per area                                                                                                                |
-| [`CLAUDE.md`](CLAUDE.md)                                              | Claude Code compatibility shim importing `AGENTS.md`; no standalone rules                                                            |
-| [`docs-ai/skills/README.md`](docs-ai/skills/README.md)                | Canonical skill set used by every agent                                                                                              |
-| [`docs-ai/core/agent-guidance.md`](docs-ai/core/agent-guidance.md)    | Source-of-truth policy for keeping agent guidance provider-neutral                                                                   |
-| [`docs/`](docs/)                                                      | Long-form references (architecture, runtime API, events, telemetry)                                                                  |
+| Surface                                                                                                           | What it carries                                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [`docs-ai/`](docs-ai/README.md)                                                                                   | Canonical provider-neutral agent guidance — project context, conventions, workflow, verification, task shapes, area + posture skills |
+| `AGENTS.md` (this) and `ui/AGENTS.md`, `internal/providers/AGENTS.md`                                             | Codebase map per area                                                                                                                |
+| [`CLAUDE.md`](CLAUDE.md)                                                                                          | Claude Code compatibility shim importing `AGENTS.md`; no standalone rules                                                            |
+| [`.github/copilot-instructions.md`](.github/copilot-instructions.md) and `.github/instructions/*.instructions.md` | GitHub Copilot compatibility shims pointing back to `AGENTS.md` and `docs-ai/`                                                       |
+| [`docs-ai/skills/README.md`](docs-ai/skills/README.md)                                                            | Canonical skill set used by every agent                                                                                              |
+| [`docs-ai/core/agent-guidance.md`](docs-ai/core/agent-guidance.md)                                                | Source-of-truth policy for keeping agent guidance provider-neutral                                                                   |
+| [`docs/`](docs/)                                                                                                  | Long-form references (architecture, runtime API, events, telemetry)                                                                  |
 
 When in doubt: read [`docs-ai/core/project-context.md`](docs-ai/core/project-context.md) and [`docs-ai/core/workflow.md`](docs-ai/core/workflow.md).
 

--- a/docs-ai/core/agent-guidance.md
+++ b/docs-ai/core/agent-guidance.md
@@ -36,12 +36,14 @@ repo guidance.
 
 ## Current Adapters
 
-| Surface                        | Role                                                                       |
-| ------------------------------ | -------------------------------------------------------------------------- |
-| `AGENTS.md`                    | Root orientation and codebase map for agents that auto-load AGENTS files.  |
-| `ui/AGENTS.md`                 | UI directory map; points to `docs-ai/skills/ui/SKILL.md`.                  |
-| `internal/providers/AGENTS.md` | Provider package map; points to `docs-ai/skills/providers/SKILL.md`.       |
-| `CLAUDE.md`                    | Claude Code compatibility shim importing `AGENTS.md`; no standalone rules. |
+| Surface                                  | Role                                                                       |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `AGENTS.md`                              | Root orientation and codebase map for agents that auto-load AGENTS files.  |
+| `ui/AGENTS.md`                           | UI directory map; points to `docs-ai/skills/ui/SKILL.md`.                  |
+| `internal/providers/AGENTS.md`           | Provider package map; points to `docs-ai/skills/providers/SKILL.md`.       |
+| `CLAUDE.md`                              | Claude Code compatibility shim importing `AGENTS.md`; no standalone rules. |
+| `.github/copilot-instructions.md`        | GitHub Copilot repo-wide shim pointing back to `AGENTS.md` and `docs-ai/`. |
+| `.github/instructions/*.instructions.md` | GitHub Copilot path shims pointing to canonical `docs-ai/` skills.         |
 
 Local tool state files under directories such as `.claude/` or `.cursor/` may
 exist for per-machine permissions, sessions, or editor state. They are ignored
@@ -56,7 +58,9 @@ When adding or changing agent guidance:
 3. If a skill is added, moved, or removed, update
    [`../skills/README.md`](../skills/README.md) in the same change.
 4. Do not add tracked `.claude/` or `.cursor/` files.
-5. Run `just agent-docs-check` for adapter consistency.
-6. Run `just docs-format-check`; run `just check-links` when links changed.
+5. Keep GitHub Copilot shims short and path-scoped; they should point to
+   `docs-ai/`, not duplicate canonical skills.
+6. Run `just agent-docs-check` for adapter consistency.
+7. Run `just docs-format-check`; run `just check-links` when links changed.
 
 Agent-doc-only changes use the `chore(agent):` commit scope.

--- a/scripts/check-agent-docs.ts
+++ b/scripts/check-agent-docs.ts
@@ -26,10 +26,20 @@ if (forbidden.length > 0) {
   fail(`tracked provider-specific adapter files are not allowed:\n${forbidden.join("\n")}`);
 }
 
+const copilotInstructionFiles = [
+  ".github/instructions/agent-docs.instructions.md",
+  ".github/instructions/backend.instructions.md",
+  ".github/instructions/providers.instructions.md",
+  ".github/instructions/tauri.instructions.md",
+  ".github/instructions/ui.instructions.md",
+];
+
 const entrypoints = [
   "AGENTS.md",
   "ui/AGENTS.md",
   "internal/providers/AGENTS.md",
+  ".github/copilot-instructions.md",
+  ...copilotInstructionFiles,
   "docs-ai/README.md",
   "docs-ai/skills/README.md",
   "docs-ai/core/agent-guidance.md",
@@ -46,6 +56,19 @@ for (const file of entrypoints) {
 const claude = read("CLAUDE.md").trim();
 if (claude !== "@AGENTS.md") {
   fail("CLAUDE.md must be exactly @AGENTS.md");
+}
+
+const copilot = read(".github/copilot-instructions.md");
+if (copilot.includes("@AGENTS.md")) {
+  fail(".github/copilot-instructions.md must point to AGENTS.md in prose, not use @AGENTS.md import syntax");
+}
+
+for (const file of copilotInstructionFiles) {
+  const content = read(file);
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!frontmatter || !/^applyTo:\s*.+$/m.test(frontmatter[1])) {
+    fail(`${file} must declare applyTo frontmatter`);
+  }
 }
 
 const agentGuidance = read("docs-ai/core/agent-guidance.md");
@@ -65,5 +88,5 @@ for (const name of skillDirs) {
 }
 
 console.log(
-  `agent-docs-check: ${entrypoints.length} entrypoints and ${skillDirs.length} skills OK; no tracked .claude/.cursor adapters`,
+  `agent-docs-check: ${entrypoints.length} entrypoints, ${copilotInstructionFiles.length} Copilot path adapters, and ${skillDirs.length} skills OK; no tracked .claude/.cursor adapters`,
 );


### PR DESCRIPTION
## Summary

- add GitHub Copilot repo-wide and path-specific instruction shims
- keep `AGENTS.md` and `docs-ai/` as the canonical provider-neutral guidance layer
- extend `agent-docs-check` to validate Copilot adapters, `applyTo` frontmatter, and no `@AGENTS.md` import in Copilot instructions

## Validation

- `just agent-docs-check`
- `just docs-format-check`
- `just check-links`
- `git diff --cached --check`
