### PR TITLE
Context Inspector V1 core contract

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -234,10 +234,12 @@ applied, revert returns `409 conflict`, leaves the workspace unchanged, and keep
 the patch artifact in `applied`.
 
 `GET /hecate/v1/tasks/{id}/runs/{run_id}/context` returns the context packet
-snapshot for a task run when the run is linked to a Hecate Chat assistant
-message. Today task runs do not own a separate context-packet store; the
-endpoint resolves the already persisted chat message packet for task-backed
-Hecate Chat runs and returns `404 not_found` when no linked packet exists.
+snapshot for a task run. Hecate first returns a run-owned packet when the run
+persisted one directly, then falls back to a linked Hecate Chat assistant
+message packet for task-backed chat runs. Native project-assignment starts now
+persist a run-owned packet, and resume/retry chains carry the latest stored
+packet forward onto the new run with updated task/run refs. Older or unrelated
+runs can still return `404 not_found` when no stored or linked packet exists.
 
 ## Approval endpoints
 
@@ -1754,6 +1756,14 @@ Deletes the assignment metadata record and collaboration artifacts attached to
 that assignment. It does not delete or cancel a linked Task, Run, Chat session,
 or external-agent execution.
 
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/context`
+
+Returns the best available context packet for the assignment. Hecate resolves
+linked Task/Run packets first, then falls back to a linked Chat
+`chat_session_id` + `message_id` packet when present. Unstarted assignments,
+legacy rows without either link, or older runs that predate snapshots return
+`404 not_found`.
+
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start`
 
 Starts a native Hecate assignment. V1 supports only assignments whose
@@ -1784,8 +1794,10 @@ or defaultless roots return `400 invalid_request`. A missing model returns
 
 The endpoint then starts the task through the canonical task runner, so normal
 task approvals, queueing, run events, artifacts, and SSE inspection apply. On
-success it updates the assignment with `task_id`, latest `run_id`, status, and
-timestamps, and returns the updated assignment:
+success it also persists a structured context packet on the created run, updates
+`context_snapshot_id` to that packet id, then updates the assignment with
+`task_id`, latest `run_id`, status, and timestamps before returning the updated
+assignment:
 
 ```json
 {
@@ -1799,6 +1811,7 @@ timestamps, and returns the updated assignment:
     "status": "queued",
     "task_id": "task_...",
     "run_id": "run_...",
+    "context_snapshot_id": "ctx_...",
     "execution": {
       "task_id": "task_...",
       "run_id": "run_...",
@@ -2478,14 +2491,27 @@ GET /hecate/v1/chat/sessions/chat_.../messages/msg_.../context
 {
   "object": "context_packet",
   "data": {
+    "id": "ctx_...",
     "version": "chat.context.v1",
     "execution_mode": "hecate_task",
     "provider": "ollama",
     "model": "llama3.1:8b",
+    "execution_profile": "chat_agent",
     "workspace": "/workspace/hecate",
     "system_prompt_included": true,
     "message_count": 3,
+    "refs": {
+      "session_id": "chat_...",
+      "message_id": "msg_...",
+      "project_id": "proj_..."
+    },
     "sources": [
+      {
+        "kind": "project",
+        "label": "Hecate",
+        "detail": "proj_...",
+        "trust": "project"
+      },
       {
         "kind": "transcript",
         "label": "Chat transcript",
@@ -2495,6 +2521,16 @@ GET /hecate/v1/chat/sessions/chat_.../messages/msg_.../context
     ],
     "items": [
       {
+        "section": "project",
+        "kind": "project",
+        "trust_level": "runtime_state",
+        "origin": "proj_...",
+        "title": "Hecate",
+        "included": true,
+        "inclusion_reason": "Project linked to this chat session"
+      },
+      {
+        "section": "runtime",
         "kind": "transcript",
         "trust_level": "runtime_state",
         "origin": "chat.transcript",
@@ -2509,10 +2545,31 @@ GET /hecate/v1/chat/sessions/chat_.../messages/msg_.../context
 ```
 
 Existing top-level fields and `sources` remain for older clients. Newer clients
-should prefer `items` for trust-labelled, provenance-aware inspection. Current
-packets intentionally snapshot visible metadata only; they do not store full
-system prompts, raw transcript text, file contents, or external-agent private
-prompt packing.
+should prefer `items` plus `refs` for trust-labelled, provenance-aware
+inspection. Each item carries a stable `section` value so later inspectors can
+group without inferring from `kind`. Current packets intentionally snapshot
+visible metadata only; they do not store full system prompts, raw transcript
+text, file contents, or external-agent private prompt packing.
+
+Section values currently used by the runtime are:
+
+- `instructions` for system-prompt and instruction-layer metadata
+- `memory` for project memory entries
+- `workspace` for the selected workspace path
+- `project` for project identity metadata
+- `project_work` for work-item, assignment, role, execution-hint, handoff, and artifact-reference metadata
+- `sources` for enabled project context-source metadata such as `workspace_doc` and `project_notes`
+- `runtime` for transcript counts, task-runtime metadata, and external-agent session metadata
+
+`included=true` means the item was part of the prepared context for that
+message or run. `included=false` means the item is related inspectable metadata
+that V1 did not inject into the runtime context. Native project-assignment
+packets currently use `included=false` for project memory, project sources,
+handoffs, and artifact refs.
+
+Legacy packets can omit `id`, `execution_profile`, `refs`, or `section`. The
+server backfills obvious request-scoped refs and default sections where it can,
+but clients should render missing fields defensively.
 
 ### `GET /hecate/v1/chat/sessions/{id}/messages/{message_id}/files`
 

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -821,6 +821,14 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 	trace.Record(telemetry.EventAgentChatRunStarted, agentChatTraceAttrs(session, adapter, runID, assistantID, map[string]any{
 		telemetry.AttrHecateRunStatus: "running",
 	}))
+	contextPacket := h.externalAgentContextPacket(r.Context(), session, adapter.Name)
+	contextPacket.ID = newChatID("ctx")
+	contextPacket = normalizeContextPacket(contextPacket, chat.ContextRefs{
+		SessionID: session.ID,
+		MessageID: assistantID,
+		RunID:     runID,
+		ProjectID: session.ProjectID,
+	})
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeExternalAgent,
@@ -836,7 +844,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		Status:        "running",
 		CostMode:      adapter.CostMode,
 		Workspace:     session.Workspace,
-		Context:       h.externalAgentContextPacket(r.Context(), session, adapter.Name),
+		Context:       contextPacket,
 		CreatedAt:     time.Now().UTC(),
 		StartedAt:     startedAt,
 		Activities: []chat.Activity{
@@ -1034,6 +1042,12 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		if result.DiffStat != "" {
 			message.Activities = append(message.Activities, newChatActivity("files_changed", "completed", "Files changed", result.DiffStat))
 		}
+		message.Context = normalizeContextPacket(message.Context, chat.ContextRefs{
+			SessionID: session.ID,
+			MessageID: assistantID,
+			RunID:     runID,
+			ProjectID: session.ProjectID,
+		})
 		message.Activities = append(message.Activities, newChatActivity(status, status, finalChatActivityTitle(status), errorText))
 	})
 	if err != nil {
@@ -1173,6 +1187,13 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 
 	history := agentChatModelHistory(session, strings.TrimSpace(req.SystemPrompt), content)
 	contextPacket := h.directModelContextPacket(r.Context(), session, provider, model, strings.TrimSpace(req.SystemPrompt))
+	contextPacket.ID = newChatID("ctx")
+	contextPacket = normalizeContextPacket(contextPacket, chat.ContextRefs{
+		SessionID: session.ID,
+		MessageID: assistantID,
+		RunID:     runID,
+		ProjectID: session.ProjectID,
+	})
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeHecateTask,
@@ -1249,6 +1270,12 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 				ContextUsed: result.Metadata.TotalTokens,
 			}
 		}
+		message.Context = normalizeContextPacket(message.Context, chat.ContextRefs{
+			SessionID: session.ID,
+			MessageID: assistantID,
+			RunID:     message.RunID,
+			ProjectID: session.ProjectID,
+		})
 		message.Activities = append(message.Activities, newChatActivity(status, status, finalChatActivityTitle(status), errorText))
 	})
 	if err != nil {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -790,6 +790,7 @@ func projectContextSourceKind(kind string) string {
 }
 
 func normalizeContextPacket(packet chat.ContextPacket, refs chat.ContextRefs) chat.ContextPacket {
+	packet = cloneContextPacket(packet)
 	if packet.Refs == nil && !contextRefsEmpty(refs) {
 		packet.Refs = &chat.ContextRefs{}
 	}
@@ -810,6 +811,20 @@ func normalizeContextPacket(packet chat.ContextPacket, refs chat.ContextRefs) ch
 		if strings.TrimSpace(packet.Items[idx].Section) == "" {
 			packet.Items[idx].Section = defaultContextItemSection(packet.Items[idx].Kind)
 		}
+	}
+	return packet
+}
+
+func cloneContextPacket(packet chat.ContextPacket) chat.ContextPacket {
+	if packet.Refs != nil {
+		refs := *packet.Refs
+		packet.Refs = &refs
+	}
+	if len(packet.Sources) > 0 {
+		packet.Sources = append([]chat.ContextSource(nil), packet.Sources...)
+	}
+	if len(packet.Items) > 0 {
+		packet.Items = append([]chat.ContextItem(nil), packet.Items...)
 	}
 	return packet
 }

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -18,6 +21,16 @@ const (
 	contextTrustOperatorMemory    = "operator_memory"
 	contextTrustWorkspaceGuidance = "workspace_guidance"
 	contextTrustRuntimeState      = "runtime_state"
+)
+
+const (
+	contextSectionInstructions = "instructions"
+	contextSectionMemory       = "memory"
+	contextSectionWorkspace    = "workspace"
+	contextSectionProject      = "project"
+	contextSectionProjectWork  = "project_work"
+	contextSectionSources      = "sources"
+	contextSectionRuntime      = "runtime"
 )
 
 func (h *Handler) HandleChatMessageContext(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +57,11 @@ func (h *Handler) HandleChatMessageContext(w http.ResponseWriter, r *http.Reques
 		if message.ID != messageID {
 			continue
 		}
-		writeChatContextPacket(w, message.Context)
+		writeChatContextPacket(w, normalizeContextPacket(message.Context, chat.ContextRefs{
+			SessionID: sessionID,
+			MessageID: messageID,
+			ProjectID: session.ProjectID,
+		}))
 		return
 	}
 	WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat message not found")
@@ -70,10 +87,13 @@ func (h *Handler) HandleTaskRunContext(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run context packet not found; only task-backed Hecate Chat runs currently expose context snapshots")
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run context packet not found; the run may predate context snapshots or have no linked run/chat packet")
 		return
 	}
-	writeChatContextPacket(w, packet)
+	writeChatContextPacket(w, normalizeContextPacket(packet, chat.ContextRefs{
+		TaskID: task.ID,
+		RunID:  run.ID,
+	}))
 }
 
 func writeChatContextPacket(w http.ResponseWriter, packet chat.ContextPacket) {
@@ -88,7 +108,49 @@ func writeChatContextPacket(w http.ResponseWriter, packet chat.ContextPacket) {
 	})
 }
 
+func (h *Handler) HandleProjectWorkAssignmentContext(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if h.projectWork == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project work store is not configured")
+		return
+	}
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	workItemID := strings.TrimSpace(r.PathValue("work_item_id"))
+	assignmentID := strings.TrimSpace(r.PathValue("assignment_id"))
+	assignment, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment not found")
+		return
+	}
+	packet, ok, err := h.contextPacketForProjectAssignment(ctx, assignment)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project assignment context packet not found")
+		return
+	}
+	writeChatContextPacket(w, normalizeContextPacket(packet, chat.ContextRefs{
+		ProjectID:    projectID,
+		WorkItemID:   workItemID,
+		AssignmentID: assignmentID,
+		RoleID:       assignment.RoleID,
+		TaskID:       assignment.TaskID,
+		RunID:        assignment.RunID,
+		SessionID:    assignment.ChatSessionID,
+		MessageID:    assignment.MessageID,
+	}))
+}
+
 func (h *Handler) contextPacketForTaskRun(ctx context.Context, task types.Task, run types.TaskRun) (chat.ContextPacket, bool, error) {
+	if packet, ok, err := contextPacketFromRun(run); err != nil || ok {
+		return packet, ok, err
+	}
 	if h == nil || h.agentChat == nil {
 		return chat.ContextPacket{}, false, nil
 	}
@@ -119,6 +181,44 @@ func (h *Handler) contextPacketForTaskRun(ctx context.Context, task types.Task, 
 	return chat.ContextPacket{}, false, nil
 }
 
+func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignment projectwork.Assignment) (chat.ContextPacket, bool, error) {
+	if h != nil && h.taskStore != nil && strings.TrimSpace(assignment.TaskID) != "" && strings.TrimSpace(assignment.RunID) != "" {
+		task, ok, err := h.taskStore.GetTask(ctx, assignment.TaskID)
+		if err != nil {
+			return chat.ContextPacket{}, false, err
+		}
+		if ok {
+			run, ok, err := h.taskStore.GetRun(ctx, assignment.TaskID, assignment.RunID)
+			if err != nil {
+				return chat.ContextPacket{}, false, err
+			}
+			if ok {
+				packet, found, err := h.contextPacketForTaskRun(ctx, task, run)
+				if err != nil || found {
+					return packet, found, err
+				}
+			}
+		}
+	}
+	if h == nil || h.agentChat == nil || strings.TrimSpace(assignment.ChatSessionID) == "" || strings.TrimSpace(assignment.MessageID) == "" {
+		return chat.ContextPacket{}, false, nil
+	}
+	session, ok, err := h.agentChat.Get(ctx, assignment.ChatSessionID)
+	if err != nil || !ok {
+		return chat.ContextPacket{}, false, err
+	}
+	for _, message := range session.Messages {
+		if message.ID != strings.TrimSpace(assignment.MessageID) {
+			continue
+		}
+		if message.Context.Empty() {
+			return chat.ContextPacket{}, false, nil
+		}
+		return message.Context, true, nil
+	}
+	return chat.ContextPacket{}, false, nil
+}
+
 func contextPacketFromSessionRun(session chat.Session, taskID, runID string) (chat.ContextPacket, bool) {
 	taskID = strings.TrimSpace(taskID)
 	runID = strings.TrimSpace(runID)
@@ -134,12 +234,28 @@ func contextPacketFromSessionRun(session chat.Session, taskID, runID string) (ch
 	return chat.ContextPacket{}, false
 }
 
+func contextPacketFromRun(run types.TaskRun) (chat.ContextPacket, bool, error) {
+	if len(run.ContextPacket) == 0 {
+		return chat.ContextPacket{}, false, nil
+	}
+	var packet chat.ContextPacket
+	if err := json.Unmarshal(run.ContextPacket, &packet); err != nil {
+		return chat.ContextPacket{}, false, fmt.Errorf("decode task run context packet: %w", err)
+	}
+	if packet.Empty() {
+		return chat.ContextPacket{}, false, nil
+	}
+	return packet, true, nil
+}
+
 func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, session.Workspace)
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
+	populateProjectRefs(&packet, session.ProjectID)
+	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
 	if packet.SystemPromptIncluded {
-		appendContextPacketSource(&packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
 			Label:  "System prompt",
 			Detail: "Configured for this direct model turn",
@@ -156,7 +272,7 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 	}
 	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
 	if strings.TrimSpace(session.Workspace) != "" {
-		appendContextPacketSource(&packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
 			Label:  "Workspace",
 			Detail: session.Workspace,
@@ -180,8 +296,11 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, session.Workspace)
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
+	packet.ExecutionProfile = "chat_agent"
+	populateProjectRefs(&packet, session.ProjectID)
+	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
 	if packet.SystemPromptIncluded {
-		appendContextPacketSource(&packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
 			Label:  "System prompt",
 			Detail: "Stored on the backing task for this task segment",
@@ -198,7 +317,7 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	}
 	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
 	if strings.TrimSpace(session.Workspace) != "" {
-		appendContextPacketSource(&packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
 			Label:  "Workspace",
 			Detail: session.Workspace,
@@ -219,7 +338,7 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 		taskDetail = "Starting a new task-backed agent loop"
 	}
 	appendTranscriptContext(&packet)
-	appendContextPacketSource(&packet, chat.ContextSource{
+	appendContextPacketSourceWithSection(&packet, contextSectionRuntime, chat.ContextSource{
 		Kind:   "task_runtime",
 		Label:  "Hecate task runtime",
 		Detail: taskDetail,
@@ -239,9 +358,11 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.Session, adapterName string) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeExternalAgent, "", "", session.Workspace)
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
+	populateProjectRefs(&packet, session.ProjectID)
+	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
 	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
 	if strings.TrimSpace(session.Workspace) != "" {
-		appendContextPacketSource(&packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
 			Label:  "Workspace",
 			Detail: session.Workspace,
@@ -261,7 +382,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 		adapterName = "External agent"
 	}
 	appendTranscriptContext(&packet)
-	appendContextPacketSource(&packet, chat.ContextSource{
+	appendContextPacketSourceWithSection(&packet, contextSectionRuntime, chat.ContextSource{
 		Kind:   "adapter_session",
 		Label:  adapterName + " ACP session",
 		Detail: "The adapter owns model packing inside its native session",
@@ -278,14 +399,156 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	return packet
 }
 
+func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string) chat.ContextPacket {
+	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
+	packet.ID = newChatID("ctx")
+	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
+	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role)) != ""
+	packet.Refs = &chat.ContextRefs{
+		TaskID:       strings.TrimSpace(assignment.TaskID),
+		RunID:        strings.TrimSpace(assignment.RunID),
+		ProjectID:    strings.TrimSpace(project.ID),
+		WorkItemID:   strings.TrimSpace(workItem.ID),
+		AssignmentID: strings.TrimSpace(assignment.ID),
+		RoleID:       strings.TrimSpace(role.ID),
+	}
+
+	appendProjectSummary(&packet, &project, true, "Included in the native project assignment launch context")
+	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "work_item",
+		Label:  firstNonEmptyString(strings.TrimSpace(workItem.Title), strings.TrimSpace(workItem.ID)),
+		Detail: strings.TrimSpace(workItem.ID),
+		Trust:  "project",
+	}, chat.ContextItem{
+		Kind:            "work_item",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(workItem.ID),
+		Title:           firstNonEmptyString(strings.TrimSpace(workItem.Title), strings.TrimSpace(workItem.ID)),
+		Body:            firstNonEmptyString(strings.TrimSpace(workItem.Brief), "No brief recorded."),
+		Included:        true,
+		InclusionReason: "Included in the native project assignment launch context",
+	})
+	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "assignment",
+		Label:  firstNonEmptyString(strings.TrimSpace(assignment.ID), "Assignment"),
+		Detail: firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask),
+		Trust:  "runtime",
+	}, chat.ContextItem{
+		Kind:            "assignment",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(assignment.ID),
+		Title:           "Assignment",
+		Body:            fmt.Sprintf("Status: %s\nDriver: %s", firstNonEmptyString(strings.TrimSpace(assignment.Status), projectwork.AssignmentStatusQueued), firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)),
+		Included:        true,
+		InclusionReason: "Included in the native project assignment launch context",
+	})
+	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "role",
+		Label:  firstNonEmptyString(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)),
+		Detail: strings.TrimSpace(role.ID),
+		Trust:  "runtime",
+	}, chat.ContextItem{
+		Kind:       "role",
+		TrustLevel: contextTrustRuntimeState,
+		Origin:     strings.TrimSpace(role.ID),
+		Title:      firstNonEmptyString(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)),
+		Body: strings.Join([]string{
+			"Description: " + firstNonEmptyString(strings.TrimSpace(role.Description), "No description recorded."),
+			"Instructions: " + firstNonEmptyString(strings.TrimSpace(role.Instructions), "No role instructions recorded."),
+		}, "\n"),
+		Included:        true,
+		InclusionReason: "Included in the native project assignment launch context",
+	})
+	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "execution_hints",
+		Label:  "Execution hints",
+		Detail: strings.TrimSpace(executionProfile),
+		Trust:  "runtime",
+	}, chat.ContextItem{
+		Kind:       "execution_hints",
+		TrustLevel: contextTrustRuntimeState,
+		Origin:     "project_assignment.execution_hints",
+		Title:      "Execution hints",
+		Body: strings.Join([]string{
+			"Driver: " + firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask),
+			"Provider: " + firstNonEmptyString(strings.TrimSpace(provider), "auto"),
+			"Model: " + firstNonEmptyString(strings.TrimSpace(model), "project/runtime default"),
+			"Profile: " + firstNonEmptyString(strings.TrimSpace(executionProfile), "none"),
+			"Role defaults: " + formatAssignmentHints([]assignmentHint{
+				{"driver", role.DefaultDriverKind},
+				{"provider", role.DefaultProvider},
+				{"model", role.DefaultModel},
+				{"profile", role.DefaultAgentProfile},
+			}),
+			"Project defaults: " + formatAssignmentHints([]assignmentHint{
+				{"provider", project.DefaultProvider},
+				{"model", project.DefaultModel},
+				{"profile", project.DefaultAgentProfile},
+				{"workspace_mode", project.DefaultWorkspaceMode},
+			}),
+		}, "\n"),
+		Included:        true,
+		InclusionReason: "Included in the native project assignment launch context",
+	})
+	if packet.SystemPromptIncluded {
+		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
+			Kind:   "system_prompt",
+			Label:  "System prompt",
+			Detail: "Stored on the native assignment task",
+			Trust:  "system",
+		}, chat.ContextItem{
+			Kind:            "system_prompt",
+			TrustLevel:      contextTrustSystemInstruction,
+			Origin:          "task.system_prompt",
+			Title:           "System prompt",
+			BodyRef:         "task_system_prompt",
+			Included:        true,
+			InclusionReason: "Stored on the native assignment task",
+		})
+	}
+	if strings.TrimSpace(workingDirectory) != "" {
+		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
+			Kind:   "workspace",
+			Label:  "Workspace",
+			Detail: strings.TrimSpace(workingDirectory),
+			Trust:  "workspace",
+		}, chat.ContextItem{
+			Kind:            "workspace",
+			TrustLevel:      contextTrustWorkspaceGuidance,
+			Origin:          strings.TrimSpace(workingDirectory),
+			Title:           "Workspace",
+			BodyRef:         strings.TrimSpace(workingDirectory),
+			Included:        true,
+			InclusionReason: "Selected as the native assignment workspace",
+		})
+	}
+	appendProjectMemoryWithInclusion(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), false, "Stored project memory is not injected into native project assignment launch context v1")
+	appendProjectContextSourcesWithInclusion(&packet, projectContextSourcesFromProject(project), false, "Stored project sources are not injected into native project assignment launch context v1")
+	appendProjectAssignmentHandoffs(&packet, h.assignmentRelevantHandoffs(ctx, assignment, role.ID), false, "Handoff references are inspectable metadata only in native project assignment launch context v1")
+	appendProjectAssignmentArtifacts(&packet, h.assignmentRelevantArtifacts(ctx, assignment), false, "Artifact references are inspectable metadata only in native project assignment launch context v1")
+	return packet
+}
+
 func (h *Handler) projectContextSources(ctx context.Context, session chat.Session) []chat.ContextSource {
-	if h == nil || h.projects == nil || strings.TrimSpace(session.ProjectID) == "" {
+	project := h.projectSummary(ctx, session.ProjectID)
+	if project == nil {
 		return nil
 	}
-	project, ok, err := h.projects.Get(ctx, session.ProjectID)
+	return projectContextSourcesFromProject(*project)
+}
+
+func (h *Handler) projectSummary(ctx context.Context, projectID string) *projects.Project {
+	if h == nil || h.projects == nil || strings.TrimSpace(projectID) == "" {
+		return nil
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil || !ok {
 		return nil
 	}
+	return &project
+}
+
+func projectContextSourcesFromProject(project projects.Project) []chat.ContextSource {
 	sources := make([]chat.ContextSource, 0, len(project.ContextSources))
 	for _, source := range project.ContextSources {
 		if !source.Enabled {
@@ -309,17 +572,65 @@ func (h *Handler) projectContextSources(ctx context.Context, session chat.Sessio
 }
 
 func (h *Handler) projectMemoryEntries(ctx context.Context, session chat.Session) []memory.Entry {
-	if h == nil || h.memory == nil || strings.TrimSpace(session.ProjectID) == "" {
+	return h.enabledProjectMemoryEntries(ctx, session.ProjectID)
+}
+
+func (h *Handler) enabledProjectMemoryEntries(ctx context.Context, projectID string) []memory.Entry {
+	if h == nil || h.memory == nil || strings.TrimSpace(projectID) == "" {
 		return nil
 	}
-	items, err := h.memory.List(ctx, memory.Filter{ProjectID: session.ProjectID})
+	items, err := h.memory.List(ctx, memory.Filter{ProjectID: projectID})
 	if err != nil {
 		return nil
 	}
 	return items
 }
 
+func (h *Handler) assignmentRelevantArtifacts(ctx context.Context, assignment projectwork.Assignment) []projectwork.CollaborationArtifact {
+	if h == nil || h.projectWork == nil {
+		return nil
+	}
+	items, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{
+		ProjectID:  assignment.ProjectID,
+		WorkItemID: assignment.WorkItemID,
+	})
+	if err != nil {
+		return nil
+	}
+	filtered := make([]projectwork.CollaborationArtifact, 0, len(items))
+	for _, item := range items {
+		if item.AssignmentID == "" || item.AssignmentID == assignment.ID {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment projectwork.Assignment, roleID string) []projectwork.Handoff {
+	if h == nil || h.projectWork == nil {
+		return nil
+	}
+	items, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{
+		ProjectID:  assignment.ProjectID,
+		WorkItemID: assignment.WorkItemID,
+	})
+	if err != nil {
+		return nil
+	}
+	filtered := make([]projectwork.Handoff, 0, len(items))
+	for _, item := range items {
+		if item.SourceAssignmentID == assignment.ID || item.TargetAssignmentID == assignment.ID || item.TargetRoleID == roleID {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
 func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
+	appendProjectMemoryWithInclusion(packet, entries, true, "Enabled project memory entry")
+}
+
+func appendProjectMemoryWithInclusion(packet *chat.ContextPacket, entries []memory.Entry, included bool, reason string) {
 	for _, entry := range entries {
 		trust := strings.TrimSpace(entry.TrustLabel)
 		if trust == "" {
@@ -329,7 +640,7 @@ func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
 		if sourceID := strings.TrimSpace(entry.SourceID); sourceID != "" {
 			sourceDetail = firstNonEmptyString(sourceDetail, "operator") + ":" + sourceID
 		}
-		appendContextPacketSource(packet, chat.ContextSource{
+		appendContextPacketSourceWithSection(packet, contextSectionMemory, chat.ContextSource{
 			Kind:   "memory",
 			Label:  entry.Title,
 			Detail: sourceDetail,
@@ -340,13 +651,17 @@ func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
 			Origin:          entry.ID,
 			Title:           entry.Title,
 			Body:            entry.Body,
-			Included:        true,
-			InclusionReason: "Enabled project memory entry",
+			Included:        included,
+			InclusionReason: reason,
 		})
 	}
 }
 
 func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.ContextSource) {
+	appendProjectContextSourcesWithInclusion(packet, sources, true, "Enabled project context source metadata")
+}
+
+func appendProjectContextSourcesWithInclusion(packet *chat.ContextPacket, sources []chat.ContextSource, included bool, reason string) {
 	for _, source := range sources {
 		item := chat.ContextItem{
 			Kind:            source.Kind,
@@ -354,16 +669,58 @@ func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.Cont
 			Origin:          firstNonEmptyString(source.Detail, source.Label),
 			Title:           source.Label,
 			BodyRef:         source.Detail,
-			Included:        true,
-			InclusionReason: "Enabled project context source metadata",
+			Included:        included,
+			InclusionReason: reason,
 		}
-		appendContextPacketSource(packet, source, item)
+		appendContextPacketSourceWithSection(packet, contextSectionSources, source, item)
+	}
+}
+
+func appendProjectAssignmentHandoffs(packet *chat.ContextPacket, items []projectwork.Handoff, included bool, reason string) {
+	for _, item := range items {
+		trust := firstNonEmptyString(strings.TrimSpace(item.TrustLabel), contextTrustRuntimeState)
+		label := firstNonEmptyString(strings.TrimSpace(item.Title), strings.TrimSpace(item.ID))
+		appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+			Kind:   "handoff",
+			Label:  label,
+			Detail: strings.TrimSpace(item.ID),
+			Trust:  trust,
+		}, chat.ContextItem{
+			Kind:            "handoff",
+			TrustLevel:      trust,
+			Origin:          strings.TrimSpace(item.ID),
+			Title:           label,
+			Body:            strings.TrimSpace(item.Summary),
+			BodyRef:         firstNonEmptyString(strings.TrimSpace(item.SourceMessageID), strings.TrimSpace(item.SourceRunID)),
+			Included:        included,
+			InclusionReason: reason,
+		})
+	}
+}
+
+func appendProjectAssignmentArtifacts(packet *chat.ContextPacket, items []projectwork.CollaborationArtifact, included bool, reason string) {
+	for _, item := range items {
+		label := firstNonEmptyString(strings.TrimSpace(item.Title), strings.TrimSpace(item.ID))
+		appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+			Kind:   "artifact_ref",
+			Label:  label,
+			Detail: strings.TrimSpace(item.Kind),
+			Trust:  "project",
+		}, chat.ContextItem{
+			Kind:            "artifact_ref",
+			TrustLevel:      contextTrustRuntimeState,
+			Origin:          strings.TrimSpace(item.ID),
+			Title:           label,
+			BodyRef:         strings.TrimSpace(item.ID),
+			Included:        included,
+			InclusionReason: reason,
+		})
 	}
 }
 
 func appendTranscriptContext(packet *chat.ContextPacket) {
 	source := transcriptContextSource(packet.MessageCount)
-	appendContextPacketSource(packet, source, chat.ContextItem{
+	appendContextPacketSourceWithSection(packet, contextSectionRuntime, source, chat.ContextItem{
 		Kind:            "transcript",
 		TrustLevel:      contextTrustRuntimeState,
 		Origin:          "chat.transcript",
@@ -374,9 +731,50 @@ func appendTranscriptContext(packet *chat.ContextPacket) {
 	})
 }
 
+func appendProjectSummary(packet *chat.ContextPacket, project *projects.Project, included bool, reason string) {
+	if project == nil || packet == nil {
+		return
+	}
+	populateProjectRefs(packet, project.ID)
+	label := strings.TrimSpace(project.Name)
+	if label == "" {
+		label = strings.TrimSpace(project.ID)
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProject, chat.ContextSource{
+		Kind:   "project",
+		Label:  label,
+		Detail: strings.TrimSpace(project.ID),
+		Trust:  "project",
+	}, chat.ContextItem{
+		Kind:            "project",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(project.ID),
+		Title:           label,
+		Included:        included,
+		InclusionReason: reason,
+	})
+}
+
+func appendContextPacketSourceWithSection(packet *chat.ContextPacket, section string, source chat.ContextSource, item chat.ContextItem) {
+	item.Section = firstNonEmptyString(strings.TrimSpace(item.Section), section)
+	appendContextPacketSource(packet, source, item)
+}
+
 func appendContextPacketSource(packet *chat.ContextPacket, source chat.ContextSource, item chat.ContextItem) {
 	packet.Sources = append(packet.Sources, source)
 	packet.Items = append(packet.Items, item)
+}
+
+func populateProjectRefs(packet *chat.ContextPacket, projectID string) {
+	if packet == nil || strings.TrimSpace(projectID) == "" {
+		return
+	}
+	if packet.Refs == nil {
+		packet.Refs = &chat.ContextRefs{}
+	}
+	if packet.Refs.ProjectID == "" {
+		packet.Refs.ProjectID = strings.TrimSpace(projectID)
+	}
 }
 
 func projectContextSourceKind(kind string) string {
@@ -388,6 +786,74 @@ func projectContextSourceKind(kind string) string {
 		return "workspace_doc"
 	default:
 		return "project_" + strings.NewReplacer(" ", "_", "-", "_").Replace(kind)
+	}
+}
+
+func normalizeContextPacket(packet chat.ContextPacket, refs chat.ContextRefs) chat.ContextPacket {
+	if packet.Refs == nil && !contextRefsEmpty(refs) {
+		packet.Refs = &chat.ContextRefs{}
+	}
+	if packet.Refs != nil {
+		packet.Refs.SessionID = firstNonEmptyString(packet.Refs.SessionID, refs.SessionID)
+		packet.Refs.MessageID = firstNonEmptyString(packet.Refs.MessageID, refs.MessageID)
+		packet.Refs.TaskID = firstNonEmptyString(packet.Refs.TaskID, refs.TaskID)
+		packet.Refs.RunID = firstNonEmptyString(packet.Refs.RunID, refs.RunID)
+		packet.Refs.ProjectID = firstNonEmptyString(packet.Refs.ProjectID, refs.ProjectID)
+		packet.Refs.WorkItemID = firstNonEmptyString(packet.Refs.WorkItemID, refs.WorkItemID)
+		packet.Refs.AssignmentID = firstNonEmptyString(packet.Refs.AssignmentID, refs.AssignmentID)
+		packet.Refs.RoleID = firstNonEmptyString(packet.Refs.RoleID, refs.RoleID)
+		if contextRefsEmpty(*packet.Refs) {
+			packet.Refs = nil
+		}
+	}
+	for idx := range packet.Items {
+		if strings.TrimSpace(packet.Items[idx].Section) == "" {
+			packet.Items[idx].Section = defaultContextItemSection(packet.Items[idx].Kind)
+		}
+	}
+	return packet
+}
+
+func marshalContextPacket(packet chat.ContextPacket) json.RawMessage {
+	if packet.Empty() {
+		return nil
+	}
+	data, err := json.Marshal(packet)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func contextRefsEmpty(refs chat.ContextRefs) bool {
+	return refs.SessionID == "" &&
+		refs.MessageID == "" &&
+		refs.TaskID == "" &&
+		refs.RunID == "" &&
+		refs.ProjectID == "" &&
+		refs.WorkItemID == "" &&
+		refs.AssignmentID == "" &&
+		refs.RoleID == ""
+}
+
+func defaultContextItemSection(kind string) string {
+	switch {
+	case kind == "system_prompt":
+		return contextSectionInstructions
+	case kind == "memory":
+		return contextSectionMemory
+	case kind == "workspace":
+		return contextSectionWorkspace
+	case kind == "project":
+		return contextSectionProject
+	case kind == "work_item" || kind == "assignment" || kind == "role" || kind == "execution_hints" || kind == "handoff" || kind == "artifact_ref":
+		return contextSectionProjectWork
+	case kind == "transcript" || kind == "task_runtime" || kind == "external_agent_session":
+		return contextSectionRuntime
+	case strings.HasPrefix(kind, "workspace_") || strings.HasPrefix(kind, "project_"):
+		return contextSectionSources
+	default:
+		return contextSectionRuntime
 	}
 }
 

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -281,6 +281,26 @@ func TestChatMessageContextEndpointReturnsPacket(t *testing.T) {
 	}
 }
 
+func TestChatMessageContextEndpointReturnsNotFoundWithoutStoredPacket(t *testing.T) {
+	ctx := context.Background()
+	chatStore := chat.NewMemoryStore()
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_1", Title: "Context test"}); err != nil {
+		t.Fatalf("Create chat session: %v", err)
+	}
+	if _, err := chatStore.AppendMessage(ctx, "chat_1", chat.Message{
+		ID:      "msg_user",
+		Role:    "user",
+		Content: "hello",
+	}); err != nil {
+		t.Fatalf("AppendMessage: %v", err)
+	}
+	handler := &Handler{agentChat: chatStore}
+	server := NewServer(slog.New(slog.NewJSONHandler(io.Discard, nil)), handler)
+	client := newAPITestClient(t, server)
+
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/chat/sessions/chat_1/messages/msg_user/context", "")
+}
+
 func TestChatMessageContextEndpointReturnsHistoricalSnapshotAfterProjectSourcesChange(t *testing.T) {
 	ctx := context.Background()
 	projectStore := newContextPacketProjectStore(t, ctx)
@@ -505,11 +525,18 @@ func TestTaskRunContextEndpointReturnsNotFoundForStandaloneRun(t *testing.T) {
 
 func TestRenderChatContextPacketIncludesItems(t *testing.T) {
 	packet := chat.ContextPacket{
+		ID:            "ctx_1",
 		Version:       chatContextPacketVersion,
 		ExecutionMode: chat.ExecutionModeExternalAgent,
 		Workspace:     "/tmp/hecate",
 		MessageCount:  2,
+		Refs: &chat.ContextRefs{
+			SessionID: "chat_1",
+			MessageID: "msg_1",
+			RunID:     "run_1",
+		},
 		Items: []chat.ContextItem{{
+			Section:         contextSectionRuntime,
 			Kind:            "external_agent_session",
 			TrustLevel:      contextTrustRuntimeState,
 			Origin:          "adapter:Cursor Agent",
@@ -526,8 +553,11 @@ func TestRenderChatContextPacketIncludesItems(t *testing.T) {
 	if rendered == nil {
 		t.Fatal("renderChatContextPacket returned nil, want packet")
 	}
+	if rendered.ID != "ctx_1" || rendered.Refs == nil || rendered.Refs.SessionID != "chat_1" || rendered.Refs.RunID != "run_1" {
+		t.Fatalf("rendered packet ids/refs = %+v, want ctx_1 with refs", rendered)
+	}
 	assertRenderedContextItem(t, *rendered, "external_agent_session", contextTrustRuntimeState, "adapter:Cursor Agent")
-	if rendered.Items[0].BodyRef != "adapter_session" || rendered.Items[0].InclusionReason != "Visible external-agent metadata" {
+	if rendered.Items[0].Section != contextSectionRuntime || rendered.Items[0].BodyRef != "adapter_session" || rendered.Items[0].InclusionReason != "Visible external-agent metadata" {
 		t.Fatalf("rendered context item missing fields: %+v", rendered.Items[0])
 	}
 }
@@ -550,17 +580,17 @@ func TestChatContextPacketSourceOrdering(t *testing.T) {
 		{
 			name: "direct model",
 			got:  sourceKinds(handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", "system")),
-			want: []string{"system_prompt", "workspace", "workspace_doc", "project_notes", "transcript"},
+			want: []string{"project", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript"},
 		},
 		{
 			name: "hecate task",
 			got:  sourceKinds(handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "system", false)),
-			want: []string{"system_prompt", "workspace", "workspace_doc", "project_notes", "transcript", "task_runtime"},
+			want: []string{"project", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript", "task_runtime"},
 		},
 		{
 			name: "external agent",
 			got:  sourceKinds(handler.externalAgentContextPacket(ctx, session, "Cursor Agent")),
-			want: []string{"workspace", "workspace_doc", "project_notes", "transcript", "adapter_session"},
+			want: []string{"project", "workspace", "workspace_doc", "project_notes", "transcript", "adapter_session"},
 		},
 	}
 

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -562,6 +562,40 @@ func TestRenderChatContextPacketIncludesItems(t *testing.T) {
 	}
 }
 
+func TestNormalizeContextPacketDoesNotMutateInput(t *testing.T) {
+	packet := chat.ContextPacket{
+		ID: "ctx_1",
+		Refs: &chat.ContextRefs{
+			SessionID: "chat_1",
+		},
+		Items: []chat.ContextItem{{
+			Kind:       "task_runtime",
+			TrustLevel: contextTrustRuntimeState,
+			Origin:     "runtime:task",
+			Title:      "Task runtime",
+			Included:   true,
+		}},
+	}
+
+	normalized := normalizeContextPacket(packet, chat.ContextRefs{
+		SessionID: "chat_1",
+		RunID:     "run_1",
+	})
+
+	if packet.Refs == nil || packet.Refs.RunID != "" {
+		t.Fatalf("input packet refs mutated to %+v, want original run_id to stay empty", packet.Refs)
+	}
+	if packet.Items[0].Section != "" {
+		t.Fatalf("input packet item section mutated to %q, want empty section", packet.Items[0].Section)
+	}
+	if normalized.Refs == nil || normalized.Refs.RunID != "run_1" {
+		t.Fatalf("normalized refs = %+v, want run_1", normalized.Refs)
+	}
+	if normalized.Items[0].Section != contextSectionRuntime {
+		t.Fatalf("normalized item section = %q, want %q", normalized.Items[0].Section, contextSectionRuntime)
+	}
+}
+
 func TestChatContextPacketSourceOrdering(t *testing.T) {
 	ctx := context.Background()
 	handler := &Handler{projects: newContextPacketProjectStore(t, ctx)}

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -136,6 +136,13 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	h.agentChatLive.publishSession(updated)
 
 	contextPacket := h.hecateTaskContextPacket(r.Context(), session, messageSnapshot.Provider, messageSnapshot.Model, strings.TrimSpace(req.SystemPrompt), forceNewTask)
+	contextPacket.ID = newChatID("ctx")
+	contextPacket = normalizeContextPacket(contextPacket, chat.ContextRefs{
+		SessionID: session.ID,
+		MessageID: assistantID,
+		TaskID:    messageSnapshot.TaskID,
+		ProjectID: session.ProjectID,
+	})
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: messageSnapshot.ExecutionMode,
@@ -166,7 +173,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	}
 	h.agentChatLive.publishSession(updated)
 
-	task, run, err := h.startOrContinueHecateAgentRun(runCtx, session, content, strings.TrimSpace(req.SystemPrompt), forceNewTask)
+	task, run, err := h.startOrContinueHecateAgentRun(runCtx, session, content, strings.TrimSpace(req.SystemPrompt), forceNewTask, contextPacket)
 	if err != nil {
 		completedAt := time.Now().UTC()
 		trace.Record(telemetry.EventAgentChatRunFailed, hecateAgentChatTraceAttrs(session, "", "", assistantID, map[string]any{
@@ -217,6 +224,13 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		message.Provider = messageSnapshot.Provider
 		message.Model = messageSnapshot.Model
 		message.Capabilities = messageSnapshot.Capabilities
+		message.Context = normalizeContextPacket(message.Context, chat.ContextRefs{
+			SessionID: session.ID,
+			MessageID: assistantID,
+			TaskID:    task.ID,
+			RunID:     run.ID,
+			ProjectID: session.ProjectID,
+		})
 		message.Activities = mergeChatActivity(message.Activities, newHecateAgentRunActivity(task.ID, run.ID, run.Status))
 	})
 	if err == nil {
@@ -404,7 +418,7 @@ func isHecateTaskToolsOnMessage(message chat.Message) bool {
 	return message.ToolsEnabled
 }
 
-func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session chat.Session, prompt, systemPrompt string, forceNewTask bool) (types.Task, types.TaskRun, error) {
+func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session chat.Session, prompt, systemPrompt string, forceNewTask bool, contextPacket chat.ContextPacket) (types.Task, types.TaskRun, error) {
 	if h.taskStore == nil || h.taskRunner == nil {
 		return types.Task{}, types.TaskRun{}, fmt.Errorf("task runtime is not configured")
 	}
@@ -438,7 +452,14 @@ func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session cha
 		if err != nil {
 			return types.Task{}, types.TaskRun{}, err
 		}
-		result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
+		result, err := h.taskRunner.StartTaskWithRunInitializer(ctx, task, newOpaqueTaskResourceID, func(run *types.TaskRun) {
+			run.ContextPacket = marshalContextPacket(normalizeContextPacket(contextPacket, chat.ContextRefs{
+				SessionID: session.ID,
+				TaskID:    task.ID,
+				RunID:     run.ID,
+				ProjectID: session.ProjectID,
+			}))
+		})
 		if err != nil {
 			return types.Task{}, types.TaskRun{}, err
 		}
@@ -459,7 +480,14 @@ func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session cha
 	if !found {
 		return types.Task{}, types.TaskRun{}, fmt.Errorf("latest task run %q not found", session.LatestRunID)
 	}
-	result, err := h.taskRunner.ContinueAgentTask(ctx, task, run, prompt, newOpaqueTaskResourceID)
+	result, err := h.taskRunner.ContinueAgentTaskWithRunInitializer(ctx, task, run, prompt, newOpaqueTaskResourceID, func(nextRun *types.TaskRun) {
+		nextRun.ContextPacket = marshalContextPacket(normalizeContextPacket(contextPacket, chat.ContextRefs{
+			SessionID: session.ID,
+			TaskID:    task.ID,
+			RunID:     nextRun.ID,
+			ProjectID: session.ProjectID,
+		}))
+	})
 	if err != nil {
 		return types.Task{}, types.TaskRun{}, err
 	}
@@ -502,6 +530,12 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 				message.RequestID = firstNonEmpty(run.RequestID, message.RequestID)
 				message.TraceID = firstNonEmpty(run.TraceID, message.TraceID)
 				message.SpanID = firstNonEmpty(run.RootSpanID, message.SpanID)
+				message.Context = normalizeContextPacket(message.Context, chat.ContextRefs{
+					SessionID: sessionID,
+					MessageID: messageID,
+					TaskID:    taskID,
+					RunID:     run.ID,
+				})
 				message.Status = agentChatStatusFromTaskRun(run.Status)
 				if liveContent != "" {
 					message.Content = liveContent

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -138,6 +138,7 @@ func renderChatContextPacket(packet chat.ContextPacket) *ChatContextPacketItem {
 	items := make([]ChatContextItem, 0, len(packet.Items))
 	for _, item := range packet.Items {
 		items = append(items, ChatContextItem{
+			Section:         item.Section,
 			Kind:            item.Kind,
 			TrustLevel:      item.TrustLevel,
 			Origin:          item.Origin,
@@ -148,14 +149,30 @@ func renderChatContextPacket(packet chat.ContextPacket) *ChatContextPacketItem {
 			InclusionReason: item.InclusionReason,
 		})
 	}
+	var refs *ChatContextRefsItem
+	if packet.Refs != nil {
+		refs = &ChatContextRefsItem{
+			SessionID:    packet.Refs.SessionID,
+			MessageID:    packet.Refs.MessageID,
+			TaskID:       packet.Refs.TaskID,
+			RunID:        packet.Refs.RunID,
+			ProjectID:    packet.Refs.ProjectID,
+			WorkItemID:   packet.Refs.WorkItemID,
+			AssignmentID: packet.Refs.AssignmentID,
+			RoleID:       packet.Refs.RoleID,
+		}
+	}
 	return &ChatContextPacketItem{
+		ID:                   packet.ID,
 		Version:              packet.Version,
 		ExecutionMode:        packet.ExecutionMode,
 		Provider:             packet.Provider,
 		Model:                packet.Model,
+		ExecutionProfile:     packet.ExecutionProfile,
 		Workspace:            packet.Workspace,
 		SystemPromptIncluded: packet.SystemPromptIncluded,
 		MessageCount:         packet.MessageCount,
+		Refs:                 refs,
 		Sources:              sources,
 		Items:                items,
 	}

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -868,6 +869,10 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	executionProfile := strings.TrimSpace(firstNonEmpty(role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
+	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workingDirectory, requestedProvider, requestedModel, executionProfile)
+	if contextPacket.ID == "" {
+		contextPacket.ID = newChatID("ctx")
+	}
 
 	taskID := newTaskID()
 	claimRejected := false
@@ -913,8 +918,19 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, fmt.Sprintf("task could not be created for assignment %s: %s", assignment.ID, err.Error()))
 		return
 	}
+	contextPacket.Refs.TaskID = task.ID
 
-	result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
+	result, err := h.taskRunner.StartTaskWithRunInitializer(ctx, task, newOpaqueTaskResourceID, func(run *types.TaskRun) {
+		contextPacket.Refs.RunID = run.ID
+		run.ContextPacket = marshalContextPacket(normalizeContextPacket(contextPacket, chat.ContextRefs{
+			TaskID:       task.ID,
+			RunID:        run.ID,
+			ProjectID:    project.ID,
+			WorkItemID:   workItem.ID,
+			AssignmentID: assignment.ID,
+			RoleID:       role.ID,
+		}))
+	})
 	if err != nil {
 		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 			item.TaskID = task.ID
@@ -941,6 +957,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	assignment, err = h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 		item.TaskID = result.Task.ID
 		item.RunID = result.Run.ID
+		item.ContextSnapshotID = contextPacket.ID
 		item.Status = projectWorkAssignmentStatusFromRun(result.Run.Status)
 		if item.StartedAt.IsZero() {
 			item.StartedAt = time.Now().UTC()

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -15,7 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -556,6 +558,165 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	}
 	if _, found, err := handler.taskStore.GetRun(t.Context(), task.ID, assignment.Data.RunID); err != nil || !found {
 		t.Fatalf("GetRun(%q) found=%v err=%v, want run", assignment.Data.RunID, found, err)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.ContextSources = []projects.ContextSource{{
+			ID:      "ctx_readme",
+			Kind:    "doc",
+			Title:   "README",
+			Path:    "README.md",
+			Enabled: true,
+		}}
+	}); err != nil {
+		t.Fatalf("Update project context sources: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_backend",
+		ProjectID:  "proj_start",
+		Title:      "Backend preference",
+		Body:       "Prefer Go-first changes.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create project memory: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_pm",
+		ProjectID:  "proj_start",
+		WorkItemID: "work_start",
+		RoleID:     "product_manager",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("Create source assignment: %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:         "art_brief",
+		ProjectID:  "proj_start",
+		WorkItemID: "work_start",
+		Kind:       projectwork.ArtifactKindBrief,
+		Title:      "Operator brief",
+		Body:       "Do the backend slice only.",
+	}); err != nil {
+		t.Fatalf("Create artifact: %v", err)
+	}
+	if _, err := handler.projectWork.CreateHandoff(t.Context(), projectwork.Handoff{
+		ID:                    "handoff_review",
+		ProjectID:             "proj_start",
+		WorkItemID:            "work_start",
+		SourceAssignmentID:    "asgn_pm",
+		TargetRoleID:          "role_backend",
+		Title:                 "Backend handoff",
+		Summary:               "Focus on the runtime contract.",
+		RecommendedNextAction: "Start the native assignment and verify the packet.",
+		TrustLabel:            "operator_reviewed",
+		CreatedByRoleID:       "product_manager",
+	}); err != nil {
+		t.Fatalf("Create handoff: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.ContextSnapshotID == "" {
+		t.Fatalf("context_snapshot_id = %q, want persisted packet id", assignment.Data.ContextSnapshotID)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	if packetResp.Data.ID != assignment.Data.ContextSnapshotID {
+		t.Fatalf("task run context id = %q, want %q", packetResp.Data.ID, assignment.Data.ContextSnapshotID)
+	}
+	if packetResp.Data.ExecutionProfile != "implementation" {
+		t.Fatalf("execution_profile = %q, want implementation", packetResp.Data.ExecutionProfile)
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != "proj_start" || packetResp.Data.Refs.WorkItemID != "work_start" || packetResp.Data.Refs.AssignmentID != "asgn_start" || packetResp.Data.Refs.RoleID != "role_backend" {
+		t.Fatalf("packet refs = %+v, want project/work/assignment/role refs", packetResp.Data.Refs)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "mem_backend"); item == nil || item.Included || item.Section != contextSectionMemory {
+		t.Fatalf("memory item = %+v, want excluded memory section item", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "README.md"); item == nil || item.Included || item.Section != contextSectionSources {
+		t.Fatalf("context source item = %+v, want excluded sources section item", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "handoff_review"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("handoff item = %+v, want excluded project_work section item", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "art_brief"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("artifact item = %+v, want excluded project_work section item", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "project_assignment.execution_hints"); item == nil || !item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("execution hints item = %+v, want included project_work item", item)
+	}
+
+	assignmentPacket := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
+	if assignmentPacket.Data.ID != assignment.Data.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want %q", assignmentPacket.Data.ID, assignment.Data.ContextSnapshotID)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentContextFallsBackToLinkedChatPacket(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Driver: projectwork.AssignmentDriverExternalAgent,
+		Status: projectwork.AssignmentStatusCompleted,
+	})
+	if _, err := handler.agentChat.Create(t.Context(), chat.Session{ID: "chat_linked", ProjectID: "proj_start"}); err != nil {
+		t.Fatalf("Create chat session: %v", err)
+	}
+	packet := normalizeContextPacket(chat.ContextPacket{
+		ID:            "ctx_linked",
+		Version:       chatContextPacketVersion,
+		ExecutionMode: chat.ExecutionModeExternalAgent,
+		Items: []chat.ContextItem{{
+			Kind:            "external_agent_session",
+			TrustLevel:      contextTrustRuntimeState,
+			Origin:          "adapter:Codex",
+			Title:           "Codex ACP session",
+			Included:        true,
+			InclusionReason: "Visible external-agent metadata for this turn",
+		}},
+	}, chat.ContextRefs{
+		SessionID: "chat_linked",
+		MessageID: "msg_linked",
+		ProjectID: "proj_start",
+	})
+	if _, err := handler.agentChat.AppendMessage(t.Context(), "chat_linked", chat.Message{
+		ID:      "msg_linked",
+		Role:    "assistant",
+		Content: "done",
+		Context: packet,
+	}); err != nil {
+		t.Fatalf("Append linked message: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateAssignment(t.Context(), "proj_start", "asgn_start", func(item *projectwork.Assignment) {
+		item.ChatSessionID = "chat_linked"
+		item.MessageID = "msg_linked"
+	}); err != nil {
+		t.Fatalf("Update assignment links: %v", err)
+	}
+
+	resp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
+	if resp.Data.ID != "ctx_linked" || resp.Data.Refs == nil || resp.Data.Refs.SessionID != "chat_linked" || resp.Data.Refs.MessageID != "msg_linked" {
+		t.Fatalf("assignment chat fallback packet = %+v, want linked chat refs", resp.Data)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -790,15 +790,29 @@ type ChatMessageItem struct {
 }
 
 type ChatContextPacketItem struct {
+	ID                   string                  `json:"id,omitempty"`
 	Version              string                  `json:"version,omitempty"`
 	ExecutionMode        string                  `json:"execution_mode,omitempty"`
 	Provider             string                  `json:"provider,omitempty"`
 	Model                string                  `json:"model,omitempty"`
+	ExecutionProfile     string                  `json:"execution_profile,omitempty"`
 	Workspace            string                  `json:"workspace,omitempty"`
 	SystemPromptIncluded bool                    `json:"system_prompt_included,omitempty"`
 	MessageCount         int                     `json:"message_count,omitempty"`
+	Refs                 *ChatContextRefsItem    `json:"refs,omitempty"`
 	Sources              []ChatContextSourceItem `json:"sources,omitempty"`
 	Items                []ChatContextItem       `json:"items,omitempty"`
+}
+
+type ChatContextRefsItem struct {
+	SessionID    string `json:"session_id,omitempty"`
+	MessageID    string `json:"message_id,omitempty"`
+	TaskID       string `json:"task_id,omitempty"`
+	RunID        string `json:"run_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	RoleID       string `json:"role_id,omitempty"`
 }
 
 type ChatContextSourceItem struct {
@@ -809,6 +823,7 @@ type ChatContextSourceItem struct {
 }
 
 type ChatContextItem struct {
+	Section         string `json:"section,omitempty"`
 	Kind            string `json:"kind"`
 	TrustLevel      string `json:"trust_level"`
 	Origin          string `json:"origin"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -96,6 +96,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleUpdateProjectWorkAssignment)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleDeleteProjectWorkAssignment)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start", handler.HandleStartProjectWorkAssignment)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/context", handler.HandleProjectWorkAssignmentContext)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleProjectWorkArtifacts)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts", handler.HandleCreateProjectWorkArtifact)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/handoffs", handler.HandleProjectHandoffs)

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -105,15 +105,29 @@ type Activity struct {
 }
 
 type ContextPacket struct {
+	ID                   string          `json:"id,omitempty"`
 	Version              string          `json:"version,omitempty"`
 	ExecutionMode        string          `json:"execution_mode,omitempty"`
 	Provider             string          `json:"provider,omitempty"`
 	Model                string          `json:"model,omitempty"`
+	ExecutionProfile     string          `json:"execution_profile,omitempty"`
 	Workspace            string          `json:"workspace,omitempty"`
 	SystemPromptIncluded bool            `json:"system_prompt_included,omitempty"`
 	MessageCount         int             `json:"message_count,omitempty"`
+	Refs                 *ContextRefs    `json:"refs,omitempty"`
 	Sources              []ContextSource `json:"sources,omitempty"`
 	Items                []ContextItem   `json:"items,omitempty"`
+}
+
+type ContextRefs struct {
+	SessionID    string `json:"session_id,omitempty"`
+	MessageID    string `json:"message_id,omitempty"`
+	TaskID       string `json:"task_id,omitempty"`
+	RunID        string `json:"run_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	RoleID       string `json:"role_id,omitempty"`
 }
 
 type ContextSource struct {
@@ -124,6 +138,7 @@ type ContextSource struct {
 }
 
 type ContextItem struct {
+	Section         string `json:"section,omitempty"`
 	Kind            string `json:"kind"`
 	TrustLevel      string `json:"trust_level"`
 	Origin          string `json:"origin"`

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -152,9 +152,10 @@ type StartTaskResult struct {
 }
 
 type startTaskOptions struct {
-	ResumeFromRun *types.TaskRun
-	ResumeReason  string
-	AppendPrompt  string
+	ResumeFromRun  *types.TaskRun
+	ResumeReason   string
+	AppendPrompt   string
+	RunInitializer func(*types.TaskRun)
 	// RetryFromTurn, when > 0, signals the new run should resume from
 	// the source run's conversation truncated to right before turn N.
 	// Used by the retry-from-turn-N code path; ignored when
@@ -427,6 +428,10 @@ func (r *Runner) StartTask(ctx context.Context, task types.Task, idgen func(pref
 	return r.startTaskWithOptions(ctx, task, idgen, startTaskOptions{})
 }
 
+func (r *Runner) StartTaskWithRunInitializer(ctx context.Context, task types.Task, idgen func(prefix string) string, init func(*types.TaskRun)) (*StartTaskResult, error) {
+	return r.startTaskWithOptions(ctx, task, idgen, startTaskOptions{RunInitializer: init})
+}
+
 func (r *Runner) ResumeTask(ctx context.Context, task types.Task, run types.TaskRun, reason string, idgen func(prefix string) string) (*StartTaskResult, error) {
 	if !types.IsTerminalTaskRunStatus(run.Status) {
 		return nil, fmt.Errorf("task run %q is not resumable", run.ID)
@@ -438,6 +443,14 @@ func (r *Runner) ResumeTask(ctx context.Context, task types.Task, run types.Task
 }
 
 func (r *Runner) ContinueAgentTask(ctx context.Context, task types.Task, run types.TaskRun, prompt string, idgen func(prefix string) string) (*StartTaskResult, error) {
+	return r.continueAgentTaskWithOptions(ctx, task, run, prompt, idgen, startTaskOptions{})
+}
+
+func (r *Runner) ContinueAgentTaskWithRunInitializer(ctx context.Context, task types.Task, run types.TaskRun, prompt string, idgen func(prefix string) string, init func(*types.TaskRun)) (*StartTaskResult, error) {
+	return r.continueAgentTaskWithOptions(ctx, task, run, prompt, idgen, startTaskOptions{RunInitializer: init})
+}
+
+func (r *Runner) continueAgentTaskWithOptions(ctx context.Context, task types.Task, run types.TaskRun, prompt string, idgen func(prefix string) string, options startTaskOptions) (*StartTaskResult, error) {
 	if task.ExecutionKind != "agent_loop" {
 		return nil, fmt.Errorf("task %q is not an agent_loop task", task.ID)
 	}
@@ -469,11 +482,10 @@ func (r *Runner) ContinueAgentTask(ctx context.Context, task types.Task, run typ
 			return nil, fmt.Errorf("task run %q has no agent_conversation artifact to continue", run.ID)
 		}
 	}
-	return r.startTaskWithOptions(ctx, task, idgen, startTaskOptions{
-		ResumeFromRun: &run,
-		ResumeReason:  "session_prompt",
-		AppendPrompt:  prompt,
-	})
+	options.ResumeFromRun = &run
+	options.ResumeReason = "session_prompt"
+	options.AppendPrompt = prompt
+	return r.startTaskWithOptions(ctx, task, idgen, options)
 }
 
 // RetryTaskFromTurn creates a new run that re-issues turn N of the
@@ -611,6 +623,12 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 			return nil, err
 		}
 	}
+	if options.ResumeFromRun != nil && len(run.ContextPacket) == 0 && len(options.ResumeFromRun.ContextPacket) > 0 {
+		run.ContextPacket = cloneRunContextPacketForNewRun(options.ResumeFromRun.ContextPacket, task.ID, run.ID, idgen)
+	}
+	if options.RunInitializer != nil {
+		options.RunInitializer(&run)
+	}
 	run, err = r.store.CreateRun(ctx, run)
 	if err != nil {
 		recordOrchestratorRunFailed(trace, task.ID, run.ID, "run_create_failed", err)
@@ -676,6 +694,34 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 		TraceID: trace.TraceID,
 		SpanID:  trace.RootSpanID(),
 	}, nil
+}
+
+func cloneRunContextPacketForNewRun(raw json.RawMessage, taskID, runID string, idgen func(string) string) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var packet map[string]any
+	if err := json.Unmarshal(raw, &packet); err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	if len(packet) == 0 {
+		return append(json.RawMessage(nil), raw...)
+	}
+	if idgen != nil {
+		packet["id"] = idgen("ctx")
+	}
+	refs, _ := packet["refs"].(map[string]any)
+	if refs == nil {
+		refs = map[string]any{}
+	}
+	refs["task_id"] = taskID
+	refs["run_id"] = runID
+	packet["refs"] = refs
+	updated, err := json.Marshal(packet)
+	if err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	return updated
 }
 
 func (r *Runner) CancelRun(ctx context.Context, task types.Task, runID string, reason string) (types.TaskRun, error) {

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"testing"
@@ -355,5 +356,149 @@ func TestRunner_FileExecutor_FullLifecycle(t *testing.T) {
 			t.Fatalf("sequence %d after %d for %s; want strictly increasing", e.Sequence, prev, e.EventType)
 		}
 		prev = e.Sequence
+	}
+}
+
+func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{QueueWorkers: 0},
+	)
+
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:               "task-resume-context",
+		Title:            "resume context",
+		Prompt:           "resume me",
+		ExecutionKind:    "stub",
+		WorkingDirectory: t.TempDir(),
+		Status:           "completed",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	run := types.TaskRun{
+		ID:         "run-resume-source",
+		TaskID:     task.ID,
+		Number:     1,
+		Status:     "completed",
+		StartedAt:  now,
+		FinishedAt: now,
+		ContextPacket: json.RawMessage(`{
+			"id":"ctx_old",
+			"refs":{"session_id":"chat_1","run_id":"run-resume-source"},
+			"items":[{"kind":"transcript","trust_level":"runtime_state","origin":"chat.transcript","title":"Chat transcript","included":true}]
+		}`),
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	result, err := runner.ResumeTask(ctx, task, run, "operator_resume", defaultResourceID)
+	if err != nil {
+		t.Fatalf("ResumeTask: %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, result.Run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
+	}
+	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+}
+
+func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{QueueWorkers: 0},
+	)
+
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:               "task-retry-context",
+		Title:            "retry context",
+		Prompt:           "retry me",
+		ExecutionKind:    "stub",
+		WorkingDirectory: t.TempDir(),
+		Status:           "completed",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	run := types.TaskRun{
+		ID:         "run-retry-source",
+		TaskID:     task.ID,
+		Number:     1,
+		Status:     "completed",
+		StartedAt:  now,
+		FinishedAt: now,
+		ContextPacket: json.RawMessage(`{
+			"id":"ctx_old_retry",
+			"refs":{"session_id":"chat_2","run_id":"run-retry-source"},
+			"items":[{"kind":"transcript","trust_level":"runtime_state","origin":"chat.transcript","title":"Chat transcript","included":true}]
+		}`),
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := store.CreateArtifact(ctx, types.TaskArtifact{
+		ID:          "artifact-conversation",
+		TaskID:      task.ID,
+		RunID:       run.ID,
+		Kind:        "agent_conversation",
+		StorageKind: "inline",
+		ContentText: `[{"role":"user","content":"hello"},{"role":"assistant","content":"done"}]`,
+		Status:      "ready",
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	result, err := runner.RetryTaskFromTurn(ctx, task, run, 1, "operator_retry", defaultResourceID)
+	if err != nil {
+		t.Fatalf("RetryTaskFromTurn: %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, result.Run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
+	}
+	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+}
+
+func assertCopiedRunContextPacket(t *testing.T, raw json.RawMessage, taskID, runID string) {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatal("ContextPacket empty, want copied packet")
+	}
+	var packet map[string]any
+	if err := json.Unmarshal(raw, &packet); err != nil {
+		t.Fatalf("Unmarshal ContextPacket: %v", err)
+	}
+	if got, _ := packet["id"].(string); got == "" || got == "ctx_old" || got == "ctx_old_retry" {
+		t.Fatalf("packet id = %q, want fresh context snapshot id", got)
+	}
+	refs, _ := packet["refs"].(map[string]any)
+	if refs == nil {
+		t.Fatalf("packet refs = nil, want task/run refs")
+	}
+	if got, _ := refs["task_id"].(string); got != taskID {
+		t.Fatalf("refs.task_id = %q, want %q", got, taskID)
+	}
+	if got, _ := refs["run_id"].(string); got != runID {
+		t.Fatalf("refs.run_id = %q, want %q", got, runID)
 	}
 }

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Task struct {
 	ID     string
@@ -168,6 +171,7 @@ type TaskRun struct {
 	RootSpanID         string
 	OtelStatusCode     string
 	OtelStatusMessage  string
+	ContextPacket      json.RawMessage
 }
 
 type TaskStep struct {


### PR DESCRIPTION
## Summary
- add a stable, inspectable context packet contract with ids, refs, execution-profile hints, and section-labelled items
- persist run-owned context packets for native project-assignment starts and resolve task/assignment context through run-owned or linked chat snapshots
- preserve run-owned context packets across resume and retry flows, and document the runtime API contract in one canonical place

## Testing
- `go test ./internal/api ./internal/chat ./internal/taskstate ./internal/projects ./internal/projectwork ./internal/memory`
- `go test ./internal/api ./internal/orchestrator ./internal/chat`