### PR TITLE
Add project work coordination backend

### DIFF
--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/retention"
 	"github.com/hecatehq/hecate/internal/router"
@@ -196,6 +197,7 @@ func runServe() {
 	usageStore := buildUsageStore(cfg, logger, sqliteClient)
 	agentChatStore := buildAgentChatStore(cfg, logger, sqliteClient)
 	projectStore := buildProjectStore(cfg, logger, sqliteClient)
+	projectWorkStore := buildProjectWorkStore(cfg, logger, sqliteClient)
 	// Approval state follows HECATE_BACKEND so chat transcripts, grants,
 	// and pending approval rows move together across memory/sqlite modes.
 	// Startup reconcile fires before the gateway accepts any request:
@@ -264,6 +266,7 @@ func runServe() {
 	handler := api.NewHandler(cfg, logger, service, controlPlaneStore, taskStore, taskQueue, providerRuntime)
 	handler.SetAgentChatStore(agentChatStore)
 	handler.SetProjectStore(projectStore)
+	handler.SetProjectWorkStore(projectWorkStore)
 	handler.SetAgentApprovalStore(approvalStore)
 	handler.SetStateCleaner(sqliteClient)
 	// Wire the cipher into the handler and its underlying runner so MCP
@@ -715,6 +718,20 @@ func buildProjectStore(cfg config.Config, logger *slog.Logger, sqliteClient *sto
 		return store
 	default:
 		return projects.NewMemoryStore()
+	}
+}
+
+func buildProjectWorkStore(cfg config.Config, logger *slog.Logger, sqliteClient *storage.SQLiteClient) projectwork.Store {
+	switch cfg.Projects.Backend {
+	case "sqlite":
+		store, err := projectwork.NewSQLiteStore(context.Background(), sqliteClient)
+		if err != nil {
+			logger.Error("project work store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	default:
+		return projectwork.NewMemoryStore()
 	}
 }
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1189,6 +1189,8 @@ orchestration. It records project-scoped agent roles, work items, assignment
 metadata, and collaboration artifacts. It does not add a new execution runtime:
 existing Tasks and Chats remain the execution surfaces, and V1 assignment
 creation only records intended or already-linked execution metadata.
+Create requests that supply an existing project-scoped ID return `409 conflict`
+instead of overwriting the existing record.
 
 Role list responses merge built-in roles with project custom roles. Built-ins
 are listable but immutable and are not seeded as duplicate project rows. The

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -432,7 +432,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project work-coordination rows, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -440,6 +440,7 @@ Tool names come back un-namespaced — the operator wants to see what the upstre
   "object": "system_reset",
   "data": {
     "projects_deleted": 1,
+    "project_work_rows_deleted": 3,
     "chat_sessions_deleted": 2,
     "tasks_deleted": 1,
     "providers_deleted": 1,
@@ -1026,15 +1027,19 @@ can remember one or more concrete workspace roots and future defaults such as
 provider, model, agent profile, tools posture, workspace mode, system prompt,
 compact command-output preference, and trusted context-source metadata.
 
-This first implementation is intentionally lightweight:
+The project catalog implementation is intentionally lightweight:
 `GET`/`POST`/`PATCH`/`DELETE /hecate/v1/projects` work, and
 `HECATE_BACKEND=sqlite` persists them. Chat sessions can carry an optional
 `project_id` so the operator UI can group history by project. Projects can
 also remember context-source metadata (`path`, `kind`, `title`, and whether the
 source is enabled). Chat message context packets include enabled sources as
 itemized `workspace_guidance` metadata for inspection, but Hecate does not
-inject those files into prompts yet. Tasks, memory, profiles, presets, and
-source-content injection are not linked to `project_id` yet.
+inject those files into prompts yet. Project work-coordination endpoints can
+persist roles, work items, assignments, and collaboration artifacts under a
+project. Assignments may record links to existing task runs or chat messages,
+but creating an assignment does not start a task, open a chat, inject context,
+or dispatch any agent. Durable memory, profiles, presets, and source-content
+injection are not linked to `project_id` yet.
 
 ### `GET /hecate/v1/projects`
 
@@ -1171,8 +1176,212 @@ PATCH /hecate/v1/projects/proj_...
 ### `DELETE /hecate/v1/projects/{id}`
 
 Deletes the project catalog entry, its roots, and chat sessions scoped to that
-project. This does not delete workspace files. Unprojected chats and chats
-scoped to other projects stay untouched. Tasks are not linked to projects yet.
+project. It also deletes project work-coordination rows for that project. This
+does not delete workspace files. Unprojected chats and chats scoped to other
+projects stay untouched. Assignment links to task/chat IDs are metadata only;
+the linked tasks or unprojected chat sessions are not deleted through assignment
+cleanup.
+
+### Project Work Coordination
+
+Project work coordination is the durable substrate for future project-team
+orchestration. It records project-scoped agent roles, work items, assignment
+metadata, and collaboration artifacts. It does not add a new execution runtime:
+existing Tasks and Chats remain the execution surfaces, and V1 assignment
+creation only records intended or already-linked execution metadata.
+
+Role list responses merge built-in roles with project custom roles. Built-ins
+are listable but immutable and are not seeded as duplicate project rows. The
+built-in IDs are:
+
+```text
+product_manager
+architect
+software_developer
+frontend_engineer
+designer
+sre
+tech_writer
+reviewer_qa
+```
+
+Supported work-item statuses are `backlog`, `ready`, `running`, `review`,
+`blocked`, `done`, and `cancelled`. Supported assignment statuses are `queued`,
+`running`, `awaiting_approval`, `completed`, `failed`, and `cancelled`.
+Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
+`decision_note`.
+
+#### `GET /hecate/v1/projects/{id}/roles`
+
+Lists built-in roles plus custom roles for the project.
+
+```json
+{
+  "object": "project_roles",
+  "data": [
+    {
+      "id": "architect",
+      "project_id": "proj_...",
+      "name": "Architect",
+      "description": "Owns technical direction, boundaries, and system trade-offs.",
+      "built_in": true
+    },
+    {
+      "id": "role_...",
+      "project_id": "proj_...",
+      "name": "Release captain",
+      "description": "Coordinates release work.",
+      "instructions": "Keep release notes current.",
+      "built_in": false,
+      "created_at": "2026-06-03T12:00:00Z",
+      "updated_at": "2026-06-03T12:00:00Z"
+    }
+  ]
+}
+```
+
+#### `POST /hecate/v1/projects/{id}/roles`
+
+Creates a custom role. `name` is required. `id` is optional; Hecate generates a
+`role_...` ID when omitted. Built-in role IDs cannot be created, updated, or
+deleted as custom roles.
+
+```json
+{
+  "name": "Release captain",
+  "description": "Coordinates release work.",
+  "instructions": "Keep release notes current."
+}
+```
+
+Returns `{ "object": "project_role", "data": { ... } }`.
+
+#### `PATCH /hecate/v1/projects/{id}/roles/{role_id}`
+
+Updates a custom role's `name`, `description`, or `instructions`. Built-in
+roles return `409 conflict`.
+
+#### `DELETE /hecate/v1/projects/{id}/roles/{role_id}`
+
+Deletes a custom role. Built-in roles return `409 conflict`.
+
+#### `GET /hecate/v1/projects/{id}/work-items`
+
+Lists work items for the project.
+
+#### `POST /hecate/v1/projects/{id}/work-items`
+
+Creates a project-scoped work item. `title` is required. `status` defaults to
+`backlog`; `priority` defaults to `normal` and accepts `low`, `normal`, `high`,
+or `urgent`.
+
+```json
+{
+  "title": "Backend substrate",
+  "brief": "Persist coordination metadata only.",
+  "status": "ready",
+  "priority": "high",
+  "owner_role_id": "software_developer",
+  "reviewer_role_ids": ["architect", "reviewer_qa"]
+}
+```
+
+Returns:
+
+```json
+{
+  "object": "project_work_item",
+  "data": {
+    "id": "work_...",
+    "project_id": "proj_...",
+    "title": "Backend substrate",
+    "brief": "Persist coordination metadata only.",
+    "status": "ready",
+    "priority": "high",
+    "owner_role_id": "software_developer",
+    "reviewer_role_ids": ["architect", "reviewer_qa"],
+    "created_at": "2026-06-03T12:00:00Z",
+    "updated_at": "2026-06-03T12:00:00Z"
+  }
+}
+```
+
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}`
+
+Returns one work item or `404 not_found`.
+
+#### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}`
+
+Updates `title`, `brief`, `status`, `priority`, `owner_role_id`, or
+`reviewer_role_ids`.
+
+#### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}`
+
+Deletes the work item and its assignments and collaboration artifacts.
+
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
+
+Lists assignment metadata for a work item.
+
+#### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
+
+Creates an assignment metadata record. `role_id` is required. Optional link
+fields (`task_id`, `run_id`, `chat_session_id`, `message_id`,
+`context_snapshot_id`) are stored as references only.
+
+```json
+{
+  "role_id": "software_developer",
+  "task_id": "task_...",
+  "run_id": "run_...",
+  "context_snapshot_id": "ctx_..."
+}
+```
+
+Returns:
+
+```json
+{
+  "object": "project_assignment",
+  "data": {
+    "id": "asgn_...",
+    "project_id": "proj_...",
+    "work_item_id": "work_...",
+    "role_id": "software_developer",
+    "status": "queued",
+    "task_id": "task_...",
+    "run_id": "run_...",
+    "context_snapshot_id": "ctx_...",
+    "created_at": "2026-06-03T12:00:00Z",
+    "updated_at": "2026-06-03T12:00:00Z"
+  }
+}
+```
+
+#### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}`
+
+Updates assignment status, role, link fields, `started_at`, or `completed_at`.
+It does not mutate or start the linked Task or Chat.
+
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
+
+Lists collaboration artifacts attached to a work item.
+
+#### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
+
+Creates a collaboration artifact. `kind` and `body` are required.
+`assignment_id` is optional; when supplied it must refer to an assignment on
+the same work item.
+
+```json
+{
+  "kind": "handoff",
+  "assignment_id": "asgn_...",
+  "title": "Backend handoff",
+  "body": "Store and API are ready for UI wiring.",
+  "author_role_id": "software_developer"
+}
+```
 
 ## Chat session endpoints
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/ratelimit"
 	"github.com/hecatehq/hecate/internal/sandbox"
 	"github.com/hecatehq/hecate/internal/secrets"
@@ -41,6 +42,7 @@ type Handler struct {
 	tracer                   profiler.Tracer
 	agentChat                chat.Store
 	projects                 projects.Store
+	projectWork              projectwork.Store
 	agentChatRunner          agentadapters.Runner
 	agentChatLive            *agentChatLive
 	agentChatIdleSweepCancel context.CancelFunc
@@ -307,6 +309,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		rateLimiter:         rl,
 		agentChat:           chat.NewMemoryStore(),
 		projects:            projects.NewMemoryStore(),
+		projectWork:         projectwork.NewMemoryStore(),
 		agentChatRunner:     agentChatRunner,
 		agentChatLive:       agentChatLive,
 		orchestratorMetrics: orchestratorMetrics,
@@ -377,6 +380,13 @@ func (h *Handler) SetProjectStore(store projects.Store) {
 		return
 	}
 	h.projects = store
+}
+
+func (h *Handler) SetProjectWorkStore(store projectwork.Store) {
+	if store == nil {
+		return
+	}
+	h.projectWork = store
 }
 
 func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -568,7 +568,7 @@ func writeProjectWorkError(w http.ResponseWriter, err error) bool {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
 	case errors.Is(err, projectwork.ErrInvalid):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	case errors.Is(err, projectwork.ErrBuiltInRole), errors.Is(err, projectwork.ErrDuplicateRole):
+	case errors.Is(err, projectwork.ErrBuiltInRole), errors.Is(err, projectwork.ErrDuplicateRole), errors.Is(err, projectwork.ErrDuplicate):
 		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
 	default:
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1,0 +1,687 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type createProjectWorkRoleRequest struct {
+	ID           string `json:"id,omitempty"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	Instructions string `json:"instructions,omitempty"`
+}
+
+type updateProjectWorkRoleRequest struct {
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	Instructions *string `json:"instructions,omitempty"`
+}
+
+type createProjectWorkItemRequest struct {
+	ID              string   `json:"id,omitempty"`
+	Title           string   `json:"title"`
+	Brief           string   `json:"brief,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	Priority        string   `json:"priority,omitempty"`
+	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+}
+
+type updateProjectWorkItemRequest struct {
+	Title           *string   `json:"title,omitempty"`
+	Brief           *string   `json:"brief,omitempty"`
+	Status          *string   `json:"status,omitempty"`
+	Priority        *string   `json:"priority,omitempty"`
+	OwnerRoleID     *string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs *[]string `json:"reviewer_role_ids,omitempty"`
+}
+
+type createProjectWorkAssignmentRequest struct {
+	ID                string `json:"id,omitempty"`
+	RoleID            string `json:"role_id"`
+	Status            string `json:"status,omitempty"`
+	TaskID            string `json:"task_id,omitempty"`
+	RunID             string `json:"run_id,omitempty"`
+	ChatSessionID     string `json:"chat_session_id,omitempty"`
+	MessageID         string `json:"message_id,omitempty"`
+	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
+	StartedAt         string `json:"started_at,omitempty"`
+	CompletedAt       string `json:"completed_at,omitempty"`
+}
+
+type updateProjectWorkAssignmentRequest struct {
+	RoleID            *string `json:"role_id,omitempty"`
+	Status            *string `json:"status,omitempty"`
+	TaskID            *string `json:"task_id,omitempty"`
+	RunID             *string `json:"run_id,omitempty"`
+	ChatSessionID     *string `json:"chat_session_id,omitempty"`
+	MessageID         *string `json:"message_id,omitempty"`
+	ContextSnapshotID *string `json:"context_snapshot_id,omitempty"`
+	StartedAt         *string `json:"started_at,omitempty"`
+	CompletedAt       *string `json:"completed_at,omitempty"`
+}
+
+type createProjectWorkArtifactRequest struct {
+	ID           string `json:"id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	Kind         string `json:"kind"`
+	Title        string `json:"title,omitempty"`
+	Body         string `json:"body"`
+	AuthorRoleID string `json:"author_role_id,omitempty"`
+}
+
+type ProjectWorkRolesResponse struct {
+	Object string                    `json:"object"`
+	Data   []ProjectWorkRoleResponse `json:"data"`
+}
+
+type ProjectWorkRoleResponse struct {
+	ID           string `json:"id"`
+	ProjectID    string `json:"project_id"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	Instructions string `json:"instructions,omitempty"`
+	BuiltIn      bool   `json:"built_in"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+type ProjectWorkRoleEnvelope struct {
+	Object string                  `json:"object"`
+	Data   ProjectWorkRoleResponse `json:"data"`
+}
+
+type ProjectWorkItemsResponse struct {
+	Object string                    `json:"object"`
+	Data   []ProjectWorkItemResponse `json:"data"`
+}
+
+type ProjectWorkItemEnvelope struct {
+	Object string                  `json:"object"`
+	Data   ProjectWorkItemResponse `json:"data"`
+}
+
+type ProjectWorkItemResponse struct {
+	ID              string   `json:"id"`
+	ProjectID       string   `json:"project_id"`
+	Title           string   `json:"title"`
+	Brief           string   `json:"brief,omitempty"`
+	Status          string   `json:"status"`
+	Priority        string   `json:"priority"`
+	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+	CreatedAt       string   `json:"created_at"`
+	UpdatedAt       string   `json:"updated_at"`
+}
+
+type ProjectWorkAssignmentsResponse struct {
+	Object string                          `json:"object"`
+	Data   []ProjectWorkAssignmentResponse `json:"data"`
+}
+
+type ProjectWorkAssignmentEnvelope struct {
+	Object string                        `json:"object"`
+	Data   ProjectWorkAssignmentResponse `json:"data"`
+}
+
+type ProjectWorkAssignmentResponse struct {
+	ID                string `json:"id"`
+	ProjectID         string `json:"project_id"`
+	WorkItemID        string `json:"work_item_id"`
+	RoleID            string `json:"role_id"`
+	Status            string `json:"status"`
+	TaskID            string `json:"task_id,omitempty"`
+	RunID             string `json:"run_id,omitempty"`
+	ChatSessionID     string `json:"chat_session_id,omitempty"`
+	MessageID         string `json:"message_id,omitempty"`
+	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+	StartedAt         string `json:"started_at,omitempty"`
+	CompletedAt       string `json:"completed_at,omitempty"`
+}
+
+type ProjectWorkArtifactsResponse struct {
+	Object string                        `json:"object"`
+	Data   []ProjectWorkArtifactResponse `json:"data"`
+}
+
+type ProjectWorkArtifactEnvelope struct {
+	Object string                      `json:"object"`
+	Data   ProjectWorkArtifactResponse `json:"data"`
+}
+
+type ProjectWorkArtifactResponse struct {
+	ID           string `json:"id"`
+	ProjectID    string `json:"project_id"`
+	WorkItemID   string `json:"work_item_id"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	Kind         string `json:"kind"`
+	Title        string `json:"title,omitempty"`
+	Body         string `json:"body"`
+	AuthorRoleID string `json:"author_role_id,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+func (h *Handler) HandleProjectWorkRoles(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	roles, err := h.projectWork.ListRoles(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	data := make([]ProjectWorkRoleResponse, 0, len(roles))
+	for _, role := range roles {
+		data = append(data, renderProjectWorkRole(role))
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkRolesResponse{Object: "project_roles", Data: data})
+}
+
+func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	var req createProjectWorkRoleRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = newOpaqueTaskResourceID("role")
+	}
+	role, err := h.projectWork.CreateRole(r.Context(), projectwork.AgentRoleProfile{
+		ID:           id,
+		ProjectID:    projectID,
+		Name:         req.Name,
+		Description:  req.Description,
+		Instructions: req.Instructions,
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
+}
+
+func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	var req updateProjectWorkRoleRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	role, err := h.projectWork.UpdateRole(r.Context(), projectID, r.PathValue("role_id"), func(item *projectwork.AgentRoleProfile) {
+		if req.Name != nil {
+			item.Name = *req.Name
+		}
+		if req.Description != nil {
+			item.Description = *req.Description
+		}
+		if req.Instructions != nil {
+			item.Instructions = *req.Instructions
+		}
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
+}
+
+func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	if err := h.projectWork.DeleteRole(r.Context(), projectID, r.PathValue("role_id")); !writeProjectWorkError(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) HandleProjectWorkItems(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	items, err := h.projectWork.ListWorkItems(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	data := make([]ProjectWorkItemResponse, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProjectWorkItem(item))
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemsResponse{Object: "project_work_items", Data: data})
+}
+
+func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	var req createProjectWorkItemRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = newOpaqueTaskResourceID("work")
+	}
+	item, err := h.projectWork.CreateWorkItem(r.Context(), projectwork.WorkItem{
+		ID:              id,
+		ProjectID:       projectID,
+		Title:           req.Title,
+		Brief:           req.Brief,
+		Status:          req.Status,
+		Priority:        req.Priority,
+		OwnerRoleID:     req.OwnerRoleID,
+		ReviewerRoleIDs: req.ReviewerRoleIDs,
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+}
+
+func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	item, ok, err := h.projectWork.GetWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+}
+
+func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	var req updateProjectWorkItemRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	item, err := h.projectWork.UpdateWorkItem(r.Context(), projectID, r.PathValue("work_item_id"), func(item *projectwork.WorkItem) {
+		if req.Title != nil {
+			item.Title = *req.Title
+		}
+		if req.Brief != nil {
+			item.Brief = *req.Brief
+		}
+		if req.Status != nil {
+			item.Status = *req.Status
+		}
+		if req.Priority != nil {
+			item.Priority = *req.Priority
+		}
+		if req.OwnerRoleID != nil {
+			item.OwnerRoleID = *req.OwnerRoleID
+		}
+		if req.ReviewerRoleIDs != nil {
+			item.ReviewerRoleIDs = *req.ReviewerRoleIDs
+		}
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+}
+
+func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	if err := h.projectWork.DeleteWorkItem(r.Context(), projectID, r.PathValue("work_item_id")); !writeProjectWorkError(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	items, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	data := make([]ProjectWorkAssignmentResponse, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProjectWorkAssignment(item))
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})
+}
+
+func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	var req createProjectWorkAssignmentRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	startedAt, completedAt, ok := parseProjectWorkRequestTimes(w, req.StartedAt, req.CompletedAt)
+	if !ok {
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = newOpaqueTaskResourceID("asgn")
+	}
+	item, err := h.projectWork.CreateAssignment(r.Context(), projectwork.Assignment{
+		ID:                id,
+		ProjectID:         projectID,
+		WorkItemID:        workItemID,
+		RoleID:            req.RoleID,
+		Status:            req.Status,
+		TaskID:            req.TaskID,
+		RunID:             req.RunID,
+		ChatSessionID:     req.ChatSessionID,
+		MessageID:         req.MessageID,
+		ContextSnapshotID: req.ContextSnapshotID,
+		StartedAt:         startedAt,
+		CompletedAt:       completedAt,
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(item)})
+}
+
+func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	assignmentID := r.PathValue("assignment_id")
+	if !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
+		return
+	}
+	var req updateProjectWorkAssignmentRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	startedAt, completedAt, ok := parseProjectWorkOptionalRequestTimes(w, req.StartedAt, req.CompletedAt)
+	if !ok {
+		return
+	}
+	item, err := h.projectWork.UpdateAssignment(r.Context(), projectID, assignmentID, func(item *projectwork.Assignment) {
+		if req.RoleID != nil {
+			item.RoleID = *req.RoleID
+		}
+		if req.Status != nil {
+			item.Status = *req.Status
+		}
+		if req.TaskID != nil {
+			item.TaskID = *req.TaskID
+		}
+		if req.RunID != nil {
+			item.RunID = *req.RunID
+		}
+		if req.ChatSessionID != nil {
+			item.ChatSessionID = *req.ChatSessionID
+		}
+		if req.MessageID != nil {
+			item.MessageID = *req.MessageID
+		}
+		if req.ContextSnapshotID != nil {
+			item.ContextSnapshotID = *req.ContextSnapshotID
+		}
+		if req.StartedAt != nil {
+			item.StartedAt = startedAt
+		}
+		if req.CompletedAt != nil {
+			item.CompletedAt = completedAt
+		}
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(item)})
+}
+
+func (h *Handler) HandleProjectWorkArtifacts(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	items, err := h.projectWork.ListArtifacts(r.Context(), projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	data := make([]ProjectWorkArtifactResponse, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProjectWorkArtifact(item))
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkArtifactsResponse{Object: "project_collaboration_artifacts", Data: data})
+}
+
+func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	var req createProjectWorkArtifactRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = newOpaqueTaskResourceID("art")
+	}
+	item, err := h.projectWork.CreateArtifact(r.Context(), projectwork.CollaborationArtifact{
+		ID:           id,
+		ProjectID:    projectID,
+		WorkItemID:   workItemID,
+		AssignmentID: req.AssignmentID,
+		Kind:         req.Kind,
+		Title:        req.Title,
+		Body:         req.Body,
+		AuthorRoleID: req.AuthorRoleID,
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkArtifactEnvelope{Object: "project_collaboration_artifact", Data: renderProjectWorkArtifact(item)})
+}
+
+func (h *Handler) requireProject(w http.ResponseWriter, r *http.Request, projectID string) bool {
+	_, ok, err := h.projects.Get(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return false
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return false
+	}
+	return true
+}
+
+func (h *Handler) requireProjectWorkItem(w http.ResponseWriter, r *http.Request, projectID, workItemID string) bool {
+	if !h.requireProject(w, r, projectID) {
+		return false
+	}
+	_, ok, err := h.projectWork.GetWorkItem(r.Context(), projectID, workItemID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return false
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+		return false
+	}
+	return true
+}
+
+func (h *Handler) requireProjectAssignment(w http.ResponseWriter, r *http.Request, projectID, workItemID, assignmentID string) bool {
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return false
+	}
+	assignments, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return false
+	}
+	for _, item := range assignments {
+		if item.ID == assignmentID {
+			return true
+		}
+	}
+	WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment not found")
+	return false
+}
+
+func writeProjectWorkError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return true
+	}
+	switch {
+	case errors.Is(err, projectwork.ErrNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
+	case errors.Is(err, projectwork.ErrInvalid):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, projectwork.ErrBuiltInRole), errors.Is(err, projectwork.ErrDuplicateRole):
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+	default:
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	}
+	return false
+}
+
+func parseProjectWorkRequestTimes(w http.ResponseWriter, startedRaw, completedRaw string) (time.Time, time.Time, bool) {
+	startedAt, err := parseOptionalProjectWorkTime(startedRaw, "started_at")
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return time.Time{}, time.Time{}, false
+	}
+	completedAt, err := parseOptionalProjectWorkTime(completedRaw, "completed_at")
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return time.Time{}, time.Time{}, false
+	}
+	return startedAt, completedAt, true
+}
+
+func parseProjectWorkOptionalRequestTimes(w http.ResponseWriter, startedRaw, completedRaw *string) (time.Time, time.Time, bool) {
+	var startedAt time.Time
+	var completedAt time.Time
+	if startedRaw != nil {
+		parsed, err := parseOptionalProjectWorkTime(*startedRaw, "started_at")
+		if err != nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return time.Time{}, time.Time{}, false
+		}
+		startedAt = parsed
+	}
+	if completedRaw != nil {
+		parsed, err := parseOptionalProjectWorkTime(*completedRaw, "completed_at")
+		if err != nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return time.Time{}, time.Time{}, false
+		}
+		completedAt = parsed
+	}
+	return startedAt, completedAt, true
+}
+
+func parseOptionalProjectWorkTime(value, field string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, errors.New(field + " must be RFC3339 timestamp")
+	}
+	return parsed.UTC(), nil
+}
+
+func renderProjectWorkRole(item projectwork.AgentRoleProfile) ProjectWorkRoleResponse {
+	return ProjectWorkRoleResponse{
+		ID:           item.ID,
+		ProjectID:    item.ProjectID,
+		Name:         item.Name,
+		Description:  item.Description,
+		Instructions: item.Instructions,
+		BuiltIn:      item.BuiltIn,
+		CreatedAt:    formatOptionalTime(item.CreatedAt),
+		UpdatedAt:    formatOptionalTime(item.UpdatedAt),
+	}
+}
+
+func renderProjectWorkItem(item projectwork.WorkItem) ProjectWorkItemResponse {
+	return ProjectWorkItemResponse{
+		ID:              item.ID,
+		ProjectID:       item.ProjectID,
+		Title:           item.Title,
+		Brief:           item.Brief,
+		Status:          item.Status,
+		Priority:        item.Priority,
+		OwnerRoleID:     item.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
+		CreatedAt:       formatOptionalTime(item.CreatedAt),
+		UpdatedAt:       formatOptionalTime(item.UpdatedAt),
+	}
+}
+
+func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignmentResponse {
+	return ProjectWorkAssignmentResponse{
+		ID:                item.ID,
+		ProjectID:         item.ProjectID,
+		WorkItemID:        item.WorkItemID,
+		RoleID:            item.RoleID,
+		Status:            item.Status,
+		TaskID:            item.TaskID,
+		RunID:             item.RunID,
+		ChatSessionID:     item.ChatSessionID,
+		MessageID:         item.MessageID,
+		ContextSnapshotID: item.ContextSnapshotID,
+		CreatedAt:         formatOptionalTime(item.CreatedAt),
+		UpdatedAt:         formatOptionalTime(item.UpdatedAt),
+		StartedAt:         formatOptionalTime(item.StartedAt),
+		CompletedAt:       formatOptionalTime(item.CompletedAt),
+	}
+}
+
+func renderProjectWorkArtifact(item projectwork.CollaborationArtifact) ProjectWorkArtifactResponse {
+	return ProjectWorkArtifactResponse{
+		ID:           item.ID,
+		ProjectID:    item.ProjectID,
+		WorkItemID:   item.WorkItemID,
+		AssignmentID: item.AssignmentID,
+		Kind:         item.Kind,
+		Title:        item.Title,
+		Body:         item.Body,
+		AuthorRoleID: item.AuthorRoleID,
+		CreatedAt:    formatOptionalTime(item.CreatedAt),
+		UpdatedAt:    formatOptionalTime(item.UpdatedAt),
+	}
+}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -81,6 +81,15 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_backend",
+		"title":"Duplicate backend substrate"
+	}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate work item status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend", bytes.NewReader([]byte(`{"status":"ready","reviewer_role_ids":["reviewer_qa"]}`))))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("patch work item status = %d body=%s, want 200", rec.Code, rec.Body.String())

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1,0 +1,246 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func newProjectWorkTestServer() (*Handler, http.Handler) {
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func TestProjectWorkAPI_CRUD(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectWorkTestServer()
+	project := createProjectForWorkTest(t, server)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/roles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("roles status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var roles ProjectWorkRolesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &roles); err != nil {
+		t.Fatalf("decode roles: %v", err)
+	}
+	if len(roles.Data) < 8 || !projectWorkRoleExists(roles.Data, "product_manager", true) {
+		t.Fatalf("roles = %+v, want built-ins", roles.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/roles", bytes.NewReader([]byte(`{
+		"id":"role_release",
+		"name":"Release captain",
+		"description":"Coordinates release work"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var role ProjectWorkRoleEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &role); err != nil {
+		t.Fatalf("decode role: %v", err)
+	}
+	if role.Data.ID != "role_release" || role.Data.BuiltIn {
+		t.Fatalf("created role = %+v, want custom role", role.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/roles/product_manager", bytes.NewReader([]byte(`{"name":"Override"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("patch built-in role status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_backend",
+		"title":"Backend substrate",
+		"brief":"Persist coordination metadata only.",
+		"priority":"high",
+		"owner_role_id":"software_developer",
+		"reviewer_role_ids":["reviewer_qa","architect"]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create work item status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var work ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &work); err != nil {
+		t.Fatalf("decode work item: %v", err)
+	}
+	if work.Data.Status != projectwork.WorkItemStatusBacklog || work.Data.Priority != "high" {
+		t.Fatalf("created work item = %+v, want backlog/high", work.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend", bytes.NewReader([]byte(`{"status":"ready","reviewer_role_ids":["reviewer_qa"]}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch work item status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &work); err != nil {
+		t.Fatalf("decode patched work item: %v", err)
+	}
+	if work.Data.Status != projectwork.WorkItemStatusReady || len(work.Data.ReviewerRoleIDs) != 1 {
+		t.Fatalf("patched work item = %+v, want ready with one reviewer", work.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_backend",
+		"role_id":"software_developer",
+		"task_id":"task_123",
+		"run_id":"run_123",
+		"context_snapshot_id":"ctx_123"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.Status != projectwork.AssignmentStatusQueued || assignment.Data.TaskID != "task_123" {
+		t.Fatalf("assignment = %+v, want queued linked task", assignment.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", bytes.NewReader([]byte(`{"status":"completed","chat_session_id":"chat_123","message_id":"msg_123"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode patched assignment: %v", err)
+	}
+	if assignment.Data.Status != projectwork.AssignmentStatusCompleted || assignment.Data.ChatSessionID != "chat_123" {
+		t.Fatalf("patched assignment = %+v, want completed linked chat", assignment.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_handoff",
+		"assignment_id":"asgn_backend",
+		"kind":"handoff",
+		"title":"Backend handoff",
+		"body":"Store and API are ready for UI wiring.",
+		"author_role_id":"software_developer"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var artifact ProjectWorkArtifactEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &artifact); err != nil {
+		t.Fatalf("decode artifact: %v", err)
+	}
+	if artifact.Data.Kind != projectwork.ArtifactKindHandoff || artifact.Data.AssignmentID != "asgn_backend" {
+		t.Fatalf("artifact = %+v, want handoff linked to assignment", artifact.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list assignments status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignments ProjectWorkAssignmentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignments); err != nil {
+		t.Fatalf("decode assignments: %v", err)
+	}
+	if len(assignments.Data) != 1 || assignments.Data[0].ID != "asgn_backend" {
+		t.Fatalf("assignments = %+v, want created assignment", assignments.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list artifacts status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var artifacts ProjectWorkArtifactsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &artifacts); err != nil {
+		t.Fatalf("decode artifacts: %v", err)
+	}
+	if len(artifacts.Data) != 1 || artifacts.Data[0].ID != "art_handoff" {
+		t.Fatalf("artifacts = %+v, want created artifact", artifacts.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete work item status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("get deleted work item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_ProjectDeletionCleansRows(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	project := createProjectForWorkTest(t, server)
+	ctx := t.Context()
+	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{ID: "role_custom", ProjectID: project.Data.ID, Name: "Custom"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_cleanup", ProjectID: project.Data.ID, Title: "Cleanup"}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{ID: "asgn_cleanup", ProjectID: project.Data.ID, WorkItemID: "work_cleanup", RoleID: "software_developer"}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(ctx, projectwork.CollaborationArtifact{ID: "art_cleanup", ProjectID: project.Data.ID, WorkItemID: "work_cleanup", Kind: projectwork.ArtifactKindReview, Body: "Looks good."}); err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID, nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete project status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	if items, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID); err != nil || len(items) != 0 {
+		t.Fatalf("project work items after project delete = %+v err=%v, want none", items, err)
+	}
+	if roles, err := handler.projectWork.ListRoles(ctx, project.Data.ID); err != nil || projectWorkRoleExistsStore(roles, "role_custom", false) {
+		t.Fatalf("project roles after project delete = %+v err=%v, want custom role gone", roles, err)
+	}
+}
+
+func createProjectForWorkTest(t *testing.T, server http.Handler) ProjectResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Hecate"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create project status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &project); err != nil {
+		t.Fatalf("decode project: %v", err)
+	}
+	return project
+}
+
+func projectWorkRoleExists(roles []ProjectWorkRoleResponse, id string, builtIn bool) bool {
+	for _, role := range roles {
+		if role.ID == id && role.BuiltIn == builtIn {
+			return true
+		}
+	}
+	return false
+}
+
+func projectWorkRoleExistsStore(roles []projectwork.AgentRoleProfile, id string, builtIn bool) bool {
+	for _, role := range roles {
+		if role.ID == id && role.BuiltIn == builtIn {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -274,6 +274,12 @@ func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	if h.projectWork != nil {
+		if _, err := h.projectWork.DeleteProject(r.Context(), id); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+	}
 	err := h.projects.Delete(r.Context(), id)
 	if errors.Is(err, projects.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -47,6 +47,12 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 	}
 	stats.ProjectsDeleted = projectsDeleted
 
+	projectWorkRowsDeleted, err := h.resetProjectWork(ctx)
+	if err != nil {
+		return stats, err
+	}
+	stats.ProjectWorkRowsDeleted = projectWorkRowsDeleted
+
 	tasksDeleted, err := h.resetTasks(ctx)
 	if err != nil {
 		return stats, err
@@ -116,6 +122,13 @@ func (h *Handler) resetProjects(ctx context.Context) (int, error) {
 		deleted++
 	}
 	return deleted, nil
+}
+
+func (h *Handler) resetProjectWork(ctx context.Context) (int, error) {
+	if h.projectWork == nil {
+		return 0, nil
+	}
+	return h.projectWork.Clear(ctx)
 }
 
 func (h *Handler) resetTasks(ctx context.Context) (int, error) {

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -60,6 +61,21 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	}); err != nil {
 		t.Fatalf("create project-free chat: %v", err)
 	}
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_reset",
+		ProjectID: project.Data.ID,
+		Title:     "Reset work",
+	}); err != nil {
+		t.Fatalf("create project work item: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_reset",
+		ProjectID:  project.Data.ID,
+		WorkItemID: "work_reset",
+		RoleID:     "software_developer",
+	}); err != nil {
+		t.Fatalf("create project assignment: %v", err)
+	}
 	if _, err := handler.taskStore.CreateTask(ctx, types.Task{ID: "task_reset", Title: "Reset me", Status: "queued"}); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
@@ -93,8 +109,8 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &reset); err != nil {
 		t.Fatalf("decode reset response: %v", err)
 	}
-	if reset.Data.ProjectsDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
-		t.Fatalf("reset stats = %+v, want one project, task, provider, rule and two chats", reset.Data)
+	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
+		t.Fatalf("reset stats = %+v, want one project, two project-work rows, one task, provider, rule and two chats", reset.Data)
 	}
 	if len(runner.closedSessions) != 2 {
 		t.Fatalf("closed sessions = %#v, want two external chats closed", runner.closedSessions)
@@ -113,6 +129,13 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	}
 	if len(projectList) != 0 {
 		t.Fatalf("projects after reset = %#v, want none", projectList)
+	}
+	workItems, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID)
+	if err != nil {
+		t.Fatalf("list project work: %v", err)
+	}
+	if len(workItems) != 0 {
+		t.Fatalf("project work after reset = %#v, want none", workItems)
 	}
 	tasks, err := handler.taskStore.ListTasks(ctx, taskstate.TaskFilter{})
 	if err != nil {
@@ -173,6 +196,10 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(projects): %v", err)
 	}
+	projectWorkStore, err := projectwork.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(projectwork): %v", err)
+	}
 	taskStore, err := taskstate.NewSQLiteStore(ctx, client)
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(taskstate): %v", err)
@@ -189,6 +216,7 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	handler := NewHandler(config.Config{}, logger, nil, cpStore, taskStore, nil, runtime)
 	handler.SetAgentChatStore(chatStore)
 	handler.SetProjectStore(projectStore)
+	handler.SetProjectWorkStore(projectWorkStore)
 	handler.SetStateCleaner(client)
 	runner := &fakeAgentChatRunner{}
 	handler.SetAgentChatRunner(runner)
@@ -207,6 +235,13 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 		NativeSessionID: "native_sqlite_external",
 	}); err != nil {
 		t.Fatalf("create chat: %v", err)
+	}
+	if _, err := projectWorkStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_sqlite_reset",
+		ProjectID: project.ID,
+		Title:     "SQLite work",
+	}); err != nil {
+		t.Fatalf("create project work: %v", err)
 	}
 	if _, err := taskStore.CreateTask(ctx, types.Task{ID: "task_sqlite_reset", Title: "SQLite task", Status: "queued"}); err != nil {
 		t.Fatalf("create task: %v", err)
@@ -235,6 +270,9 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	}
 	if reset.Data.DatabaseRowsDeleted == 0 {
 		t.Fatalf("database rows deleted = 0, want remaining sqlite rows cleared; stats=%+v", reset.Data)
+	}
+	if reset.Data.ProjectWorkRowsDeleted != 1 {
+		t.Fatalf("project work rows deleted = %d, want 1", reset.Data.ProjectWorkRowsDeleted)
 	}
 	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_sqlite_external" {
 		t.Fatalf("closed sessions = %#v, want sqlite external chat closed", runner.closedSessions)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1013,6 +1013,7 @@ type SystemResetDataResponse struct {
 
 type SystemResetDataResponseItem struct {
 	ProjectsDeleted            int `json:"projects_deleted"`
+	ProjectWorkRowsDeleted     int `json:"project_work_rows_deleted"`
 	ChatSessionsDeleted        int `json:"chat_sessions_deleted"`
 	TasksDeleted               int `json:"tasks_deleted"`
 	ProvidersDeleted           int `json:"providers_deleted"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,20 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/roles", handler.HandleProjectWorkRoles)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/roles", handler.HandleCreateProjectWorkRole)
+	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/roles/{role_id}", handler.HandleUpdateProjectWorkRole)
+	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/roles/{role_id}", handler.HandleDeleteProjectWorkRole)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items", handler.HandleProjectWorkItems)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items", handler.HandleCreateProjectWorkItem)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleProjectWorkItem)
+	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleUpdateProjectWorkItem)
+	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleDeleteProjectWorkItem)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleProjectWorkAssignments)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleCreateProjectWorkAssignment)
+	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleUpdateProjectWorkAssignment)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleProjectWorkArtifacts)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleCreateProjectWorkArtifact)
 }
 
 func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -438,6 +438,9 @@ INSERT INTO %s (
 		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
 	)
 	if err != nil {
+		if isSQLiteConstraint(err) {
+			return Assignment{}, ErrDuplicate
+		}
 		return Assignment{}, err
 	}
 	return s.getRequiredAssignment(ctx, assignment.ProjectID, assignment.ID)
@@ -536,8 +539,11 @@ func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact Collaboration
 	}
 	if artifact.AssignmentID != "" {
 		assignment, err := s.getRequiredAssignment(ctx, artifact.ProjectID, artifact.AssignmentID)
-		if err != nil {
+		if errors.Is(err, ErrNotFound) {
 			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", err)
+		}
+		if err != nil {
+			return CollaborationArtifact{}, err
 		}
 		if assignment.WorkItemID != artifact.WorkItemID {
 			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
@@ -552,6 +558,9 @@ INSERT INTO %s (
 		formatTime(artifact.CreatedAt), formatTime(artifact.UpdatedAt),
 	)
 	if err != nil {
+		if isSQLiteConstraint(err) {
+			return CollaborationArtifact{}, ErrDuplicate
+		}
 		return CollaborationArtifact{}, err
 	}
 	return s.getRequiredArtifact(ctx, artifact.ProjectID, artifact.ID)
@@ -622,6 +631,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.workItemsTbl),
 		item.ID, item.ProjectID, item.Title, item.Brief, item.Status, item.Priority,
 		item.OwnerRoleID, formatTime(item.CreatedAt), formatTime(item.UpdatedAt),
 	); err != nil {
+		if isSQLiteConstraint(err) {
+			return ErrDuplicate
+		}
 		return err
 	}
 	return s.replaceReviewers(ctx, tx, item)

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -1,0 +1,831 @@
+package projectwork
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+type SQLiteStore struct {
+	mu             sync.Mutex
+	db             *sql.DB
+	rolesTbl       string
+	workItemsTbl   string
+	reviewersTbl   string
+	assignmentsTbl string
+	artifactsTbl   string
+}
+
+func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
+	if client == nil || client.DB() == nil {
+		return nil, fmt.Errorf("sqlite client is required")
+	}
+	store := &SQLiteStore{
+		db:             client.DB(),
+		rolesTbl:       client.QualifiedTable("project_work_roles"),
+		workItemsTbl:   client.QualifiedTable("project_work_items"),
+		reviewersTbl:   client.QualifiedTable("project_work_item_reviewers"),
+		assignmentsTbl: client.QualifiedTable("project_work_assignments"),
+		artifactsTbl:   client.QualifiedTable("project_work_artifacts"),
+	}
+	if err := store.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLiteStore) Backend() string {
+	return "sqlite"
+}
+
+func (s *SQLiteStore) migrate(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	instructions TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`, s.rolesTbl)); err != nil {
+		return fmt.Errorf("create project work roles table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	title TEXT NOT NULL,
+	brief TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL,
+	priority TEXT NOT NULL,
+	owner_role_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`, s.workItemsTbl)); err != nil {
+		return fmt.Errorf("create project work items table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	role_id TEXT NOT NULL,
+	PRIMARY KEY(project_id, work_item_id, role_id)
+)`, s.reviewersTbl)); err != nil {
+		return fmt.Errorf("create project work item reviewers table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	role_id TEXT NOT NULL,
+	status TEXT NOT NULL,
+	task_id TEXT NOT NULL DEFAULT '',
+	run_id TEXT NOT NULL DEFAULT '',
+	chat_session_id TEXT NOT NULL DEFAULT '',
+	message_id TEXT NOT NULL DEFAULT '',
+	context_snapshot_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	started_at TEXT NOT NULL DEFAULT '',
+	completed_at TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY(project_id, id)
+)`, s.assignmentsTbl)); err != nil {
+		return fmt.Errorf("create project work assignments table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	assignment_id TEXT NOT NULL DEFAULT '',
+	kind TEXT NOT NULL,
+	title TEXT NOT NULL DEFAULT '',
+	body TEXT NOT NULL,
+	author_role_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`, s.artifactsTbl)); err != nil {
+		return fmt.Errorf("create project work artifacts table: %w", err)
+	}
+	for _, stmt := range []struct {
+		table string
+		name  string
+		cols  string
+	}{
+		{s.rolesTbl, "project_idx", "project_id"},
+		{s.workItemsTbl, "project_idx", "project_id"},
+		{s.reviewersTbl, "work_item_idx", "project_id, work_item_id"},
+		{s.assignmentsTbl, "work_item_idx", "project_id, work_item_id"},
+		{s.artifactsTbl, "work_item_idx", "project_id, work_item_id"},
+	} {
+		name := strings.Trim(stmt.table, `"`) + "_" + stmt.name
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (%s)`, name, stmt.table, stmt.cols)); err != nil {
+			return fmt.Errorf("create %s index: %w", stmt.name, err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) ListRoles(ctx context.Context, projectID string) ([]AgentRoleProfile, error) {
+	projectID = strings.TrimSpace(projectID)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, name, description, instructions, created_at, updated_at
+FROM %s
+WHERE project_id = ?
+ORDER BY name ASC, id ASC`, s.rolesTbl), projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := BuiltInRoleProfiles(projectID)
+	for rows.Next() {
+		role, err := scanRole(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, role)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sortRoles(items)
+	return items, nil
+}
+
+func (s *SQLiteStore) CreateRole(ctx context.Context, role AgentRoleProfile) (AgentRoleProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	role = normalizeRole(role, time.Now().UTC())
+	if IsBuiltInRoleID(role.ID) || role.BuiltIn {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	if err := validateRole(role); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (id, project_id, name, description, instructions, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, s.rolesTbl),
+		role.ID, role.ProjectID, role.Name, role.Description, role.Instructions,
+		formatTime(role.CreatedAt), formatTime(role.UpdatedAt),
+	)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return AgentRoleProfile{}, ErrDuplicateRole
+		}
+		return AgentRoleProfile{}, err
+	}
+	return s.getCustomRole(ctx, role.ProjectID, role.ID)
+}
+
+func (s *SQLiteStore) UpdateRole(ctx context.Context, projectID, id string, update func(*AgentRoleProfile)) (AgentRoleProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	if IsBuiltInRoleID(id) {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	role, err := s.getCustomRole(ctx, projectID, id)
+	if err != nil {
+		return AgentRoleProfile{}, err
+	}
+	originalID := role.ID
+	originalProjectID := role.ProjectID
+	originalCreatedAt := role.CreatedAt
+	if update != nil {
+		update(&role)
+	}
+	if strings.TrimSpace(role.ID) != originalID || strings.TrimSpace(role.ProjectID) != originalProjectID {
+		return AgentRoleProfile{}, fmt.Errorf("%w: role id and project_id cannot be changed", ErrInvalid)
+	}
+	role.ID = originalID
+	role.ProjectID = originalProjectID
+	role.CreatedAt = originalCreatedAt
+	role.UpdatedAt = time.Now().UTC()
+	role = normalizeRole(role, role.UpdatedAt)
+	if role.BuiltIn || IsBuiltInRoleID(role.ID) {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	if err := validateRole(role); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
+UPDATE %s
+SET name = ?, description = ?, instructions = ?, updated_at = ?
+WHERE project_id = ? AND id = ?`, s.rolesTbl),
+		role.Name, role.Description, role.Instructions, formatTime(role.UpdatedAt), projectID, id,
+	)
+	if err != nil {
+		return AgentRoleProfile{}, err
+	}
+	return s.getCustomRole(ctx, projectID, id)
+}
+
+func (s *SQLiteStore) DeleteRole(ctx context.Context, projectID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	if IsBuiltInRoleID(id) {
+		return ErrBuiltInRole
+	}
+	res, err := s.db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND id = ?`, s.rolesTbl), projectID, id)
+	if err != nil {
+		return err
+	}
+	return requireAffected(res)
+}
+
+func (s *SQLiteStore) ListWorkItems(ctx context.Context, projectID string) ([]WorkItem, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at
+FROM %s
+WHERE project_id = ?
+ORDER BY updated_at DESC, id ASC`, s.workItemsTbl), strings.TrimSpace(projectID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []WorkItem
+	for rows.Next() {
+		item, err := scanWorkItem(rows)
+		if err != nil {
+			return nil, err
+		}
+		reviewers, err := s.loadReviewers(ctx, item.ProjectID, item.ID)
+		if err != nil {
+			return nil, err
+		}
+		item.ReviewerRoleIDs = reviewers
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) CreateWorkItem(ctx context.Context, item WorkItem) (WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item = normalizeWorkItem(item, time.Now().UTC())
+	if err := validateWorkItem(item); err != nil {
+		return WorkItem{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	if err := s.insertWorkItem(ctx, tx, item); err != nil {
+		_ = tx.Rollback()
+		return WorkItem{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return WorkItem{}, err
+	}
+	return s.getRequiredWorkItem(ctx, item.ProjectID, item.ID)
+}
+
+func (s *SQLiteStore) GetWorkItem(ctx context.Context, projectID, id string) (WorkItem, bool, error) {
+	item, err := s.getRequiredWorkItem(ctx, projectID, id)
+	if errors.Is(err, ErrNotFound) {
+		return WorkItem{}, false, nil
+	}
+	if err != nil {
+		return WorkItem{}, false, err
+	}
+	return item, true, nil
+}
+
+func (s *SQLiteStore) UpdateWorkItem(ctx context.Context, projectID, id string, update func(*WorkItem)) (WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	item, err := s.getRequiredWorkItem(ctx, projectID, id)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalCreatedAt := item.CreatedAt
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID || strings.TrimSpace(item.ProjectID) != originalProjectID {
+		return WorkItem{}, fmt.Errorf("%w: work item id and project_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeWorkItem(item, item.UpdatedAt)
+	if err := validateWorkItem(item); err != nil {
+		return WorkItem{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+UPDATE %s
+SET title = ?, brief = ?, status = ?, priority = ?, owner_role_id = ?, updated_at = ?
+WHERE project_id = ? AND id = ?`, s.workItemsTbl),
+		item.Title, item.Brief, item.Status, item.Priority, item.OwnerRoleID,
+		formatTime(item.UpdatedAt), projectID, id,
+	); err != nil {
+		_ = tx.Rollback()
+		return WorkItem{}, err
+	}
+	if err := s.replaceReviewers(ctx, tx, item); err != nil {
+		_ = tx.Rollback()
+		return WorkItem{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return WorkItem{}, err
+	}
+	return s.getRequiredWorkItem(ctx, projectID, id)
+}
+
+func (s *SQLiteStore) DeleteWorkItem(ctx context.Context, projectID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, stmt := range []string{
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.artifactsTbl),
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.assignmentsTbl),
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.reviewersTbl),
+	} {
+		if _, err := tx.ExecContext(ctx, stmt, projectID, id); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND id = ?`, s.workItemsTbl), projectID, id)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := requireAffected(res); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilter) ([]Assignment, error) {
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	query := fmt.Sprintf(`
+SELECT id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+FROM %s
+WHERE project_id = ?`, s.assignmentsTbl)
+	args := []any{filter.ProjectID}
+	if filter.WorkItemID != "" {
+		query += ` AND work_item_id = ?`
+		args = append(args, filter.WorkItemID)
+	}
+	query += ` ORDER BY created_at ASC, id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Assignment
+	for rows.Next() {
+		item, err := scanAssignment(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) CreateAssignment(ctx context.Context, assignment Assignment) (Assignment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	assignment = normalizeAssignment(assignment, time.Now().UTC())
+	if err := validateAssignment(assignment); err != nil {
+		return Assignment{}, err
+	}
+	if _, ok, err := s.GetWorkItem(ctx, assignment.ProjectID, assignment.WorkItemID); err != nil {
+		return Assignment{}, err
+	} else if !ok {
+		return Assignment{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id,
+	message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
+		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID,
+		assignment.Status, assignment.TaskID, assignment.RunID, assignment.ChatSessionID,
+		assignment.MessageID, assignment.ContextSnapshotID, formatTime(assignment.CreatedAt),
+		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
+	)
+	if err != nil {
+		return Assignment{}, err
+	}
+	return s.getRequiredAssignment(ctx, assignment.ProjectID, assignment.ID)
+}
+
+func (s *SQLiteStore) UpdateAssignment(ctx context.Context, projectID, id string, update func(*Assignment)) (Assignment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	item, err := s.getRequiredAssignment(ctx, projectID, id)
+	if err != nil {
+		return Assignment{}, err
+	}
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalWorkItemID := item.WorkItemID
+	originalCreatedAt := item.CreatedAt
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID ||
+		strings.TrimSpace(item.ProjectID) != originalProjectID ||
+		strings.TrimSpace(item.WorkItemID) != originalWorkItemID {
+		return Assignment{}, fmt.Errorf("%w: assignment id, project_id, and work_item_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.WorkItemID = originalWorkItemID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeAssignment(item, item.UpdatedAt)
+	if err := validateAssignment(item); err != nil {
+		return Assignment{}, err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
+UPDATE %s
+SET role_id = ?, status = ?, task_id = ?, run_id = ?, chat_session_id = ?, message_id = ?,
+	context_snapshot_id = ?, updated_at = ?, started_at = ?, completed_at = ?
+WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
+		item.RoleID, item.Status, item.TaskID, item.RunID, item.ChatSessionID,
+		item.MessageID, item.ContextSnapshotID, formatTime(item.UpdatedAt),
+		formatTime(item.StartedAt), formatTime(item.CompletedAt), projectID, id,
+	)
+	if err != nil {
+		return Assignment{}, err
+	}
+	return s.getRequiredAssignment(ctx, projectID, id)
+}
+
+func (s *SQLiteStore) ListArtifacts(ctx context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error) {
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	filter.AssignmentID = strings.TrimSpace(filter.AssignmentID)
+	query := fmt.Sprintf(`
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
+FROM %s
+WHERE project_id = ?`, s.artifactsTbl)
+	args := []any{filter.ProjectID}
+	if filter.WorkItemID != "" {
+		query += ` AND work_item_id = ?`
+		args = append(args, filter.WorkItemID)
+	}
+	if filter.AssignmentID != "" {
+		query += ` AND assignment_id = ?`
+		args = append(args, filter.AssignmentID)
+	}
+	query += ` ORDER BY created_at ASC, id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CollaborationArtifact
+	for rows.Next() {
+		item, err := scanArtifact(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact CollaborationArtifact) (CollaborationArtifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	artifact = normalizeArtifact(artifact, time.Now().UTC())
+	if err := validateArtifact(artifact); err != nil {
+		return CollaborationArtifact{}, err
+	}
+	if _, ok, err := s.GetWorkItem(ctx, artifact.ProjectID, artifact.WorkItemID); err != nil {
+		return CollaborationArtifact{}, err
+	} else if !ok {
+		return CollaborationArtifact{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	if artifact.AssignmentID != "" {
+		assignment, err := s.getRequiredAssignment(ctx, artifact.ProjectID, artifact.AssignmentID)
+		if err != nil {
+			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", err)
+		}
+		if assignment.WorkItemID != artifact.WorkItemID {
+			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
+		}
+	}
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.artifactsTbl),
+		artifact.ID, artifact.ProjectID, artifact.WorkItemID, artifact.AssignmentID,
+		artifact.Kind, artifact.Title, artifact.Body, artifact.AuthorRoleID,
+		formatTime(artifact.CreatedAt), formatTime(artifact.UpdatedAt),
+	)
+	if err != nil {
+		return CollaborationArtifact{}, err
+	}
+	return s.getRequiredArtifact(ctx, artifact.ProjectID, artifact.ID)
+}
+
+func (s *SQLiteStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deleteWhereProject(ctx, strings.TrimSpace(projectID))
+}
+
+func (s *SQLiteStore) Clear(ctx context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	deleted := 0
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	for _, table := range []string{s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, table))
+		if err != nil {
+			_ = tx.Rollback()
+			return deleted, err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			_ = tx.Rollback()
+			return deleted, err
+		}
+		deleted += int(n)
+	}
+	if err := tx.Commit(); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+func (s *SQLiteStore) deleteWhereProject(ctx context.Context, projectID string) (int, error) {
+	deleted := 0
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	for _, table := range []string{s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ?`, table), projectID)
+		if err != nil {
+			_ = tx.Rollback()
+			return deleted, err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			_ = tx.Rollback()
+			return deleted, err
+		}
+		deleted += int(n)
+	}
+	if err := tx.Commit(); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+func (s *SQLiteStore) insertWorkItem(ctx context.Context, tx *sql.Tx, item WorkItem) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.workItemsTbl),
+		item.ID, item.ProjectID, item.Title, item.Brief, item.Status, item.Priority,
+		item.OwnerRoleID, formatTime(item.CreatedAt), formatTime(item.UpdatedAt),
+	); err != nil {
+		return err
+	}
+	return s.replaceReviewers(ctx, tx, item)
+}
+
+func (s *SQLiteStore) replaceReviewers(ctx context.Context, tx *sql.Tx, item WorkItem) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.reviewersTbl), item.ProjectID, item.ID); err != nil {
+		return err
+	}
+	for _, roleID := range item.ReviewerRoleIDs {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (project_id, work_item_id, role_id)
+VALUES (?, ?, ?)`, s.reviewersTbl), item.ProjectID, item.ID, roleID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) loadReviewers(ctx context.Context, projectID, workItemID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT role_id
+FROM %s
+WHERE project_id = ? AND work_item_id = ?
+ORDER BY role_id ASC`, s.reviewersTbl), projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var reviewers []string
+	for rows.Next() {
+		var roleID string
+		if err := rows.Scan(&roleID); err != nil {
+			return nil, err
+		}
+		reviewers = append(reviewers, roleID)
+	}
+	return reviewers, rows.Err()
+}
+
+func (s *SQLiteStore) getCustomRole(ctx context.Context, projectID, id string) (AgentRoleProfile, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, name, description, instructions, created_at, updated_at
+FROM %s
+WHERE project_id = ? AND id = ?`, s.rolesTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
+	role, err := scanRole(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentRoleProfile{}, ErrNotFound
+	}
+	return role, err
+}
+
+func (s *SQLiteStore) getRequiredWorkItem(ctx context.Context, projectID, id string) (WorkItem, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at
+FROM %s
+WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
+	item, err := scanWorkItem(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkItem{}, ErrNotFound
+	}
+	if err != nil {
+		return WorkItem{}, err
+	}
+	reviewers, err := s.loadReviewers(ctx, item.ProjectID, item.ID)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	item.ReviewerRoleIDs = reviewers
+	return item, nil
+}
+
+func (s *SQLiteStore) getRequiredAssignment(ctx context.Context, projectID, id string) (Assignment, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+FROM %s
+WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
+	item, err := scanAssignment(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Assignment{}, ErrNotFound
+	}
+	return item, err
+}
+
+func (s *SQLiteStore) getRequiredArtifact(ctx context.Context, projectID, id string) (CollaborationArtifact, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
+FROM %s
+WHERE project_id = ? AND id = ?`, s.artifactsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
+	item, err := scanArtifact(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CollaborationArtifact{}, ErrNotFound
+	}
+	return item, err
+}
+
+type scanner interface {
+	Scan(...any) error
+}
+
+func scanRole(row scanner) (AgentRoleProfile, error) {
+	var item AgentRoleProfile
+	var createdAt, updatedAt string
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.Name, &item.Description, &item.Instructions, &createdAt, &updatedAt); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	var err error
+	if item.CreatedAt, err = parseTime(createdAt); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	if item.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	return item, nil
+}
+
+func scanWorkItem(row scanner) (WorkItem, error) {
+	var item WorkItem
+	var createdAt, updatedAt string
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.Title, &item.Brief, &item.Status, &item.Priority, &item.OwnerRoleID, &createdAt, &updatedAt); err != nil {
+		return WorkItem{}, err
+	}
+	var err error
+	if item.CreatedAt, err = parseTime(createdAt); err != nil {
+		return WorkItem{}, err
+	}
+	if item.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return WorkItem{}, err
+	}
+	return item, nil
+}
+
+func scanAssignment(row scanner) (Assignment, error) {
+	var item Assignment
+	var createdAt, updatedAt, startedAt, completedAt string
+	if err := row.Scan(
+		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.Status,
+		&item.TaskID, &item.RunID, &item.ChatSessionID, &item.MessageID,
+		&item.ContextSnapshotID, &createdAt, &updatedAt, &startedAt, &completedAt,
+	); err != nil {
+		return Assignment{}, err
+	}
+	var err error
+	if item.CreatedAt, err = parseTime(createdAt); err != nil {
+		return Assignment{}, err
+	}
+	if item.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return Assignment{}, err
+	}
+	if item.StartedAt, err = parseTime(startedAt); err != nil {
+		return Assignment{}, err
+	}
+	if item.CompletedAt, err = parseTime(completedAt); err != nil {
+		return Assignment{}, err
+	}
+	return item, nil
+}
+
+func scanArtifact(row scanner) (CollaborationArtifact, error) {
+	var item CollaborationArtifact
+	var createdAt, updatedAt string
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.WorkItemID, &item.AssignmentID, &item.Kind, &item.Title, &item.Body, &item.AuthorRoleID, &createdAt, &updatedAt); err != nil {
+		return CollaborationArtifact{}, err
+	}
+	var err error
+	if item.CreatedAt, err = parseTime(createdAt); err != nil {
+		return CollaborationArtifact{}, err
+	}
+	if item.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return CollaborationArtifact{}, err
+	}
+	return item, nil
+}
+
+func requireAffected(res sql.Result) error {
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func isSQLiteConstraint(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "constraint")
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed.UTC(), nil
+}

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -1,0 +1,793 @@
+package projectwork
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	WorkItemStatusBacklog   = "backlog"
+	WorkItemStatusReady     = "ready"
+	WorkItemStatusRunning   = "running"
+	WorkItemStatusReview    = "review"
+	WorkItemStatusBlocked   = "blocked"
+	WorkItemStatusDone      = "done"
+	WorkItemStatusCancelled = "cancelled"
+
+	AssignmentStatusQueued           = "queued"
+	AssignmentStatusRunning          = "running"
+	AssignmentStatusAwaitingApproval = "awaiting_approval"
+	AssignmentStatusCompleted        = "completed"
+	AssignmentStatusFailed           = "failed"
+	AssignmentStatusCancelled        = "cancelled"
+
+	ArtifactKindBrief        = "brief"
+	ArtifactKindHandoff      = "handoff"
+	ArtifactKindReview       = "review"
+	ArtifactKindDecisionNote = "decision_note"
+)
+
+var (
+	ErrNotFound      = errors.New("project work record not found")
+	ErrInvalid       = errors.New("invalid project work record")
+	ErrBuiltInRole   = errors.New("built-in role cannot be mutated")
+	ErrDuplicateRole = errors.New("project role already exists")
+)
+
+type AgentRoleProfile struct {
+	ID           string
+	ProjectID    string
+	Name         string
+	Description  string
+	Instructions string
+	BuiltIn      bool
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type WorkItem struct {
+	ID              string
+	ProjectID       string
+	Title           string
+	Brief           string
+	Status          string
+	Priority        string
+	OwnerRoleID     string
+	ReviewerRoleIDs []string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type Assignment struct {
+	ID                string
+	ProjectID         string
+	WorkItemID        string
+	RoleID            string
+	Status            string
+	TaskID            string
+	RunID             string
+	ChatSessionID     string
+	MessageID         string
+	ContextSnapshotID string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	StartedAt         time.Time
+	CompletedAt       time.Time
+}
+
+type CollaborationArtifact struct {
+	ID           string
+	ProjectID    string
+	WorkItemID   string
+	AssignmentID string
+	Kind         string
+	Title        string
+	Body         string
+	AuthorRoleID string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type AssignmentFilter struct {
+	ProjectID  string
+	WorkItemID string
+}
+
+type ArtifactFilter struct {
+	ProjectID    string
+	WorkItemID   string
+	AssignmentID string
+}
+
+type Store interface {
+	Backend() string
+	ListRoles(ctx context.Context, projectID string) ([]AgentRoleProfile, error)
+	CreateRole(ctx context.Context, role AgentRoleProfile) (AgentRoleProfile, error)
+	UpdateRole(ctx context.Context, projectID, id string, update func(*AgentRoleProfile)) (AgentRoleProfile, error)
+	DeleteRole(ctx context.Context, projectID, id string) error
+	ListWorkItems(ctx context.Context, projectID string) ([]WorkItem, error)
+	CreateWorkItem(ctx context.Context, item WorkItem) (WorkItem, error)
+	GetWorkItem(ctx context.Context, projectID, id string) (WorkItem, bool, error)
+	UpdateWorkItem(ctx context.Context, projectID, id string, update func(*WorkItem)) (WorkItem, error)
+	DeleteWorkItem(ctx context.Context, projectID, id string) error
+	ListAssignments(ctx context.Context, filter AssignmentFilter) ([]Assignment, error)
+	CreateAssignment(ctx context.Context, assignment Assignment) (Assignment, error)
+	UpdateAssignment(ctx context.Context, projectID, id string, update func(*Assignment)) (Assignment, error)
+	ListArtifacts(ctx context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error)
+	CreateArtifact(ctx context.Context, artifact CollaborationArtifact) (CollaborationArtifact, error)
+	DeleteProject(ctx context.Context, projectID string) (int, error)
+	Clear(ctx context.Context) (int, error)
+}
+
+type MemoryStore struct {
+	mu          sync.Mutex
+	roles       map[string]AgentRoleProfile
+	workItems   map[string]WorkItem
+	assignments map[string]Assignment
+	artifacts   map[string]CollaborationArtifact
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		roles:       make(map[string]AgentRoleProfile),
+		workItems:   make(map[string]WorkItem),
+		assignments: make(map[string]Assignment),
+		artifacts:   make(map[string]CollaborationArtifact),
+	}
+}
+
+func (s *MemoryStore) Backend() string {
+	return "memory"
+}
+
+func BuiltInRoleProfiles(projectID string) []AgentRoleProfile {
+	projectID = strings.TrimSpace(projectID)
+	roles := []AgentRoleProfile{
+		{ID: "product_manager", Name: "Product Manager", Description: "Shapes product intent, scope, and acceptance criteria."},
+		{ID: "architect", Name: "Architect", Description: "Owns technical direction, boundaries, and system trade-offs."},
+		{ID: "software_developer", Name: "Software Developer", Description: "Implements backend and shared application behavior."},
+		{ID: "frontend_engineer", Name: "Frontend Engineer", Description: "Implements user-facing application surfaces."},
+		{ID: "designer", Name: "Designer", Description: "Owns interaction, information architecture, and visual quality."},
+		{ID: "sre", Name: "SRE", Description: "Owns deployability, reliability, observability, and operations."},
+		{ID: "tech_writer", Name: "Technical Writer", Description: "Turns implementation and decisions into clear operator-facing docs."},
+		{ID: "reviewer_qa", Name: "Reviewer QA", Description: "Reviews behavior, risks, regressions, and verification gaps."},
+	}
+	for idx := range roles {
+		roles[idx].ProjectID = projectID
+		roles[idx].BuiltIn = true
+	}
+	return roles
+}
+
+func IsBuiltInRoleID(id string) bool {
+	id = strings.TrimSpace(id)
+	for _, role := range BuiltInRoleProfiles("") {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MemoryStore) ListRoles(_ context.Context, projectID string) ([]AgentRoleProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	items := BuiltInRoleProfiles(projectID)
+	for _, role := range s.roles {
+		if role.ProjectID == projectID {
+			items = append(items, cloneRole(role))
+		}
+	}
+	sortRoles(items)
+	return items, nil
+}
+
+func (s *MemoryStore) CreateRole(_ context.Context, role AgentRoleProfile) (AgentRoleProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	role = normalizeRole(role, time.Now().UTC())
+	if IsBuiltInRoleID(role.ID) || role.BuiltIn {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	if err := validateRole(role); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	key := roleKey(role.ProjectID, role.ID)
+	if _, exists := s.roles[key]; exists {
+		return AgentRoleProfile{}, ErrDuplicateRole
+	}
+	s.roles[key] = cloneRole(role)
+	return cloneRole(role), nil
+}
+
+func (s *MemoryStore) UpdateRole(_ context.Context, projectID, id string, update func(*AgentRoleProfile)) (AgentRoleProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	if IsBuiltInRoleID(id) {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	key := roleKey(projectID, id)
+	role, ok := s.roles[key]
+	if !ok {
+		return AgentRoleProfile{}, ErrNotFound
+	}
+	role = cloneRole(role)
+	originalID := role.ID
+	originalProjectID := role.ProjectID
+	originalCreatedAt := role.CreatedAt
+	if update != nil {
+		update(&role)
+	}
+	if strings.TrimSpace(role.ID) != originalID || strings.TrimSpace(role.ProjectID) != originalProjectID {
+		return AgentRoleProfile{}, fmt.Errorf("%w: role id and project_id cannot be changed", ErrInvalid)
+	}
+	role.ID = originalID
+	role.ProjectID = originalProjectID
+	role.CreatedAt = originalCreatedAt
+	role.UpdatedAt = time.Now().UTC()
+	role = normalizeRole(role, role.UpdatedAt)
+	if role.BuiltIn || IsBuiltInRoleID(role.ID) {
+		return AgentRoleProfile{}, ErrBuiltInRole
+	}
+	if err := validateRole(role); err != nil {
+		return AgentRoleProfile{}, err
+	}
+	s.roles[key] = cloneRole(role)
+	return cloneRole(role), nil
+}
+
+func (s *MemoryStore) DeleteRole(_ context.Context, projectID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	if IsBuiltInRoleID(id) {
+		return ErrBuiltInRole
+	}
+	key := roleKey(projectID, id)
+	if _, ok := s.roles[key]; !ok {
+		return ErrNotFound
+	}
+	delete(s.roles, key)
+	return nil
+}
+
+func (s *MemoryStore) ListWorkItems(_ context.Context, projectID string) ([]WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	items := make([]WorkItem, 0, len(s.workItems))
+	for _, item := range s.workItems {
+		if item.ProjectID == projectID {
+			items = append(items, cloneWorkItem(item))
+		}
+	}
+	sortWorkItems(items)
+	return items, nil
+}
+
+func (s *MemoryStore) CreateWorkItem(_ context.Context, item WorkItem) (WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item = normalizeWorkItem(item, time.Now().UTC())
+	if err := validateWorkItem(item); err != nil {
+		return WorkItem{}, err
+	}
+	s.workItems[workItemKey(item.ProjectID, item.ID)] = cloneWorkItem(item)
+	return cloneWorkItem(item), nil
+}
+
+func (s *MemoryStore) GetWorkItem(_ context.Context, projectID, id string) (WorkItem, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.workItems[workItemKey(projectID, id)]
+	if !ok {
+		return WorkItem{}, false, nil
+	}
+	return cloneWorkItem(item), true, nil
+}
+
+func (s *MemoryStore) UpdateWorkItem(_ context.Context, projectID, id string, update func(*WorkItem)) (WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := workItemKey(projectID, id)
+	item, ok := s.workItems[key]
+	if !ok {
+		return WorkItem{}, ErrNotFound
+	}
+	item = cloneWorkItem(item)
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalCreatedAt := item.CreatedAt
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID || strings.TrimSpace(item.ProjectID) != originalProjectID {
+		return WorkItem{}, fmt.Errorf("%w: work item id and project_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeWorkItem(item, item.UpdatedAt)
+	if err := validateWorkItem(item); err != nil {
+		return WorkItem{}, err
+	}
+	s.workItems[key] = cloneWorkItem(item)
+	return cloneWorkItem(item), nil
+}
+
+func (s *MemoryStore) DeleteWorkItem(_ context.Context, projectID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	id = strings.TrimSpace(id)
+	key := workItemKey(projectID, id)
+	if _, ok := s.workItems[key]; !ok {
+		return ErrNotFound
+	}
+	delete(s.workItems, key)
+	for key, assignment := range s.assignments {
+		if assignment.ProjectID == projectID && assignment.WorkItemID == id {
+			delete(s.assignments, key)
+		}
+	}
+	for key, artifact := range s.artifacts {
+		if artifact.ProjectID == projectID && artifact.WorkItemID == id {
+			delete(s.artifacts, key)
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) ListAssignments(_ context.Context, filter AssignmentFilter) ([]Assignment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	items := make([]Assignment, 0, len(s.assignments))
+	for _, item := range s.assignments {
+		if item.ProjectID != filter.ProjectID {
+			continue
+		}
+		if filter.WorkItemID != "" && item.WorkItemID != filter.WorkItemID {
+			continue
+		}
+		items = append(items, cloneAssignment(item))
+	}
+	sortAssignments(items)
+	return items, nil
+}
+
+func (s *MemoryStore) CreateAssignment(_ context.Context, assignment Assignment) (Assignment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	assignment = normalizeAssignment(assignment, time.Now().UTC())
+	if err := validateAssignment(assignment); err != nil {
+		return Assignment{}, err
+	}
+	if _, ok := s.workItems[workItemKey(assignment.ProjectID, assignment.WorkItemID)]; !ok {
+		return Assignment{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	s.assignments[assignmentKey(assignment.ProjectID, assignment.ID)] = cloneAssignment(assignment)
+	return cloneAssignment(assignment), nil
+}
+
+func (s *MemoryStore) UpdateAssignment(_ context.Context, projectID, id string, update func(*Assignment)) (Assignment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := assignmentKey(projectID, id)
+	item, ok := s.assignments[key]
+	if !ok {
+		return Assignment{}, ErrNotFound
+	}
+	item = cloneAssignment(item)
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalWorkItemID := item.WorkItemID
+	originalCreatedAt := item.CreatedAt
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID ||
+		strings.TrimSpace(item.ProjectID) != originalProjectID ||
+		strings.TrimSpace(item.WorkItemID) != originalWorkItemID {
+		return Assignment{}, fmt.Errorf("%w: assignment id, project_id, and work_item_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.WorkItemID = originalWorkItemID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeAssignment(item, item.UpdatedAt)
+	if err := validateAssignment(item); err != nil {
+		return Assignment{}, err
+	}
+	s.assignments[key] = cloneAssignment(item)
+	return cloneAssignment(item), nil
+}
+
+func (s *MemoryStore) ListArtifacts(_ context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	filter.AssignmentID = strings.TrimSpace(filter.AssignmentID)
+	items := make([]CollaborationArtifact, 0, len(s.artifacts))
+	for _, item := range s.artifacts {
+		if item.ProjectID != filter.ProjectID {
+			continue
+		}
+		if filter.WorkItemID != "" && item.WorkItemID != filter.WorkItemID {
+			continue
+		}
+		if filter.AssignmentID != "" && item.AssignmentID != filter.AssignmentID {
+			continue
+		}
+		items = append(items, cloneArtifact(item))
+	}
+	sortArtifacts(items)
+	return items, nil
+}
+
+func (s *MemoryStore) CreateArtifact(_ context.Context, artifact CollaborationArtifact) (CollaborationArtifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	artifact = normalizeArtifact(artifact, time.Now().UTC())
+	if err := validateArtifact(artifact); err != nil {
+		return CollaborationArtifact{}, err
+	}
+	if _, ok := s.workItems[workItemKey(artifact.ProjectID, artifact.WorkItemID)]; !ok {
+		return CollaborationArtifact{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	if artifact.AssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(artifact.ProjectID, artifact.AssignmentID)]
+		if !ok || assignment.WorkItemID != artifact.WorkItemID {
+			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
+		}
+	}
+	s.artifacts[artifactKey(artifact.ProjectID, artifact.ID)] = cloneArtifact(artifact)
+	return cloneArtifact(artifact), nil
+}
+
+func (s *MemoryStore) DeleteProject(_ context.Context, projectID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	deleted := 0
+	for key, item := range s.roles {
+		if item.ProjectID == projectID {
+			delete(s.roles, key)
+			deleted++
+		}
+	}
+	for key, item := range s.workItems {
+		if item.ProjectID == projectID {
+			delete(s.workItems, key)
+			deleted++
+		}
+	}
+	for key, item := range s.assignments {
+		if item.ProjectID == projectID {
+			delete(s.assignments, key)
+			deleted++
+		}
+	}
+	for key, item := range s.artifacts {
+		if item.ProjectID == projectID {
+			delete(s.artifacts, key)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (s *MemoryStore) Clear(_ context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	deleted := len(s.roles) + len(s.workItems) + len(s.assignments) + len(s.artifacts)
+	s.roles = make(map[string]AgentRoleProfile)
+	s.workItems = make(map[string]WorkItem)
+	s.assignments = make(map[string]Assignment)
+	s.artifacts = make(map[string]CollaborationArtifact)
+	return deleted, nil
+}
+
+func normalizeRole(role AgentRoleProfile, now time.Time) AgentRoleProfile {
+	role.ID = strings.TrimSpace(role.ID)
+	role.ProjectID = strings.TrimSpace(role.ProjectID)
+	role.Name = strings.TrimSpace(role.Name)
+	role.Description = strings.TrimSpace(role.Description)
+	role.Instructions = strings.TrimSpace(role.Instructions)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if role.CreatedAt.IsZero() {
+		role.CreatedAt = now
+	}
+	if role.UpdatedAt.IsZero() {
+		role.UpdatedAt = role.CreatedAt
+	}
+	return role
+}
+
+func normalizeWorkItem(item WorkItem, now time.Time) WorkItem {
+	item.ID = strings.TrimSpace(item.ID)
+	item.ProjectID = strings.TrimSpace(item.ProjectID)
+	item.Title = strings.TrimSpace(item.Title)
+	item.Brief = strings.TrimSpace(item.Brief)
+	item.Status = strings.TrimSpace(item.Status)
+	item.Priority = strings.TrimSpace(item.Priority)
+	item.OwnerRoleID = strings.TrimSpace(item.OwnerRoleID)
+	item.ReviewerRoleIDs = normalizeStringList(item.ReviewerRoleIDs)
+	if item.Status == "" {
+		item.Status = WorkItemStatusBacklog
+	}
+	if item.Priority == "" {
+		item.Priority = "normal"
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = item.CreatedAt
+	}
+	return item
+}
+
+func normalizeAssignment(item Assignment, now time.Time) Assignment {
+	item.ID = strings.TrimSpace(item.ID)
+	item.ProjectID = strings.TrimSpace(item.ProjectID)
+	item.WorkItemID = strings.TrimSpace(item.WorkItemID)
+	item.RoleID = strings.TrimSpace(item.RoleID)
+	item.Status = strings.TrimSpace(item.Status)
+	item.TaskID = strings.TrimSpace(item.TaskID)
+	item.RunID = strings.TrimSpace(item.RunID)
+	item.ChatSessionID = strings.TrimSpace(item.ChatSessionID)
+	item.MessageID = strings.TrimSpace(item.MessageID)
+	item.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
+	if item.Status == "" {
+		item.Status = AssignmentStatusQueued
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = item.CreatedAt
+	}
+	return item
+}
+
+func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationArtifact {
+	item.ID = strings.TrimSpace(item.ID)
+	item.ProjectID = strings.TrimSpace(item.ProjectID)
+	item.WorkItemID = strings.TrimSpace(item.WorkItemID)
+	item.AssignmentID = strings.TrimSpace(item.AssignmentID)
+	item.Kind = strings.TrimSpace(item.Kind)
+	item.Title = strings.TrimSpace(item.Title)
+	item.Body = strings.TrimSpace(item.Body)
+	item.AuthorRoleID = strings.TrimSpace(item.AuthorRoleID)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = item.CreatedAt
+	}
+	return item
+}
+
+func validateRole(role AgentRoleProfile) error {
+	if role.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if role.ID == "" {
+		return fmt.Errorf("%w: role id is required", ErrInvalid)
+	}
+	if role.Name == "" {
+		return fmt.Errorf("%w: role name is required", ErrInvalid)
+	}
+	return nil
+}
+
+func validateWorkItem(item WorkItem) error {
+	if item.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if item.ID == "" {
+		return fmt.Errorf("%w: work item id is required", ErrInvalid)
+	}
+	if item.Title == "" {
+		return fmt.Errorf("%w: work item title is required", ErrInvalid)
+	}
+	if !validWorkItemStatus(item.Status) {
+		return fmt.Errorf("%w: unsupported work item status %q", ErrInvalid, item.Status)
+	}
+	if !validPriority(item.Priority) {
+		return fmt.Errorf("%w: unsupported work item priority %q", ErrInvalid, item.Priority)
+	}
+	return nil
+}
+
+func validateAssignment(item Assignment) error {
+	if item.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if item.ID == "" {
+		return fmt.Errorf("%w: assignment id is required", ErrInvalid)
+	}
+	if item.WorkItemID == "" {
+		return fmt.Errorf("%w: work_item_id is required", ErrInvalid)
+	}
+	if item.RoleID == "" {
+		return fmt.Errorf("%w: role_id is required", ErrInvalid)
+	}
+	if !validAssignmentStatus(item.Status) {
+		return fmt.Errorf("%w: unsupported assignment status %q", ErrInvalid, item.Status)
+	}
+	return nil
+}
+
+func validateArtifact(item CollaborationArtifact) error {
+	if item.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if item.ID == "" {
+		return fmt.Errorf("%w: artifact id is required", ErrInvalid)
+	}
+	if item.WorkItemID == "" {
+		return fmt.Errorf("%w: work_item_id is required", ErrInvalid)
+	}
+	if !validArtifactKind(item.Kind) {
+		return fmt.Errorf("%w: unsupported collaboration artifact kind %q", ErrInvalid, item.Kind)
+	}
+	if item.Body == "" {
+		return fmt.Errorf("%w: artifact body is required", ErrInvalid)
+	}
+	return nil
+}
+
+func validWorkItemStatus(status string) bool {
+	switch status {
+	case WorkItemStatusBacklog, WorkItemStatusReady, WorkItemStatusRunning, WorkItemStatusReview, WorkItemStatusBlocked, WorkItemStatusDone, WorkItemStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func validAssignmentStatus(status string) bool {
+	switch status {
+	case AssignmentStatusQueued, AssignmentStatusRunning, AssignmentStatusAwaitingApproval, AssignmentStatusCompleted, AssignmentStatusFailed, AssignmentStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func validArtifactKind(kind string) bool {
+	switch kind {
+	case ArtifactKindBrief, ArtifactKindHandoff, ArtifactKindReview, ArtifactKindDecisionNote:
+		return true
+	default:
+		return false
+	}
+}
+
+func validPriority(priority string) bool {
+	switch priority {
+	case "low", "normal", "high", "urgent":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func roleKey(projectID, id string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
+}
+
+func workItemKey(projectID, id string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
+}
+
+func assignmentKey(projectID, id string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
+}
+
+func artifactKey(projectID, id string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
+}
+
+func cloneRole(item AgentRoleProfile) AgentRoleProfile {
+	return item
+}
+
+func cloneWorkItem(item WorkItem) WorkItem {
+	item.ReviewerRoleIDs = append([]string(nil), item.ReviewerRoleIDs...)
+	return item
+}
+
+func cloneAssignment(item Assignment) Assignment {
+	return item
+}
+
+func cloneArtifact(item CollaborationArtifact) CollaborationArtifact {
+	return item
+}
+
+func sortRoles(items []AgentRoleProfile) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].BuiltIn != items[j].BuiltIn {
+			return items[i].BuiltIn
+		}
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortWorkItems(items []WorkItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
+			return items[i].UpdatedAt.After(items[j].UpdatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortAssignments(items []Assignment) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].CreatedAt.Before(items[j].CreatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortArtifacts(items []CollaborationArtifact) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].CreatedAt.Before(items[j].CreatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -37,6 +37,7 @@ var (
 	ErrInvalid       = errors.New("invalid project work record")
 	ErrBuiltInRole   = errors.New("built-in role cannot be mutated")
 	ErrDuplicateRole = errors.New("project role already exists")
+	ErrDuplicate     = errors.New("project work record already exists")
 )
 
 type AgentRoleProfile struct {
@@ -281,7 +282,11 @@ func (s *MemoryStore) CreateWorkItem(_ context.Context, item WorkItem) (WorkItem
 	if err := validateWorkItem(item); err != nil {
 		return WorkItem{}, err
 	}
-	s.workItems[workItemKey(item.ProjectID, item.ID)] = cloneWorkItem(item)
+	key := workItemKey(item.ProjectID, item.ID)
+	if _, exists := s.workItems[key]; exists {
+		return WorkItem{}, ErrDuplicate
+	}
+	s.workItems[key] = cloneWorkItem(item)
 	return cloneWorkItem(item), nil
 }
 
@@ -377,7 +382,11 @@ func (s *MemoryStore) CreateAssignment(_ context.Context, assignment Assignment)
 	if _, ok := s.workItems[workItemKey(assignment.ProjectID, assignment.WorkItemID)]; !ok {
 		return Assignment{}, fmt.Errorf("%w: work item not found", ErrNotFound)
 	}
-	s.assignments[assignmentKey(assignment.ProjectID, assignment.ID)] = cloneAssignment(assignment)
+	key := assignmentKey(assignment.ProjectID, assignment.ID)
+	if _, exists := s.assignments[key]; exists {
+		return Assignment{}, ErrDuplicate
+	}
+	s.assignments[key] = cloneAssignment(assignment)
 	return cloneAssignment(assignment), nil
 }
 
@@ -454,7 +463,11 @@ func (s *MemoryStore) CreateArtifact(_ context.Context, artifact CollaborationAr
 			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
 		}
 	}
-	s.artifacts[artifactKey(artifact.ProjectID, artifact.ID)] = cloneArtifact(artifact)
+	key := artifactKey(artifact.ProjectID, artifact.ID)
+	if _, exists := s.artifacts[key]; exists {
+		return CollaborationArtifact{}, ErrDuplicate
+	}
+	s.artifacts[key] = cloneArtifact(artifact)
 	return cloneArtifact(artifact), nil
 }
 

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -1,0 +1,268 @@
+package projectwork
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: func(t *testing.T) Store { return newSQLiteTestStore(t) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tc.new(t)
+
+			roles, err := store.ListRoles(ctx, "proj_alpha")
+			if err != nil {
+				t.Fatalf("ListRoles built-ins: %v", err)
+			}
+			if len(roles) < 8 || !roleIDExists(roles, "product_manager") || !roleIDExists(roles, "reviewer_qa") {
+				t.Fatalf("built-in roles = %+v, want default project team roles", roles)
+			}
+
+			custom, err := store.CreateRole(ctx, AgentRoleProfile{
+				ID:           "role_release_captain",
+				ProjectID:    "proj_alpha",
+				Name:         " Release Captain ",
+				Description:  " Coordinates releases ",
+				Instructions: "Keep release notes current.",
+			})
+			if err != nil {
+				t.Fatalf("CreateRole: %v", err)
+			}
+			if custom.Name != "Release Captain" || custom.BuiltIn {
+				t.Fatalf("custom role = %+v, want normalized custom role", custom)
+			}
+			if _, err := store.CreateRole(ctx, AgentRoleProfile{ID: "product_manager", ProjectID: "proj_alpha", Name: "Override"}); !errors.Is(err, ErrBuiltInRole) {
+				t.Fatalf("CreateRole built-in error = %v, want ErrBuiltInRole", err)
+			}
+			if err := store.DeleteRole(ctx, "proj_alpha", "product_manager"); !errors.Is(err, ErrBuiltInRole) {
+				t.Fatalf("DeleteRole built-in error = %v, want ErrBuiltInRole", err)
+			}
+
+			work, err := store.CreateWorkItem(ctx, WorkItem{
+				ID:              "work_api",
+				ProjectID:       "proj_alpha",
+				Title:           " Add project work API ",
+				Brief:           "Persist work coordination metadata.",
+				Priority:        "high",
+				OwnerRoleID:     "software_developer",
+				ReviewerRoleIDs: []string{"reviewer_qa", "architect", "reviewer_qa"},
+			})
+			if err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
+			if work.Status != WorkItemStatusBacklog || len(work.ReviewerRoleIDs) != 2 || work.ReviewerRoleIDs[0] != "architect" {
+				t.Fatalf("work item = %+v, want defaults and normalized reviewers", work)
+			}
+
+			got, ok, err := store.GetWorkItem(ctx, "proj_alpha", "work_api")
+			if err != nil || !ok {
+				t.Fatalf("GetWorkItem ok=%v err=%v, want work item", ok, err)
+			}
+			got.ReviewerRoleIDs[0] = "mutated"
+			gotAgain, _, err := store.GetWorkItem(ctx, "proj_alpha", "work_api")
+			if err != nil {
+				t.Fatalf("GetWorkItem after mutation: %v", err)
+			}
+			if gotAgain.ReviewerRoleIDs[0] != "architect" {
+				t.Fatalf("stored reviewers mutated to %+v", gotAgain.ReviewerRoleIDs)
+			}
+
+			updatedWork, err := store.UpdateWorkItem(ctx, "proj_alpha", "work_api", func(item *WorkItem) {
+				item.Status = WorkItemStatusReady
+				item.ReviewerRoleIDs = []string{"reviewer_qa"}
+			})
+			if err != nil {
+				t.Fatalf("UpdateWorkItem: %v", err)
+			}
+			if updatedWork.Status != WorkItemStatusReady || len(updatedWork.ReviewerRoleIDs) != 1 {
+				t.Fatalf("updated work item = %+v, want ready with one reviewer", updatedWork)
+			}
+
+			assignment, err := store.CreateAssignment(ctx, Assignment{
+				ID:                "asgn_impl",
+				ProjectID:         "proj_alpha",
+				WorkItemID:        "work_api",
+				RoleID:            "software_developer",
+				TaskID:            "task_123",
+				RunID:             "run_123",
+				ContextSnapshotID: "ctx_123",
+			})
+			if err != nil {
+				t.Fatalf("CreateAssignment: %v", err)
+			}
+			if assignment.Status != AssignmentStatusQueued {
+				t.Fatalf("assignment status = %q, want queued", assignment.Status)
+			}
+
+			startedAt := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+			updatedAssignment, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
+				item.Status = AssignmentStatusRunning
+				item.StartedAt = startedAt
+			})
+			if err != nil {
+				t.Fatalf("UpdateAssignment: %v", err)
+			}
+			if updatedAssignment.Status != AssignmentStatusRunning || !updatedAssignment.StartedAt.Equal(startedAt) {
+				t.Fatalf("updated assignment = %+v, want running with start time", updatedAssignment)
+			}
+
+			artifact, err := store.CreateArtifact(ctx, CollaborationArtifact{
+				ID:           "art_brief",
+				ProjectID:    "proj_alpha",
+				WorkItemID:   "work_api",
+				AssignmentID: "asgn_impl",
+				Kind:         ArtifactKindBrief,
+				Title:        "Implementation brief",
+				Body:         "Build the backend substrate only.",
+				AuthorRoleID: "product_manager",
+			})
+			if err != nil {
+				t.Fatalf("CreateArtifact: %v", err)
+			}
+			if artifact.Kind != ArtifactKindBrief || artifact.Body == "" {
+				t.Fatalf("artifact = %+v, want brief artifact", artifact)
+			}
+
+			assignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListAssignments: %v", err)
+			}
+			if len(assignments) != 1 || assignments[0].ID != "asgn_impl" {
+				t.Fatalf("assignments = %+v, want created assignment", assignments)
+			}
+			artifacts, err := store.ListArtifacts(ctx, ArtifactFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListArtifacts: %v", err)
+			}
+			if len(artifacts) != 1 || artifacts[0].ID != "art_brief" {
+				t.Fatalf("artifacts = %+v, want created artifact", artifacts)
+			}
+
+			if err := store.DeleteWorkItem(ctx, "proj_alpha", "work_api"); err != nil {
+				t.Fatalf("DeleteWorkItem: %v", err)
+			}
+			assignments, err = store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha"})
+			if err != nil {
+				t.Fatalf("ListAssignments after delete: %v", err)
+			}
+			artifacts, err = store.ListArtifacts(ctx, ArtifactFilter{ProjectID: "proj_alpha"})
+			if err != nil {
+				t.Fatalf("ListArtifacts after delete: %v", err)
+			}
+			if len(assignments) != 0 || len(artifacts) != 0 {
+				t.Fatalf("work item delete left assignments=%+v artifacts=%+v", assignments, artifacts)
+			}
+		})
+	}
+}
+
+func TestStoreConformance_ProjectCleanup(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: func(t *testing.T) Store { return newSQLiteTestStore(t) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tc.new(t)
+			if _, err := store.CreateRole(ctx, AgentRoleProfile{ID: "role_custom", ProjectID: "proj_alpha", Name: "Custom"}); err != nil {
+				t.Fatalf("CreateRole: %v", err)
+			}
+			if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_alpha", ProjectID: "proj_alpha", Title: "Alpha"}); err != nil {
+				t.Fatalf("CreateWorkItem alpha: %v", err)
+			}
+			if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_beta", ProjectID: "proj_beta", Title: "Beta"}); err != nil {
+				t.Fatalf("CreateWorkItem beta: %v", err)
+			}
+			if _, err := store.CreateAssignment(ctx, Assignment{ID: "asgn_alpha", ProjectID: "proj_alpha", WorkItemID: "work_alpha", RoleID: "software_developer"}); err != nil {
+				t.Fatalf("CreateAssignment: %v", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_alpha", ProjectID: "proj_alpha", WorkItemID: "work_alpha", Kind: ArtifactKindDecisionNote, Body: "Ship it."}); err != nil {
+				t.Fatalf("CreateArtifact: %v", err)
+			}
+
+			deleted, err := store.DeleteProject(ctx, "proj_alpha")
+			if err != nil {
+				t.Fatalf("DeleteProject: %v", err)
+			}
+			if deleted != 4 {
+				t.Fatalf("DeleteProject deleted = %d, want 4", deleted)
+			}
+			if roles, err := store.ListRoles(ctx, "proj_alpha"); err != nil || roleIDExists(roles, "role_custom") {
+				t.Fatalf("roles after project delete = %+v err=%v, want only built-ins", roles, err)
+			}
+			if items, err := store.ListWorkItems(ctx, "proj_alpha"); err != nil || len(items) != 0 {
+				t.Fatalf("alpha work items after delete = %+v err=%v, want none", items, err)
+			}
+			if items, err := store.ListWorkItems(ctx, "proj_beta"); err != nil || len(items) != 1 {
+				t.Fatalf("beta work items after alpha delete = %+v err=%v, want retained", items, err)
+			}
+
+			cleared, err := store.Clear(ctx)
+			if err != nil {
+				t.Fatalf("Clear: %v", err)
+			}
+			if cleared != 1 {
+				t.Fatalf("Clear deleted = %d, want remaining beta work item", cleared)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_UpdateRejectsIDChanges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_alpha", ProjectID: "proj_alpha", Title: "Alpha"}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := store.UpdateWorkItem(ctx, "proj_alpha", "work_alpha", func(item *WorkItem) {
+		item.ID = "work_beta"
+	}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("UpdateWorkItem id change error = %v, want ErrInvalid", err)
+	}
+}
+
+func newSQLiteTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	client, err := storage.NewSQLiteClient(context.Background(), storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "projectwork.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	store, err := NewSQLiteStore(context.Background(), client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	return store
+}
+
+func roleIDExists(roles []AgentRoleProfile, id string) bool {
+	for _, role := range roles {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -137,6 +137,16 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				t.Fatalf("artifact = %+v, want brief artifact", artifact)
 			}
 
+			if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_api", ProjectID: "proj_alpha", Title: "Duplicate"}); !errors.Is(err, ErrDuplicate) {
+				t.Fatalf("duplicate CreateWorkItem error = %v, want ErrDuplicate", err)
+			}
+			if _, err := store.CreateAssignment(ctx, Assignment{ID: "asgn_impl", ProjectID: "proj_alpha", WorkItemID: "work_api", RoleID: "software_developer"}); !errors.Is(err, ErrDuplicate) {
+				t.Fatalf("duplicate CreateAssignment error = %v, want ErrDuplicate", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_brief", ProjectID: "proj_alpha", WorkItemID: "work_api", Kind: ArtifactKindBrief, Body: "Duplicate"}); !errors.Is(err, ErrDuplicate) {
+				t.Fatalf("duplicate CreateArtifact error = %v, want ErrDuplicate", err)
+			}
+
 			assignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
 			if err != nil {
 				t.Fatalf("ListAssignments: %v", err)


### PR DESCRIPTION
## Summary
- add durable memory and SQLite stores for project-scoped roles, work items, assignments, and collaboration artifacts
- expose project-scoped Hecate-native endpoints for roles, work items, assignments, and artifacts
- clean project-work rows during project deletion and system reset, including reset stats
- document endpoint shapes and the V1 metadata-only assignment limitation

## Validation
- `go build ./...`
- `go test ./internal/projectwork ./internal/api ./internal/projects`
- `go vet ./internal/projectwork ./internal/api ./internal/projects`