### PR TITLE
feat(projects): add role execution defaults

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1269,6 +1269,10 @@ Lists built-in roles plus custom roles for the project.
       "name": "Release captain",
       "description": "Coordinates release work.",
       "instructions": "Keep release notes current.",
+      "default_driver_kind": "hecate_task",
+      "default_provider": "ollama",
+      "default_model": "ministral-3:latest",
+      "default_agent_profile": "implementation",
       "built_in": false,
       "created_at": "2026-06-03T12:00:00Z",
       "updated_at": "2026-06-03T12:00:00Z"
@@ -1281,13 +1285,23 @@ Lists built-in roles plus custom roles for the project.
 
 Creates a custom role. `name` is required. `id` is optional; Hecate generates a
 `role_...` ID when omitted. Built-in role IDs cannot be created, updated, or
-deleted as custom roles.
+deleted as custom roles. Role defaults are execution hints: `default_driver_kind`
+can seed new assignment driver kind, and `default_provider`, `default_model`,
+and `default_agent_profile` can seed native task/chat launches before project
+defaults are used. Provider, model, and profile hints are stored as supplied
+and are not validated against the live provider catalog when the role is saved;
+stale or unroutable values fail later when an assignment or chat launch uses
+them.
 
 ```json
 {
   "name": "Release captain",
   "description": "Coordinates release work.",
-  "instructions": "Keep release notes current."
+  "instructions": "Keep release notes current.",
+  "default_driver_kind": "hecate_task",
+  "default_provider": "ollama",
+  "default_model": "ministral-3:latest",
+  "default_agent_profile": "implementation"
 }
 ```
 
@@ -1295,8 +1309,8 @@ Returns `{ "object": "project_role", "data": { ... } }`.
 
 #### `PATCH /hecate/v1/projects/{id}/roles/{role_id}`
 
-Updates a custom role's `name`, `description`, or `instructions`. Built-in
-roles return `409 conflict`.
+Updates a custom role's `name`, `description`, `instructions`, or role default
+execution hints. Built-in roles return `409 conflict`.
 
 #### `DELETE /hecate/v1/projects/{id}/roles/{role_id}`
 
@@ -1438,8 +1452,11 @@ Starting verifies that the project, work item, assignment, and role exist, then
 creates a normal Task with `execution_kind="agent_loop"`,
 `origin_kind="project_work_item"`, and `origin_id` set to the work item ID. The
 task title, prompt, and system prompt are composed from the work item brief,
-role profile, and project defaults. Project default provider/model/workspace
-settings are copied onto the task when configured. The workspace root must
+role instructions, and project defaults. Role default provider/model/profile
+override project defaults for the backing task when configured; project
+provider/model/workspace settings remain the fallback. Provider and model
+defaults are route hints, so catalog/routing validation happens during task
+start instead of role save. The workspace root must
 resolve to an absolute existing project root before a task is created; missing
 or defaultless roots return `400 invalid_request`. A missing model returns
 `422 model_not_configured`.

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -19,16 +19,24 @@ import (
 )
 
 type createProjectWorkRoleRequest struct {
-	ID           string `json:"id,omitempty"`
-	Name         string `json:"name"`
-	Description  string `json:"description,omitempty"`
-	Instructions string `json:"instructions,omitempty"`
+	ID                  string `json:"id,omitempty"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	Instructions        string `json:"instructions,omitempty"`
+	DefaultDriverKind   string `json:"default_driver_kind,omitempty"`
+	DefaultProvider     string `json:"default_provider,omitempty"`
+	DefaultModel        string `json:"default_model,omitempty"`
+	DefaultAgentProfile string `json:"default_agent_profile,omitempty"`
 }
 
 type updateProjectWorkRoleRequest struct {
-	Name         *string `json:"name,omitempty"`
-	Description  *string `json:"description,omitempty"`
-	Instructions *string `json:"instructions,omitempty"`
+	Name                *string `json:"name,omitempty"`
+	Description         *string `json:"description,omitempty"`
+	Instructions        *string `json:"instructions,omitempty"`
+	DefaultDriverKind   *string `json:"default_driver_kind,omitempty"`
+	DefaultProvider     *string `json:"default_provider,omitempty"`
+	DefaultModel        *string `json:"default_model,omitempty"`
+	DefaultAgentProfile *string `json:"default_agent_profile,omitempty"`
 }
 
 type createProjectWorkItemRequest struct {
@@ -96,14 +104,18 @@ type ProjectWorkRolesResponse struct {
 }
 
 type ProjectWorkRoleResponse struct {
-	ID           string `json:"id"`
-	ProjectID    string `json:"project_id"`
-	Name         string `json:"name"`
-	Description  string `json:"description,omitempty"`
-	Instructions string `json:"instructions,omitempty"`
-	BuiltIn      bool   `json:"built_in"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
+	ID                  string `json:"id"`
+	ProjectID           string `json:"project_id"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	Instructions        string `json:"instructions,omitempty"`
+	DefaultDriverKind   string `json:"default_driver_kind,omitempty"`
+	DefaultProvider     string `json:"default_provider,omitempty"`
+	DefaultModel        string `json:"default_model,omitempty"`
+	DefaultAgentProfile string `json:"default_agent_profile,omitempty"`
+	BuiltIn             bool   `json:"built_in"`
+	CreatedAt           string `json:"created_at,omitempty"`
+	UpdatedAt           string `json:"updated_at,omitempty"`
 }
 
 type ProjectWorkRoleEnvelope struct {
@@ -237,11 +249,15 @@ func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Req
 		id = newOpaqueTaskResourceID("role")
 	}
 	role, err := h.projectWork.CreateRole(r.Context(), projectwork.AgentRoleProfile{
-		ID:           id,
-		ProjectID:    projectID,
-		Name:         req.Name,
-		Description:  req.Description,
-		Instructions: req.Instructions,
+		ID:                  id,
+		ProjectID:           projectID,
+		Name:                req.Name,
+		Description:         req.Description,
+		Instructions:        req.Instructions,
+		DefaultDriverKind:   req.DefaultDriverKind,
+		DefaultProvider:     req.DefaultProvider,
+		DefaultModel:        req.DefaultModel,
+		DefaultAgentProfile: req.DefaultAgentProfile,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -267,6 +283,18 @@ func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Req
 		}
 		if req.Instructions != nil {
 			item.Instructions = *req.Instructions
+		}
+		if req.DefaultDriverKind != nil {
+			item.DefaultDriverKind = *req.DefaultDriverKind
+		}
+		if req.DefaultProvider != nil {
+			item.DefaultProvider = *req.DefaultProvider
+		}
+		if req.DefaultModel != nil {
+			item.DefaultModel = *req.DefaultModel
+		}
+		if req.DefaultAgentProfile != nil {
+			item.DefaultAgentProfile = *req.DefaultAgentProfile
 		}
 	})
 	if !writeProjectWorkError(w, err) {
@@ -462,12 +490,21 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if id == "" {
 		id = newOpaqueTaskResourceID("asgn")
 	}
+	driverKind := strings.TrimSpace(req.DriverKind)
+	if driverKind == "" {
+		if role, ok, err := h.loadProjectWorkRole(r.Context(), projectID, req.RoleID); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		} else if ok {
+			driverKind = role.DefaultDriverKind
+		}
+	}
 	item, err := h.projectWork.CreateAssignment(r.Context(), projectwork.Assignment{
 		ID:                id,
 		ProjectID:         projectID,
 		WorkItemID:        workItemID,
 		RoleID:            req.RoleID,
-		DriverKind:        req.DriverKind,
+		DriverKind:        driverKind,
 		Status:            req.Status,
 		TaskID:            req.TaskID,
 		RunID:             req.RunID,
@@ -654,11 +691,13 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
-	requestedModel := strings.TrimSpace(firstNonEmpty(project.DefaultModel, h.config.Router.DefaultModel))
+	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
+	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel, h.config.Router.DefaultModel))
 	if requestedModel == "" {
 		WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, "project assignment start requires a default model")
 		return
 	}
+	executionProfile := strings.TrimSpace(firstNonEmpty(role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
 
 	taskID := newTaskID()
 	claimRejected := false
@@ -687,7 +726,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	task, err := h.createProjectAssignmentTask(ctx, taskID, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedModel)
+	task, err := h.createProjectAssignmentTask(ctx, taskID, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile)
 	if err != nil {
 		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 			if item.TaskID == taskID && item.RunID == "" {
@@ -871,7 +910,7 @@ func selectProjectAssignmentRoot(project projects.Project) (projects.Root, bool)
 	return projects.Root{}, false
 }
 
-func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedModel string) (types.Task, error) {
+func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile string) (types.Task, error) {
 	now := time.Now().UTC()
 	task := types.Task{
 		ID:                 taskID,
@@ -879,7 +918,7 @@ func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string
 		Prompt:             projectAssignmentPrompt(project, workItem, assignment, role),
 		SystemPrompt:       projectAssignmentSystemPrompt(project, role),
 		ExecutionKind:      "agent_loop",
-		ExecutionProfile:   "project_assignment",
+		ExecutionProfile:   executionProfile,
 		OriginKind:         "project_work_item",
 		OriginID:           workItem.ID,
 		WorkspaceMode:      workspaceMode,
@@ -887,7 +926,7 @@ func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string
 		SandboxAllowedRoot: workingDirectory,
 		Status:             "queued",
 		Priority:           firstNonEmpty(workItem.Priority, "normal"),
-		RequestedProvider:  strings.TrimSpace(project.DefaultProvider),
+		RequestedProvider:  requestedProvider,
 		RequestedModel:     requestedModel,
 		CreatedAt:          now,
 		UpdatedAt:          now,
@@ -1380,14 +1419,18 @@ func projectWorkItemStatusFromAssignments(storedStatus string, assignments []Pro
 
 func renderProjectWorkRole(item projectwork.AgentRoleProfile) ProjectWorkRoleResponse {
 	return ProjectWorkRoleResponse{
-		ID:           item.ID,
-		ProjectID:    item.ProjectID,
-		Name:         item.Name,
-		Description:  item.Description,
-		Instructions: item.Instructions,
-		BuiltIn:      item.BuiltIn,
-		CreatedAt:    formatOptionalTime(item.CreatedAt),
-		UpdatedAt:    formatOptionalTime(item.UpdatedAt),
+		ID:                  item.ID,
+		ProjectID:           item.ProjectID,
+		Name:                item.Name,
+		Description:         item.Description,
+		Instructions:        item.Instructions,
+		DefaultDriverKind:   item.DefaultDriverKind,
+		DefaultProvider:     item.DefaultProvider,
+		DefaultModel:        item.DefaultModel,
+		DefaultAgentProfile: item.DefaultAgentProfile,
+		BuiltIn:             item.BuiltIn,
+		CreatedAt:           formatOptionalTime(item.CreatedAt),
+		UpdatedAt:           formatOptionalTime(item.UpdatedAt),
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -52,7 +52,12 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/roles", bytes.NewReader([]byte(`{
 		"id":"role_release",
 		"name":"Release captain",
-		"description":"Coordinates release work"
+		"description":"Coordinates release work",
+		"instructions":"Keep release notes current.",
+		"default_driver_kind":"external_agent",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4",
+		"default_agent_profile":"safe_external_review"
 	}`))))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
@@ -63,6 +68,9 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 	if role.Data.ID != "role_release" || role.Data.BuiltIn {
 		t.Fatalf("created role = %+v, want custom role", role.Data)
+	}
+	if role.Data.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || role.Data.DefaultProvider != "anthropic" || role.Data.DefaultModel != "claude-sonnet-4" || role.Data.DefaultAgentProfile != "safe_external_review" {
+		t.Fatalf("created role defaults = %+v, want role execution defaults", role.Data)
 	}
 
 	rec = httptest.NewRecorder()
@@ -301,6 +309,47 @@ func TestProjectWorkAPI_ProjectDeletionCleansRows(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_CreateAssignmentUsesRoleDefaultDriver(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectWorkTestServer()
+	project := createProjectForWorkTest(t, server)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/roles", bytes.NewReader([]byte(`{
+		"id":"role_external",
+		"name":"External reviewer",
+		"default_driver_kind":"external_agent"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_external",
+		"title":"External assignment default"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create work item status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_external/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_external",
+		"role_id":"role_external"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.DriverKind != projectwork.AssignmentDriverExternalAgent {
+		t.Fatalf("assignment driver_kind = %q, want role default external_agent", assignment.Data.DriverKind)
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -336,8 +385,8 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	if task.ExecutionKind != "agent_loop" || task.OriginKind != "project_work_item" || task.OriginID != "work_start" {
 		t.Fatalf("task execution/origin = %q %q/%q, want agent_loop project_work_item/work_start", task.ExecutionKind, task.OriginKind, task.OriginID)
 	}
-	if task.RequestedProvider != "ollama" || task.RequestedModel != "qwen2.5-coder" {
-		t.Fatalf("task provider/model = %q/%q, want ollama/qwen2.5-coder", task.RequestedProvider, task.RequestedModel)
+	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "implementation" {
+		t.Fatalf("task provider/model/profile = %q/%q/%q, want role defaults", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
 	}
 	if task.WorkingDirectory != workspace || task.SandboxAllowedRoot != workspace || task.WorkspaceMode != "in_place" {
 		t.Fatalf("task workspace = dir %q root %q mode %q, want %q in_place", task.WorkingDirectory, task.SandboxAllowedRoot, task.WorkspaceMode, workspace)
@@ -352,6 +401,35 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	}
 	if _, found, err := handler.taskStore.GetRun(t.Context(), task.ID, assignment.Data.RunID); err != nil || !found {
 		t.Fatalf("GetRun(%q) found=%v err=%v, want run", assignment.Data.RunID, found, err)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentFallsBackToProjectDefaults(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		ProjectAgentProfile: "project_review",
+		WithoutRoleDefaults: true,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+	}
+	if task.RequestedProvider != "ollama" || task.RequestedModel != "qwen2.5-coder" || task.ExecutionProfile != "project_review" {
+		t.Fatalf("task provider/model/profile = %q/%q/%q, want project defaults", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
 	}
 }
 
@@ -734,11 +812,13 @@ func (s failingCreateTaskStore) CreateTask(context.Context, types.Task) (types.T
 }
 
 type projectWorkAssignmentStartSeed struct {
-	Workspace string
-	Driver    string
-	Status    string
-	TaskID    string
-	RunID     string
+	Workspace           string
+	Driver              string
+	Status              string
+	TaskID              string
+	RunID               string
+	ProjectAgentProfile string
+	WithoutRoleDefaults bool
 }
 
 func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed projectWorkAssignmentStartSeed) {
@@ -751,6 +831,9 @@ func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed pro
 		DefaultWorkspaceMode: "in_place",
 		DefaultSystemPrompt:  "Project default system prompt.",
 	}
+	if seed.ProjectAgentProfile != "" {
+		project.DefaultAgentProfile = seed.ProjectAgentProfile
+	}
 	if seed.Workspace != "" {
 		project.Roots = []projects.Root{{ID: "root_start", Path: seed.Workspace, Kind: "git", Active: true}}
 		project.DefaultRootID = "root_start"
@@ -758,12 +841,18 @@ func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed pro
 	if _, err := handler.projects.Create(t.Context(), project); err != nil {
 		t.Fatalf("Create project: %v", err)
 	}
-	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+	role := projectwork.AgentRoleProfile{
 		ID:           "role_backend",
 		ProjectID:    "proj_start",
 		Name:         "Backend engineer",
 		Instructions: "Follow backend invariants.",
-	}); err != nil {
+	}
+	if !seed.WithoutRoleDefaults {
+		role.DefaultProvider = "anthropic"
+		role.DefaultModel = "claude-sonnet-4"
+		role.DefaultAgentProfile = "implementation"
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), role); err != nil {
 		t.Fatalf("CreateRole: %v", err)
 	}
 	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -52,6 +52,10 @@ CREATE TABLE IF NOT EXISTS %s (
 	name TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	instructions TEXT NOT NULL DEFAULT '',
+	default_driver_kind TEXT NOT NULL DEFAULT '',
+	default_provider TEXT NOT NULL DEFAULT '',
+	default_model TEXT NOT NULL DEFAULT '',
+	default_agent_profile TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY(project_id, id)
@@ -122,6 +126,11 @@ CREATE TABLE IF NOT EXISTS %s (
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "driver_kind", `TEXT NOT NULL DEFAULT 'hecate_task'`); err != nil {
 		return err
 	}
+	for _, column := range []string{"default_driver_kind", "default_provider", "default_model", "default_agent_profile"} {
+		if err := s.ensureColumn(ctx, s.rolesTbl, column, `TEXT NOT NULL DEFAULT ''`); err != nil {
+			return err
+		}
+	}
 	for _, stmt := range []struct {
 		table string
 		name  string
@@ -184,7 +193,7 @@ func (s *SQLiteStore) columnExists(ctx context.Context, quotedTable, column stri
 func (s *SQLiteStore) ListRoles(ctx context.Context, projectID string) ([]AgentRoleProfile, error) {
 	projectID = strings.TrimSpace(projectID)
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, name, description, instructions, created_at, updated_at
+SELECT id, project_id, name, description, instructions, default_driver_kind, default_provider, default_model, default_agent_profile, created_at, updated_at
 FROM %s
 WHERE project_id = ?
 ORDER BY name ASC, id ASC`, s.rolesTbl), projectID)
@@ -218,9 +227,10 @@ func (s *SQLiteStore) CreateRole(ctx context.Context, role AgentRoleProfile) (Ag
 		return AgentRoleProfile{}, err
 	}
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (id, project_id, name, description, instructions, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)`, s.rolesTbl),
+INSERT INTO %s (id, project_id, name, description, instructions, default_driver_kind, default_provider, default_model, default_agent_profile, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.rolesTbl),
 		role.ID, role.ProjectID, role.Name, role.Description, role.Instructions,
+		role.DefaultDriverKind, role.DefaultProvider, role.DefaultModel, role.DefaultAgentProfile,
 		formatTime(role.CreatedAt), formatTime(role.UpdatedAt),
 	)
 	if err != nil {
@@ -266,9 +276,11 @@ func (s *SQLiteStore) UpdateRole(ctx context.Context, projectID, id string, upda
 	}
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
-SET name = ?, description = ?, instructions = ?, updated_at = ?
+SET name = ?, description = ?, instructions = ?, default_driver_kind = ?, default_provider = ?, default_model = ?, default_agent_profile = ?, updated_at = ?
 WHERE project_id = ? AND id = ?`, s.rolesTbl),
-		role.Name, role.Description, role.Instructions, formatTime(role.UpdatedAt), projectID, id,
+		role.Name, role.Description, role.Instructions,
+		role.DefaultDriverKind, role.DefaultProvider, role.DefaultModel, role.DefaultAgentProfile,
+		formatTime(role.UpdatedAt), projectID, id,
 	)
 	if err != nil {
 		return AgentRoleProfile{}, err
@@ -757,7 +769,7 @@ ORDER BY role_id ASC`, s.reviewersTbl), projectID, workItemID)
 
 func (s *SQLiteStore) getCustomRole(ctx context.Context, projectID, id string) (AgentRoleProfile, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, name, description, instructions, created_at, updated_at
+SELECT id, project_id, name, description, instructions, default_driver_kind, default_provider, default_model, default_agent_profile, created_at, updated_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.rolesTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	role, err := scanRole(row)
@@ -818,7 +830,19 @@ type scanner interface {
 func scanRole(row scanner) (AgentRoleProfile, error) {
 	var item AgentRoleProfile
 	var createdAt, updatedAt string
-	if err := row.Scan(&item.ID, &item.ProjectID, &item.Name, &item.Description, &item.Instructions, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(
+		&item.ID,
+		&item.ProjectID,
+		&item.Name,
+		&item.Description,
+		&item.Instructions,
+		&item.DefaultDriverKind,
+		&item.DefaultProvider,
+		&item.DefaultModel,
+		&item.DefaultAgentProfile,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
 		return AgentRoleProfile{}, err
 	}
 	var err error

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -44,14 +44,18 @@ var (
 )
 
 type AgentRoleProfile struct {
-	ID           string
-	ProjectID    string
-	Name         string
-	Description  string
-	Instructions string
-	BuiltIn      bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID                  string
+	ProjectID           string
+	Name                string
+	Description         string
+	Instructions        string
+	DefaultDriverKind   string
+	DefaultProvider     string
+	DefaultModel        string
+	DefaultAgentProfile string
+	BuiltIn             bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 type WorkItem struct {
@@ -545,6 +549,10 @@ func normalizeRole(role AgentRoleProfile, now time.Time) AgentRoleProfile {
 	role.Name = strings.TrimSpace(role.Name)
 	role.Description = strings.TrimSpace(role.Description)
 	role.Instructions = strings.TrimSpace(role.Instructions)
+	role.DefaultDriverKind = strings.TrimSpace(role.DefaultDriverKind)
+	role.DefaultProvider = strings.TrimSpace(role.DefaultProvider)
+	role.DefaultModel = strings.TrimSpace(role.DefaultModel)
+	role.DefaultAgentProfile = strings.TrimSpace(role.DefaultAgentProfile)
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -644,6 +652,9 @@ func validateRole(role AgentRoleProfile) error {
 	}
 	if role.Name == "" {
 		return fmt.Errorf("%w: role name is required", ErrInvalid)
+	}
+	if role.DefaultDriverKind != "" && !validAssignmentDriverKind(role.DefaultDriverKind) {
+		return fmt.Errorf("%w: unsupported role default_driver_kind %q", ErrInvalid, role.DefaultDriverKind)
 	}
 	return nil
 }

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -33,17 +33,41 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			}
 
 			custom, err := store.CreateRole(ctx, AgentRoleProfile{
-				ID:           "role_release_captain",
-				ProjectID:    "proj_alpha",
-				Name:         " Release Captain ",
-				Description:  " Coordinates releases ",
-				Instructions: "Keep release notes current.",
+				ID:                  "role_release_captain",
+				ProjectID:           "proj_alpha",
+				Name:                " Release Captain ",
+				Description:         " Coordinates releases ",
+				Instructions:        "Keep release notes current.",
+				DefaultDriverKind:   " hecate_task ",
+				DefaultProvider:     " ollama ",
+				DefaultModel:        " ministral-3:latest ",
+				DefaultAgentProfile: " implementation ",
 			})
 			if err != nil {
 				t.Fatalf("CreateRole: %v", err)
 			}
 			if custom.Name != "Release Captain" || custom.BuiltIn {
 				t.Fatalf("custom role = %+v, want normalized custom role", custom)
+			}
+			if custom.DefaultDriverKind != AssignmentDriverHecateTask || custom.DefaultProvider != "ollama" || custom.DefaultModel != "ministral-3:latest" || custom.DefaultAgentProfile != "implementation" {
+				t.Fatalf("custom role defaults = %+v, want normalized execution defaults", custom)
+			}
+			updatedRole, err := store.UpdateRole(ctx, "proj_alpha", "role_release_captain", func(item *AgentRoleProfile) {
+				item.DefaultDriverKind = AssignmentDriverExternalAgent
+				item.DefaultProvider = "anthropic"
+				item.DefaultModel = "claude-sonnet-4"
+				item.DefaultAgentProfile = "safe_external_review"
+			})
+			if err != nil {
+				t.Fatalf("UpdateRole defaults: %v", err)
+			}
+			if updatedRole.DefaultDriverKind != AssignmentDriverExternalAgent || updatedRole.DefaultProvider != "anthropic" || updatedRole.DefaultModel != "claude-sonnet-4" || updatedRole.DefaultAgentProfile != "safe_external_review" {
+				t.Fatalf("updated role defaults = %+v, want updated defaults", updatedRole)
+			}
+			if _, err := store.UpdateRole(ctx, "proj_alpha", "role_release_captain", func(item *AgentRoleProfile) {
+				item.DefaultDriverKind = "unsupported"
+			}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("UpdateRole unsupported default driver error = %v, want ErrInvalid", err)
 			}
 			if _, err := store.CreateRole(ctx, AgentRoleProfile{ID: "product_manager", ProjectID: "proj_alpha", Name: "Override"}); !errors.Is(err, ErrBuiltInRole) {
 				t.Fatalf("CreateRole built-in error = %v, want ErrBuiltInRole", err)
@@ -333,6 +357,64 @@ INSERT INTO `+assignmentsTbl+` (
 	}
 	if len(assignments) != 1 || assignments[0].DriverKind != AssignmentDriverHecateTask {
 		t.Fatalf("assignments = %+v, want legacy assignment backfilled to hecate_task", assignments)
+	}
+}
+
+func TestSQLiteStore_AddsRoleDefaultColumnsToExistingTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "projectwork.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	rolesTbl := client.QualifiedTable("project_work_roles")
+	if _, err := client.DB().ExecContext(ctx, `
+CREATE TABLE `+rolesTbl+` (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	instructions TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`); err != nil {
+		t.Fatalf("create legacy roles table: %v", err)
+	}
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := client.DB().ExecContext(ctx, `
+INSERT INTO `+rolesTbl+` (
+	id, project_id, name, description, instructions, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"role_legacy", "proj_alpha", "Legacy role", "Older schema", "Keep going.", now, now,
+	); err != nil {
+		t.Fatalf("insert legacy role: %v", err)
+	}
+
+	store, err := NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	roles, err := store.ListRoles(ctx, "proj_alpha")
+	if err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	var legacy AgentRoleProfile
+	for _, role := range roles {
+		if role.ID == "role_legacy" {
+			legacy = role
+			break
+		}
+	}
+	if legacy.ID == "" {
+		t.Fatalf("roles = %+v, want legacy role", roles)
+	}
+	if legacy.DefaultDriverKind != "" || legacy.DefaultProvider != "" || legacy.DefaultModel != "" || legacy.DefaultAgentProfile != "" {
+		t.Fatalf("legacy role defaults = %+v, want empty migrated defaults", legacy)
 	}
 }
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -7,8 +7,10 @@ import { ProvidersAndModelsProvider } from "../../app/state/providersAndModels";
 import { ProjectsProvider } from "../../app/state/projects";
 import {
   createProjectAssignment,
+  createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
+  deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
@@ -18,6 +20,7 @@ import {
   startProjectAssignment,
   updateProject,
   updateProjectAssignment,
+  updateProjectWorkRole,
   updateProjectWorkItem,
 } from "../../lib/api";
 import {
@@ -48,6 +51,9 @@ vi.mock("../../lib/api", async (importOriginal) => {
     startProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
     createProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
     createProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
+    createProjectWorkRole: vi.fn(async () => ({ object: "project_role", data: null })),
+    updateProjectWorkRole: vi.fn(async () => ({ object: "project_role", data: null })),
+    deleteProjectWorkRole: vi.fn(async () => undefined),
     updateProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
     deleteProjectWorkItem: vi.fn(async () => undefined),
     updateProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
@@ -152,6 +158,29 @@ function resetProjectWorkMocks() {
     object: "project_assignment",
     data: { ...hecateAssignment, id: "asgn_new", status: "queued", execution: undefined },
   });
+  vi.mocked(createProjectWorkRole).mockResolvedValue({
+    object: "project_role",
+    data: {
+      id: "role_frontend_custom",
+      project_id: "proj_1",
+      name: "Frontend implementer",
+      built_in: false,
+    },
+  });
+  vi.mocked(updateProjectWorkRole).mockResolvedValue({
+    object: "project_role",
+    data: {
+      id: "role_frontend_custom",
+      project_id: "proj_1",
+      name: "Frontend implementer",
+      default_driver_kind: "external_agent",
+      default_provider: "anthropic",
+      default_model: "claude-sonnet-4",
+      default_agent_profile: "safe_external_review",
+      built_in: false,
+    },
+  });
+  vi.mocked(deleteProjectWorkRole).mockResolvedValue(undefined);
   vi.mocked(updateProjectWorkItem).mockResolvedValue({
     object: "project_work_item",
     data: { ...workItem, title: "Edited cockpit UI", status: "review", priority: "urgent" },
@@ -193,6 +222,9 @@ afterEach(() => {
   vi.mocked(startProjectAssignment).mockReset();
   vi.mocked(createProjectWorkItem).mockReset();
   vi.mocked(createProjectAssignment).mockReset();
+  vi.mocked(createProjectWorkRole).mockReset();
+  vi.mocked(updateProjectWorkRole).mockReset();
+  vi.mocked(deleteProjectWorkRole).mockReset();
   vi.mocked(updateProjectWorkItem).mockReset();
   vi.mocked(deleteProjectWorkItem).mockReset();
   vi.mocked(updateProjectAssignment).mockReset();
@@ -572,6 +604,88 @@ describe("ProjectsView cockpit", () => {
       role_id: "software_developer",
       driver_kind: "external_agent",
     });
+  });
+
+  it("uses a role default driver when adding assignments", async () => {
+    const externalRole: ProjectWorkRoleRecord = {
+      id: "role_external",
+      project_id: project.id,
+      name: "External reviewer",
+      default_driver_kind: "external_agent",
+      built_in: false,
+    };
+    resetProjectWorkMocks();
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [role, externalRole],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    fireEvent.change(screen.getByLabelText("Role"), {
+      target: { value: "role_external" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+
+    expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
+      role_id: "role_external",
+      driver_kind: "external_agent",
+    });
+  });
+
+  it("creates custom roles with execution defaults", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Roles" }));
+    const dialog = screen.getByRole("dialog", { name: "Project roles" });
+    await userEvent.click(within(dialog).getByRole("button", { name: /New custom role/i }));
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Frontend implementer" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Description"), {
+      target: { value: "Builds UI" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Instructions"), {
+      target: { value: "Use existing UI primitives." },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Default driver"), {
+      target: { value: "hecate_task" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Default profile"), {
+      target: { value: "implementation" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Default provider"), {
+      target: { value: "ollama" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Default model"), {
+      target: { value: "ministral-3:latest" },
+    });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create role" }));
+
+    expect(createProjectWorkRole).toHaveBeenCalledWith(project.id, {
+      name: "Frontend implementer",
+      description: "Builds UI",
+      instructions: "Use existing UI primitives.",
+      default_driver_kind: "hecate_task",
+      default_provider: "ollama",
+      default_model: "ministral-3:latest",
+      default_agent_profile: "implementation",
+    });
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: "Save role" })).toBeTruthy();
+    });
+    expect(within(dialog).getByRole("button", { name: "Delete role" })).toBeTruthy();
   });
 
   it("edits and deletes assignments from the selected work item", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -5,8 +5,10 @@ import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import {
   ApiError,
   createProjectAssignment,
+  createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
+  deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
@@ -16,6 +18,7 @@ import {
   startProjectAssignment,
   updateProject,
   updateProjectAssignment,
+  updateProjectWorkRole,
   updateProjectWorkItem,
 } from "../../lib/api";
 import { formatAbsoluteTime } from "../../lib/format";
@@ -93,6 +96,17 @@ type ProjectDefaultsForm = {
   workspaceMode: string;
 };
 
+type RoleForm = {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  defaultDriverKind: string;
+  defaultProvider: string;
+  defaultModel: string;
+  defaultAgentProfile: string;
+};
+
 const WORK_ITEM_STATUSES = [
   "backlog",
   "ready",
@@ -158,6 +172,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [defaultsModalOpen, setDefaultsModalOpen] = useState(false);
   const [defaultsPending, setDefaultsPending] = useState(false);
   const [defaultsError, setDefaultsError] = useState("");
+  const [rolesModalOpen, setRolesModalOpen] = useState(false);
+  const [rolesPending, setRolesPending] = useState(false);
+  const [rolesError, setRolesError] = useState("");
   const [newWorkModalOpen, setNewWorkModalOpen] = useState(false);
   const [newWorkPending, setNewWorkPending] = useState(false);
   const [newWorkError, setNewWorkError] = useState("");
@@ -368,6 +385,68 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setDefaultsError(errorMessage(error, "Failed to update project defaults."));
     } finally {
       setDefaultsPending(false);
+    }
+  }
+
+  async function reloadRoles(projectID = selectedProjectID) {
+    if (!projectID) return;
+    const payload = await getProjectWorkRoles(projectID);
+    setRoles(payload.data ?? []);
+  }
+
+  async function handleCreateRole(form: RoleForm) {
+    if (!selectedProjectID) return undefined;
+    const name = form.name.trim();
+    if (!name) return undefined;
+    setRolesPending(true);
+    setRolesError("");
+    try {
+      const payload = await createProjectWorkRole(selectedProjectID, rolePayloadFromForm(form));
+      setRoles((current) => upsertRole(current, payload.data));
+      return payload.data;
+    } catch (error) {
+      setRolesError(errorMessage(error, "Failed to create role."));
+      return undefined;
+    } finally {
+      setRolesPending(false);
+    }
+  }
+
+  async function handleUpdateRole(roleID: string, form: RoleForm) {
+    if (!selectedProjectID) return undefined;
+    const name = form.name.trim();
+    if (!name) return undefined;
+    setRolesPending(true);
+    setRolesError("");
+    try {
+      const payload = await updateProjectWorkRole(
+        selectedProjectID,
+        roleID,
+        rolePayloadFromForm(form),
+      );
+      setRoles((current) => upsertRole(current, payload.data));
+      return payload.data;
+    } catch (error) {
+      setRolesError(errorMessage(error, "Failed to update role."));
+      return undefined;
+    } finally {
+      setRolesPending(false);
+    }
+  }
+
+  async function handleDeleteRole(role: ProjectWorkRoleRecord) {
+    if (!selectedProjectID || role.built_in) return false;
+    setRolesPending(true);
+    setRolesError("");
+    try {
+      await deleteProjectWorkRole(selectedProjectID, role.id);
+      await reloadRoles(selectedProjectID);
+      return true;
+    } catch (error) {
+      setRolesError(errorMessage(error, "Failed to delete role."));
+      return false;
+    } finally {
+      setRolesPending(false);
     }
   }
 
@@ -601,6 +680,10 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             setDefaultsError("");
             setDefaultsModalOpen(true);
           }}
+          onManageRoles={() => {
+            setRolesError("");
+            setRolesModalOpen(true);
+          }}
           onNewWorkItem={() => {
             setNewWorkError("");
             setNewWorkModalOpen(true);
@@ -688,6 +771,18 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           project={selectedProject}
           onClose={() => setDefaultsModalOpen(false)}
           onSave={handleSaveProjectDefaults}
+        />
+      )}
+
+      {selectedProject && rolesModalOpen && (
+        <RolesModal
+          error={rolesError}
+          pending={rolesPending}
+          roles={roles}
+          onClose={() => setRolesModalOpen(false)}
+          onCreate={handleCreateRole}
+          onDelete={handleDeleteRole}
+          onUpdate={handleUpdateRole}
         />
       )}
 
@@ -916,11 +1011,13 @@ function ProjectIndexRow({
 function ProjectHeader({
   project,
   onEditDefaults,
+  onManageRoles,
   onNewWorkItem,
   onRefresh,
 }: {
   project: ProjectRecord | null;
   onEditDefaults: () => void;
+  onManageRoles: () => void;
   onNewWorkItem: () => void;
   onRefresh: () => void;
 }) {
@@ -944,6 +1041,14 @@ function ProjectHeader({
         disabled={!project}
       >
         Defaults
+      </button>
+      <button
+        className="btn btn-ghost btn-sm"
+        type="button"
+        onClick={onManageRoles}
+        disabled={!project}
+      >
+        Roles
       </button>
       <button
         className="btn btn-primary btn-sm"
@@ -1149,7 +1254,12 @@ function WorkItemDetail({
               <AssignmentRow
                 key={assignment.id}
                 assignment={assignment}
-                chatModel={assignment.execution?.model || project?.default_model || ""}
+                chatModel={
+                  assignment.execution?.model ||
+                  roleByID.get(assignment.role_id)?.default_model ||
+                  project?.default_model ||
+                  ""
+                }
                 error={assignmentErrors[assignment.id] ?? ""}
                 onDelete={() => onDeleteAssignment(assignment)}
                 onEdit={() => onEditAssignment(assignment)}
@@ -1159,8 +1269,15 @@ function WorkItemDetail({
                         onOpenChat?.({
                           projectID: project.id,
                           provider:
-                            assignment.execution?.provider || project.default_provider || "",
-                          model: assignment.execution?.model || project.default_model || "",
+                            assignment.execution?.provider ||
+                            roleByID.get(assignment.role_id)?.default_provider ||
+                            project.default_provider ||
+                            "",
+                          model:
+                            assignment.execution?.model ||
+                            roleByID.get(assignment.role_id)?.default_model ||
+                            project.default_model ||
+                            "",
                         })
                     : undefined
                 }
@@ -1314,6 +1431,255 @@ function ProjectDefaultsModal({
           Native Hecate assignments copy these defaults when creating the backing task.
         </div>
       </form>
+    </Modal>
+  );
+}
+
+function RolesModal({
+  error,
+  pending,
+  roles,
+  onClose,
+  onCreate,
+  onDelete,
+  onUpdate,
+}: {
+  error: string;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onCreate: (
+    form: RoleForm,
+  ) => ProjectWorkRoleRecord | undefined | Promise<ProjectWorkRoleRecord | undefined>;
+  onDelete: (role: ProjectWorkRoleRecord) => boolean | Promise<boolean>;
+  onUpdate: (
+    roleID: string,
+    form: RoleForm,
+  ) => ProjectWorkRoleRecord | undefined | Promise<ProjectWorkRoleRecord | undefined>;
+}) {
+  const customRoles = roles.filter((role) => !role.built_in);
+  const firstEditable = customRoles[0] ?? null;
+  const [selectedRoleID, setSelectedRoleID] = useState(firstEditable?.id ?? "new");
+  const selectedRole = roles.find((role) => role.id === selectedRoleID) ?? null;
+  const editingBuiltIn = Boolean(selectedRole?.built_in);
+  const editingNew = selectedRoleID === "new";
+  const [form, setForm] = useState<RoleForm>(() =>
+    selectedRole ? roleFormFromRecord(selectedRole) : emptyRoleForm(),
+  );
+
+  function selectRole(roleID: string) {
+    setSelectedRoleID(roleID);
+    const role = roles.find((item) => item.id === roleID) ?? null;
+    setForm(role ? roleFormFromRecord(role) : emptyRoleForm());
+  }
+
+  function selectRoleRecord(role: ProjectWorkRoleRecord) {
+    setSelectedRoleID(role.id);
+    setForm(roleFormFromRecord(role));
+  }
+
+  const canSave = form.name.trim().length > 0 && !editingBuiltIn;
+  const submit = async () => {
+    if (!canSave) return;
+    if (editingNew) {
+      const role = await onCreate(form);
+      if (role) {
+        selectRoleRecord(role);
+      }
+      return;
+    }
+    const role = await onUpdate(selectedRoleID, form);
+    if (role) {
+      selectRoleRecord(role);
+    }
+  };
+
+  async function deleteSelectedRole(role: ProjectWorkRoleRecord) {
+    const deleted = await onDelete(role);
+    if (!deleted) return;
+    const nextRole = roles.find((item) => !item.built_in && item.id !== role.id) ?? null;
+    if (nextRole) {
+      selectRoleRecord(nextRole);
+      return;
+    }
+    setSelectedRoleID("new");
+    setForm(emptyRoleForm());
+  }
+
+  return (
+    <Modal
+      title="Project roles"
+      onClose={onClose}
+      width={760}
+      footer={
+        <div style={{ display: "flex", gap: 8, width: "100%" }}>
+          {selectedRole && !selectedRole.built_in && !editingNew && (
+            <button
+              className="btn btn-ghost"
+              type="button"
+              disabled={pending}
+              onClick={() => void deleteSelectedRole(selectedRole)}
+              style={{ color: "var(--red)" }}
+            >
+              Delete role
+            </button>
+          )}
+          <button
+            className="btn btn-primary"
+            type="button"
+            disabled={pending || !canSave}
+            onClick={() => void submit()}
+            style={{ marginLeft: "auto" }}
+          >
+            {pending ? "Saving…" : editingNew ? "Create role" : "Save role"}
+          </button>
+        </div>
+      }
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, minHeight: 420 }}>
+        <div
+          style={{
+            borderRight: "1px solid var(--border)",
+            paddingRight: 10,
+            display: "grid",
+            alignContent: "start",
+            gap: 6,
+          }}
+        >
+          <button
+            className={selectedRoleID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"}
+            type="button"
+            onClick={() => selectRole("new")}
+            style={{ justifyContent: "flex-start" }}
+          >
+            <Icon d={Icons.plus} size={12} />
+            New custom role
+          </button>
+          {roles.map((role) => (
+            <button
+              key={role.id}
+              className={
+                selectedRoleID === role.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
+              }
+              type="button"
+              onClick={() => selectRole(role.id)}
+              style={{ justifyContent: "flex-start", minWidth: 0 }}
+            >
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{role.name}</span>
+              {role.built_in && <span className="badge badge-muted">built-in</span>}
+            </button>
+          ))}
+        </div>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submit();
+          }}
+          style={{ display: "grid", gap: 12, alignContent: "start" }}
+        >
+          {error && <InlineError message={error} />}
+          {editingBuiltIn && (
+            <div style={subtleTextStyle}>
+              Built-in roles are read-only. Create a custom role to override instructions or
+              execution defaults for this project.
+            </div>
+          )}
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Name</span>
+            <input
+              className="input"
+              value={form.name}
+              disabled={editingBuiltIn}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              autoFocus={editingNew}
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Description</span>
+            <textarea
+              className="input"
+              value={form.description}
+              disabled={editingBuiltIn}
+              rows={2}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, description: event.target.value }))
+              }
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Instructions</span>
+            <textarea
+              className="input"
+              value={form.instructions}
+              disabled={editingBuiltIn}
+              rows={5}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, instructions: event.target.value }))
+              }
+            />
+          </label>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Default driver</span>
+              <select
+                className="input"
+                value={form.defaultDriverKind}
+                disabled={editingBuiltIn}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, defaultDriverKind: event.target.value }))
+                }
+              >
+                <option value="">assignment default</option>
+                <option value="hecate_task">hecate_task</option>
+                <option value="external_agent">external_agent</option>
+              </select>
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Default profile</span>
+              <input
+                className="input"
+                value={form.defaultAgentProfile}
+                disabled={editingBuiltIn}
+                placeholder="implementation"
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    defaultAgentProfile: event.target.value,
+                  }))
+                }
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Default provider</span>
+              <input
+                className="input"
+                value={form.defaultProvider}
+                disabled={editingBuiltIn}
+                placeholder="ollama"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, defaultProvider: event.target.value }))
+                }
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Default model</span>
+              <input
+                className="input"
+                value={form.defaultModel}
+                disabled={editingBuiltIn}
+                placeholder="ministral-3:latest"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, defaultModel: event.target.value }))
+                }
+              />
+            </label>
+          </div>
+          <div style={subtleTextStyle}>
+            Role defaults are execution hints. Assignments can still override the driver, and
+            project defaults remain the fallback.
+          </div>
+        </form>
+      </div>
     </Modal>
   );
 }
@@ -1574,9 +1940,10 @@ function NewAssignmentModal({
   onClose: () => void;
   onCreate: (form: NewAssignmentForm) => void | Promise<void>;
 }) {
+  const defaultRole = roles.find((role) => role.id === "software_developer") ?? roles[0] ?? null;
   const [form, setForm] = useState<NewAssignmentForm>({
-    roleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
-    driverKind: "hecate_task",
+    roleID: defaultRole?.id ?? "",
+    driverKind: defaultDriverForRole(defaultRole),
   });
   const valid = form.roleID.trim().length > 0;
   return (
@@ -1610,7 +1977,15 @@ function NewAssignmentModal({
             className="input"
             autoFocus
             value={form.roleID}
-            onChange={(event) => setForm((current) => ({ ...current, roleID: event.target.value }))}
+            onChange={(event) => {
+              const roleID = event.target.value;
+              const role = roles.find((item) => item.id === roleID) ?? null;
+              setForm((current) => ({
+                ...current,
+                roleID,
+                driverKind: defaultDriverForRole(role),
+              }));
+            }}
           >
             {roles.map((role) => (
               <option key={role.id} value={role.id}>
@@ -1977,6 +2352,60 @@ function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemS
 
 function defaultModelID(models: ModelRecord[]): string {
   return models.find((model) => model.metadata?.default)?.id || models[0]?.id || "";
+}
+
+function emptyRoleForm(): RoleForm {
+  return {
+    id: "",
+    name: "",
+    description: "",
+    instructions: "",
+    defaultDriverKind: "",
+    defaultProvider: "",
+    defaultModel: "",
+    defaultAgentProfile: "",
+  };
+}
+
+function roleFormFromRecord(role: ProjectWorkRoleRecord): RoleForm {
+  return {
+    id: role.id,
+    name: role.name,
+    description: role.description ?? "",
+    instructions: role.instructions ?? "",
+    defaultDriverKind: role.default_driver_kind ?? "",
+    defaultProvider: role.default_provider ?? "",
+    defaultModel: role.default_model ?? "",
+    defaultAgentProfile: role.default_agent_profile ?? "",
+  };
+}
+
+function rolePayloadFromForm(form: RoleForm) {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    instructions: form.instructions.trim(),
+    default_driver_kind: form.defaultDriverKind.trim(),
+    default_provider: form.defaultProvider.trim(),
+    default_model: form.defaultModel.trim(),
+    default_agent_profile: form.defaultAgentProfile.trim(),
+  };
+}
+
+function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
+  return role?.default_driver_kind || "hecate_task";
+}
+
+function upsertRole(items: ProjectWorkRoleRecord[], item: ProjectWorkRoleRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  const next = index === -1 ? [item, ...items] : items.slice();
+  if (index !== -1) {
+    next[index] = item;
+  }
+  return next.sort((a, b) => {
+    if (a.built_in !== b.built_in) return a.built_in ? -1 : 1;
+    return a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+  });
 }
 
 function upsertWorkItem(items: ProjectWorkItemRecord[], item: ProjectWorkItemRecord) {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -5,10 +5,12 @@ import {
   cancelChatApproval,
   chatCompletions,
   createProjectAssignment,
+  createProjectWorkRole,
   createProjectWorkItem,
   deleteChatGrant,
   deletePolicyRule,
   deleteProjectAssignment,
+  deleteProjectWorkRole,
   deleteProjectWorkItem,
   discoverLocalProviders,
   dispatchChatStreamEvent,
@@ -44,6 +46,7 @@ import {
   updateChatSession,
   updateProject,
   updateProjectAssignment,
+  updateProjectWorkRole,
   updateProjectWorkItem,
   type ApiError,
 } from "./api";
@@ -352,6 +355,66 @@ describe("api client", () => {
           driver_kind: "hecate_task",
         }),
       }),
+    );
+  });
+
+  it("creates, updates, and deletes project roles with execution defaults", async () => {
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ object: "project_role", data: { id: "role/1" } }))
+      .mockResolvedValueOnce(jsonResponse({ object: "project_role", data: { id: "role/1" } }))
+      .mockResolvedValueOnce(jsonResponse(null));
+
+    await createProjectWorkRole("proj/1", {
+      name: "Frontend implementer",
+      description: "Builds UI",
+      instructions: "Use existing UI primitives.",
+      default_driver_kind: "hecate_task",
+      default_provider: "ollama",
+      default_model: "ministral-3:latest",
+      default_agent_profile: "implementation",
+    });
+    await updateProjectWorkRole("proj/1", "role/1", {
+      default_driver_kind: "external_agent",
+      default_provider: "anthropic",
+      default_model: "claude-sonnet-4",
+      default_agent_profile: "safe_external_review",
+    });
+    await deleteProjectWorkRole("proj/1", "role/1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/hecate/v1/projects/proj%2F1/roles",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "Frontend implementer",
+          description: "Builds UI",
+          instructions: "Use existing UI primitives.",
+          default_driver_kind: "hecate_task",
+          default_provider: "ollama",
+          default_model: "ministral-3:latest",
+          default_agent_profile: "implementation",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/hecate/v1/projects/proj%2F1/roles/role%2F1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          default_driver_kind: "external_agent",
+          default_provider: "anthropic",
+          default_model: "claude-sonnet-4",
+          default_agent_profile: "safe_external_review",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/hecate/v1/projects/proj%2F1/roles/role%2F1",
+      expect.objectContaining({ method: "DELETE" }),
     );
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -50,6 +50,7 @@ import type { RetentionRunResponse, RetentionRunsResponse } from "../types/reten
 import type {
   CreateProjectPayload,
   CreateProjectAssignmentPayload,
+  CreateProjectWorkRolePayload,
   CreateProjectWorkItemPayload,
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
@@ -57,10 +58,12 @@ import type {
   ProjectResponse,
   ProjectWorkItemsResponse,
   ProjectWorkItemResponse,
+  ProjectWorkRoleResponse,
   ProjectWorkRolesResponse,
   ProjectsResponse,
   UpdateProjectAssignmentPayload,
   UpdateProjectPayload,
+  UpdateProjectWorkRolePayload,
   UpdateProjectWorkItemPayload,
 } from "../types/project";
 
@@ -330,6 +333,34 @@ export async function deleteProject(id: string): Promise<void> {
 export async function getProjectWorkRoles(projectID: string): Promise<ProjectWorkRolesResponse> {
   return fetchJSON<ProjectWorkRolesResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/roles`,
+  );
+}
+
+export async function createProjectWorkRole(
+  projectID: string,
+  payload: CreateProjectWorkRolePayload,
+): Promise<ProjectWorkRoleResponse> {
+  return fetchJSON<ProjectWorkRoleResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/roles`,
+    { method: "POST", body: payload },
+  );
+}
+
+export async function updateProjectWorkRole(
+  projectID: string,
+  roleID: string,
+  payload: UpdateProjectWorkRolePayload,
+): Promise<ProjectWorkRoleResponse> {
+  return fetchJSON<ProjectWorkRoleResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/roles/${encodeURIComponent(roleID)}`,
+    { method: "PATCH", body: payload },
+  );
+}
+
+export async function deleteProjectWorkRole(projectID: string, roleID: string): Promise<void> {
+  return fetchJSON<void>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/roles/${encodeURIComponent(roleID)}`,
+    { method: "DELETE" },
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -90,10 +90,27 @@ export type ProjectWorkRoleRecord = {
   name: string;
   description?: string;
   instructions?: string;
+  default_driver_kind?: ProjectAssignmentDriverKind | string;
+  default_provider?: string;
+  default_model?: string;
+  default_agent_profile?: string;
   built_in: boolean;
   created_at?: string;
   updated_at?: string;
 };
+
+export type CreateProjectWorkRolePayload = {
+  id?: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  default_driver_kind?: ProjectAssignmentDriverKind | string;
+  default_provider?: string;
+  default_model?: string;
+  default_agent_profile?: string;
+};
+
+export type UpdateProjectWorkRolePayload = Partial<CreateProjectWorkRolePayload>;
 
 export type ProjectWorkItemStatus =
   | "backlog"
@@ -214,6 +231,11 @@ export type ProjectCollaborationArtifactRecord = {
 export type ProjectWorkRolesResponse = {
   object: string;
   data: ProjectWorkRoleRecord[];
+};
+
+export type ProjectWorkRoleResponse = {
+  object: string;
+  data: ProjectWorkRoleRecord;
 };
 
 export type ProjectWorkItemsResponse = {


### PR DESCRIPTION
## Summary

- Add durable role execution defaults for driver kind, provider, model, and agent profile across memory and SQLite project-work stores.
- Expose role defaults through the project-work role API and Projects UI role management modal.
- Let assignment creation inherit a selected role default driver and let native assignment start resolve role defaults before project defaults.
- Document the role-default fields and assignment-start fallback behavior in the runtime API reference.

## Validation

- `go build ./...`
- `go vet ./internal/projectwork ./internal/api`
- `go test ./internal/projectwork ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`

## Notes

- This keeps roles as project responsibilities and treats profile/model/provider values as runtime hints, without adding a full profile or preset subsystem.