### PR TITLE
Add project health cockpit

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -2,7 +2,7 @@
 
 This guide covers the source-build toolchain, local-build path, UI hot reload,
 website development, the test surface, and the screenshot tooling. For the
-simplest get-it-running flow, see [Quick Start](../README.md#quick-start) — the
+simplest get-it-running flow, see [Start Here](../README.md#start-here) — the
 desktop app is the recommended on-ramp for macOS personal use; Docker is the
 more predictable path for server use and for Linux/Windows until those desktop
 bundles are manually tested.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -231,7 +231,12 @@ Initial UI should stay lightweight:
 - Let future “Use model” and “Use external agent” flows attach to the same project when started from the same workspace.
 - Let agent profiles expose whether project memory is injected, visible only,
   or disabled for that agent.
-- Add a project details surface later for defaults, memory, trusted docs, and recent activity.
+- Show a compact project health band in the project cockpit that derives
+  operational status from existing activity, assignment execution rollups,
+  handoff summaries, project defaults, memory entries, memory candidates, and
+  context-source metadata.
+- Keep the project details surface focused on defaults, memory, trusted docs,
+  activity, and assignment drill-downs.
 
 Avoid turning Projects into a heavy project-management product. This is a runtime identity and context boundary first.
 
@@ -263,8 +268,14 @@ assignment, but the handoff record itself does not dispatch another agent.
 The Projects UI also derives a compact project timeline / decision log from
 activity rows, structured handoffs, collaboration artifacts, project memory
 entries, and memory candidates; explicit decisions are only shown when existing
-`decision_note` artifacts are present. Broader task `project_id` scoping,
-profiles, and presets are not linked to `project_id` yet.
+`decision_note` artifacts are present. The Projects cockpit derives a compact
+health band from that activity response plus
+project defaults, handoff summaries, memory candidates, and memory/context
+metadata so operators can scan active work, waiting approvals, blocked or stale
+assignments, recent completions, pending handoffs, memory review work, missing
+provider/model defaults, and context readiness without adding a separate
+persisted health model. Broader task `project_id` scoping, profiles, and presets
+are not linked to `project_id` yet.
 
 Persist `project_id` on:
 

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-The [Quick Start](../README.md#quick-start) covers `docker run` end-to-end. This page is the reference for everything past the first run: pinning images, the compose profile, the binary install, storage tiers, and rate limits.
+The [Start Here](../README.md#start-here) guide covers `docker run` end-to-end. This page is the reference for everything past the first run: pinning images, the compose profile, the binary install, storage tiers, and rate limits.
 
 Hecate defaults to `127.0.0.1:8765` and enforces same-origin for browser requests, but same-origin is not a network security boundary. If you change `HECATE_ADDRESS` to expose Hecate beyond the local machine, startup now requires `HECATE_ALLOW_NON_LOOPBACK_BIND=1`; set it only with your own access controls, firewall, or reverse proxy in front. The current security model is documented in [Security](security.md).
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -59,7 +59,7 @@ Hecate stores local configuration and operational state on disk.
 - Provider credentials and settings are local to the gateway data directory / desktop app data directory.
 - Missing SQLite data directories are created as owner-only on POSIX (`0700`), and database files are created or repaired as `0600`. Hecate does not chmod existing parent directories supplied by the operator.
 - Do not commit `.env`, SQLite databases, release keys, update signing keys, or platform credential files.
-- External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own, proxy, or pool those accounts. See [External agent adapters](../design/accepted/external-agent-adapters.md#credential-and-account-boundaries) for credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok Build.
+- External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own, proxy, or pool those accounts. See [External agent adapters](../runtime/external-agent-adapters.md#credential-and-account-boundaries) for credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok Build.
 - Stdio MCP servers inherit only runtime-essential environment variables from the gateway. Server credentials must be configured explicitly on that MCP server entry.
 - If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach an unprotected inference path may be able to spend those credentials. Use your own network access control; set `HECATE_INFERENCE_TOKEN` for provider-compatible `/v1/*` clients and `HECATE_RUNTIME_TOKEN` for Hecate-native chat, task, and control-plane clients.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1425,6 +1425,15 @@ items, assignments, projected task/run execution summaries, linked chat/task
 identifiers, and recent collaboration artifact signals without mutating any
 project-work or task rows.
 
+The Projects UI also derives a compact Project Health band from this response
+plus the project defaults, memory candidates, and memory/context-source lists.
+That health view is a client-side projection for operator orientation: active
+work, approvals waiting, pending handoffs, memory candidates awaiting review,
+blocked/failed/cancelled assignments, recent completions, stale or missing
+linked execution, missing provider/model defaults, and memory/context readiness.
+It does not add a separate recommendation engine, dependency model, persisted
+health record, or new API contract.
+
 The top-level envelope follows the Hecate-native convention:
 
 ```json

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -45,6 +45,7 @@ import launchContextContractRaw from "../../test/fixtures/launch-context-v1-cont
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type {
   ProjectAssignmentRecord,
+  ProjectActivityData,
   ProjectMemoryCandidateRecord,
   ProjectMemoryRecord,
   ProjectRecord,
@@ -1311,6 +1312,622 @@ describe("ProjectsView cockpit", () => {
     expect(
       screen.getByText(/No explicit decision notes yet. Existing decision_note artifacts/),
     ).toBeTruthy();
+  });
+
+  it("renders project health signals and jumps to attention targets", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectMemory).mockResolvedValue({
+      object: "project_memory",
+      data: [memoryEntry],
+    });
+    const onOpenTask = vi.fn();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(<ProjectsView onOpenTask={onOpenTask} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("Project Health")).toBeTruthy();
+    expect(within(health).getByText("0 active, 1 waiting, 0 blocked or failed")).toBeTruthy();
+    expect(within(health).getByText("Waiting approval")).toBeTruthy();
+    expect(within(health).getByText("Blocked / failed")).toBeTruthy();
+    expect(within(health).getByText("Project memory")).toBeTruthy();
+    expect(within(health).getByText("1 enabled")).toBeTruthy();
+    expect(within(health).getByText(/Approval waiting: Build cockpit UI/i)).toBeTruthy();
+
+    await userEvent.click(within(health).getByRole("button", { name: "Open attention task" }));
+    expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
+
+    await userEvent.click(within(health).getByRole("button", { name: "Edit defaults" }));
+    expect(screen.getByRole("dialog", { name: "Project defaults" })).toBeTruthy();
+  });
+
+  it("keeps project health failed counts separate from approval and stale blocked rows", async () => {
+    resetProjectWorkMocks();
+    const failedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_failed",
+      status: "failed",
+      execution: {
+        ...hecateAssignment.execution,
+        status: "failed",
+        pending_approval_count: 0,
+      },
+      updated_at: "2026-06-02T12:00:00Z",
+    };
+    const staleAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_stale_health",
+      status: "running",
+      execution: {
+        ...hecateAssignment.execution,
+        status: "running",
+        pending_approval_count: 0,
+        missing: true,
+      },
+      updated_at: "2026-06-01T08:00:00Z",
+    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: {
+        project_id: project.id,
+        summary: {
+          work_item_count: 1,
+          assignment_count: 3,
+          active_count: 0,
+          blocked_count: 3,
+          completed_count: 0,
+          recent_count: 3,
+        },
+        buckets: {
+          active: [],
+          blocked: [
+            {
+              id: hecateAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "running",
+                priority: workItem.priority,
+              },
+              assignment: hecateAssignment,
+              role,
+              status: "awaiting_approval",
+              blocking_signal: "awaiting_approval",
+              status_summary: "2 approval pending",
+              linked_task_id: "task_1",
+              linked_run_id: "run_1",
+              artifact_summary: { count: 0 },
+              handoff_summary: { count: 0 },
+              updated_at: "2026-06-02T11:00:00Z",
+            },
+            {
+              id: failedAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "running",
+                priority: workItem.priority,
+              },
+              assignment: failedAssignment,
+              role,
+              status: "failed",
+              blocking_signal: "failed",
+              status_summary: "execution failed",
+              linked_task_id: "task_1",
+              linked_run_id: "run_failed",
+              artifact_summary: { count: 0 },
+              handoff_summary: { count: 0 },
+              updated_at: "2026-06-02T12:00:00Z",
+            },
+            {
+              id: staleAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "running",
+                priority: workItem.priority,
+              },
+              assignment: staleAssignment,
+              role,
+              status: "running",
+              blocking_signal: "stale_unknown",
+              status_summary: "linked run missing",
+              linked_task_id: "task_1",
+              linked_run_id: "run_missing",
+              artifact_summary: { count: 0 },
+              handoff_summary: { count: 0 },
+              updated_at: "2026-06-01T08:00:00Z",
+            },
+          ],
+          completed: [],
+          recent: [],
+        },
+        recent: [],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("0 active, 1 waiting, 1 blocked or failed")).toBeTruthy();
+    expect(within(health).getByText("Stale / unknown")).toBeTruthy();
+    expect(within(health).getByText(/Execution needs review: Build cockpit UI/i)).toBeTruthy();
+  });
+
+  it("surfaces handoff and memory candidate health after project promotion surfaces load", async () => {
+    resetProjectWorkMocks();
+    const handoffActivity: ProjectActivityData = {
+      project_id: project.id,
+      summary: {
+        work_item_count: 1,
+        assignment_count: 1,
+        active_count: 0,
+        blocked_count: 0,
+        completed_count: 0,
+        recent_count: 1,
+      },
+      buckets: {
+        active: [],
+        blocked: [],
+        completed: [],
+        recent: [
+          {
+            id: hecateAssignment.id,
+            project_id: project.id,
+            work_item: {
+              id: workItem.id,
+              title: workItem.title,
+              status: "running",
+              priority: workItem.priority,
+            },
+            assignment: {
+              ...hecateAssignment,
+              execution: {
+                ...hecateAssignment.execution,
+                status: "running",
+                pending_approval_count: 0,
+              },
+            },
+            role,
+            status: "running",
+            blocking_signal: "running",
+            status_summary: "work recently updated",
+            linked_task_id: "task_1",
+            linked_run_id: "run_1",
+            artifact_summary: { count: 0 },
+            handoff_summary: {
+              count: 4,
+              pending_count: 1,
+              accepted_count: 1,
+              latest_status: "pending",
+              latest_title: "QA handoff",
+              latest_at: "2026-06-04T10:00:00Z",
+            },
+            recent_handoffs: [
+              {
+                id: "handoff_pending",
+                project_id: project.id,
+                work_item_id: workItem.id,
+                source_assignment_id: hecateAssignment.id,
+                target_role_id: "reviewer_qa",
+                title: "QA handoff",
+                summary: "Implementation is ready for review.",
+                recommended_next_action: "Create a queued QA assignment.",
+                status: "pending",
+                provenance_kind: "agent_draft",
+                trust_label: "operator_reviewed",
+                created_at: "2026-06-04T10:00:00Z",
+                updated_at: "2026-06-04T10:00:00Z",
+                status_changed_at: "2026-06-04T10:00:00Z",
+              },
+              {
+                id: "handoff_superseded",
+                project_id: project.id,
+                work_item_id: workItem.id,
+                title: "Old QA handoff",
+                summary: "Earlier handoff.",
+                recommended_next_action: "Ignore the old handoff.",
+                status: "superseded",
+                provenance_kind: "operator",
+                trust_label: "operator_reviewed",
+                created_at: "2026-06-04T09:00:00Z",
+                updated_at: "2026-06-04T09:30:00Z",
+                status_changed_at: "2026-06-04T09:30:00Z",
+              },
+              {
+                id: "handoff_accepted",
+                project_id: project.id,
+                work_item_id: workItem.id,
+                title: "Accepted QA handoff",
+                summary: "Already accepted.",
+                recommended_next_action: "Use the accepted target assignment.",
+                status: "accepted",
+                provenance_kind: "operator",
+                trust_label: "operator_reviewed",
+                created_at: "2026-06-04T08:45:00Z",
+                updated_at: "2026-06-04T09:15:00Z",
+                status_changed_at: "2026-06-04T09:15:00Z",
+              },
+              {
+                id: "handoff_dismissed",
+                project_id: project.id,
+                work_item_id: workItem.id,
+                title: "Dismissed QA handoff",
+                summary: "No longer needed.",
+                recommended_next_action: "No action.",
+                status: "dismissed",
+                provenance_kind: "operator",
+                trust_label: "operator_reviewed",
+                created_at: "2026-06-04T08:00:00Z",
+                updated_at: "2026-06-04T08:30:00Z",
+                status_changed_at: "2026-06-04T08:30:00Z",
+              },
+            ],
+            updated_at: "2026-06-04T10:00:00Z",
+          },
+        ],
+      },
+      recent: [],
+    };
+    const sourceHandoffItem = handoffActivity.buckets.recent[0]!;
+    handoffActivity.buckets.recent.push({
+      ...sourceHandoffItem,
+      id: "asgn_target",
+      assignment: {
+        ...sourceHandoffItem.assignment,
+        id: "asgn_target",
+        role_id: "reviewer_qa",
+      },
+      role: {
+        ...role,
+        id: "reviewer_qa",
+        name: "Reviewer QA",
+      },
+    });
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: handoffActivity,
+    });
+    vi.mocked(getProjectMemoryCandidates).mockResolvedValue({
+      object: "project_memory_candidates",
+      data: [
+        memoryCandidate,
+        {
+          ...memoryCandidate,
+          id: "memcand_promoted",
+          title: "Promoted convention",
+          status: "promoted",
+        },
+        {
+          ...memoryCandidate,
+          id: "memcand_rejected",
+          title: "Rejected guess",
+          status: "rejected",
+        },
+      ],
+    });
+
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("Pending handoffs")).toBeTruthy();
+    expect(within(health).getByText("1 accepted, 1 superseded, 1 dismissed")).toBeTruthy();
+    expect(within(health).getByText(/Pending handoff: Build cockpit UI/i)).toBeTruthy();
+    expect(within(health).getByText(/QA handoff/i)).toBeTruthy();
+    expect(within(health).getByText("1 pending review")).toBeTruthy();
+    expect(within(health).getByText("1 promoted, 1 rejected")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Promote memory candidate Promoted convention" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Reject memory candidate Rejected guess" }),
+    ).toBeNull();
+
+    await user.click(within(health).getByRole("button", { name: "Review memory candidate" }));
+    expect(screen.getByRole("button", { name: "Promote memory" })).toBeTruthy();
+  });
+
+  it("uses project health filters to focus activity buckets", async () => {
+    resetProjectWorkMocks();
+    const activeActivity: ProjectActivityData = {
+      project_id: project.id,
+      summary: {
+        work_item_count: 1,
+        assignment_count: 1,
+        active_count: 1,
+        blocked_count: 0,
+        completed_count: 0,
+        recent_count: 1,
+      },
+      buckets: {
+        active: [
+          {
+            id: "asgn_active",
+            project_id: project.id,
+            work_item: {
+              id: workItem.id,
+              title: workItem.title,
+              status: "running",
+              priority: workItem.priority,
+            },
+            assignment: {
+              ...hecateAssignment,
+              id: "asgn_active",
+              status: "running",
+              execution: { ...hecateAssignment.execution, status: "running" },
+            },
+            role,
+            status: "running",
+            blocking_signal: "running",
+            status_summary: "run live now",
+            linked_task_id: "task_1",
+            linked_run_id: "run_1",
+            artifact_summary: { count: 1 },
+            updated_at: "2026-06-02T11:05:00Z",
+          },
+        ],
+        blocked: [],
+        completed: [],
+        recent: [],
+      },
+      recent: [],
+    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: activeActivity,
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("No blocked assignments for this project.")).toBeTruthy();
+    const health = screen.getByLabelText("Project health");
+    await userEvent.click(
+      within(health).getByRole("button", { name: "Show active work assignments" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("run live now").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("surfaces missing defaults and empty context in project health", async () => {
+    resetProjectWorkMocks();
+    const projectWithoutDefaults: ProjectRecord = {
+      ...project,
+      default_provider: undefined,
+      default_model: undefined,
+      context_sources: [
+        {
+          id: "ctx_1",
+          kind: "doc",
+          title: "Notes",
+          path: "notes.md",
+          enabled: false,
+          created_at: "2026-06-02T09:00:00Z",
+          updated_at: "2026-06-02T09:00:00Z",
+        },
+      ],
+    };
+    vi.mocked(getProjectMemory).mockResolvedValue({ object: "project_memory", data: [] });
+    window.localStorage.setItem("hecate.project", projectWithoutDefaults.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [projectWithoutDefaults],
+      activeProjectID: projectWithoutDefaults.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("Provider/model defaults missing")).toBeTruthy();
+    expect(within(health).getByText("No project memory or context sources enabled")).toBeTruthy();
+    expect(within(health).getByText("No enabled memory or context sources")).toBeTruthy();
+
+    await userEvent.click(within(health).getByRole("button", { name: "Add memory" }));
+    expect(screen.getByRole("dialog", { name: "New project memory" })).toBeTruthy();
+  });
+
+  it("surfaces stale and missing linked execution in project health", async () => {
+    resetProjectWorkMocks();
+    const staleAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_stale",
+      status: "running",
+      execution: {
+        ...hecateAssignment.execution,
+        status: "running",
+        pending_approval_count: 0,
+        missing: true,
+      },
+      updated_at: "2026-06-01T08:00:00Z",
+    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: {
+        project_id: project.id,
+        summary: {
+          work_item_count: 1,
+          assignment_count: 1,
+          active_count: 0,
+          blocked_count: 1,
+          completed_count: 0,
+          recent_count: 1,
+        },
+        buckets: {
+          active: [],
+          blocked: [
+            {
+              id: staleAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "running",
+                priority: workItem.priority,
+              },
+              assignment: staleAssignment,
+              role,
+              status: "running",
+              blocking_signal: "stale_unknown",
+              status_summary: "linked run missing",
+              linked_task_id: "task_1",
+              linked_run_id: "run_missing",
+              artifact_summary: { count: 0 },
+              updated_at: "2026-06-01T08:00:00Z",
+            },
+          ],
+          completed: [],
+          recent: [],
+        },
+        recent: [],
+      },
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [staleAssignment] }],
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [staleAssignment],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("Stale / unknown")).toBeTruthy();
+    expect(within(health).getByText(/Stale or unknown assignment: Build cockpit UI/i)).toBeTruthy();
+    expect(within(health).getByText(/linked run missing/i)).toBeTruthy();
+
+    await userEvent.click(within(health).getByRole("button", { name: "View blocked" }));
+    await waitFor(() => {
+      expect(screen.getAllByText("linked run missing").length).toBeGreaterThan(1);
+    });
+  });
+
+  it("renders an all-clear project health state when context and defaults are ready", async () => {
+    resetProjectWorkMocks();
+    const readyProject: ProjectRecord = {
+      ...project,
+      context_sources: [
+        {
+          id: "ctx_ready",
+          kind: "doc",
+          title: "Runbook",
+          path: "docs/runbook.md",
+          enabled: true,
+          created_at: "2026-06-04T09:00:00Z",
+          updated_at: "2026-06-04T09:00:00Z",
+        },
+      ],
+    };
+    const completedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      status: "completed",
+      execution: {
+        ...hecateAssignment.execution,
+        status: "completed",
+        pending_approval_count: 0,
+        finished_at: "2026-06-04T10:00:00Z",
+      },
+      updated_at: "2026-06-04T10:00:00Z",
+      completed_at: "2026-06-04T10:00:00Z",
+    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: {
+        project_id: readyProject.id,
+        summary: {
+          work_item_count: 1,
+          assignment_count: 1,
+          active_count: 0,
+          blocked_count: 0,
+          completed_count: 1,
+          recent_count: 1,
+        },
+        buckets: {
+          active: [],
+          blocked: [],
+          completed: [
+            {
+              id: completedAssignment.id,
+              project_id: readyProject.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "done",
+                priority: workItem.priority,
+              },
+              assignment: completedAssignment,
+              role,
+              status: "completed",
+              blocking_signal: "completed",
+              status_summary: "completed",
+              linked_task_id: "task_1",
+              linked_run_id: "run_1",
+              artifact_summary: { count: 1 },
+              updated_at: "2026-06-04T10:00:00Z",
+            },
+          ],
+          recent: [],
+        },
+        recent: [],
+      },
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, status: "done", assignments: [completedAssignment] }],
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [completedAssignment],
+    });
+    vi.mocked(getProjectMemory).mockResolvedValue({
+      object: "project_memory",
+      data: [memoryEntry],
+    });
+    window.localStorage.setItem("hecate.project", readyProject.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [readyProject],
+      activeProjectID: readyProject.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const health = await screen.findByLabelText("Project health");
+    expect(within(health).getByText("0 active, 0 waiting, 0 blocked or failed")).toBeTruthy();
+    expect(
+      within(health).getByText(
+        /No approvals, pending handoffs, memory reviews, failures, stale assignments, or missing launch defaults detected./i,
+      ),
+    ).toBeTruthy();
+    expect(within(health).getByText("1 memory / 1 source")).toBeTruthy();
+    expect(within(health).getByText("1/1 memory, 1 sources")).toBeTruthy();
   });
 
   it("starts not-started assignments from the activity inbox", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -118,6 +118,61 @@ type ProjectTimelineItem = {
   assignment?: ProjectAssignmentRecord;
 };
 
+type ProjectHealthMetric = {
+  key:
+    | ProjectActivityBucketKey
+    | "approvals"
+    | "failed"
+    | "stale"
+    | "defaults"
+    | "context"
+    | "handoffs"
+    | "memory_candidates";
+  label: string;
+  value: number | string;
+  status: string;
+  detail: string;
+  bucket?: ProjectActivityBucketKey;
+};
+
+type ProjectHealthAttention = {
+  id: string;
+  title: string;
+  detail: string;
+  status: string;
+  bucket?: ProjectActivityBucketKey;
+  workItemID?: string;
+  taskID?: string;
+  runID?: string;
+  candidateID?: string;
+  actionLabel?: string;
+};
+
+type ProjectHealthSummary = {
+  activeNow: number;
+  waitingApproval: number;
+  blockedOrFailed: number;
+  recentCompleted: number;
+  staleAssignments: number;
+  missingDefaults: boolean;
+  enabledMemory: number;
+  savedMemory: number;
+  enabledContextSources: number;
+  memoryCandidates: {
+    pending: number;
+    promoted: number;
+    rejected: number;
+  };
+  handoffs: {
+    total: number;
+    pending: number;
+    accepted: number;
+    superseded: number;
+    dismissed: number;
+  };
+  attention: ProjectHealthAttention[];
+};
+
 type NewWorkItemForm = {
   title: string;
   brief: string;
@@ -295,6 +350,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [workItems, setWorkItems] = useState<ProjectWorkItemRecord[]>([]);
   const [workItemSummaries, setWorkItemSummaries] = useState<Record<string, WorkItemSummary>>({});
   const [activity, setActivity] = useState<ProjectActivityData | null>(null);
+  const [activityBucket, setActivityBucket] = useState<ProjectActivityBucketKey>("blocked");
   const [roles, setRoles] = useState<ProjectWorkRoleRecord[]>([]);
   const [selectedWorkItemID, setSelectedWorkItemID] = useState("");
   const [selectedWorkItem, setSelectedWorkItem] = useState<ProjectWorkItemRecord | null>(null);
@@ -1121,6 +1177,24 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       </section>
 
       <section style={detailStyle} aria-label="Selected work item">
+        <ProjectHealthPanel
+          activity={activity}
+          bucket={activityBucket}
+          loading={workLoadState === "loading"}
+          memoryCandidates={memoryCandidates}
+          memoryEntries={memoryEntries}
+          onBucketChange={setActivityBucket}
+          onEditDefaults={() => {
+            setDefaultsError("");
+            setDefaultsModalOpen(true);
+          }}
+          onNewMemory={() => setEditingMemory("new")}
+          onOpenTask={onOpenTask}
+          onReviewCandidate={setPromotingCandidate}
+          onSelectWorkItem={setSelectedWorkItemID}
+          project={selectedProject}
+          workItems={workItems}
+        />
         <ProjectTimelinePanel
           activity={activity}
           artifacts={artifacts}
@@ -1137,9 +1211,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
         />
         <ProjectActivityInbox
           activity={activity}
+          bucket={activityBucket}
           loading={workLoadState === "loading"}
           onOpenChat={onOpenChat}
           onOpenTask={onOpenTask}
+          onBucketChange={setActivityBucket}
           onSelectWorkItem={setSelectedWorkItemID}
           onStartAssignment={(assignment, workItemID) =>
             void handleStartAssignment(assignment, workItemID)
@@ -1625,11 +1701,250 @@ function WorkItemRow({
   );
 }
 
+function ProjectHealthPanel({
+  activity,
+  bucket,
+  loading,
+  memoryCandidates,
+  memoryEntries,
+  onBucketChange,
+  onEditDefaults,
+  onNewMemory,
+  onOpenTask,
+  onReviewCandidate,
+  onSelectWorkItem,
+  project,
+  workItems,
+}: {
+  activity: ProjectActivityData | null;
+  bucket: ProjectActivityBucketKey;
+  loading: boolean;
+  memoryCandidates: ProjectMemoryCandidateRecord[];
+  memoryEntries: ProjectMemoryRecord[];
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
+  onEditDefaults: () => void;
+  onNewMemory: () => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  project: ProjectRecord | null;
+  workItems: ProjectWorkItemRecord[];
+}) {
+  const health = useMemo(
+    () => buildProjectHealthSummary(project, activity, workItems, memoryEntries, memoryCandidates),
+    [activity, memoryCandidates, memoryEntries, project, workItems],
+  );
+  if (!project) return null;
+
+  const metrics = projectHealthMetrics(health);
+  const contextDetail =
+    health.enabledMemory > 0 || health.enabledContextSources > 0
+      ? `${health.enabledMemory} memory / ${health.enabledContextSources} source`
+      : "No enabled memory or context sources";
+  const candidateDetail =
+    health.memoryCandidates.pending > 0
+      ? `${health.memoryCandidates.pending} pending review`
+      : `${health.memoryCandidates.promoted} promoted, ${health.memoryCandidates.rejected} rejected`;
+
+  return (
+    <section style={{ padding: "16px 16px 0" }} aria-label="Project health">
+      <div style={panelStyle}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={sectionLabelStyle}>Project Health</div>
+            <div style={{ ...titleStyle, fontSize: 14, marginTop: 3 }}>
+              What needs attention now
+            </div>
+            <div style={{ ...subtleTextStyle, marginTop: 4 }}>
+              {loading && !activity
+                ? "Loading project status…"
+                : `${health.activeNow} active, ${health.waitingApproval} waiting, ${health.blockedOrFailed} blocked or failed`}
+            </div>
+          </div>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onEditDefaults}>
+            <Icon d={Icons.settings} size={12} />
+            Edit defaults
+          </button>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onNewMemory}>
+            <Icon d={Icons.plus} size={12} />
+            Add memory
+          </button>
+        </div>
+
+        <div style={healthMetricGridStyle}>
+          {metrics.map((metric) => (
+            <button
+              key={metric.key}
+              className="btn btn-ghost"
+              type="button"
+              aria-pressed={metric.bucket ? bucket === metric.bucket : undefined}
+              aria-label={
+                metric.bucket
+                  ? `Show ${metric.label.toLowerCase()} assignments`
+                  : `Project ${metric.label.toLowerCase()} status`
+              }
+              onClick={() => {
+                if (metric.bucket) onBucketChange(metric.bucket);
+                if (metric.key === "defaults") onEditDefaults();
+                if (metric.key === "context") onNewMemory();
+              }}
+              style={healthMetricStyle}
+            >
+              <Badge status={metric.status} label={String(metric.value)} />
+              <span style={{ ...titleStyle, whiteSpace: "normal" }}>{metric.label}</span>
+              <span style={subtleTextStyle}>{metric.detail}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 12 }}>
+          <div style={healthColumnStyle}>
+            <div style={sectionLabelStyle}>Needs Attention</div>
+            {health.attention.length === 0 ? (
+              <div style={{ ...subtleTextStyle, marginTop: 8 }}>
+                No approvals, pending handoffs, memory reviews, failures, stale assignments, or
+                missing launch defaults detected.
+              </div>
+            ) : (
+              <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+                {health.attention.map((item) => (
+                  <ProjectHealthAttentionRow
+                    key={item.id}
+                    item={item}
+                    onBucketChange={onBucketChange}
+                    onOpenTask={onOpenTask}
+                    onReviewCandidate={onReviewCandidate}
+                    onSelectWorkItem={onSelectWorkItem}
+                    reviewCandidate={memoryCandidates.find(
+                      (candidate) => candidate.id === item.candidateID,
+                    )}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <div style={healthColumnStyle}>
+            <div style={sectionLabelStyle}>Memory / Context</div>
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              <div style={healthContextLineStyle}>
+                <span style={titleStyle}>Project memory</span>
+                <span
+                  className={health.enabledMemory > 0 ? "badge badge-muted" : "badge badge-amber"}
+                >
+                  {health.enabledMemory} enabled
+                </span>
+              </div>
+              <div style={healthContextLineStyle}>
+                <span style={titleStyle}>Context sources</span>
+                <span
+                  className={
+                    health.enabledContextSources > 0 ? "badge badge-muted" : "badge badge-amber"
+                  }
+                >
+                  {health.enabledContextSources} enabled
+                </span>
+              </div>
+              <div style={healthContextLineStyle}>
+                <span style={titleStyle}>Memory candidates</span>
+                <span
+                  className={
+                    health.memoryCandidates.pending > 0 ? "badge badge-amber" : "badge badge-muted"
+                  }
+                >
+                  {health.memoryCandidates.pending} pending
+                </span>
+              </div>
+              <div style={subtleTextStyle}>{contextDetail}</div>
+              <div style={subtleTextStyle}>{candidateDetail}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProjectHealthAttentionRow({
+  item,
+  onBucketChange,
+  onOpenTask,
+  onReviewCandidate,
+  onSelectWorkItem,
+  reviewCandidate,
+}: {
+  item: ProjectHealthAttention;
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
+  onReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  reviewCandidate?: ProjectMemoryCandidateRecord;
+}) {
+  return (
+    <div style={healthAttentionStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <Badge status={item.status} label={activitySignalLabel(item.status)} />
+        <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{item.title}</div>
+        {item.bucket && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={() => onBucketChange(item.bucket!)}
+          >
+            {item.actionLabel ?? "Inbox"}
+          </button>
+        )}
+        {item.workItemID && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-label="Open attention details"
+            onClick={() => onSelectWorkItem(item.workItemID!)}
+          >
+            Details
+          </button>
+        )}
+        {item.taskID && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-label="Open attention task"
+            onClick={() => onOpenTask?.(item.taskID!, item.runID)}
+            disabled={!onOpenTask}
+          >
+            <Icon d={Icons.tasks} size={12} />
+            Task
+          </button>
+        )}
+        {reviewCandidate && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-label="Review memory candidate"
+            onClick={() => onReviewCandidate(reviewCandidate)}
+          >
+            Review candidate
+          </button>
+        )}
+      </div>
+      <div style={{ ...subtleTextStyle, marginTop: 6 }}>{item.detail}</div>
+    </div>
+  );
+}
+
 function ProjectActivityInbox({
   activity,
+  bucket,
   loading,
   onOpenChat,
   onOpenTask,
+  onBucketChange,
   onSelectWorkItem,
   onStartAssignment,
   project,
@@ -1637,16 +1952,17 @@ function ProjectActivityInbox({
   workItems,
 }: {
   activity: ProjectActivityData | null;
+  bucket: ProjectActivityBucketKey;
   loading: boolean;
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
   onSelectWorkItem: (workItemID: string) => void;
   onStartAssignment: (assignment: ProjectAssignmentRecord, workItemID: string) => void;
   project: ProjectRecord | null;
   startingAssignmentID: string;
   workItems: ProjectWorkItemRecord[];
 }) {
-  const [bucket, setBucket] = useState<ProjectActivityBucketKey>("blocked");
   const counts = activity?.summary;
   const buckets = activity?.buckets;
   const selectedItems = buckets?.[bucket] ?? [];
@@ -1680,7 +1996,7 @@ function ProjectActivityInbox({
                 key={tab.id}
                 className={bucket === tab.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"}
                 type="button"
-                onClick={() => setBucket(tab.id)}
+                onClick={() => onBucketChange(tab.id)}
               >
                 {tab.label}
                 <span className="badge badge-muted">{tab.count}</span>
@@ -2278,32 +2594,39 @@ function ProjectMemoryCandidateRow({
   pendingReject: boolean;
 }) {
   const source = formatCandidateSource(candidate);
+  const pending = candidate.status === "pending";
   return (
     <div style={memoryEntryStyle}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-        <span className="badge badge-amber">{candidate.status}</span>
+        <span className={pending ? "badge badge-amber" : "badge badge-muted"}>
+          {candidate.status}
+        </span>
         <span className="badge badge-muted">{candidate.suggested_trust_label}</span>
         <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{candidate.title}</div>
-        <button
-          className="btn btn-primary btn-sm"
-          type="button"
-          aria-label={`Promote memory candidate ${candidate.title}`}
-          onClick={onPromote}
-          title="Promote"
-        >
-          <Icon d={Icons.check} size={12} />
-        </button>
-        <button
-          className="btn btn-ghost btn-sm"
-          type="button"
-          aria-label={`Reject memory candidate ${candidate.title}`}
-          disabled={pendingReject}
-          onClick={onReject}
-          title="Reject"
-          style={{ color: "var(--red)" }}
-        >
-          <Icon d={Icons.x} size={12} />
-        </button>
+        {pending && (
+          <>
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              aria-label={`Promote memory candidate ${candidate.title}`}
+              onClick={onPromote}
+              title="Promote"
+            >
+              <Icon d={Icons.check} size={12} />
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              aria-label={`Reject memory candidate ${candidate.title}`}
+              disabled={pendingReject}
+              onClick={onReject}
+              title="Reject"
+              style={{ color: "var(--red)" }}
+            >
+              <Icon d={Icons.x} size={12} />
+            </button>
+          </>
+        )}
       </div>
       <div style={memoryBodyStyle}>{candidate.body}</div>
       <div style={metaLineStyle}>
@@ -4146,6 +4469,267 @@ function buildProjectTimelineItems({
   return Array.from(items.values()).sort(compareTimelineItems);
 }
 
+function buildProjectHealthSummary(
+  project: ProjectRecord | null,
+  activity: ProjectActivityData | null,
+  workItems: ProjectWorkItemRecord[],
+  memoryEntries: ProjectMemoryRecord[],
+  memoryCandidates: ProjectMemoryCandidateRecord[],
+): ProjectHealthSummary {
+  const activityItems = uniqueActivityItems(activity);
+  const projectedAssignments = workItems.flatMap((item) =>
+    (item.assignments ?? []).map((assignment) => ({
+      assignment,
+      workItem: item,
+      status: assignment.execution?.status || assignment.status,
+    })),
+  );
+  const waitingItems = activityItems.filter((item) => isWaitingApprovalActivity(item));
+  const failedItems = activityItems.filter((item) => isFailedOrCancelledActivity(item));
+  const staleItems = [
+    ...activityItems.filter((item) => item.blocking_signal === "stale_unknown"),
+    ...activityItems.filter((item) => item.assignment.execution?.missing),
+    ...projectedAssignments
+      .filter((item) => isStaleAssignment(item.assignment, item.status))
+      .map((item) => projectAssignmentToActivityAttention(project, item.workItem, item.assignment)),
+  ].filter(Boolean) as ProjectActivityItemRecord[];
+  const notStartedItems = activityItems.filter((item) => item.blocking_signal === "not_started");
+  const enabledMemory = memoryEntries.filter((entry) => entry.enabled).length;
+  const enabledContextSources = (project?.context_sources ?? []).filter(
+    (source) => source.enabled,
+  ).length;
+  const memoryCandidateSummary = summarizeProjectMemoryCandidates(memoryCandidates);
+  const handoffSummary = summarizeProjectHandoffs(activityItems);
+  const summary = activity?.summary;
+  const missingDefaults = Boolean(project && (!project.default_provider || !project.default_model));
+  const attention: ProjectHealthAttention[] = [];
+  const firstWaiting = waitingItems[0];
+  if (firstWaiting) {
+    attention.push(
+      activityAttention(firstWaiting, "Approval waiting", "View approvals", "blocked"),
+    );
+  }
+  const firstFailed = failedItems[0];
+  if (firstFailed) {
+    attention.push(
+      activityAttention(firstFailed, "Execution needs review", "View blocked", "blocked"),
+    );
+  }
+  if (missingDefaults && project) {
+    attention.push({
+      id: `${project.id}:defaults`,
+      title: "Provider/model defaults missing",
+      detail: "Native project starts and assignment chats need a default provider and model.",
+      status: "awaiting_approval",
+    });
+  }
+  const firstPendingHandoff = activityItems.find((item) => hasPendingHandoff(item));
+  if (firstPendingHandoff) {
+    const latestHandoff = firstPendingHandoff.recent_handoffs?.find(
+      (handoff) => handoff.status === "pending",
+    );
+    attention.push({
+      id: `${firstPendingHandoff.id}:handoff`,
+      title: `Pending handoff: ${firstPendingHandoff.work_item.title}`,
+      detail: [
+        firstNonEmpty(
+          latestHandoff?.title,
+          firstPendingHandoff.handoff_summary?.latest_title,
+          "Handoff awaiting operator follow-up",
+        ),
+        firstPendingHandoff.role.name || firstPendingHandoff.assignment.role_id,
+        firstPendingHandoff.handoff_summary?.latest_at
+          ? `updated ${formatAbsoluteTime(firstPendingHandoff.handoff_summary.latest_at)}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      status: "awaiting_approval",
+      bucket: "recent",
+      workItemID: firstPendingHandoff.work_item.id,
+      actionLabel: "View recent",
+    });
+  }
+  const firstStale = staleItems[0];
+  if (firstStale) {
+    attention.push(
+      activityAttention(firstStale, "Stale or unknown assignment", "View blocked", "blocked"),
+    );
+  }
+  const firstNotStarted = notStartedItems[0];
+  if (firstNotStarted) {
+    attention.push(
+      activityAttention(firstNotStarted, "Assignment not started", "View blocked", "blocked"),
+    );
+  }
+  if (enabledMemory === 0 && enabledContextSources === 0 && project) {
+    attention.push({
+      id: `${project.id}:context`,
+      title: "No project memory or context sources enabled",
+      detail: "Project-scoped context is empty for new chats and linked context packets.",
+      status: "stale_unknown",
+    });
+  }
+  const firstPendingCandidate = memoryCandidates.find(
+    (candidate) => candidate.status === "pending",
+  );
+  if (firstPendingCandidate) {
+    attention.push({
+      id: `${firstPendingCandidate.id}:memory-candidate`,
+      title: "Memory candidate pending review",
+      detail: `${firstPendingCandidate.title} · ${firstPendingCandidate.suggested_trust_label}`,
+      status: "awaiting_approval",
+      candidateID: firstPendingCandidate.id,
+    });
+  }
+
+  return {
+    activeNow: summary?.active_count ?? countActivityBySignals(activityItems, ["running"]),
+    waitingApproval: waitingItems.length,
+    blockedOrFailed: failedItems.length,
+    recentCompleted: activity?.buckets.completed.length ?? summary?.completed_count ?? 0,
+    staleAssignments: uniqueByID(staleItems).length,
+    missingDefaults,
+    enabledMemory,
+    savedMemory: memoryEntries.length,
+    enabledContextSources,
+    memoryCandidates: memoryCandidateSummary,
+    handoffs: handoffSummary,
+    attention: uniqueAttention(attention).slice(0, 5),
+  };
+}
+
+function projectHealthMetrics(health: ProjectHealthSummary): ProjectHealthMetric[] {
+  return [
+    {
+      key: "active",
+      label: "Active work",
+      value: health.activeNow,
+      status: health.activeNow > 0 ? "running" : "completed",
+      detail: "queued, running, or live",
+      bucket: "active",
+    },
+    {
+      key: "approvals",
+      label: "Waiting approval",
+      value: health.waitingApproval,
+      status: health.waitingApproval > 0 ? "awaiting_approval" : "completed",
+      detail: "operator decisions pending",
+      bucket: "blocked",
+    },
+    {
+      key: "handoffs",
+      label: "Pending handoffs",
+      value: health.handoffs.pending,
+      status: health.handoffs.pending > 0 ? "awaiting_approval" : "completed",
+      detail: `${health.handoffs.accepted} accepted, ${health.handoffs.superseded} superseded, ${health.handoffs.dismissed} dismissed`,
+      bucket: "recent",
+    },
+    {
+      key: "failed",
+      label: "Blocked / failed",
+      value: health.blockedOrFailed,
+      status: health.blockedOrFailed > 0 ? "failed" : "completed",
+      detail: "blocked, failed, cancelled",
+      bucket: "blocked",
+    },
+    {
+      key: "completed",
+      label: "Recent completions",
+      value: health.recentCompleted,
+      status: "completed",
+      detail: "finished project work",
+      bucket: "completed",
+    },
+    {
+      key: "stale",
+      label: "Stale / unknown",
+      value: health.staleAssignments,
+      status: health.staleAssignments > 0 ? "stale_unknown" : "completed",
+      detail: "old active or missing linked run",
+      bucket: "blocked",
+    },
+    {
+      key: "defaults",
+      label: "Defaults",
+      value: health.missingDefaults ? "missing" : "set",
+      status: health.missingDefaults ? "awaiting_approval" : "completed",
+      detail: "provider and model",
+    },
+    {
+      key: "context",
+      label: "Context",
+      value: health.enabledMemory + health.enabledContextSources,
+      status:
+        health.enabledMemory + health.enabledContextSources > 0 ? "completed" : "stale_unknown",
+      detail: `${health.enabledMemory}/${health.savedMemory} memory, ${health.enabledContextSources} sources`,
+    },
+    {
+      key: "memory_candidates",
+      label: "Memory candidates",
+      value: health.memoryCandidates.pending,
+      status: health.memoryCandidates.pending > 0 ? "awaiting_approval" : "completed",
+      detail: `${health.memoryCandidates.promoted} promoted, ${health.memoryCandidates.rejected} rejected`,
+    },
+  ];
+}
+
+function summarizeProjectMemoryCandidates(
+  candidates: ProjectMemoryCandidateRecord[],
+): ProjectHealthSummary["memoryCandidates"] {
+  return candidates.reduce<ProjectHealthSummary["memoryCandidates"]>(
+    (summary, candidate) => {
+      if (candidate.status === "pending") summary.pending += 1;
+      if (candidate.status === "promoted") summary.promoted += 1;
+      if (candidate.status === "rejected") summary.rejected += 1;
+      return summary;
+    },
+    { pending: 0, promoted: 0, rejected: 0 },
+  );
+}
+
+function summarizeProjectHandoffs(
+  items: ProjectActivityItemRecord[],
+): ProjectHealthSummary["handoffs"] {
+  const seenHandoffIDs = new Set<string>();
+  return items.reduce<ProjectHealthSummary["handoffs"]>(
+    (summary, item) => {
+      const handoffSummary = item.handoff_summary;
+      const recentHandoffs = item.recent_handoffs ?? [];
+      if (recentHandoffs.length > 0) {
+        for (const handoff of recentHandoffs) {
+          if (seenHandoffIDs.has(handoff.id)) continue;
+          seenHandoffIDs.add(handoff.id);
+          addHandoffStatus(summary, handoff.status);
+        }
+        return summary;
+      }
+      if (handoffSummary) {
+        summary.total += handoffSummary.count;
+        summary.pending += handoffSummary.pending_count ?? 0;
+        summary.accepted += handoffSummary.accepted_count ?? 0;
+      }
+      return summary;
+    },
+    { total: 0, pending: 0, accepted: 0, superseded: 0, dismissed: 0 },
+  );
+}
+
+function addHandoffStatus(summary: ProjectHealthSummary["handoffs"], status: string) {
+  summary.total += 1;
+  if (status === "pending") summary.pending += 1;
+  if (status === "accepted") summary.accepted += 1;
+  if (status === "superseded") summary.superseded += 1;
+  if (status === "dismissed") summary.dismissed += 1;
+}
+
+function hasPendingHandoff(item: ProjectActivityItemRecord): boolean {
+  return (
+    (item.handoff_summary?.pending_count ?? 0) > 0 ||
+    Boolean(item.recent_handoffs?.some((handoff) => handoff.status === "pending"))
+  );
+}
+
 function projectActivityItems(activity: ProjectActivityData | null): ProjectActivityItemRecord[] {
   if (!activity) return [];
   return [
@@ -4155,6 +4739,10 @@ function projectActivityItems(activity: ProjectActivityData | null): ProjectActi
     ...activity.buckets.recent,
     ...(activity.recent ?? []),
   ];
+}
+
+function uniqueActivityItems(activity: ProjectActivityData | null): ProjectActivityItemRecord[] {
+  return uniqueByID(projectActivityItems(activity));
 }
 
 function addTimelineArtifact(
@@ -4240,6 +4828,112 @@ function timelineBadgeClass(item: ProjectTimelineItem): string {
   }
   if (item.kind === "memory" && item.status === "stale_unknown") return "badge badge-amber";
   return "badge badge-muted";
+}
+
+function uniqueByID<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    unique.push(item);
+  }
+  return unique;
+}
+
+function uniqueAttention(items: ProjectHealthAttention[]): ProjectHealthAttention[] {
+  return uniqueByID(items);
+}
+
+function isWaitingApprovalActivity(item: ProjectActivityItemRecord): boolean {
+  return (
+    item.blocking_signal === "awaiting_approval" ||
+    item.status === "awaiting_approval" ||
+    Boolean(item.assignment.execution?.pending_approval_count)
+  );
+}
+
+function isFailedOrCancelledActivity(item: ProjectActivityItemRecord): boolean {
+  return (
+    item.blocking_signal === "failed" ||
+    item.status === "failed" ||
+    item.status === "cancelled" ||
+    item.assignment.execution?.status === "failed" ||
+    item.assignment.execution?.status === "cancelled"
+  );
+}
+
+function countActivityBySignals(items: ProjectActivityItemRecord[], signals: string[]): number {
+  return items.filter(
+    (item) => signals.includes(item.blocking_signal) || signals.includes(item.status),
+  ).length;
+}
+
+function isStaleAssignment(assignment: ProjectAssignmentRecord, status: string): boolean {
+  if (status !== "queued" && status !== "running" && status !== "awaiting_approval") return false;
+  const updatedAt = Date.parse(assignment.updated_at || assignment.started_at || "");
+  if (!Number.isFinite(updatedAt)) return false;
+  return Date.now() - updatedAt > 24 * 60 * 60 * 1000;
+}
+
+function projectAssignmentToActivityAttention(
+  project: ProjectRecord | null,
+  workItem: ProjectWorkItemRecord,
+  assignment: ProjectAssignmentRecord,
+): ProjectActivityItemRecord | null {
+  if (!project) return null;
+  return {
+    id: assignment.id,
+    project_id: project.id,
+    work_item: {
+      id: workItem.id,
+      title: workItem.title,
+      status: workItem.status,
+      priority: workItem.priority,
+    },
+    assignment,
+    role: {
+      id: assignment.role_id,
+      project_id: project.id,
+      name: assignment.role_id,
+      built_in: false,
+    },
+    status: assignment.execution?.status || assignment.status,
+    blocking_signal: "stale_unknown",
+    status_summary: "active assignment has not changed recently",
+    linked_task_id: assignment.execution?.task_id || assignment.task_id,
+    linked_run_id: assignment.execution?.run_id || assignment.run_id,
+    artifact_summary: { count: assignment.execution?.artifact_count ?? 0 },
+    updated_at: assignment.updated_at,
+  };
+}
+
+function activityAttention(
+  item: ProjectActivityItemRecord,
+  title: string,
+  actionLabel: string,
+  bucket: ProjectActivityBucketKey,
+): ProjectHealthAttention {
+  const taskID =
+    item.linked_task_id || item.assignment.execution?.task_id || item.assignment.task_id;
+  const runID = item.linked_run_id || item.assignment.execution?.run_id || item.assignment.run_id;
+  return {
+    id: item.id,
+    title: `${title}: ${item.work_item.title}`,
+    detail: [
+      item.status_summary,
+      item.role.name || item.assignment.role_id,
+      item.updated_at ? `updated ${formatAbsoluteTime(item.updated_at)}` : "",
+    ]
+      .filter(Boolean)
+      .join(" · "),
+    status: item.blocking_signal || item.status,
+    bucket,
+    workItemID: item.work_item.id,
+    taskID,
+    runID,
+    actionLabel,
+  };
 }
 
 function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemSummary {
@@ -4773,6 +5467,43 @@ const decisionItemStyle: CSSProperties = {
   borderTop: "1px solid var(--border)",
   paddingTop: 8,
   minWidth: 0,
+};
+
+const healthMetricGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(132px, 1fr))",
+  gap: 8,
+  marginBottom: 12,
+};
+
+const healthMetricStyle: CSSProperties = {
+  alignItems: "flex-start",
+  border: "1px solid var(--border)",
+  display: "grid",
+  gap: 6,
+  justifyContent: "stretch",
+  minHeight: 92,
+  padding: 10,
+  textAlign: "left",
+};
+
+const healthColumnStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  paddingTop: 10,
+};
+
+const healthAttentionStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  padding: 9,
+};
+
+const healthContextLineStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  gap: 8,
+  justifyContent: "space-between",
 };
 
 const artifactStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- Add a compact Project Health panel to the Projects cockpit for active work, approvals, blocked/stale work, recent completions, missing defaults, and memory/context readiness.
- Integrate the rebased health view with handoff activity summaries, memory candidate promotion, and project timeline/decision log surfaces.
- Add ProjectsView coverage for health filters, attention actions, stale/default/context states, handoff indicators, memory candidate review entry points, resolved-candidate action guards, handoff dedupe, and failed-count semantics.
- Update runtime API and project RFC docs to describe the client-side health projection in the reorganized docs paths.

## Rebase Notes
- Rebased onto current master at 3961b598, including #306 agent handoffs, #307 memory promotion, #308 project timeline, and #311 docs structure follow-up.
- Kept handoff, timeline, and memory promotion semantics in their existing surfaces; the health panel only aggregates compact counts and links into those flows.

## Review Fixes
- Dedupe health handoff counts by recent_handoffs[].id when activity rows include the same handoff through source and target assignments.
- Count Blocked / failed from failed/cancelled activity signals instead of the broader blocked bucket summary, so it no longer overlaps waiting approval and stale/unknown tiles.
- Resolved memory candidates render as status-only rows, so promoted/rejected candidates are not offered for promotion or rejection again.

## Checks
- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test