### PR TITLE
Start native project work assignments

### DIFF
--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -240,8 +240,10 @@ stores, plus `GET`/`POST`/`PATCH`/`DELETE /hecate/v1/projects`.
 This landed as a foundation plus chat grouping: project records and roots can be
 persisted, trusted context-source metadata can be attached to a project, and
 chat sessions can carry `project_id`. Chat context packets snapshot enabled
-project context-source metadata as itemized provenance. Tasks, memory entries,
-profiles, and presets are not linked to `project_id` yet.
+project context-source metadata as itemized provenance. Project work
+assignments can now start native Tasks linked back via `origin_kind` /
+`origin_id`; broader task `project_id` scoping, memory entries, profiles, and
+presets are not linked to `project_id` yet.
 
 Persist `project_id` on:
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1187,8 +1187,10 @@ cleanup.
 Project work coordination is the durable substrate for future project-team
 orchestration. It records project-scoped agent roles, work items, assignment
 metadata, and collaboration artifacts. It does not add a new execution runtime:
-existing Tasks and Chats remain the execution surfaces, and V1 assignment
-creation only records intended or already-linked execution metadata.
+existing Tasks and Chats remain the execution surfaces. Assignment creation
+only records intended or already-linked execution metadata; the separate native
+assignment start endpoint can create and start a Hecate-owned `agent_loop` task
+for `driver_kind="hecate_task"` assignments.
 Create requests that supply an existing project-scoped ID return `409 conflict`
 instead of overwriting the existing record.
 
@@ -1210,6 +1212,8 @@ reviewer_qa
 Supported work-item statuses are `backlog`, `ready`, `running`, `review`,
 `blocked`, `done`, and `cancelled`. Supported assignment statuses are `queued`,
 `running`, `awaiting_approval`, `completed`, `failed`, and `cancelled`.
+Supported assignment driver kinds are `hecate_task` and `external_agent`, but
+native assignment start V1 only dispatches `hecate_task`.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
 
@@ -1327,13 +1331,15 @@ Lists assignment metadata for a work item.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 
-Creates an assignment metadata record. `role_id` is required. Optional link
-fields (`task_id`, `run_id`, `chat_session_id`, `message_id`,
-`context_snapshot_id`) are stored as references only.
+Creates an assignment metadata record. `role_id` is required. `driver_kind`
+defaults to `hecate_task`. Optional link fields (`task_id`, `run_id`,
+`chat_session_id`, `message_id`, `context_snapshot_id`) are stored as
+references only.
 
 ```json
 {
   "role_id": "software_developer",
+  "driver_kind": "hecate_task",
   "task_id": "task_...",
   "run_id": "run_...",
   "context_snapshot_id": "ctx_..."
@@ -1350,6 +1356,7 @@ Returns:
     "project_id": "proj_...",
     "work_item_id": "work_...",
     "role_id": "software_developer",
+    "driver_kind": "hecate_task",
     "status": "queued",
     "task_id": "task_...",
     "run_id": "run_...",
@@ -1364,6 +1371,61 @@ Returns:
 
 Updates assignment status, role, link fields, `started_at`, or `completed_at`.
 It does not mutate or start the linked Task or Chat.
+
+#### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start`
+
+Starts a native Hecate assignment. V1 supports only assignments whose
+`driver_kind` is `hecate_task`; `external_agent` assignments return
+`409 conflict` and must still be run through the external-agent chat/session
+surface. The request body is optional. When present, `driver_kind` must match
+the stored assignment driver.
+
+```json
+{
+  "driver_kind": "hecate_task"
+}
+```
+
+Starting verifies that the project, work item, assignment, and role exist, then
+creates a normal Task with `execution_kind="agent_loop"`,
+`origin_kind="project_work_item"`, and `origin_id` set to the work item ID. The
+task title, prompt, and system prompt are composed from the work item brief,
+role profile, and project defaults. Project default provider/model/workspace
+settings are copied onto the task when configured. The workspace root must
+resolve to an absolute existing project root before a task is created; missing
+or defaultless roots return `400 invalid_request`. A missing model returns
+`422 model_not_configured`.
+
+The endpoint then starts the task through the canonical task runner, so normal
+task approvals, queueing, run events, artifacts, and SSE inspection apply. On
+success it updates the assignment with `task_id`, latest `run_id`, status, and
+timestamps, and returns the updated assignment:
+
+```json
+{
+  "object": "project_assignment",
+  "data": {
+    "id": "asgn_...",
+    "project_id": "proj_...",
+    "work_item_id": "work_...",
+    "role_id": "software_developer",
+    "driver_kind": "hecate_task",
+    "status": "queued",
+    "task_id": "task_...",
+    "run_id": "run_...",
+    "created_at": "2026-06-03T12:00:00Z",
+    "updated_at": "2026-06-03T12:00:01Z",
+    "started_at": "2026-06-03T12:00:01Z"
+  }
+}
+```
+
+Repeated starts for an assignment that already has an active execution return
+`409` with the current assignment envelope and do not create another task/run.
+Assignments in terminal states (`completed`, `failed`, `cancelled`) also return
+`409`. If task creation succeeds but task start fails, Hecate keeps the
+assignment's `task_id`, marks the assignment `failed`, and returns an error so
+the operator can inspect the linked task instead of losing the partial state.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -717,7 +717,9 @@ func projectWorkAssignmentHasActiveExecution(ctx context.Context, store taskRunL
 		}
 	}
 	switch strings.TrimSpace(assignment.Status) {
-	case projectwork.AssignmentStatusQueued, projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+		return true, nil
+	case projectwork.AssignmentStatusQueued:
 		return strings.TrimSpace(assignment.TaskID) != "" || strings.TrimSpace(assignment.RunID) != "", nil
 	default:
 		return false, nil

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -601,15 +601,17 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	if err != nil {
 		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 			if item.TaskID == taskID && item.RunID == "" {
-				item.Status = projectwork.AssignmentStatusFailed
-				item.CompletedAt = time.Now().UTC()
+				item.TaskID = ""
+				item.Status = projectwork.AssignmentStatusQueued
+				item.StartedAt = time.Time{}
+				item.CompletedAt = time.Time{}
 			}
 		})
 		if updateErr != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("%s; assignment status update failed: %v", err.Error(), updateErr))
 			return
 		}
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("task %s could not be created for assignment: %s", assignment.TaskID, err.Error()))
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("task could not be created for assignment %s: %s", assignment.ID, err.Error()))
 		return
 	}
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -499,11 +501,9 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
-	var req startProjectWorkAssignmentRequest
-	if r.Body != http.NoBody && r.ContentLength != 0 {
-		if !decodeJSON(w, r, &req) {
-			return
-		}
+	req, ok := decodeOptionalProjectWorkAssignmentStartRequest(w, r)
+	if !ok {
+		return
 	}
 
 	project, ok, err := h.projects.Get(ctx, projectID)
@@ -575,13 +575,14 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	task, err := h.createProjectAssignmentTask(ctx, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedModel)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
+	taskID := newTaskID()
+	claimRejected := false
 	assignment, err = h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
-		item.TaskID = task.ID
+		if item.TaskID != "" || item.RunID != "" || projectWorkAssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverHecateTask {
+			claimRejected = true
+			return
+		}
+		item.TaskID = taskID
 		item.Status = projectwork.AssignmentStatusQueued
 		if item.StartedAt.IsZero() {
 			item.StartedAt = time.Now().UTC()
@@ -589,6 +590,26 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if claimRejected {
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		return
+	}
+
+	task, err := h.createProjectAssignmentTask(ctx, taskID, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedModel)
+	if err != nil {
+		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
+			if item.TaskID == taskID && item.RunID == "" {
+				item.Status = projectwork.AssignmentStatusFailed
+				item.CompletedAt = time.Now().UTC()
+			}
+		})
+		if updateErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("%s; assignment status update failed: %v", err.Error(), updateErr))
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("task %s could not be created for assignment: %s", assignment.TaskID, err.Error()))
 		return
 	}
 
@@ -629,6 +650,22 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+}
+
+func decodeOptionalProjectWorkAssignmentStartRequest(w http.ResponseWriter, r *http.Request) (startProjectWorkAssignmentRequest, bool) {
+	var req startProjectWorkAssignmentRequest
+	if r.Body == nil || r.Body == http.NoBody {
+		return req, true
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			return req, true
+		}
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be valid JSON")
+		return startProjectWorkAssignmentRequest{}, false
+	}
+	return req, true
 }
 
 func (h *Handler) loadProjectWorkAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (projectwork.Assignment, bool, error) {
@@ -735,10 +772,10 @@ func selectProjectAssignmentRoot(project projects.Project) (projects.Root, bool)
 	return projects.Root{}, false
 }
 
-func (h *Handler) createProjectAssignmentTask(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedModel string) (types.Task, error) {
+func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedModel string) (types.Task, error) {
 	now := time.Now().UTC()
 	task := types.Task{
-		ID:                 newTaskID(),
+		ID:                 taskID,
 		Title:              projectAssignmentTaskTitle(workItem, role),
 		Prompt:             projectAssignmentPrompt(project, workItem, assignment, role),
 		SystemPrompt:       projectAssignmentSystemPrompt(project, role),

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1,12 +1,19 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/pkg/types"
 )
 
 type createProjectWorkRoleRequest struct {
@@ -44,6 +51,7 @@ type updateProjectWorkItemRequest struct {
 type createProjectWorkAssignmentRequest struct {
 	ID                string `json:"id,omitempty"`
 	RoleID            string `json:"role_id"`
+	DriverKind        string `json:"driver_kind,omitempty"`
 	Status            string `json:"status,omitempty"`
 	TaskID            string `json:"task_id,omitempty"`
 	RunID             string `json:"run_id,omitempty"`
@@ -56,6 +64,7 @@ type createProjectWorkAssignmentRequest struct {
 
 type updateProjectWorkAssignmentRequest struct {
 	RoleID            *string `json:"role_id,omitempty"`
+	DriverKind        *string `json:"driver_kind,omitempty"`
 	Status            *string `json:"status,omitempty"`
 	TaskID            *string `json:"task_id,omitempty"`
 	RunID             *string `json:"run_id,omitempty"`
@@ -64,6 +73,10 @@ type updateProjectWorkAssignmentRequest struct {
 	ContextSnapshotID *string `json:"context_snapshot_id,omitempty"`
 	StartedAt         *string `json:"started_at,omitempty"`
 	CompletedAt       *string `json:"completed_at,omitempty"`
+}
+
+type startProjectWorkAssignmentRequest struct {
+	DriverKind string `json:"driver_kind,omitempty"`
 }
 
 type createProjectWorkArtifactRequest struct {
@@ -134,6 +147,7 @@ type ProjectWorkAssignmentResponse struct {
 	ProjectID         string `json:"project_id"`
 	WorkItemID        string `json:"work_item_id"`
 	RoleID            string `json:"role_id"`
+	DriverKind        string `json:"driver_kind"`
 	Status            string `json:"status"`
 	TaskID            string `json:"task_id,omitempty"`
 	RunID             string `json:"run_id,omitempty"`
@@ -399,6 +413,7 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 		ProjectID:         projectID,
 		WorkItemID:        workItemID,
 		RoleID:            req.RoleID,
+		DriverKind:        req.DriverKind,
 		Status:            req.Status,
 		TaskID:            req.TaskID,
 		RunID:             req.RunID,
@@ -433,6 +448,9 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 		if req.RoleID != nil {
 			item.RoleID = *req.RoleID
 		}
+		if req.DriverKind != nil {
+			item.DriverKind = *req.DriverKind
+		}
 		if req.Status != nil {
 			item.Status = *req.Status
 		}
@@ -462,6 +480,352 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(item)})
+}
+
+func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	assignmentID := r.PathValue("assignment_id")
+	if h.taskStore == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
+		return
+	}
+	if h.taskRunner == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
+		return
+	}
+	if h.projects == nil || h.projectWork == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
+		return
+	}
+	var req startProjectWorkAssignmentRequest
+	if r.Body != http.NoBody && r.ContentLength != 0 {
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+	}
+
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+		return
+	}
+	assignment, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment not found")
+		return
+	}
+	role, ok, err := h.loadProjectWorkRole(ctx, projectID, assignment.RoleID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment role not found")
+		return
+	}
+	if driver := strings.TrimSpace(req.DriverKind); driver != "" && driver != assignment.DriverKind {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("assignment driver_kind is %q, not %q", assignment.DriverKind, driver))
+		return
+	}
+	if assignment.DriverKind != projectwork.AssignmentDriverHecateTask {
+		WriteError(w, http.StatusConflict, errCodeConflict, fmt.Sprintf("assignment driver_kind %q is not supported by native start; V1 supports %q only", assignment.DriverKind, projectwork.AssignmentDriverHecateTask))
+		return
+	}
+	if projectWorkAssignmentIsTerminal(assignment.Status) {
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		return
+	}
+	active, err := projectWorkAssignmentHasActiveExecution(ctx, h.taskStore, assignment)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if active {
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		return
+	}
+
+	workingDirectory, workspaceMode, err := resolveProjectAssignmentWorkspace(project)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	requestedModel := strings.TrimSpace(firstNonEmpty(project.DefaultModel, h.config.Router.DefaultModel))
+	if requestedModel == "" {
+		WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, "project assignment start requires a default model")
+		return
+	}
+
+	task, err := h.createProjectAssignmentTask(ctx, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedModel)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	assignment, err = h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
+		item.TaskID = task.ID
+		item.Status = projectwork.AssignmentStatusQueued
+		if item.StartedAt.IsZero() {
+			item.StartedAt = time.Now().UTC()
+		}
+	})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+
+	result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
+	if err != nil {
+		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
+			item.TaskID = task.ID
+			item.Status = projectwork.AssignmentStatusFailed
+			item.CompletedAt = time.Now().UTC()
+		})
+		if updateErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("%s; assignment status update failed: %v", err.Error(), updateErr))
+			return
+		}
+		if errors.Is(err, orchestrator.ErrAgentLoopMisconfigured) {
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, err.Error())
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("task %s was created but start failed: %s", assignment.TaskID, err.Error()))
+		return
+	}
+	if result.TraceID != "" {
+		w.Header().Set("X-Trace-Id", result.TraceID)
+	}
+	if result.SpanID != "" {
+		w.Header().Set("X-Span-Id", result.SpanID)
+	}
+	assignment, err = h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
+		item.TaskID = result.Task.ID
+		item.RunID = result.Run.ID
+		item.Status = projectWorkAssignmentStatusFromRun(result.Run.Status)
+		if item.StartedAt.IsZero() {
+			item.StartedAt = time.Now().UTC()
+		}
+	})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+}
+
+func (h *Handler) loadProjectWorkAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (projectwork.Assignment, bool, error) {
+	items, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return projectwork.Assignment{}, false, err
+	}
+	for _, item := range items {
+		if item.ID == strings.TrimSpace(assignmentID) {
+			return item, true, nil
+		}
+	}
+	return projectwork.Assignment{}, false, nil
+}
+
+func (h *Handler) loadProjectWorkRole(ctx context.Context, projectID, roleID string) (projectwork.AgentRoleProfile, bool, error) {
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, false, err
+	}
+	roleID = strings.TrimSpace(roleID)
+	for _, role := range roles {
+		if role.ID == roleID {
+			return role, true, nil
+		}
+	}
+	return projectwork.AgentRoleProfile{}, false, nil
+}
+
+func projectWorkAssignmentIsTerminal(status string) bool {
+	switch strings.TrimSpace(status) {
+	case projectwork.AssignmentStatusCompleted, projectwork.AssignmentStatusFailed, projectwork.AssignmentStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectWorkAssignmentHasActiveExecution(ctx context.Context, store taskRunLookupStore, assignment projectwork.Assignment) (bool, error) {
+	if strings.TrimSpace(assignment.RunID) != "" && strings.TrimSpace(assignment.TaskID) != "" && store != nil {
+		run, found, err := store.GetRun(ctx, assignment.TaskID, assignment.RunID)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return !types.IsTerminalTaskRunStatus(run.Status), nil
+		}
+	}
+	switch strings.TrimSpace(assignment.Status) {
+	case projectwork.AssignmentStatusQueued, projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+		return strings.TrimSpace(assignment.TaskID) != "" || strings.TrimSpace(assignment.RunID) != "", nil
+	default:
+		return false, nil
+	}
+}
+
+type taskRunLookupStore interface {
+	GetRun(ctx context.Context, taskID, runID string) (types.TaskRun, bool, error)
+}
+
+func resolveProjectAssignmentWorkspace(project projects.Project) (string, string, error) {
+	root, ok := selectProjectAssignmentRoot(project)
+	if !ok {
+		return "", "", fmt.Errorf("project has no workspace root; add a project root before starting an assignment")
+	}
+	path := strings.TrimSpace(root.Path)
+	if path == "" {
+		return "", "", fmt.Errorf("project root %q has no path", root.ID)
+	}
+	if !filepath.IsAbs(path) {
+		return "", "", fmt.Errorf("project root %q path must be absolute", root.ID)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", "", fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("project root %q is not a directory", root.ID)
+	}
+	workspaceMode := strings.TrimSpace(project.DefaultWorkspaceMode)
+	if workspaceMode == "" {
+		workspaceMode = "ephemeral"
+	}
+	return path, workspaceMode, nil
+}
+
+func selectProjectAssignmentRoot(project projects.Project) (projects.Root, bool) {
+	defaultRootID := strings.TrimSpace(project.DefaultRootID)
+	if defaultRootID != "" {
+		for _, root := range project.Roots {
+			if root.ID == defaultRootID {
+				return root, true
+			}
+		}
+	}
+	for _, root := range project.Roots {
+		if root.Active {
+			return root, true
+		}
+	}
+	if len(project.Roots) > 0 {
+		return project.Roots[0], true
+	}
+	return projects.Root{}, false
+}
+
+func (h *Handler) createProjectAssignmentTask(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedModel string) (types.Task, error) {
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:                 newTaskID(),
+		Title:              projectAssignmentTaskTitle(workItem, role),
+		Prompt:             projectAssignmentPrompt(project, workItem, assignment, role),
+		SystemPrompt:       projectAssignmentSystemPrompt(project, role),
+		ExecutionKind:      "agent_loop",
+		ExecutionProfile:   "project_assignment",
+		OriginKind:         "project_work_item",
+		OriginID:           workItem.ID,
+		WorkspaceMode:      workspaceMode,
+		WorkingDirectory:   workingDirectory,
+		SandboxAllowedRoot: workingDirectory,
+		Status:             "queued",
+		Priority:           firstNonEmpty(workItem.Priority, "normal"),
+		RequestedProvider:  strings.TrimSpace(project.DefaultProvider),
+		RequestedModel:     requestedModel,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return h.taskStore.CreateTask(ctx, task)
+}
+
+func projectAssignmentTaskTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) string {
+	title := strings.TrimSpace(workItem.Title)
+	roleName := strings.TrimSpace(role.Name)
+	switch {
+	case title != "" && roleName != "":
+		return title + " - " + roleName
+	case title != "":
+		return title
+	case roleName != "":
+		return roleName + " assignment"
+	default:
+		return "Project work assignment"
+	}
+}
+
+func projectAssignmentPrompt(project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) string {
+	sections := []string{
+		"Project: " + firstNonEmpty(project.Name, project.ID),
+		"Work item: " + firstNonEmpty(workItem.Title, workItem.ID),
+	}
+	if brief := strings.TrimSpace(workItem.Brief); brief != "" {
+		sections = append(sections, "Work item brief:\n"+brief)
+	}
+	if roleName := strings.TrimSpace(role.Name); roleName != "" {
+		sections = append(sections, "Assigned role: "+roleName)
+	}
+	if description := strings.TrimSpace(role.Description); description != "" {
+		sections = append(sections, "Role description:\n"+description)
+	}
+	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
+		sections = append(sections, "Role instructions:\n"+instructions)
+	}
+	sections = append(sections,
+		"Assignment ID: "+assignment.ID,
+		"Execute this assignment as a native Hecate agent_loop task. Keep outputs and artifacts linked to this work item.",
+	)
+	return strings.Join(sections, "\n\n")
+}
+
+func projectAssignmentSystemPrompt(project projects.Project, role projectwork.AgentRoleProfile) string {
+	var parts []string
+	if prompt := strings.TrimSpace(project.DefaultSystemPrompt); prompt != "" {
+		parts = append(parts, prompt)
+	}
+	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
+		parts = append(parts, instructions)
+	} else if role.Name != "" {
+		parts = append(parts, "Act as the "+strings.TrimSpace(role.Name)+" for this project work assignment.")
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func projectWorkAssignmentStatusFromRun(status string) string {
+	switch strings.TrimSpace(status) {
+	case "awaiting_approval":
+		return projectwork.AssignmentStatusAwaitingApproval
+	case "running":
+		return projectwork.AssignmentStatusRunning
+	case "completed":
+		return projectwork.AssignmentStatusCompleted
+	case "failed":
+		return projectwork.AssignmentStatusFailed
+	case "cancelled":
+		return projectwork.AssignmentStatusCancelled
+	default:
+		return projectwork.AssignmentStatusQueued
+	}
 }
 
 func (h *Handler) HandleProjectWorkArtifacts(w http.ResponseWriter, r *http.Request) {
@@ -658,6 +1022,7 @@ func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignm
 		ProjectID:         item.ProjectID,
 		WorkItemID:        item.WorkItemID,
 		RoleID:            item.RoleID,
+		DriverKind:        item.DriverKind,
 		Status:            item.Status,
 		TaskID:            item.TaskID,
 		RunID:             item.RunID,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/taskstate"
@@ -401,6 +402,44 @@ func TestProjectWorkAPI_StartAssignmentTerminalReturnsCurrentAssignment(t *testi
 	}
 	if len(tasks) != 0 {
 		t.Fatalf("tasks = %+v, want none created", tasks)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentPreservesTaskLinkWhenStartFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	failingRunner := orchestrator.NewRunner(quietLogger(), nil, nil, orchestrator.Config{})
+	t.Cleanup(func() { _ = failingRunner.Shutdown(t.Context()) })
+	handler.taskRunner = failingRunner
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("start failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_start", WorkItemID: "work_start"})
+	if err != nil {
+		t.Fatalf("ListAssignments: %v", err)
+	}
+	if len(assignments) != 1 {
+		t.Fatalf("assignments = %+v, want one assignment", assignments)
+	}
+	assignment := assignments[0]
+	if assignment.TaskID == "" {
+		t.Fatalf("assignment task_id is empty, want preserved task link")
+	}
+	if assignment.Status != projectwork.AssignmentStatusFailed {
+		t.Fatalf("assignment status = %q, want failed", assignment.Status)
+	}
+	if assignment.CompletedAt.IsZero() {
+		t.Fatalf("assignment completed_at is zero, want failure timestamp")
+	}
+	if _, found, err := handler.taskStore.GetTask(t.Context(), assignment.TaskID); err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want preserved task", assignment.TaskID, found, err)
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +17,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
 )
 
 func newProjectWorkTestServer() (*Handler, http.Handler) {
@@ -513,6 +516,47 @@ func TestProjectWorkAPI_StartAssignmentPreservesTaskLinkWhenStartFails(t *testin
 	if _, found, err := handler.taskStore.GetTask(t.Context(), assignment.TaskID); err != nil || !found {
 		t.Fatalf("GetTask(%q) found=%v err=%v, want preserved task", assignment.TaskID, found, err)
 	}
+}
+
+func TestProjectWorkAPI_StartAssignmentClearsClaimWhenTaskCreateFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	handler.taskStore = failingCreateTaskStore{Store: handler.taskStore}
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("task create failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_start", WorkItemID: "work_start"})
+	if err != nil {
+		t.Fatalf("ListAssignments: %v", err)
+	}
+	if len(assignments) != 1 {
+		t.Fatalf("assignments = %+v, want one assignment", assignments)
+	}
+	assignment := assignments[0]
+	if assignment.TaskID != "" || assignment.RunID != "" {
+		t.Fatalf("assignment links = %q/%q, want cleared task/run links", assignment.TaskID, assignment.RunID)
+	}
+	if assignment.Status != projectwork.AssignmentStatusQueued {
+		t.Fatalf("assignment status = %q, want queued for retry", assignment.Status)
+	}
+	if !assignment.StartedAt.IsZero() || !assignment.CompletedAt.IsZero() {
+		t.Fatalf("assignment timestamps = started %v completed %v, want cleared", assignment.StartedAt, assignment.CompletedAt)
+	}
+}
+
+type failingCreateTaskStore struct {
+	taskstate.Store
+}
+
+func (s failingCreateTaskStore) CreateTask(context.Context, types.Task) (types.Task, error) {
+	return types.Task{}, errors.New("create task failed")
 }
 
 type projectWorkAssignmentStartSeed struct {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -276,6 +278,38 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentAllowsChunkedEmptyBody(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", io.NopCloser(strings.NewReader("")))
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment with empty chunked body status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", strings.NewReader(`{`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("start assignment malformed body status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentRejectsMissingWorkspaceRoot(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -363,6 +397,44 @@ func TestProjectWorkAPI_StartAssignmentRepeatedReturnsCurrentAssignment(t *testi
 	}
 	if second.Data.TaskID != first.Data.TaskID || second.Data.RunID != first.Data.RunID {
 		t.Fatalf("second assignment links = %q/%q, want existing %q/%q", second.Data.TaskID, second.Data.RunID, first.Data.TaskID, first.Data.RunID)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(tasks))
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentConcurrentRequestsCreateOneTask(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	var wg sync.WaitGroup
+	statuses := make(chan int, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+			statuses <- rec.Code
+		}()
+	}
+	wg.Wait()
+	close(statuses)
+
+	counts := map[int]int{}
+	for status := range statuses {
+		counts[status]++
+	}
+	if counts[http.StatusOK] != 1 || counts[http.StatusConflict] != 1 {
+		t.Fatalf("concurrent start statuses = %+v, want one 200 and one 409", counts)
 	}
 	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
 	if err != nil {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -410,6 +410,35 @@ func TestProjectWorkAPI_StartAssignmentRepeatedReturnsCurrentAssignment(t *testi
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentLinklessActiveStatusReturnsConflict(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			handler, server := newProjectWorkTestServer()
+			seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+				Workspace: t.TempDir(),
+				Driver:    projectwork.AssignmentDriverHecateTask,
+				Status:    status,
+			})
+
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("start status = %d body=%s, want 409", rec.Code, rec.Body.String())
+			}
+			tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+			if err != nil {
+				t.Fatalf("ListTasks: %v", err)
+			}
+			if len(tasks) != 0 {
+				t.Fatalf("tasks = %+v, want none created", tasks)
+			}
+		})
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentConcurrentRequestsCreateOneTask(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/taskstate"
 )
 
 func newProjectWorkTestServer() (*Handler, http.Handler) {
@@ -220,6 +222,246 @@ func TestProjectWorkAPI_ProjectDeletionCleansRows(t *testing.T) {
 	if roles, err := handler.projectWork.ListRoles(ctx, project.Data.ID); err != nil || projectWorkRoleExistsStore(roles, "role_custom", false) {
 		t.Fatalf("project roles after project delete = %+v err=%v, want custom role gone", roles, err)
 	}
+}
+
+func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.TaskID == "" || assignment.Data.RunID == "" {
+		t.Fatalf("assignment links = task %q run %q, want both set", assignment.Data.TaskID, assignment.Data.RunID)
+	}
+	if assignment.Data.DriverKind != projectwork.AssignmentDriverHecateTask {
+		t.Fatalf("driver_kind = %q, want hecate_task", assignment.Data.DriverKind)
+	}
+
+	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+	}
+	if task.ExecutionKind != "agent_loop" || task.OriginKind != "project_work_item" || task.OriginID != "work_start" {
+		t.Fatalf("task execution/origin = %q %q/%q, want agent_loop project_work_item/work_start", task.ExecutionKind, task.OriginKind, task.OriginID)
+	}
+	if task.RequestedProvider != "ollama" || task.RequestedModel != "qwen2.5-coder" {
+		t.Fatalf("task provider/model = %q/%q, want ollama/qwen2.5-coder", task.RequestedProvider, task.RequestedModel)
+	}
+	if task.WorkingDirectory != workspace || task.SandboxAllowedRoot != workspace || task.WorkspaceMode != "in_place" {
+		t.Fatalf("task workspace = dir %q root %q mode %q, want %q in_place", task.WorkingDirectory, task.SandboxAllowedRoot, task.WorkspaceMode, workspace)
+	}
+	for _, want := range []string{"Implement the native assignment start path.", "Follow backend invariants."} {
+		if !strings.Contains(task.Prompt, want) {
+			t.Fatalf("task prompt = %q, want %q", task.Prompt, want)
+		}
+	}
+	if !strings.Contains(task.SystemPrompt, "Follow backend invariants.") || !strings.Contains(task.SystemPrompt, "Project default system prompt.") {
+		t.Fatalf("task system_prompt = %q, want role and project prompts", task.SystemPrompt)
+	}
+	if _, found, err := handler.taskStore.GetRun(t.Context(), task.ID, assignment.Data.RunID); err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v, want run", assignment.Data.RunID, found, err)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentRejectsMissingWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Driver: projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("start missing workspace status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want none created", tasks)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentRejectsUnsupportedDriver(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverExternalAgent,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("start external assignment status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentRejectsDriverMismatch(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("start mismatched driver status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want none created", tasks)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentRepeatedReturnsCurrentAssignment(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first start status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var first ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first assignment: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("second start status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var second ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode second assignment: %v", err)
+	}
+	if second.Data.TaskID != first.Data.TaskID || second.Data.RunID != first.Data.RunID {
+		t.Fatalf("second assignment links = %q/%q, want existing %q/%q", second.Data.TaskID, second.Data.RunID, first.Data.TaskID, first.Data.RunID)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(tasks))
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentTerminalReturnsCurrentAssignment(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+		Status:    projectwork.AssignmentStatusCompleted,
+		TaskID:    "task_existing",
+		RunID:     "run_existing",
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("terminal start status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.TaskID != "task_existing" || assignment.Data.RunID != "run_existing" {
+		t.Fatalf("terminal assignment links = %q/%q, want existing links", assignment.Data.TaskID, assignment.Data.RunID)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want none created", tasks)
+	}
+}
+
+type projectWorkAssignmentStartSeed struct {
+	Workspace string
+	Driver    string
+	Status    string
+	TaskID    string
+	RunID     string
+}
+
+func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed projectWorkAssignmentStartSeed) {
+	t.Helper()
+	project := projects.Project{
+		ID:                   "proj_start",
+		Name:                 "Hecate",
+		DefaultProvider:      "ollama",
+		DefaultModel:         "qwen2.5-coder",
+		DefaultWorkspaceMode: "in_place",
+		DefaultSystemPrompt:  "Project default system prompt.",
+	}
+	if seed.Workspace != "" {
+		project.Roots = []projects.Root{{ID: "root_start", Path: seed.Workspace, Kind: "git", Active: true}}
+		project.DefaultRootID = "root_start"
+	}
+	if _, err := handler.projects.Create(t.Context(), project); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:           "role_backend",
+		ProjectID:    "proj_start",
+		Name:         "Backend engineer",
+		Instructions: "Follow backend invariants.",
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_start",
+		ProjectID: "proj_start",
+		Title:     "Native assignment start",
+		Brief:     "Implement the native assignment start path.",
+		Priority:  "high",
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_start",
+		ProjectID:  "proj_start",
+		WorkItemID: "work_start",
+		RoleID:     "role_backend",
+		DriverKind: seed.Driver,
+		Status:     seed.Status,
+		TaskID:     seed.TaskID,
+		RunID:      seed.RunID,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+}
+
+func taskstateFilterAll() taskstate.TaskFilter {
+	return taskstate.TaskFilter{Limit: 0}
 }
 
 func createProjectForWorkTest(t *testing.T, server http.Handler) ProjectResponse {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleProjectWorkAssignments)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleCreateProjectWorkAssignment)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleUpdateProjectWorkAssignment)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start", handler.HandleStartProjectWorkAssignment)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleProjectWorkArtifacts)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleCreateProjectWorkArtifact)
 }

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS %s (
 	project_id TEXT NOT NULL,
 	work_item_id TEXT NOT NULL,
 	role_id TEXT NOT NULL,
+	driver_kind TEXT NOT NULL DEFAULT 'hecate_task',
 	status TEXT NOT NULL,
 	task_id TEXT NOT NULL DEFAULT '',
 	run_id TEXT NOT NULL DEFAULT '',
@@ -118,6 +119,9 @@ CREATE TABLE IF NOT EXISTS %s (
 )`, s.artifactsTbl)); err != nil {
 		return fmt.Errorf("create project work artifacts table: %w", err)
 	}
+	if err := s.ensureColumn(ctx, s.assignmentsTbl, "driver_kind", `TEXT NOT NULL DEFAULT 'hecate_task'`); err != nil {
+		return err
+	}
 	for _, stmt := range []struct {
 		table string
 		name  string
@@ -135,6 +139,46 @@ CREATE TABLE IF NOT EXISTS %s (
 		}
 	}
 	return nil
+}
+
+func (s *SQLiteStore) ensureColumn(ctx context.Context, quotedTable, column, definition string) error {
+	exists, err := s.columnExists(ctx, quotedTable, column)
+	if err != nil {
+		return fmt.Errorf("inspect sqlite project work columns: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, quotedTable, column, definition)); err != nil {
+		return fmt.Errorf("migrate sqlite project work %s: %w", column, err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) columnExists(ctx context.Context, quotedTable, column string) (bool, error) {
+	bare := strings.Trim(quotedTable, `"`)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info("%s")`, bare))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid          int
+			name         string
+			columnType   string
+			notNull      int
+			defaultValue sql.NullString
+			pk           int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func (s *SQLiteStore) ListRoles(ctx context.Context, projectID string) ([]AgentRoleProfile, error) {
@@ -390,7 +434,7 @@ func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilt
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ?`, s.assignmentsTbl)
 	args := []any{filter.ProjectID}
@@ -429,10 +473,10 @@ func (s *SQLiteStore) CreateAssignment(ctx context.Context, assignment Assignmen
 	}
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id,
+	id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id,
 	message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
-		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
+		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID, assignment.DriverKind,
 		assignment.Status, assignment.TaskID, assignment.RunID, assignment.ChatSessionID,
 		assignment.MessageID, assignment.ContextSnapshotID, formatTime(assignment.CreatedAt),
 		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
@@ -478,10 +522,10 @@ func (s *SQLiteStore) UpdateAssignment(ctx context.Context, projectID, id string
 	}
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
-SET role_id = ?, status = ?, task_id = ?, run_id = ?, chat_session_id = ?, message_id = ?,
+SET role_id = ?, driver_kind = ?, status = ?, task_id = ?, run_id = ?, chat_session_id = ?, message_id = ?,
 	context_snapshot_id = ?, updated_at = ?, started_at = ?, completed_at = ?
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
-		item.RoleID, item.Status, item.TaskID, item.RunID, item.ChatSessionID,
+		item.RoleID, item.DriverKind, item.Status, item.TaskID, item.RunID, item.ChatSessionID,
 		item.MessageID, item.ContextSnapshotID, formatTime(item.UpdatedAt),
 		formatTime(item.StartedAt), formatTime(item.CompletedAt), projectID, id,
 	)
@@ -708,7 +752,7 @@ WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID),
 
 func (s *SQLiteStore) getRequiredAssignment(ctx context.Context, projectID, id string) (Assignment, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanAssignment(row)
@@ -770,7 +814,7 @@ func scanAssignment(row scanner) (Assignment, error) {
 	var item Assignment
 	var createdAt, updatedAt, startedAt, completedAt string
 	if err := row.Scan(
-		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.Status,
+		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.DriverKind, &item.Status,
 		&item.TaskID, &item.RunID, &item.ChatSessionID, &item.MessageID,
 		&item.ContextSnapshotID, &createdAt, &updatedAt, &startedAt, &completedAt,
 	); err != nil {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	AssignmentDriverHecateTask    = "hecate_task"
+	AssignmentDriverExternalAgent = "external_agent"
+
 	WorkItemStatusBacklog   = "backlog"
 	WorkItemStatusReady     = "ready"
 	WorkItemStatusRunning   = "running"
@@ -69,6 +72,7 @@ type Assignment struct {
 	ProjectID         string
 	WorkItemID        string
 	RoleID            string
+	DriverKind        string
 	Status            string
 	TaskID            string
 	RunID             string
@@ -564,6 +568,7 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 	item.ProjectID = strings.TrimSpace(item.ProjectID)
 	item.WorkItemID = strings.TrimSpace(item.WorkItemID)
 	item.RoleID = strings.TrimSpace(item.RoleID)
+	item.DriverKind = strings.TrimSpace(item.DriverKind)
 	item.Status = strings.TrimSpace(item.Status)
 	item.TaskID = strings.TrimSpace(item.TaskID)
 	item.RunID = strings.TrimSpace(item.RunID)
@@ -572,6 +577,9 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 	item.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
 	if item.Status == "" {
 		item.Status = AssignmentStatusQueued
+	}
+	if item.DriverKind == "" {
+		item.DriverKind = AssignmentDriverHecateTask
 	}
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -651,10 +659,22 @@ func validateAssignment(item Assignment) error {
 	if item.RoleID == "" {
 		return fmt.Errorf("%w: role_id is required", ErrInvalid)
 	}
+	if !validAssignmentDriverKind(item.DriverKind) {
+		return fmt.Errorf("%w: unsupported assignment driver_kind %q", ErrInvalid, item.DriverKind)
+	}
 	if !validAssignmentStatus(item.Status) {
 		return fmt.Errorf("%w: unsupported assignment status %q", ErrInvalid, item.Status)
 	}
 	return nil
+}
+
+func validAssignmentDriverKind(kind string) bool {
+	switch kind {
+	case AssignmentDriverHecateTask, AssignmentDriverExternalAgent:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateArtifact(item CollaborationArtifact) error {

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -107,17 +107,26 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if assignment.Status != AssignmentStatusQueued {
 				t.Fatalf("assignment status = %q, want queued", assignment.Status)
 			}
+			if assignment.DriverKind != AssignmentDriverHecateTask {
+				t.Fatalf("assignment driver_kind = %q, want hecate_task", assignment.DriverKind)
+			}
 
 			startedAt := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 			updatedAssignment, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
+				item.DriverKind = AssignmentDriverExternalAgent
 				item.Status = AssignmentStatusRunning
 				item.StartedAt = startedAt
 			})
 			if err != nil {
 				t.Fatalf("UpdateAssignment: %v", err)
 			}
-			if updatedAssignment.Status != AssignmentStatusRunning || !updatedAssignment.StartedAt.Equal(startedAt) {
+			if updatedAssignment.DriverKind != AssignmentDriverExternalAgent || updatedAssignment.Status != AssignmentStatusRunning || !updatedAssignment.StartedAt.Equal(startedAt) {
 				t.Fatalf("updated assignment = %+v, want running with start time", updatedAssignment)
+			}
+			if _, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
+				item.DriverKind = "unsupported"
+			}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("UpdateAssignment unsupported driver error = %v, want ErrInvalid", err)
 			}
 
 			artifact, err := store.CreateArtifact(ctx, CollaborationArtifact{
@@ -248,6 +257,61 @@ func TestMemoryStore_UpdateRejectsIDChanges(t *testing.T) {
 		item.ID = "work_beta"
 	}); !errors.Is(err, ErrInvalid) {
 		t.Fatalf("UpdateWorkItem id change error = %v, want ErrInvalid", err)
+	}
+}
+
+func TestSQLiteStore_AddsAssignmentDriverKindToExistingTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "projectwork.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	assignmentsTbl := client.QualifiedTable("project_work_assignments")
+	if _, err := client.DB().ExecContext(ctx, `
+CREATE TABLE `+assignmentsTbl+` (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	role_id TEXT NOT NULL,
+	status TEXT NOT NULL,
+	task_id TEXT NOT NULL DEFAULT '',
+	run_id TEXT NOT NULL DEFAULT '',
+	chat_session_id TEXT NOT NULL DEFAULT '',
+	message_id TEXT NOT NULL DEFAULT '',
+	context_snapshot_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	started_at TEXT NOT NULL DEFAULT '',
+	completed_at TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY(project_id, id)
+)`); err != nil {
+		t.Fatalf("create legacy assignments table: %v", err)
+	}
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := client.DB().ExecContext(ctx, `
+INSERT INTO `+assignmentsTbl+` (
+	id, project_id, work_item_id, role_id, status, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"asgn_legacy", "proj_alpha", "work_alpha", "software_developer", AssignmentStatusQueued, now, now,
+	); err != nil {
+		t.Fatalf("insert legacy assignment: %v", err)
+	}
+
+	store, err := NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	assignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha"})
+	if err != nil {
+		t.Fatalf("ListAssignments: %v", err)
+	}
+	if len(assignments) != 1 || assignments[0].DriverKind != AssignmentDriverHecateTask {
+		t.Fatalf("assignments = %+v, want legacy assignment backfilled to hecate_task", assignments)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `driver_kind` to project-work assignments with memory/sqlite parity and sqlite backfill
- add a native assignment start endpoint that creates and starts a canonical `agent_loop` task linked to the work item
- document the endpoint and V1 native-only limitations, with focused tests for success, conflicts, validation, and migration behavior

## Validation

- `go build ./...`
- `go test ./internal/api ./internal/projectwork ./internal/projects ./internal/taskstate`
- `go vet ./internal/api ./internal/projectwork ./internal/projects ./internal/taskstate`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
