### PR TITLE
fix(ui): improve transcript activity readability

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1053,10 +1053,14 @@ test("agent chat previews failed tool stdout and stderr in Advanced details", as
   await page.getByText(/1 (failed )?tool/).click();
   await page.getByText("Advanced").first().click();
 
-  await expect(page.getByText(/Preview the related run output/)).toBeVisible();
+  await expect(page.getByText(/Preview the related run output/)).toHaveCount(0);
+  await page.getByText(/Output and artifacts/).click();
+  await expect(page.getByText("git-stdout.txt")).toBeVisible();
+  await page.getByText("Output", { exact: true }).first().click();
   await expect(page.getByText("On branch feature/chat-message-queue")).toBeVisible();
+  await expect(page.getByText("git-stderr.txt")).toBeVisible();
+  await page.getByText("Output", { exact: true }).nth(1).click();
   await expect(page.getByText("fatal: not a git repository")).toBeVisible();
-  await expect(page.getByText("Open task output")).toBeVisible();
   await expect(page.getByText("No output preview was captured for this snapshot.")).toHaveCount(0);
 });
 

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -207,26 +207,36 @@ export function ChatTranscript({
         onScroll={handleScroll}
         style={{ height: "100%", overflowY: "auto", padding: "16px 0" }}
       >
-        {transcriptItems.map((item) => {
-          if (item.type === "segment") {
-            return <ChatSegmentDivider key={item.key} segment={item.segment} />;
-          }
-          const m = item.message;
-          return (
-            <ChatTranscriptRow
-              key={item.key}
-              message={m}
-              isHecateAgentChat={isHecateAgentChat}
-              activeModel={activeChatSession?.model}
-              copied={copiedMsgId === m.id}
-              onCopy={handleCopy}
-              onOpenTask={handleOpenTask}
-              onOpenTrace={handleOpenTrace}
-              onOpenWorkspaceChanges={workspaceChangesHandler}
-              openExternalAgentSetup={handleOpenSetup}
-            />
-          );
-        })}
+        {(() => {
+          let latestUserPrompt = "";
+          return transcriptItems.map((item) => {
+            if (item.type === "segment") {
+              return <ChatSegmentDivider key={item.key} segment={item.segment} />;
+            }
+            const m = item.message;
+            const role = m.role === "assistant" ? "assistant" : "user";
+            const turnPrompt = role === "assistant" ? latestUserPrompt : undefined;
+            if (role === "user") {
+              latestUserPrompt = visibleMessageContent(m);
+            }
+            return (
+              <ChatTranscriptRow
+                key={item.key}
+                message={m}
+                isHecateAgentChat={isHecateAgentChat}
+                activeModel={activeChatSession?.model}
+                copied={copiedMsgId === m.id}
+                copiedDebug={copiedMsgId === `${m.id}:debug`}
+                turnPrompt={turnPrompt}
+                onCopy={handleCopy}
+                onOpenTask={handleOpenTask}
+                onOpenTrace={handleOpenTrace}
+                onOpenWorkspaceChanges={workspaceChangesHandler}
+                openExternalAgentSetup={handleOpenSetup}
+              />
+            );
+          });
+        })()}
 
         {/* Pending tool calls */}
         {pendingToolCalls.length > 0 && (
@@ -342,6 +352,8 @@ type ChatTranscriptRowProps = {
   isHecateAgentChat: boolean;
   activeModel?: string;
   copied: boolean;
+  copiedDebug: boolean;
+  turnPrompt?: string;
   onCopy: (id: string, text: string) => void;
   onOpenTask: (taskID: string, runID?: string) => void;
   onOpenTrace: (requestID: string) => void;
@@ -359,6 +371,8 @@ const ChatTranscriptRow = memo(function ChatTranscriptRow({
   isHecateAgentChat,
   activeModel,
   copied,
+  copiedDebug,
+  turnPrompt,
   onCopy,
   onOpenTask,
   onOpenTrace,
@@ -366,8 +380,7 @@ const ChatTranscriptRow = memo(function ChatTranscriptRow({
   openExternalAgentSetup,
 }: ChatTranscriptRowProps) {
   const role = m.role === "assistant" ? "assistant" : "user";
-  const content =
-    typeof m.content === "string" ? m.content : m.content === null ? "" : JSON.stringify(m.content);
+  const content = visibleMessageContent(m);
   const time = m.created_at
     ? new Date(m.created_at).toLocaleTimeString("en-US", {
         hour: "2-digit",
@@ -445,9 +458,17 @@ const ChatTranscriptRow = memo(function ChatTranscriptRow({
       setupAction={externalAgentSetupAction(role, m, openExternalAgentSetup)}
       onCopy={onCopy}
       copied={copied}
+      copiedDebug={copiedDebug}
+      turnPrompt={turnPrompt}
     />
   );
 });
+
+function visibleMessageContent(message: VisibleChatMessage): string {
+  if (typeof message.content === "string") return message.content;
+  if (message.content === null) return "";
+  return JSON.stringify(message.content);
+}
 
 export function buildTranscriptItems(
   messages: VisibleChatMessage[],

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -294,7 +294,7 @@ describe("TaskDetail runtime activity and patches", () => {
 
     expect(screen.getByText("Ran git")).toBeTruthy();
     expect(screen.getByText("Artifacts · 2 items")).toBeTruthy();
-    expect(screen.getAllByText("Workspace changes").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Workspace diff snapshot").length).toBeGreaterThan(0);
     expect(screen.getAllByText("git-changes.json").length).toBeGreaterThan(0);
     expect(screen.getByText("Final answer artifact")).toBeTruthy();
     expect(screen.getAllByText("agent-final-answer.txt").length).toBeGreaterThan(0);
@@ -348,8 +348,8 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText(/builtin\.agent_loop/)).toBeVisible();
   });
 
-  it("previews related stdout and stderr on failed tool advanced details", async () => {
-    const { render, user } = setup({
+  it("previews related stdout and stderr on failed tool advanced details", () => {
+    const { render } = setup({
       activity: [
         makeActivity({
           id: "activity-tool",
@@ -392,8 +392,6 @@ describe("TaskDetail runtime activity and patches", () => {
     render();
 
     expect(screen.getByText("Artifacts · 2 items")).toBeTruthy();
-    await user.click(screen.getAllByText("Advanced")[0]);
-
     expect(screen.getByText(/This tool failed/)).toBeTruthy();
     expect(screen.getByText("command")).toBeTruthy();
     expect(screen.getByText("git status")).toBeTruthy();
@@ -437,8 +435,8 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText(/nothing to commit/)).toBeTruthy();
   });
 
-  it("keeps empty stderr discoverable for failed tool diagnostics", async () => {
-    const { render, user } = setup({
+  it("keeps empty stderr discoverable for failed tool diagnostics", () => {
+    const { render } = setup({
       activity: [
         makeActivity({
           id: "activity-tool",
@@ -478,15 +476,13 @@ describe("TaskDetail runtime activity and patches", () => {
     });
     render();
 
-    await user.click(screen.getAllByText("Advanced")[0]);
-
     expect(screen.getByText("stdout notes")).toBeTruthy();
     expect(screen.getByText("shell-stderr.txt")).toBeTruthy();
     expect(screen.getByText("No bytes captured for this stream.")).toBeTruthy();
   });
 
-  it("shows missing output streams for failed tool diagnostics", async () => {
-    const { render, user } = setup({
+  it("shows missing output streams for failed tool diagnostics", () => {
+    const { render } = setup({
       activity: [
         makeActivity({
           id: "activity-tool",
@@ -502,8 +498,6 @@ describe("TaskDetail runtime activity and patches", () => {
     });
     render();
 
-    await user.click(screen.getAllByText("Advanced")[0]);
-
     expect(screen.getByText("git status")).toBeTruthy();
     expect(screen.getByText("128")).toBeTruthy();
     expect(
@@ -511,8 +505,8 @@ describe("TaskDetail runtime activity and patches", () => {
     ).toBeTruthy();
   });
 
-  it("does not show output from another step when a failed tool has no matching artifacts", async () => {
-    const { render, user } = setup({
+  it("does not show output from another step when a failed tool has no matching artifacts", () => {
+    const { render } = setup({
       activity: [
         makeActivity({
           id: "activity-tool",
@@ -541,16 +535,14 @@ describe("TaskDetail runtime activity and patches", () => {
     });
     render();
 
-    await user.click(screen.getAllByText("Advanced")[0]);
-
     expect(
       screen.getByText("No stdout or stderr artifacts were captured for this tool."),
     ).toBeTruthy();
     expect(screen.queryByText("unrelated output")).toBeNull();
   });
 
-  it("shows when a failed tool has stdout but no stderr artifact", async () => {
-    const { render, user } = setup({
+  it("shows when a failed tool has stdout but no stderr artifact", () => {
+    const { render } = setup({
       activity: [
         makeActivity({
           id: "activity-tool",
@@ -578,8 +570,6 @@ describe("TaskDetail runtime activity and patches", () => {
       ],
     });
     render();
-
-    await user.click(screen.getAllByText("Advanced")[0]);
 
     expect(screen.getByText("stdout only")).toBeTruthy();
     expect(screen.getByText("stderr artifact was not captured for this tool.")).toBeTruthy();

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -477,7 +477,7 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText(/cancelled · 2 interrupted tools/)).toBeInTheDocument();
   });
 
-  it("includes workspace changes in the summary without duplicating a timeline row", () => {
+  it("includes workspace diff snapshots in the summary without duplicating a timeline row", () => {
     const activities: ChatActivityRecord[] = [
       { type: "tool_call", title: "read_file", status: "completed" },
     ];
@@ -487,8 +487,8 @@ describe("TranscriptActivityTimeline", () => {
         diffStat="src/foo.ts | 3 +-\n1 file changed, 2 insertions(+), 1 deletion(-)"
       />,
     );
-    expect(screen.getByText(/workspace changes/)).toBeInTheDocument();
-    expect(screen.queryByText("Workspace changes")).toBeNull();
+    expect(screen.getByText(/workspace diff snapshot/)).toBeInTheDocument();
+    expect(screen.queryByText("Workspace diff snapshot")).toBeNull();
     expect(screen.queryByText("1 file changed, 2 insertions(+), 1 deletion(-)")).toBeNull();
   });
 
@@ -509,7 +509,7 @@ describe("TranscriptActivityTimeline", () => {
       />,
     );
 
-    expect(screen.queryByText("Workspace changes")).toBeNull();
+    expect(screen.queryByText("Workspace diff snapshot")).toBeNull();
     expect(screen.queryByText("2 files changed, 72 insertions(+), 3 deletions(-)")).toBeNull();
   });
 

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -141,7 +141,7 @@ export function TranscriptActivityTimeline({
           ? `${failedTools} failed tool${failedTools === 1 ? "" : "s"}`
           : `${tools.length} tool${tools.length === 1 ? "" : "s"}`
       : "",
-    diffStat ? "workspace changes" : "",
+    diffStat ? "workspace diff snapshot" : "",
   ]
     .filter(Boolean)
     .join(" · ");
@@ -223,6 +223,8 @@ function TimelineActivityLine({
 }) {
   const children = activity.children ?? [];
   const advancedContent = renderAdvancedActivity?.(activity);
+  const shouldAutoOpenAdvanced =
+    activity.type !== "tool_group" && activityEffectiveStatus(activity) === "failed";
   const line =
     activity.type === "plan" ? (
       <PlanActivityLine activity={activity} />
@@ -230,7 +232,10 @@ function TimelineActivityLine({
       <ActivityLine activity={activity} prefix={activityLinePrefix(activity)} />
     );
   const hasAdvanced = children.length > 0 || Boolean(advancedContent);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(shouldAutoOpenAdvanced);
+  useEffect(() => {
+    if (shouldAutoOpenAdvanced) setAdvancedOpen(true);
+  }, [shouldAutoOpenAdvanced]);
   if (!hasAdvanced) return line;
 
   return (
@@ -238,6 +243,7 @@ function TimelineActivityLine({
       {line}
       <details
         onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+        open={advancedOpen}
         style={{ marginLeft: 15 }}
       >
         <summary
@@ -320,7 +326,8 @@ function CommandGroupActivities({
 
 function advancedSummaryLabel(activity: ChatActivityRecord): string {
   if (activity.type === "tool_group" && (activity.children?.length ?? 0) > 0) return "Commands";
-  if (activity.type === "changed_files" || activity.type === "files_changed") return "Files";
+  if (activity.type === "changed_files" || activity.type === "files_changed")
+    return "Workspace diff";
   if (activity.type === "output") return "Output";
   if (activity.type === "artifact" && isOutputArtifactActivity(activity)) return "Output";
   if (

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -699,6 +699,46 @@ describe("TranscriptMessageRow", () => {
     expect(output.textContent).not.toContain(String.fromCharCode(27));
   });
 
+  it("preserves surrounding whitespace in copied raw command output", async () => {
+    const user = userEvent.setup();
+    const originalClipboard = navigator.clipboard;
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_shell",
+        status: "completed",
+        kind: "execute",
+        detail: "execute · output: wrapped",
+        artifact_preview: `\n  ${String.fromCharCode(27)}[32mraw line${String.fromCharCode(27)}[0m  \n`,
+      },
+    ];
+
+    try {
+      render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+      await user.click(screen.getByText("Output"));
+      await user.click(screen.getByRole("button", { name: "Show raw Tool output" }));
+
+      const output = screen.getByText(/raw line/);
+      expect(output.textContent).toContain("\n  raw line");
+      expect(output.textContent).not.toContain(String.fromCharCode(27));
+
+      const writeText = vi.fn(() => Promise.resolve());
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+
+      await user.click(screen.getByRole("button", { name: "Copy Tool output" }));
+      expect(writeText).toHaveBeenCalledWith("\n  raw line  \n");
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
+  });
+
   it("renders arrow-separated read-context output with real line breaks", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -318,8 +318,66 @@ describe("TranscriptMessageRow", () => {
     const onCopy = vi.fn();
     const user = userEvent.setup();
     render(<TranscriptMessageRow {...baseProps} onCopy={onCopy} />);
-    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button", { name: "Copy message" }));
     expect(onCopy).toHaveBeenCalledWith("m1", "hello");
+  });
+
+  it("copies a quiet turn debug bundle for assistant messages", async () => {
+    const onCopy = vi.fn();
+    const user = userEvent.setup();
+    const contextPacket: ChatContextPacketRecord = {
+      execution_mode: "external_agent",
+      provider: "grok",
+      model: "grok-build",
+      workspace: "/tmp/hecate",
+      message_count: 2,
+      sources: [
+        {
+          kind: "workspace",
+          label: "Workspace",
+          detail: "/tmp/hecate",
+          trust: "local",
+        },
+      ],
+    };
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_shell",
+        status: "completed",
+        kind: "execute",
+        detail: "execute",
+      },
+    ];
+
+    render(
+      <TranscriptMessageRow
+        {...baseProps}
+        activities={activities}
+        badge="completed"
+        contextPacket={contextPacket}
+        onCopy={onCopy}
+        runtimeMeta="Run run_123 · 2.0s"
+        runtimeMetaTitle="Run run_123 · Native session native_123"
+        taskLink={{ label: "Task task_123", onClick: vi.fn() }}
+        traceLink={{ label: "Trace req_1234", title: "request req_1234", onClick: vi.fn() }}
+        turnPrompt="What changed?"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy turn debug bundle" }));
+
+    expect(onCopy).toHaveBeenCalledWith(
+      "m1:debug",
+      expect.stringContaining("Prompt\nWhat changed?"),
+    );
+    const bundle = onCopy.mock.calls[0][1] as string;
+    expect(bundle).toContain("Response\nhello");
+    expect(bundle).toContain("trace: Trace req_1234 (request req_1234)");
+    expect(bundle).toContain("task: Task task_123");
+    expect(bundle).toContain("Activity\n[completed] tool_call Ran command");
+    expect(bundle).toContain("Context packet\n");
+    expect(bundle).toContain('"workspace": "/tmp/hecate"');
   });
 
   it("renders task and trace header links as compact debug actions", async () => {
@@ -430,7 +488,7 @@ describe("TranscriptMessageRow", () => {
     };
 
     render(<TranscriptMessageRow {...baseProps} contextPacket={contextPacket} />);
-    const summary = screen.getByText(/context · 3 messages · ollama · llama3\.1:8b/);
+    const summary = screen.getByText(/what the agent saw · 3 messages · ollama · llama3\.1:8b/);
     expect(summary).toBeInTheDocument();
 
     await user.click(summary);
@@ -479,9 +537,14 @@ describe("TranscriptMessageRow", () => {
       />,
     );
 
+    await user.click(screen.getByRole("button", { name: "Open Task task_123" }));
+    expect(onOpenTask).toHaveBeenCalledTimes(1);
+
     await user.click(screen.getByText(/1 failed tool/));
-    await user.click(screen.getByText("Advanced"));
-    expect(screen.getByText(/Preview the related run output/)).toBeInTheDocument();
+    await user.click(screen.getByText(/Output and artifacts · 2 items/));
+    for (const summary of screen.getAllByText("Output")) {
+      await user.click(summary);
+    }
     expect(
       [...container.querySelectorAll("pre")].some((node) =>
         node.textContent?.startsWith("  diff --git"),
@@ -489,8 +552,6 @@ describe("TranscriptMessageRow", () => {
     ).toBe(true);
     expect(screen.getByText(/\+hello/)).toBeInTheDocument();
     expect(screen.getByText("fatal: not a git repository")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Open task output" }));
-    expect(onOpenTask).toHaveBeenCalledTimes(1);
   });
 
   it("does not link empty stderr artifacts from failed tools", async () => {
@@ -529,7 +590,8 @@ describe("TranscriptMessageRow", () => {
     );
 
     await user.click(screen.getByText(/1 failed tool/));
-    await user.click(screen.getByText("Advanced"));
+    await user.click(screen.getByText(/Output and artifacts · 1 item/));
+    await user.click(screen.getByText("Output"));
     expect(screen.getByText("stdout details")).toBeInTheDocument();
     expect(screen.queryByText("Preview unavailable in this snapshot.")).toBeNull();
   });
@@ -706,6 +768,27 @@ describe("TranscriptMessageRow", () => {
     expect(output).not.toHaveTextContent(/\d+\s*\|/);
   });
 
+  it("strips box-drawing line gutters from read-context output", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_read",
+        status: "completed",
+        kind: "read",
+        detail: 'read · output: 1 │ <h1 align="center">\n2 │ <img src="docs/assets/brand.png">',
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    await user.click(screen.getByText("Output"));
+
+    const output = screen.getByText(/<h1 align="center">/);
+    expect(output.textContent).toContain('<h1 align="center">\n<img src="docs/assets/brand.png">');
+    expect(output).not.toHaveTextContent(/\d+\s*│/);
+  });
+
   it("does not duplicate captured diffs when the workspace-changes chip is available", () => {
     const diff = [
       "diff --git a/README.md b/README.md",
@@ -785,7 +868,7 @@ describe("TranscriptMessageRow", () => {
       />,
     );
 
-    const changesSummary = screen.getByText(/^workspace changes/);
+    const changesSummary = screen.getByText(/^workspace diff snapshot/);
     expect(changesSummary.tagName).toBe("SUMMARY");
     await user.click(changesSummary);
 

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type {
   ChatActivityRecord,
@@ -13,7 +13,11 @@ import { DiffViewer } from "../shared/DiffViewer";
 import { Icon, Icons } from "../shared/Icons";
 import { DiffStatList, TranscriptActivityTimeline } from "./TranscriptActivityTimeline";
 import { TranscriptMarkdown } from "./TranscriptMarkdown";
-import { capturedToolOutput } from "./transcriptActivityHelpers";
+import {
+  activityDisplay,
+  activityEffectiveStatus,
+  capturedToolOutput,
+} from "./transcriptActivityHelpers";
 
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
@@ -44,6 +48,8 @@ export function TranscriptMessageRow({
   setupAction,
   onCopy,
   copied,
+  turnPrompt,
+  copiedDebug,
 }: {
   id: string;
   role: "user" | "assistant";
@@ -77,6 +83,8 @@ export function TranscriptMessageRow({
   setupAction?: { label: string; title?: string; onClick: () => void };
   onCopy: (id: string, text: string) => void;
   copied: boolean;
+  turnPrompt?: string;
+  copiedDebug?: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
   const isAssistant = role === "assistant";
@@ -115,7 +123,7 @@ export function TranscriptMessageRow({
   const renderActivityAdvanced =
     isAssistant && visibleActivities?.length
       ? (activity: ChatActivityRecord) =>
-          renderAgentActivityAdvanced(activity, visibleActivities, {
+          renderAgentActivityAdvanced(activity, {
             taskLink,
             diffStat,
             diff,
@@ -210,10 +218,45 @@ export function TranscriptMessageRow({
                 transition: "opacity 0.15s",
               }}
             >
+              {isAssistant && (
+                <button
+                  aria-label="Copy turn debug bundle"
+                  className="btn btn-ghost btn-sm"
+                  title="Copy prompt, response, activity summary, trace, and context packet"
+                  style={{ padding: "2px 6px", gap: 4 }}
+                  onClick={() =>
+                    onCopy(
+                      `${id}:debug`,
+                      buildTurnDebugBundle({
+                        id,
+                        model,
+                        badge,
+                        content,
+                        turnPrompt,
+                        traceLabel: traceLink?.label,
+                        traceTitle: traceLink?.title,
+                        taskLabel: taskLink?.label,
+                        runtimeMeta,
+                        runtimeMetaTitle,
+                        diffStat,
+                        activities: visibleActivities,
+                        contextPacket,
+                        error,
+                      }),
+                    )
+                  }
+                  type="button"
+                >
+                  <Icon d={copiedDebug ? Icons.check : Icons.copy} size={12} />
+                  <span style={{ fontSize: 10 }}>debug</span>
+                </button>
+              )}
               <button
+                aria-label="Copy message"
                 className="btn btn-ghost btn-sm"
                 style={{ padding: "2px 6px", gap: 4 }}
                 onClick={() => onCopy(id, content)}
+                type="button"
               >
                 <Icon d={copied ? Icons.check : Icons.copy} size={12} />
               </button>
@@ -304,7 +347,6 @@ export function TranscriptMessageRow({
 
 function renderAgentActivityAdvanced(
   activity: ChatActivityRecord,
-  activities: ChatActivityRecord[],
   options: {
     taskLink?: { label: string; title?: string; onClick: () => void };
     diffStat?: string;
@@ -335,34 +377,24 @@ function renderAgentActivityAdvanced(
   }
 
   if (activity.type !== "tool_call" || activity.status !== "failed") return null;
-
-  const outputArtifacts = relatedOutputArtifacts(activities);
-  if (outputArtifacts.length === 0) return null;
+  if (!options.taskLink) return null;
 
   return (
     <div style={{ display: "grid", gap: 7 }}>
       <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.5 }}>
-        This tool failed. Preview the related run output here, or open the backing task for the full
-        capture.
+        This tool failed. Open the backing task for the full run output and approval history.
       </div>
-      <div style={{ display: "grid", gap: 7 }}>
-        {outputArtifacts.map((artifact) => (
-          <OutputArtifactPreview key={artifact.artifact_id || artifact.title} artifact={artifact} />
-        ))}
+      <div>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={options.taskLink.onClick}
+          title={`Open ${options.taskLink.label} output`}
+          style={{ fontSize: 10, padding: "2px 7px" }}
+        >
+          Open task output
+        </button>
       </div>
-      {options.taskLink && (
-        <div>
-          <button
-            type="button"
-            className="btn btn-ghost btn-sm"
-            onClick={options.taskLink.onClick}
-            title={`Open ${options.taskLink.label} output`}
-            style={{ fontSize: 10, padding: "2px 7px" }}
-          >
-            Open task output
-          </button>
-        </div>
-      )}
     </div>
   );
 }
@@ -398,7 +430,12 @@ function ActivityFilesPreview({
 }
 
 function ToolOutputPreview({ title, output }: { title: string; output: string }) {
-  const preview = normalizeToolOutputPreview(output);
+  const [showRaw, setShowRaw] = useState(false);
+  const [wrap, setWrap] = useState(true);
+  const prettyPreview = useMemo(() => normalizeToolOutputPreview(output), [output]);
+  const rawPreview = useMemo(() => normalizeRawToolOutput(output), [output]);
+  const preview = showRaw ? rawPreview : prettyPreview;
+  const copyLabel = `Copy ${title}`;
   return (
     <div
       style={{
@@ -410,14 +447,46 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
     >
       <div
         style={{
+          alignItems: "center",
           borderBottom: "1px solid var(--border)",
           color: "var(--t1)",
+          display: "flex",
+          gap: 8,
           fontFamily: "var(--font-mono)",
           fontSize: 10,
           padding: "4px 7px",
         }}
       >
-        {title}
+        <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{title}</span>
+        <div style={{ display: "flex", gap: 4, marginLeft: "auto" }}>
+          <button
+            aria-label={copyLabel}
+            className="btn btn-ghost btn-sm"
+            onClick={() => navigator.clipboard?.writeText(preview).catch(() => {})}
+            style={{ fontSize: 10, padding: "1px 6px" }}
+            type="button"
+          >
+            Copy
+          </button>
+          <button
+            aria-label={showRaw ? `Show cleaned ${title}` : `Show raw ${title}`}
+            className="btn btn-ghost btn-sm"
+            onClick={() => setShowRaw((current) => !current)}
+            style={{ fontSize: 10, padding: "1px 6px" }}
+            type="button"
+          >
+            {showRaw ? "Clean" : "Raw"}
+          </button>
+          <button
+            aria-label={wrap ? `Disable wrapping for ${title}` : `Wrap ${title}`}
+            className="btn btn-ghost btn-sm"
+            onClick={() => setWrap((current) => !current)}
+            style={{ fontSize: 10, padding: "1px 6px" }}
+            type="button"
+          >
+            {wrap ? "No wrap" : "Wrap"}
+          </button>
+        </div>
       </div>
       <pre
         style={{
@@ -429,7 +498,7 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
           maxHeight: 180,
           overflow: "auto",
           padding: "7px",
-          whiteSpace: "pre-wrap",
+          whiteSpace: wrap ? "pre-wrap" : "pre",
         }}
       >
         {preview}
@@ -439,24 +508,26 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
 }
 
 function normalizeToolOutputPreview(output: string): string {
-  const withoutAnsi = stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-
-  return stripLineNumberGutters(withoutAnsi)
+  return stripLineNumberGutters(normalizeRawToolOutput(output))
     .replace(/^\n+/, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 
+function normalizeRawToolOutput(output: string): string {
+  return stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+}
+
 function stripLineNumberGutters(output: string): string {
   if (!looksLikeLineNumberGutter(output)) return output;
   return output
-    .replace(/(^|\n)[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/g, "$1")
-    .replace(/[ \t]+\d{1,6}\s*(?:>|→|\|)\s*/g, "\n");
+    .replace(/(^|\n)[ \t]*\d{1,6}\s*(?:>|→|\||│)\s*/g, "$1")
+    .replace(/[ \t]+\d{1,6}\s*(?:>|→|\||│)\s*/g, "\n");
 }
 
 function looksLikeLineNumberGutter(output: string): boolean {
-  const matches = output.match(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\|)\s*/g) ?? [];
-  return matches.length > 1 || /^[ \t]*\d{1,6}\s*(?:>|→|\|)\s*/.test(output);
+  const matches = output.match(/(?:^|[ \t\n])\d{1,6}\s*(?:>|→|\||│)\s*/g) ?? [];
+  return matches.length > 1 || /^[ \t]*\d{1,6}\s*(?:>|→|\||│)\s*/.test(output);
 }
 
 function stripAnsi(value: string): string {
@@ -477,7 +548,7 @@ function CapturedDiffDetails({ diffStat, diff }: { diffStat?: string; diff?: str
           fontSize: 11,
         }}
       >
-        workspace changes{summary ? ` · ${summary}` : ""}
+        workspace diff snapshot{summary ? ` · ${summary}` : ""}
       </summary>
       <div style={{ display: "grid", gap: 7, marginTop: 6 }}>
         {stat && <DiffStatList diffStat={stat} />}
@@ -554,22 +625,6 @@ function OutputArtifactPreview({ artifact }: { artifact: ChatActivityRecord }) {
       )}
     </div>
   );
-}
-
-function relatedOutputArtifacts(activities: ChatActivityRecord[]): ChatActivityRecord[] {
-  const seen = new Set<string>();
-  const out: ChatActivityRecord[] = [];
-  for (const activity of activities) {
-    if (activity.type !== "artifact") continue;
-    if ((activity.artifact_size_bytes ?? 0) <= 0) continue;
-    const label = `${activity.title} ${activity.detail ?? ""} ${activity.kind ?? ""}`.toLowerCase();
-    if (!/\b(std(out|err)|git-std(out|err))\b/.test(label)) continue;
-    const key = activity.artifact_id || activity.title;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(activity);
-  }
-  return out;
 }
 
 function isOutputArtifactActivity(activity: ChatActivityRecord): boolean {
@@ -805,7 +860,7 @@ function ContextInspector({ packet }: { packet: ChatContextPacketRecord }) {
   const modelLabel = [packet.provider, packet.model].filter(Boolean).join(" · ");
   const sources = packet.sources ?? [];
   const summaryParts = [
-    "context",
+    "what the agent saw",
     packet.message_count
       ? `${packet.message_count} message${packet.message_count === 1 ? "" : "s"}`
       : "",
@@ -1033,4 +1088,68 @@ function formatLineCount(value: string): string {
   if (!trimmed) return "0 lines";
   const count = trimmed.split(/\r?\n/).length;
   return `${count} line${count === 1 ? "" : "s"}`;
+}
+
+function buildTurnDebugBundle(input: {
+  id: string;
+  model?: string;
+  badge?: string;
+  content: string;
+  turnPrompt?: string;
+  traceLabel?: string;
+  traceTitle?: string;
+  taskLabel?: string;
+  runtimeMeta?: string;
+  runtimeMetaTitle?: string;
+  diffStat?: string;
+  activities?: ChatActivityRecord[];
+  contextPacket?: ChatContextPacketRecord;
+  error?: string;
+}): string {
+  const sections: string[] = [];
+  const meta = [
+    `message: ${input.id}`,
+    input.model ? `model: ${input.model}` : "",
+    input.badge ? `status: ${input.badge}` : "",
+    input.taskLabel ? `task: ${input.taskLabel}` : "",
+    input.traceLabel
+      ? `trace: ${input.traceLabel}${input.traceTitle ? ` (${input.traceTitle})` : ""}`
+      : "",
+    input.runtimeMeta
+      ? `runtime: ${input.runtimeMeta}${input.runtimeMetaTitle ? ` (${input.runtimeMetaTitle})` : ""}`
+      : "",
+  ].filter(Boolean);
+  sections.push(["Turn", ...meta].join("\n"));
+  if (input.turnPrompt?.trim()) {
+    sections.push(`Prompt\n${input.turnPrompt.trim()}`);
+  }
+  if (input.content.trim()) {
+    sections.push(`Response\n${input.content.trim()}`);
+  }
+  if (input.error?.trim()) {
+    sections.push(`Error\n${input.error.trim()}`);
+  }
+  if (input.diffStat?.trim()) {
+    sections.push(`Workspace diff\n${input.diffStat.trim()}`);
+  }
+  if (input.activities?.length) {
+    sections.push(`Activity\n${input.activities.map(formatDebugActivity).join("\n")}`);
+  }
+  if (input.contextPacket && !contextPacketEmpty(input.contextPacket)) {
+    sections.push(`Context packet\n${JSON.stringify(input.contextPacket, null, 2)}`);
+  }
+  return `${sections.join("\n\n")}\n`;
+}
+
+function formatDebugActivity(activity: ChatActivityRecord): string {
+  const display = activityDisplay(activity);
+  const status = activityEffectiveStatus(activity);
+  return [
+    status ? `[${status}]` : "",
+    activity.type,
+    display.title,
+    display.detail ? `— ${display.detail}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 }

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -462,7 +462,9 @@ function ToolOutputPreview({ title, output }: { title: string; output: string })
           <button
             aria-label={copyLabel}
             className="btn btn-ghost btn-sm"
-            onClick={() => navigator.clipboard?.writeText(preview).catch(() => {})}
+            onClick={() => {
+              void navigator.clipboard?.writeText(preview)?.catch(() => {});
+            }}
             style={{ fontSize: 10, padding: "1px 6px" }}
             type="button"
           >
@@ -515,7 +517,7 @@ function normalizeToolOutputPreview(output: string): string {
 }
 
 function normalizeRawToolOutput(output: string): string {
-  return stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+  return stripAnsi(output).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 function stripLineNumberGutters(output: string): string {

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -350,6 +350,23 @@ describe("activityDisplay", () => {
     expect(capturedToolOutput(command)).toBe("total 88064 drwxr-xr-x@ 45 chicoxyzzy staff");
   });
 
+  it("keeps the command label while moving captured output into the preview", () => {
+    const command = activity({
+      type: "tool_call",
+      title: "call_shell",
+      status: "completed",
+      kind: "execute",
+      detail:
+        'execute · /bin/zsh -lc "ls -la" · output captured · total 88064 drwxr-xr-x@ 45 chicoxyzzy staff',
+    });
+
+    expect(activityDisplay(command)).toEqual({
+      title: "Ran command",
+      detail: '/bin/zsh -lc "ls -la"',
+    });
+    expect(capturedToolOutput(command)).toBe("total 88064 drwxr-xr-x@ 45 chicoxyzzy staff");
+  });
+
   it("uses adapter detail hints to humanize opaque external-agent tool ids", () => {
     expect(
       activityDisplay(
@@ -421,7 +438,7 @@ describe("activityDisplay", () => {
         activity({ type: "files_changed", title: "Files changed", detail: "2 files changed" }),
       ),
     ).toEqual({
-      title: "Workspace changes",
+      title: "Workspace diff snapshot",
       detail: "2 files changed",
     });
   });

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -267,7 +267,7 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
     return { title: "Thinking", detail: activity.detail };
   }
   if (activity.type === "files_changed") {
-    return { title: "Workspace changes", detail: activity.detail };
+    return { title: "Workspace diff snapshot", detail: activity.detail };
   }
   if (activity.type === "artifact") {
     return { title: "Artifact", detail: cleanActivityDetail(activity) || activity.title };
@@ -277,7 +277,7 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
   }
   if (activity.type === "changed_files") {
     return {
-      title: "Workspace changes",
+      title: "Workspace diff snapshot",
       detail: formatDiffStatSummary(cleanActivityDetail(activity) || activity.title),
     };
   }
@@ -452,10 +452,7 @@ function isAdapterContextReadFailure(activity: ChatActivityRecord): boolean {
 }
 
 function toolDetailHasOutput(activity: ChatActivityRecord): boolean {
-  return (
-    Boolean(capturedToolOutput(activity)) ||
-    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
-  );
+  return Boolean(capturedToolOutput(activity));
 }
 
 function hasFailureLikeToolOutput(activity: ChatActivityRecord): boolean {
@@ -474,19 +471,36 @@ function compactToolOutputDetail(detail: string): string | undefined {
   const { prefix, output } = parsed;
   if (/^failed to read file:/i.test(output)) return `${prefix} · read failed`;
   if (/^cannot read binary file:/i.test(output)) return `${prefix} · binary file skipped`;
-  return simpleToolOutputPrefix(prefix) ? undefined : prefix;
+  const compactPrefix = compactToolOutputPrefix(prefix);
+  return compactPrefix || undefined;
 }
 
 function simpleToolOutputPrefix(prefix: string): boolean {
   return /^(execute|read|write|edit|command|shell)$/i.test(prefix.trim());
 }
 
+function compactToolOutputPrefix(prefix: string): string | undefined {
+  const parts = prefix
+    .split(/\s*·\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1 && simpleToolOutputPrefix(parts[0])) return undefined;
+  if (parts.length > 1 && simpleToolOutputPrefix(parts[0])) {
+    return parts.slice(1).join(" · ") || undefined;
+  }
+  return parts.join(" · ");
+}
+
 function parseToolOutputDetail(detail: string): { prefix: string; output: string } | undefined {
-  const match = detail.match(/^(.+?)\s*·\s*output(?:\s+captured)?(?:\s*(?::|·)\s*|\s+)(.+)$/is);
-  if (!match) return undefined;
+  const marker = detail.match(/\s*·\s*output(?:\s+captured)?(?:\s*(?::|·)\s*|\s+)/i);
+  if (!marker || marker.index === undefined) return undefined;
+  const prefix = detail.slice(0, marker.index).trim();
+  const output = detail.slice(marker.index + marker[0].length).trim();
+  if (!prefix || !output) return undefined;
   return {
-    prefix: match[1].trim(),
-    output: match[2].trim(),
+    prefix,
+    output,
   };
 }
 

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -400,11 +400,12 @@ function toolActivityDetail(
 
 export function capturedToolOutput(activity: ChatActivityRecord): string | undefined {
   if (activity.type !== "tool_call") return undefined;
-  const preview = activity.artifact_preview?.trimEnd();
+  const preview = activity.artifact_preview;
+  const hasPreview = typeof preview === "string" && preview.trim().length > 0;
   const detail = activity.detail?.trim();
   const parsed = detail ? parseToolOutputDetail(detail)?.output : undefined;
-  if (preview && parsed) return parsed.length > preview.length ? parsed : preview;
-  return preview || parsed;
+  if (hasPreview && parsed) return parsed.length > preview.length ? parsed : preview;
+  return hasPreview ? preview : parsed;
 }
 
 function isThinkingToolActivity(activity: ChatActivityRecord): boolean {


### PR DESCRIPTION
## Summary

- Clean up transcript activity rows so noisy command output and workspace diff snapshots are easier to scan.
- Add readable tool/read output previews, failed-diagnostic auto-open behavior, and a quiet assistant debug-bundle copy action.
- Update transcript and task detail tests for the shared timeline behavior.

## Verification

```sh
cd ui
bun run lint
bun run format:check
bun run typecheck
bun run test
```

All UI checks passed locally.