### PR TITLE
feat(projects): project work execution status

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1188,7 +1188,7 @@ Project work coordination is the durable substrate for future project-team
 orchestration. It records project-scoped agent roles, work items, assignment
 metadata, and collaboration artifacts. It does not add a new execution runtime:
 existing Tasks and Chats remain the execution surfaces. Assignment creation
-only records intended or already-linked execution metadata; the separate native
+records intended or already-linked execution metadata; the separate native
 assignment start endpoint can create and start a Hecate-owned `agent_loop` task
 for `driver_kind="hecate_task"` assignments.
 Create requests that supply an existing project-scoped ID return `409 conflict`
@@ -1216,6 +1216,37 @@ Supported assignment driver kinds are `hecate_task` and `external_agent`, but
 native assignment start V1 only dispatches `hecate_task`.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
+
+Assignment responses are projected from linked canonical task/run state when
+`task_id` and `run_id` point at a Hecate task run. If `task_id` is present and
+`run_id` is empty, Hecate uses that task's `latest_run_id` when available. The
+stored assignment row is coordination metadata; reads do not mutate the task,
+run, or assignment rows. Run statuses map directly into assignment statuses:
+
+| Task/run status     | Project assignment status |
+| ------------------- | ------------------------- |
+| `queued`            | `queued`                  |
+| `running`           | `running`                 |
+| `awaiting_approval` | `awaiting_approval`       |
+| `completed`         | `completed`               |
+| `failed`            | `failed`                  |
+| `cancelled`         | `cancelled`               |
+
+If the linked task/run is missing, Hecate keeps the stored assignment status
+and marks the nested `execution` summary as `missing`. If a linked run is older
+than a newer explicit terminal assignment update, the assignment keeps that
+explicit project-work terminal status instead of being overwritten by stale
+runtime state. The `execution` summary may include `task_status`, `run_status`,
+projected `status`, pending approval count, step/approval/artifact counts,
+model/provider, last error, run timestamps, and trace ID.
+
+Work-item list and detail responses apply the same conservative rollup over
+projected assignment statuses: any active linked assignment (`queued`,
+`running`, or `awaiting_approval`) makes the work item `running`; all
+assignments `completed` makes it `done`; all assignments `cancelled` makes it
+`cancelled`; any failed assignment, or any cancelled assignment mixed with a
+non-cancelled assignment, makes it `blocked`. Otherwise the stored work-item
+status is returned.
 
 #### `GET /hecate/v1/projects/{id}/roles`
 
@@ -1361,6 +1392,13 @@ Returns:
     "task_id": "task_...",
     "run_id": "run_...",
     "context_snapshot_id": "ctx_...",
+    "execution": {
+      "task_id": "task_...",
+      "run_id": "run_...",
+      "task_status": "queued",
+      "run_status": "queued",
+      "status": "queued"
+    },
     "created_at": "2026-06-03T12:00:00Z",
     "updated_at": "2026-06-03T12:00:00Z"
   }
@@ -1413,6 +1451,13 @@ timestamps, and returns the updated assignment:
     "status": "queued",
     "task_id": "task_...",
     "run_id": "run_...",
+    "execution": {
+      "task_id": "task_...",
+      "run_id": "run_...",
+      "task_status": "queued",
+      "run_status": "queued",
+      "status": "queued"
+    },
     "created_at": "2026-06-03T12:00:00Z",
     "updated_at": "2026-06-03T12:00:01Z",
     "started_at": "2026-06-03T12:00:01Z"

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -134,6 +134,25 @@ type ProjectWorkItemResponse struct {
 	UpdatedAt       string   `json:"updated_at"`
 }
 
+type ProjectWorkAssignmentExecutionResponse struct {
+	TaskID               string `json:"task_id,omitempty"`
+	RunID                string `json:"run_id,omitempty"`
+	TaskStatus           string `json:"task_status,omitempty"`
+	RunStatus            string `json:"run_status,omitempty"`
+	Status               string `json:"status,omitempty"`
+	PendingApprovalCount int    `json:"pending_approval_count,omitempty"`
+	StepCount            int    `json:"step_count,omitempty"`
+	ApprovalCount        int    `json:"approval_count,omitempty"`
+	ArtifactCount        int    `json:"artifact_count,omitempty"`
+	Model                string `json:"model,omitempty"`
+	Provider             string `json:"provider,omitempty"`
+	LastError            string `json:"last_error,omitempty"`
+	StartedAt            string `json:"started_at,omitempty"`
+	FinishedAt           string `json:"finished_at,omitempty"`
+	TraceID              string `json:"trace_id,omitempty"`
+	Missing              bool   `json:"missing,omitempty"`
+}
+
 type ProjectWorkAssignmentsResponse struct {
 	Object string                          `json:"object"`
 	Data   []ProjectWorkAssignmentResponse `json:"data"`
@@ -145,21 +164,22 @@ type ProjectWorkAssignmentEnvelope struct {
 }
 
 type ProjectWorkAssignmentResponse struct {
-	ID                string `json:"id"`
-	ProjectID         string `json:"project_id"`
-	WorkItemID        string `json:"work_item_id"`
-	RoleID            string `json:"role_id"`
-	DriverKind        string `json:"driver_kind"`
-	Status            string `json:"status"`
-	TaskID            string `json:"task_id,omitempty"`
-	RunID             string `json:"run_id,omitempty"`
-	ChatSessionID     string `json:"chat_session_id,omitempty"`
-	MessageID         string `json:"message_id,omitempty"`
-	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
-	StartedAt         string `json:"started_at,omitempty"`
-	CompletedAt       string `json:"completed_at,omitempty"`
+	ID                string                                  `json:"id"`
+	ProjectID         string                                  `json:"project_id"`
+	WorkItemID        string                                  `json:"work_item_id"`
+	RoleID            string                                  `json:"role_id"`
+	DriverKind        string                                  `json:"driver_kind"`
+	Status            string                                  `json:"status"`
+	TaskID            string                                  `json:"task_id,omitempty"`
+	RunID             string                                  `json:"run_id,omitempty"`
+	ChatSessionID     string                                  `json:"chat_session_id,omitempty"`
+	MessageID         string                                  `json:"message_id,omitempty"`
+	ContextSnapshotID string                                  `json:"context_snapshot_id,omitempty"`
+	CreatedAt         string                                  `json:"created_at"`
+	UpdatedAt         string                                  `json:"updated_at"`
+	StartedAt         string                                  `json:"started_at,omitempty"`
+	CompletedAt       string                                  `json:"completed_at,omitempty"`
+	Execution         *ProjectWorkAssignmentExecutionResponse `json:"execution,omitempty"`
 }
 
 type ProjectWorkArtifactsResponse struct {
@@ -275,9 +295,20 @@ func (h *Handler) HandleProjectWorkItems(w http.ResponseWriter, r *http.Request)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	assignments, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
 	data := make([]ProjectWorkItemResponse, 0, len(items))
 	for _, item := range items {
-		data = append(data, renderProjectWorkItem(item))
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(r.Context(), item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		data = append(data, projected)
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkItemsResponse{Object: "project_work_items", Data: data})
 }
@@ -308,7 +339,12 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	WriteJSON(w, http.StatusCreated, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
 
 func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) {
@@ -325,7 +361,12 @@ func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) 
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
 
 func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +401,12 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: renderProjectWorkItem(item)})
+	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
 
 func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Request) {
@@ -387,7 +433,12 @@ func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Re
 	}
 	data := make([]ProjectWorkAssignmentResponse, 0, len(items))
 	for _, item := range items {
-		data = append(data, renderProjectWorkAssignment(item))
+		projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		data = append(data, projected)
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})
 }
@@ -428,7 +479,12 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	WriteJSON(w, http.StatusCreated, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(item)})
+	projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
 
 func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
@@ -481,7 +537,12 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(item)})
+	projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
 
 func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
@@ -551,7 +612,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if projectWorkAssignmentIsTerminal(assignment.Status) {
-		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if projectErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+			return
+		}
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
 	active, err := projectWorkAssignmentHasActiveExecution(ctx, h.taskStore, assignment)
@@ -560,7 +626,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if active {
-		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if projectErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+			return
+		}
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
 
@@ -593,7 +664,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if claimRejected {
-		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if projectErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+			return
+		}
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
 
@@ -651,7 +727,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: renderProjectWorkAssignment(assignment)})
+	projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
 
 func decodeOptionalProjectWorkAssignmentStartRequest(w http.ResponseWriter, r *http.Request) (startProjectWorkAssignmentRequest, bool) {
@@ -1027,6 +1108,259 @@ func parseOptionalProjectWorkTime(value, field string) (time.Time, error) {
 		return time.Time{}, errors.New(field + " must be RFC3339 timestamp")
 	}
 	return parsed.UTC(), nil
+}
+
+func (h *Handler) renderProjectedProjectWorkItem(ctx context.Context, item projectwork.WorkItem) (ProjectWorkItemResponse, error) {
+	if h == nil || h.projectWork == nil {
+		return renderProjectWorkItem(item), nil
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{
+		ProjectID:  item.ProjectID,
+		WorkItemID: item.ID,
+	})
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	return h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignments)
+}
+
+func (h *Handler) renderProjectedProjectWorkItemWithAssignments(ctx context.Context, item projectwork.WorkItem, assignments []projectwork.Assignment) (ProjectWorkItemResponse, error) {
+	response := renderProjectWorkItem(item)
+	if len(assignments) == 0 {
+		return response, nil
+	}
+	projected := make([]ProjectWorkAssignmentResponse, 0, len(assignments))
+	for _, assignment := range assignments {
+		projectedAssignment, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if err != nil {
+			return ProjectWorkItemResponse{}, err
+		}
+		projected = append(projected, projectedAssignment)
+	}
+	response.Status = projectWorkItemStatusFromAssignments(item.Status, projected)
+	return response, nil
+}
+
+func (h *Handler) renderProjectedProjectWorkAssignment(ctx context.Context, item projectwork.Assignment) (ProjectWorkAssignmentResponse, error) {
+	response := renderProjectWorkAssignment(item)
+	projection, err := h.projectWorkAssignmentExecution(ctx, item)
+	if err != nil {
+		return ProjectWorkAssignmentResponse{}, err
+	}
+	if projection == nil {
+		return response, nil
+	}
+	response.Execution = &projection.Execution
+	if projection.Status != "" {
+		response.Status = projection.Status
+	}
+	if response.StartedAt == "" && !projection.StartedAt.IsZero() {
+		response.StartedAt = formatOptionalTime(projection.StartedAt)
+	}
+	if response.CompletedAt == "" && !projection.CompletedAt.IsZero() {
+		response.CompletedAt = formatOptionalTime(projection.CompletedAt)
+	}
+	return response, nil
+}
+
+type projectWorkAssignmentExecutionProjection struct {
+	Execution   ProjectWorkAssignmentExecutionResponse
+	Status      string
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+func (h *Handler) projectWorkAssignmentExecution(ctx context.Context, assignment projectwork.Assignment) (*projectWorkAssignmentExecutionProjection, error) {
+	taskID := strings.TrimSpace(assignment.TaskID)
+	runID := strings.TrimSpace(assignment.RunID)
+	if taskID == "" {
+		return nil, nil
+	}
+	projection := &projectWorkAssignmentExecutionProjection{
+		Status:    assignment.Status,
+		StartedAt: assignment.StartedAt,
+		Execution: ProjectWorkAssignmentExecutionResponse{
+			TaskID: taskID,
+			RunID:  runID,
+		},
+	}
+	if h == nil || h.taskStore == nil {
+		projection.Execution.Missing = true
+		return projection, nil
+	}
+
+	var task types.Task
+	if taskID != "" {
+		foundTask, found, err := h.taskStore.GetTask(ctx, taskID)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			projection.Execution.Missing = true
+			return projection, nil
+		}
+		task = foundTask
+		projection.Execution.TaskStatus = task.Status
+		if runID == "" {
+			runID = strings.TrimSpace(task.LatestRunID)
+			projection.Execution.RunID = runID
+		}
+	}
+
+	if runID == "" {
+		status := projectWorkAssignmentStatusFromRun(task.Status)
+		projection.Execution.Status = status
+		projection.Status = projectWorkProjectedAssignmentStatus(assignment, status, task.UpdatedAt)
+		return projection, nil
+	}
+
+	run, found, err := h.taskStore.GetRun(ctx, taskID, runID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		projection.Execution.Missing = true
+		return projection, nil
+	}
+
+	status := projectWorkAssignmentStatusFromRun(run.Status)
+	pendingApprovalCount := 0
+	if status == projectwork.AssignmentStatusAwaitingApproval {
+		pendingCount, err := projectWorkPendingApprovalCount(ctx, h.taskStore, taskID, runID)
+		if err != nil {
+			return nil, err
+		}
+		pendingApprovalCount = pendingCount
+	}
+	projection.Status = projectWorkProjectedAssignmentStatus(assignment, status, projectWorkRunProjectionTime(run))
+	projection.StartedAt = firstNonZeroTime(assignment.StartedAt, run.StartedAt)
+	if types.IsTerminalTaskRunStatus(run.Status) {
+		projection.CompletedAt = firstNonZeroTime(assignment.CompletedAt, run.FinishedAt)
+	} else {
+		projection.CompletedAt = assignment.CompletedAt
+	}
+	projection.Execution = ProjectWorkAssignmentExecutionResponse{
+		TaskID:               taskID,
+		RunID:                runID,
+		TaskStatus:           task.Status,
+		RunStatus:            run.Status,
+		Status:               status,
+		PendingApprovalCount: pendingApprovalCount,
+		StepCount:            run.StepCount,
+		ApprovalCount:        run.ApprovalCount,
+		ArtifactCount:        run.ArtifactCount,
+		Model:                run.Model,
+		Provider:             run.Provider,
+		LastError:            run.LastError,
+		StartedAt:            formatOptionalTime(run.StartedAt),
+		FinishedAt:           formatOptionalTime(run.FinishedAt),
+		TraceID:              run.TraceID,
+	}
+	return projection, nil
+}
+
+func groupProjectWorkAssignmentsByWorkItem(assignments []projectwork.Assignment) map[string][]projectwork.Assignment {
+	if len(assignments) == 0 {
+		return map[string][]projectwork.Assignment{}
+	}
+	grouped := make(map[string][]projectwork.Assignment, len(assignments))
+	for _, assignment := range assignments {
+		grouped[assignment.WorkItemID] = append(grouped[assignment.WorkItemID], assignment)
+	}
+	return grouped
+}
+
+func projectWorkProjectedAssignmentStatus(assignment projectwork.Assignment, projectedStatus string, projectedAt time.Time) string {
+	projectedStatus = strings.TrimSpace(projectedStatus)
+	if projectedStatus == "" {
+		return assignment.Status
+	}
+	if projectWorkAssignmentIsTerminal(assignment.Status) && assignment.Status != projectedStatus {
+		if projectedAt.IsZero() || !projectedAt.After(assignment.UpdatedAt) {
+			return assignment.Status
+		}
+	}
+	return projectedStatus
+}
+
+func projectWorkRunProjectionTime(run types.TaskRun) time.Time {
+	if !run.FinishedAt.IsZero() {
+		return run.FinishedAt
+	}
+	return run.StartedAt
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func projectWorkPendingApprovalCount(ctx context.Context, store taskRunApprovalStore, taskID, runID string) (int, error) {
+	if store == nil {
+		return 0, nil
+	}
+	approvals, err := store.ListApprovals(ctx, taskID)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, approval := range approvals {
+		if approval.RunID == runID && approval.Status == "pending" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+type taskRunApprovalStore interface {
+	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
+}
+
+func projectWorkItemStatusFromAssignments(storedStatus string, assignments []ProjectWorkAssignmentResponse) string {
+	if len(assignments) == 0 {
+		return storedStatus
+	}
+	allCompleted := true
+	allCancelled := true
+	hasFailedOrCancelled := false
+	for _, assignment := range assignments {
+		switch assignment.Status {
+		case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+			return projectwork.WorkItemStatusRunning
+		case projectwork.AssignmentStatusQueued:
+			if assignment.Execution != nil && !assignment.Execution.Missing && (assignment.Execution.RunID != "" || assignment.Execution.TaskID != "") {
+				return projectwork.WorkItemStatusRunning
+			}
+			allCompleted = false
+			allCancelled = false
+		case projectwork.AssignmentStatusCompleted:
+			allCancelled = false
+		case projectwork.AssignmentStatusFailed:
+			allCompleted = false
+			allCancelled = false
+			hasFailedOrCancelled = true
+		case projectwork.AssignmentStatusCancelled:
+			allCompleted = false
+			hasFailedOrCancelled = true
+		default:
+			allCompleted = false
+			allCancelled = false
+		}
+	}
+	switch {
+	case allCompleted:
+		return projectwork.WorkItemStatusDone
+	case allCancelled:
+		return projectwork.WorkItemStatusCancelled
+	case hasFailedOrCancelled:
+		return projectwork.WorkItemStatusBlocked
+	default:
+		return storedStatus
+	}
 }
 
 func renderProjectWorkRole(item projectwork.AgentRoleProfile) ProjectWorkRoleResponse {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -8,14 +8,17 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -253,6 +256,9 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	}
 	if assignment.Data.DriverKind != projectwork.AssignmentDriverHecateTask {
 		t.Fatalf("driver_kind = %q, want hecate_task", assignment.Data.DriverKind)
+	}
+	if assignment.Data.Execution == nil || assignment.Data.Execution.TaskID != assignment.Data.TaskID || assignment.Data.Execution.RunID != assignment.Data.RunID {
+		t.Fatalf("assignment execution = %+v, want linked task/run summary", assignment.Data.Execution)
 	}
 
 	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
@@ -580,6 +586,77 @@ func TestProjectWorkAPI_StartAssignmentClearsClaimWhenTaskCreateFails(t *testing
 	}
 }
 
+func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
+	t.Parallel()
+	for _, backend := range []string{"memory", "sqlite"} {
+		backend := backend
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+			handler, server := newProjectWorkProjectionTestServer(t, backend)
+			seedProjectWorkProjectionTest(t, handler)
+
+			running := getProjectWorkAssignmentForTest(t, server, "work_running", "asgn_running")
+			if running.Status != projectwork.AssignmentStatusRunning || running.Execution == nil || running.Execution.RunStatus != "running" {
+				t.Fatalf("running assignment = %+v, want projected running execution", running)
+			}
+			if running.StartedAt == "" {
+				t.Fatalf("running assignment started_at is empty, want projected run timestamp")
+			}
+			assertStoredProjectWorkAssignmentStatusForTest(t, handler, "work_running", "asgn_running", projectwork.AssignmentStatusQueued)
+
+			queued := getProjectWorkAssignmentForTest(t, server, "work_queued", "asgn_queued")
+			if queued.Status != projectwork.AssignmentStatusQueued || queued.Execution == nil || queued.Execution.RunStatus != "queued" {
+				t.Fatalf("queued assignment = %+v, want projected queued execution", queued)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_queued", projectwork.WorkItemStatusRunning)
+
+			awaiting := getProjectWorkAssignmentForTest(t, server, "work_awaiting", "asgn_awaiting")
+			if awaiting.Status != projectwork.AssignmentStatusAwaitingApproval || awaiting.Execution == nil || awaiting.Execution.PendingApprovalCount != 1 {
+				t.Fatalf("awaiting assignment = %+v, want awaiting approval with one pending approval", awaiting)
+			}
+
+			completed := getProjectWorkAssignmentForTest(t, server, "work_completed", "asgn_completed")
+			if completed.Status != projectwork.AssignmentStatusCompleted || completed.CompletedAt == "" || completed.Execution == nil || completed.Execution.RunStatus != "completed" {
+				t.Fatalf("completed assignment = %+v, want completed projection", completed)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_completed", projectwork.WorkItemStatusDone)
+
+			failed := getProjectWorkAssignmentForTest(t, server, "work_failed", "asgn_failed")
+			if failed.Status != projectwork.AssignmentStatusFailed || failed.Execution == nil || failed.Execution.LastError != "model failed" {
+				t.Fatalf("failed assignment = %+v, want failed projection with run error", failed)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_failed", projectwork.WorkItemStatusBlocked)
+
+			cancelled := getProjectWorkAssignmentForTest(t, server, "work_cancelled", "asgn_cancelled")
+			if cancelled.Status != projectwork.AssignmentStatusCancelled || cancelled.Execution == nil || cancelled.Execution.RunStatus != "cancelled" {
+				t.Fatalf("cancelled assignment = %+v, want cancelled projection", cancelled)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_cancelled", projectwork.WorkItemStatusCancelled)
+
+			missing := getProjectWorkAssignmentForTest(t, server, "work_missing", "asgn_missing")
+			if missing.Status != projectwork.AssignmentStatusQueued || missing.Execution == nil || !missing.Execution.Missing {
+				t.Fatalf("missing assignment = %+v, want stored queued status with missing execution marker", missing)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_missing", projectwork.WorkItemStatusReady)
+
+			runOnly := getProjectWorkAssignmentForTest(t, server, "work_run_only", "asgn_run_only")
+			if runOnly.Status != projectwork.AssignmentStatusQueued || runOnly.RunID == "" || runOnly.Execution != nil {
+				t.Fatalf("run-only assignment = %+v, want stored queued status without execution projection", runOnly)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_run_only", projectwork.WorkItemStatusReady)
+
+			manual := getProjectWorkAssignmentForTest(t, server, "work_manual_terminal", "asgn_manual_terminal")
+			if manual.Status != projectwork.AssignmentStatusFailed || manual.Execution == nil || manual.Execution.RunStatus != "completed" {
+				t.Fatalf("manual terminal assignment = %+v, want newer explicit failed status over stale completed run", manual)
+			}
+			assertProjectWorkStatusForTest(t, server, "work_manual_terminal", projectwork.WorkItemStatusBlocked)
+
+			assertProjectWorkStatusForTest(t, server, "work_mixed", projectwork.WorkItemStatusBlocked)
+			assertProjectWorkListStatusForTest(t, server, "work_mixed", projectwork.WorkItemStatusBlocked)
+		})
+	}
+}
+
 type failingCreateTaskStore struct {
 	taskstate.Store
 }
@@ -646,6 +723,273 @@ func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed pro
 
 func taskstateFilterAll() taskstate.TaskFilter {
 	return taskstate.TaskFilter{Limit: 0}
+}
+
+func newProjectWorkProjectionTestServer(t *testing.T, backend string) (*Handler, http.Handler) {
+	t.Helper()
+	if backend == "memory" {
+		return newProjectWorkTestServer()
+	}
+	ctx := t.Context()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "projection.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	projectStore, err := projects.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(projects): %v", err)
+	}
+	projectWorkStore, err := projectwork.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(projectwork): %v", err)
+	}
+	taskStore, err := taskstate.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(taskstate): %v", err)
+	}
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, taskStore, nil)
+	t.Cleanup(func() { _ = handler.taskRunner.Shutdown(t.Context()) })
+	handler.SetProjectStore(projectStore)
+	handler.SetProjectWorkStore(projectWorkStore)
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func seedProjectWorkProjectionTest(t *testing.T, handler *Handler) {
+	t.Helper()
+	ctx := t.Context()
+	if _, err := handler.projects.Create(ctx, projects.Project{ID: "proj_projection", Name: "Projection"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{ID: "role_projection", ProjectID: "proj_projection", Name: "Projection engineer"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	base := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		workID            string
+		assignmentID      string
+		assignmentStatus  string
+		runStatus         string
+		runStartedAt      time.Time
+		runFinishedAt     time.Time
+		assignmentUpdated time.Time
+		lastError         string
+		approvalPending   bool
+		missing           bool
+	}{
+		{workID: "work_running", assignmentID: "asgn_running", runStatus: "running", runStartedAt: base.Add(1 * time.Minute)},
+		{workID: "work_queued", assignmentID: "asgn_queued", runStatus: "queued"},
+		{workID: "work_awaiting", assignmentID: "asgn_awaiting", runStatus: "awaiting_approval", runStartedAt: base.Add(2 * time.Minute), approvalPending: true},
+		{workID: "work_completed", assignmentID: "asgn_completed", runStatus: "completed", runStartedAt: base.Add(3 * time.Minute), runFinishedAt: base.Add(4 * time.Minute)},
+		{workID: "work_failed", assignmentID: "asgn_failed", runStatus: "failed", runStartedAt: base.Add(5 * time.Minute), runFinishedAt: base.Add(6 * time.Minute), lastError: "model failed"},
+		{workID: "work_cancelled", assignmentID: "asgn_cancelled", runStatus: "cancelled", runStartedAt: base.Add(7 * time.Minute), runFinishedAt: base.Add(8 * time.Minute)},
+		{workID: "work_missing", assignmentID: "asgn_missing", runStatus: "queued", missing: true},
+		{workID: "work_manual_terminal", assignmentID: "asgn_manual_terminal", assignmentStatus: projectwork.AssignmentStatusFailed, runStatus: "completed", runStartedAt: base.Add(9 * time.Minute), runFinishedAt: base.Add(10 * time.Minute), assignmentUpdated: base.Add(11 * time.Minute)},
+	}
+	for _, tc := range cases {
+		seedProjectWorkProjectionCase(t, handler, tc.workID, tc.assignmentID, tc.assignmentStatus, tc.runStatus, tc.runStartedAt, tc.runFinishedAt, tc.assignmentUpdated, tc.lastError, tc.approvalPending, tc.missing)
+	}
+	seedProjectWorkRunOnlyProjectionCase(t, handler)
+	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_completed", "", "completed", base.Add(12*time.Minute), base.Add(13*time.Minute), time.Time{}, "", false, false)
+	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_failed", "", "failed", base.Add(14*time.Minute), base.Add(15*time.Minute), time.Time{}, "review failed", false, false)
+}
+
+func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
+	t.Helper()
+	ctx := t.Context()
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_run_only",
+		ProjectID: "proj_projection",
+		Title:     "work_run_only",
+		Status:    projectwork.WorkItemStatusReady,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_run_only): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_run_only",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_run_only",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+		RunID:      "run_without_task",
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_run_only): %v", err)
+	}
+}
+
+func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assignmentID, assignmentStatus, runStatus string, runStartedAt, runFinishedAt, assignmentUpdated time.Time, lastError string, approvalPending, missing bool) {
+	t.Helper()
+	ctx := t.Context()
+	if _, ok, err := handler.projectWork.GetWorkItem(ctx, "proj_projection", workID); err != nil {
+		t.Fatalf("GetWorkItem(%s): %v", workID, err)
+	} else if !ok {
+		if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+			ID:        workID,
+			ProjectID: "proj_projection",
+			Title:     workID,
+			Status:    projectwork.WorkItemStatusReady,
+		}); err != nil {
+			t.Fatalf("CreateWorkItem(%s): %v", workID, err)
+		}
+	}
+
+	taskID := "task_" + assignmentID
+	runID := "run_" + assignmentID
+	if assignmentStatus == "" {
+		assignmentStatus = projectwork.AssignmentStatusQueued
+	}
+	if assignmentUpdated.IsZero() {
+		assignmentUpdated = runStartedAt.Add(-time.Minute)
+		if runStartedAt.IsZero() {
+			assignmentUpdated = time.Date(2026, 6, 3, 11, 59, 0, 0, time.UTC)
+		}
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         assignmentID,
+		ProjectID:  "proj_projection",
+		WorkItemID: workID,
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     assignmentStatus,
+		TaskID:     taskID,
+		RunID:      runID,
+		CreatedAt:  assignmentUpdated,
+		UpdatedAt:  assignmentUpdated,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(%s): %v", assignmentID, err)
+	}
+	if missing {
+		return
+	}
+	if _, err := handler.taskStore.CreateTask(ctx, types.Task{
+		ID:          taskID,
+		Title:       assignmentID,
+		Status:      runStatus,
+		LatestRunID: runID,
+		CreatedAt:   assignmentUpdated,
+		UpdatedAt:   firstNonZeroTime(runFinishedAt, runStartedAt, assignmentUpdated),
+	}); err != nil {
+		t.Fatalf("CreateTask(%s): %v", taskID, err)
+	}
+	if _, err := handler.taskStore.CreateRun(ctx, types.TaskRun{
+		ID:            runID,
+		TaskID:        taskID,
+		Number:        1,
+		Status:        runStatus,
+		Model:         "qwen2.5-coder",
+		Provider:      "ollama",
+		StepCount:     2,
+		ApprovalCount: boolToInt(approvalPending),
+		ArtifactCount: 1,
+		LastError:     lastError,
+		StartedAt:     runStartedAt,
+		FinishedAt:    runFinishedAt,
+		TraceID:       "trace_" + assignmentID,
+	}); err != nil {
+		t.Fatalf("CreateRun(%s): %v", runID, err)
+	}
+	if approvalPending {
+		if _, err := handler.taskStore.CreateApproval(ctx, types.TaskApproval{
+			ID:        "ap_" + assignmentID,
+			TaskID:    taskID,
+			RunID:     runID,
+			Kind:      "agent_loop_tool_call",
+			Status:    "pending",
+			CreatedAt: runStartedAt,
+		}); err != nil {
+			t.Fatalf("CreateApproval(%s): %v", assignmentID, err)
+		}
+	}
+}
+
+func getProjectWorkAssignmentForTest(t *testing.T, server http.Handler, workID, assignmentID string) ProjectWorkAssignmentResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/"+workID+"/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list assignments %s status = %d body=%s, want 200", workID, rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkAssignmentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode assignments: %v", err)
+	}
+	for _, assignment := range response.Data {
+		if assignment.ID == assignmentID {
+			return assignment
+		}
+	}
+	t.Fatalf("assignment %s not found in %+v", assignmentID, response.Data)
+	return ProjectWorkAssignmentResponse{}
+}
+
+func assertProjectWorkStatusForTest(t *testing.T, server http.Handler, workID, want string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/"+workID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get work item %s status = %d body=%s, want 200", workID, rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work item: %v", err)
+	}
+	if response.Data.Status != want {
+		t.Fatalf("work item %s status = %q, want %q", workID, response.Data.Status, want)
+	}
+}
+
+func assertProjectWorkListStatusForTest(t *testing.T, server http.Handler, workID, want string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list work items status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work items: %v", err)
+	}
+	for _, item := range response.Data {
+		if item.ID == workID {
+			if item.Status != want {
+				t.Fatalf("work item list status = %q, want %q", item.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("work item %s not found in %+v", workID, response.Data)
+}
+
+func assertStoredProjectWorkAssignmentStatusForTest(t *testing.T, handler *Handler, workID, assignmentID, want string) {
+	t.Helper()
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{
+		ProjectID:  "proj_projection",
+		WorkItemID: workID,
+	})
+	if err != nil {
+		t.Fatalf("ListAssignments(%s): %v", workID, err)
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			if assignment.Status != want {
+				t.Fatalf("stored assignment status = %q, want %q", assignment.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("stored assignment %s not found in %+v", assignmentID, assignments)
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func createProjectForWorkTest(t *testing.T, server http.Handler) ProjectResponse {


### PR DESCRIPTION
## Summary

- Project project-work assignment reads from linked canonical task/run state and return a nested execution summary.
- Roll work-item status up conservatively from projected assignment statuses across list and detail responses.
- Document assignment projection, missing-link behavior, stale terminal protection, and execution summary fields.

@copilot please review.

## Verification

- `go build ./...`
- `go test ./internal/api ./internal/projectwork ./internal/projects ./internal/taskstate`
- `go vet ./internal/api ./internal/projectwork ./internal/projects ./internal/taskstate`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
