### PR TITLE
feat(projects): add project cockpit UI

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1304,7 +1304,11 @@ Deletes a custom role. Built-in roles return `409 conflict`.
 
 #### `GET /hecate/v1/projects/{id}/work-items`
 
-Lists work items for the project.
+Lists work items for the project. Each item includes projected assignment
+summaries in `assignments` when assignments exist, so callers can render list
+status/count signals without issuing one assignment request per work item.
+The nested assignment objects use the same shape as
+`GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`.
 
 #### `POST /hecate/v1/projects/{id}/work-items`
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1410,6 +1410,12 @@ Returns:
 Updates assignment status, role, link fields, `started_at`, or `completed_at`.
 It does not mutate or start the linked Task or Chat.
 
+#### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}`
+
+Deletes the assignment metadata record and collaboration artifacts attached to
+that assignment. It does not delete or cancel a linked Task, Run, Chat session,
+or external-agent execution.
+
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start`
 
 Starts a native Hecate assignment. V1 supports only assignments whose

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -122,16 +122,17 @@ type ProjectWorkItemEnvelope struct {
 }
 
 type ProjectWorkItemResponse struct {
-	ID              string   `json:"id"`
-	ProjectID       string   `json:"project_id"`
-	Title           string   `json:"title"`
-	Brief           string   `json:"brief,omitempty"`
-	Status          string   `json:"status"`
-	Priority        string   `json:"priority"`
-	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
-	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
-	CreatedAt       string   `json:"created_at"`
-	UpdatedAt       string   `json:"updated_at"`
+	ID              string                          `json:"id"`
+	ProjectID       string                          `json:"project_id"`
+	Title           string                          `json:"title"`
+	Brief           string                          `json:"brief,omitempty"`
+	Status          string                          `json:"status"`
+	Priority        string                          `json:"priority"`
+	OwnerRoleID     string                          `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string                        `json:"reviewer_role_ids,omitempty"`
+	Assignments     []ProjectWorkAssignmentResponse `json:"assignments,omitempty"`
+	CreatedAt       string                          `json:"created_at"`
+	UpdatedAt       string                          `json:"updated_at"`
 }
 
 type ProjectWorkAssignmentExecutionResponse struct {
@@ -1150,6 +1151,7 @@ func (h *Handler) renderProjectedProjectWorkItemWithAssignments(ctx context.Cont
 		}
 		projected = append(projected, projectedAssignment)
 	}
+	response.Assignments = projected
 	response.Status = projectWorkItemStatusFromAssignments(item.Status, projected)
 	return response, nil
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -545,6 +545,19 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
 
+func (h *Handler) HandleDeleteProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	assignmentID := r.PathValue("assignment_id")
+	if !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
+		return
+	}
+	if err := h.projectWork.DeleteAssignment(r.Context(), projectID, workItemID, assignmentID); !writeProjectWorkError(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	projectID := r.PathValue("id")

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -177,6 +177,21 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_other",
+		"title":"Other work"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create other work item status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_other/assignments/asgn_backend", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("delete assignment with wrong work item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", nil))
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("delete assignment status = %d body=%s, want 204", rec.Code, rec.Body.String())

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -132,6 +132,19 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list work items with assignment summaries status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listedWork ProjectWorkItemsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listedWork); err != nil {
+		t.Fatalf("decode listed work items: %v", err)
+	}
+	if len(listedWork.Data) != 1 || len(listedWork.Data[0].Assignments) != 1 || listedWork.Data[0].Assignments[0].ID != "asgn_backend" {
+		t.Fatalf("listed work assignments = %+v, want projected assignment summary", listedWork.Data)
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", bytes.NewReader([]byte(`{"status":"completed","chat_session_id":"chat_123","message_id":"msg_123"}`))))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("patch assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -177,6 +177,46 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete assignment status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list assignments after delete status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignments); err != nil {
+		t.Fatalf("decode assignments after delete: %v", err)
+	}
+	if len(assignments.Data) != 0 {
+		t.Fatalf("assignments after delete = %+v, want none", assignments.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_backend",
+		"role_id":"software_developer"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("recreate assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_handoff",
+		"assignment_id":"asgn_backend",
+		"kind":"handoff",
+		"title":"Backend handoff",
+		"body":"Store and API are ready for UI wiring.",
+		"author_role_id":"software_developer"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("recreate artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list artifacts status = %d body=%s, want 200", rec.Code, rec.Body.String())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleProjectWorkAssignments)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleCreateProjectWorkAssignment)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleUpdateProjectWorkAssignment)
+	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleDeleteProjectWorkAssignment)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start", handler.HandleStartProjectWorkAssignment)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleProjectWorkArtifacts)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleCreateProjectWorkArtifact)

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -535,6 +535,43 @@ WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
 	return s.getRequiredAssignment(ctx, projectID, id)
 }
 
+func (s *SQLiteStore) DeleteAssignment(ctx context.Context, projectID, workItemID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	id = strings.TrimSpace(id)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND assignment_id = ?`, s.artifactsTbl),
+		projectID,
+		id,
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	res, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ? AND id = ?`, s.assignmentsTbl),
+		projectID,
+		workItemID,
+		id,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := requireAffected(res); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *SQLiteStore) ListArtifacts(ctx context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error) {
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -123,6 +123,7 @@ type Store interface {
 	ListAssignments(ctx context.Context, filter AssignmentFilter) ([]Assignment, error)
 	CreateAssignment(ctx context.Context, assignment Assignment) (Assignment, error)
 	UpdateAssignment(ctx context.Context, projectID, id string, update func(*Assignment)) (Assignment, error)
+	DeleteAssignment(ctx context.Context, projectID, workItemID, id string) error
 	ListArtifacts(ctx context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error)
 	CreateArtifact(ctx context.Context, artifact CollaborationArtifact) (CollaborationArtifact, error)
 	DeleteProject(ctx context.Context, projectID string) (int, error)
@@ -426,6 +427,26 @@ func (s *MemoryStore) UpdateAssignment(_ context.Context, projectID, id string, 
 	}
 	s.assignments[key] = cloneAssignment(item)
 	return cloneAssignment(item), nil
+}
+
+func (s *MemoryStore) DeleteAssignment(_ context.Context, projectID, workItemID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	id = strings.TrimSpace(id)
+	key := assignmentKey(projectID, id)
+	assignment, ok := s.assignments[key]
+	if !ok || assignment.WorkItemID != workItemID {
+		return ErrNotFound
+	}
+	delete(s.assignments, key)
+	for key, artifact := range s.artifacts {
+		if artifact.ProjectID == projectID && artifact.AssignmentID == id {
+			delete(s.artifacts, key)
+		}
+	}
+	return nil
 }
 
 func (s *MemoryStore) ListArtifacts(_ context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error) {

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -171,6 +171,27 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				t.Fatalf("artifacts = %+v, want created artifact", artifacts)
 			}
 
+			if err := store.DeleteAssignment(ctx, "proj_alpha", "work_api", "asgn_impl"); err != nil {
+				t.Fatalf("DeleteAssignment: %v", err)
+			}
+			assignments, err = store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListAssignments after assignment delete: %v", err)
+			}
+			artifacts, err = store.ListArtifacts(ctx, ArtifactFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListArtifacts after assignment delete: %v", err)
+			}
+			if len(assignments) != 0 || len(artifacts) != 0 {
+				t.Fatalf("assignment delete left assignments=%+v artifacts=%+v", assignments, artifacts)
+			}
+			if _, err := store.CreateAssignment(ctx, Assignment{ID: "asgn_impl", ProjectID: "proj_alpha", WorkItemID: "work_api", RoleID: "software_developer"}); err != nil {
+				t.Fatalf("recreate assignment after delete: %v", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_brief", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindBrief, Body: "Brief again."}); err != nil {
+				t.Fatalf("recreate artifact after delete: %v", err)
+			}
+
 			if err := store.DeleteWorkItem(ctx, "proj_alpha", "work_api"); err != nil {
 				t.Fatalf("DeleteWorkItem: %v", err)
 			}

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -7,6 +7,65 @@ import {
   createRuntimeConsoleFixture,
 } from "../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../test/runtime-console-render";
+import {
+  getProjectAssignments,
+  getProjectCollaborationArtifacts,
+  getProjectWorkItem,
+  getProjectWorkItems,
+  getProjectWorkRoles,
+} from "../lib/api";
+import type { ProjectAssignmentRecord, ProjectWorkItemRecord } from "../types/project";
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  const emptyWorkItem = {
+    id: "",
+    project_id: "",
+    title: "",
+    status: "backlog",
+    priority: "normal",
+    created_at: "",
+    updated_at: "",
+  };
+  return {
+    ...actual,
+    getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
+    getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
+    getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: emptyWorkItem })),
+    getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
+    getProjectCollaborationArtifacts: vi.fn(async () => ({
+      object: "project_collaboration_artifacts",
+      data: [],
+    })),
+  };
+});
+
+function resetProjectWorkMocks() {
+  const emptyWorkItem: ProjectWorkItemRecord = {
+    id: "",
+    project_id: "",
+    title: "",
+    status: "backlog",
+    priority: "normal",
+    created_at: "",
+    updated_at: "",
+  };
+  vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [] });
+  vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });
+  vi.mocked(getProjectWorkItem).mockResolvedValue({
+    object: "project_work_item",
+    data: emptyWorkItem,
+  });
+  vi.mocked(getProjectAssignments).mockResolvedValue({ object: "project_assignments", data: [] });
+  vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
+    object: "project_collaboration_artifacts",
+    data: [],
+  });
+}
+
+beforeEach(() => {
+  resetProjectWorkMocks();
+});
 
 // Workspace lineup is fixed. Numeric keyboard workspace switching was
 // removed so text inputs, screen readers, and browser shortcuts own the
@@ -426,6 +485,104 @@ describe("ConsoleShell navigation", () => {
       agentID: "hecate",
       projectID: "proj_1",
     });
+  });
+
+  it("forces Hecate chats when opening chat from a project assignment", async () => {
+    const createChatSession = vi.fn(async () => undefined);
+    const onSelectWorkspace = vi.fn();
+    const project = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [
+        {
+          id: "root_1",
+          path: "/Users/alice/dev/hecate",
+          kind: "workspace",
+          active: true,
+          created_at: "2026-05-21T10:00:00Z",
+          updated_at: "2026-05-21T10:00:00Z",
+        },
+      ],
+      default_root_id: "root_1",
+      default_provider: "ollama",
+      default_model: "qwen2.5-coder",
+      created_at: "2026-05-21T10:00:00Z",
+      updated_at: "2026-05-21T10:00:00Z",
+    };
+    const workItem: ProjectWorkItemRecord = {
+      id: "work_1",
+      project_id: project.id,
+      title: "Build cockpit UI",
+      brief: "Open a model chat from this assignment.",
+      status: "ready",
+      priority: "high",
+      owner_role_id: "software_developer",
+      created_at: "2026-06-02T10:00:00Z",
+      updated_at: "2026-06-02T11:00:00Z",
+    };
+    const assignment: ProjectAssignmentRecord = {
+      id: "asgn_1",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      role_id: "software_developer",
+      driver_kind: "hecate_task",
+      status: "queued",
+      created_at: "2026-06-02T10:00:00Z",
+      updated_at: "2026-06-02T11:00:00Z",
+      execution: {
+        status: "queued",
+        provider: "ollama",
+        model: "qwen2.5-coder",
+      },
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [
+        {
+          id: "software_developer",
+          project_id: project.id,
+          name: "Software developer",
+          built_in: true,
+        },
+      ],
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [assignment] }],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: workItem,
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [assignment],
+    });
+    const state = createRuntimeConsoleFixture({
+      chatTarget: "external_agent",
+      defaultChatTarget: "external_agent",
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="projects" onSelectWorkspace={onSelectWorkspace} />,
+        {
+          state,
+          actions: { ...createRuntimeConsoleActions(), createChatSession },
+        },
+      ),
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open chat" }));
+
+    expect(createChatSession).toHaveBeenCalledWith({
+      agentID: "hecate",
+      projectID: project.id,
+      provider: "ollama",
+      model: "qwen2.5-coder",
+    });
+    expect(onSelectWorkspace).toHaveBeenCalledWith("chats");
   });
 
   it("moves the active chat when selecting a different project", () => {

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -12,10 +12,11 @@ import { withRuntimeConsole } from "../test/runtime-console-render";
 // removed so text inputs, screen readers, and browser shortcuts own the
 // number keys without surprises.
 describe("getAvailableWorkspaces", () => {
-  it("returns chats / runs / connections / overview / usage / settings", () => {
+  it("returns chats / projects / runs / connections / overview / usage / settings", () => {
     const ws = getAvailableWorkspaces();
     expect(ws.map((w) => w.id)).toEqual([
       "chats",
+      "projects",
       "runs",
       "connections",
       "overview",
@@ -24,6 +25,7 @@ describe("getAvailableWorkspaces", () => {
     ]);
     expect(ws.map((w) => w.label)).toEqual([
       "Chats",
+      "Projects",
       "Tasks",
       "Connections",
       "Observability",
@@ -130,6 +132,27 @@ describe("ConsoleShell titlebar", () => {
 });
 
 describe("ConsoleShell navigation", () => {
+  it("renders Projects as a top-level workspace and switches to the Projects view", async () => {
+    const state = createRuntimeConsoleFixture();
+    const onSelectWorkspace = vi.fn();
+    render(
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="projects" onSelectWorkspace={onSelectWorkspace} />,
+        {
+          state,
+          actions: createRuntimeConsoleActions(),
+        },
+      ),
+    );
+
+    expect(screen.getByRole("button", { name: "Projects" })).toBeEnabled();
+    expect(
+      await screen.findByText("No projects yet", undefined, { timeout: 30_000 }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+    expect(onSelectWorkspace).toHaveBeenCalledWith("runs");
+  });
+
   it("keeps Chats available when no providers are configured", async () => {
     const state = createRuntimeConsoleFixture({
       chatTarget: "agent",

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useEffect, useState } from "react";
 
 import { useChat, type ChatState } from "./state/chat";
 import { useProvidersAndModels } from "./state/providersAndModels";
+import { useProjects } from "./state/projects";
 import { useRuntime } from "./state/runtime";
 import { useSettings } from "./state/settings";
 import { useChatTarget } from "./state/derived";
@@ -12,6 +13,7 @@ import type { ChatUsageRecord } from "../types/chat";
 import { UpdateBanner } from "../features/shared/UpdateBanner";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriOnMacOS } from "../lib/tauri";
+import type { ProviderFilter } from "../types/provider";
 
 // Each workspace view is its own dynamic chunk so the initial
 // page load only ships the shell + active workspace, not all six.
@@ -38,6 +40,9 @@ const ChatView = lazy(() =>
 const ProvidersView = lazy(() =>
   import("../features/providers/ProvidersView").then((m) => ({ default: m.ProvidersView })),
 );
+const ProjectsView = lazy(() =>
+  import("../features/projects/ProjectsView").then((m) => ({ default: m.ProjectsView })),
+);
 const TasksView = lazy(() =>
   import("../features/runs/TasksView").then((m) => ({ default: m.TasksView })),
 );
@@ -48,6 +53,7 @@ const TasksView = lazy(() =>
 // adding a workspace updates both surfaces in one place.
 export const WORKSPACE_IDS = [
   "overview",
+  "projects",
   "runs",
   "chats",
   "connections",
@@ -64,6 +70,7 @@ type WorkspaceDefinition = {
 
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
 type TraceFocusRequest = { requestID: string; nonce: number };
+type ProjectChatRequest = { projectID: string; provider?: string; model?: string };
 
 // Icon paths match the design handoff
 const IC = {
@@ -74,6 +81,11 @@ const IC = {
   chat: "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z",
   tasks:
     "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4",
+  projects: [
+    "M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
+    "M8 12h8",
+    "M8 16h5",
+  ],
   connections: [
     "M9.75 7.5v3.75m4.5-3.75v3.75",
     "M7.5 11.25h9v2.25a4.5 4.5 0 01-9 0v-2.25z",
@@ -184,6 +196,7 @@ const MoonIcon = <SvgIcon d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />;
 type WorkspaceLineupEntry = WorkspaceDefinition;
 const WS: Record<WorkspaceID, WorkspaceLineupEntry> = {
   chats: { id: "chats", label: "Chats", icon: <SvgIcon d={IC.chat} /> },
+  projects: { id: "projects", label: "Projects", icon: <SvgIcon d={IC.projects} /> },
   connections: { id: "connections", label: "Connections", icon: <SvgIcon d={IC.connections} /> },
   runs: { id: "runs", label: "Tasks", icon: <SvgIcon d={IC.tasks} /> },
   overview: { id: "overview", label: "Observability", icon: <SvgIcon d={IC.observe} /> },
@@ -191,10 +204,10 @@ const WS: Record<WorkspaceID, WorkspaceLineupEntry> = {
   settings: { id: "settings", label: "Settings", icon: <SvgIcon d={IC.settings} /> },
 };
 
-const BARE_WORKSPACES: WorkspaceID[] = ["chats", "runs"];
+const BARE_WORKSPACES: WorkspaceID[] = ["chats", "projects", "runs"];
 
 export function getAvailableWorkspaces(): WorkspaceDefinition[] {
-  return [WS.chats, WS.runs, WS.connections, WS.overview, WS.usage, WS.settings];
+  return [WS.chats, WS.projects, WS.runs, WS.connections, WS.overview, WS.usage, WS.settings];
 }
 
 export function ConsoleShell({
@@ -266,6 +279,7 @@ function AuthenticatedShell({
 }) {
   const runtime = useRuntime();
   const chat = useChat();
+  const projects = useProjects();
   const providersAndModels = useProvidersAndModels();
   const settings = useSettings();
   const chatTarget = useChatTarget();
@@ -283,6 +297,29 @@ function AuthenticatedShell({
   function openTaskFromChat(taskID: string, runID?: string) {
     setTaskFocusRequest({ taskID, runID, nonce: Date.now() });
     onSelectWorkspace("runs");
+  }
+
+  function openTaskFromProject(taskID: string, runID?: string) {
+    setTaskFocusRequest({ taskID, runID, nonce: Date.now() });
+    onSelectWorkspace("runs");
+  }
+
+  function openChatFromProject(request: ProjectChatRequest) {
+    if (request.projectID) {
+      void projects.actions.selectProject(request.projectID);
+    }
+    if (request.provider) {
+      chatActions.selectProviderRoute(request.provider as ProviderFilter);
+    }
+    if (request.model) {
+      chat.actions.setModel(request.model);
+    }
+    void chatActions.createChatSession({
+      projectID: request.projectID,
+      provider: request.provider,
+      model: request.model,
+    });
+    onSelectWorkspace("chats");
   }
 
   function openChatFromTask(sessionID: string) {
@@ -381,6 +418,9 @@ function AuthenticatedShell({
                   onOpenChat={openChatFromTask}
                   onOpenTrace={openTraceFromChat}
                 />
+              )}
+              {activeWorkspace === "projects" && (
+                <ProjectsView onOpenChat={openChatFromProject} onOpenTask={openTaskFromProject} />
               )}
               {activeWorkspace === "connections" && <ProvidersView />}
               {activeWorkspace === "usage" && <UsageView />}

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -315,6 +315,7 @@ function AuthenticatedShell({
       chat.actions.setModel(request.model);
     }
     void chatActions.createChatSession({
+      agentID: "hecate",
       projectID: request.projectID,
       provider: request.provider,
       model: request.model,

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -812,7 +812,9 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const requestedAgentID = options?.agentID?.trim();
     const createProjectID =
       options && "projectID" in options ? options.projectID?.trim() || "" : activeProjectID;
-    const requestedProviderFilter = (options?.provider?.trim() || providerFilter) as ProviderFilter;
+    const requestedProviderFilter = (
+      options && "provider" in options ? options.provider?.trim() || "auto" : providerFilter
+    ) as ProviderFilter;
     const requestedSelectionModel =
       options && "model" in options ? options.model?.trim() || "" : model;
     const createExternalAgent =
@@ -895,8 +897,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ...(toolsEnabled && workspace ? { workspace } : {}),
         ...(toolsEnabled ? { rtk_enabled: hecateRTKEnabled } : {}),
       });
-      setProviderFilter(requestedProviderFilter);
-      setModel(requestedModel);
       setActiveChatSessionID(created.data.id);
       // Same per-session pinning as the submit path: chatTarget stays
       // "agent" and the tools-on/off intent for this session is recorded

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -179,6 +179,13 @@ function modelAvailableForProviderFilter(
 
 export { chatSessionIsExternal, chatSessionIsBusy };
 
+export type CreateChatSessionOptions = {
+  agentID?: string;
+  projectID?: string;
+  provider?: string;
+  model?: string;
+};
+
 type ChatActionsReturn = {
   applyChatSession: (session: ChatSessionRecord) => void;
   syncHecateSelectionFromSession: (session: ChatSessionRecord | null) => void;
@@ -191,7 +198,7 @@ type ChatActionsReturn = {
   cancelAgentChat: () => Promise<void>;
   updateToolResult: (index: number, result: string) => void;
   submitToolResults: () => Promise<void>;
-  createChatSession: (options?: { agentID?: string; projectID?: string }) => Promise<void>;
+  createChatSession: (options?: CreateChatSessionOptions) => Promise<void>;
   selectChatSession: (id: string) => Promise<void>;
   startNewChat: () => void;
   deleteChatSession: (id: string) => Promise<void>;
@@ -801,10 +808,13 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     };
   }
 
-  async function createChatSession(options?: { agentID?: string; projectID?: string }) {
+  async function createChatSession(options?: CreateChatSessionOptions) {
     const requestedAgentID = options?.agentID?.trim();
     const createProjectID =
       options && "projectID" in options ? options.projectID?.trim() || "" : activeProjectID;
+    const requestedProviderFilter = (options?.provider?.trim() || providerFilter) as ProviderFilter;
+    const requestedSelectionModel =
+      options && "model" in options ? options.model?.trim() || "" : model;
     const createExternalAgent =
       requestedAgentID && requestedAgentID !== "hecate"
         ? true
@@ -849,8 +859,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const toolsEnabled = effectiveHecateToolsEnabled({
       requested: requestedExecutionMode,
       models,
-      providerFilter,
-      model,
+      providerFilter: requestedProviderFilter,
+      model: requestedSelectionModel,
       // No active session yet — fall back to the user default. The
       // composer hasn't had a chance to call setChatToolsEnabled
       // against the new session ID, so the per-session map can't
@@ -862,9 +872,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     // a routable default. Tools-off chat is still a Hecate-owned session,
     // but it dispatches directly to the selected model.
     const requestedModel =
-      toolsEnabled && model && !modelAvailableForProviderFilter(models, providerFilter, model)
+      toolsEnabled &&
+      requestedSelectionModel &&
+      !modelAvailableForProviderFilter(models, requestedProviderFilter, requestedSelectionModel)
         ? ""
-        : model;
+        : requestedSelectionModel;
     const workspace = workspaceForNewChat(createProjectID);
     if (toolsEnabled && !workspace) {
       setChatErrorState(chatWorkspaceRequiredError());
@@ -878,11 +890,13 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       const created = await createChatSessionRequest({
         ...(createProjectID ? { project_id: createProjectID } : {}),
         agent_id: "hecate",
-        provider: providerFilter === "auto" ? "" : providerFilter,
+        provider: requestedProviderFilter === "auto" ? "" : requestedProviderFilter,
         model: requestedModel,
         ...(toolsEnabled && workspace ? { workspace } : {}),
         ...(toolsEnabled ? { rtk_enabled: hecateRTKEnabled } : {}),
       });
+      setProviderFilter(requestedProviderFilter);
+      setModel(requestedModel);
       setActiveChatSessionID(created.data.id);
       // Same per-session pinning as the submit path: chatTarget stays
       // "agent" and the tools-on/off intent for this session is recorded

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -126,7 +126,7 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [role] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({
     object: "project_work_items",
-    data: [workItem],
+    data: [{ ...workItem, assignments: [hecateAssignment] }],
   });
   vi.mocked(getProjectWorkItem).mockResolvedValue({
     object: "project_work_item",
@@ -291,7 +291,7 @@ describe("ProjectsView cockpit", () => {
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
   });
 
-  it("surfaces partial assignment summary load failures", async () => {
+  it("uses projected work-item assignments for list summaries without per-item requests", async () => {
     resetProjectWorkMocks();
     const secondWorkItem: ProjectWorkItemRecord = {
       ...workItem,
@@ -300,18 +300,14 @@ describe("ProjectsView cockpit", () => {
     };
     vi.mocked(getProjectWorkItems).mockResolvedValue({
       object: "project_work_items",
-      data: [workItem, secondWorkItem],
+      data: [
+        { ...workItem, assignments: [hecateAssignment] },
+        {
+          ...secondWorkItem,
+          assignments: [{ ...hecateAssignment, id: "asgn_2", work_item_id: secondWorkItem.id }],
+        },
+      ],
     });
-    vi.mocked(getProjectAssignments)
-      .mockRejectedValueOnce(new Error("assignment request failed"))
-      .mockResolvedValueOnce({
-        object: "project_assignments",
-        data: [{ ...hecateAssignment, work_item_id: secondWorkItem.id }],
-      })
-      .mockResolvedValueOnce({
-        object: "project_assignments",
-        data: [],
-      });
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -319,22 +315,17 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    expect(
-      await screen.findByText(
-        "Some assignment summaries failed to load. Refresh project work to retry.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Write project docs")).toBeTruthy();
-    expect(
-      within(screen.getByRole("button", { name: "Open work item Build cockpit UI" })).queryByText(
-        "1 assignment",
-      ),
-    ).toBeNull();
-    expect(
-      within(screen.getByRole("button", { name: "Open work item Write project docs" })).getByText(
-        "1 assignment",
-      ),
-    ).toBeTruthy();
+    const firstRow = await screen.findByRole("button", {
+      name: "Open work item Build cockpit UI",
+    });
+    const secondRow = await screen.findByRole("button", {
+      name: "Open work item Write project docs",
+    });
+    expect(within(firstRow).queryByText("1 assignment")).toBeTruthy();
+    expect(within(secondRow).getByText("1 assignment")).toBeTruthy();
+    await waitFor(() => {
+      expect(getProjectAssignments).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("shows selected work item assignments and projected execution state", async () => {
@@ -584,7 +575,7 @@ describe("ProjectsView cockpit", () => {
     window.localStorage.setItem("hecate.project", project.id);
     const queuedAssignment = {
       ...hecateAssignment,
-      status: "queued",
+      status: "running",
       execution: { ...hecateAssignment.execution, status: "queued" },
     };
     vi.mocked(getProjectAssignments).mockResolvedValue({
@@ -607,6 +598,36 @@ describe("ProjectsView cockpit", () => {
     await waitFor(() => {
       expect(getProjectWorkItem).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("renders finished-only assignment timestamps without a blank started label", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [
+        {
+          ...hecateAssignment,
+          status: "completed",
+          started_at: undefined,
+          completed_at: "2026-06-02T12:00:00Z",
+          execution: {
+            ...hecateAssignment.execution,
+            status: "completed",
+            started_at: undefined,
+            finished_at: "2026-06-02T12:00:00Z",
+          },
+        },
+      ],
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText(/^Finished /)).toBeTruthy();
+    expect(screen.queryByText(/^Started\s*$/)).toBeNull();
   });
 
   it("does not expose native start for external-agent assignments", async () => {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -291,6 +291,61 @@ describe("ProjectsView cockpit", () => {
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
   });
 
+  it("clears stale work item selection before switching projects", async () => {
+    resetProjectWorkMocks();
+    const secondProject: ProjectRecord = {
+      ...project,
+      id: "proj_2",
+      name: "Apollo",
+      roots: [
+        {
+          ...project.roots[0],
+          id: "root_2",
+          path: "/Users/alice/dev/apollo",
+        },
+      ],
+    };
+    const secondWorkItem: ProjectWorkItemRecord = {
+      ...workItem,
+      id: "work_2",
+      project_id: "proj_2",
+      title: "Build Apollo cockpit",
+      brief: "Show Apollo project work.",
+    };
+    vi.mocked(getProjectWorkItems).mockImplementation(async (projectID) => ({
+      object: "project_work_items",
+      data:
+        projectID === secondProject.id
+          ? [{ ...secondWorkItem, assignments: [] }]
+          : [{ ...workItem, assignments: [hecateAssignment] }],
+    }));
+    vi.mocked(getProjectWorkItem).mockImplementation(async (projectID, workItemID) => ({
+      object: "project_work_item",
+      data:
+        projectID === secondProject.id && workItemID === secondWorkItem.id
+          ? secondWorkItem
+          : workItem,
+    }));
+    vi.mocked(getProjectAssignments).mockImplementation(async (projectID) => ({
+      object: "project_assignments",
+      data: projectID === secondProject.id ? [] : [hecateAssignment],
+    }));
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project, secondProject],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Open project Apollo" }));
+
+    expect(await screen.findByText("Show Apollo project work.")).toBeTruthy();
+    expect(getProjectWorkItem).toHaveBeenCalledWith(secondProject.id, secondWorkItem.id);
+    expect(getProjectWorkItem).not.toHaveBeenCalledWith(secondProject.id, workItem.id);
+  });
+
   it("uses projected work-item assignments for list summaries without per-item requests", async () => {
     resetProjectWorkMocks();
     const secondWorkItem: ProjectWorkItemRecord = {
@@ -326,6 +381,52 @@ describe("ProjectsView cockpit", () => {
     await waitFor(() => {
       expect(getProjectAssignments).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("preserves the selected work item when refreshing project work", async () => {
+    resetProjectWorkMocks();
+    const secondWorkItem: ProjectWorkItemRecord = {
+      ...workItem,
+      id: "work_2",
+      title: "Write project docs",
+      brief: "Document the project workflow.",
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [
+        { ...workItem, assignments: [hecateAssignment] },
+        { ...secondWorkItem, assignments: [] },
+      ],
+    });
+    vi.mocked(getProjectWorkItem).mockImplementation(async (_projectID, workItemID) => ({
+      object: "project_work_item",
+      data: workItemID === secondWorkItem.id ? secondWorkItem : workItem,
+    }));
+    vi.mocked(getProjectAssignments).mockImplementation(async (_projectID, workItemID) => ({
+      object: "project_assignments",
+      data: workItemID === secondWorkItem.id ? [] : [hecateAssignment],
+    }));
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const secondRow = await screen.findByRole("button", {
+      name: "Open work item Write project docs",
+    });
+    await userEvent.click(secondRow);
+    expect(await screen.findByText("Document the project workflow.")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Refresh project work" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Open work item Write project docs" }),
+      ).toHaveAttribute("aria-current", "true");
+    });
+    expect(await screen.findByText("Document the project workflow.")).toBeTruthy();
   });
 
   it("shows selected work item assignments and projected execution state", async () => {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -353,6 +353,11 @@ describe("ProjectsView cockpit", () => {
       id: "work_2",
       title: "Write project docs",
     };
+    const emptyWorkItem: ProjectWorkItemRecord = {
+      ...workItem,
+      id: "work_3",
+      title: "Plan empty lane",
+    };
     vi.mocked(getProjectWorkItems).mockResolvedValue({
       object: "project_work_items",
       data: [
@@ -361,6 +366,7 @@ describe("ProjectsView cockpit", () => {
           ...secondWorkItem,
           assignments: [{ ...hecateAssignment, id: "asgn_2", work_item_id: secondWorkItem.id }],
         },
+        emptyWorkItem,
       ],
     });
     window.localStorage.setItem("hecate.project", project.id);
@@ -376,8 +382,12 @@ describe("ProjectsView cockpit", () => {
     const secondRow = await screen.findByRole("button", {
       name: "Open work item Write project docs",
     });
+    const emptyRow = await screen.findByRole("button", {
+      name: "Open work item Plan empty lane",
+    });
     expect(within(firstRow).queryByText("1 assignment")).toBeTruthy();
     expect(within(secondRow).getByText("1 assignment")).toBeTruthy();
+    expect(within(emptyRow).queryByText(/assignment/)).toBeNull();
     await waitFor(() => {
       expect(getProjectAssignments).toHaveBeenCalledTimes(1);
     });

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1,0 +1,585 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ProvidersAndModelsProvider } from "../../app/state/providersAndModels";
+import { ProjectsProvider } from "../../app/state/projects";
+import {
+  createProjectAssignment,
+  createProjectWorkItem,
+  deleteProjectAssignment,
+  deleteProjectWorkItem,
+  getProjectAssignments,
+  getProjectCollaborationArtifacts,
+  getProjectWorkItem,
+  getProjectWorkItems,
+  getProjectWorkRoles,
+  startProjectAssignment,
+  updateProject,
+  updateProjectAssignment,
+  updateProjectWorkItem,
+} from "../../lib/api";
+import {
+  createRuntimeConsoleActions,
+  createRuntimeConsoleFixture,
+} from "../../test/runtime-console-fixture";
+import { withRuntimeConsole } from "../../test/runtime-console-render";
+import type {
+  ProjectAssignmentRecord,
+  ProjectRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { ProjectsView } from "./ProjectsView";
+
+vi.mock("../../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/api")>();
+  return {
+    ...actual,
+    getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
+    getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
+    getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
+    getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
+    getProjectCollaborationArtifacts: vi.fn(async () => ({
+      object: "project_collaboration_artifacts",
+      data: [],
+    })),
+    startProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
+    createProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
+    createProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
+    updateProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
+    deleteProjectWorkItem: vi.fn(async () => undefined),
+    updateProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
+    deleteProjectAssignment: vi.fn(async () => undefined),
+    updateProject: vi.fn(async () => ({ object: "project", data: null })),
+  };
+});
+
+const project: ProjectRecord = {
+  id: "proj_1",
+  name: "Hecate",
+  roots: [
+    {
+      id: "root_1",
+      path: "/Users/alice/dev/hecate",
+      kind: "git",
+      git_branch: "main",
+      active: true,
+      created_at: "2026-06-01T10:00:00Z",
+      updated_at: "2026-06-01T10:00:00Z",
+    },
+  ],
+  default_provider: "ollama",
+  default_model: "qwen2.5-coder",
+  created_at: "2026-06-01T10:00:00Z",
+  updated_at: "2026-06-01T11:00:00Z",
+};
+
+const role: ProjectWorkRoleRecord = {
+  id: "software_developer",
+  project_id: "proj_1",
+  name: "Software developer",
+  built_in: true,
+};
+
+const workItem: ProjectWorkItemRecord = {
+  id: "work_1",
+  project_id: "proj_1",
+  title: "Build cockpit UI",
+  brief: "Expose project work and native starts.",
+  status: "ready",
+  priority: "high",
+  owner_role_id: "software_developer",
+  reviewer_role_ids: ["reviewer_qa"],
+  created_at: "2026-06-02T10:00:00Z",
+  updated_at: "2026-06-02T11:00:00Z",
+};
+
+const hecateAssignment: ProjectAssignmentRecord = {
+  id: "asgn_1",
+  project_id: "proj_1",
+  work_item_id: "work_1",
+  role_id: "software_developer",
+  driver_kind: "hecate_task",
+  status: "queued",
+  task_id: "task_1",
+  run_id: "run_1",
+  execution: {
+    task_id: "task_1",
+    run_id: "run_1",
+    status: "awaiting_approval",
+    task_status: "running",
+    run_status: "awaiting_approval",
+    pending_approval_count: 2,
+    step_count: 4,
+    artifact_count: 1,
+    provider: "ollama",
+    model: "qwen2.5-coder",
+  },
+  created_at: "2026-06-02T10:00:00Z",
+  updated_at: "2026-06-02T11:00:00Z",
+  started_at: "2026-06-02T10:30:00Z",
+};
+
+function resetProjectWorkMocks() {
+  vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [role] });
+  vi.mocked(getProjectWorkItems).mockResolvedValue({
+    object: "project_work_items",
+    data: [workItem],
+  });
+  vi.mocked(getProjectWorkItem).mockResolvedValue({
+    object: "project_work_item",
+    data: workItem,
+  });
+  vi.mocked(getProjectAssignments).mockResolvedValue({
+    object: "project_assignments",
+    data: [hecateAssignment],
+  });
+  vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
+    object: "project_collaboration_artifacts",
+    data: [],
+  });
+  vi.mocked(startProjectAssignment).mockResolvedValue({
+    object: "project_assignment",
+    data: { ...hecateAssignment, status: "running" },
+  });
+  vi.mocked(createProjectWorkItem).mockResolvedValue({
+    object: "project_work_item",
+    data: { ...workItem, id: "work_new", title: "New cockpit work" },
+  });
+  vi.mocked(createProjectAssignment).mockResolvedValue({
+    object: "project_assignment",
+    data: { ...hecateAssignment, id: "asgn_new", status: "queued", execution: undefined },
+  });
+  vi.mocked(updateProjectWorkItem).mockResolvedValue({
+    object: "project_work_item",
+    data: { ...workItem, title: "Edited cockpit UI", status: "review", priority: "urgent" },
+  });
+  vi.mocked(deleteProjectWorkItem).mockResolvedValue(undefined);
+  vi.mocked(updateProjectAssignment).mockResolvedValue({
+    object: "project_assignment",
+    data: { ...hecateAssignment, role_id: "software_developer", status: "running" },
+  });
+  vi.mocked(deleteProjectAssignment).mockResolvedValue(undefined);
+  vi.mocked(updateProject).mockResolvedValue({
+    object: "project",
+    data: {
+      ...project,
+      default_provider: "ollama",
+      default_model: "ministral-3:latest",
+      default_workspace_mode: "in_place",
+    },
+  });
+}
+
+function directWrapper(initialState: Parameters<typeof ProjectsProvider>[0]["initialState"]) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ProvidersAndModelsProvider>
+        <ProjectsProvider initialState={initialState}>{children}</ProjectsProvider>
+      </ProvidersAndModelsProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.mocked(getProjectWorkRoles).mockReset();
+  vi.mocked(getProjectWorkItems).mockReset();
+  vi.mocked(getProjectWorkItem).mockReset();
+  vi.mocked(getProjectAssignments).mockReset();
+  vi.mocked(getProjectCollaborationArtifacts).mockReset();
+  vi.mocked(startProjectAssignment).mockReset();
+  vi.mocked(createProjectWorkItem).mockReset();
+  vi.mocked(createProjectAssignment).mockReset();
+  vi.mocked(updateProjectWorkItem).mockReset();
+  vi.mocked(deleteProjectWorkItem).mockReset();
+  vi.mocked(updateProjectAssignment).mockReset();
+  vi.mocked(deleteProjectAssignment).mockReset();
+  vi.mocked(updateProject).mockReset();
+});
+
+describe("ProjectsView index", () => {
+  it("renders project rows with roots and defaults", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [project] }),
+    });
+
+    expect(screen.getByRole("button", { name: "Open project Hecate" })).toBeTruthy();
+    expect(screen.getByText("/Users/alice/dev/hecate")).toBeTruthy();
+    expect(screen.getByText("ollama / qwen2.5-coder")).toBeTruthy();
+    expect(await screen.findByText("Build cockpit UI")).toBeTruthy();
+  });
+
+  it("renders empty, loading, and error states for the project index", () => {
+    const empty = render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [] }),
+    });
+    expect(screen.getByText("No projects yet")).toBeTruthy();
+    empty.unmount();
+
+    render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [], loading: true }),
+    });
+    expect(screen.getByText("Loading projects…")).toBeTruthy();
+    cleanup();
+
+    render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [], error: "project list failed" }),
+    });
+    expect(screen.getByText("project list failed")).toBeTruthy();
+  });
+
+  it("uses existing project actions for create, rename, and delete", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    const actions = {
+      ...createRuntimeConsoleActions(),
+      createProjectFromFolder: vi.fn(async () => project),
+      renameProject: vi.fn(async () => undefined),
+      deleteProject: vi.fn(async () => true),
+    };
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions }));
+
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    expect(actions.createProjectFromFolder).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Rename project Hecate" }));
+    fireEvent.change(screen.getByLabelText("Rename Hecate"), {
+      target: { value: "Hecate console" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(actions.renameProject).toHaveBeenCalledWith(project.id, "Hecate console");
+
+    await user.click(screen.getByRole("button", { name: "Delete project Hecate" }));
+    expect(
+      screen.getByText(/Workspace files and the git repository are not deleted/i),
+    ).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Delete project record" }));
+    expect(actions.deleteProject).toHaveBeenCalledWith(project.id);
+  });
+});
+
+describe("ProjectsView cockpit", () => {
+  it("loads work items after selecting a project", async () => {
+    resetProjectWorkMocks();
+    const state = createRuntimeConsoleFixture({ projects: [project] });
+    const actions = {
+      ...createRuntimeConsoleActions(),
+      selectProject: vi.fn(async () => undefined),
+    };
+    render(withRuntimeConsole(<ProjectsView />, { state, actions }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Open project Hecate" }));
+
+    await waitFor(() => {
+      expect(getProjectWorkItems).toHaveBeenCalledWith(project.id);
+    });
+    expect(actions.selectProject).toHaveBeenCalledWith(project.id);
+    expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
+  });
+
+  it("shows selected work item assignments and projected execution state", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
+    const detail = screen.getByLabelText("Selected work item");
+    expect(within(detail).getByText("Software developer")).toBeTruthy();
+    expect(within(detail).getByText("approval")).toBeTruthy();
+    expect(within(detail).getByText("2 approval pending")).toBeTruthy();
+    expect(within(detail).getByText("4 steps")).toBeTruthy();
+    expect(within(detail).getByText("ollama / qwen2.5-coder")).toBeTruthy();
+  });
+
+  it("opens chat from an assignment using the projected model", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const onOpenChat = vi.fn();
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(<ProjectsView onOpenChat={onOpenChat} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: "Open chat" }));
+
+    expect(onOpenChat).toHaveBeenCalledWith({
+      projectID: project.id,
+      provider: "ollama",
+      model: "qwen2.5-coder",
+    });
+  });
+
+  it("creates work items from the Projects cockpit", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Work" }));
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "New cockpit work" },
+    });
+    fireEvent.change(screen.getByLabelText("Brief"), {
+      target: { value: "Make project work creatable in the UI." },
+    });
+    fireEvent.change(screen.getByLabelText("Priority"), {
+      target: { value: "urgent" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Create work item" }));
+
+    expect(createProjectWorkItem).toHaveBeenCalledWith(project.id, {
+      title: "New cockpit work",
+      brief: "Make project work creatable in the UI.",
+      status: "ready",
+      priority: "urgent",
+      owner_role_id: "software_developer",
+    });
+  });
+
+  it("edits and deletes work items from the selected detail", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const detail = screen.getByLabelText("Selected work item");
+    expect(await within(detail).findByText("Expose project work and native starts.")).toBeTruthy();
+
+    await userEvent.click(within(detail).getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Edited cockpit UI" },
+    });
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "review" },
+    });
+    fireEvent.change(screen.getByLabelText("Priority"), {
+      target: { value: "urgent" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Save work item" }));
+
+    expect(updateProjectWorkItem).toHaveBeenCalledWith(project.id, workItem.id, {
+      title: "Edited cockpit UI",
+      brief: "Expose project work and native starts.",
+      status: "review",
+      priority: "urgent",
+      owner_role_id: "software_developer",
+      reviewer_role_ids: ["reviewer_qa"],
+    });
+
+    await userEvent.click(within(detail).getByRole("button", { name: "Delete" }));
+    expect(
+      screen.getByText(/Linked tasks, runs, chats, workspace files, and git history/i),
+    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Delete work item" }));
+
+    expect(deleteProjectWorkItem).toHaveBeenCalledWith(project.id, workItem.id);
+  });
+
+  it("adds assignments from the selected work item", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    fireEvent.change(screen.getByLabelText("Driver"), {
+      target: { value: "external_agent" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+
+    expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
+      role_id: "software_developer",
+      driver_kind: "external_agent",
+    });
+  });
+
+  it("edits and deletes assignments from the selected work item", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit assignment asgn_1" }));
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "running" },
+    });
+    fireEvent.change(screen.getByLabelText("Driver"), {
+      target: { value: "external_agent" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Save assignment" }));
+
+    expect(updateProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      hecateAssignment.id,
+      {
+        role_id: "software_developer",
+        driver_kind: "external_agent",
+        status: "running",
+        task_id: "task_1",
+        run_id: "run_1",
+        chat_session_id: "",
+        message_id: "",
+        context_snapshot_id: "",
+      },
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete assignment asgn_1" }));
+    expect(
+      screen.getByText(/Linked tasks, runs, chats, and external-agent executions/i),
+    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Delete assignment" }));
+
+    expect(deleteProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      hecateAssignment.id,
+    );
+  });
+
+  it("updates project defaults needed by native starts", async () => {
+    resetProjectWorkMocks();
+    const projectWithUpdatedDefaults = {
+      ...project,
+      default_model: "ministral-3:latest",
+    };
+    window.localStorage.setItem("hecate.project", projectWithUpdatedDefaults.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [projectWithUpdatedDefaults],
+      activeProjectID: projectWithUpdatedDefaults.id,
+      providers: [
+        {
+          name: "ollama",
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          credential_state: "not_required",
+        },
+      ],
+      providerPresets: [
+        {
+          id: "ollama",
+          name: "Ollama",
+          kind: "local",
+          protocol: "openai",
+          base_url: "http://127.0.0.1:11434/v1",
+        },
+      ],
+      models: [
+        {
+          id: "qwen2.5-coder",
+          owned_by: "ollama",
+          metadata: { provider: "ollama", provider_kind: "local" },
+        },
+        {
+          id: "ministral-3:latest",
+          owned_by: "ollama",
+          metadata: { provider: "ollama", provider_kind: "local" },
+        },
+      ],
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Defaults" }));
+    expect(screen.getByRole("button", { name: /Ollama/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Model picker: ministral-3:latest/i })).toBeTruthy();
+    expect(screen.queryByLabelText("Provider ID")).toBeNull();
+    expect(screen.queryByLabelText("Model")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /Model picker/i }));
+    await userEvent.click(await screen.findByText("qwen2.5-coder"));
+    expect(screen.getByRole("dialog", { name: "Project defaults" })).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Save defaults" }));
+
+    expect(updateProject).toHaveBeenCalledWith(projectWithUpdatedDefaults.id, {
+      default_provider: "ollama",
+      default_model: "qwen2.5-coder",
+      default_workspace_mode: "in_place",
+    });
+  });
+
+  it("starts native Hecate assignments and refreshes detail state", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const queuedAssignment = {
+      ...hecateAssignment,
+      status: "queued",
+      execution: { ...hecateAssignment.execution, status: "queued" },
+    };
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [queuedAssignment],
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Start" }));
+
+    expect(startProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      queuedAssignment.id,
+    );
+    await waitFor(() => {
+      expect(getProjectWorkItem).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not expose native start for external-agent assignments", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [
+        {
+          ...hecateAssignment,
+          id: "asgn_external",
+          driver_kind: "external_agent",
+          status: "queued",
+          execution: undefined,
+        },
+      ],
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Start in Chats")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Start" })).toBeNull();
+  });
+});

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -241,6 +241,7 @@ describe("ProjectsView index", () => {
       createProjectFromFolder: vi.fn(async () => project),
       renameProject: vi.fn(async () => undefined),
       deleteProject: vi.fn(async () => true),
+      selectProject: vi.fn(async () => undefined),
     };
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -252,7 +253,11 @@ describe("ProjectsView index", () => {
     expect(actions.createProjectFromFolder).toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Rename project Hecate" }));
-    fireEvent.change(screen.getByLabelText("Rename Hecate"), {
+    const renameInput = screen.getByLabelText("Rename Hecate");
+    await user.type(renameInput, " workspace");
+    expect(renameInput).toHaveValue("Hecate workspace");
+    expect(actions.selectProject).not.toHaveBeenCalled();
+    fireEvent.change(renameInput, {
       target: { value: "Hecate console" },
     });
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -284,6 +289,52 @@ describe("ProjectsView cockpit", () => {
     });
     expect(actions.selectProject).toHaveBeenCalledWith(project.id);
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
+  });
+
+  it("surfaces partial assignment summary load failures", async () => {
+    resetProjectWorkMocks();
+    const secondWorkItem: ProjectWorkItemRecord = {
+      ...workItem,
+      id: "work_2",
+      title: "Write project docs",
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [workItem, secondWorkItem],
+    });
+    vi.mocked(getProjectAssignments)
+      .mockRejectedValueOnce(new Error("assignment request failed"))
+      .mockResolvedValueOnce({
+        object: "project_assignments",
+        data: [{ ...hecateAssignment, work_item_id: secondWorkItem.id }],
+      })
+      .mockResolvedValueOnce({
+        object: "project_assignments",
+        data: [],
+      });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(
+      await screen.findByText(
+        "Some assignment summaries failed to load. Refresh project work to retry.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Write project docs")).toBeTruthy();
+    expect(
+      within(screen.getByRole("button", { name: "Open work item Build cockpit UI" })).queryByText(
+        "1 assignment",
+      ),
+    ).toBeNull();
+    expect(
+      within(screen.getByRole("button", { name: "Open work item Write project docs" })).getByText(
+        "1 assignment",
+      ),
+    ).toBeTruthy();
   });
 
   it("shows selected work item assignments and projected execution state", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -230,19 +230,21 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     );
   }, [projects.activeProjectID, projects.state.projects]);
 
-  const loadWorkForProject = useCallback(async (projectID: string) => {
+  const loadWorkForProject = useCallback(async (projectID: string, preferredWorkItemID = "") => {
     setWorkError("");
     setDetailError("");
     setAssignmentErrors({});
     setWorkItems([]);
     setWorkItemSummaries({});
-    setSelectedWorkItemID("");
-    setSelectedWorkItem(null);
-    setAssignments([]);
-    setArtifacts([]);
+    if (!preferredWorkItemID) {
+      setSelectedWorkItemID("");
+      setSelectedWorkItem(null);
+      setAssignments([]);
+      setArtifacts([]);
+    }
     if (!projectID) {
       setWorkLoadState("idle");
-      return;
+      return "";
     }
     setWorkLoadState("loading");
     try {
@@ -261,12 +263,16 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           ),
         ),
       );
-      const nextSelectedID = nextItems[0]?.id || "";
+      const nextSelectedID = nextItems.some((item) => item.id === preferredWorkItemID)
+        ? preferredWorkItemID
+        : nextItems[0]?.id || "";
       setSelectedWorkItemID(nextSelectedID);
       setWorkLoadState("loaded");
+      return nextSelectedID;
     } catch (error) {
       setWorkLoadState("error");
       setWorkError(errorMessage(error, "Failed to load project work."));
+      return "";
     }
   }, []);
 
@@ -312,6 +318,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   }, [loadWorkItemDetail, selectedProjectID, selectedWorkItemID]);
 
   function openProject(projectID: string) {
+    if (projectID !== selectedProjectID) {
+      setSelectedWorkItemID("");
+    }
     setSelectedProjectID(projectID);
     void projects.actions.selectProject(projectID);
   }
@@ -505,9 +514,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
 
   async function refreshSelectedWorkItem() {
     if (!selectedProjectID) return;
-    await loadWorkForProject(selectedProjectID);
-    if (selectedWorkItemID) {
-      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    if (refreshedWorkItemID) {
+      await loadWorkItemDetail(selectedProjectID, refreshedWorkItemID);
     }
   }
 
@@ -589,7 +598,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       <section style={workListStyle} aria-label="Project work items">
         <ProjectHeader
           project={selectedProject}
-          onRefresh={() => void loadWorkForProject(selectedProjectID)}
+          onRefresh={refreshSelectedWorkItem}
           onEditDefaults={() => {
             setDefaultsError("");
             setDefaultsModalOpen(true);

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -258,9 +258,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setWorkItems(nextItems);
       setWorkItemSummaries(
         Object.fromEntries(
-          nextItems.flatMap((item) =>
-            item.assignments ? [[item.id, summarizeAssignments(item.assignments)] as const] : [],
-          ),
+          nextItems.map((item) => [item.id, summarizeAssignments(item.assignments ?? [])] as const),
         ),
       );
       const nextSelectedID = nextItems.some((item) => item.id === preferredWorkItemID)

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -254,16 +254,24 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
-      const assignmentLists = await Promise.all(
-        nextItems.map((item) =>
-          getProjectAssignments(projectID, item.id)
-            .then((res) => [item.id, res.data ?? []] as const)
-            .catch(() => [item.id, [] as ProjectAssignmentRecord[]] as const),
-        ),
+      const assignmentResults = await Promise.allSettled(
+        nextItems.map(async (item) => {
+          const res = await getProjectAssignments(projectID, item.id);
+          return [item.id, res.data ?? []] as const;
+        }),
       );
       setWorkItemSummaries(
-        Object.fromEntries(assignmentLists.map(([id, list]) => [id, summarizeAssignments(list)])),
+        Object.fromEntries(
+          assignmentResults.flatMap((result) =>
+            result.status === "fulfilled"
+              ? [[result.value[0], summarizeAssignments(result.value[1])] as const]
+              : [],
+          ),
+        ),
       );
+      if (assignmentResults.some((result) => result.status === "rejected")) {
+        setWorkError("Some assignment summaries failed to load. Refresh project work to retry.");
+      }
       const nextSelectedID = nextItems[0]?.id || "";
       setSelectedWorkItemID(nextSelectedID);
       setWorkLoadState("loaded");
@@ -825,6 +833,7 @@ function ProjectIndexRow({
       aria-label={`Open project ${project.name}`}
       onClick={onOpen}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key !== "Enter" && event.key !== " ") return;
         event.preventDefault();
         onOpen();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1,0 +1,2118 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+
+import { useProjects } from "../../app/state/projects";
+import { useProvidersAndModels } from "../../app/state/providersAndModels";
+import {
+  ApiError,
+  createProjectAssignment,
+  createProjectWorkItem,
+  deleteProjectAssignment,
+  deleteProjectWorkItem,
+  getProjectAssignments,
+  getProjectCollaborationArtifacts,
+  getProjectWorkItem,
+  getProjectWorkItems,
+  getProjectWorkRoles,
+  startProjectAssignment,
+  updateProject,
+  updateProjectAssignment,
+  updateProjectWorkItem,
+} from "../../lib/api";
+import { formatAbsoluteTime } from "../../lib/format";
+import { projectDefaultWorkspace } from "../../lib/project-workspace";
+import type {
+  ProjectAssignmentRecord,
+  ProjectCollaborationArtifactRecord,
+  ProjectRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+  UpdateProjectAssignmentPayload,
+  UpdateProjectPayload,
+  UpdateProjectWorkItemPayload,
+} from "../../types/project";
+import type { ModelRecord } from "../../types/model";
+import type { ProviderPresetRecord } from "../../types/provider";
+import {
+  Badge,
+  ConfirmModal,
+  CopyableID,
+  Icon,
+  Icons,
+  InlineError,
+  Modal,
+  ModelPicker,
+  ProviderPicker,
+  type ProviderOption,
+} from "../shared/ui";
+
+type Props = {
+  onOpenChat?: (request: { projectID: string; provider?: string; model?: string }) => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+};
+
+type WorkItemSummary = {
+  assignmentCount: number;
+  activeCount: number;
+  failedCount: number;
+  completedCount: number;
+};
+
+type LoadState = "idle" | "loading" | "loaded" | "error";
+
+type NewWorkItemForm = {
+  title: string;
+  brief: string;
+  priority: string;
+  ownerRoleID: string;
+};
+
+type NewAssignmentForm = {
+  roleID: string;
+  driverKind: string;
+};
+
+type EditWorkItemForm = NewWorkItemForm & {
+  id: string;
+  status: string;
+  reviewerRoleIDs: string;
+};
+
+type EditAssignmentForm = NewAssignmentForm & {
+  id: string;
+  status: string;
+  taskID: string;
+  runID: string;
+  chatSessionID: string;
+  messageID: string;
+  contextSnapshotID: string;
+};
+
+type ProjectDefaultsForm = {
+  provider: string;
+  model: string;
+  workspaceMode: string;
+};
+
+const WORK_ITEM_STATUSES = [
+  "backlog",
+  "ready",
+  "running",
+  "review",
+  "blocked",
+  "done",
+  "cancelled",
+];
+const WORK_ITEM_PRIORITIES = ["low", "normal", "high", "urgent"];
+const ASSIGNMENT_STATUSES = [
+  "queued",
+  "running",
+  "awaiting_approval",
+  "completed",
+  "failed",
+  "cancelled",
+];
+
+const shellStyle: CSSProperties = {
+  display: "flex",
+  height: "100%",
+  minHeight: 0,
+  background: "var(--bg0)",
+};
+
+const sidePanelStyle: CSSProperties = {
+  width: 280,
+  borderRight: "1px solid var(--border)",
+  background: "var(--bg1)",
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+  flexShrink: 0,
+};
+
+const workListStyle: CSSProperties = {
+  width: 320,
+  borderRight: "1px solid var(--border)",
+  background: "var(--bg0)",
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+  flexShrink: 0,
+};
+
+const detailStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  minHeight: 0,
+  overflow: "auto",
+  background: "var(--bg0)",
+};
+
+export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
+  const projects = useProjects();
+  const providersAndModels = useProvidersAndModels();
+  const [selectedProjectID, setSelectedProjectID] = useState(projects.activeProjectID);
+  const [renamingProjectID, setRenamingProjectID] = useState("");
+  const [renameValue, setRenameValue] = useState("");
+  const [deleteProjectID, setDeleteProjectID] = useState("");
+  const [deletePending, setDeletePending] = useState(false);
+  const [defaultsModalOpen, setDefaultsModalOpen] = useState(false);
+  const [defaultsPending, setDefaultsPending] = useState(false);
+  const [defaultsError, setDefaultsError] = useState("");
+  const [newWorkModalOpen, setNewWorkModalOpen] = useState(false);
+  const [newWorkPending, setNewWorkPending] = useState(false);
+  const [newWorkError, setNewWorkError] = useState("");
+  const [editingWorkItem, setEditingWorkItem] = useState<ProjectWorkItemRecord | null>(null);
+  const [editWorkPending, setEditWorkPending] = useState(false);
+  const [editWorkError, setEditWorkError] = useState("");
+  const [deleteWorkItem, setDeleteWorkItem] = useState<ProjectWorkItemRecord | null>(null);
+  const [deleteWorkPending, setDeleteWorkPending] = useState(false);
+  const [newAssignmentModalOpen, setNewAssignmentModalOpen] = useState(false);
+  const [newAssignmentPending, setNewAssignmentPending] = useState(false);
+  const [newAssignmentError, setNewAssignmentError] = useState("");
+  const [editingAssignment, setEditingAssignment] = useState<ProjectAssignmentRecord | null>(null);
+  const [editAssignmentPending, setEditAssignmentPending] = useState(false);
+  const [editAssignmentError, setEditAssignmentError] = useState("");
+  const [deleteAssignment, setDeleteAssignment] = useState<ProjectAssignmentRecord | null>(null);
+  const [deleteAssignmentPending, setDeleteAssignmentPending] = useState(false);
+  const [workItems, setWorkItems] = useState<ProjectWorkItemRecord[]>([]);
+  const [workItemSummaries, setWorkItemSummaries] = useState<Record<string, WorkItemSummary>>({});
+  const [roles, setRoles] = useState<ProjectWorkRoleRecord[]>([]);
+  const [selectedWorkItemID, setSelectedWorkItemID] = useState("");
+  const [selectedWorkItem, setSelectedWorkItem] = useState<ProjectWorkItemRecord | null>(null);
+  const [assignments, setAssignments] = useState<ProjectAssignmentRecord[]>([]);
+  const [artifacts, setArtifacts] = useState<ProjectCollaborationArtifactRecord[]>([]);
+  const [workLoadState, setWorkLoadState] = useState<LoadState>("idle");
+  const [detailLoadState, setDetailLoadState] = useState<LoadState>("idle");
+  const [workError, setWorkError] = useState("");
+  const [detailError, setDetailError] = useState("");
+  const [assignmentErrors, setAssignmentErrors] = useState<Record<string, string>>({});
+  const [startingAssignmentID, setStartingAssignmentID] = useState("");
+
+  const selectedProject = useMemo(
+    () => projects.state.projects.find((project) => project.id === selectedProjectID) ?? null,
+    [projects.state.projects, selectedProjectID],
+  );
+  const pendingDeleteProject =
+    projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
+  const roleByID = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
+  const providerPresets = providersAndModels.state.providerPresets;
+  const providerOptions = useMemo<ProviderOption[]>(() => {
+    return providersAndModels.state.providers
+      .filter((provider) => provider.healthy && provider.name)
+      .map((provider) => {
+        const preset = providerPresets.find((item) => item.id === provider.name);
+        return {
+          id: provider.name,
+          name: preset?.name || provider.name,
+          healthy: provider.healthy,
+          kind: preset?.kind ?? provider.kind,
+          configured:
+            provider.credential_ready ??
+            (provider.credential_state === "configured" ||
+              provider.credential_state === "not_required"),
+        };
+      });
+  }, [providerPresets, providersAndModels.state.providers]);
+
+  useEffect(() => {
+    if (projects.state.projects.length === 0) {
+      setSelectedProjectID("");
+      return;
+    }
+    if (projects.activeProjectID) {
+      setSelectedProjectID(projects.activeProjectID);
+      return;
+    }
+    setSelectedProjectID((current) =>
+      current && projects.state.projects.some((project) => project.id === current)
+        ? current
+        : projects.state.projects[0]?.id || "",
+    );
+  }, [projects.activeProjectID, projects.state.projects]);
+
+  const loadWorkForProject = useCallback(async (projectID: string) => {
+    setWorkError("");
+    setDetailError("");
+    setAssignmentErrors({});
+    setWorkItems([]);
+    setWorkItemSummaries({});
+    setSelectedWorkItemID("");
+    setSelectedWorkItem(null);
+    setAssignments([]);
+    setArtifacts([]);
+    if (!projectID) {
+      setWorkLoadState("idle");
+      return;
+    }
+    setWorkLoadState("loading");
+    try {
+      const [rolesRes, workRes] = await Promise.all([
+        getProjectWorkRoles(projectID),
+        getProjectWorkItems(projectID),
+      ]);
+      const nextRoles = rolesRes.data ?? [];
+      const nextItems = workRes.data ?? [];
+      setRoles(nextRoles);
+      setWorkItems(nextItems);
+      const assignmentLists = await Promise.all(
+        nextItems.map((item) =>
+          getProjectAssignments(projectID, item.id)
+            .then((res) => [item.id, res.data ?? []] as const)
+            .catch(() => [item.id, [] as ProjectAssignmentRecord[]] as const),
+        ),
+      );
+      setWorkItemSummaries(
+        Object.fromEntries(assignmentLists.map(([id, list]) => [id, summarizeAssignments(list)])),
+      );
+      const nextSelectedID = nextItems[0]?.id || "";
+      setSelectedWorkItemID(nextSelectedID);
+      setWorkLoadState("loaded");
+    } catch (error) {
+      setWorkLoadState("error");
+      setWorkError(errorMessage(error, "Failed to load project work."));
+    }
+  }, []);
+
+  const loadWorkItemDetail = useCallback(async (projectID: string, workItemID: string) => {
+    setDetailError("");
+    setAssignmentErrors({});
+    if (!projectID || !workItemID) {
+      setSelectedWorkItem(null);
+      setAssignments([]);
+      setArtifacts([]);
+      setDetailLoadState("idle");
+      return;
+    }
+    setDetailLoadState("loading");
+    try {
+      const [itemRes, assignmentRes, artifactRes] = await Promise.all([
+        getProjectWorkItem(projectID, workItemID),
+        getProjectAssignments(projectID, workItemID),
+        getProjectCollaborationArtifacts(projectID, workItemID),
+      ]);
+      setSelectedWorkItem(itemRes.data);
+      setAssignments(assignmentRes.data ?? []);
+      setArtifacts(artifactRes.data ?? []);
+      setWorkItems((current) => upsertWorkItem(current, itemRes.data));
+      setWorkItemSummaries((current) => ({
+        ...current,
+        [workItemID]: summarizeAssignments(assignmentRes.data ?? []),
+      }));
+      setDetailLoadState("loaded");
+    } catch (error) {
+      setDetailLoadState("error");
+      setDetailError(errorMessage(error, "Failed to load work item detail."));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadWorkForProject(selectedProjectID);
+  }, [loadWorkForProject, selectedProjectID]);
+
+  useEffect(() => {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    void loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+  }, [loadWorkItemDetail, selectedProjectID, selectedWorkItemID]);
+
+  function openProject(projectID: string) {
+    setSelectedProjectID(projectID);
+    void projects.actions.selectProject(projectID);
+  }
+
+  function startRename(project: ProjectRecord) {
+    setRenamingProjectID(project.id);
+    setRenameValue(project.name);
+  }
+
+  async function commitRename(project: ProjectRecord) {
+    const nextName = renameValue.trim();
+    setRenamingProjectID("");
+    if (!nextName || nextName === project.name) return;
+    await projects.actions.renameProject(project.id, nextName);
+  }
+
+  async function confirmDeleteProject() {
+    if (!pendingDeleteProject) return;
+    setDeletePending(true);
+    try {
+      const deleted = await projects.actions.deleteProject(pendingDeleteProject.id);
+      if (deleted) {
+        setDeleteProjectID("");
+        if (selectedProjectID === pendingDeleteProject.id) {
+          setSelectedProjectID("");
+        }
+      }
+    } finally {
+      setDeletePending(false);
+    }
+  }
+
+  async function handleSaveProjectDefaults(form: ProjectDefaultsForm) {
+    if (!selectedProject) return;
+    setDefaultsPending(true);
+    setDefaultsError("");
+    const patch: UpdateProjectPayload = {
+      default_provider: form.provider.trim(),
+      default_model: form.model.trim(),
+      default_workspace_mode: form.workspaceMode.trim(),
+    };
+    try {
+      const payload = await updateProject(selectedProject.id, patch);
+      projects.actions.setProjects((current) => upsertProject(current, payload.data));
+      setDefaultsModalOpen(false);
+    } catch (error) {
+      setDefaultsError(errorMessage(error, "Failed to update project defaults."));
+    } finally {
+      setDefaultsPending(false);
+    }
+  }
+
+  async function handleCreateWorkItem(form: NewWorkItemForm) {
+    if (!selectedProjectID) return;
+    const title = form.title.trim();
+    if (!title) return;
+    setNewWorkPending(true);
+    setNewWorkError("");
+    try {
+      const payload = await createProjectWorkItem(selectedProjectID, {
+        title,
+        brief: form.brief.trim() || undefined,
+        status: "ready",
+        priority: form.priority || "normal",
+        owner_role_id: form.ownerRoleID || undefined,
+      });
+      setWorkItems((current) => upsertWorkItem(current, payload.data));
+      setWorkItemSummaries((current) => ({
+        ...current,
+        [payload.data.id]: {
+          assignmentCount: 0,
+          activeCount: 0,
+          failedCount: 0,
+          completedCount: 0,
+        },
+      }));
+      setSelectedWorkItemID(payload.data.id);
+      setNewWorkModalOpen(false);
+      await loadWorkItemDetail(selectedProjectID, payload.data.id);
+    } catch (error) {
+      setNewWorkError(errorMessage(error, "Failed to create work item."));
+    } finally {
+      setNewWorkPending(false);
+    }
+  }
+
+  async function handleUpdateWorkItem(form: EditWorkItemForm) {
+    if (!selectedProjectID) return;
+    const title = form.title.trim();
+    if (!title) return;
+    setEditWorkPending(true);
+    setEditWorkError("");
+    const patch: UpdateProjectWorkItemPayload = {
+      title,
+      brief: form.brief.trim(),
+      status: form.status,
+      priority: form.priority || "normal",
+      owner_role_id: form.ownerRoleID,
+      reviewer_role_ids: splitRoleIDs(form.reviewerRoleIDs),
+    };
+    try {
+      const payload = await updateProjectWorkItem(selectedProjectID, form.id, patch);
+      setWorkItems((current) => upsertWorkItem(current, payload.data));
+      setSelectedWorkItem(payload.data);
+      setEditingWorkItem(null);
+      await loadWorkItemDetail(selectedProjectID, payload.data.id);
+    } catch (error) {
+      setEditWorkError(errorMessage(error, "Failed to update work item."));
+    } finally {
+      setEditWorkPending(false);
+    }
+  }
+
+  async function confirmDeleteWorkItem() {
+    if (!selectedProjectID || !deleteWorkItem) return;
+    setDeleteWorkPending(true);
+    try {
+      await deleteProjectWorkItem(selectedProjectID, deleteWorkItem.id);
+      setDeleteWorkItem(null);
+      await loadWorkForProject(selectedProjectID);
+    } finally {
+      setDeleteWorkPending(false);
+    }
+  }
+
+  async function handleCreateAssignment(form: NewAssignmentForm) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const roleID = form.roleID.trim();
+    if (!roleID) return;
+    setNewAssignmentPending(true);
+    setNewAssignmentError("");
+    try {
+      const payload = await createProjectAssignment(selectedProjectID, selectedWorkItemID, {
+        role_id: roleID,
+        driver_kind: form.driverKind || "hecate_task",
+      });
+      setAssignments((current) => upsertAssignment(current, payload.data));
+      setNewAssignmentModalOpen(false);
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setNewAssignmentError(errorMessage(error, "Failed to create assignment."));
+    } finally {
+      setNewAssignmentPending(false);
+    }
+  }
+
+  async function handleUpdateAssignment(form: EditAssignmentForm) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const roleID = form.roleID.trim();
+    if (!roleID) return;
+    setEditAssignmentPending(true);
+    setEditAssignmentError("");
+    const patch: UpdateProjectAssignmentPayload = {
+      role_id: roleID,
+      driver_kind: form.driverKind || "hecate_task",
+      status: form.status || "queued",
+      task_id: form.taskID.trim(),
+      run_id: form.runID.trim(),
+      chat_session_id: form.chatSessionID.trim(),
+      message_id: form.messageID.trim(),
+      context_snapshot_id: form.contextSnapshotID.trim(),
+    };
+    try {
+      const payload = await updateProjectAssignment(
+        selectedProjectID,
+        selectedWorkItemID,
+        form.id,
+        patch,
+      );
+      setAssignments((current) => upsertAssignment(current, payload.data));
+      setEditingAssignment(null);
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setEditAssignmentError(errorMessage(error, "Failed to update assignment."));
+    } finally {
+      setEditAssignmentPending(false);
+    }
+  }
+
+  async function confirmDeleteAssignment() {
+    if (!selectedProjectID || !selectedWorkItemID || !deleteAssignment) return;
+    setDeleteAssignmentPending(true);
+    try {
+      await deleteProjectAssignment(selectedProjectID, selectedWorkItemID, deleteAssignment.id);
+      setDeleteAssignment(null);
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    } finally {
+      setDeleteAssignmentPending(false);
+    }
+  }
+
+  async function refreshSelectedWorkItem() {
+    if (!selectedProjectID) return;
+    await loadWorkForProject(selectedProjectID);
+    if (selectedWorkItemID) {
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    }
+  }
+
+  async function handleStartAssignment(assignment: ProjectAssignmentRecord) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    setStartingAssignmentID(assignment.id);
+    setAssignmentErrors((current) => ({ ...current, [assignment.id]: "" }));
+    try {
+      const res = await startProjectAssignment(
+        selectedProjectID,
+        selectedWorkItemID,
+        assignment.id,
+      );
+      setAssignments((current) => upsertAssignment(current, res.data));
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setAssignmentErrors((current) => ({
+        ...current,
+        [assignment.id]: errorMessage(error, "Failed to start assignment."),
+      }));
+      if (error instanceof ApiError && error.status === 409) {
+        await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+      }
+    } finally {
+      setStartingAssignmentID("");
+    }
+  }
+
+  return (
+    <div style={shellStyle}>
+      <section style={sidePanelStyle} aria-label="Projects">
+        <div style={topbarStyle}>
+          <div>
+            <div style={sectionLabelStyle}>Projects</div>
+            <div style={subtleTextStyle}>{projects.state.projects.length} records</div>
+          </div>
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={() => void projects.actions.createProjectFromFolder()}
+          >
+            <Icon d={Icons.folder} size={13} />
+            Add
+          </button>
+        </div>
+        {projects.state.error && (
+          <div style={{ padding: 10 }}>
+            <InlineError message={projects.state.error} />
+          </div>
+        )}
+        <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+          {projects.state.loading && projects.state.projects.length === 0 && (
+            <EmptyBlock title="Loading projects…" detail="Checking the local project catalog." />
+          )}
+          {!projects.state.loading && projects.state.projects.length === 0 && (
+            <EmptyBlock
+              title="No projects yet"
+              detail="Add a workspace folder to create the first durable project record."
+            />
+          )}
+          {projects.state.projects.map((project) => (
+            <ProjectIndexRow
+              key={project.id}
+              active={project.id === selectedProjectID}
+              project={project}
+              renaming={renamingProjectID === project.id}
+              renameValue={renameValue}
+              onRenameChange={setRenameValue}
+              onRenameCancel={() => setRenamingProjectID("")}
+              onRenameCommit={() => void commitRename(project)}
+              onRenameStart={() => startRename(project)}
+              onDelete={() => setDeleteProjectID(project.id)}
+              onOpen={() => openProject(project.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section style={workListStyle} aria-label="Project work items">
+        <ProjectHeader
+          project={selectedProject}
+          onRefresh={() => void loadWorkForProject(selectedProjectID)}
+          onEditDefaults={() => {
+            setDefaultsError("");
+            setDefaultsModalOpen(true);
+          }}
+          onNewWorkItem={() => {
+            setNewWorkError("");
+            setNewWorkModalOpen(true);
+          }}
+        />
+        {workError && (
+          <div style={{ padding: 10 }}>
+            <InlineError message={workError} />
+          </div>
+        )}
+        <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+          {!selectedProject && (
+            <EmptyBlock
+              title="Select a project"
+              detail="Project work appears after opening a project."
+            />
+          )}
+          {selectedProject && workLoadState === "loading" && workItems.length === 0 && (
+            <EmptyBlock
+              title="Loading work…"
+              detail="Reading roles, work items, and assignments."
+            />
+          )}
+          {selectedProject &&
+            workLoadState !== "loading" &&
+            workItems.length === 0 &&
+            !workError && (
+              <EmptyBlock
+                title="No work items"
+                detail="Project work coordination is empty for this project."
+              />
+            )}
+          {workItems.map((item) => (
+            <WorkItemRow
+              key={item.id}
+              active={item.id === selectedWorkItemID}
+              item={item}
+              summary={workItemSummaries[item.id]}
+              role={item.owner_role_id ? roleByID.get(item.owner_role_id) : undefined}
+              onSelect={() => setSelectedWorkItemID(item.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section style={detailStyle} aria-label="Selected work item">
+        <WorkItemDetail
+          assignments={assignments}
+          artifacts={artifacts}
+          assignmentErrors={assignmentErrors}
+          detailError={detailError}
+          loading={detailLoadState === "loading"}
+          onOpenTask={onOpenTask}
+          onRefresh={refreshSelectedWorkItem}
+          onDeleteWorkItem={(item) => setDeleteWorkItem(item)}
+          onEditAssignment={(assignment) => {
+            setEditAssignmentError("");
+            setEditingAssignment(assignment);
+          }}
+          onEditWorkItem={(item) => {
+            setEditWorkError("");
+            setEditingWorkItem(item);
+          }}
+          onDeleteAssignment={(assignment) => setDeleteAssignment(assignment)}
+          onOpenChat={onOpenChat}
+          onStartAssignment={handleStartAssignment}
+          project={selectedProject}
+          roleByID={roleByID}
+          startingAssignmentID={startingAssignmentID}
+          workItem={selectedWorkItem}
+          onAddAssignment={() => {
+            setNewAssignmentError("");
+            setNewAssignmentModalOpen(true);
+          }}
+        />
+      </section>
+
+      {selectedProject && defaultsModalOpen && (
+        <ProjectDefaultsModal
+          error={defaultsError}
+          models={providersAndModels.state.models}
+          pending={defaultsPending}
+          providerOptions={providerOptions}
+          providerPresets={providerPresets}
+          project={selectedProject}
+          onClose={() => setDefaultsModalOpen(false)}
+          onSave={handleSaveProjectDefaults}
+        />
+      )}
+
+      {selectedProject && newWorkModalOpen && (
+        <NewWorkItemModal
+          error={newWorkError}
+          pending={newWorkPending}
+          roles={roles}
+          onClose={() => setNewWorkModalOpen(false)}
+          onCreate={handleCreateWorkItem}
+        />
+      )}
+
+      {selectedWorkItem && newAssignmentModalOpen && (
+        <NewAssignmentModal
+          error={newAssignmentError}
+          pending={newAssignmentPending}
+          roles={roles}
+          onClose={() => setNewAssignmentModalOpen(false)}
+          onCreate={handleCreateAssignment}
+        />
+      )}
+
+      {editingWorkItem && (
+        <EditWorkItemModal
+          error={editWorkError}
+          item={editingWorkItem}
+          pending={editWorkPending}
+          roles={roles}
+          onClose={() => setEditingWorkItem(null)}
+          onSave={handleUpdateWorkItem}
+        />
+      )}
+
+      {editingAssignment && (
+        <EditAssignmentModal
+          assignment={editingAssignment}
+          error={editAssignmentError}
+          pending={editAssignmentPending}
+          roles={roles}
+          onClose={() => setEditingAssignment(null)}
+          onSave={handleUpdateAssignment}
+        />
+      )}
+
+      {pendingDeleteProject && (
+        <ConfirmModal
+          title="Delete project"
+          danger
+          pending={deletePending}
+          confirmLabel="Delete project record"
+          onClose={() => setDeleteProjectID("")}
+          onConfirm={confirmDeleteProject}
+          message={
+            <>
+              Hecate will delete the project record, project roots, project-scoped chats, and
+              project work coordination state for <strong>{pendingDeleteProject.name}</strong>.
+              Workspace files and the git repository are not deleted.
+            </>
+          }
+        />
+      )}
+
+      {deleteWorkItem && (
+        <ConfirmModal
+          title="Delete work item"
+          danger
+          pending={deleteWorkPending}
+          confirmLabel="Delete work item"
+          onClose={() => setDeleteWorkItem(null)}
+          onConfirm={confirmDeleteWorkItem}
+          message={
+            <>
+              Delete <strong>{deleteWorkItem.title}</strong> and its assignments and collaboration
+              artifacts. Linked tasks, runs, chats, workspace files, and git history are not
+              deleted.
+            </>
+          }
+        />
+      )}
+
+      {deleteAssignment && (
+        <ConfirmModal
+          title="Delete assignment"
+          danger
+          pending={deleteAssignmentPending}
+          confirmLabel="Delete assignment"
+          onClose={() => setDeleteAssignment(null)}
+          onConfirm={confirmDeleteAssignment}
+          message={
+            <>
+              Delete the assignment metadata record for{" "}
+              <strong>
+                {roleByID.get(deleteAssignment.role_id)?.name ?? deleteAssignment.role_id}
+              </strong>
+              . Linked tasks, runs, chats, and external-agent executions are not deleted or
+              cancelled.
+            </>
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+function ProjectIndexRow({
+  active,
+  project,
+  renaming,
+  renameValue,
+  onRenameChange,
+  onRenameCancel,
+  onRenameCommit,
+  onRenameStart,
+  onDelete,
+  onOpen,
+}: {
+  active: boolean;
+  project: ProjectRecord;
+  renaming: boolean;
+  renameValue: string;
+  onRenameChange: (value: string) => void;
+  onRenameCancel: () => void;
+  onRenameCommit: () => void;
+  onRenameStart: () => void;
+  onDelete: () => void;
+  onOpen: () => void;
+}) {
+  const workspace = projectDefaultWorkspace(project) || "No default root";
+  const defaults =
+    project.default_provider || project.default_model
+      ? [project.default_provider, project.default_model].filter(Boolean).join(" / ")
+      : "No default model";
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-current={active ? "true" : undefined}
+      aria-label={`Open project ${project.name}`}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onOpen();
+      }}
+      style={{
+        padding: "10px 12px",
+        borderBottom: "1px solid var(--border)",
+        borderLeft: active ? "2px solid var(--teal)" : "2px solid transparent",
+        background: active ? "var(--bg2)" : "transparent",
+        cursor: "pointer",
+      }}
+    >
+      {renaming ? (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRenameCommit();
+          }}
+          onClick={(event) => event.stopPropagation()}
+          style={{ display: "flex", gap: 6 }}
+        >
+          <input
+            className="input"
+            aria-label={`Rename ${project.name}`}
+            value={renameValue}
+            onChange={(event) => onRenameChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") onRenameCancel();
+            }}
+            autoFocus
+          />
+          <button className="btn btn-primary btn-sm" type="submit">
+            Save
+          </button>
+        </form>
+      ) : (
+        <>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{project.name}</div>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              aria-label={`Rename project ${project.name}`}
+              title="Rename"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRenameStart();
+              }}
+            >
+              <Icon d={Icons.edit} size={12} />
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              aria-label={`Delete project ${project.name}`}
+              title="Delete"
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete();
+              }}
+              style={{ color: "var(--red)" }}
+            >
+              <Icon d={Icons.trash} size={12} />
+            </button>
+          </div>
+          <div style={pathTextStyle} title={workspace}>
+            {workspace}
+          </div>
+          <div style={metaLineStyle}>
+            <span>{defaults}</span>
+            <span>
+              {project.last_opened_at
+                ? `Opened ${formatAbsoluteTime(project.last_opened_at)}`
+                : `Updated ${formatAbsoluteTime(project.updated_at)}`}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ProjectHeader({
+  project,
+  onEditDefaults,
+  onNewWorkItem,
+  onRefresh,
+}: {
+  project: ProjectRecord | null;
+  onEditDefaults: () => void;
+  onNewWorkItem: () => void;
+  onRefresh: () => void;
+}) {
+  const workspace = project ? projectDefaultWorkspace(project) : "";
+  return (
+    <div style={{ ...topbarStyle, minHeight: 68 }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={sectionLabelStyle}>Cockpit</div>
+        <div style={{ ...titleStyle, fontSize: 14 }}>{project?.name ?? "No project selected"}</div>
+        {project && (
+          <div style={pathTextStyle} title={workspace || "No default root"}>
+            {workspace || "No default root"}{" "}
+            {project.default_model ? `· ${project.default_model}` : ""}
+          </div>
+        )}
+      </div>
+      <button
+        className="btn btn-ghost btn-sm"
+        type="button"
+        onClick={onEditDefaults}
+        disabled={!project}
+      >
+        Defaults
+      </button>
+      <button
+        className="btn btn-primary btn-sm"
+        type="button"
+        onClick={onNewWorkItem}
+        disabled={!project}
+      >
+        <Icon d={Icons.plus} size={13} />
+        Work
+      </button>
+      <button
+        className="btn btn-ghost btn-sm"
+        type="button"
+        aria-label="Refresh project work"
+        title="Refresh"
+        onClick={onRefresh}
+        disabled={!project}
+      >
+        <Icon d={Icons.refresh} size={13} />
+      </button>
+    </div>
+  );
+}
+
+function WorkItemRow({
+  active,
+  item,
+  role,
+  summary,
+  onSelect,
+}: {
+  active: boolean;
+  item: ProjectWorkItemRecord;
+  role?: ProjectWorkRoleRecord;
+  summary?: WorkItemSummary;
+  onSelect: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-current={active ? "true" : undefined}
+      aria-label={`Open work item ${item.title}`}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect();
+      }}
+      style={{
+        padding: "11px 12px",
+        borderBottom: "1px solid var(--border)",
+        borderLeft: active ? "2px solid var(--teal)" : "2px solid transparent",
+        background: active ? "var(--bg1)" : "transparent",
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        <Badge status={item.status} label={workStatusLabel(item.status)} />
+        <span className="badge badge-muted">{item.priority}</span>
+        {summary && summary.assignmentCount > 0 && (
+          <span className="badge badge-muted">
+            {summary.assignmentCount} assignment{summary.assignmentCount === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+      <div style={titleStyle}>{item.title}</div>
+      <div style={metaLineStyle}>
+        <span>{role?.name ?? item.owner_role_id ?? "No owner role"}</span>
+        {summary && summary.activeCount > 0 && <span>{summary.activeCount} active</span>}
+        {summary && summary.failedCount > 0 && <span>{summary.failedCount} failed</span>}
+        {summary && summary.completedCount > 0 && <span>{summary.completedCount} done</span>}
+      </div>
+    </div>
+  );
+}
+
+function WorkItemDetail({
+  assignments,
+  artifacts,
+  assignmentErrors,
+  detailError,
+  loading,
+  onAddAssignment,
+  onDeleteAssignment,
+  onDeleteWorkItem,
+  onEditAssignment,
+  onEditWorkItem,
+  onOpenChat,
+  onOpenTask,
+  onRefresh,
+  onStartAssignment,
+  project,
+  roleByID,
+  startingAssignmentID,
+  workItem,
+}: {
+  assignments: ProjectAssignmentRecord[];
+  artifacts: ProjectCollaborationArtifactRecord[];
+  assignmentErrors: Record<string, string>;
+  detailError: string;
+  loading: boolean;
+  onAddAssignment: () => void;
+  onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onDeleteWorkItem: (item: ProjectWorkItemRecord) => void;
+  onEditAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onEditWorkItem: (item: ProjectWorkItemRecord) => void;
+  onOpenChat?: (request: { projectID: string; provider?: string; model?: string }) => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onRefresh: () => void;
+  onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
+  project: ProjectRecord | null;
+  roleByID: Map<string, ProjectWorkRoleRecord>;
+  startingAssignmentID: string;
+  workItem: ProjectWorkItemRecord | null;
+}) {
+  if (!workItem) {
+    return (
+      <EmptyBlock
+        title={loading ? "Loading detail…" : "Select a work item"}
+        detail="Assignments and collaboration artifacts appear here."
+      />
+    );
+  }
+  return (
+    <div style={{ padding: 16, display: "grid", gap: 16 }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={sectionLabelStyle}>Work item</div>
+          <h2 style={{ margin: "4px 0 8px", fontSize: 18, color: "var(--t0)" }}>
+            {workItem.title}
+          </h2>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            <Badge status={workItem.status} label={workStatusLabel(workItem.status)} />
+            <span className="badge badge-muted">{workItem.priority}</span>
+            <span className="badge badge-muted">
+              Updated {formatAbsoluteTime(workItem.updated_at)}
+            </span>
+          </div>
+        </div>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={() => onEditWorkItem(workItem)}
+        >
+          <Icon d={Icons.edit} size={13} />
+          Edit
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={() => onDeleteWorkItem(workItem)}
+          style={{ color: "var(--red)" }}
+        >
+          <Icon d={Icons.trash} size={13} />
+          Delete
+        </button>
+        <button className="btn btn-ghost btn-sm" type="button" onClick={onRefresh}>
+          <Icon d={Icons.refresh} size={13} />
+          Refresh
+        </button>
+      </div>
+      {detailError && <InlineError message={detailError} />}
+      <div style={panelStyle}>
+        <div style={sectionLabelStyle}>Brief</div>
+        <p style={{ margin: "8px 0 0", fontSize: 13, color: "var(--t1)", lineHeight: 1.55 }}>
+          {workItem.brief || "No brief recorded."}
+        </p>
+        <div style={{ ...metaLineStyle, marginTop: 10 }}>
+          <span>Created {formatAbsoluteTime(workItem.created_at)}</span>
+          {workItem.owner_role_id && (
+            <span>
+              Owner {roleByID.get(workItem.owner_role_id)?.name ?? workItem.owner_role_id}
+            </span>
+          )}
+          {workItem.reviewer_role_ids && workItem.reviewer_role_ids.length > 0 && (
+            <span>
+              {workItem.reviewer_role_ids.length} reviewer role
+              {workItem.reviewer_role_ids.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+      </div>
+      <div style={panelStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+          <div style={sectionLabelStyle}>Assignments</div>
+          <span className="badge badge-muted">{assignments.length}</span>
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={onAddAssignment}
+            style={{ marginLeft: "auto" }}
+          >
+            <Icon d={Icons.plus} size={12} />
+            Assignment
+          </button>
+        </div>
+        {assignments.length === 0 ? (
+          <div style={subtleTextStyle}>No assignments recorded for this work item.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {assignments.map((assignment) => (
+              <AssignmentRow
+                key={assignment.id}
+                assignment={assignment}
+                chatModel={assignment.execution?.model || project?.default_model || ""}
+                error={assignmentErrors[assignment.id] ?? ""}
+                onDelete={() => onDeleteAssignment(assignment)}
+                onEdit={() => onEditAssignment(assignment)}
+                onOpenChat={
+                  project
+                    ? () =>
+                        onOpenChat?.({
+                          projectID: project.id,
+                          provider:
+                            assignment.execution?.provider || project.default_provider || "",
+                          model: assignment.execution?.model || project.default_model || "",
+                        })
+                    : undefined
+                }
+                onOpenTask={onOpenTask}
+                onStart={() => onStartAssignment(assignment)}
+                role={roleByID.get(assignment.role_id)}
+                starting={startingAssignmentID === assignment.id}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <div style={panelStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+          <div style={sectionLabelStyle}>Collaboration Artifacts</div>
+          <span className="badge badge-muted">{artifacts.length}</span>
+        </div>
+        {artifacts.length === 0 ? (
+          <div style={subtleTextStyle}>No collaboration artifacts recorded yet.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            {artifacts.map((artifact) => (
+              <div key={artifact.id} style={artifactStyle}>
+                <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                  <span className="badge badge-muted">{artifact.kind}</span>
+                  <span style={titleStyle}>{artifact.title || artifact.id}</span>
+                </div>
+                <div style={{ marginTop: 6, fontSize: 12, color: "var(--t2)", lineHeight: 1.45 }}>
+                  {artifact.body}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectDefaultsModal({
+  error,
+  models,
+  pending,
+  providerOptions,
+  providerPresets,
+  project,
+  onClose,
+  onSave,
+}: {
+  error: string;
+  models: ModelRecord[];
+  pending: boolean;
+  providerOptions: ProviderOption[];
+  providerPresets: ProviderPresetRecord[];
+  project: ProjectRecord;
+  onClose: () => void;
+  onSave: (form: ProjectDefaultsForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<ProjectDefaultsForm>({
+    provider: project.default_provider ?? "",
+    model: project.default_model ?? "",
+    workspaceMode: project.default_workspace_mode ?? "in_place",
+  });
+  const scopedModels = useMemo(() => {
+    if (!form.provider) return models;
+    return models.filter((model) => model.metadata?.provider === form.provider);
+  }, [form.provider, models]);
+  const selectedModel = useMemo(() => {
+    if (form.model) return form.model;
+    return defaultModelID(scopedModels);
+  }, [form.model, scopedModels]);
+
+  function handleProviderChange(provider: string) {
+    setForm((current) => {
+      const nextModels = provider
+        ? models.filter((model) => model.metadata?.provider === provider)
+        : models;
+      const modelStillValid =
+        current.model &&
+        nextModels.some(
+          (model) =>
+            model.id === current.model && (!provider || model.metadata?.provider === provider),
+        );
+      return {
+        ...current,
+        provider,
+        model: modelStillValid ? current.model : defaultModelID(nextModels),
+      };
+    });
+  }
+  const submitForm = () => onSave({ ...form, model: selectedModel });
+
+  return (
+    <Modal
+      title="Project defaults"
+      onClose={onClose}
+      width={520}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending}
+          onClick={() => void submitForm()}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save defaults"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submitForm();
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <div style={fieldStyle}>
+          <span style={fieldLabelStyle}>Provider and model</span>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <ProviderPicker
+              value={form.provider}
+              onChange={handleProviderChange}
+              options={providerOptions}
+              emptyLabel="select provider"
+            />
+            <ModelPicker
+              value={selectedModel}
+              onChange={(model) => setForm((current) => ({ ...current, model }))}
+              models={scopedModels}
+              presets={providerPresets}
+              showProvider={!form.provider}
+            />
+          </div>
+        </div>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Workspace mode</span>
+          <select
+            className="input"
+            value={form.workspaceMode}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, workspaceMode: event.target.value }))
+            }
+          >
+            <option value="in_place">in_place</option>
+            <option value="persistent">persistent</option>
+            <option value="ephemeral">ephemeral</option>
+          </select>
+        </label>
+        <div style={subtleTextStyle}>
+          Native Hecate assignments copy these defaults when creating the backing task.
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function NewWorkItemModal({
+  error,
+  pending,
+  roles,
+  onClose,
+  onCreate,
+}: {
+  error: string;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onCreate: (form: NewWorkItemForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<NewWorkItemForm>({
+    title: "",
+    brief: "",
+    priority: "normal",
+    ownerRoleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
+  });
+  const valid = form.title.trim().length > 0;
+  return (
+    <Modal
+      title="New work item"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Creating…" : "Create work item"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+            placeholder="Implement project cockpit"
+          />
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Brief</span>
+          <textarea
+            className="input"
+            value={form.brief}
+            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
+            rows={5}
+            placeholder="Describe the outcome, constraints, and handoff expectations."
+            style={{ resize: "vertical", minHeight: 110 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Priority</span>
+            <select
+              className="input"
+              value={form.priority}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, priority: event.target.value }))
+              }
+            >
+              <option value="low">low</option>
+              <option value="normal">normal</option>
+              <option value="high">high</option>
+              <option value="urgent">urgent</option>
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Owner role</span>
+            <select
+              className="input"
+              value={form.ownerRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
+              }
+            >
+              <option value="">No owner</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function EditWorkItemModal({
+  error,
+  item,
+  pending,
+  roles,
+  onClose,
+  onSave,
+}: {
+  error: string;
+  item: ProjectWorkItemRecord;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: EditWorkItemForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<EditWorkItemForm>({
+    id: item.id,
+    title: item.title,
+    brief: item.brief ?? "",
+    status: item.status,
+    priority: item.priority || "normal",
+    ownerRoleID: item.owner_role_id ?? "",
+    reviewerRoleIDs: (item.reviewer_role_ids ?? []).join(", "),
+  });
+  const valid = form.title.trim().length > 0;
+  return (
+    <Modal
+      title="Edit work item"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save work item"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+          />
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Brief</span>
+          <textarea
+            className="input"
+            value={form.brief}
+            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
+            rows={5}
+            style={{ resize: "vertical", minHeight: 110 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {WORK_ITEM_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Priority</span>
+            <select
+              className="input"
+              value={form.priority}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, priority: event.target.value }))
+              }
+            >
+              {WORK_ITEM_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Owner role</span>
+            <select
+              className="input"
+              value={form.ownerRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
+              }
+            >
+              <option value="">No owner</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Reviewer roles</span>
+            <input
+              className="input"
+              value={form.reviewerRoleIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, reviewerRoleIDs: event.target.value }))
+              }
+              placeholder="reviewer_qa, architect"
+            />
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function NewAssignmentModal({
+  error,
+  pending,
+  roles,
+  onClose,
+  onCreate,
+}: {
+  error: string;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onCreate: (form: NewAssignmentForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<NewAssignmentForm>({
+    roleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
+    driverKind: "hecate_task",
+  });
+  const valid = form.roleID.trim().length > 0;
+  return (
+    <Modal
+      title="Add assignment"
+      onClose={onClose}
+      width={520}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Adding…" : "Add assignment"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Role</span>
+          <select
+            className="input"
+            autoFocus
+            value={form.roleID}
+            onChange={(event) => setForm((current) => ({ ...current, roleID: event.target.value }))}
+          >
+            {roles.map((role) => (
+              <option key={role.id} value={role.id}>
+                {role.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Driver</span>
+          <select
+            className="input"
+            value={form.driverKind}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, driverKind: event.target.value }))
+            }
+          >
+            <option value="hecate_task">hecate_task</option>
+            <option value="external_agent">external_agent</option>
+          </select>
+        </label>
+        {form.driverKind === "external_agent" && (
+          <div style={subtleTextStyle}>
+            External assignment execution is recorded here but still starts from Chats.
+          </div>
+        )}
+      </form>
+    </Modal>
+  );
+}
+
+function EditAssignmentModal({
+  assignment,
+  error,
+  pending,
+  roles,
+  onClose,
+  onSave,
+}: {
+  assignment: ProjectAssignmentRecord;
+  error: string;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: EditAssignmentForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<EditAssignmentForm>({
+    id: assignment.id,
+    roleID: assignment.role_id,
+    driverKind: assignment.driver_kind || "hecate_task",
+    status: assignment.status || "queued",
+    taskID: assignment.task_id ?? "",
+    runID: assignment.run_id ?? "",
+    chatSessionID: assignment.chat_session_id ?? "",
+    messageID: assignment.message_id ?? "",
+    contextSnapshotID: assignment.context_snapshot_id ?? "",
+  });
+  const valid = form.roleID.trim().length > 0;
+  return (
+    <Modal
+      title="Edit assignment"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save assignment"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Role</span>
+            <select
+              className="input"
+              autoFocus
+              value={form.roleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, roleID: event.target.value }))
+              }
+            >
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {ASSIGNMENT_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Driver</span>
+          <select
+            className="input"
+            value={form.driverKind}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, driverKind: event.target.value }))
+            }
+          >
+            <option value="hecate_task">hecate_task</option>
+            <option value="external_agent">external_agent</option>
+          </select>
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Task ID</span>
+            <input
+              className="input"
+              value={form.taskID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, taskID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Run ID</span>
+            <input
+              className="input"
+              value={form.runID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, runID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Chat session ID</span>
+            <input
+              className="input"
+              value={form.chatSessionID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, chatSessionID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Message ID</span>
+            <input
+              className="input"
+              value={form.messageID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, messageID: event.target.value }))
+              }
+            />
+          </label>
+        </div>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Context snapshot ID</span>
+          <input
+            className="input"
+            value={form.contextSnapshotID}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, contextSnapshotID: event.target.value }))
+            }
+          />
+        </label>
+        <div style={subtleTextStyle}>
+          Editing assignment metadata does not mutate or cancel linked task, run, or chat execution.
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function AssignmentRow({
+  assignment,
+  chatModel,
+  error,
+  onDelete,
+  onEdit,
+  onOpenChat,
+  onOpenTask,
+  onStart,
+  role,
+  starting,
+}: {
+  assignment: ProjectAssignmentRecord;
+  chatModel: string;
+  error: string;
+  onDelete: () => void;
+  onEdit: () => void;
+  onOpenChat?: () => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onStart: () => void;
+  role?: ProjectWorkRoleRecord;
+  starting: boolean;
+}) {
+  const execution = assignment.execution;
+  const taskID = execution?.task_id || assignment.task_id || "";
+  const runID = execution?.run_id || assignment.run_id || "";
+  const startable = assignment.driver_kind === "hecate_task" && assignment.status === "queued";
+  const external = assignment.driver_kind === "external_agent";
+  return (
+    <div style={assignmentStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Badge
+          status={execution?.status || assignment.status}
+          label={assignmentStatusLabel(execution?.status || assignment.status)}
+        />
+        <span className="badge badge-muted">{assignment.driver_kind}</span>
+        <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
+          {role?.name ?? assignment.role_id}
+        </div>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          aria-label={`Edit assignment ${assignment.id}`}
+          onClick={onEdit}
+          title="Edit"
+        >
+          <Icon d={Icons.edit} size={12} />
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          aria-label={`Delete assignment ${assignment.id}`}
+          onClick={onDelete}
+          title="Delete"
+          style={{ color: "var(--red)" }}
+        >
+          <Icon d={Icons.trash} size={12} />
+        </button>
+        {startable && (
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={onStart}
+            disabled={starting}
+          >
+            <Icon d={Icons.send} size={12} />
+            {starting ? "Starting…" : "Start"}
+          </button>
+        )}
+        {external && (
+          <span
+            style={subtleTextStyle}
+            title="External assignment execution is not implemented yet."
+          >
+            Start in Chats
+          </span>
+        )}
+      </div>
+      <div
+        style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 8, alignItems: "center" }}
+      >
+        {taskID && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={() => onOpenTask?.(taskID, runID)}
+            disabled={!onOpenTask}
+          >
+            <Icon d={Icons.tasks} size={12} />
+            Open task
+          </button>
+        )}
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onOpenChat}
+          disabled={!onOpenChat || !chatModel}
+          title={
+            chatModel ? `Open chat with ${chatModel}` : "Set project defaults before opening chat."
+          }
+        >
+          <Icon d={Icons.chat} size={12} />
+          Open chat
+        </button>
+        {taskID && <CopyableID text={taskID} compact />}
+        {runID && <CopyableID text={runID} compact />}
+        {execution?.pending_approval_count ? (
+          <span className="badge badge-amber">
+            {execution.pending_approval_count} approval pending
+          </span>
+        ) : null}
+        {typeof execution?.step_count === "number" && (
+          <span className="badge badge-muted">{execution.step_count} steps</span>
+        )}
+        {typeof execution?.artifact_count === "number" && (
+          <span className="badge badge-muted">{execution.artifact_count} artifacts</span>
+        )}
+        {execution?.provider || execution?.model ? (
+          <span className="badge badge-muted">
+            {[execution.provider, execution.model].filter(Boolean).join(" / ")}
+          </span>
+        ) : null}
+        {execution?.missing && <span className="badge badge-amber">linked run missing</span>}
+      </div>
+      {(assignment.started_at ||
+        execution?.started_at ||
+        assignment.completed_at ||
+        execution?.finished_at) && (
+        <div style={{ ...metaLineStyle, marginTop: 8 }}>
+          <span>Started {formatAbsoluteTime(execution?.started_at || assignment.started_at)}</span>
+          {(execution?.finished_at || assignment.completed_at) && (
+            <span>
+              Finished {formatAbsoluteTime(execution?.finished_at || assignment.completed_at)}
+            </span>
+          )}
+        </div>
+      )}
+      {execution?.last_error && (
+        <div style={{ marginTop: 8 }}>
+          <InlineError message={execution.last_error} />
+        </div>
+      )}
+      {error && (
+        <div style={{ marginTop: 8 }}>
+          <InlineError message={error} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyBlock({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div
+      style={{ padding: 24, textAlign: "center", display: "grid", gap: 8, placeItems: "center" }}
+    >
+      <div style={{ color: "var(--t0)", fontSize: 14, fontWeight: 600 }}>{title}</div>
+      <div style={{ color: "var(--t3)", fontSize: 12, lineHeight: 1.5, maxWidth: 320 }}>
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemSummary {
+  return assignments.reduce<WorkItemSummary>(
+    (summary, assignment) => {
+      const status = assignment.execution?.status || assignment.status;
+      summary.assignmentCount += 1;
+      if (status === "running" || status === "queued" || status === "awaiting_approval") {
+        summary.activeCount += 1;
+      }
+      if (status === "failed") summary.failedCount += 1;
+      if (status === "completed") summary.completedCount += 1;
+      return summary;
+    },
+    { assignmentCount: 0, activeCount: 0, failedCount: 0, completedCount: 0 },
+  );
+}
+
+function defaultModelID(models: ModelRecord[]): string {
+  return models.find((model) => model.metadata?.default)?.id || models[0]?.id || "";
+}
+
+function upsertWorkItem(items: ProjectWorkItemRecord[], item: ProjectWorkItemRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  if (index === -1) return [item, ...items];
+  const next = items.slice();
+  next[index] = item;
+  return next;
+}
+
+function upsertProject(items: ProjectRecord[], item: ProjectRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  if (index === -1) return [item, ...items];
+  const next = items.slice();
+  next[index] = item;
+  return next;
+}
+
+function upsertAssignment(items: ProjectAssignmentRecord[], item: ProjectAssignmentRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  if (index === -1) return [item, ...items];
+  const next = items.slice();
+  next[index] = item;
+  return next;
+}
+
+function splitRoleIDs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    return error.operatorAction
+      ? `${error.message} ${error.operatorAction}`
+      : error.message || fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+function workStatusLabel(status: string): string {
+  if (status === "done") return "done";
+  return status.replaceAll("_", " ");
+}
+
+function assignmentStatusLabel(status: string | undefined): string {
+  if (!status) return "unknown";
+  if (status === "awaiting_approval") return "approval";
+  if (status === "completed") return "done";
+  return status.replaceAll("_", " ");
+}
+
+const topbarStyle: CSSProperties = {
+  minHeight: "var(--topbar-h)",
+  padding: "8px 10px",
+  borderBottom: "1px solid var(--border)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 8,
+  flexShrink: 0,
+};
+
+const sectionLabelStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  color: "var(--teal)",
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+};
+
+const titleStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: 13,
+  fontWeight: 600,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const subtleTextStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.4,
+};
+
+const pathTextStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 11,
+  fontFamily: "var(--font-mono)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  marginTop: 5,
+};
+
+const metaLineStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  color: "var(--t3)",
+  fontSize: 11,
+  marginTop: 6,
+};
+
+const fieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  background: "var(--bg1)",
+  borderRadius: "var(--radius-sm)",
+  padding: 12,
+};
+
+const assignmentStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  background: "var(--bg2)",
+  borderRadius: "var(--radius-sm)",
+  padding: 10,
+};
+
+const artifactStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  paddingTop: 8,
+};

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -254,24 +254,13 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
-      const assignmentResults = await Promise.allSettled(
-        nextItems.map(async (item) => {
-          const res = await getProjectAssignments(projectID, item.id);
-          return [item.id, res.data ?? []] as const;
-        }),
-      );
       setWorkItemSummaries(
         Object.fromEntries(
-          assignmentResults.flatMap((result) =>
-            result.status === "fulfilled"
-              ? [[result.value[0], summarizeAssignments(result.value[1])] as const]
-              : [],
+          nextItems.flatMap((item) =>
+            item.assignments ? [[item.id, summarizeAssignments(item.assignments)] as const] : [],
           ),
         ),
       );
-      if (assignmentResults.some((result) => result.status === "rejected")) {
-        setWorkError("Some assignment summaries failed to load. Refresh project work to retry.");
-      }
       const nextSelectedID = nextItems[0]?.id || "";
       setSelectedWorkItemID(nextSelectedID);
       setWorkLoadState("loaded");
@@ -1832,15 +1821,15 @@ function AssignmentRow({
   const execution = assignment.execution;
   const taskID = execution?.task_id || assignment.task_id || "";
   const runID = execution?.run_id || assignment.run_id || "";
-  const startable = assignment.driver_kind === "hecate_task" && assignment.status === "queued";
+  const projectedStatus = execution?.status || assignment.status;
+  const startable = assignment.driver_kind === "hecate_task" && projectedStatus === "queued";
   const external = assignment.driver_kind === "external_agent";
+  const startedAt = execution?.started_at || assignment.started_at;
+  const finishedAt = execution?.finished_at || assignment.completed_at;
   return (
     <div style={assignmentStyle}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <Badge
-          status={execution?.status || assignment.status}
-          label={assignmentStatusLabel(execution?.status || assignment.status)}
-        />
+        <Badge status={projectedStatus} label={assignmentStatusLabel(projectedStatus)} />
         <span className="badge badge-muted">{assignment.driver_kind}</span>
         <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
           {role?.name ?? assignment.role_id}
@@ -1930,17 +1919,10 @@ function AssignmentRow({
         ) : null}
         {execution?.missing && <span className="badge badge-amber">linked run missing</span>}
       </div>
-      {(assignment.started_at ||
-        execution?.started_at ||
-        assignment.completed_at ||
-        execution?.finished_at) && (
+      {(startedAt || finishedAt) && (
         <div style={{ ...metaLineStyle, marginTop: 8 }}>
-          <span>Started {formatAbsoluteTime(execution?.started_at || assignment.started_at)}</span>
-          {(execution?.finished_at || assignment.completed_at) && (
-            <span>
-              Finished {formatAbsoluteTime(execution?.finished_at || assignment.completed_at)}
-            </span>
-          )}
+          {startedAt && <span>Started {formatAbsoluteTime(startedAt)}</span>}
+          {finishedAt && <span>Finished {formatAbsoluteTime(finishedAt)}</span>}
         </div>
       )}
       {execution?.last_error && (

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -206,6 +206,7 @@ export function ModelPicker({
     <div className="dropdown-wrap" ref={ref}>
       <button
         ref={triggerRef}
+        type="button"
         aria-label={`Model picker: ${label}`}
         aria-expanded={open}
         aria-haspopup="listbox"

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -4,8 +4,12 @@ import {
   buildRequestOptions,
   cancelChatApproval,
   chatCompletions,
+  createProjectAssignment,
+  createProjectWorkItem,
   deleteChatGrant,
   deletePolicyRule,
+  deleteProjectAssignment,
+  deleteProjectWorkItem,
   discoverLocalProviders,
   dispatchChatStreamEvent,
   getChatMessageFileDiff,
@@ -13,6 +17,11 @@ import {
   getChatWorkspaceFileDiff,
   getChatWorkspaceFiles,
   getChatApproval,
+  getProjectAssignments,
+  getProjectCollaborationArtifacts,
+  getProjectWorkItem,
+  getProjectWorkItems,
+  getProjectWorkRoles,
   getUsageEvents,
   getUsageSummary,
   getSession,
@@ -29,9 +38,13 @@ import {
   setChatSettings,
   setProviderAPIKey,
   setProviderBaseURL,
+  startProjectAssignment,
   streamChatSession,
   upsertPolicyRule,
   updateChatSession,
+  updateProject,
+  updateProjectAssignment,
+  updateProjectWorkItem,
   type ApiError,
 } from "./api";
 
@@ -238,6 +251,189 @@ describe("api client", () => {
     expect(result.data.request_id).toBe("req-123");
     expect(result.data.spans).toHaveLength(1);
     expect(result.data.spans?.[0]?.events).toHaveLength(2);
+  });
+
+  it("builds project work coordination requests", async () => {
+    fetchMock.mockClear();
+    for (let i = 0; i < 5; i += 1) {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
+    }
+
+    await getProjectWorkRoles("proj/1");
+    await getProjectWorkItems("proj/1");
+    await getProjectWorkItem("proj/1", "work/1");
+    await getProjectAssignments("proj/1", "work/1");
+    await getProjectCollaborationArtifacts("proj/1", "work/1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/hecate/v1/projects/proj%2F1/roles",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/hecate/v1/projects/proj%2F1/work-items",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("starts native project assignments with the hecate driver kind", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ object: "project_assignment", data: { id: "asgn_1" } }),
+    );
+
+    await startProjectAssignment("proj_1", "work_1", "asgn_1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj_1/work-items/work_1/assignments/asgn_1/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ driver_kind: "hecate_task" }),
+      }),
+    );
+  });
+
+  it("creates project work items and assignments", async () => {
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ object: "project_work_item", data: { id: "work_1" } }))
+      .mockResolvedValueOnce(
+        jsonResponse({ object: "project_assignment", data: { id: "asgn_1" } }),
+      );
+
+    await createProjectWorkItem("proj_1", {
+      title: "Project cockpit",
+      brief: "Create records from the UI.",
+      status: "ready",
+      priority: "high",
+      owner_role_id: "software_developer",
+    });
+    await createProjectAssignment("proj_1", "work_1", {
+      role_id: "software_developer",
+      driver_kind: "hecate_task",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/hecate/v1/projects/proj_1/work-items",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Project cockpit",
+          brief: "Create records from the UI.",
+          status: "ready",
+          priority: "high",
+          owner_role_id: "software_developer",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/hecate/v1/projects/proj_1/work-items/work_1/assignments",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          role_id: "software_developer",
+          driver_kind: "hecate_task",
+        }),
+      }),
+    );
+  });
+
+  it("updates and deletes project work items and assignments", async () => {
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ object: "project_work_item", data: { id: "work/1" } }))
+      .mockResolvedValueOnce(jsonResponse(null))
+      .mockResolvedValueOnce(jsonResponse({ object: "project_assignment", data: { id: "asgn/1" } }))
+      .mockResolvedValueOnce(jsonResponse(null));
+
+    await updateProjectWorkItem("proj/1", "work/1", {
+      title: "Edited work",
+      status: "ready",
+      priority: "urgent",
+      owner_role_id: "frontend_engineer",
+    });
+    await deleteProjectWorkItem("proj/1", "work/1");
+    await updateProjectAssignment("proj/1", "work/1", "asgn/1", {
+      role_id: "frontend_engineer",
+      driver_kind: "external_agent",
+      status: "running",
+    });
+    await deleteProjectAssignment("proj/1", "work/1", "asgn/1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          title: "Edited work",
+          status: "ready",
+          priority: "urgent",
+          owner_role_id: "frontend_engineer",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments/asgn%2F1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          role_id: "frontend_engineer",
+          driver_kind: "external_agent",
+          status: "running",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments/asgn%2F1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("updates project execution defaults", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ object: "project", data: { id: "proj_1" } }));
+
+    await updateProject("proj_1", {
+      default_provider: "ollama",
+      default_model: "ministral-3:latest",
+      default_workspace_mode: "in_place",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj_1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          default_provider: "ollama",
+          default_model: "ministral-3:latest",
+          default_workspace_mode: "in_place",
+        }),
+      }),
+    );
   });
 
   describe("provider REST API", () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -49,9 +49,19 @@ import type { UsageEventsResponse, UsageSummaryResponse } from "../types/usage";
 import type { RetentionRunResponse, RetentionRunsResponse } from "../types/retention";
 import type {
   CreateProjectPayload,
+  CreateProjectAssignmentPayload,
+  CreateProjectWorkItemPayload,
+  ProjectAssignmentResponse,
+  ProjectAssignmentsResponse,
+  ProjectCollaborationArtifactsResponse,
   ProjectResponse,
+  ProjectWorkItemsResponse,
+  ProjectWorkItemResponse,
+  ProjectWorkRolesResponse,
   ProjectsResponse,
+  UpdateProjectAssignmentPayload,
   UpdateProjectPayload,
+  UpdateProjectWorkItemPayload,
 } from "../types/project";
 
 type RequestOptions = {
@@ -315,6 +325,118 @@ export async function deleteProject(id: string): Promise<void> {
   return fetchJSON<void>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+}
+
+export async function getProjectWorkRoles(projectID: string): Promise<ProjectWorkRolesResponse> {
+  return fetchJSON<ProjectWorkRolesResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/roles`,
+  );
+}
+
+export async function getProjectWorkItems(projectID: string): Promise<ProjectWorkItemsResponse> {
+  return fetchJSON<ProjectWorkItemsResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items`,
+  );
+}
+
+export async function createProjectWorkItem(
+  projectID: string,
+  payload: CreateProjectWorkItemPayload,
+): Promise<ProjectWorkItemResponse> {
+  return fetchJSON<ProjectWorkItemResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items`,
+    { method: "POST", body: payload },
+  );
+}
+
+export async function getProjectWorkItem(
+  projectID: string,
+  workItemID: string,
+): Promise<ProjectWorkItemResponse> {
+  return fetchJSON<ProjectWorkItemResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}`,
+  );
+}
+
+export async function updateProjectWorkItem(
+  projectID: string,
+  workItemID: string,
+  payload: UpdateProjectWorkItemPayload,
+): Promise<ProjectWorkItemResponse> {
+  return fetchJSON<ProjectWorkItemResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}`,
+    { method: "PATCH", body: payload },
+  );
+}
+
+export async function deleteProjectWorkItem(projectID: string, workItemID: string): Promise<void> {
+  return fetchJSON<void>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function getProjectAssignments(
+  projectID: string,
+  workItemID: string,
+): Promise<ProjectAssignmentsResponse> {
+  return fetchJSON<ProjectAssignmentsResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments`,
+  );
+}
+
+export async function createProjectAssignment(
+  projectID: string,
+  workItemID: string,
+  payload: CreateProjectAssignmentPayload,
+): Promise<ProjectAssignmentResponse> {
+  return fetchJSON<ProjectAssignmentResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments`,
+    { method: "POST", body: payload },
+  );
+}
+
+export async function updateProjectAssignment(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+  payload: UpdateProjectAssignmentPayload,
+): Promise<ProjectAssignmentResponse> {
+  return fetchJSON<ProjectAssignmentResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}`,
+    { method: "PATCH", body: payload },
+  );
+}
+
+export async function deleteProjectAssignment(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+): Promise<void> {
+  return fetchJSON<void>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function startProjectAssignment(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+): Promise<ProjectAssignmentResponse> {
+  return fetchJSON<ProjectAssignmentResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/start`,
+    { method: "POST", body: { driver_kind: "hecate_task" } },
+  );
+}
+
+export async function getProjectCollaborationArtifacts(
+  projectID: string,
+  workItemID: string,
+): Promise<ProjectCollaborationArtifactsResponse> {
+  return fetchJSON<ProjectCollaborationArtifactsResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/artifacts`,
+  );
 }
 
 export async function getChatSessions(): Promise<ChatSessionsResponse> {

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -761,6 +761,163 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.activeChatSession?.project_id).toBe("proj_1");
   });
 
+  it("launches a scoped Hecate chat with requested provider and model via the created session", async () => {
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
+    window.localStorage.setItem("hecate.providerFilter", "openai");
+    window.localStorage.setItem("hecate.model", "gpt-4o-mini");
+    let createBody: any = null;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/v1/models": () =>
+          jsonResponse({
+            object: "list",
+            data: [
+              {
+                id: "gpt-4o-mini",
+                owned_by: "openai",
+                metadata: { provider: "openai", provider_kind: "cloud" },
+              },
+              {
+                id: "llama3.1:8b",
+                owned_by: "ollama",
+                metadata: { provider: "ollama", provider_kind: "local" },
+              },
+            ],
+          }),
+        "/hecate/v1/providers/status": () =>
+          jsonResponse({
+            object: "provider_status",
+            data: [
+              {
+                name: "openai",
+                kind: "cloud",
+                default_model: "gpt-4o-mini",
+                models: ["gpt-4o-mini"],
+                healthy: true,
+                status: "healthy",
+              },
+              {
+                name: "ollama",
+                kind: "local",
+                default_model: "llama3.1:8b",
+                models: ["llama3.1:8b"],
+                healthy: true,
+                status: "healthy",
+              },
+            ],
+          }),
+        "/hecate/v1/settings": () =>
+          jsonResponse({
+            object: "settings",
+            data: {
+              backend: "memory",
+              providers: [
+                {
+                  id: "openai",
+                  name: "OpenAI",
+                  kind: "cloud",
+                  credential_configured: true,
+                },
+                {
+                  id: "ollama",
+                  name: "Ollama",
+                  kind: "local",
+                  credential_configured: true,
+                },
+              ],
+              policy_rules: [],
+              events: [],
+            },
+          }),
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_scoped_ollama",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: createBody.provider,
+                model: createBody.model,
+                status: "idle",
+                messages: [],
+              },
+            });
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession({
+        agentID: "hecate",
+        provider: "ollama",
+        model: "llama3.1:8b",
+      });
+    });
+
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      provider: "ollama",
+      model: "llama3.1:8b",
+    });
+    expect(result.current.state.activeChatSessionID).toBe("chat_scoped_ollama");
+    expect(result.current.state.providerFilter).toBe("ollama");
+    expect(result.current.state.model).toBe("llama3.1:8b");
+  });
+
+  it("does not fall back to ambient provider or model when scoped launch passes explicit empty values", async () => {
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
+    window.localStorage.setItem("hecate.providerFilter", "openai");
+    window.localStorage.setItem("hecate.model", "gpt-4o-mini");
+    let createBody: any = null;
+    fetchMock.mockImplementation(
+      defaultBackendMock({
+        "/hecate/v1/chat/sessions": (init) => {
+          if (init?.method === "POST") {
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_auto_empty",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: "",
+                model: "",
+                status: "idle",
+                messages: [],
+              },
+            });
+          }
+          return jsonResponse({ object: "chat_sessions", data: [] });
+        },
+      }),
+    );
+
+    const { result } = renderRuntimeConsoleHook();
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.actions.createChatSession({
+        agentID: "hecate",
+        provider: "",
+        model: "",
+      });
+    });
+
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      provider: "",
+      model: "",
+    });
+    expect(result.current.state.activeChatSessionID).toBe("chat_auto_empty");
+  });
+
   it("honors an explicit project scope when creating an external-agent chat", async () => {
     window.localStorage.setItem("hecate.chatTarget", "external_agent");
     window.localStorage.setItem("hecate.agentAdapterID", "claude_code");

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -200,7 +200,12 @@ export type RuntimeConsoleFixtureActions = {
   copyCommand: (command: string) => Promise<void>;
   cancelAgentChat: () => Promise<void>;
   chooseAgentWorkspace: () => Promise<boolean>;
-  createChatSession: (options?: { agentID?: string; projectID?: string }) => Promise<void>;
+  createChatSession: (options?: {
+    agentID?: string;
+    projectID?: string;
+    provider?: string;
+    model?: string;
+  }) => Promise<void>;
   deleteChatSession: (id: string) => Promise<void>;
   deletePolicyRule: (id: string) => Promise<void>;
   loadDashboard: () => Promise<void>;

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -115,6 +115,7 @@ export type ProjectWorkItemRecord = {
   priority: ProjectWorkItemPriority | string;
   owner_role_id?: string;
   reviewer_role_ids?: string[];
+  assignments?: ProjectAssignmentRecord[];
   created_at: string;
   updated_at: string;
 };

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -9,11 +9,22 @@ export type ProjectRootRecord = {
   updated_at: string;
 };
 
+export type ProjectContextSourceRecord = {
+  id: string;
+  kind: string;
+  title?: string;
+  path: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
 export type ProjectRecord = {
   id: string;
   name: string;
   description?: string;
   roots: ProjectRootRecord[];
+  context_sources?: ProjectContextSourceRecord[];
   default_root_id?: string;
   default_provider?: string;
   default_model?: string;
@@ -46,10 +57,19 @@ export type ProjectRootPayload = {
   active?: boolean;
 };
 
+export type ProjectContextSourcePayload = {
+  id?: string;
+  kind?: string;
+  title?: string;
+  path: string;
+  enabled?: boolean;
+};
+
 export type CreateProjectPayload = {
   name: string;
   description?: string;
   roots?: ProjectRootPayload[];
+  context_sources?: ProjectContextSourcePayload[];
   default_root_id?: string;
   default_provider?: string;
   default_model?: string;
@@ -62,4 +82,160 @@ export type CreateProjectPayload = {
 
 export type UpdateProjectPayload = Partial<CreateProjectPayload> & {
   last_opened_at?: string;
+};
+
+export type ProjectWorkRoleRecord = {
+  id: string;
+  project_id: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  built_in: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type ProjectWorkItemStatus =
+  | "backlog"
+  | "ready"
+  | "running"
+  | "review"
+  | "blocked"
+  | "done"
+  | "cancelled";
+
+export type ProjectWorkItemPriority = "low" | "normal" | "high" | "urgent";
+
+export type ProjectWorkItemRecord = {
+  id: string;
+  project_id: string;
+  title: string;
+  brief?: string;
+  status: ProjectWorkItemStatus | string;
+  priority: ProjectWorkItemPriority | string;
+  owner_role_id?: string;
+  reviewer_role_ids?: string[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type CreateProjectWorkItemPayload = {
+  id?: string;
+  title: string;
+  brief?: string;
+  status?: ProjectWorkItemStatus | string;
+  priority?: ProjectWorkItemPriority | string;
+  owner_role_id?: string;
+  reviewer_role_ids?: string[];
+};
+
+export type UpdateProjectWorkItemPayload = Partial<CreateProjectWorkItemPayload>;
+
+export type ProjectAssignmentStatus =
+  | "queued"
+  | "running"
+  | "awaiting_approval"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type ProjectAssignmentDriverKind = "hecate_task" | "external_agent";
+
+export type ProjectAssignmentExecutionSummary = {
+  task_id?: string;
+  run_id?: string;
+  task_status?: string;
+  run_status?: string;
+  status?: ProjectAssignmentStatus | string;
+  pending_approval_count?: number;
+  step_count?: number;
+  approval_count?: number;
+  artifact_count?: number;
+  model?: string;
+  provider?: string;
+  last_error?: string;
+  started_at?: string;
+  finished_at?: string;
+  trace_id?: string;
+  missing?: boolean;
+};
+
+export type ProjectAssignmentRecord = {
+  id: string;
+  project_id: string;
+  work_item_id: string;
+  role_id: string;
+  driver_kind: ProjectAssignmentDriverKind | string;
+  status: ProjectAssignmentStatus | string;
+  task_id?: string;
+  run_id?: string;
+  chat_session_id?: string;
+  message_id?: string;
+  context_snapshot_id?: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+  execution?: ProjectAssignmentExecutionSummary;
+};
+
+export type CreateProjectAssignmentPayload = {
+  id?: string;
+  role_id: string;
+  driver_kind?: ProjectAssignmentDriverKind | string;
+  status?: ProjectAssignmentStatus | string;
+  task_id?: string;
+  run_id?: string;
+  chat_session_id?: string;
+  message_id?: string;
+  context_snapshot_id?: string;
+  started_at?: string;
+  completed_at?: string;
+};
+
+export type UpdateProjectAssignmentPayload = Partial<CreateProjectAssignmentPayload>;
+
+export type ProjectCollaborationArtifactKind = "brief" | "handoff" | "review" | "decision_note";
+
+export type ProjectCollaborationArtifactRecord = {
+  id: string;
+  project_id: string;
+  work_item_id: string;
+  assignment_id?: string;
+  kind: ProjectCollaborationArtifactKind | string;
+  title?: string;
+  body: string;
+  author_role_id?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectWorkRolesResponse = {
+  object: string;
+  data: ProjectWorkRoleRecord[];
+};
+
+export type ProjectWorkItemsResponse = {
+  object: string;
+  data: ProjectWorkItemRecord[];
+};
+
+export type ProjectWorkItemResponse = {
+  object: string;
+  data: ProjectWorkItemRecord;
+};
+
+export type ProjectAssignmentsResponse = {
+  object: string;
+  data: ProjectAssignmentRecord[];
+};
+
+export type ProjectAssignmentResponse = {
+  object: string;
+  data: ProjectAssignmentRecord;
+};
+
+export type ProjectCollaborationArtifactsResponse = {
+  object: string;
+  data: ProjectCollaborationArtifactRecord[];
 };


### PR DESCRIPTION
## Summary
- Add Projects as a top-level operator workspace with project list, create, rename, delete, defaults editing, and selected-project cockpit UI.
- Add project work item and assignment inspection, creation, edit, delete, native start, task links, and scoped chat launch from assignments.
- Add project-work TypeScript mirrors/API helpers plus assignment delete API support for memory/sqlite stores.
- Document assignment delete semantics in the runtime API.

## Verification
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `go test ./internal/projectwork ./internal/api`
