### PR TITLE
feat(projects): add project activity inbox

### DIFF
--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -244,8 +244,11 @@ persisted, trusted context-source metadata can be attached to a project, and
 chat sessions can carry `project_id`. Chat context packets snapshot enabled
 project context-source metadata as itemized provenance. Project work
 assignments can now start native Tasks linked back via `origin_kind` /
-`origin_id`; broader task `project_id` scoping, memory entries, profiles, and
-presets are not linked to `project_id` yet.
+`origin_id`, and `GET /hecate/v1/projects/{id}/activity` exposes a read-only
+project activity inbox over work items, assignments, linked task/run/chat ids,
+status signals, and recent collaboration artifacts. Broader task `project_id`
+scoping, memory entries, profiles, and presets are not linked to `project_id`
+yet.
 
 Persist `project_id` on:
 
@@ -275,7 +278,7 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 6. Add project-scoped memory.
 7. Add agent-profile memory-source selection.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.
-9. Add project activity aggregation.
+9. Add project activity aggregation. Done for the read-only V1 inbox.
 10. Update docs, screenshots, and e2e coverage.
 
 ## Test Plan

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1251,6 +1251,114 @@ assignments `completed` makes it `done`; all assignments `cancelled` makes it
 non-cancelled assignment, makes it `blocked`. Otherwise the stored work-item
 status is returned.
 
+#### `GET /hecate/v1/projects/{id}/activity`
+
+Returns a read-only project activity inbox for the operator cockpit. The
+response is bounded and deterministic: Hecate composes existing project work
+items, assignments, projected task/run execution summaries, linked chat/task
+identifiers, and recent collaboration artifact signals without mutating any
+project-work or task rows.
+
+The top-level envelope follows the Hecate-native convention:
+
+```json
+{
+  "object": "project_activity",
+  "data": {
+    "project_id": "proj_...",
+    "summary": {
+      "work_item_count": 3,
+      "assignment_count": 5,
+      "active_count": 1,
+      "blocked_count": 2,
+      "completed_count": 2,
+      "recent_count": 1
+    },
+    "buckets": {
+      "blocked": [
+        {
+          "id": "asgn_...",
+          "project_id": "proj_...",
+          "work_item": {
+            "id": "work_...",
+            "title": "Backend substrate",
+            "status": "running",
+            "priority": "high"
+          },
+          "assignment": {
+            "id": "asgn_...",
+            "project_id": "proj_...",
+            "work_item_id": "work_...",
+            "role_id": "software_developer",
+            "driver_kind": "hecate_task",
+            "status": "awaiting_approval",
+            "task_id": "task_...",
+            "run_id": "run_...",
+            "execution": {
+              "task_id": "task_...",
+              "run_id": "run_...",
+              "task_status": "running",
+              "run_status": "awaiting_approval",
+              "status": "awaiting_approval",
+              "pending_approval_count": 1
+            },
+            "created_at": "2026-06-03T12:00:00Z",
+            "updated_at": "2026-06-03T12:01:00Z"
+          },
+          "role": {
+            "id": "software_developer",
+            "project_id": "proj_...",
+            "name": "Software Developer",
+            "built_in": true
+          },
+          "status": "awaiting_approval",
+          "blocking_signal": "awaiting_approval",
+          "status_summary": "1 approval pending",
+          "linked_task_id": "task_...",
+          "linked_run_id": "run_...",
+          "artifact_summary": {
+            "count": 1,
+            "latest_kind": "handoff",
+            "latest_title": "Backend handoff",
+            "latest_at": "2026-06-03T12:03:00Z",
+            "assignment_id": "asgn_..."
+          },
+          "recent_artifacts": [
+            {
+              "id": "art_...",
+              "project_id": "proj_...",
+              "work_item_id": "work_...",
+              "assignment_id": "asgn_...",
+              "kind": "handoff",
+              "title": "Backend handoff",
+              "body": "Ready for review.",
+              "created_at": "2026-06-03T12:03:00Z",
+              "updated_at": "2026-06-03T12:03:00Z"
+            }
+          ],
+          "updated_at": "2026-06-03T12:03:00Z"
+        }
+      ],
+      "active": [],
+      "completed": [],
+      "recent": []
+    },
+    "recent": []
+  }
+}
+```
+
+`blocking_signal` is the compact V1 operator signal. Known values are
+`awaiting_approval`, `failed`, `not_started`, `running`, `completed`, and
+`stale_unknown`. `not_started` means a queued assignment has no linked task,
+run, or chat identifiers. `stale_unknown` covers missing linked task/run
+records, run-only links without enough task context, and unknown status values.
+Rows are sorted by most recent assignment/work/artifact update, then assignment
+ID. Each bucket is capped at 20 rows; `recent` mirrors
+`buckets.recent`. The example above leaves the mirrored recent arrays empty for
+brevity; real responses include the same item shape there when `recent_count`
+is non-zero.
+
 #### `GET /hecate/v1/projects/{id}/roles`
 
 Lists built-in roles plus custom roles for the project.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1357,7 +1357,8 @@ Rows are sorted by most recent assignment/work/artifact update, then assignment
 ID. Each bucket is capped at 20 rows; `recent` mirrors
 `buckets.recent`. The example above leaves the mirrored recent arrays empty for
 brevity; real responses include the same item shape there when `recent_count`
-is non-zero.
+is non-zero. `artifact_summary.assignment_id` is present only when the latest
+summarized artifact is assignment-scoped; work-item-level artifacts omit it.
 
 #### `GET /hecate/v1/projects/{id}/roles`
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -216,6 +217,80 @@ type ProjectWorkArtifactResponse struct {
 	AuthorRoleID string `json:"author_role_id,omitempty"`
 	CreatedAt    string `json:"created_at"`
 	UpdatedAt    string `json:"updated_at"`
+}
+
+type ProjectActivityEnvelope struct {
+	Object string                      `json:"object"`
+	Data   ProjectActivityDataResponse `json:"data"`
+}
+
+type ProjectActivityDataResponse struct {
+	ProjectID string                         `json:"project_id"`
+	Summary   ProjectActivitySummaryResponse `json:"summary"`
+	Buckets   ProjectActivityBucketsResponse `json:"buckets"`
+	Recent    []ProjectActivityItemResponse  `json:"recent"`
+}
+
+type ProjectActivitySummaryResponse struct {
+	WorkItemCount   int `json:"work_item_count"`
+	AssignmentCount int `json:"assignment_count"`
+	ActiveCount     int `json:"active_count"`
+	BlockedCount    int `json:"blocked_count"`
+	CompletedCount  int `json:"completed_count"`
+	RecentCount     int `json:"recent_count"`
+}
+
+type ProjectActivityBucketsResponse struct {
+	Active    []ProjectActivityItemResponse `json:"active"`
+	Blocked   []ProjectActivityItemResponse `json:"blocked"`
+	Completed []ProjectActivityItemResponse `json:"completed"`
+	Recent    []ProjectActivityItemResponse `json:"recent"`
+}
+
+type ProjectActivityItemResponse struct {
+	ID              string                                 `json:"id"`
+	ProjectID       string                                 `json:"project_id"`
+	WorkItem        ProjectActivityWorkItemResponse        `json:"work_item"`
+	Assignment      ProjectWorkAssignmentResponse          `json:"assignment"`
+	Role            ProjectWorkRoleResponse                `json:"role"`
+	Status          string                                 `json:"status"`
+	BlockingSignal  string                                 `json:"blocking_signal"`
+	StatusSummary   string                                 `json:"status_summary"`
+	LinkedTaskID    string                                 `json:"linked_task_id,omitempty"`
+	LinkedRunID     string                                 `json:"linked_run_id,omitempty"`
+	LinkedChatID    string                                 `json:"linked_chat_id,omitempty"`
+	LinkedMessageID string                                 `json:"linked_message_id,omitempty"`
+	RecentArtifacts []ProjectWorkArtifactResponse          `json:"recent_artifacts,omitempty"`
+	ArtifactSummary ProjectActivityArtifactSummaryResponse `json:"artifact_summary"`
+	UpdatedAt       string                                 `json:"updated_at"`
+}
+
+type ProjectActivityWorkItemResponse struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Status   string `json:"status"`
+	Priority string `json:"priority"`
+}
+
+type ProjectActivityArtifactSummaryResponse struct {
+	Count        int    `json:"count"`
+	LatestKind   string `json:"latest_kind,omitempty"`
+	LatestTitle  string `json:"latest_title,omitempty"`
+	LatestAt     string `json:"latest_at,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+}
+
+func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	activity, err := h.renderProjectActivity(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectActivityEnvelope{Object: "project_activity", Data: activity})
 }
 
 func (h *Handler) HandleProjectWorkRoles(w http.ResponseWriter, r *http.Request) {
@@ -1439,6 +1514,307 @@ func projectWorkPendingApprovalCount(ctx context.Context, store taskRunApprovalS
 
 type taskRunApprovalStore interface {
 	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
+}
+
+func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	workItems, err := h.projectWork.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	artifacts, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+
+	roleByID := make(map[string]projectwork.AgentRoleProfile, len(roles))
+	for _, role := range roles {
+		roleByID[role.ID] = role
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
+	for _, item := range workItems {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return ProjectActivityDataResponse{}, err
+		}
+		projectedWorkItems[item.ID] = projected
+	}
+
+	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
+	items := make([]ProjectActivityItemResponse, 0, len(assignments))
+	for _, assignment := range assignments {
+		projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if err != nil {
+			return ProjectActivityDataResponse{}, err
+		}
+		workItem := projectedWorkItems[assignment.WorkItemID]
+		activityArtifacts := artifactsByAssignment[assignment.ID]
+		if len(activityArtifacts) == 0 {
+			activityArtifacts = artifactsByWorkItem[assignment.WorkItemID]
+		}
+		role, _ := roleByID[assignment.RoleID]
+		items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts))
+	}
+	sortProjectActivityItems(items)
+
+	response := ProjectActivityDataResponse{
+		ProjectID: projectID,
+		Recent:    boundedProjectActivityItems(items, 20),
+	}
+	response.Summary.WorkItemCount = len(workItems)
+	response.Summary.AssignmentCount = len(assignments)
+	for _, item := range items {
+		switch projectActivityBucket(item) {
+		case "active":
+			response.Buckets.Active = append(response.Buckets.Active, item)
+			response.Summary.ActiveCount++
+		case "blocked":
+			response.Buckets.Blocked = append(response.Buckets.Blocked, item)
+			response.Summary.BlockedCount++
+		case "completed":
+			response.Buckets.Completed = append(response.Buckets.Completed, item)
+			response.Summary.CompletedCount++
+		}
+	}
+	response.Buckets.Recent = response.Recent
+	response.Summary.RecentCount = len(response.Recent)
+	response.Buckets.Active = boundedProjectActivityItems(response.Buckets.Active, 20)
+	response.Buckets.Blocked = boundedProjectActivityItems(response.Buckets.Blocked, 20)
+	response.Buckets.Completed = boundedProjectActivityItems(response.Buckets.Completed, 20)
+	return response, nil
+}
+
+func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact) ProjectActivityItemResponse {
+	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts, assignment.ID)
+	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
+	if status == "" {
+		status = "unknown"
+	}
+	signal := projectActivityBlockingSignal(assignment)
+	return ProjectActivityItemResponse{
+		ID:              assignment.ID,
+		ProjectID:       assignment.ProjectID,
+		WorkItem:        renderProjectActivityWorkItem(workItem),
+		Assignment:      assignment,
+		Role:            renderProjectWorkRole(role),
+		Status:          status,
+		BlockingSignal:  signal,
+		StatusSummary:   projectActivityStatusSummary(assignment, signal, artifactSummary.Count),
+		LinkedTaskID:    firstNonEmpty(projectActivityExecutionTaskID(assignment), assignment.TaskID),
+		LinkedRunID:     firstNonEmpty(projectActivityExecutionRunID(assignment), assignment.RunID),
+		LinkedChatID:    assignment.ChatSessionID,
+		LinkedMessageID: assignment.MessageID,
+		RecentArtifacts: recentArtifacts,
+		ArtifactSummary: artifactSummary,
+		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, artifactSummary),
+	}
+}
+
+func renderProjectActivityWorkItem(item ProjectWorkItemResponse) ProjectActivityWorkItemResponse {
+	return ProjectActivityWorkItemResponse{
+		ID:       item.ID,
+		Title:    item.Title,
+		Status:   item.Status,
+		Priority: item.Priority,
+	}
+}
+
+func renderProjectActivityArtifactSignals(artifacts []projectwork.CollaborationArtifact, assignmentID string) (ProjectActivityArtifactSummaryResponse, []ProjectWorkArtifactResponse) {
+	if len(artifacts) == 0 {
+		return ProjectActivityArtifactSummaryResponse{}, nil
+	}
+	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := items[i], items[j]
+		if !left.UpdatedAt.Equal(right.UpdatedAt) {
+			return left.UpdatedAt.After(right.UpdatedAt)
+		}
+		if !left.CreatedAt.Equal(right.CreatedAt) {
+			return left.CreatedAt.After(right.CreatedAt)
+		}
+		return left.ID < right.ID
+	})
+	latest := items[0]
+	summary := ProjectActivityArtifactSummaryResponse{
+		Count:        len(items),
+		LatestKind:   latest.Kind,
+		LatestTitle:  firstNonEmpty(latest.Title, latest.ID),
+		LatestAt:     formatOptionalTime(firstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
+		AssignmentID: assignmentID,
+	}
+	limit := len(items)
+	if limit > 3 {
+		limit = 3
+	}
+	recent := make([]ProjectWorkArtifactResponse, 0, limit)
+	for _, artifact := range items[:limit] {
+		recent = append(recent, renderProjectWorkArtifact(artifact))
+	}
+	return summary, recent
+}
+
+func groupProjectActivityArtifacts(artifacts []projectwork.CollaborationArtifact) (map[string][]projectwork.CollaborationArtifact, map[string][]projectwork.CollaborationArtifact) {
+	byAssignment := make(map[string][]projectwork.CollaborationArtifact)
+	byWorkItem := make(map[string][]projectwork.CollaborationArtifact)
+	for _, artifact := range artifacts {
+		if artifact.AssignmentID != "" {
+			byAssignment[artifact.AssignmentID] = append(byAssignment[artifact.AssignmentID], artifact)
+			continue
+		}
+		byWorkItem[artifact.WorkItemID] = append(byWorkItem[artifact.WorkItemID], artifact)
+	}
+	return byAssignment, byWorkItem
+}
+
+func sortProjectActivityItems(items []ProjectActivityItemResponse) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := parseProjectActivityTime(items[i].UpdatedAt), parseProjectActivityTime(items[j].UpdatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func boundedProjectActivityItems(items []ProjectActivityItemResponse, limit int) []ProjectActivityItemResponse {
+	if len(items) == 0 {
+		return []ProjectActivityItemResponse{}
+	}
+	if limit > 0 && len(items) > limit {
+		return append([]ProjectActivityItemResponse(nil), items[:limit]...)
+	}
+	return append([]ProjectActivityItemResponse(nil), items...)
+}
+
+func projectActivityBucket(item ProjectActivityItemResponse) string {
+	switch item.BlockingSignal {
+	case "awaiting_approval", "failed", "not_started", "stale_unknown":
+		return "blocked"
+	case "completed":
+		return "completed"
+	case "running":
+		return "active"
+	default:
+		return "active"
+	}
+}
+
+func projectActivityBlockingSignal(assignment ProjectWorkAssignmentResponse) string {
+	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
+	switch status {
+	case projectwork.AssignmentStatusAwaitingApproval:
+		return "awaiting_approval"
+	case projectwork.AssignmentStatusFailed:
+		return "failed"
+	case projectwork.AssignmentStatusCompleted:
+		return "completed"
+	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusQueued:
+		if assignment.Execution == nil && assignment.TaskID == "" && assignment.RunID != "" {
+			return "stale_unknown"
+		}
+		if assignment.Execution != nil && assignment.Execution.Missing {
+			return "stale_unknown"
+		}
+		if status == projectwork.AssignmentStatusQueued && assignment.TaskID == "" && assignment.RunID == "" && assignment.ChatSessionID == "" {
+			return "not_started"
+		}
+		return "running"
+	default:
+		if assignment.Execution != nil && assignment.Execution.Missing {
+			return "stale_unknown"
+		}
+		return "stale_unknown"
+	}
+}
+
+func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, signal string, artifactCount int) string {
+	switch signal {
+	case "awaiting_approval":
+		count := 0
+		if assignment.Execution != nil {
+			count = assignment.Execution.PendingApprovalCount
+		}
+		if count > 0 {
+			return fmt.Sprintf("%d approval pending", count)
+		}
+		return "awaiting approval"
+	case "failed":
+		if assignment.Execution != nil && assignment.Execution.LastError != "" {
+			return assignment.Execution.LastError
+		}
+		return "failed run"
+	case "not_started":
+		return "not started"
+	case "running":
+		return "running"
+	case "completed":
+		if artifactCount > 0 {
+			return fmt.Sprintf("completed with %d artifact%s", artifactCount, pluralSuffix(artifactCount))
+		}
+		return "completed"
+	default:
+		return "stale or unknown"
+	}
+}
+
+func projectActivityExecutionStatus(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.Execution == nil {
+		return ""
+	}
+	return assignment.Execution.Status
+}
+
+func projectActivityExecutionTaskID(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.Execution == nil {
+		return ""
+	}
+	return assignment.Execution.TaskID
+}
+
+func projectActivityExecutionRunID(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.Execution == nil {
+		return ""
+	}
+	return assignment.Execution.RunID
+}
+
+func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, artifacts ProjectActivityArtifactSummaryResponse) string {
+	latest := parseProjectActivityTime(firstNonEmpty(assignment.CompletedAt, assignment.StartedAt, assignment.UpdatedAt, assignment.CreatedAt))
+	workUpdated := parseProjectActivityTime(workItem.UpdatedAt)
+	artifactUpdated := parseProjectActivityTime(artifacts.LatestAt)
+	if workUpdated.After(latest) {
+		latest = workUpdated
+	}
+	if artifactUpdated.After(latest) {
+		latest = artifactUpdated
+	}
+	return formatOptionalTime(latest)
+}
+
+func parseProjectActivityTime(value string) time.Time {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func projectWorkItemStatusFromAssignments(storedStatus string, assignments []ProjectWorkAssignmentResponse) string {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1550,18 +1550,15 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 
 	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
 	items := make([]ProjectActivityItemResponse, 0, len(assignments))
-	for _, assignment := range assignments {
-		projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
-		if err != nil {
-			return ProjectActivityDataResponse{}, err
+	for _, workItem := range projectedWorkItems {
+		for _, projected := range workItem.Assignments {
+			activityArtifacts := artifactsByAssignment[projected.ID]
+			if len(activityArtifacts) == 0 {
+				activityArtifacts = artifactsByWorkItem[projected.WorkItemID]
+			}
+			role, _ := roleByID[projected.RoleID]
+			items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts))
 		}
-		workItem := projectedWorkItems[assignment.WorkItemID]
-		activityArtifacts := artifactsByAssignment[assignment.ID]
-		if len(activityArtifacts) == 0 {
-			activityArtifacts = artifactsByWorkItem[assignment.WorkItemID]
-		}
-		role, _ := roleByID[assignment.RoleID]
-		items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts))
 	}
 	sortProjectActivityItems(items)
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1590,7 +1590,7 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 }
 
 func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact) ProjectActivityItemResponse {
-	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts, assignment.ID)
+	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts)
 	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
 	if status == "" {
 		status = "unknown"
@@ -1624,7 +1624,7 @@ func renderProjectActivityWorkItem(item ProjectWorkItemResponse) ProjectActivity
 	}
 }
 
-func renderProjectActivityArtifactSignals(artifacts []projectwork.CollaborationArtifact, assignmentID string) (ProjectActivityArtifactSummaryResponse, []ProjectWorkArtifactResponse) {
+func renderProjectActivityArtifactSignals(artifacts []projectwork.CollaborationArtifact) (ProjectActivityArtifactSummaryResponse, []ProjectWorkArtifactResponse) {
 	if len(artifacts) == 0 {
 		return ProjectActivityArtifactSummaryResponse{}, nil
 	}
@@ -1645,7 +1645,7 @@ func renderProjectActivityArtifactSignals(artifacts []projectwork.CollaborationA
 		LatestKind:   latest.Kind,
 		LatestTitle:  firstNonEmpty(latest.Title, latest.ID),
 		LatestAt:     formatOptionalTime(firstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
-		AssignmentID: assignmentID,
+		AssignmentID: latest.AssignmentID,
 	}
 	limit := len(items)
 	if limit > 3 {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -914,6 +914,71 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
+	t.Parallel()
+	for _, backend := range []string{"memory", "sqlite"} {
+		backend := backend
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+			handler, server := newProjectWorkProjectionTestServer(t, backend)
+			seedProjectWorkProjectionTest(t, handler)
+
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/activity", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("activity status = %d body=%s, want 200", rec.Code, rec.Body.String())
+			}
+			var response ProjectActivityEnvelope
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode activity: %v", err)
+			}
+			if response.Object != "project_activity" || response.Data.ProjectID != "proj_projection" {
+				t.Fatalf("activity envelope = %+v, want project_activity for project", response)
+			}
+			if response.Data.Summary.WorkItemCount == 0 || response.Data.Summary.AssignmentCount == 0 {
+				t.Fatalf("activity summary = %+v, want work and assignment counts", response.Data.Summary)
+			}
+
+			awaiting := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_awaiting")
+			if awaiting.BlockingSignal != "awaiting_approval" || awaiting.Assignment.Execution == nil || awaiting.Assignment.Execution.PendingApprovalCount != 1 {
+				t.Fatalf("awaiting activity = %+v, want approval blocking signal", awaiting)
+			}
+			if awaiting.WorkItem.Status != projectwork.WorkItemStatusRunning || awaiting.Role.Name != "Projection engineer" {
+				t.Fatalf("awaiting context = %+v, want projected work item and role", awaiting)
+			}
+
+			failed := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_failed")
+			if failed.BlockingSignal != "failed" || failed.StatusSummary != "model failed" {
+				t.Fatalf("failed activity = %+v, want failed signal and compact error", failed)
+			}
+
+			missing := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_missing")
+			if missing.BlockingSignal != "stale_unknown" || missing.LinkedTaskID == "" {
+				t.Fatalf("missing activity = %+v, want stale/unknown with linked task id", missing)
+			}
+
+			runOnly := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_run_only")
+			if runOnly.BlockingSignal != "stale_unknown" || runOnly.LinkedRunID != "run_without_task" {
+				t.Fatalf("run-only activity = %+v, want stale/unknown with linked run id", runOnly)
+			}
+
+			notStarted := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_not_started")
+			if notStarted.BlockingSignal != "not_started" || notStarted.LinkedTaskID != "" || notStarted.LinkedRunID != "" {
+				t.Fatalf("not-started activity = %+v, want not_started without linked runtime ids", notStarted)
+			}
+
+			completed := findProjectActivityItemForTest(t, response.Data.Buckets.Completed, "asgn_completed")
+			if completed.BlockingSignal != "completed" || completed.ArtifactSummary.Count != 1 || completed.ArtifactSummary.LatestTitle != "Completion handoff" {
+				t.Fatalf("completed activity = %+v, want artifact signal", completed)
+			}
+
+			if len(response.Data.Recent) == 0 || len(response.Data.Buckets.Recent) != len(response.Data.Recent) {
+				t.Fatalf("recent activity = %+v buckets=%+v, want mirrored recent list", response.Data.Recent, response.Data.Buckets.Recent)
+			}
+		})
+	}
+}
+
 type failingCreateTaskStore struct {
 	taskstate.Store
 }
@@ -1062,6 +1127,7 @@ func seedProjectWorkProjectionTest(t *testing.T, handler *Handler) {
 		seedProjectWorkProjectionCase(t, handler, tc.workID, tc.assignmentID, tc.assignmentStatus, tc.runStatus, tc.runStartedAt, tc.runFinishedAt, tc.assignmentUpdated, tc.lastError, tc.approvalPending, tc.missing)
 	}
 	seedProjectWorkRunOnlyProjectionCase(t, handler)
+	seedProjectWorkNotStartedProjectionCase(t, handler)
 	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_completed", "", "completed", base.Add(12*time.Minute), base.Add(13*time.Minute), time.Time{}, "", false, false)
 	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_failed", "", "failed", base.Add(14*time.Minute), base.Add(15*time.Minute), time.Time{}, "review failed", false, false)
 }
@@ -1087,6 +1153,31 @@ func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
 		RunID:      "run_without_task",
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_run_only): %v", err)
+	}
+}
+
+func seedProjectWorkNotStartedProjectionCase(t *testing.T, handler *Handler) {
+	t.Helper()
+	ctx := t.Context()
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_not_started",
+		ProjectID: "proj_projection",
+		Title:     "work_not_started",
+		Status:    projectwork.WorkItemStatusReady,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_not_started): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_not_started",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_not_started",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+		CreatedAt:  time.Date(2026, 6, 3, 11, 58, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 3, 11, 58, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_not_started): %v", err)
 	}
 }
 
@@ -1173,6 +1264,21 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 			t.Fatalf("CreateApproval(%s): %v", assignmentID, err)
 		}
 	}
+	if assignmentID == "asgn_completed" {
+		if _, err := handler.projectWork.CreateArtifact(ctx, projectwork.CollaborationArtifact{
+			ID:           "art_" + assignmentID,
+			ProjectID:    "proj_projection",
+			WorkItemID:   workID,
+			AssignmentID: assignmentID,
+			Kind:         projectwork.ArtifactKindHandoff,
+			Title:        "Completion handoff",
+			Body:         "Ready for review.",
+			CreatedAt:    runFinishedAt.Add(time.Minute),
+			UpdatedAt:    runFinishedAt.Add(time.Minute),
+		}); err != nil {
+			t.Fatalf("CreateArtifact(%s): %v", assignmentID, err)
+		}
+	}
 }
 
 func getProjectWorkAssignmentForTest(t *testing.T, server http.Handler, workID, assignmentID string) ProjectWorkAssignmentResponse {
@@ -1251,6 +1357,17 @@ func assertStoredProjectWorkAssignmentStatusForTest(t *testing.T, handler *Handl
 		}
 	}
 	t.Fatalf("stored assignment %s not found in %+v", assignmentID, assignments)
+}
+
+func findProjectActivityItemForTest(t *testing.T, items []ProjectActivityItemResponse, assignmentID string) ProjectActivityItemResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.Assignment.ID == assignmentID {
+			return item
+		}
+	}
+	t.Fatalf("activity assignment %s not found in %+v", assignmentID, items)
+	return ProjectActivityItemResponse{}
 }
 
 func boolToInt(value bool) int {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -966,9 +966,12 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			if notStarted.BlockingSignal != "not_started" || notStarted.LinkedTaskID != "" || notStarted.LinkedRunID != "" {
 				t.Fatalf("not-started activity = %+v, want not_started without linked runtime ids", notStarted)
 			}
+			if notStarted.ArtifactSummary.Count != 1 || notStarted.ArtifactSummary.AssignmentID != "" {
+				t.Fatalf("not-started artifact summary = %+v, want work-item artifact without assignment attribution", notStarted.ArtifactSummary)
+			}
 
 			completed := findProjectActivityItemForTest(t, response.Data.Buckets.Completed, "asgn_completed")
-			if completed.BlockingSignal != "completed" || completed.ArtifactSummary.Count != 1 || completed.ArtifactSummary.LatestTitle != "Completion handoff" {
+			if completed.BlockingSignal != "completed" || completed.ArtifactSummary.Count != 1 || completed.ArtifactSummary.LatestTitle != "Completion handoff" || completed.ArtifactSummary.AssignmentID != "asgn_completed" {
 				t.Fatalf("completed activity = %+v, want artifact signal", completed)
 			}
 
@@ -1178,6 +1181,18 @@ func seedProjectWorkNotStartedProjectionCase(t *testing.T, handler *Handler) {
 		UpdatedAt:  time.Date(2026, 6, 3, 11, 58, 0, 0, time.UTC),
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_not_started): %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(ctx, projectwork.CollaborationArtifact{
+		ID:         "art_work_not_started",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_not_started",
+		Kind:       projectwork.ArtifactKindHandoff,
+		Title:      "Work-item handoff",
+		Body:       "Shared at the work-item level.",
+		CreatedAt:  time.Date(2026, 6, 3, 11, 58, 30, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 3, 11, 58, 30, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateArtifact(work_not_started): %v", err)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/activity", handler.HandleProjectActivity)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/roles", handler.HandleProjectWorkRoles)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roles", handler.HandleCreateProjectWorkRole)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/roles/{role_id}", handler.HandleUpdateProjectWorkRole)

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -10,6 +10,7 @@ import {
 import { withRuntimeConsole } from "../test/runtime-console-render";
 import {
   getProjectAssignments,
+  getProjectActivity,
   getProjectCollaborationArtifacts,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -30,6 +31,10 @@ vi.mock("../lib/api", async (importOriginal) => {
   };
   return {
     ...actual,
+    getProjectActivity: vi.fn(async () => ({
+      object: "project_activity",
+      data: emptyActivityData(),
+    })),
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: emptyWorkItem })),
@@ -41,6 +46,27 @@ vi.mock("../lib/api", async (importOriginal) => {
   };
 });
 
+function emptyActivityData() {
+  return {
+    project_id: "",
+    summary: {
+      work_item_count: 0,
+      assignment_count: 0,
+      active_count: 0,
+      blocked_count: 0,
+      completed_count: 0,
+      recent_count: 0,
+    },
+    buckets: {
+      active: [],
+      blocked: [],
+      completed: [],
+      recent: [],
+    },
+    recent: [],
+  };
+}
+
 function resetProjectWorkMocks() {
   const emptyWorkItem: ProjectWorkItemRecord = {
     id: "",
@@ -51,6 +77,10 @@ function resetProjectWorkMocks() {
     created_at: "",
     updated_at: "",
   };
+  vi.mocked(getProjectActivity).mockResolvedValue({
+    object: "project_activity",
+    data: emptyActivityData(),
+  });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });
   vi.mocked(getProjectWorkItem).mockResolvedValue({

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -12,6 +12,7 @@ import {
   deleteProjectAssignment,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
+  getProjectActivity,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
   getProjectWorkItem,
@@ -44,10 +45,35 @@ type LaunchContextContract = {
 
 const launchContextContract = launchContextContractRaw as LaunchContextContract;
 
+function emptyActivityData() {
+  return {
+    project_id: "",
+    summary: {
+      work_item_count: 0,
+      assignment_count: 0,
+      active_count: 0,
+      blocked_count: 0,
+      completed_count: 0,
+      recent_count: 0,
+    },
+    buckets: {
+      active: [],
+      blocked: [],
+      completed: [],
+      recent: [],
+    },
+    recent: [],
+  };
+}
+
 vi.mock("../../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/api")>();
   return {
     ...actual,
+    getProjectActivity: vi.fn(async () => ({
+      object: "project_activity",
+      data: emptyActivityData(),
+    })),
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
@@ -143,6 +169,60 @@ const hecateAssignment: ProjectAssignmentRecord = {
 };
 
 function resetProjectWorkMocks() {
+  vi.mocked(getProjectActivity).mockResolvedValue({
+    object: "project_activity",
+    data: {
+      project_id: project.id,
+      summary: {
+        work_item_count: 1,
+        assignment_count: 1,
+        active_count: 0,
+        blocked_count: 1,
+        completed_count: 0,
+        recent_count: 1,
+      },
+      buckets: {
+        active: [],
+        blocked: [
+          {
+            id: hecateAssignment.id,
+            project_id: project.id,
+            work_item: {
+              id: workItem.id,
+              title: workItem.title,
+              status: "running",
+              priority: workItem.priority,
+            },
+            assignment: hecateAssignment,
+            role,
+            status: "awaiting_approval",
+            blocking_signal: "awaiting_approval",
+            status_summary: "2 approval pending",
+            linked_task_id: "task_1",
+            linked_run_id: "run_1",
+            artifact_summary: { count: 1, latest_kind: "handoff", latest_title: "Runtime notes" },
+            recent_artifacts: [
+              {
+                id: "art_1",
+                project_id: project.id,
+                work_item_id: workItem.id,
+                assignment_id: hecateAssignment.id,
+                kind: "handoff",
+                title: "Runtime notes",
+                body: "Approval is waiting.",
+                created_at: "2026-06-02T11:05:00Z",
+                updated_at: "2026-06-02T11:05:00Z",
+              },
+            ],
+            updated_at: "2026-06-02T11:05:00Z",
+          },
+        ],
+        completed: [],
+        recent: [],
+      },
+      recent: [],
+    },
+  });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [role] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({
     object: "project_work_items",
@@ -240,6 +320,7 @@ function expectLaunchContextContract(text: string) {
 
 afterEach(() => {
   window.localStorage.clear();
+  vi.mocked(getProjectActivity).mockReset();
   vi.mocked(getProjectWorkRoles).mockReset();
   vi.mocked(getProjectWorkItems).mockReset();
   vi.mocked(getProjectWorkItem).mockReset();
@@ -269,7 +350,7 @@ describe("ProjectsView index", () => {
     expect(screen.getByRole("button", { name: "Open project Hecate" })).toBeTruthy();
     expect(screen.getByText("/Users/alice/dev/hecate")).toBeTruthy();
     expect(screen.getByText("ollama / qwen2.5-coder")).toBeTruthy();
-    expect(await screen.findByText("Build cockpit UI")).toBeTruthy();
+    expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
   });
 
   it("renders empty, loading, and error states for the project index", () => {
@@ -509,10 +590,115 @@ describe("ProjectsView cockpit", () => {
     expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
     const detail = screen.getByLabelText("Selected work item");
     expect(within(detail).getByText("Software developer")).toBeTruthy();
-    expect(within(detail).getByText("approval")).toBeTruthy();
-    expect(within(detail).getByText("2 approval pending")).toBeTruthy();
+    expect(within(detail).getAllByText("approval").length).toBeGreaterThan(0);
+    expect(within(detail).getAllByText("2 approval pending").length).toBeGreaterThan(0);
     expect(within(detail).getByText("4 steps")).toBeTruthy();
     expect(within(detail).getByText("ollama / qwen2.5-coder")).toBeTruthy();
+  });
+
+  it("renders project activity inbox states and actions", async () => {
+    resetProjectWorkMocks();
+    const onOpenTask = vi.fn();
+    const onOpenChat = vi.fn();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(<ProjectsView onOpenTask={onOpenTask} onOpenChat={onOpenChat} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
+
+    expect(await screen.findByText("Activity Inbox")).toBeTruthy();
+    expect(screen.getByText("1 assignments across 1 work items")).toBeTruthy();
+    expect(screen.getAllByText("2 approval pending").length).toBeGreaterThan(0);
+    expect(screen.getByText("handoff: Runtime notes")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Task" }));
+    expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
+
+    await userEvent.click(screen.getByRole("button", { name: "Chat" }));
+    expect(onOpenChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectID: project.id,
+        model: "qwen2.5-coder",
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(screen.getByRole("button", { name: "Open work item Build cockpit UI" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("starts not-started assignments from the activity inbox", async () => {
+    resetProjectWorkMocks();
+    const notStartedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_not_started",
+      task_id: "",
+      run_id: "",
+      status: "queued",
+      execution: undefined,
+      started_at: undefined,
+    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: {
+        project_id: project.id,
+        summary: {
+          work_item_count: 1,
+          assignment_count: 1,
+          active_count: 0,
+          blocked_count: 1,
+          completed_count: 0,
+          recent_count: 1,
+        },
+        buckets: {
+          active: [],
+          blocked: [
+            {
+              id: notStartedAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "ready",
+                priority: workItem.priority,
+              },
+              assignment: notStartedAssignment,
+              role,
+              status: "queued",
+              blocking_signal: "not_started",
+              status_summary: "not started",
+              artifact_summary: { count: 0 },
+              updated_at: "2026-06-02T11:00:00Z",
+            },
+          ],
+          completed: [],
+          recent: [],
+        },
+        recent: [],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Start" }));
+
+    expect(startProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      notStartedAssignment.id,
+    );
   });
 
   it("opens chat from an assignment using the projected model", async () => {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -613,7 +613,9 @@ describe("ProjectsView cockpit", () => {
     );
 
     expect(await screen.findByText("Activity Inbox")).toBeTruthy();
-    expect(screen.getByText("1 assignments across 1 work items")).toBeTruthy();
+    expect(
+      screen.getByText(/1 assignments across 1 work items; newest 20 per bucket/),
+    ).toBeTruthy();
     expect(screen.getAllByText("2 approval pending").length).toBeGreaterThan(0);
     expect(screen.getByText("handoff: Runtime notes")).toBeTruthy();
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -430,6 +430,21 @@ describe("ProjectsView cockpit", () => {
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
   });
 
+  it("keeps project work visible when activity loading fails", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectActivity).mockRejectedValueOnce(new Error("activity failed"));
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
+    expect(screen.getByText("No activity is recorded for this project yet.")).toBeTruthy();
+    expect(screen.queryByText("activity failed")).toBeNull();
+  });
+
   it("clears stale work item selection before switching projects", async () => {
     resetProjectWorkMocks();
     const secondProject: ProjectRecord = {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -280,16 +280,17 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
     setWorkLoadState("loading");
     try {
+      const activityLoad = getProjectActivity(projectID).catch(() => null);
       const [rolesRes, workRes, activityRes] = await Promise.all([
         getProjectWorkRoles(projectID),
         getProjectWorkItems(projectID),
-        getProjectActivity(projectID),
+        activityLoad,
       ]);
       const nextRoles = rolesRes.data ?? [];
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
-      setActivity(activityRes.data ?? null);
+      setActivity(activityRes?.data ?? null);
       setWorkItemSummaries(
         Object.fromEntries(
           nextItems.map((item) => [item.id, summarizeAssignments(item.assignments ?? [])] as const),

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -10,6 +10,7 @@ import {
   deleteProjectAssignment,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
+  getProjectActivity,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
   getProjectWorkItem,
@@ -25,6 +26,8 @@ import { formatAbsoluteTime } from "../../lib/format";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type {
   ProjectAssignmentRecord,
+  ProjectActivityData,
+  ProjectActivityItemRecord,
   ProjectCollaborationArtifactRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
@@ -67,6 +70,8 @@ type WorkItemSummary = {
   failedCount: number;
   completedCount: number;
 };
+
+type ProjectActivityBucketKey = "active" | "blocked" | "completed" | "recent";
 
 type LoadState = "idle" | "loading" | "loaded" | "error";
 
@@ -201,6 +206,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [deleteAssignmentPending, setDeleteAssignmentPending] = useState(false);
   const [workItems, setWorkItems] = useState<ProjectWorkItemRecord[]>([]);
   const [workItemSummaries, setWorkItemSummaries] = useState<Record<string, WorkItemSummary>>({});
+  const [activity, setActivity] = useState<ProjectActivityData | null>(null);
   const [roles, setRoles] = useState<ProjectWorkRoleRecord[]>([]);
   const [selectedWorkItemID, setSelectedWorkItemID] = useState("");
   const [selectedWorkItem, setSelectedWorkItem] = useState<ProjectWorkItemRecord | null>(null);
@@ -261,6 +267,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setAssignmentErrors({});
     setWorkItems([]);
     setWorkItemSummaries({});
+    setActivity(null);
     if (!preferredWorkItemID) {
       setSelectedWorkItemID("");
       setSelectedWorkItem(null);
@@ -273,14 +280,16 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
     setWorkLoadState("loading");
     try {
-      const [rolesRes, workRes] = await Promise.all([
+      const [rolesRes, workRes, activityRes] = await Promise.all([
         getProjectWorkRoles(projectID),
         getProjectWorkItems(projectID),
+        getProjectActivity(projectID),
       ]);
       const nextRoles = rolesRes.data ?? [];
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
+      setActivity(activityRes.data ?? null);
       setWorkItemSummaries(
         Object.fromEntries(
           nextItems.map((item) => [item.id, summarizeAssignments(item.assignments ?? [])] as const),
@@ -605,25 +614,26 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
-  async function handleStartAssignment(assignment: ProjectAssignmentRecord) {
-    if (!selectedProjectID || !selectedWorkItemID) return;
+  async function handleStartAssignment(
+    assignment: ProjectAssignmentRecord,
+    workItemID = selectedWorkItemID,
+  ) {
+    if (!selectedProjectID || !workItemID) return;
     setStartingAssignmentID(assignment.id);
     setAssignmentErrors((current) => ({ ...current, [assignment.id]: "" }));
     try {
-      const res = await startProjectAssignment(
-        selectedProjectID,
-        selectedWorkItemID,
-        assignment.id,
-      );
+      const res = await startProjectAssignment(selectedProjectID, workItemID, assignment.id);
       setAssignments((current) => upsertAssignment(current, res.data));
-      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+      await loadWorkForProject(selectedProjectID, workItemID);
+      await loadWorkItemDetail(selectedProjectID, workItemID);
     } catch (error) {
       setAssignmentErrors((current) => ({
         ...current,
         [assignment.id]: errorMessage(error, "Failed to start assignment."),
       }));
       if (error instanceof ApiError && error.status === 409) {
-        await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+        await loadWorkForProject(selectedProjectID, workItemID);
+        await loadWorkItemDetail(selectedProjectID, workItemID);
       }
     } finally {
       setStartingAssignmentID("");
@@ -738,6 +748,19 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       </section>
 
       <section style={detailStyle} aria-label="Selected work item">
+        <ProjectActivityInbox
+          activity={activity}
+          loading={workLoadState === "loading"}
+          onOpenChat={onOpenChat}
+          onOpenTask={onOpenTask}
+          onSelectWorkItem={setSelectedWorkItemID}
+          onStartAssignment={(assignment, workItemID) =>
+            void handleStartAssignment(assignment, workItemID)
+          }
+          project={selectedProject}
+          startingAssignmentID={startingAssignmentID}
+          workItems={workItems}
+        />
         <WorkItemDetail
           assignments={assignments}
           artifacts={artifacts}
@@ -1130,6 +1153,214 @@ function WorkItemRow({
         {summary && summary.failedCount > 0 && <span>{summary.failedCount} failed</span>}
         {summary && summary.completedCount > 0 && <span>{summary.completedCount} done</span>}
       </div>
+    </div>
+  );
+}
+
+function ProjectActivityInbox({
+  activity,
+  loading,
+  onOpenChat,
+  onOpenTask,
+  onSelectWorkItem,
+  onStartAssignment,
+  project,
+  startingAssignmentID,
+  workItems,
+}: {
+  activity: ProjectActivityData | null;
+  loading: boolean;
+  onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  onStartAssignment: (assignment: ProjectAssignmentRecord, workItemID: string) => void;
+  project: ProjectRecord | null;
+  startingAssignmentID: string;
+  workItems: ProjectWorkItemRecord[];
+}) {
+  const [bucket, setBucket] = useState<ProjectActivityBucketKey>("blocked");
+  const counts = activity?.summary;
+  const buckets = activity?.buckets;
+  const selectedItems = buckets?.[bucket] ?? [];
+  const tabs: Array<{ id: ProjectActivityBucketKey; label: string; count: number }> = [
+    { id: "blocked", label: "Blocked", count: counts?.blocked_count ?? 0 },
+    { id: "active", label: "Active", count: counts?.active_count ?? 0 },
+    { id: "completed", label: "Completed", count: counts?.completed_count ?? 0 },
+    { id: "recent", label: "Recent", count: counts?.recent_count ?? 0 },
+  ];
+
+  if (!project) {
+    return null;
+  }
+
+  return (
+    <div style={{ padding: "16px 16px 0", display: "grid", gap: 10 }}>
+      <div style={panelStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+          <div>
+            <div style={sectionLabelStyle}>Activity Inbox</div>
+            <div style={{ ...subtleTextStyle, marginTop: 3 }}>
+              {loading && !activity
+                ? "Loading project activity…"
+                : `${counts?.assignment_count ?? 0} assignments across ${counts?.work_item_count ?? 0} work items`}
+            </div>
+          </div>
+          <div style={{ marginLeft: "auto", display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                className={bucket === tab.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"}
+                type="button"
+                onClick={() => setBucket(tab.id)}
+              >
+                {tab.label}
+                <span className="badge badge-muted">{tab.count}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        {!activity && !loading && (
+          <div style={subtleTextStyle}>No activity is recorded for this project yet.</div>
+        )}
+        {activity && selectedItems.length === 0 && (
+          <div style={subtleTextStyle}>No {bucket} assignments for this project.</div>
+        )}
+        {selectedItems.length > 0 && (
+          <div style={{ display: "grid", gap: 8 }}>
+            {selectedItems.map((item) => {
+              const workItem =
+                workItems.find((candidate) => candidate.id === item.work_item.id) ??
+                projectActivityWorkItemToWorkItem(project.id, item.work_item);
+              const chatModel =
+                item.assignment.execution?.model ||
+                item.role.default_model ||
+                project.default_model ||
+                "";
+              return (
+                <ProjectActivityRow
+                  key={item.id}
+                  chatModel={chatModel}
+                  item={item}
+                  onOpenChat={
+                    project
+                      ? () =>
+                          onOpenChat?.(
+                            buildProjectAssignmentChatLaunchRequest({
+                              project,
+                              workItem,
+                              assignment: item.assignment,
+                              role: item.role,
+                            }),
+                          )
+                      : undefined
+                  }
+                  onOpenTask={onOpenTask}
+                  onSelectWorkItem={() => onSelectWorkItem(item.work_item.id)}
+                  onStart={() => onStartAssignment(item.assignment, item.work_item.id)}
+                  starting={startingAssignmentID === item.assignment.id}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectActivityRow({
+  chatModel,
+  item,
+  onOpenChat,
+  onOpenTask,
+  onSelectWorkItem,
+  onStart,
+  starting,
+}: {
+  chatModel: string;
+  item: ProjectActivityItemRecord;
+  onOpenChat?: () => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onSelectWorkItem: () => void;
+  onStart: () => void;
+  starting: boolean;
+}) {
+  const signal = item.blocking_signal;
+  const taskID = item.linked_task_id || item.assignment.task_id || "";
+  const runID = item.linked_run_id || item.assignment.run_id || "";
+  const startable = item.assignment.driver_kind === "hecate_task" && signal === "not_started";
+  return (
+    <div style={activityRowStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <Badge status={signal} label={activitySignalLabel(signal)} />
+        <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
+          {item.work_item.title}
+          <span style={{ color: "var(--t2)", fontWeight: 400 }}>
+            {" "}
+            / {item.role.name || item.assignment.role_id}
+          </span>
+        </div>
+        <button className="btn btn-ghost btn-sm" type="button" onClick={onSelectWorkItem}>
+          Details
+        </button>
+        {taskID && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={() => onOpenTask?.(taskID, runID)}
+            disabled={!onOpenTask}
+          >
+            <Icon d={Icons.tasks} size={12} />
+            Task
+          </button>
+        )}
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onOpenChat}
+          disabled={!onOpenChat || !chatModel}
+          title={
+            chatModel ? `Open chat with ${chatModel}` : "Set project defaults before opening chat."
+          }
+        >
+          <Icon d={Icons.chat} size={12} />
+          Chat
+        </button>
+        {startable && (
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={onStart}
+            disabled={starting}
+          >
+            <Icon d={Icons.send} size={12} />
+            {starting ? "Starting…" : "Start"}
+          </button>
+        )}
+      </div>
+      <div style={{ ...metaLineStyle, marginTop: 7 }}>
+        <span>{item.status_summary}</span>
+        <span>{item.assignment.driver_kind}</span>
+        {taskID && <span>task {shortID(taskID)}</span>}
+        {runID && <span>run {shortID(runID)}</span>}
+        {item.linked_chat_id && <span>chat {shortID(item.linked_chat_id)}</span>}
+        {item.artifact_summary.count > 0 && (
+          <span>
+            {item.artifact_summary.count} artifact
+            {item.artifact_summary.count === 1 ? "" : "s"}
+          </span>
+        )}
+        {item.updated_at && <span>Updated {formatAbsoluteTime(item.updated_at)}</span>}
+      </div>
+      {item.recent_artifacts && item.recent_artifacts.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7 }}>
+          {item.recent_artifacts.map((artifact) => (
+            <span key={artifact.id} className="badge badge-muted">
+              {artifact.kind}: {artifact.title || artifact.id}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -2545,6 +2776,41 @@ function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
   return role?.default_driver_kind || "hecate_task";
 }
 
+function projectActivityWorkItemToWorkItem(
+  projectID: string,
+  item: ProjectActivityItemRecord["work_item"],
+): ProjectWorkItemRecord {
+  return {
+    id: item.id,
+    project_id: projectID,
+    title: item.title,
+    status: item.status,
+    priority: item.priority,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function activitySignalLabel(signal: string): string {
+  switch (signal) {
+    case "awaiting_approval":
+      return "approval";
+    case "not_started":
+      return "not started";
+    case "stale_unknown":
+      return "unknown";
+    case "completed":
+      return "done";
+    default:
+      return signal.replaceAll("_", " ");
+  }
+}
+
+function shortID(id: string): string {
+  if (id.length <= 12) return id;
+  return id.slice(0, 10) + "...";
+}
+
 function upsertRole(items: ProjectWorkRoleRecord[], item: ProjectWorkRoleRecord) {
   const index = items.findIndex((current) => current.id === item.id);
   const next = index === -1 ? [item, ...items] : items.slice();
@@ -2686,6 +2952,11 @@ const assignmentStyle: CSSProperties = {
   background: "var(--bg2)",
   borderRadius: "var(--radius-sm)",
   padding: 10,
+};
+
+const activityRowStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  paddingTop: 9,
 };
 
 const artifactStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1188,6 +1188,7 @@ function ProjectActivityInbox({
     { id: "completed", label: "Completed", count: counts?.completed_count ?? 0 },
     { id: "recent", label: "Recent", count: counts?.recent_count ?? 0 },
   ];
+  const selectedTotal = tabs.find((tab) => tab.id === bucket)?.count ?? selectedItems.length;
 
   if (!project) {
     return null;
@@ -1202,7 +1203,7 @@ function ProjectActivityInbox({
             <div style={{ ...subtleTextStyle, marginTop: 3 }}>
               {loading && !activity
                 ? "Loading project activity…"
-                : `${counts?.assignment_count ?? 0} assignments across ${counts?.work_item_count ?? 0} work items`}
+                : `${counts?.assignment_count ?? 0} assignments across ${counts?.work_item_count ?? 0} work items; newest 20 per bucket`}
             </div>
           </div>
           <div style={{ marginLeft: "auto", display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -1227,6 +1228,11 @@ function ProjectActivityInbox({
         )}
         {selectedItems.length > 0 && (
           <div style={{ display: "grid", gap: 8 }}>
+            {selectedTotal > selectedItems.length && (
+              <div style={subtleTextStyle}>
+                Showing {selectedItems.length} of {selectedTotal} {bucket} assignments.
+              </div>
+            )}
             {selectedItems.map((item) => {
               const workItem =
                 workItems.find((candidate) => candidate.id === item.work_item.id) ??

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -20,6 +20,7 @@ import {
   getChatWorkspaceFiles,
   getChatApproval,
   getProjectAssignments,
+  getProjectActivity,
   getProjectCollaborationArtifacts,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -258,10 +259,11 @@ describe("api client", () => {
 
   it("builds project work coordination requests", async () => {
     fetchMock.mockClear();
-    for (let i = 0; i < 5; i += 1) {
+    for (let i = 0; i < 6; i += 1) {
       fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
     }
 
+    await getProjectActivity("proj/1");
     await getProjectWorkRoles("proj/1");
     await getProjectWorkItems("proj/1");
     await getProjectWorkItem("proj/1", "work/1");
@@ -270,26 +272,31 @@ describe("api client", () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "/hecate/v1/projects/proj%2F1/roles",
+      "/hecate/v1/projects/proj%2F1/activity",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/hecate/v1/projects/proj%2F1/work-items",
+      "/hecate/v1/projects/proj%2F1/roles",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      "/hecate/v1/projects/proj%2F1/work-items",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       4,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       5,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      6,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
       expect.objectContaining({ method: "GET" }),
     );

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -54,6 +54,7 @@ import type {
   CreateProjectWorkItemPayload,
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
+  ProjectActivityResponse,
   ProjectCollaborationArtifactsResponse,
   ProjectResponse,
   ProjectWorkItemsResponse,
@@ -328,6 +329,12 @@ export async function deleteProject(id: string): Promise<void> {
   return fetchJSON<void>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+}
+
+export async function getProjectActivity(projectID: string): Promise<ProjectActivityResponse> {
+  return fetchJSON<ProjectActivityResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/activity`,
+  );
 }
 
 export async function getProjectWorkRoles(projectID: string): Promise<ProjectWorkRolesResponse> {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -235,7 +235,7 @@ export type ProjectActivitySignal =
   | "running"
   | "completed"
   | "stale_unknown"
-  | string;
+  | (string & {});
 
 export type ProjectActivityWorkItemRecord = {
   id: string;

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -228,6 +228,76 @@ export type ProjectCollaborationArtifactRecord = {
   updated_at: string;
 };
 
+export type ProjectActivitySignal =
+  | "awaiting_approval"
+  | "failed"
+  | "not_started"
+  | "running"
+  | "completed"
+  | "stale_unknown"
+  | string;
+
+export type ProjectActivityWorkItemRecord = {
+  id: string;
+  title: string;
+  status: ProjectWorkItemStatus | string;
+  priority: ProjectWorkItemPriority | string;
+};
+
+export type ProjectActivityArtifactSummary = {
+  count: number;
+  latest_kind?: string;
+  latest_title?: string;
+  latest_at?: string;
+  assignment_id?: string;
+};
+
+export type ProjectActivityItemRecord = {
+  id: string;
+  project_id: string;
+  work_item: ProjectActivityWorkItemRecord;
+  assignment: ProjectAssignmentRecord;
+  role: ProjectWorkRoleRecord;
+  status: ProjectAssignmentStatus | string;
+  blocking_signal: ProjectActivitySignal;
+  status_summary: string;
+  linked_task_id?: string;
+  linked_run_id?: string;
+  linked_chat_id?: string;
+  linked_message_id?: string;
+  recent_artifacts?: ProjectCollaborationArtifactRecord[];
+  artifact_summary: ProjectActivityArtifactSummary;
+  updated_at: string;
+};
+
+export type ProjectActivitySummary = {
+  work_item_count: number;
+  assignment_count: number;
+  active_count: number;
+  blocked_count: number;
+  completed_count: number;
+  recent_count: number;
+};
+
+export type ProjectActivityBuckets = {
+  active: ProjectActivityItemRecord[];
+  blocked: ProjectActivityItemRecord[];
+  completed: ProjectActivityItemRecord[];
+  recent: ProjectActivityItemRecord[];
+};
+
+export type ProjectActivityData = {
+  project_id: string;
+  summary: ProjectActivitySummary;
+  buckets: ProjectActivityBuckets;
+  recent: ProjectActivityItemRecord[];
+};
+
+export type ProjectActivityResponse = {
+  object: string;
+  data: ProjectActivityData;
+};
+
 export type ProjectWorkRolesResponse = {
   object: string;
   data: ProjectWorkRoleRecord[];


### PR DESCRIPTION
## Summary

- Add a read-only `GET /hecate/v1/projects/{id}/activity` endpoint for project-level work activity.
- Aggregate projected assignment execution state, blocking signals, linked task/run/chat identifiers, and recent artifact signals.
- Add a compact Activity Inbox to Projects with blocked, active, completed, and recent buckets plus existing task/chat/detail/start actions.
- Document the endpoint contract and update the project RFC implementation status.

## Validation

- `go build ./...`
- `go vet ./internal/projectwork ./internal/api`
- `go test ./internal/projectwork ./internal/api`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`