### PR TITLE
Add agent handoffs

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -15,6 +15,7 @@ These are **persisted events** (rows in the `task_state_run_events` table). They
 
 - [Quick reference](#quick-reference)
 - [Runtime snapshot payloads](#runtime-snapshot-payloads)
+- [Project handoff activity](#project-handoff-activity)
 - [Run lifecycle](#run-lifecycle)
 - [Approvals](#approvals)
 - [Agent loop](#agent-loop)
@@ -85,6 +86,15 @@ are written; older alpha rows replay as they were stored rather than being
 normalized or migrated.
 The stream endpoint itself is read-only: live projection frames are not appended
 to `run_events`.
+
+## Project handoff activity
+
+Structured project handoffs are not persisted to the task run-event log in V1.
+Creating, accepting, superseding, dismissing, or deleting a handoff mutates the
+project-work handoff record and updates project activity projections returned
+from `GET /hecate/v1/projects/{id}/activity` as `handoff_summary` and
+`recent_handoffs` on matching assignment/work-item activity rows. The public
+`/hecate/v1/events` feeds remain scoped to task/run events.
 
 ## Runtime snapshot payloads
 

--- a/docs/rfcs/agent-memory.md
+++ b/docs/rfcs/agent-memory.md
@@ -313,7 +313,10 @@ visibility at the point of use.
 4. Deleted or edited entries do not rewrite historical context packet snapshots.
 5. Memory cannot override Hecate security policy, approvals, sandboxing, or
    workspace validation.
-6. Memory entries should have size guardrails. Initial proposal: warn at 5,000
+6. Structured project handoffs may link memory entry IDs as context references,
+   but creating or accepting a handoff does not create, edit, enable, or
+   promote memory.
+7. Memory entries should have size guardrails. Initial proposal: warn at 5,000
    characters and block at 20,000 characters per entry unless overridden.
 
 ## Implementation Plan
@@ -322,10 +325,11 @@ visibility at the point of use.
 | --- | --------------------------------------------------------------------------------------------------------------- |
 | 1   | Landed: project-scoped `internal/memory/` store with memory + SQLite backends, CRUD API, UI management surface. |
 | 2   | Landed for chat packets: enabled project memory emits labelled `memory` context items.                          |
-| 3   | Add `/active` introspection once profiles/surface selection exist beyond project scope.                         |
-| 4   | Agent profile memory-source selection for Hecate Chat and external agents.                                      |
-| 5   | Extend active-memory indicators into Chat/Task Detail and standalone task-run context packets.                  |
-| 6   | Docs, screenshots, and e2e coverage for scoped memory visibility.                                               |
+| 3   | Landed for project handoffs: handoff records can reference memory IDs without writing or promoting memory.      |
+| 4   | Add `/active` introspection once profiles/surface selection exist beyond project scope.                         |
+| 5   | Agent profile memory-source selection for Hecate Chat and external agents.                                      |
+| 6   | Extend active-memory indicators into Chat/Task Detail and standalone task-run context packets.                  |
+| 7   | Docs, screenshots, and e2e coverage for scoped memory visibility.                                               |
 
 This should land after the first context-packet implementation. Otherwise
 memory will have no durable "what saw this entry?" audit trail.

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -292,13 +292,13 @@ packets are audit snapshots owned by their parent message/run.
 
 ## Implementation Plan
 
-| PR  | Scope                                                                                                                                     |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Landed: enrich chat-message packet types, assembly for direct-model, tools-on, and external-agent turns, plus context inspector API.      |
-| 2   | Landed for chat messages: persist itemized snapshots through memory and SQLite chat stores. Task-run lookup resolves linked chat packets. |
-| 3   | Landed for chat messages: UI context inspector groups itemized packet data by trust level.                                                |
-| 4   | Wire token estimates from the context-window RFC against packet items.                                                                    |
-| 5   | Landed for project memory: enabled entries appear as labelled chat packet items. Broader profile/surface memory selection remains future. |
+| PR  | Scope                                                                                                                                        |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Landed: enrich chat-message packet types, assembly for direct-model, tools-on, and external-agent turns, plus context inspector API.         |
+| 2   | Landed for chat messages: persist itemized snapshots through memory and SQLite chat stores. Task-run lookup resolves linked chat packets.    |
+| 3   | Landed for chat messages: UI context inspector groups itemized packet data by trust level.                                                   |
+| 4   | Wire token estimates from the context-window RFC against packet items.                                                                       |
+| 5   | Landed for project memory: enabled entries appear as labelled chat packet items. Broader profile/surface memory selection remains future.    |
 | 6   | Landed for project handoffs: handoff records can carry explicit context refs and linked memory IDs, but they are not injected automatically. |
 
 The first packet work was intentionally small: no summarization, no vector

--- a/docs/rfcs/context-assembly-and-injection-boundaries.md
+++ b/docs/rfcs/context-assembly-and-injection-boundaries.md
@@ -299,10 +299,12 @@ packets are audit snapshots owned by their parent message/run.
 | 3   | Landed for chat messages: UI context inspector groups itemized packet data by trust level.                                                |
 | 4   | Wire token estimates from the context-window RFC against packet items.                                                                    |
 | 5   | Landed for project memory: enabled entries appear as labelled chat packet items. Broader profile/surface memory selection remains future. |
+| 6   | Landed for project handoffs: handoff records can carry explicit context refs and linked memory IDs, but they are not injected automatically. |
 
 The first packet work was intentionally small: no summarization, no vector
-retrieval. Project memory now uses the audit boundary, while broader context
-assembly remains explicit future work.
+retrieval. Project memory now uses the audit boundary, and structured handoffs
+can point at context that an operator may choose to carry forward. Broader
+context assembly and automatic injection remain explicit future work.
 
 ## Test Plan
 

--- a/docs/rfcs/projects.md
+++ b/docs/rfcs/projects.md
@@ -249,8 +249,15 @@ context-packet items, but writes remain operator-driven. Project work
 assignments can now start native Tasks linked back via `origin_kind` /
 `origin_id`, and `GET /hecate/v1/projects/{id}/activity` exposes a read-only
 project activity inbox over work items, assignments, linked task/run/chat ids,
-status signals, and recent collaboration artifacts. Broader task `project_id`
-scoping, profiles, and presets are not linked to `project_id` yet.
+status signals, recent collaboration artifacts, and structured handoff signals.
+Structured project handoffs now persist as operator-controlled records that can
+carry source assignment/run/chat refs, target role or assignment hints,
+recommended next action text, linked artifact IDs, linked memory IDs, context
+refs, provenance labels, and `pending` / `accepted` / `superseded` /
+`dismissed` status. A handoff may help the operator create or start a follow-up
+assignment, but the handoff record itself does not dispatch another agent.
+Broader task `project_id` scoping, profiles, and presets are not linked to
+`project_id` yet.
 
 Persist `project_id` on:
 
@@ -281,7 +288,9 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 7. Add agent-profile memory-source selection.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.
 9. Add project activity aggregation. Done for the read-only V1 inbox.
-10. Update docs, screenshots, and e2e coverage.
+10. Add structured handoffs. Done for memory + SQLite store parity, API, UI
+    actions, and activity projection signals.
+11. Update docs, screenshots, and e2e coverage.
 
 ## Test Plan
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1042,10 +1042,14 @@ inject those files into prompts yet. Project work-coordination endpoints can
 persist roles, work items, assignments, and collaboration artifacts under a
 project. Assignments may record links to existing task runs or chat messages,
 but creating an assignment does not start a task, open a chat, inject context,
-or dispatch any agent. Project memory entries are structured project-scoped
-records with Markdown-compatible `body` text; they are not Markdown files, and
-they are written only through explicit operator API/UI actions. Enabled project
-memory entries appear as itemized chat context-packet metadata with their
+or dispatch any agent. Project handoffs are structured project-scoped records
+for passing context and a recommended next action from one assignment/run/chat
+to another role or assignment. They can link artifacts, memory entries, and
+context references, but they do not launch follow-up work by themselves.
+Project memory entries are structured project-scoped records with
+Markdown-compatible `body` text; they are not Markdown files, and they are
+written only through explicit operator API/UI actions. Enabled project memory
+entries appear as itemized chat context-packet metadata with their
 `trust_label`, but Hecate still does not perform automatic memory extraction,
 embeddings, retrieval ranking, or source-content injection. Profiles, presets,
 and source-content injection are not linked to `project_id` yet.
@@ -1319,6 +1323,8 @@ Supported assignment driver kinds are `hecate_task` and `external_agent`, but
 native assignment start V1 only dispatches `hecate_task`.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
+Supported structured handoff statuses are `pending`, `accepted`, `superseded`,
+and `dismissed`.
 
 Assignment responses are projected from linked canonical task/run state when
 `task_id` and `run_id` point at a Hecate task run. If `task_id` is present and
@@ -1423,6 +1429,16 @@ The top-level envelope follows the Hecate-native convention:
             "latest_at": "2026-06-03T12:03:00Z",
             "assignment_id": "asgn_..."
           },
+          "handoff_summary": {
+            "count": 1,
+            "pending_count": 1,
+            "accepted_count": 0,
+            "latest_status": "pending",
+            "latest_title": "QA handoff",
+            "latest_at": "2026-06-03T12:04:00Z",
+            "assignment_id": "asgn_...",
+            "target_role_id": "reviewer_qa"
+          },
           "recent_artifacts": [
             {
               "id": "art_...",
@@ -1436,7 +1452,25 @@ The top-level envelope follows the Hecate-native convention:
               "updated_at": "2026-06-03T12:03:00Z"
             }
           ],
-          "updated_at": "2026-06-03T12:03:00Z"
+          "recent_handoffs": [
+            {
+              "id": "handoff_...",
+              "project_id": "proj_...",
+              "work_item_id": "work_...",
+              "source_assignment_id": "asgn_...",
+              "target_role_id": "reviewer_qa",
+              "title": "QA handoff",
+              "summary": "Implementation is ready for review.",
+              "recommended_next_action": "Create a queued QA assignment.",
+              "status": "pending",
+              "provenance_kind": "agent_draft",
+              "trust_label": "operator_reviewed",
+              "created_at": "2026-06-03T12:04:00Z",
+              "updated_at": "2026-06-03T12:04:00Z",
+              "status_changed_at": "2026-06-03T12:04:00Z"
+            }
+          ],
+          "updated_at": "2026-06-03T12:04:00Z"
         }
       ],
       "active": [],
@@ -1459,6 +1493,11 @@ ID. Each bucket is capped at 20 rows; `recent` mirrors
 brevity; real responses include the same item shape there when `recent_count`
 is non-zero. `artifact_summary.assignment_id` is present only when the latest
 summarized artifact is assignment-scoped; work-item-level artifacts omit it.
+`handoff_summary` and `recent_handoffs` are activity projections over
+structured handoff records attached to the same work item and, when present,
+the same source or target assignment. Handoffs that are not assignment-linked
+are still available from the handoff list/detail endpoints; V1 does not create
+standalone activity rows for them.
 
 #### `GET /hecate/v1/projects/{id}/roles`
 
@@ -1711,6 +1750,94 @@ Assignments in terminal states (`completed`, `failed`, `cancelled`) also return
 `409`. If task creation succeeds but task start fails, Hecate keeps the
 assignment's `task_id`, marks the assignment `failed`, and returns an error so
 the operator can inspect the linked task instead of losing the partial state.
+
+#### `GET /hecate/v1/projects/{id}/handoffs`
+
+Lists structured handoff records for the project. Optional query parameters:
+`work_item_id=<id>` and `status=<pending|accepted|superseded|dismissed>`.
+Responses use `{ "object": "project_handoffs", "data": [...] }`.
+
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs`
+
+Lists structured handoff records for one work item. Handoffs are sorted by
+latest update time, newest first.
+
+```json
+{
+  "object": "project_handoffs",
+  "data": [
+    {
+      "id": "handoff_...",
+      "project_id": "proj_...",
+      "work_item_id": "work_...",
+      "source_assignment_id": "asgn_...",
+      "source_run_id": "run_...",
+      "source_chat_session_id": "chat_...",
+      "source_message_id": "msg_...",
+      "target_role_id": "reviewer_qa",
+      "target_assignment_id": "asgn_review_...",
+      "target_work_item_id": "work_followup_...",
+      "title": "QA handoff",
+      "summary": "The implementation is ready for review.",
+      "recommended_next_action": "Review the changed files and run the focused checks.",
+      "linked_artifact_ids": ["art_..."],
+      "linked_memory_ids": ["mem_..."],
+      "context_refs": ["ctx_..."],
+      "status": "pending",
+      "provenance_kind": "agent_draft",
+      "trust_label": "operator_reviewed",
+      "created_by_role_id": "software_developer",
+      "created_at": "2026-06-03T12:00:00Z",
+      "updated_at": "2026-06-03T12:00:00Z",
+      "status_changed_at": "2026-06-03T12:00:00Z"
+    }
+  ]
+}
+```
+
+#### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs`
+
+Creates a handoff. `title`, `summary`, and `recommended_next_action` are
+required. `status` defaults to `pending`, `provenance_kind` defaults to
+`operator`, and `trust_label` defaults to `operator_reviewed`. Source/target
+assignment IDs, if supplied, must belong to the same work item. Linked artifact
+IDs, memory IDs, and context refs are stored as references only; creating a
+handoff does not write memory, inject context, start a task, or open a chat.
+
+```json
+{
+  "source_assignment_id": "asgn_...",
+  "target_role_id": "reviewer_qa",
+  "title": "QA handoff",
+  "summary": "The implementation is ready for review.",
+  "recommended_next_action": "Create a queued QA assignment and run focused UI tests.",
+  "linked_artifact_ids": ["art_..."],
+  "linked_memory_ids": ["mem_..."],
+  "context_refs": ["ctx_..."],
+  "provenance_kind": "agent_draft",
+  "trust_label": "operator_reviewed",
+  "created_by_role_id": "software_developer"
+}
+```
+
+Returns `{ "object": "project_handoff", "data": { ... } }`.
+
+#### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}`
+
+Updates handoff refs, target hints, text fields, linked IDs, provenance/trust
+metadata, or `status`. Status changes update `status_changed_at`.
+
+#### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}/status`
+
+Transitions only the handoff status. The body is `{ "status": "accepted" }`
+where status is one of `pending`, `accepted`, `superseded`, or `dismissed`.
+Accepting a handoff records operator intent; it does not automatically start a
+linked assignment.
+
+#### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}`
+
+Deletes the handoff record. It does not delete linked artifacts, memory
+entries, tasks, runs, chats, work items, or assignments.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -2017,11 +2017,18 @@ func groupProjectActivityHandoffs(handoffs []projectwork.Handoff) (map[string][]
 	byAssignment := make(map[string][]projectwork.Handoff)
 	byWorkItem := make(map[string][]projectwork.Handoff)
 	for _, handoff := range handoffs {
+		attached := false
 		if handoff.SourceAssignmentID != "" {
 			byAssignment[handoff.SourceAssignmentID] = append(byAssignment[handoff.SourceAssignmentID], handoff)
-			continue
+			attached = true
 		}
-		byWorkItem[handoff.WorkItemID] = append(byWorkItem[handoff.WorkItemID], handoff)
+		if handoff.TargetAssignmentID != "" && handoff.TargetAssignmentID != handoff.SourceAssignmentID {
+			byAssignment[handoff.TargetAssignmentID] = append(byAssignment[handoff.TargetAssignmentID], handoff)
+			attached = true
+		}
+		if !attached {
+			byWorkItem[handoff.WorkItemID] = append(byWorkItem[handoff.WorkItemID], handoff)
+		}
 	}
 	return byAssignment, byWorkItem
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -99,6 +99,51 @@ type createProjectWorkArtifactRequest struct {
 	AuthorRoleID string `json:"author_role_id,omitempty"`
 }
 
+type createProjectHandoffRequest struct {
+	ID                    string   `json:"id,omitempty"`
+	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       string   `json:"source_message_id,omitempty"`
+	TargetRoleID          string   `json:"target_role_id,omitempty"`
+	TargetAssignmentID    string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      string   `json:"target_work_item_id,omitempty"`
+	Title                 string   `json:"title"`
+	Summary               string   `json:"summary"`
+	RecommendedNextAction string   `json:"recommended_next_action"`
+	LinkedArtifactIDs     []string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       []string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           []string `json:"context_refs,omitempty"`
+	Status                string   `json:"status,omitempty"`
+	ProvenanceKind        string   `json:"provenance_kind,omitempty"`
+	TrustLabel            string   `json:"trust_label,omitempty"`
+	CreatedByRoleID       string   `json:"created_by_role_id,omitempty"`
+}
+
+type updateProjectHandoffRequest struct {
+	SourceAssignmentID    *string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           *string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   *string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       *string   `json:"source_message_id,omitempty"`
+	TargetRoleID          *string   `json:"target_role_id,omitempty"`
+	TargetAssignmentID    *string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      *string   `json:"target_work_item_id,omitempty"`
+	Title                 *string   `json:"title,omitempty"`
+	Summary               *string   `json:"summary,omitempty"`
+	RecommendedNextAction *string   `json:"recommended_next_action,omitempty"`
+	LinkedArtifactIDs     *[]string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       *[]string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           *[]string `json:"context_refs,omitempty"`
+	Status                *string   `json:"status,omitempty"`
+	ProvenanceKind        *string   `json:"provenance_kind,omitempty"`
+	TrustLabel            *string   `json:"trust_label,omitempty"`
+	CreatedByRoleID       *string   `json:"created_by_role_id,omitempty"`
+}
+
+type updateProjectHandoffStatusRequest struct {
+	Status string `json:"status"`
+}
+
 type ProjectWorkRolesResponse struct {
 	Object string                    `json:"object"`
 	Data   []ProjectWorkRoleResponse `json:"data"`
@@ -219,6 +264,42 @@ type ProjectWorkArtifactResponse struct {
 	UpdatedAt    string `json:"updated_at"`
 }
 
+type ProjectHandoffsResponse struct {
+	Object string                   `json:"object"`
+	Data   []ProjectHandoffResponse `json:"data"`
+}
+
+type ProjectHandoffEnvelope struct {
+	Object string                 `json:"object"`
+	Data   ProjectHandoffResponse `json:"data"`
+}
+
+type ProjectHandoffResponse struct {
+	ID                    string   `json:"id"`
+	ProjectID             string   `json:"project_id"`
+	WorkItemID            string   `json:"work_item_id"`
+	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       string   `json:"source_message_id,omitempty"`
+	TargetRoleID          string   `json:"target_role_id,omitempty"`
+	TargetAssignmentID    string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      string   `json:"target_work_item_id,omitempty"`
+	Title                 string   `json:"title"`
+	Summary               string   `json:"summary"`
+	RecommendedNextAction string   `json:"recommended_next_action"`
+	LinkedArtifactIDs     []string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       []string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           []string `json:"context_refs,omitempty"`
+	Status                string   `json:"status"`
+	ProvenanceKind        string   `json:"provenance_kind"`
+	TrustLabel            string   `json:"trust_label"`
+	CreatedByRoleID       string   `json:"created_by_role_id,omitempty"`
+	CreatedAt             string   `json:"created_at"`
+	UpdatedAt             string   `json:"updated_at"`
+	StatusChangedAt       string   `json:"status_changed_at"`
+}
+
 type ProjectActivityEnvelope struct {
 	Object string                      `json:"object"`
 	Data   ProjectActivityDataResponse `json:"data"`
@@ -262,6 +343,8 @@ type ProjectActivityItemResponse struct {
 	LinkedMessageID string                                 `json:"linked_message_id,omitempty"`
 	RecentArtifacts []ProjectWorkArtifactResponse          `json:"recent_artifacts,omitempty"`
 	ArtifactSummary ProjectActivityArtifactSummaryResponse `json:"artifact_summary"`
+	RecentHandoffs  []ProjectHandoffResponse               `json:"recent_handoffs,omitempty"`
+	HandoffSummary  ProjectActivityHandoffSummaryResponse  `json:"handoff_summary"`
 	UpdatedAt       string                                 `json:"updated_at"`
 }
 
@@ -278,6 +361,18 @@ type ProjectActivityArtifactSummaryResponse struct {
 	LatestTitle  string `json:"latest_title,omitempty"`
 	LatestAt     string `json:"latest_at,omitempty"`
 	AssignmentID string `json:"assignment_id,omitempty"`
+}
+
+type ProjectActivityHandoffSummaryResponse struct {
+	Count          int    `json:"count"`
+	PendingCount   int    `json:"pending_count,omitempty"`
+	AcceptedCount  int    `json:"accepted_count,omitempty"`
+	LatestStatus   string `json:"latest_status,omitempty"`
+	LatestTitle    string `json:"latest_title,omitempty"`
+	LatestAt       string `json:"latest_at,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	TargetRoleID   string `json:"target_role_id,omitempty"`
+	TargetWorkItem string `json:"target_work_item_id,omitempty"`
 }
 
 func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) {
@@ -1193,6 +1288,197 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 	WriteJSON(w, http.StatusCreated, ProjectWorkArtifactEnvelope{Object: "project_collaboration_artifact", Data: renderProjectWorkArtifact(item)})
 }
 
+func (h *Handler) HandleProjectHandoffs(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	filter := projectwork.HandoffFilter{
+		ProjectID:  projectID,
+		WorkItemID: strings.TrimSpace(r.URL.Query().Get("work_item_id")),
+		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+	}
+	items, err := h.projectWork.ListHandoffs(r.Context(), filter)
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	data := make([]ProjectHandoffResponse, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProjectHandoff(item))
+	}
+	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
+}
+
+func (h *Handler) HandleProjectWorkItemHandoffs(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	items, err := h.projectWork.ListHandoffs(r.Context(), projectwork.HandoffFilter{
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	data := make([]ProjectHandoffResponse, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProjectHandoff(item))
+	}
+	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
+}
+
+func (h *Handler) HandleCreateProjectHandoff(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	var req createProjectHandoffRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		id = newOpaqueTaskResourceID("handoff")
+	}
+	item, err := h.projectWork.CreateHandoff(r.Context(), projectwork.Handoff{
+		ID:                    id,
+		ProjectID:             projectID,
+		WorkItemID:            workItemID,
+		SourceAssignmentID:    req.SourceAssignmentID,
+		SourceRunID:           req.SourceRunID,
+		SourceChatSessionID:   req.SourceChatSessionID,
+		SourceMessageID:       req.SourceMessageID,
+		TargetRoleID:          req.TargetRoleID,
+		TargetAssignmentID:    req.TargetAssignmentID,
+		TargetWorkItemID:      req.TargetWorkItemID,
+		Title:                 req.Title,
+		Summary:               req.Summary,
+		RecommendedNextAction: req.RecommendedNextAction,
+		LinkedArtifactIDs:     req.LinkedArtifactIDs,
+		LinkedMemoryIDs:       req.LinkedMemoryIDs,
+		ContextRefs:           req.ContextRefs,
+		Status:                req.Status,
+		ProvenanceKind:        req.ProvenanceKind,
+		TrustLabel:            req.TrustLabel,
+		CreatedByRoleID:       req.CreatedByRoleID,
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
+}
+
+func (h *Handler) HandleUpdateProjectHandoff(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	handoffID := r.PathValue("handoff_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	var req updateProjectHandoffRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	item, err := h.projectWork.UpdateHandoff(r.Context(), projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
+		applyProjectHandoffPatch(item, req)
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
+}
+
+func (h *Handler) HandleUpdateProjectHandoffStatus(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	handoffID := r.PathValue("handoff_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	var req updateProjectHandoffStatusRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	item, err := h.projectWork.UpdateHandoff(r.Context(), projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
+		item.Status = req.Status
+	})
+	if !writeProjectWorkError(w, err) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
+}
+
+func (h *Handler) HandleDeleteProjectHandoff(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	handoffID := r.PathValue("handoff_id")
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+		return
+	}
+	if err := h.projectWork.DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func applyProjectHandoffPatch(item *projectwork.Handoff, req updateProjectHandoffRequest) {
+	if req.SourceAssignmentID != nil {
+		item.SourceAssignmentID = *req.SourceAssignmentID
+	}
+	if req.SourceRunID != nil {
+		item.SourceRunID = *req.SourceRunID
+	}
+	if req.SourceChatSessionID != nil {
+		item.SourceChatSessionID = *req.SourceChatSessionID
+	}
+	if req.SourceMessageID != nil {
+		item.SourceMessageID = *req.SourceMessageID
+	}
+	if req.TargetRoleID != nil {
+		item.TargetRoleID = *req.TargetRoleID
+	}
+	if req.TargetAssignmentID != nil {
+		item.TargetAssignmentID = *req.TargetAssignmentID
+	}
+	if req.TargetWorkItemID != nil {
+		item.TargetWorkItemID = *req.TargetWorkItemID
+	}
+	if req.Title != nil {
+		item.Title = *req.Title
+	}
+	if req.Summary != nil {
+		item.Summary = *req.Summary
+	}
+	if req.RecommendedNextAction != nil {
+		item.RecommendedNextAction = *req.RecommendedNextAction
+	}
+	if req.LinkedArtifactIDs != nil {
+		item.LinkedArtifactIDs = *req.LinkedArtifactIDs
+	}
+	if req.LinkedMemoryIDs != nil {
+		item.LinkedMemoryIDs = *req.LinkedMemoryIDs
+	}
+	if req.ContextRefs != nil {
+		item.ContextRefs = *req.ContextRefs
+	}
+	if req.Status != nil {
+		item.Status = *req.Status
+	}
+	if req.ProvenanceKind != nil {
+		item.ProvenanceKind = *req.ProvenanceKind
+	}
+	if req.TrustLabel != nil {
+		item.TrustLabel = *req.TrustLabel
+	}
+	if req.CreatedByRoleID != nil {
+		item.CreatedByRoleID = *req.CreatedByRoleID
+	}
+}
+
 func (h *Handler) requireProject(w http.ResponseWriter, r *http.Request, projectID string) bool {
 	_, ok, err := h.projects.Get(r.Context(), projectID)
 	if err != nil {
@@ -1533,6 +1819,10 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 	if err != nil {
 		return ProjectActivityDataResponse{}, err
 	}
+	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
 
 	roleByID := make(map[string]projectwork.AgentRoleProfile, len(roles))
 	for _, role := range roles {
@@ -1549,6 +1839,7 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 	}
 
 	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
+	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(handoffs)
 	items := make([]ProjectActivityItemResponse, 0, len(assignments))
 	for _, workItem := range projectedWorkItems {
 		for _, projected := range workItem.Assignments {
@@ -1556,8 +1847,12 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 			if len(activityArtifacts) == 0 {
 				activityArtifacts = artifactsByWorkItem[projected.WorkItemID]
 			}
+			activityHandoffs := handoffsByAssignment[projected.ID]
+			if len(activityHandoffs) == 0 {
+				activityHandoffs = handoffsByWorkItem[projected.WorkItemID]
+			}
 			role, _ := roleByID[projected.RoleID]
-			items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts))
+			items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts, activityHandoffs))
 		}
 	}
 	sortProjectActivityItems(items)
@@ -1589,8 +1884,9 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 	return response, nil
 }
 
-func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact) ProjectActivityItemResponse {
+func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) ProjectActivityItemResponse {
 	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts)
+	handoffSummary, recentHandoffs := renderProjectActivityHandoffSignals(handoffs)
 	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
 	if status == "" {
 		status = "unknown"
@@ -1611,7 +1907,9 @@ func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment Proj
 		LinkedMessageID: assignment.MessageID,
 		RecentArtifacts: recentArtifacts,
 		ArtifactSummary: artifactSummary,
-		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, artifactSummary),
+		RecentHandoffs:  recentHandoffs,
+		HandoffSummary:  handoffSummary,
+		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, artifactSummary, handoffSummary),
 	}
 }
 
@@ -1667,6 +1965,63 @@ func groupProjectActivityArtifacts(artifacts []projectwork.CollaborationArtifact
 			continue
 		}
 		byWorkItem[artifact.WorkItemID] = append(byWorkItem[artifact.WorkItemID], artifact)
+	}
+	return byAssignment, byWorkItem
+}
+
+func renderProjectActivityHandoffSignals(handoffs []projectwork.Handoff) (ProjectActivityHandoffSummaryResponse, []ProjectHandoffResponse) {
+	if len(handoffs) == 0 {
+		return ProjectActivityHandoffSummaryResponse{}, nil
+	}
+	items := append([]projectwork.Handoff(nil), handoffs...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := items[i], items[j]
+		if !left.UpdatedAt.Equal(right.UpdatedAt) {
+			return left.UpdatedAt.After(right.UpdatedAt)
+		}
+		if !left.CreatedAt.Equal(right.CreatedAt) {
+			return left.CreatedAt.After(right.CreatedAt)
+		}
+		return left.ID < right.ID
+	})
+	latest := items[0]
+	summary := ProjectActivityHandoffSummaryResponse{
+		Count:          len(items),
+		LatestStatus:   latest.Status,
+		LatestTitle:    firstNonEmpty(latest.Title, latest.ID),
+		LatestAt:       formatOptionalTime(firstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
+		AssignmentID:   latest.SourceAssignmentID,
+		TargetRoleID:   latest.TargetRoleID,
+		TargetWorkItem: latest.TargetWorkItemID,
+	}
+	for _, item := range items {
+		switch item.Status {
+		case projectwork.HandoffStatusPending:
+			summary.PendingCount++
+		case projectwork.HandoffStatusAccepted:
+			summary.AcceptedCount++
+		}
+	}
+	limit := len(items)
+	if limit > 3 {
+		limit = 3
+	}
+	recent := make([]ProjectHandoffResponse, 0, limit)
+	for _, handoff := range items[:limit] {
+		recent = append(recent, renderProjectHandoff(handoff))
+	}
+	return summary, recent
+}
+
+func groupProjectActivityHandoffs(handoffs []projectwork.Handoff) (map[string][]projectwork.Handoff, map[string][]projectwork.Handoff) {
+	byAssignment := make(map[string][]projectwork.Handoff)
+	byWorkItem := make(map[string][]projectwork.Handoff)
+	for _, handoff := range handoffs {
+		if handoff.SourceAssignmentID != "" {
+			byAssignment[handoff.SourceAssignmentID] = append(byAssignment[handoff.SourceAssignmentID], handoff)
+			continue
+		}
+		byWorkItem[handoff.WorkItemID] = append(byWorkItem[handoff.WorkItemID], handoff)
 	}
 	return byAssignment, byWorkItem
 }
@@ -1783,15 +2138,19 @@ func projectActivityExecutionRunID(assignment ProjectWorkAssignmentResponse) str
 	return assignment.Execution.RunID
 }
 
-func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, artifacts ProjectActivityArtifactSummaryResponse) string {
+func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, artifacts ProjectActivityArtifactSummaryResponse, handoffs ProjectActivityHandoffSummaryResponse) string {
 	latest := parseProjectActivityTime(firstNonEmpty(assignment.CompletedAt, assignment.StartedAt, assignment.UpdatedAt, assignment.CreatedAt))
 	workUpdated := parseProjectActivityTime(workItem.UpdatedAt)
 	artifactUpdated := parseProjectActivityTime(artifacts.LatestAt)
+	handoffUpdated := parseProjectActivityTime(handoffs.LatestAt)
 	if workUpdated.After(latest) {
 		latest = workUpdated
 	}
 	if artifactUpdated.After(latest) {
 		latest = artifactUpdated
+	}
+	if handoffUpdated.After(latest) {
+		latest = handoffUpdated
 	}
 	return formatOptionalTime(latest)
 }
@@ -1921,5 +2280,33 @@ func renderProjectWorkArtifact(item projectwork.CollaborationArtifact) ProjectWo
 		AuthorRoleID: item.AuthorRoleID,
 		CreatedAt:    formatOptionalTime(item.CreatedAt),
 		UpdatedAt:    formatOptionalTime(item.UpdatedAt),
+	}
+}
+
+func renderProjectHandoff(item projectwork.Handoff) ProjectHandoffResponse {
+	return ProjectHandoffResponse{
+		ID:                    item.ID,
+		ProjectID:             item.ProjectID,
+		WorkItemID:            item.WorkItemID,
+		SourceAssignmentID:    item.SourceAssignmentID,
+		SourceRunID:           item.SourceRunID,
+		SourceChatSessionID:   item.SourceChatSessionID,
+		SourceMessageID:       item.SourceMessageID,
+		TargetRoleID:          item.TargetRoleID,
+		TargetAssignmentID:    item.TargetAssignmentID,
+		TargetWorkItemID:      item.TargetWorkItemID,
+		Title:                 item.Title,
+		Summary:               item.Summary,
+		RecommendedNextAction: item.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), item.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), item.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), item.ContextRefs...),
+		Status:                item.Status,
+		ProvenanceKind:        item.ProvenanceKind,
+		TrustLabel:            item.TrustLabel,
+		CreatedByRoleID:       item.CreatedByRoleID,
+		CreatedAt:             formatOptionalTime(item.CreatedAt),
+		UpdatedAt:             formatOptionalTime(item.UpdatedAt),
+		StatusChangedAt:       formatOptionalTime(item.StatusChangedAt),
 	}
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1071,6 +1071,14 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			if completed.BlockingSignal != "completed" || completed.ArtifactSummary.Count != 1 || completed.ArtifactSummary.LatestTitle != "Completion handoff" || completed.ArtifactSummary.AssignmentID != "asgn_completed" {
 				t.Fatalf("completed activity = %+v, want artifact signal", completed)
 			}
+			if completed.HandoffSummary.Count != 1 || completed.HandoffSummary.LatestTitle != "Review follow-up" {
+				t.Fatalf("completed handoff summary = %+v, want source assignment handoff signal", completed.HandoffSummary)
+			}
+
+			queued := findProjectActivityItemForTest(t, response.Data.Buckets.Active, "asgn_queued")
+			if queued.HandoffSummary.Count != 1 || queued.HandoffSummary.LatestTitle != "Review follow-up" || queued.HandoffSummary.TargetWorkItem != "work_queued" {
+				t.Fatalf("target handoff summary = %+v, want target assignment handoff signal", queued.HandoffSummary)
+			}
 
 			if len(response.Data.Recent) == 0 || len(response.Data.Buckets.Recent) != len(response.Data.Recent) {
 				t.Fatalf("recent activity = %+v buckets=%+v, want mirrored recent list", response.Data.Recent, response.Data.Buckets.Recent)
@@ -1389,6 +1397,21 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 			UpdatedAt:    runFinishedAt.Add(time.Minute),
 		}); err != nil {
 			t.Fatalf("CreateArtifact(%s): %v", assignmentID, err)
+		}
+		if _, err := handler.projectWork.CreateHandoff(ctx, projectwork.Handoff{
+			ID:                    "handoff_review_followup",
+			ProjectID:             "proj_projection",
+			WorkItemID:            workID,
+			SourceAssignmentID:    assignmentID,
+			TargetAssignmentID:    "asgn_queued",
+			TargetWorkItemID:      "work_queued",
+			Title:                 "Review follow-up",
+			Summary:               "Implementation is ready for queue review.",
+			RecommendedNextAction: "Review the queued follow-up assignment.",
+			CreatedAt:             runFinishedAt.Add(2 * time.Minute),
+			UpdatedAt:             runFinishedAt.Add(2 * time.Minute),
+		}); err != nil {
+			t.Fatalf("CreateHandoff(%s): %v", assignmentID, err)
 		}
 	}
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -227,6 +227,84 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs", bytes.NewReader([]byte(`{
+		"id":"handoff_backend",
+		"source_assignment_id":"asgn_backend",
+		"source_run_id":"run_123",
+		"source_chat_session_id":"chat_123",
+		"source_message_id":"msg_123",
+		"target_role_id":"reviewer_qa",
+		"title":"Review backend substrate",
+		"summary":"Store and API are ready for operator review.",
+		"recommended_next_action":"Review the tests and start a QA assignment if acceptable.",
+		"linked_artifact_ids":["art_handoff","art_handoff"],
+		"linked_memory_ids":["mem_123"],
+		"context_refs":["ctx_123"],
+		"provenance_kind":"agent_draft",
+		"trust_label":"operator_reviewed",
+		"created_by_role_id":"software_developer"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create handoff status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var handoff ProjectHandoffEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoff); err != nil {
+		t.Fatalf("decode handoff: %v", err)
+	}
+	if handoff.Data.Status != projectwork.HandoffStatusPending || handoff.Data.TargetRoleID != "reviewer_qa" || len(handoff.Data.LinkedArtifactIDs) != 1 {
+		t.Fatalf("handoff = %+v, want pending structured handoff", handoff.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var handoffs ProjectHandoffsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoffs); err != nil {
+		t.Fatalf("decode handoffs: %v", err)
+	}
+	if len(handoffs.Data) != 1 || handoffs.Data[0].ID != "handoff_backend" {
+		t.Fatalf("handoffs = %+v, want created handoff", handoffs.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs/handoff_backend/status", bytes.NewReader([]byte(`{"status":"accepted"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("accept handoff status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoff); err != nil {
+		t.Fatalf("decode accepted handoff: %v", err)
+	}
+	if handoff.Data.Status != projectwork.HandoffStatusAccepted || handoff.Data.StatusChangedAt == "" {
+		t.Fatalf("accepted handoff = %+v, want status timestamp", handoff.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/handoffs?work_item_id=work_backend&status=accepted", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("project handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoffs); err != nil {
+		t.Fatalf("decode project handoffs: %v", err)
+	}
+	if len(handoffs.Data) != 1 || handoffs.Data[0].ID != "handoff_backend" || handoffs.Data[0].Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("project handoffs = %+v, want accepted handoff", handoffs.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs/handoff_backend", bytes.NewReader([]byte(`{"target_assignment_id":"asgn_backend","recommended_next_action":"Start the linked follow-up assignment."}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch handoff status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoff); err != nil {
+		t.Fatalf("decode patched handoff: %v", err)
+	}
+	if handoff.Data.TargetAssignmentID != "asgn_backend" || handoff.Data.RecommendedNextAction != "Start the linked follow-up assignment." {
+		t.Fatalf("patched handoff = %+v, want linked target assignment", handoff.Data)
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list assignments status = %d body=%s, want 200", rec.Code, rec.Body.String())
@@ -237,6 +315,19 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 	if len(assignments.Data) != 1 || assignments.Data[0].ID != "asgn_backend" {
 		t.Fatalf("assignments = %+v, want created assignment", assignments.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/activity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activity with handoff status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var activity ProjectActivityEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &activity); err != nil {
+		t.Fatalf("decode activity: %v", err)
+	}
+	if len(activity.Data.Recent) == 0 || activity.Data.Recent[0].HandoffSummary.Count != 1 || activity.Data.Recent[0].HandoffSummary.LatestStatus != projectwork.HandoffStatusAccepted {
+		t.Fatalf("activity handoff summary = %+v, want accepted handoff signal", activity.Data.Recent)
 	}
 
 	rec = httptest.NewRecorder()
@@ -252,6 +343,12 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_other/assignments/asgn_backend", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("delete assignment with wrong work item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs/handoff_backend", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete handoff status = %d body=%s, want 204", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -94,6 +94,12 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start", handler.HandleStartProjectWorkAssignment)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleProjectWorkArtifacts)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleCreateProjectWorkArtifact)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/handoffs", handler.HandleProjectHandoffs)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs", handler.HandleProjectWorkItemHandoffs)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs", handler.HandleCreateProjectHandoff)
+	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}", handler.HandleUpdateProjectHandoff)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}/status", handler.HandleUpdateProjectHandoffStatus)
+	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs/{handoff_id}", handler.HandleDeleteProjectHandoff)
 }
 
 func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -3,6 +3,7 @@ package projectwork
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -20,6 +21,7 @@ type SQLiteStore struct {
 	reviewersTbl   string
 	assignmentsTbl string
 	artifactsTbl   string
+	handoffsTbl    string
 }
 
 func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
@@ -33,6 +35,7 @@ func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteS
 		reviewersTbl:   client.QualifiedTable("project_work_item_reviewers"),
 		assignmentsTbl: client.QualifiedTable("project_work_assignments"),
 		artifactsTbl:   client.QualifiedTable("project_work_artifacts"),
+		handoffsTbl:    client.QualifiedTable("project_handoffs"),
 	}
 	if err := store.migrate(ctx); err != nil {
 		return nil, err
@@ -123,6 +126,35 @@ CREATE TABLE IF NOT EXISTS %s (
 )`, s.artifactsTbl)); err != nil {
 		return fmt.Errorf("create project work artifacts table: %w", err)
 	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	source_assignment_id TEXT NOT NULL DEFAULT '',
+	source_run_id TEXT NOT NULL DEFAULT '',
+	source_chat_session_id TEXT NOT NULL DEFAULT '',
+	source_message_id TEXT NOT NULL DEFAULT '',
+	target_role_id TEXT NOT NULL DEFAULT '',
+	target_assignment_id TEXT NOT NULL DEFAULT '',
+	target_work_item_id TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL,
+	summary TEXT NOT NULL,
+	recommended_next_action TEXT NOT NULL,
+	linked_artifact_ids TEXT NOT NULL DEFAULT '[]',
+	linked_memory_ids TEXT NOT NULL DEFAULT '[]',
+	context_refs TEXT NOT NULL DEFAULT '[]',
+	status TEXT NOT NULL,
+	provenance_kind TEXT NOT NULL DEFAULT '',
+	trust_label TEXT NOT NULL DEFAULT '',
+	created_by_role_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	status_changed_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`, s.handoffsTbl)); err != nil {
+		return fmt.Errorf("create project handoffs table: %w", err)
+	}
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "driver_kind", `TEXT NOT NULL DEFAULT 'hecate_task'`); err != nil {
 		return err
 	}
@@ -141,6 +173,7 @@ CREATE TABLE IF NOT EXISTS %s (
 		{s.reviewersTbl, "work_item_idx", "project_id, work_item_id"},
 		{s.assignmentsTbl, "work_item_idx", "project_id, work_item_id"},
 		{s.artifactsTbl, "work_item_idx", "project_id, work_item_id"},
+		{s.handoffsTbl, "work_item_idx", "project_id, work_item_id"},
 	} {
 		name := strings.Trim(stmt.table, `"`) + "_" + stmt.name
 		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (%s)`, name, stmt.table, stmt.cols)); err != nil {
@@ -421,6 +454,7 @@ func (s *SQLiteStore) DeleteWorkItem(ctx context.Context, projectID, id string) 
 		return err
 	}
 	for _, stmt := range []string{
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.handoffsTbl),
 		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.artifactsTbl),
 		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.assignmentsTbl),
 		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ?`, s.reviewersTbl),
@@ -566,6 +600,16 @@ func (s *SQLiteStore) DeleteAssignment(ctx context.Context, projectID, workItemI
 		_ = tx.Rollback()
 		return err
 	}
+	if _, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND (source_assignment_id = ? OR target_assignment_id = ?)`, s.handoffsTbl),
+		projectID,
+		id,
+		id,
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
 	res, err := tx.ExecContext(
 		ctx,
 		fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ? AND id = ?`, s.assignmentsTbl),
@@ -659,6 +703,171 @@ INSERT INTO %s (
 	return s.getRequiredArtifact(ctx, artifact.ProjectID, artifact.ID)
 }
 
+func (s *SQLiteStore) ListHandoffs(ctx context.Context, filter HandoffFilter) ([]Handoff, error) {
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	filter.Status = strings.TrimSpace(filter.Status)
+	query := fmt.Sprintf(`
+SELECT id, project_id, work_item_id, source_assignment_id, source_run_id, source_chat_session_id, source_message_id, target_role_id, target_assignment_id, target_work_item_id, title, summary, recommended_next_action, linked_artifact_ids, linked_memory_ids, context_refs, status, provenance_kind, trust_label, created_by_role_id, created_at, updated_at, status_changed_at
+FROM %s
+WHERE project_id = ?`, s.handoffsTbl)
+	args := []any{filter.ProjectID}
+	if filter.WorkItemID != "" {
+		query += ` AND work_item_id = ?`
+		args = append(args, filter.WorkItemID)
+	}
+	if filter.Status != "" {
+		query += ` AND status = ?`
+		args = append(args, filter.Status)
+	}
+	query += ` ORDER BY updated_at DESC, created_at DESC, id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Handoff
+	for rows.Next() {
+		item, err := scanHandoff(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) CreateHandoff(ctx context.Context, handoff Handoff) (Handoff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handoff = normalizeHandoff(handoff, time.Now().UTC(), false)
+	if err := validateHandoff(handoff); err != nil {
+		return Handoff{}, err
+	}
+	if _, ok, err := s.GetWorkItem(ctx, handoff.ProjectID, handoff.WorkItemID); err != nil {
+		return Handoff{}, err
+	} else if !ok {
+		return Handoff{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	if err := s.validateHandoffAssignments(ctx, handoff); err != nil {
+		return Handoff{}, err
+	}
+	linkedArtifacts, err := encodeStringList(handoff.LinkedArtifactIDs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	linkedMemory, err := encodeStringList(handoff.LinkedMemoryIDs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	contextRefs, err := encodeStringList(handoff.ContextRefs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, project_id, work_item_id, source_assignment_id, source_run_id, source_chat_session_id, source_message_id,
+	target_role_id, target_assignment_id, target_work_item_id, title, summary, recommended_next_action,
+	linked_artifact_ids, linked_memory_ids, context_refs, status, provenance_kind, trust_label, created_by_role_id,
+	created_at, updated_at, status_changed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.handoffsTbl),
+		handoff.ID, handoff.ProjectID, handoff.WorkItemID, handoff.SourceAssignmentID,
+		handoff.SourceRunID, handoff.SourceChatSessionID, handoff.SourceMessageID,
+		handoff.TargetRoleID, handoff.TargetAssignmentID, handoff.TargetWorkItemID,
+		handoff.Title, handoff.Summary, handoff.RecommendedNextAction, linkedArtifacts,
+		linkedMemory, contextRefs, handoff.Status, handoff.ProvenanceKind,
+		handoff.TrustLabel, handoff.CreatedByRoleID, formatTime(handoff.CreatedAt),
+		formatTime(handoff.UpdatedAt), formatTime(handoff.StatusChangedAt),
+	)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return Handoff{}, ErrDuplicate
+		}
+		return Handoff{}, err
+	}
+	return s.getRequiredHandoff(ctx, handoff.ProjectID, handoff.ID)
+}
+
+func (s *SQLiteStore) UpdateHandoff(ctx context.Context, projectID, workItemID, id string, update func(*Handoff)) (Handoff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, err := s.getRequiredHandoff(ctx, projectID, id)
+	if err != nil {
+		return Handoff{}, err
+	}
+	if item.WorkItemID != strings.TrimSpace(workItemID) {
+		return Handoff{}, ErrNotFound
+	}
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalWorkItemID := item.WorkItemID
+	originalCreatedAt := item.CreatedAt
+	originalStatus := item.Status
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID ||
+		strings.TrimSpace(item.ProjectID) != originalProjectID ||
+		strings.TrimSpace(item.WorkItemID) != originalWorkItemID {
+		return Handoff{}, fmt.Errorf("%w: handoff id, project_id, and work_item_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.WorkItemID = originalWorkItemID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeHandoff(item, item.UpdatedAt, strings.TrimSpace(item.Status) != originalStatus)
+	if err := validateHandoff(item); err != nil {
+		return Handoff{}, err
+	}
+	if err := s.validateHandoffAssignments(ctx, item); err != nil {
+		return Handoff{}, err
+	}
+	linkedArtifacts, err := encodeStringList(item.LinkedArtifactIDs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	linkedMemory, err := encodeStringList(item.LinkedMemoryIDs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	contextRefs, err := encodeStringList(item.ContextRefs)
+	if err != nil {
+		return Handoff{}, err
+	}
+	res, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+UPDATE %s SET
+	source_assignment_id = ?, source_run_id = ?, source_chat_session_id = ?, source_message_id = ?,
+	target_role_id = ?, target_assignment_id = ?, target_work_item_id = ?, title = ?, summary = ?,
+	recommended_next_action = ?, linked_artifact_ids = ?, linked_memory_ids = ?, context_refs = ?,
+	status = ?, provenance_kind = ?, trust_label = ?, created_by_role_id = ?, updated_at = ?, status_changed_at = ?
+WHERE project_id = ? AND id = ? AND work_item_id = ?`, s.handoffsTbl),
+		item.SourceAssignmentID, item.SourceRunID, item.SourceChatSessionID, item.SourceMessageID,
+		item.TargetRoleID, item.TargetAssignmentID, item.TargetWorkItemID, item.Title,
+		item.Summary, item.RecommendedNextAction, linkedArtifacts, linkedMemory, contextRefs,
+		item.Status, item.ProvenanceKind, item.TrustLabel, item.CreatedByRoleID,
+		formatTime(item.UpdatedAt), formatTime(item.StatusChangedAt),
+		item.ProjectID, item.ID, item.WorkItemID,
+	)
+	if err != nil {
+		return Handoff{}, err
+	}
+	if err := requireAffected(res); err != nil {
+		return Handoff{}, err
+	}
+	return s.getRequiredHandoff(ctx, item.ProjectID, item.ID)
+}
+
+func (s *SQLiteStore) DeleteHandoff(ctx context.Context, projectID, workItemID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res, err := s.db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ? AND work_item_id = ? AND id = ?`, s.handoffsTbl), strings.TrimSpace(projectID), strings.TrimSpace(workItemID), strings.TrimSpace(id))
+	if err != nil {
+		return err
+	}
+	return requireAffected(res)
+}
+
 func (s *SQLiteStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -673,7 +882,7 @@ func (s *SQLiteStore) Clear(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	for _, table := range []string{s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
+	for _, table := range []string{s.handoffsTbl, s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
 		res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, table))
 		if err != nil {
 			_ = tx.Rollback()
@@ -698,7 +907,7 @@ func (s *SQLiteStore) deleteWhereProject(ctx context.Context, projectID string) 
 	if err != nil {
 		return 0, err
 	}
-	for _, table := range []string{s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
+	for _, table := range []string{s.handoffsTbl, s.artifactsTbl, s.assignmentsTbl, s.reviewersTbl, s.workItemsTbl, s.rolesTbl} {
 		res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE project_id = ?`, table), projectID)
 		if err != nil {
 			_ = tx.Rollback()
@@ -823,6 +1032,46 @@ WHERE project_id = ? AND id = ?`, s.artifactsTbl), strings.TrimSpace(projectID),
 	return item, err
 }
 
+func (s *SQLiteStore) getRequiredHandoff(ctx context.Context, projectID, id string) (Handoff, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, work_item_id, source_assignment_id, source_run_id, source_chat_session_id, source_message_id, target_role_id, target_assignment_id, target_work_item_id, title, summary, recommended_next_action, linked_artifact_ids, linked_memory_ids, context_refs, status, provenance_kind, trust_label, created_by_role_id, created_at, updated_at, status_changed_at
+FROM %s
+WHERE project_id = ? AND id = ?`, s.handoffsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
+	item, err := scanHandoff(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Handoff{}, ErrNotFound
+	}
+	return item, err
+}
+
+func (s *SQLiteStore) validateHandoffAssignments(ctx context.Context, handoff Handoff) error {
+	if handoff.SourceAssignmentID != "" {
+		assignment, err := s.getRequiredAssignment(ctx, handoff.ProjectID, handoff.SourceAssignmentID)
+		if errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("%w: source assignment not found", err)
+		}
+		if err != nil {
+			return err
+		}
+		if assignment.WorkItemID != handoff.WorkItemID {
+			return fmt.Errorf("%w: source assignment not found", ErrNotFound)
+		}
+	}
+	if handoff.TargetAssignmentID != "" {
+		assignment, err := s.getRequiredAssignment(ctx, handoff.ProjectID, handoff.TargetAssignmentID)
+		if errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("%w: target assignment not found", err)
+		}
+		if err != nil {
+			return err
+		}
+		if handoff.TargetWorkItemID != "" && assignment.WorkItemID != handoff.TargetWorkItemID {
+			return fmt.Errorf("%w: target assignment not found", ErrNotFound)
+		}
+	}
+	return nil
+}
+
 type scanner interface {
 	Scan(...any) error
 }
@@ -913,6 +1162,43 @@ func scanArtifact(row scanner) (CollaborationArtifact, error) {
 	return item, nil
 }
 
+func scanHandoff(row scanner) (Handoff, error) {
+	var item Handoff
+	var linkedArtifactIDs, linkedMemoryIDs, contextRefs string
+	var createdAt, updatedAt, statusChangedAt string
+	if err := row.Scan(
+		&item.ID, &item.ProjectID, &item.WorkItemID, &item.SourceAssignmentID,
+		&item.SourceRunID, &item.SourceChatSessionID, &item.SourceMessageID,
+		&item.TargetRoleID, &item.TargetAssignmentID, &item.TargetWorkItemID,
+		&item.Title, &item.Summary, &item.RecommendedNextAction,
+		&linkedArtifactIDs, &linkedMemoryIDs, &contextRefs, &item.Status,
+		&item.ProvenanceKind, &item.TrustLabel, &item.CreatedByRoleID,
+		&createdAt, &updatedAt, &statusChangedAt,
+	); err != nil {
+		return Handoff{}, err
+	}
+	var err error
+	if item.LinkedArtifactIDs, err = decodeStringList(linkedArtifactIDs); err != nil {
+		return Handoff{}, err
+	}
+	if item.LinkedMemoryIDs, err = decodeStringList(linkedMemoryIDs); err != nil {
+		return Handoff{}, err
+	}
+	if item.ContextRefs, err = decodeStringList(contextRefs); err != nil {
+		return Handoff{}, err
+	}
+	if item.CreatedAt, err = parseTime(createdAt); err != nil {
+		return Handoff{}, err
+	}
+	if item.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return Handoff{}, err
+	}
+	if item.StatusChangedAt, err = parseTime(statusChangedAt); err != nil {
+		return Handoff{}, err
+	}
+	return item, nil
+}
+
 func requireAffected(res sql.Result) error {
 	affected, err := res.RowsAffected()
 	if err != nil {
@@ -926,6 +1212,30 @@ func requireAffected(res sql.Result) error {
 
 func isSQLiteConstraint(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "constraint")
+}
+
+func encodeStringList(values []string) (string, error) {
+	values = normalizeStringList(values)
+	if values == nil {
+		values = []string{}
+	}
+	data, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func decodeStringList(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(value), &values); err != nil {
+		return nil, err
+	}
+	return normalizeStringList(values), nil
 }
 
 func formatTime(value time.Time) string {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -33,6 +33,11 @@ const (
 	ArtifactKindHandoff      = "handoff"
 	ArtifactKindReview       = "review"
 	ArtifactKindDecisionNote = "decision_note"
+
+	HandoffStatusPending    = "pending"
+	HandoffStatusAccepted   = "accepted"
+	HandoffStatusSuperseded = "superseded"
+	HandoffStatusDismissed  = "dismissed"
 )
 
 var (
@@ -102,6 +107,32 @@ type CollaborationArtifact struct {
 	UpdatedAt    time.Time
 }
 
+type Handoff struct {
+	ID                    string
+	ProjectID             string
+	WorkItemID            string
+	SourceAssignmentID    string
+	SourceRunID           string
+	SourceChatSessionID   string
+	SourceMessageID       string
+	TargetRoleID          string
+	TargetAssignmentID    string
+	TargetWorkItemID      string
+	Title                 string
+	Summary               string
+	RecommendedNextAction string
+	LinkedArtifactIDs     []string
+	LinkedMemoryIDs       []string
+	ContextRefs           []string
+	Status                string
+	ProvenanceKind        string
+	TrustLabel            string
+	CreatedByRoleID       string
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	StatusChangedAt       time.Time
+}
+
 type AssignmentFilter struct {
 	ProjectID  string
 	WorkItemID string
@@ -111,6 +142,12 @@ type ArtifactFilter struct {
 	ProjectID    string
 	WorkItemID   string
 	AssignmentID string
+}
+
+type HandoffFilter struct {
+	ProjectID  string
+	WorkItemID string
+	Status     string
 }
 
 type Store interface {
@@ -130,6 +167,10 @@ type Store interface {
 	DeleteAssignment(ctx context.Context, projectID, workItemID, id string) error
 	ListArtifacts(ctx context.Context, filter ArtifactFilter) ([]CollaborationArtifact, error)
 	CreateArtifact(ctx context.Context, artifact CollaborationArtifact) (CollaborationArtifact, error)
+	ListHandoffs(ctx context.Context, filter HandoffFilter) ([]Handoff, error)
+	CreateHandoff(ctx context.Context, handoff Handoff) (Handoff, error)
+	UpdateHandoff(ctx context.Context, projectID, workItemID, id string, update func(*Handoff)) (Handoff, error)
+	DeleteHandoff(ctx context.Context, projectID, workItemID, id string) error
 	DeleteProject(ctx context.Context, projectID string) (int, error)
 	Clear(ctx context.Context) (int, error)
 }
@@ -140,6 +181,7 @@ type MemoryStore struct {
 	workItems   map[string]WorkItem
 	assignments map[string]Assignment
 	artifacts   map[string]CollaborationArtifact
+	handoffs    map[string]Handoff
 }
 
 func NewMemoryStore() *MemoryStore {
@@ -148,6 +190,7 @@ func NewMemoryStore() *MemoryStore {
 		workItems:   make(map[string]WorkItem),
 		assignments: make(map[string]Assignment),
 		artifacts:   make(map[string]CollaborationArtifact),
+		handoffs:    make(map[string]Handoff),
 	}
 }
 
@@ -359,6 +402,11 @@ func (s *MemoryStore) DeleteWorkItem(_ context.Context, projectID, id string) er
 			delete(s.artifacts, key)
 		}
 	}
+	for key, handoff := range s.handoffs {
+		if handoff.ProjectID == projectID && handoff.WorkItemID == id {
+			delete(s.handoffs, key)
+		}
+	}
 	return nil
 }
 
@@ -450,6 +498,11 @@ func (s *MemoryStore) DeleteAssignment(_ context.Context, projectID, workItemID,
 			delete(s.artifacts, key)
 		}
 	}
+	for key, handoff := range s.handoffs {
+		if handoff.ProjectID == projectID && (handoff.SourceAssignmentID == id || handoff.TargetAssignmentID == id) {
+			delete(s.handoffs, key)
+		}
+	}
 	return nil
 }
 
@@ -500,6 +553,124 @@ func (s *MemoryStore) CreateArtifact(_ context.Context, artifact CollaborationAr
 	return cloneArtifact(artifact), nil
 }
 
+func (s *MemoryStore) ListHandoffs(_ context.Context, filter HandoffFilter) ([]Handoff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
+	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	filter.Status = strings.TrimSpace(filter.Status)
+	items := make([]Handoff, 0, len(s.handoffs))
+	for _, item := range s.handoffs {
+		if item.ProjectID != filter.ProjectID {
+			continue
+		}
+		if filter.WorkItemID != "" && item.WorkItemID != filter.WorkItemID {
+			continue
+		}
+		if filter.Status != "" && item.Status != filter.Status {
+			continue
+		}
+		items = append(items, cloneHandoff(item))
+	}
+	sortHandoffs(items)
+	return items, nil
+}
+
+func (s *MemoryStore) CreateHandoff(_ context.Context, handoff Handoff) (Handoff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handoff = normalizeHandoff(handoff, time.Now().UTC(), false)
+	if err := validateHandoff(handoff); err != nil {
+		return Handoff{}, err
+	}
+	if _, ok := s.workItems[workItemKey(handoff.ProjectID, handoff.WorkItemID)]; !ok {
+		return Handoff{}, fmt.Errorf("%w: work item not found", ErrNotFound)
+	}
+	if handoff.SourceAssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(handoff.ProjectID, handoff.SourceAssignmentID)]
+		if !ok || assignment.WorkItemID != handoff.WorkItemID {
+			return Handoff{}, fmt.Errorf("%w: source assignment not found", ErrNotFound)
+		}
+	}
+	if handoff.TargetAssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(handoff.ProjectID, handoff.TargetAssignmentID)]
+		if !ok {
+			return Handoff{}, fmt.Errorf("%w: target assignment not found", ErrNotFound)
+		}
+		if handoff.TargetWorkItemID != "" && assignment.WorkItemID != handoff.TargetWorkItemID {
+			return Handoff{}, fmt.Errorf("%w: target assignment not found", ErrNotFound)
+		}
+	}
+	key := handoffKey(handoff.ProjectID, handoff.ID)
+	if _, exists := s.handoffs[key]; exists {
+		return Handoff{}, ErrDuplicate
+	}
+	s.handoffs[key] = cloneHandoff(handoff)
+	return cloneHandoff(handoff), nil
+}
+
+func (s *MemoryStore) UpdateHandoff(_ context.Context, projectID, workItemID, id string, update func(*Handoff)) (Handoff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := handoffKey(projectID, id)
+	item, ok := s.handoffs[key]
+	if !ok || item.WorkItemID != strings.TrimSpace(workItemID) {
+		return Handoff{}, ErrNotFound
+	}
+	item = cloneHandoff(item)
+	originalID := item.ID
+	originalProjectID := item.ProjectID
+	originalWorkItemID := item.WorkItemID
+	originalCreatedAt := item.CreatedAt
+	originalStatus := item.Status
+	if update != nil {
+		update(&item)
+	}
+	if strings.TrimSpace(item.ID) != originalID ||
+		strings.TrimSpace(item.ProjectID) != originalProjectID ||
+		strings.TrimSpace(item.WorkItemID) != originalWorkItemID {
+		return Handoff{}, fmt.Errorf("%w: handoff id, project_id, and work_item_id cannot be changed", ErrInvalid)
+	}
+	item.ID = originalID
+	item.ProjectID = originalProjectID
+	item.WorkItemID = originalWorkItemID
+	item.CreatedAt = originalCreatedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = normalizeHandoff(item, item.UpdatedAt, strings.TrimSpace(item.Status) != originalStatus)
+	if err := validateHandoff(item); err != nil {
+		return Handoff{}, err
+	}
+	if item.SourceAssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(item.ProjectID, item.SourceAssignmentID)]
+		if !ok || assignment.WorkItemID != item.WorkItemID {
+			return Handoff{}, fmt.Errorf("%w: source assignment not found", ErrNotFound)
+		}
+	}
+	if item.TargetAssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(item.ProjectID, item.TargetAssignmentID)]
+		if !ok {
+			return Handoff{}, fmt.Errorf("%w: target assignment not found", ErrNotFound)
+		}
+		if item.TargetWorkItemID != "" && assignment.WorkItemID != item.TargetWorkItemID {
+			return Handoff{}, fmt.Errorf("%w: target assignment not found", ErrNotFound)
+		}
+	}
+	s.handoffs[key] = cloneHandoff(item)
+	return cloneHandoff(item), nil
+}
+
+func (s *MemoryStore) DeleteHandoff(_ context.Context, projectID, workItemID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := handoffKey(projectID, id)
+	handoff, ok := s.handoffs[key]
+	if !ok || handoff.WorkItemID != strings.TrimSpace(workItemID) {
+		return ErrNotFound
+	}
+	delete(s.handoffs, key)
+	return nil
+}
+
 func (s *MemoryStore) DeleteProject(_ context.Context, projectID string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -529,17 +700,24 @@ func (s *MemoryStore) DeleteProject(_ context.Context, projectID string) (int, e
 			deleted++
 		}
 	}
+	for key, item := range s.handoffs {
+		if item.ProjectID == projectID {
+			delete(s.handoffs, key)
+			deleted++
+		}
+	}
 	return deleted, nil
 }
 
 func (s *MemoryStore) Clear(_ context.Context) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	deleted := len(s.roles) + len(s.workItems) + len(s.assignments) + len(s.artifacts)
+	deleted := len(s.roles) + len(s.workItems) + len(s.assignments) + len(s.artifacts) + len(s.handoffs)
 	s.roles = make(map[string]AgentRoleProfile)
 	s.workItems = make(map[string]WorkItem)
 	s.assignments = make(map[string]Assignment)
 	s.artifacts = make(map[string]CollaborationArtifact)
+	s.handoffs = make(map[string]Handoff)
 	return deleted, nil
 }
 
@@ -643,6 +821,51 @@ func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationA
 	return item
 }
 
+func normalizeHandoff(item Handoff, now time.Time, statusChanged bool) Handoff {
+	item.ID = strings.TrimSpace(item.ID)
+	item.ProjectID = strings.TrimSpace(item.ProjectID)
+	item.WorkItemID = strings.TrimSpace(item.WorkItemID)
+	item.SourceAssignmentID = strings.TrimSpace(item.SourceAssignmentID)
+	item.SourceRunID = strings.TrimSpace(item.SourceRunID)
+	item.SourceChatSessionID = strings.TrimSpace(item.SourceChatSessionID)
+	item.SourceMessageID = strings.TrimSpace(item.SourceMessageID)
+	item.TargetRoleID = strings.TrimSpace(item.TargetRoleID)
+	item.TargetAssignmentID = strings.TrimSpace(item.TargetAssignmentID)
+	item.TargetWorkItemID = strings.TrimSpace(item.TargetWorkItemID)
+	item.Title = strings.TrimSpace(item.Title)
+	item.Summary = strings.TrimSpace(item.Summary)
+	item.RecommendedNextAction = strings.TrimSpace(item.RecommendedNextAction)
+	item.LinkedArtifactIDs = normalizeStringList(item.LinkedArtifactIDs)
+	item.LinkedMemoryIDs = normalizeStringList(item.LinkedMemoryIDs)
+	item.ContextRefs = normalizeStringList(item.ContextRefs)
+	item.Status = strings.TrimSpace(item.Status)
+	item.ProvenanceKind = strings.TrimSpace(item.ProvenanceKind)
+	item.TrustLabel = strings.TrimSpace(item.TrustLabel)
+	item.CreatedByRoleID = strings.TrimSpace(item.CreatedByRoleID)
+	if item.Status == "" {
+		item.Status = HandoffStatusPending
+	}
+	if item.ProvenanceKind == "" {
+		item.ProvenanceKind = "operator"
+	}
+	if item.TrustLabel == "" {
+		item.TrustLabel = "operator_reviewed"
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = item.CreatedAt
+	}
+	if item.StatusChangedAt.IsZero() || statusChanged {
+		item.StatusChangedAt = now
+	}
+	return item
+}
+
 func validateRole(role AgentRoleProfile) error {
 	if role.ProjectID == "" {
 		return fmt.Errorf("%w: project_id is required", ErrInvalid)
@@ -728,6 +951,31 @@ func validateArtifact(item CollaborationArtifact) error {
 	return nil
 }
 
+func validateHandoff(item Handoff) error {
+	if item.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if item.ID == "" {
+		return fmt.Errorf("%w: handoff id is required", ErrInvalid)
+	}
+	if item.WorkItemID == "" {
+		return fmt.Errorf("%w: work_item_id is required", ErrInvalid)
+	}
+	if item.Title == "" {
+		return fmt.Errorf("%w: handoff title is required", ErrInvalid)
+	}
+	if item.Summary == "" {
+		return fmt.Errorf("%w: handoff summary is required", ErrInvalid)
+	}
+	if item.RecommendedNextAction == "" {
+		return fmt.Errorf("%w: recommended_next_action is required", ErrInvalid)
+	}
+	if !validHandoffStatus(item.Status) {
+		return fmt.Errorf("%w: unsupported handoff status %q", ErrInvalid, item.Status)
+	}
+	return nil
+}
+
 func validWorkItemStatus(status string) bool {
 	switch status {
 	case WorkItemStatusBacklog, WorkItemStatusReady, WorkItemStatusRunning, WorkItemStatusReview, WorkItemStatusBlocked, WorkItemStatusDone, WorkItemStatusCancelled:
@@ -749,6 +997,15 @@ func validAssignmentStatus(status string) bool {
 func validArtifactKind(kind string) bool {
 	switch kind {
 	case ArtifactKindBrief, ArtifactKindHandoff, ArtifactKindReview, ArtifactKindDecisionNote:
+		return true
+	default:
+		return false
+	}
+}
+
+func validHandoffStatus(status string) bool {
+	switch status {
+	case HandoffStatusPending, HandoffStatusAccepted, HandoffStatusSuperseded, HandoffStatusDismissed:
 		return true
 	default:
 		return false
@@ -801,6 +1058,10 @@ func artifactKey(projectID, id string) string {
 	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
 }
 
+func handoffKey(projectID, id string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(id)
+}
+
 func cloneRole(item AgentRoleProfile) AgentRoleProfile {
 	return item
 }
@@ -815,6 +1076,13 @@ func cloneAssignment(item Assignment) Assignment {
 }
 
 func cloneArtifact(item CollaborationArtifact) CollaborationArtifact {
+	return item
+}
+
+func cloneHandoff(item Handoff) Handoff {
+	item.LinkedArtifactIDs = append([]string(nil), item.LinkedArtifactIDs...)
+	item.LinkedMemoryIDs = append([]string(nil), item.LinkedMemoryIDs...)
+	item.ContextRefs = append([]string(nil), item.ContextRefs...)
 	return item
 }
 
@@ -852,6 +1120,18 @@ func sortArtifacts(items []CollaborationArtifact) {
 	sort.SliceStable(items, func(i, j int) bool {
 		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
 			return items[i].CreatedAt.Before(items[j].CreatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortHandoffs(items []Handoff) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
+			return items[i].UpdatedAt.After(items[j].UpdatedAt)
+		}
+		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].CreatedAt.After(items[j].CreatedAt)
 		}
 		return items[i].ID < items[j].ID
 	})

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -170,6 +170,45 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				t.Fatalf("artifact = %+v, want brief artifact", artifact)
 			}
 
+			handoff, err := store.CreateHandoff(ctx, Handoff{
+				ID:                    "handoff_impl",
+				ProjectID:             "proj_alpha",
+				WorkItemID:            "work_api",
+				SourceAssignmentID:    "asgn_impl",
+				SourceRunID:           "run_123",
+				TargetRoleID:          "reviewer_qa",
+				Title:                 "Implementation handoff",
+				Summary:               "Backend substrate is ready for review.",
+				RecommendedNextAction: "Review the API and storage behavior.",
+				LinkedArtifactIDs:     []string{"art_brief", "art_brief"},
+				LinkedMemoryIDs:       []string{"mem_project"},
+				ContextRefs:           []string{"ctx_123"},
+				ProvenanceKind:        "agent_draft",
+				TrustLabel:            "operator_reviewed",
+				CreatedByRoleID:       "software_developer",
+			})
+			if err != nil {
+				t.Fatalf("CreateHandoff: %v", err)
+			}
+			if handoff.Status != HandoffStatusPending || len(handoff.LinkedArtifactIDs) != 1 || handoff.ProvenanceKind != "agent_draft" {
+				t.Fatalf("handoff = %+v, want pending normalized handoff", handoff)
+			}
+			updatedHandoff, err := store.UpdateHandoff(ctx, "proj_alpha", "work_api", "handoff_impl", func(item *Handoff) {
+				item.Status = HandoffStatusAccepted
+				item.TargetAssignmentID = "asgn_impl"
+			})
+			if err != nil {
+				t.Fatalf("UpdateHandoff: %v", err)
+			}
+			if updatedHandoff.Status != HandoffStatusAccepted || updatedHandoff.TargetAssignmentID != "asgn_impl" || updatedHandoff.StatusChangedAt.IsZero() {
+				t.Fatalf("updated handoff = %+v, want accepted linked handoff", updatedHandoff)
+			}
+			if _, err := store.UpdateHandoff(ctx, "proj_alpha", "work_api", "handoff_impl", func(item *Handoff) {
+				item.Status = "unsupported"
+			}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("UpdateHandoff unsupported status error = %v, want ErrInvalid", err)
+			}
+
 			if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_api", ProjectID: "proj_alpha", Title: "Duplicate"}); !errors.Is(err, ErrDuplicate) {
 				t.Fatalf("duplicate CreateWorkItem error = %v, want ErrDuplicate", err)
 			}
@@ -178,6 +217,9 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			}
 			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_brief", ProjectID: "proj_alpha", WorkItemID: "work_api", Kind: ArtifactKindBrief, Body: "Duplicate"}); !errors.Is(err, ErrDuplicate) {
 				t.Fatalf("duplicate CreateArtifact error = %v, want ErrDuplicate", err)
+			}
+			if _, err := store.CreateHandoff(ctx, Handoff{ID: "handoff_impl", ProjectID: "proj_alpha", WorkItemID: "work_api", Title: "Duplicate", Summary: "Duplicate.", RecommendedNextAction: "Ignore."}); !errors.Is(err, ErrDuplicate) {
+				t.Fatalf("duplicate CreateHandoff error = %v, want ErrDuplicate", err)
 			}
 
 			assignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
@@ -194,6 +236,13 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if len(artifacts) != 1 || artifacts[0].ID != "art_brief" {
 				t.Fatalf("artifacts = %+v, want created artifact", artifacts)
 			}
+			handoffs, err := store.ListHandoffs(ctx, HandoffFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListHandoffs: %v", err)
+			}
+			if len(handoffs) != 1 || handoffs[0].ID != "handoff_impl" {
+				t.Fatalf("handoffs = %+v, want created handoff", handoffs)
+			}
 
 			if err := store.DeleteAssignment(ctx, "proj_alpha", "work_api", "asgn_impl"); err != nil {
 				t.Fatalf("DeleteAssignment: %v", err)
@@ -206,14 +255,21 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListArtifacts after assignment delete: %v", err)
 			}
-			if len(assignments) != 0 || len(artifacts) != 0 {
-				t.Fatalf("assignment delete left assignments=%+v artifacts=%+v", assignments, artifacts)
+			handoffs, err = store.ListHandoffs(ctx, HandoffFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
+			if err != nil {
+				t.Fatalf("ListHandoffs after assignment delete: %v", err)
+			}
+			if len(assignments) != 0 || len(artifacts) != 0 || len(handoffs) != 0 {
+				t.Fatalf("assignment delete left assignments=%+v artifacts=%+v handoffs=%+v", assignments, artifacts, handoffs)
 			}
 			if _, err := store.CreateAssignment(ctx, Assignment{ID: "asgn_impl", ProjectID: "proj_alpha", WorkItemID: "work_api", RoleID: "software_developer"}); err != nil {
 				t.Fatalf("recreate assignment after delete: %v", err)
 			}
 			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_brief", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindBrief, Body: "Brief again."}); err != nil {
 				t.Fatalf("recreate artifact after delete: %v", err)
+			}
+			if _, err := store.CreateHandoff(ctx, Handoff{ID: "handoff_impl", ProjectID: "proj_alpha", WorkItemID: "work_api", SourceAssignmentID: "asgn_impl", Title: "Handoff again", Summary: "Ready again.", RecommendedNextAction: "Review again."}); err != nil {
+				t.Fatalf("recreate handoff after delete: %v", err)
 			}
 
 			if err := store.DeleteWorkItem(ctx, "proj_alpha", "work_api"); err != nil {
@@ -227,8 +283,12 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListArtifacts after delete: %v", err)
 			}
-			if len(assignments) != 0 || len(artifacts) != 0 {
-				t.Fatalf("work item delete left assignments=%+v artifacts=%+v", assignments, artifacts)
+			handoffs, err = store.ListHandoffs(ctx, HandoffFilter{ProjectID: "proj_alpha"})
+			if err != nil {
+				t.Fatalf("ListHandoffs after delete: %v", err)
+			}
+			if len(assignments) != 0 || len(artifacts) != 0 || len(handoffs) != 0 {
+				t.Fatalf("work item delete left assignments=%+v artifacts=%+v handoffs=%+v", assignments, artifacts, handoffs)
 			}
 		})
 	}

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -12,6 +12,7 @@ import {
   getProjectAssignments,
   getProjectActivity,
   getProjectCollaborationArtifacts,
+  getProjectHandoffs,
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
@@ -43,6 +44,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       object: "project_collaboration_artifacts",
       data: [],
     })),
+    getProjectHandoffs: vi.fn(async () => ({ object: "project_handoffs", data: [] })),
   };
 });
 
@@ -90,6 +92,10 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectAssignments).mockResolvedValue({ object: "project_assignments", data: [] });
   vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
     object: "project_collaboration_artifacts",
+    data: [],
+  });
+  vi.mocked(getProjectHandoffs).mockResolvedValue({
+    object: "project_handoffs",
     data: [],
   });
 }

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1210,6 +1210,7 @@ describe("ProjectsView cockpit", () => {
           summary: "Ready for review.",
           recommended_next_action: "Create a QA assignment.",
           target_role_id: "reviewer_qa",
+          target_work_item_id: "work_followup",
           status: "pending",
           provenance_kind: "agent_draft",
           trust_label: "operator_reviewed",
@@ -1221,7 +1222,13 @@ describe("ProjectsView cockpit", () => {
     });
     vi.mocked(createProjectAssignment).mockResolvedValueOnce({
       object: "project_assignment",
-      data: { ...hecateAssignment, id: "asgn_new", role_id: "reviewer_qa", status: "queued" },
+      data: {
+        ...hecateAssignment,
+        id: "asgn_new",
+        work_item_id: "work_followup",
+        role_id: "reviewer_qa",
+        status: "queued",
+      },
     });
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
@@ -1235,7 +1242,7 @@ describe("ProjectsView cockpit", () => {
     await userEvent.click(within(detail).getByRole("button", { name: "Target assignment" }));
 
     await waitFor(() => {
-      expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
+      expect(createProjectAssignment).toHaveBeenCalledWith(project.id, "work_followup", {
         role_id: "reviewer_qa",
         driver_kind: "hecate_task",
       });

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -8,16 +8,19 @@ import { ProjectsProvider } from "../../app/state/projects";
 import { SettingsProvider } from "../../app/state/settings";
 import {
   createProjectAssignment,
+  createProjectHandoff,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
+  deleteProjectHandoff,
   deleteProjectMemory,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
+  getProjectHandoffs,
   getProjectMemory,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -25,6 +28,8 @@ import {
   startProjectAssignment,
   updateProject,
   updateProjectAssignment,
+  updateProjectHandoff,
+  updateProjectHandoffStatus,
   updateProjectMemory,
   updateProjectWorkRole,
   updateProjectWorkItem,
@@ -88,7 +93,12 @@ vi.mock("../../lib/api", async (importOriginal) => {
       object: "project_collaboration_artifacts",
       data: [],
     })),
+    getProjectHandoffs: vi.fn(async () => ({ object: "project_handoffs", data: [] })),
     getProjectMemory: vi.fn(async () => ({ object: "project_memory", data: [] })),
+    createProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
+    updateProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
+    updateProjectHandoffStatus: vi.fn(async () => ({ object: "project_handoff", data: null })),
+    deleteProjectHandoff: vi.fn(async () => undefined),
     createProjectMemory: vi.fn(async () => ({ object: "project_memory_entry", data: null })),
     updateProjectMemory: vi.fn(async () => ({ object: "project_memory_entry", data: null })),
     deleteProjectMemory: vi.fn(async () => undefined),
@@ -224,6 +234,7 @@ function resetProjectWorkMocks() {
             linked_task_id: "task_1",
             linked_run_id: "run_1",
             artifact_summary: { count: 1, latest_kind: "handoff", latest_title: "Runtime notes" },
+            handoff_summary: { count: 0 },
             recent_artifacts: [
               {
                 id: "art_1",
@@ -263,7 +274,64 @@ function resetProjectWorkMocks() {
     object: "project_collaboration_artifacts",
     data: [],
   });
+  vi.mocked(getProjectHandoffs).mockResolvedValue({
+    object: "project_handoffs",
+    data: [],
+  });
   vi.mocked(getProjectMemory).mockResolvedValue({ object: "project_memory", data: [] });
+  vi.mocked(createProjectHandoff).mockResolvedValue({
+    object: "project_handoff",
+    data: {
+      id: "handoff_new",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      title: "QA handoff",
+      summary: "Ready for review.",
+      recommended_next_action: "Start QA.",
+      status: "pending",
+      provenance_kind: "operator",
+      trust_label: "operator_reviewed",
+      created_at: "2026-06-02T12:00:00Z",
+      updated_at: "2026-06-02T12:00:00Z",
+      status_changed_at: "2026-06-02T12:00:00Z",
+    },
+  });
+  vi.mocked(updateProjectHandoff).mockResolvedValue({
+    object: "project_handoff",
+    data: {
+      id: "handoff_new",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      title: "QA handoff",
+      summary: "Ready for review.",
+      recommended_next_action: "Start QA.",
+      target_assignment_id: "asgn_new",
+      status: "accepted",
+      provenance_kind: "operator",
+      trust_label: "operator_reviewed",
+      created_at: "2026-06-02T12:00:00Z",
+      updated_at: "2026-06-02T12:05:00Z",
+      status_changed_at: "2026-06-02T12:05:00Z",
+    },
+  });
+  vi.mocked(updateProjectHandoffStatus).mockResolvedValue({
+    object: "project_handoff",
+    data: {
+      id: "handoff_new",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      title: "QA handoff",
+      summary: "Ready for review.",
+      recommended_next_action: "Start QA.",
+      status: "accepted",
+      provenance_kind: "operator",
+      trust_label: "operator_reviewed",
+      created_at: "2026-06-02T12:00:00Z",
+      updated_at: "2026-06-02T12:05:00Z",
+      status_changed_at: "2026-06-02T12:05:00Z",
+    },
+  });
+  vi.mocked(deleteProjectHandoff).mockResolvedValue(undefined);
   vi.mocked(createProjectMemory).mockResolvedValue({
     object: "project_memory_entry",
     data: { ...memoryEntry, id: "mem_new", title: "Review posture" },
@@ -361,7 +429,12 @@ afterEach(() => {
   vi.mocked(getProjectWorkItem).mockReset();
   vi.mocked(getProjectAssignments).mockReset();
   vi.mocked(getProjectCollaborationArtifacts).mockReset();
+  vi.mocked(getProjectHandoffs).mockReset();
   vi.mocked(getProjectMemory).mockReset();
+  vi.mocked(createProjectHandoff).mockReset();
+  vi.mocked(updateProjectHandoff).mockReset();
+  vi.mocked(updateProjectHandoffStatus).mockReset();
+  vi.mocked(deleteProjectHandoff).mockReset();
   vi.mocked(createProjectMemory).mockReset();
   vi.mocked(updateProjectMemory).mockReset();
   vi.mocked(deleteProjectMemory).mockReset();
@@ -1122,6 +1195,62 @@ describe("ProjectsView cockpit", () => {
       role_id: "software_developer",
       driver_kind: "external_agent",
     });
+  });
+
+  it("creates target assignments from handoffs without starting them", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectHandoffs).mockResolvedValue({
+      object: "project_handoffs",
+      data: [
+        {
+          id: "handoff_1",
+          project_id: project.id,
+          work_item_id: workItem.id,
+          title: "QA handoff",
+          summary: "Ready for review.",
+          recommended_next_action: "Create a QA assignment.",
+          target_role_id: "reviewer_qa",
+          status: "pending",
+          provenance_kind: "agent_draft",
+          trust_label: "operator_reviewed",
+          created_at: "2026-06-02T12:00:00Z",
+          updated_at: "2026-06-02T12:00:00Z",
+          status_changed_at: "2026-06-02T12:00:00Z",
+        },
+      ],
+    });
+    vi.mocked(createProjectAssignment).mockResolvedValueOnce({
+      object: "project_assignment",
+      data: { ...hecateAssignment, id: "asgn_new", role_id: "reviewer_qa", status: "queued" },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const detail = screen.getByLabelText("Selected work item");
+    expect(await within(detail).findByText("QA handoff")).toBeTruthy();
+    await userEvent.click(within(detail).getByRole("button", { name: "Target assignment" }));
+
+    await waitFor(() => {
+      expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
+        role_id: "reviewer_qa",
+        driver_kind: "hecate_task",
+      });
+    });
+    expect(updateProjectHandoff).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      "handoff_1",
+      expect.objectContaining({
+        target_assignment_id: "asgn_new",
+        target_role_id: "reviewer_qa",
+        status: "accepted",
+      }),
+    );
+    expect(startProjectAssignment).not.toHaveBeenCalled();
   });
 
   it("uses a role default driver when adding assignments", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -848,14 +848,18 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!selectedProjectID || !selectedWorkItemID) return;
     const roleID = (handoff.target_role_id || "software_developer").trim();
     if (!roleID) return;
+    const targetWorkItemID = (handoff.target_work_item_id || selectedWorkItemID).trim();
+    if (!targetWorkItemID) return;
     setHandoffActionID(handoff.id);
     setHandoffError("");
     try {
-      const assignment = await createProjectAssignment(selectedProjectID, selectedWorkItemID, {
+      const assignment = await createProjectAssignment(selectedProjectID, targetWorkItemID, {
         role_id: roleID,
         driver_kind: "hecate_task",
       });
-      setAssignments((current) => upsertAssignment(current, assignment.data));
+      if (targetWorkItemID === selectedWorkItemID) {
+        setAssignments((current) => upsertAssignment(current, assignment.data));
+      }
       const updated = await updateProjectHandoff(
         selectedProjectID,
         selectedWorkItemID,

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -6,16 +6,19 @@ import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
   createProjectAssignment,
+  createProjectHandoff,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
+  deleteProjectHandoff,
   deleteProjectMemory,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
+  getProjectHandoffs,
   getProjectMemory,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -23,6 +26,8 @@ import {
   startProjectAssignment,
   updateProject,
   updateProjectAssignment,
+  updateProjectHandoff,
+  updateProjectHandoffStatus,
   updateProjectMemory,
   updateProjectWorkRole,
   updateProjectWorkItem,
@@ -35,6 +40,8 @@ import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
   ProjectCollaborationArtifactRecord,
+  CreateProjectHandoffPayload,
+  ProjectHandoffRecord,
   ProjectMemoryRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
@@ -110,6 +117,22 @@ type EditAssignmentForm = NewAssignmentForm & {
   contextSnapshotID: string;
 };
 
+type HandoffForm = {
+  id: string;
+  sourceAssignmentID: string;
+  targetRoleID: string;
+  targetAssignmentID: string;
+  title: string;
+  summary: string;
+  recommendedNextAction: string;
+  linkedArtifactIDs: string;
+  linkedMemoryIDs: string;
+  contextRefs: string;
+  status: string;
+  provenanceKind: string;
+  trustLabel: string;
+};
+
 type ProjectDefaultsForm = {
   provider: string;
   model: string;
@@ -154,6 +177,7 @@ const ASSIGNMENT_STATUSES = [
   "failed",
   "cancelled",
 ];
+const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"];
 const MEMORY_TRUST_LABELS = [
   "operator_memory",
   "generated_summary",
@@ -244,6 +268,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [selectedWorkItem, setSelectedWorkItem] = useState<ProjectWorkItemRecord | null>(null);
   const [assignments, setAssignments] = useState<ProjectAssignmentRecord[]>([]);
   const [artifacts, setArtifacts] = useState<ProjectCollaborationArtifactRecord[]>([]);
+  const [handoffs, setHandoffs] = useState<ProjectHandoffRecord[]>([]);
+  const [editingHandoff, setEditingHandoff] = useState<ProjectHandoffRecord | "new" | null>(null);
+  const [handoffPending, setHandoffPending] = useState(false);
+  const [handoffError, setHandoffError] = useState("");
+  const [handoffActionID, setHandoffActionID] = useState("");
   const [workLoadState, setWorkLoadState] = useState<LoadState>("idle");
   const [detailLoadState, setDetailLoadState] = useState<LoadState>("idle");
   const [workError, setWorkError] = useState("");
@@ -337,6 +366,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setSelectedWorkItem(null);
       setAssignments([]);
       setArtifacts([]);
+      setHandoffs([]);
     }
     if (!projectID) {
       setWorkLoadState("idle");
@@ -403,19 +433,22 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setSelectedWorkItem(null);
       setAssignments([]);
       setArtifacts([]);
+      setHandoffs([]);
       setDetailLoadState("idle");
       return;
     }
     setDetailLoadState("loading");
     try {
-      const [itemRes, assignmentRes, artifactRes] = await Promise.all([
+      const [itemRes, assignmentRes, artifactRes, handoffRes] = await Promise.all([
         getProjectWorkItem(projectID, workItemID),
         getProjectAssignments(projectID, workItemID),
         getProjectCollaborationArtifacts(projectID, workItemID),
+        getProjectHandoffs(projectID, workItemID),
       ]);
       setSelectedWorkItem(itemRes.data);
       setAssignments(assignmentRes.data ?? []);
       setArtifacts(artifactRes.data ?? []);
+      setHandoffs(handoffRes.data ?? []);
       setWorkItems((current) => upsertWorkItem(current, itemRes.data));
       setWorkItemSummaries((current) => ({
         ...current,
@@ -739,6 +772,122 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
+  async function handleSaveHandoff(form: HandoffForm) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const title = form.title.trim();
+    const summary = form.summary.trim();
+    const recommendedNextAction = form.recommendedNextAction.trim();
+    if (!title || !summary || !recommendedNextAction) return;
+    const payload: CreateProjectHandoffPayload = {
+      source_assignment_id: form.sourceAssignmentID.trim(),
+      target_role_id: form.targetRoleID.trim(),
+      target_assignment_id: form.targetAssignmentID.trim(),
+      title,
+      summary,
+      recommended_next_action: recommendedNextAction,
+      linked_artifact_ids: splitIDs(form.linkedArtifactIDs),
+      linked_memory_ids: splitIDs(form.linkedMemoryIDs),
+      context_refs: splitIDs(form.contextRefs),
+      status: form.status || "pending",
+      provenance_kind: form.provenanceKind.trim() || "operator",
+      trust_label: form.trustLabel.trim() || "operator_reviewed",
+    };
+    setHandoffPending(true);
+    setHandoffError("");
+    try {
+      const res =
+        editingHandoff === "new"
+          ? await createProjectHandoff(selectedProjectID, selectedWorkItemID, payload)
+          : await updateProjectHandoff(selectedProjectID, selectedWorkItemID, form.id, payload);
+      setHandoffs((current) => upsertHandoff(current, res.data));
+      setEditingHandoff(null);
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setHandoffError(errorMessage(error, "Failed to save handoff."));
+    } finally {
+      setHandoffPending(false);
+    }
+  }
+
+  async function handleSetHandoffStatus(handoff: ProjectHandoffRecord, status: string) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    setHandoffActionID(handoff.id);
+    setHandoffError("");
+    try {
+      const res = await updateProjectHandoffStatus(
+        selectedProjectID,
+        selectedWorkItemID,
+        handoff.id,
+        status,
+      );
+      setHandoffs((current) => upsertHandoff(current, res.data));
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setHandoffError(errorMessage(error, "Failed to update handoff status."));
+    } finally {
+      setHandoffActionID("");
+    }
+  }
+
+  async function handleDeleteHandoff(handoff: ProjectHandoffRecord) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    setHandoffActionID(handoff.id);
+    setHandoffError("");
+    try {
+      await deleteProjectHandoff(selectedProjectID, selectedWorkItemID, handoff.id);
+      setHandoffs((current) => current.filter((item) => item.id !== handoff.id));
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setHandoffError(errorMessage(error, "Failed to delete handoff."));
+    } finally {
+      setHandoffActionID("");
+    }
+  }
+
+  async function handleCreateAssignmentFromHandoff(handoff: ProjectHandoffRecord) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const roleID = (handoff.target_role_id || "software_developer").trim();
+    if (!roleID) return;
+    setHandoffActionID(handoff.id);
+    setHandoffError("");
+    try {
+      const assignment = await createProjectAssignment(selectedProjectID, selectedWorkItemID, {
+        role_id: roleID,
+        driver_kind: "hecate_task",
+      });
+      setAssignments((current) => upsertAssignment(current, assignment.data));
+      const updated = await updateProjectHandoff(
+        selectedProjectID,
+        selectedWorkItemID,
+        handoff.id,
+        {
+          target_assignment_id: assignment.data.id,
+          target_role_id: assignment.data.role_id,
+          status: "accepted",
+        },
+      );
+      setHandoffs((current) => upsertHandoff(current, updated.data));
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setHandoffError(errorMessage(error, "Failed to create target assignment."));
+    } finally {
+      setHandoffActionID("");
+    }
+  }
+
+  async function handleStartHandoff(handoff: ProjectHandoffRecord) {
+    const assignment = assignments.find((item) => item.id === handoff.target_assignment_id);
+    if (!assignment) {
+      setHandoffError("Handoff has no loaded target assignment to start.");
+      return;
+    }
+    await handleStartAssignment(assignment, selectedWorkItemID);
+    if (handoff.status === "pending") {
+      await handleSetHandoffStatus(handoff, "accepted");
+    }
+  }
+
   async function refreshSelectedWorkItem() {
     if (!selectedProjectID) return;
     const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, selectedWorkItemID);
@@ -907,12 +1056,21 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
         <WorkItemDetail
           assignments={assignments}
           artifacts={artifacts}
+          handoffActionID={handoffActionID}
+          handoffError={handoffError}
+          handoffs={handoffs}
           assignmentErrors={assignmentErrors}
           detailError={detailError}
           loading={detailLoadState === "loading"}
           onOpenTask={onOpenTask}
           onRefresh={refreshSelectedWorkItem}
+          onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
+          onDeleteHandoff={(handoff) => void handleDeleteHandoff(handoff)}
           onDeleteWorkItem={(item) => setDeleteWorkItem(item)}
+          onEditHandoff={(handoff) => {
+            setHandoffError("");
+            setEditingHandoff(handoff);
+          }}
           onEditAssignment={(assignment) => {
             setEditAssignmentError("");
             setEditingAssignment(assignment);
@@ -924,6 +1082,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           onDeleteAssignment={(assignment) => setDeleteAssignment(assignment)}
           onOpenChat={onOpenChat}
           onStartAssignment={handleStartAssignment}
+          onStartHandoff={(handoff) => void handleStartHandoff(handoff)}
+          onSetHandoffStatus={(handoff, status) => void handleSetHandoffStatus(handoff, status)}
           project={selectedProject}
           roleByID={roleByID}
           startingAssignmentID={startingAssignmentID}
@@ -931,6 +1091,10 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           onAddAssignment={() => {
             setNewAssignmentError("");
             setNewAssignmentModalOpen(true);
+          }}
+          onAddHandoff={() => {
+            setHandoffError("");
+            setEditingHandoff("new");
           }}
         />
       </section>
@@ -1010,6 +1174,19 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           pending={memoryPending}
           onClose={() => setEditingMemory(null)}
           onSave={handleSaveMemory}
+        />
+      )}
+
+      {editingHandoff && selectedWorkItem && (
+        <ProjectHandoffModal
+          key={editingHandoff === "new" ? "new" : editingHandoff.id}
+          assignments={assignments}
+          handoff={editingHandoff === "new" ? null : editingHandoff}
+          error={handoffError}
+          pending={handoffPending}
+          roles={roles}
+          onClose={() => setEditingHandoff(null)}
+          onSave={handleSaveHandoff}
         />
       )}
 
@@ -1466,6 +1643,7 @@ function ProjectActivityRow({
   const taskID = item.linked_task_id || item.assignment.task_id || "";
   const runID = item.linked_run_id || item.assignment.run_id || "";
   const startable = item.assignment.driver_kind === "hecate_task" && signal === "not_started";
+  const handoffCount = item.handoff_summary?.count ?? 0;
   return (
     <div style={activityRowStyle}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
@@ -1527,6 +1705,12 @@ function ProjectActivityRow({
             {item.artifact_summary.count === 1 ? "" : "s"}
           </span>
         )}
+        {handoffCount > 0 && (
+          <span>
+            {handoffCount} handoff
+            {handoffCount === 1 ? "" : "s"}
+          </span>
+        )}
         {item.updated_at && <span>Updated {formatAbsoluteTime(item.updated_at)}</span>}
       </div>
       {item.recent_artifacts && item.recent_artifacts.length > 0 && (
@@ -1534,6 +1718,15 @@ function ProjectActivityRow({
           {item.recent_artifacts.map((artifact) => (
             <span key={artifact.id} className="badge badge-muted">
               {artifact.kind}: {artifact.title || artifact.id}
+            </span>
+          ))}
+        </div>
+      )}
+      {item.recent_handoffs && item.recent_handoffs.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7 }}>
+          {item.recent_handoffs.map((handoff) => (
+            <span key={handoff.id} className="badge badge-muted">
+              {handoff.status}: {handoff.title || handoff.id}
             </span>
           ))}
         </div>
@@ -1788,18 +1981,27 @@ function ProjectMemoryModal({
 function WorkItemDetail({
   assignments,
   artifacts,
+  handoffActionID,
+  handoffError,
+  handoffs,
   assignmentErrors,
   detailError,
   loading,
   onAddAssignment,
+  onAddHandoff,
+  onCreateAssignmentFromHandoff,
   onDeleteAssignment,
+  onDeleteHandoff,
   onDeleteWorkItem,
   onEditAssignment,
+  onEditHandoff,
   onEditWorkItem,
   onOpenChat,
   onOpenTask,
   onRefresh,
   onStartAssignment,
+  onStartHandoff,
+  onSetHandoffStatus,
   project,
   roleByID,
   startingAssignmentID,
@@ -1807,18 +2009,27 @@ function WorkItemDetail({
 }: {
   assignments: ProjectAssignmentRecord[];
   artifacts: ProjectCollaborationArtifactRecord[];
+  handoffActionID: string;
+  handoffError: string;
+  handoffs: ProjectHandoffRecord[];
   assignmentErrors: Record<string, string>;
   detailError: string;
   loading: boolean;
   onAddAssignment: () => void;
+  onAddHandoff: () => void;
+  onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
   onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onDeleteHandoff: (handoff: ProjectHandoffRecord) => void;
   onDeleteWorkItem: (item: ProjectWorkItemRecord) => void;
   onEditAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onEditHandoff: (handoff: ProjectHandoffRecord) => void;
   onEditWorkItem: (item: ProjectWorkItemRecord) => void;
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onRefresh: () => void;
   onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onStartHandoff: (handoff: ProjectHandoffRecord) => void;
+  onSetHandoffStatus: (handoff: ProjectHandoffRecord, status: string) => void;
   project: ProjectRecord | null;
   roleByID: Map<string, ProjectWorkRoleRecord>;
   startingAssignmentID: string;
@@ -1963,6 +2174,43 @@ function WorkItemDetail({
                   {artifact.body}
                 </div>
               </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div style={panelStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+          <div style={sectionLabelStyle}>Handoffs</div>
+          <span className="badge badge-muted">{handoffs.length}</span>
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={onAddHandoff}
+            style={{ marginLeft: "auto" }}
+          >
+            <Icon d={Icons.plus} size={12} />
+            Handoff
+          </button>
+        </div>
+        {handoffError && <InlineError message={handoffError} />}
+        {handoffs.length === 0 ? (
+          <div style={subtleTextStyle}>No structured handoffs recorded for this work item.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            {handoffs.map((handoff) => (
+              <ProjectHandoffRow
+                key={handoff.id}
+                actionPending={handoffActionID === handoff.id}
+                assignment={assignments.find((item) => item.id === handoff.target_assignment_id)}
+                handoff={handoff}
+                onCreateAssignment={() => onCreateAssignmentFromHandoff(handoff)}
+                onDelete={() => onDeleteHandoff(handoff)}
+                onEdit={() => onEditHandoff(handoff)}
+                onSetStatus={(status) => onSetHandoffStatus(handoff, status)}
+                onStart={() => onStartHandoff(handoff)}
+                role={handoff.target_role_id ? roleByID.get(handoff.target_role_id) : undefined}
+                starting={startingAssignmentID === handoff.target_assignment_id}
+              />
             ))}
           </div>
         )}
@@ -2864,6 +3112,199 @@ function EditAssignmentModal({
   );
 }
 
+function ProjectHandoffModal({
+  assignments,
+  error,
+  handoff,
+  pending,
+  roles,
+  onClose,
+  onSave,
+}: {
+  assignments: ProjectAssignmentRecord[];
+  error: string;
+  handoff: ProjectHandoffRecord | null;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: HandoffForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<HandoffForm>(() => handoffFormFromRecord(handoff));
+  const valid =
+    form.title.trim().length > 0 &&
+    form.summary.trim().length > 0 &&
+    form.recommendedNextAction.trim().length > 0;
+  return (
+    <Modal
+      title={handoff ? "Edit handoff" : "New handoff"}
+      onClose={onClose}
+      width={620}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save handoff"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+            placeholder="QA review handoff"
+          />
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Summary</span>
+          <textarea
+            className="input"
+            value={form.summary}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, summary: event.target.value }))
+            }
+            rows={4}
+            style={{ resize: "vertical", minHeight: 90 }}
+          />
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Recommended next action</span>
+          <textarea
+            className="input"
+            value={form.recommendedNextAction}
+            onChange={(event) =>
+              setForm((current) => ({
+                ...current,
+                recommendedNextAction: event.target.value,
+              }))
+            }
+            rows={3}
+            style={{ resize: "vertical", minHeight: 76 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Source assignment</span>
+            <select
+              className="input"
+              value={form.sourceAssignmentID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceAssignmentID: event.target.value }))
+              }
+            >
+              <option value="">No source assignment</option>
+              {assignments.map((assignment) => (
+                <option key={assignment.id} value={assignment.id}>
+                  {shortID(assignment.id)} · {assignment.role_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Target role</span>
+            <select
+              className="input"
+              value={form.targetRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, targetRoleID: event.target.value }))
+              }
+            >
+              <option value="">No target role</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Target assignment</span>
+            <select
+              className="input"
+              value={form.targetAssignmentID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, targetAssignmentID: event.target.value }))
+              }
+            >
+              <option value="">No target assignment</option>
+              {assignments.map((assignment) => (
+                <option key={assignment.id} value={assignment.id}>
+                  {shortID(assignment.id)} · {assignment.role_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {HANDOFF_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Artifact IDs</span>
+            <input
+              className="input"
+              value={form.linkedArtifactIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, linkedArtifactIDs: event.target.value }))
+              }
+              placeholder="art_1, art_2"
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Memory IDs</span>
+            <input
+              className="input"
+              value={form.linkedMemoryIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, linkedMemoryIDs: event.target.value }))
+              }
+              placeholder="mem_1"
+            />
+          </label>
+        </div>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Context refs</span>
+          <input
+            className="input"
+            value={form.contextRefs}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, contextRefs: event.target.value }))
+            }
+            placeholder="ctx_1, task/run/context"
+          />
+        </label>
+      </form>
+    </Modal>
+  );
+}
+
 function AssignmentRow({
   assignment,
   chatModel,
@@ -3008,6 +3449,130 @@ function AssignmentRow({
   );
 }
 
+function ProjectHandoffRow({
+  actionPending,
+  assignment,
+  handoff,
+  onCreateAssignment,
+  onDelete,
+  onEdit,
+  onSetStatus,
+  onStart,
+  role,
+  starting,
+}: {
+  actionPending: boolean;
+  assignment?: ProjectAssignmentRecord;
+  handoff: ProjectHandoffRecord;
+  onCreateAssignment: () => void;
+  onDelete: () => void;
+  onEdit: () => void;
+  onSetStatus: (status: string) => void;
+  onStart: () => void;
+  role?: ProjectWorkRoleRecord;
+  starting: boolean;
+}) {
+  const startable =
+    assignment?.driver_kind === "hecate_task" &&
+    (assignment.execution?.status || assignment.status) === "queued";
+  const canCreateAssignment = !assignment && handoff.status !== "dismissed";
+  return (
+    <div style={artifactStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Badge status={handoff.status} label={handoffStatusLabel(handoff.status)} />
+        <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{handoff.title}</div>
+        <button className="btn btn-ghost btn-sm" type="button" onClick={onEdit}>
+          <Icon d={Icons.edit} size={12} />
+          Edit
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onDelete}
+          disabled={actionPending}
+          style={{ color: "var(--red)" }}
+        >
+          <Icon d={Icons.trash} size={12} />
+          Delete
+        </button>
+      </div>
+      <div style={{ marginTop: 7, fontSize: 12, color: "var(--t2)", lineHeight: 1.45 }}>
+        {handoff.summary}
+      </div>
+      <div style={{ marginTop: 7, fontSize: 12, color: "var(--t1)", lineHeight: 1.45 }}>
+        Next: {handoff.recommended_next_action}
+      </div>
+      <div style={{ ...metaLineStyle, marginTop: 8 }}>
+        {role && <span>target {role.name}</span>}
+        {handoff.target_assignment_id && (
+          <span>assignment {shortID(handoff.target_assignment_id)}</span>
+        )}
+        <span>{handoff.provenance_kind}</span>
+        <span>{handoff.trust_label}</span>
+        {handoff.updated_at && <span>Updated {formatAbsoluteTime(handoff.updated_at)}</span>}
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 9 }}>
+        {handoff.status === "pending" && (
+          <>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              onClick={() => onSetStatus("accepted")}
+              disabled={actionPending}
+            >
+              <Icon d={Icons.check} size={12} />
+              Accept
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              onClick={() => onSetStatus("dismissed")}
+              disabled={actionPending}
+            >
+              Dismiss
+            </button>
+          </>
+        )}
+        {handoff.status !== "superseded" && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={() => onSetStatus("superseded")}
+            disabled={actionPending}
+          >
+            Supersede
+          </button>
+        )}
+        {canCreateAssignment && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={onCreateAssignment}
+            disabled={actionPending}
+          >
+            <Icon d={Icons.plus} size={12} />
+            Target assignment
+          </button>
+        )}
+        {assignment && (
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            onClick={onStart}
+            disabled={!startable || starting}
+            title={
+              startable ? "Start linked native assignment" : "Linked assignment is not queued."
+            }
+          >
+            <Icon d={Icons.send} size={12} />
+            {starting ? "Starting…" : "Start from handoff"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function EmptyBlock({ title, detail }: { title: string; detail: string }) {
   return (
     <div
@@ -3076,6 +3641,24 @@ function rolePayloadFromForm(form: RoleForm) {
     default_provider: form.defaultProvider.trim(),
     default_model: form.defaultModel.trim(),
     default_agent_profile: form.defaultAgentProfile.trim(),
+  };
+}
+
+function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): HandoffForm {
+  return {
+    id: handoff?.id ?? "",
+    sourceAssignmentID: handoff?.source_assignment_id ?? "",
+    targetRoleID: handoff?.target_role_id ?? "",
+    targetAssignmentID: handoff?.target_assignment_id ?? "",
+    title: handoff?.title ?? "",
+    summary: handoff?.summary ?? "",
+    recommendedNextAction: handoff?.recommended_next_action ?? "",
+    linkedArtifactIDs: (handoff?.linked_artifact_ids ?? []).join(", "),
+    linkedMemoryIDs: (handoff?.linked_memory_ids ?? []).join(", "),
+    contextRefs: (handoff?.context_refs ?? []).join(", "),
+    status: handoff?.status ?? "pending",
+    provenanceKind: handoff?.provenance_kind ?? "operator",
+    trustLabel: handoff?.trust_label ?? "operator_reviewed",
   };
 }
 
@@ -3328,7 +3911,25 @@ function upsertAssignment(items: ProjectAssignmentRecord[], item: ProjectAssignm
   return next;
 }
 
+function upsertHandoff(items: ProjectHandoffRecord[], item: ProjectHandoffRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  const next = index === -1 ? [item, ...items] : items.slice();
+  if (index !== -1) {
+    next[index] = item;
+  }
+  return next.sort((left, right) => {
+    const byTime = (right.updated_at || right.created_at).localeCompare(
+      left.updated_at || left.created_at,
+    );
+    return byTime || left.id.localeCompare(right.id);
+  });
+}
+
 function splitRoleIDs(value: string): string[] {
+  return splitIDs(value);
+}
+
+function splitIDs(value: string): string[] {
   return value
     .split(",")
     .map((item) => item.trim())
@@ -3354,6 +3955,21 @@ function assignmentStatusLabel(status: string | undefined): string {
   if (status === "awaiting_approval") return "approval";
   if (status === "completed") return "done";
   return status.replaceAll("_", " ");
+}
+
+function handoffStatusLabel(status: string): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "accepted":
+      return "Accepted";
+    case "superseded":
+      return "Superseded";
+    case "dismissed":
+      return "Dismissed";
+    default:
+      return status || "Unknown";
+  }
 }
 
 const topbarStyle: CSSProperties = {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -5,12 +5,14 @@ import {
   cancelChatApproval,
   chatCompletions,
   createProjectAssignment,
+  createProjectHandoff,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteChatGrant,
   deletePolicyRule,
   deleteProjectAssignment,
+  deleteProjectHandoff,
   deleteProjectMemory,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
@@ -24,6 +26,7 @@ import {
   getProjectAssignments,
   getProjectActivity,
   getProjectCollaborationArtifacts,
+  getProjectHandoffs,
   getProjectMemory,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -50,6 +53,8 @@ import {
   updateChatSession,
   updateProject,
   updateProjectAssignment,
+  updateProjectHandoff,
+  updateProjectHandoffStatus,
   updateProjectMemory,
   updateProjectWorkRole,
   updateProjectWorkItem,
@@ -263,7 +268,7 @@ describe("api client", () => {
 
   it("builds project work coordination requests", async () => {
     fetchMock.mockClear();
-    for (let i = 0; i < 6; i += 1) {
+    for (let i = 0; i < 7; i += 1) {
       fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
     }
 
@@ -273,6 +278,7 @@ describe("api client", () => {
     await getProjectWorkItem("proj/1", "work/1");
     await getProjectAssignments("proj/1", "work/1");
     await getProjectCollaborationArtifacts("proj/1", "work/1");
+    await getProjectHandoffs("proj/1", "work/1");
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -303,6 +309,79 @@ describe("api client", () => {
       6,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
       expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      7,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("manages project handoff records", async () => {
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ object: "project_handoff", data: { id: "handoff/1" } }))
+      .mockResolvedValueOnce(jsonResponse({ object: "project_handoff", data: { id: "handoff/1" } }))
+      .mockResolvedValueOnce(jsonResponse({ object: "project_handoff", data: { id: "handoff/1" } }))
+      .mockResolvedValueOnce(jsonResponse(null));
+
+    await createProjectHandoff("proj/1", "work/1", {
+      title: "Review next",
+      summary: "Implementation is ready.",
+      recommended_next_action: "Start QA.",
+      source_assignment_id: "asgn/1",
+      target_role_id: "reviewer_qa",
+      linked_artifact_ids: ["art/1"],
+      linked_memory_ids: ["mem/1"],
+      context_refs: ["ctx/1"],
+      provenance_kind: "agent_draft",
+      trust_label: "operator_reviewed",
+    });
+    await updateProjectHandoff("proj/1", "work/1", "handoff/1", {
+      target_assignment_id: "asgn/2",
+    });
+    await updateProjectHandoffStatus("proj/1", "work/1", "handoff/1", "accepted");
+    await deleteProjectHandoff("proj/1", "work/1", "handoff/1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Review next",
+          summary: "Implementation is ready.",
+          recommended_next_action: "Start QA.",
+          source_assignment_id: "asgn/1",
+          target_role_id: "reviewer_qa",
+          linked_artifact_ids: ["art/1"],
+          linked_memory_ids: ["mem/1"],
+          context_refs: ["ctx/1"],
+          provenance_kind: "agent_draft",
+          trust_label: "operator_reviewed",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs/handoff%2F1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ target_assignment_id: "asgn/2" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs/handoff%2F1/status",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ status: "accepted" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs/handoff%2F1",
+      expect.objectContaining({ method: "DELETE" }),
     );
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -51,12 +51,15 @@ import type {
   CreateProjectPayload,
   CreateProjectMemoryPayload,
   CreateProjectAssignmentPayload,
+  CreateProjectHandoffPayload,
   CreateProjectWorkRolePayload,
   CreateProjectWorkItemPayload,
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
   ProjectActivityResponse,
   ProjectCollaborationArtifactsResponse,
+  ProjectHandoffResponse,
+  ProjectHandoffsResponse,
   ProjectMemoryListResponse,
   ProjectMemoryResponse,
   ProjectResponse,
@@ -66,6 +69,7 @@ import type {
   ProjectWorkRolesResponse,
   ProjectsResponse,
   UpdateProjectAssignmentPayload,
+  UpdateProjectHandoffPayload,
   UpdateProjectMemoryPayload,
   UpdateProjectPayload,
   UpdateProjectWorkRolePayload,
@@ -516,6 +520,61 @@ export async function getProjectCollaborationArtifacts(
 ): Promise<ProjectCollaborationArtifactsResponse> {
   return fetchJSON<ProjectCollaborationArtifactsResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/artifacts`,
+  );
+}
+
+export async function getProjectHandoffs(
+  projectID: string,
+  workItemID: string,
+): Promise<ProjectHandoffsResponse> {
+  return fetchJSON<ProjectHandoffsResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/handoffs`,
+  );
+}
+
+export async function createProjectHandoff(
+  projectID: string,
+  workItemID: string,
+  payload: CreateProjectHandoffPayload,
+): Promise<ProjectHandoffResponse> {
+  return fetchJSON<ProjectHandoffResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/handoffs`,
+    { method: "POST", body: payload },
+  );
+}
+
+export async function updateProjectHandoff(
+  projectID: string,
+  workItemID: string,
+  handoffID: string,
+  payload: UpdateProjectHandoffPayload,
+): Promise<ProjectHandoffResponse> {
+  return fetchJSON<ProjectHandoffResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/handoffs/${encodeURIComponent(handoffID)}`,
+    { method: "PATCH", body: payload },
+  );
+}
+
+export async function updateProjectHandoffStatus(
+  projectID: string,
+  workItemID: string,
+  handoffID: string,
+  status: string,
+): Promise<ProjectHandoffResponse> {
+  return fetchJSON<ProjectHandoffResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/handoffs/${encodeURIComponent(handoffID)}/status`,
+    { method: "POST", body: { status } },
+  );
+}
+
+export async function deleteProjectHandoff(
+  projectID: string,
+  workItemID: string,
+  handoffID: string,
+): Promise<void> {
+  return fetchJSON<void>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/handoffs/${encodeURIComponent(handoffID)}`,
+    { method: "DELETE" },
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -263,6 +263,57 @@ export type ProjectCollaborationArtifactRecord = {
   updated_at: string;
 };
 
+export type ProjectHandoffStatus = "pending" | "accepted" | "superseded" | "dismissed";
+
+export type ProjectHandoffRecord = {
+  id: string;
+  project_id: string;
+  work_item_id: string;
+  source_assignment_id?: string;
+  source_run_id?: string;
+  source_chat_session_id?: string;
+  source_message_id?: string;
+  target_role_id?: string;
+  target_assignment_id?: string;
+  target_work_item_id?: string;
+  title: string;
+  summary: string;
+  recommended_next_action: string;
+  linked_artifact_ids?: string[];
+  linked_memory_ids?: string[];
+  context_refs?: string[];
+  status: ProjectHandoffStatus | string;
+  provenance_kind: string;
+  trust_label: string;
+  created_by_role_id?: string;
+  created_at: string;
+  updated_at: string;
+  status_changed_at: string;
+};
+
+export type CreateProjectHandoffPayload = {
+  id?: string;
+  source_assignment_id?: string;
+  source_run_id?: string;
+  source_chat_session_id?: string;
+  source_message_id?: string;
+  target_role_id?: string;
+  target_assignment_id?: string;
+  target_work_item_id?: string;
+  title: string;
+  summary: string;
+  recommended_next_action: string;
+  linked_artifact_ids?: string[];
+  linked_memory_ids?: string[];
+  context_refs?: string[];
+  status?: ProjectHandoffStatus | string;
+  provenance_kind?: string;
+  trust_label?: string;
+  created_by_role_id?: string;
+};
+
+export type UpdateProjectHandoffPayload = Partial<CreateProjectHandoffPayload>;
+
 export type ProjectActivitySignal =
   | "awaiting_approval"
   | "failed"
@@ -287,6 +338,18 @@ export type ProjectActivityArtifactSummary = {
   assignment_id?: string;
 };
 
+export type ProjectActivityHandoffSummary = {
+  count: number;
+  pending_count?: number;
+  accepted_count?: number;
+  latest_status?: ProjectHandoffStatus | string;
+  latest_title?: string;
+  latest_at?: string;
+  assignment_id?: string;
+  target_role_id?: string;
+  target_work_item_id?: string;
+};
+
 export type ProjectActivityItemRecord = {
   id: string;
   project_id: string;
@@ -302,6 +365,8 @@ export type ProjectActivityItemRecord = {
   linked_message_id?: string;
   recent_artifacts?: ProjectCollaborationArtifactRecord[];
   artifact_summary: ProjectActivityArtifactSummary;
+  recent_handoffs?: ProjectHandoffRecord[];
+  handoff_summary?: ProjectActivityHandoffSummary;
   updated_at: string;
 };
 
@@ -366,4 +431,14 @@ export type ProjectAssignmentResponse = {
 export type ProjectCollaborationArtifactsResponse = {
   object: string;
   data: ProjectCollaborationArtifactRecord[];
+};
+
+export type ProjectHandoffsResponse = {
+  object: string;
+  data: ProjectHandoffRecord[];
+};
+
+export type ProjectHandoffResponse = {
+  object: string;
+  data: ProjectHandoffRecord;
 };


### PR DESCRIPTION
## Summary

Adds a conservative V1 structured handoff primitive for project work so one assignment/run/chat can pass context and a recommended next action to another role or assignment while keeping follow-up execution operator-controlled.

## Changes

- Add project-scoped handoff records with memory and SQLite store parity.
- Add Hecate-native handoff list/create/update/status/delete API endpoints with project activity handoff projections.
- Add Projects UI handoff management plus explicit target-assignment and start-from-handoff actions.
- Update runtime API docs, event catalog notes, and project/memory/context RFCs for the V1 boundaries.

## Validation

- go test ./internal/projectwork ./internal/api
- go vet ./internal/projectwork ./internal/api
- go test -race -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- git diff --check