### PR TITLE
Add context inspector views for chats, runs, and assignments

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -92,7 +92,7 @@ for the context packet boundary.
 | [Projects](accepted/projects.md)                                                                    | Accepted           | Projects, context, and memory |
 | [Context assembly and injection boundaries](proposals/context-assembly-and-injection-boundaries.md) | Proposal; partial  | Projects, context, and memory |
 | [Agent memory](proposals/agent-memory.md)                                                           | Proposal; partial  | Projects, context, and memory |
-| [Run evidence and portable memory](proposals/run-evidence-and-portable-memory.md)                    | Proposal           | Projects, context, and memory |
+| [Run evidence and portable memory](proposals/run-evidence-and-portable-memory.md)                   | Proposal           | Projects, context, and memory |
 | [LLM context window management](proposals/llm-context-window-management.md)                         | Proposal           | Projects, context, and memory |
 | [Workflow runbooks v0](proposals/workflow-runbooks-v0.md)                                           | Proposal           | Workflow runbooks             |
 | [Hecate Chat and model capabilities](accepted/hecate-chat-model-capabilities.md)                    | Accepted           | Agent and chat runtime        |

--- a/docs/design/proposals/run-evidence-and-portable-memory.md
+++ b/docs/design/proposals/run-evidence-and-portable-memory.md
@@ -89,15 +89,15 @@ type RunEvidenceRecord struct {
 
 Candidate `Kind` values:
 
-| Kind                 | Subject                                                 |
-| -------------------- | ------------------------------------------------------- |
-| `run_event`          | Persisted `TaskRunEvent` canonical JSON.                |
-| `approval_requested` | `TaskApproval` request body and policy reason.          |
-| `approval_resolved`  | Approval decision, operator, note, and resolved time.   |
-| `artifact_created`   | Artifact metadata plus content hash.                    |
-| `artifact_reverted`  | Revert metadata plus before/after content hashes.       |
-| `grant_created`      | External-agent durable grant scope and expiry.          |
-| `grant_revoked`      | Revocation reason and parent grant reference.           |
+| Kind                 | Subject                                                  |
+| -------------------- | -------------------------------------------------------- |
+| `run_event`          | Persisted `TaskRunEvent` canonical JSON.                 |
+| `approval_requested` | `TaskApproval` request body and policy reason.           |
+| `approval_resolved`  | Approval decision, operator, note, and resolved time.    |
+| `artifact_created`   | Artifact metadata plus content hash.                     |
+| `artifact_reverted`  | Revert metadata plus before/after content hashes.        |
+| `grant_created`      | External-agent durable grant scope and expiry.           |
+| `grant_revoked`      | Revocation reason and parent grant reference.            |
 | `context_snapshot`   | Context packet metadata and item hashes, not raw secret. |
 
 The chain should be deterministic over canonical JSON. Store the hash and
@@ -194,11 +194,11 @@ changing active project memory immediately.
 
 States:
 
-| State       | Meaning                                                             |
-| ----------- | ------------------------------------------------------------------- |
-| `draft`     | Candidate exists only for review or the current run.                |
-| `active`    | Candidate is included in an experimental context packet.            |
-| `merged`    | Operator promoted it into durable memory.                           |
+| State       | Meaning                                                              |
+| ----------- | -------------------------------------------------------------------- |
+| `draft`     | Candidate exists only for review or the current run.                 |
+| `active`    | Candidate is included in an experimental context packet.             |
+| `merged`    | Operator promoted it into durable memory.                            |
 | `discarded` | Operator rejected it; future context assembly ignores it by default. |
 
 Memory branches should reuse the existing memory-candidate promotion posture:

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -134,6 +134,7 @@ The `task` resource accepts these fields on `POST /hecate/v1/tasks`:
 
 - `execution_kind` — one of `shell`, `git`, `file`, `agent_loop`
 - `prompt` — the user-facing prompt; required for `agent_loop`, optional description for the others
+- `project_id` — optional owning project id. Empty / omitted creates an unprojected task; `GET /hecate/v1/tasks?project_id=` lists only unprojected tasks
 - `system_prompt` — per-task agent prompt (narrowest of the three-layer composition); `agent_loop` only
 - `shell_command` / `git_command` / `file_path` / `file_content` / `file_operation` — execution-kind-specific
 - `working_directory` — absolute path; required when `workspace_mode=in_place`
@@ -163,7 +164,7 @@ The `task` resource accepts these fields on `POST /hecate/v1/tasks`:
 ## Lifecycle endpoints
 
 - `POST /hecate/v1/tasks`
-- `GET /hecate/v1/tasks`
+- `GET /hecate/v1/tasks` — optional `project_id` query scopes the list. Pass an empty value (`?project_id=`) for unprojected tasks only.
 - `GET /hecate/v1/tasks/{id}`
 - `DELETE /hecate/v1/tasks/{id}`
 - `POST /hecate/v1/tasks/{id}/start` — returns `422 model_not_configured` when an `agent_loop` task has no `requested_model` set. No run is created.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2551,6 +2551,14 @@ group without inferring from `kind`. Current packets intentionally snapshot
 visible metadata only; they do not store full system prompts, raw transcript
 text, file contents, or external-agent private prompt packing.
 
+Operator UI note: the current React console renders these packets as a compact
+"what the agent saw" inspector. Chats expose it inline on assistant transcript
+rows; Task Detail and Project assignment detail expose it behind an
+`Inspect context` modal. The UI groups rows by `section`, keeps trust labels on
+each item, falls back to legacy `sources` when `items` are absent, and uses
+operator-facing copy such as `Not captured` when a snapshot does not expose the
+full system prompt text.
+
 Section values currently used by the runtime are:
 
 - `instructions` for system-prompt and instruction-layer metadata

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -432,6 +432,7 @@ func (h *Handler) startOrContinueHecateAgentRun(ctx context.Context, session cha
 			ID:                 newTaskID(),
 			Title:              title,
 			Prompt:             prompt,
+			ProjectID:          session.ProjectID,
 			SystemPrompt:       strings.TrimSpace(systemPrompt),
 			ExecutionKind:      "agent_loop",
 			ExecutionProfile:   "chat_agent",

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1103,6 +1103,7 @@ func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string
 		ID:                 taskID,
 		Title:              projectAssignmentTaskTitle(workItem, role),
 		Prompt:             projectAssignmentPrompt(project, workItem, assignment, role),
+		ProjectID:          project.ID,
 		SystemPrompt:       projectAssignmentSystemPrompt(project, role),
 		ExecutionKind:      "agent_loop",
 		ExecutionProfile:   executionProfile,

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -80,12 +80,27 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 	if priority == "" {
 		priority = "normal"
 	}
+	projectID := strings.TrimSpace(req.ProjectID)
+	if projectID != "" {
+		if h.projects == nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
+			return
+		}
+		if _, ok, err := h.projects.Get(ctx, projectID); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		} else if !ok {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project not found")
+			return
+		}
+	}
 
 	now := time.Now().UTC()
 	task := types.Task{
 		ID:                 newTaskID(),
 		Title:              title,
 		Prompt:             prompt,
+		ProjectID:          projectID,
 		SystemPrompt:       strings.TrimSpace(req.SystemPrompt),
 		ExecutionProfile:   strings.TrimSpace(req.ExecutionProfile),
 		Repo:               strings.TrimSpace(req.Repo),
@@ -194,6 +209,13 @@ func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 	filter := taskstate.TaskFilter{
 		Status: strings.TrimSpace(r.URL.Query().Get("status")),
 		Limit:  limit,
+	}
+	if rawProjectIDs, ok := r.URL.Query()["project_id"]; ok {
+		projectID := strings.TrimSpace("")
+		if len(rawProjectIDs) > 0 {
+			projectID = strings.TrimSpace(rawProjectIDs[0])
+		}
+		filter.ProjectID = &projectID
 	}
 	result, err := h.taskStore.ListTasks(ctx, filter)
 	if err != nil {
@@ -706,6 +728,7 @@ func renderTaskItem(task types.Task) TaskItem {
 		ID:                 task.ID,
 		Title:              task.Title,
 		Prompt:             task.Prompt,
+		ProjectID:          task.ProjectID,
 		SystemPrompt:       task.SystemPrompt,
 		ExecutionProfile:   task.ExecutionProfile,
 		OriginKind:         task.OriginKind,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hecatehq/hecate/internal/mcp"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/ratelimit"
 	"github.com/hecatehq/hecate/internal/retention"
@@ -4103,10 +4104,17 @@ func TestTasksCreateListAndGet(t *testing.T) {
 
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	project, err := apiHandler.projects.Create(context.Background(), projects.Project{
+		ID:   "proj_ui",
+		Name: "UI",
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
 	handler := NewServer(logger, apiHandler)
 	tasks := newTaskTestClient(t, handler)
 
-	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Upgrade TypeScript","prompt":"Upgrade the UI workspace to TypeScript 7 beta.","repo":"hecate","base_branch":"main","workspace_mode":"ephemeral","requested_model":"gpt-5.4-mini","requested_provider":"openai","budget_micros_usd":500000}`)
+	created := mustTaskRequestJSON[TaskResponse](tasks, http.MethodPost, "/hecate/v1/tasks", `{"title":"Upgrade TypeScript","prompt":"Upgrade the UI workspace to TypeScript 7 beta.","project_id":"proj_ui","repo":"hecate","base_branch":"main","workspace_mode":"ephemeral","requested_model":"gpt-5.4-mini","requested_provider":"openai","budget_micros_usd":500000}`)
 	if created.Object != "task" {
 		t.Fatalf("object = %q, want task", created.Object)
 	}
@@ -4119,6 +4127,9 @@ func TestTasksCreateListAndGet(t *testing.T) {
 	if created.Data.Repo != "hecate" {
 		t.Fatalf("repo = %q, want hecate", created.Data.Repo)
 	}
+	if created.Data.ProjectID != project.ID {
+		t.Fatalf("project_id = %q, want %q", created.Data.ProjectID, project.ID)
+	}
 
 	listed := mustTaskRequestJSON[TasksResponse](tasks, http.MethodGet, "/hecate/v1/tasks?limit=10", "")
 	if listed.Object != "tasks" {
@@ -4130,6 +4141,19 @@ func TestTasksCreateListAndGet(t *testing.T) {
 	if listed.Data[0].ID != created.Data.ID {
 		t.Fatalf("listed task id = %q, want %q", listed.Data[0].ID, created.Data.ID)
 	}
+	if listed.Data[0].ProjectID != project.ID {
+		t.Fatalf("listed project_id = %q, want %q", listed.Data[0].ProjectID, project.ID)
+	}
+
+	projectListed := mustTaskRequestJSON[TasksResponse](tasks, http.MethodGet, "/hecate/v1/tasks?limit=10&project_id=proj_ui", "")
+	if len(projectListed.Data) != 1 || projectListed.Data[0].ID != created.Data.ID {
+		t.Fatalf("project-scoped tasks = %#v, want only created task", projectListed.Data)
+	}
+
+	unprojectedListed := mustTaskRequestJSON[TasksResponse](tasks, http.MethodGet, "/hecate/v1/tasks?limit=10&project_id=", "")
+	if len(unprojectedListed.Data) != 0 {
+		t.Fatalf("unprojected task list = %#v, want none", unprojectedListed.Data)
+	}
 
 	fetched := mustTaskRequestJSON[TaskResponse](tasks, http.MethodGet, "/hecate/v1/tasks/"+created.Data.ID, "")
 	if fetched.Data.ID != created.Data.ID {
@@ -4137,6 +4161,9 @@ func TestTasksCreateListAndGet(t *testing.T) {
 	}
 	if fetched.Data.Prompt != "Upgrade the UI workspace to TypeScript 7 beta." {
 		t.Fatalf("prompt = %q, want original prompt", fetched.Data.Prompt)
+	}
+	if fetched.Data.ProjectID != project.ID {
+		t.Fatalf("fetched project_id = %q, want %q", fetched.Data.ProjectID, project.ID)
 	}
 
 	startRecorder := tasks.mustRequest(http.MethodPost, "/hecate/v1/tasks/"+created.Data.ID+"/start", "")

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -5,6 +5,9 @@ import "github.com/hecatehq/hecate/internal/eventprotocol"
 type CreateTaskRequest struct {
 	Title  string `json:"title"`
 	Prompt string `json:"prompt"`
+	// ProjectID links a manually-created task to the selected project.
+	// Empty / omitted creates an unprojected task.
+	ProjectID string `json:"project_id,omitempty"`
 	// SystemPrompt is the per-task system prompt for agent_loop runs.
 	// It's the narrowest layer in the four-level composition (global
 	// → tenant → workspace CLAUDE.md/AGENTS.md → this).
@@ -186,6 +189,7 @@ type TaskItem struct {
 	ID                 string `json:"id"`
 	Title              string `json:"title"`
 	Prompt             string `json:"prompt"`
+	ProjectID          string `json:"project_id,omitempty"`
 	SystemPrompt       string `json:"system_prompt,omitempty"`
 	ExecutionProfile   string `json:"execution_profile,omitempty"`
 	OriginKind         string `json:"origin_kind,omitempty"`

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -292,6 +292,53 @@ func runStoreListTasksFilterAndLimit(t *testing.T, store Store) {
 	if len(statused) != 2 {
 		t.Fatalf("ListTasks status len = %d, want 2", len(statused))
 	}
+
+	projectID := "proj_a"
+	projectScoped, err := store.ListTasks(ctx, TaskFilter{ProjectID: &projectID})
+	if err != nil {
+		t.Fatalf("ListTasks(project_id): %v", err)
+	}
+	if len(projectScoped) != 0 {
+		t.Fatalf("ListTasks project_id len = %d, want 0 before project-linked fixtures", len(projectScoped))
+	}
+
+	for i, spec := range []struct {
+		id        string
+		projectID string
+		ts        time.Time
+	}{
+		{"t-proj-1", "proj_a", now.Add(1 * time.Minute)},
+		{"t-proj-2", "proj_b", now.Add(2 * time.Minute)},
+		{"t-none", "", now.Add(3 * time.Minute)},
+	} {
+		_, err := store.CreateTask(ctx, types.Task{
+			ID:        spec.id,
+			Status:    "queued",
+			ProjectID: spec.projectID,
+			CreatedAt: spec.ts,
+			UpdatedAt: spec.ts,
+		})
+		if err != nil {
+			t.Fatalf("CreateTask(project[%d]): %v", i, err)
+		}
+	}
+
+	projectScoped, err = store.ListTasks(ctx, TaskFilter{ProjectID: &projectID})
+	if err != nil {
+		t.Fatalf("ListTasks(project_id scoped): %v", err)
+	}
+	if len(projectScoped) != 1 || projectScoped[0].ID != "t-proj-1" {
+		t.Fatalf("ListTasks project scope = %#v, want only t-proj-1", projectScoped)
+	}
+
+	noProjectID := ""
+	unprojected, err := store.ListTasks(ctx, TaskFilter{ProjectID: &noProjectID})
+	if err != nil {
+		t.Fatalf("ListTasks(project_id empty): %v", err)
+	}
+	if len(unprojected) == 0 || unprojected[0].ID != "t-none" {
+		t.Fatalf("ListTasks unprojected = %#v, want t-none first", unprojected)
+	}
 }
 
 func runStoreApprovalRoundTrip(t *testing.T, store Store) {

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -75,6 +75,9 @@ func (s *MemoryStore) ListTasks(_ context.Context, filter TaskFilter) ([]types.T
 		if filter.Status != "" && task.Status != filter.Status {
 			continue
 		}
+		if filter.ProjectID != nil && task.ProjectID != *filter.ProjectID {
+			continue
+		}
 		items = append(items, task)
 	}
 	sort.Slice(items, func(i, j int) bool {

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -105,6 +105,14 @@ func (s *SQLiteStore) ListTasks(ctx context.Context, filter TaskFilter) ([]types
 		args = append(args, filter.Status)
 		where = append(where, "status = ?")
 	}
+	if filter.ProjectID != nil {
+		if *filter.ProjectID == "" {
+			where = append(where, "json_extract(payload, '$.ProjectID') IS NULL OR json_extract(payload, '$.ProjectID') = ''")
+		} else {
+			args = append(args, *filter.ProjectID)
+			where = append(where, "json_extract(payload, '$.ProjectID') = ?")
+		}
+	}
 	limitSQL := ""
 	if filter.Limit > 0 {
 		args = append(args, filter.Limit)

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -8,8 +8,9 @@ import (
 )
 
 type TaskFilter struct {
-	Status string
-	Limit  int
+	Status    string
+	ProjectID *string
+	Limit     int
 }
 
 type ArtifactFilter struct {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -9,6 +9,10 @@ type Task struct {
 	ID     string
 	Title  string
 	Prompt string
+	// ProjectID links the task to an operator project when it was
+	// created from a project-scoped surface (manual Tasks, Hecate Chat,
+	// or project assignments). Empty means the task is unscoped.
+	ProjectID string
 	// SystemPrompt is the per-task agent system prompt. When set, it
 	// becomes the narrowest layer in the composition: global default →
 	// workspace CLAUDE.md/AGENTS.md → this. Concatenated, broadest

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -18,6 +18,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
+  getProjectAssignmentContext,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
@@ -103,6 +104,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
     getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
+    getProjectAssignmentContext: vi.fn(async () => ({ object: "context_packet", data: null })),
     getProjectCollaborationArtifacts: vi.fn(async () => ({
       object: "project_collaboration_artifacts",
       data: [],
@@ -311,6 +313,32 @@ function resetProjectWorkMocks() {
     object: "project_assignments",
     data: [hecateAssignment],
   });
+  vi.mocked(getProjectAssignmentContext).mockResolvedValue({
+    object: "context_packet",
+    data: {
+      id: "ctx_assignment_1",
+      execution_mode: "hecate_task",
+      provider: "ollama",
+      model: "qwen2.5-coder",
+      execution_profile: "implementation",
+      refs: {
+        project_id: project.id,
+        work_item_id: workItem.id,
+        assignment_id: hecateAssignment.id,
+      },
+      items: [
+        {
+          section: "project_work",
+          kind: "work_item",
+          trust_level: "runtime_state",
+          origin: workItem.id,
+          title: workItem.title,
+          body: workItem.brief,
+          included: true,
+        },
+      ],
+    },
+  });
   vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
     object: "project_collaboration_artifacts",
     data: [],
@@ -481,6 +509,7 @@ afterEach(() => {
   vi.mocked(getProjectWorkItems).mockReset();
   vi.mocked(getProjectWorkItem).mockReset();
   vi.mocked(getProjectAssignments).mockReset();
+  vi.mocked(getProjectAssignmentContext).mockReset();
   vi.mocked(getProjectCollaborationArtifacts).mockReset();
   vi.mocked(getProjectHandoffs).mockReset();
   vi.mocked(getProjectMemory).mockReset();
@@ -1132,6 +1161,16 @@ describe("ProjectsView cockpit", () => {
 
     await userEvent.click(within(detail).getByRole("button", { name: "Open task" }));
     expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
+
+    await userEvent.click(within(detail).getByRole("button", { name: "Inspect context" }));
+    expect(getProjectAssignmentContext).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      hecateAssignment.id,
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Assignment asgn_1 context" });
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByText("Expose project work and native starts.")).toBeTruthy();
 
     await userEvent.click(within(detail).getByRole("button", { name: "Open chat" }));
     expect(onOpenChat).toHaveBeenCalledWith(

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -23,6 +23,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
+  getProjectAssignmentContext,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
@@ -46,6 +47,7 @@ import { formatAbsoluteTime } from "../../lib/format";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import { providerDisplayName } from "../../lib/provider-utils";
 import { ChatRightPanel } from "../chats/ChatRightPanel";
+import { ContextInspectorModalTrigger } from "../shared/ContextInspector";
 import { useFloatingMenu } from "../shared/useFloatingMenu";
 import {
   activitySignalLabel,
@@ -76,6 +78,7 @@ import type {
 } from "../../types/project";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderPresetRecord } from "../../types/provider";
+import type { ContextPacketRecord } from "../../types/context";
 import {
   Badge,
   ConfirmModal,
@@ -2921,6 +2924,18 @@ function WorkItemDetail({
                   onStart={() => onStartAssignment(assignment)}
                   role={roleByID.get(assignment.role_id)}
                   starting={startingAssignmentID === assignment.id}
+                  loadContext={
+                    project
+                      ? async () =>
+                          (
+                            await getProjectAssignmentContext(
+                              project.id,
+                              workItem.id,
+                              assignment.id,
+                            )
+                          ).data
+                      : null
+                  }
                 />
               ))}
             </div>
@@ -4151,6 +4166,7 @@ function AssignmentRow({
   assignment,
   chatModel,
   error,
+  loadContext,
   onDelete,
   onEdit,
   onOpenChat,
@@ -4162,6 +4178,7 @@ function AssignmentRow({
   assignment: ProjectAssignmentRecord;
   chatModel: string;
   error: string;
+  loadContext?: (() => Promise<ContextPacketRecord>) | null;
   onDelete: () => void;
   onEdit: () => void;
   onOpenChat?: () => void;
@@ -4239,6 +4256,14 @@ function AssignmentRow({
             Open task
           </button>
         )}
+        <ContextInspectorModalTrigger
+          buttonLabel="Inspect context"
+          buttonTitle="Inspect the best available stored context snapshot for this assignment."
+          loadPacket={loadContext}
+          modalTitle={`Assignment ${assignment.id} context`}
+          resourceKey={assignment.id}
+          unavailableDetail="This assignment does not have a stored context packet yet. Unstarted assignments, legacy rows, and older linked runs can legitimately return no snapshot."
+        />
         <button
           className="btn btn-ghost btn-sm"
           type="button"

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "../../lib/api";
 import { TaskDetail } from "./TaskDetail";
+import type { ContextPacketRecord } from "../../types/context";
 import type {
   TaskActivityRecord,
   TaskArtifactRecord,
@@ -197,6 +199,51 @@ describe("TaskDetail run picker", () => {
     const { render } = setup({ runs: [], run: null });
     render();
     expect(screen.queryByRole("button", { name: /select run/i })).toBeNull();
+  });
+
+  it("opens a context inspector for the selected run", async () => {
+    const loadContext = vi.fn<() => Promise<ContextPacketRecord>>().mockResolvedValue({
+      id: "ctx_run_1",
+      execution_mode: "hecate_task",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      execution_profile: "chat_agent",
+      refs: { task_id: "task-1", run_id: "run-1" },
+      items: [
+        {
+          section: "runtime",
+          kind: "task_runtime",
+          trust_level: "runtime_state",
+          origin: "hecate.task_runtime",
+          title: "Hecate task runtime",
+          body: "Continuing the existing task-backed agent loop",
+          included: true,
+        },
+      ],
+    });
+    const { render, user } = setup({ loadContext });
+    render();
+
+    await user.click(screen.getByRole("button", { name: "Inspect context" }));
+
+    expect(loadContext).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Run #1 context")).toBeInTheDocument();
+    expect(screen.getByText("Linked refs")).toBeInTheDocument();
+    expect(screen.getAllByText("Hecate task runtime").length).toBeGreaterThan(0);
+    expect(screen.getByText("chat_agent")).toBeInTheDocument();
+  });
+
+  it("shows an unavailable state when the run has no stored context snapshot", async () => {
+    const loadContext = vi
+      .fn<() => Promise<ContextPacketRecord>>()
+      .mockRejectedValue(new ApiError("not found", 404));
+    const { render, user } = setup({ loadContext });
+    render();
+
+    await user.click(screen.getByRole("button", { name: "Inspect context" }));
+
+    expect(await screen.findByText("Context snapshot unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/Older runs may predate context persistence/i)).toBeInTheDocument();
   });
 });
 

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -233,6 +233,69 @@ describe("TaskDetail run picker", () => {
     expect(screen.getByText("chat_agent")).toBeInTheDocument();
   });
 
+  it("does not refetch or flicker when the parent rerenders with a new loadContext identity", async () => {
+    const loadContext = vi.fn<() => Promise<ContextPacketRecord>>().mockResolvedValue({
+      id: "ctx_run_1",
+      execution_mode: "hecate_task",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      execution_profile: "chat_agent",
+      refs: { task_id: "task-1", run_id: "run-1" },
+      items: [
+        {
+          section: "runtime",
+          kind: "task_runtime",
+          trust_level: "runtime_state",
+          origin: "hecate.task_runtime",
+          title: "Hecate task runtime",
+          body: "Continuing the existing task-backed agent loop",
+          included: true,
+        },
+      ],
+    });
+    const task = makeTask();
+    const run = makeRun();
+    const baseProps: React.ComponentProps<typeof TaskDetail> = {
+      task,
+      run,
+      runs: [run],
+      selectedRunID: run.id,
+      events: [],
+      steps: [],
+      artifacts: [],
+      activity: [],
+      approvals: [],
+      streamTurnCosts: new Map(),
+      streamState: "live",
+      busyAction: "",
+      notice: null,
+      onSelectRun: vi.fn(),
+      onResolveApproval: vi.fn(),
+      onCancelRun: vi.fn(),
+      onRetryRun: vi.fn(),
+      onResumeRun: vi.fn(),
+      onRefresh: vi.fn(),
+      onRetryFromTurn: vi.fn(),
+      onResumeRaisingCeiling: vi.fn(),
+      onApplyPatch: vi.fn(),
+      onRevertPatch: vi.fn(),
+    };
+    const user = userEvent.setup();
+    const view = render(<TaskDetail {...baseProps} loadContext={() => loadContext()} />);
+
+    await user.click(screen.getByRole("button", { name: "Inspect context" }));
+
+    expect(await screen.findByText("Run #1 context")).toBeInTheDocument();
+    expect(loadContext).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Loading context snapshot…")).toBeNull();
+
+    view.rerender(<TaskDetail {...baseProps} loadContext={() => loadContext()} />);
+
+    expect(loadContext).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Loading context snapshot…")).toBeNull();
+    expect(screen.getByText("Run #1 context")).toBeInTheDocument();
+  });
+
   it("shows an unavailable state when the run has no stored context snapshot", async () => {
     const loadContext = vi
       .fn<() => Promise<ContextPacketRecord>>()
@@ -346,6 +409,14 @@ describe("TaskDetail runtime activity and patches", () => {
           path: "agent-final-answer.txt",
           status: "ready",
         }),
+        makeActivity({
+          id: "activity-conversation",
+          type: "artifact",
+          title: "agent-conversation.json",
+          kind: "agent_conversation",
+          path: "agent-conversation.json",
+          status: "ready",
+        }),
       ],
     });
     render();
@@ -354,8 +425,8 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.getByText("Artifacts · 2 items")).toBeTruthy();
     expect(screen.getAllByText("Workspace diff snapshot").length).toBeGreaterThan(0);
     expect(screen.getAllByText("git-changes.json").length).toBeGreaterThan(0);
-    expect(screen.getByText("Final answer artifact")).toBeTruthy();
     expect(screen.getAllByText("agent-final-answer.txt").length).toBeGreaterThan(0);
+    expect(screen.queryByText("agent-conversation.json")).toBeNull();
 
     await user.click(screen.getAllByText("Advanced")[0]);
     expect(screen.getByText("step-git")).toBeTruthy();
@@ -378,6 +449,26 @@ describe("TaskDetail runtime activity and patches", () => {
 
     expect(screen.getAllByText("file-0.ts").length).toBeGreaterThan(0);
     expect(screen.getAllByText("file-12.ts").length).toBeGreaterThan(0);
+  });
+
+  it("hides agent conversation artifacts from runtime activity because the conversation renders separately", () => {
+    const { render } = setup({
+      activity: [
+        makeActivity({
+          id: "activity-conversation",
+          type: "artifact",
+          title: "agent-conversation.json",
+          kind: "agent_conversation",
+          path: "agent-conversation.json",
+          status: "ready",
+        }),
+      ],
+    });
+    render();
+
+    expect(screen.getByText(/Runtime activity/i)).toBeTruthy();
+    expect(screen.queryByText("Agent conversation")).toBeNull();
+    expect(screen.queryByText("agent-conversation.json")).toBeNull();
   });
 
   it("renders task approval rows without leaking internal agent-loop markers", async () => {
@@ -781,6 +872,30 @@ describe("TaskDetail runtime debugging", () => {
     expect(screen.getByText(/Run created/i)).toBeTruthy();
     expect(screen.getByText(/Queued/i)).toBeTruthy();
     expect(screen.getByText(/Completed/i)).toBeTruthy();
+  });
+
+  it("renders timeline rows as sequence, then time, then status", () => {
+    const events: TaskRunEventRecord[] = [
+      makeEvent({
+        event_id: "evt_01HX0000000000000000000999",
+        sequence: 1,
+        type: "run.created",
+        occurred_at: "2026-04-27T17:00:00Z",
+      }),
+    ];
+    const { render } = setup({ events });
+    render();
+
+    const sequence = screen.getByText("#1");
+    const row = sequence.parentElement as HTMLDivElement | null;
+    expect(row).toBeTruthy();
+    const cells = row ? Array.from(row.children) : [];
+
+    expect(cells).toHaveLength(3);
+    expect(cells[0]?.textContent).toContain("#1");
+    expect(cells[1]?.textContent).toMatch(/[:]/);
+    expect(cells[1]?.textContent).not.toContain("Run created");
+    expect(cells[2]?.textContent).toContain("Run created");
   });
 
   it("hides snapshot sync events and renders compact operator labels", () => {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import type { ContextPacketRecord } from "../../types/context";
 import type {
   TaskActivityRecord,
   TaskApprovalRecord,
@@ -15,6 +16,7 @@ import {
   formatMicrosUSD,
 } from "../../lib/format";
 import { providerDisplayName } from "../../lib/provider-utils";
+import { ContextInspectorModalTrigger } from "../shared/ContextInspector";
 import { Badge, BrandAvatar, CopyableID, Dot, Icon, Icons, Modal } from "../shared/ui";
 import { DiffViewer } from "../shared/DiffViewer";
 import { TranscriptActivityTimeline } from "../transcript/TranscriptActivityTimeline";
@@ -386,6 +388,7 @@ type Props = {
   onResumeRaisingCeiling: (budgetMicrosUSD: number) => void;
   onApplyPatch: (artifactID: string) => void;
   onRevertPatch: (artifactID: string) => void;
+  loadContext?: (() => Promise<ContextPacketRecord>) | null;
   // onOpenTrace opens the Observability drawer pre-targeted on the
   // run's request_id. Surfaced as a clickable Request ID in the run
   // metadata grid when both the callback and the run.request_id are
@@ -419,6 +422,7 @@ export function TaskDetail({
   onResumeRaisingCeiling,
   onApplyPatch,
   onRevertPatch,
+  loadContext,
   onOpenTrace,
 }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
@@ -624,6 +628,16 @@ export function TaskDetail({
           >
             <Icon d={Icons.refresh} size={13} />
           </button>
+          {run && (
+            <ContextInspectorModalTrigger
+              buttonLabel="Inspect context"
+              buttonTitle="Inspect the stored context snapshot for this run."
+              loadPacket={loadContext}
+              modalTitle={`Run #${run.number} context`}
+              resourceKey={run.id}
+              unavailableDetail="This run has no stored context snapshot yet. Older runs may predate context persistence, and unrelated runs may have no linked chat packet to fall back to."
+            />
+          )}
         </div>
       </div>
 

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -844,7 +844,7 @@ export function TaskDetail({
                       key={event.event_id || `${event.sequence}-${event.type}`}
                       style={{
                         display: "grid",
-                        gridTemplateColumns: "64px minmax(132px, auto) minmax(0, 1fr)",
+                        gridTemplateColumns: "64px minmax(116px, auto) minmax(0, 1fr)",
                         gap: 10,
                         alignItems: "start",
                       }}
@@ -854,19 +854,20 @@ export function TaskDetail({
                       >
                         #{event.sequence}
                       </div>
-                      <span style={{ minWidth: 0 }} title={meta.label}>
-                        <Badge status={meta.tone} label={meta.label} />
-                      </span>
+                      <div
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 11,
+                          color: "var(--t2)",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {event.occurred_at ? formatLocaleTime(event.occurred_at) : "streamed"}
+                      </div>
                       <div style={{ minWidth: 0 }}>
-                        <div
-                          style={{
-                            fontFamily: "var(--font-mono)",
-                            fontSize: 11,
-                            color: "var(--t2)",
-                          }}
-                        >
-                          {event.occurred_at ? formatLocaleTime(event.occurred_at) : "streamed"}
-                        </div>
+                        <span style={{ minWidth: 0 }} title={meta.label}>
+                          <Badge status={meta.tone} label={meta.label} />
+                        </span>
                         {(() => {
                           const note = describeRunEventNote(event);
                           return note ? (
@@ -1359,9 +1360,16 @@ function StepRowTitle({ step }: { step: TaskStepRecord }) {
 }
 
 function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
-  const activityByID = new Map(activity.map((item) => [item.id, item]));
-  const outputArtifacts = useMemo(() => buildOutputActivityIndex(activity), [activity]);
-  const rows = activity.map(taskActivityToTranscriptActivity);
+  const visibleActivity = useMemo(
+    () =>
+      activity.filter(
+        (item) => !(item.type === "artifact" && (item.kind ?? "").trim() === "agent_conversation"),
+      ),
+    [activity],
+  );
+  const activityByID = new Map(visibleActivity.map((item) => [item.id, item]));
+  const outputArtifacts = useMemo(() => buildOutputActivityIndex(visibleActivity), [visibleActivity]);
+  const rows = visibleActivity.map(taskActivityToTranscriptActivity);
   return (
     <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>
       <div className="kicker" style={{ marginBottom: 8 }}>

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -1368,7 +1368,10 @@ function RuntimeActivity({ activity }: { activity: TaskActivityRecord[] }) {
     [activity],
   );
   const activityByID = new Map(visibleActivity.map((item) => [item.id, item]));
-  const outputArtifacts = useMemo(() => buildOutputActivityIndex(visibleActivity), [visibleActivity]);
+  const outputArtifacts = useMemo(
+    () => buildOutputActivityIndex(visibleActivity),
+    [visibleActivity],
+  );
   const rows = visibleActivity.map(taskActivityToTranscriptActivity);
   return (
     <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>

--- a/ui/src/features/runs/TasksView.test.tsx
+++ b/ui/src/features/runs/TasksView.test.tsx
@@ -42,6 +42,7 @@ const task: TaskRecord = {
   id: "task_1",
   title: "Review project cockpit",
   prompt: "Review project cockpit",
+  project_id: "",
   status: "completed",
   execution_kind: "agent_loop",
   latest_run_id: "run_1",
@@ -159,6 +160,91 @@ describe("TasksView empty state", () => {
         "/workspace/default",
       );
     });
+  });
+
+  it("loads tasks scoped to the active project", async () => {
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [],
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      projects: [project],
+      activeProjectID: project.id,
+    });
+
+    render(withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await waitFor(() => {
+      expect(vi.mocked(getTasks)).toHaveBeenCalledWith(30, project.id);
+    });
+  });
+
+  it("switches the visible task list when the selected project changes", async () => {
+    const projectA: ProjectRecord = {
+      id: "proj_a",
+      name: "Alpha",
+      roots: [],
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const projectB: ProjectRecord = {
+      id: "proj_b",
+      name: "Beta",
+      roots: [],
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const alphaTask: TaskRecord = {
+      ...task,
+      id: "task_alpha",
+      title: "Alpha task",
+      prompt: "Alpha task",
+      project_id: projectA.id,
+      latest_run_id: "",
+    };
+    const betaTask: TaskRecord = {
+      ...task,
+      id: "task_beta",
+      title: "Beta task",
+      prompt: "Beta task",
+      project_id: projectB.id,
+      latest_run_id: "",
+    };
+    vi.mocked(getTasks).mockImplementation(async (_limit, projectID) => {
+      if (projectID === projectA.id) return { object: "list", data: [alphaTask] };
+      if (projectID === projectB.id) return { object: "list", data: [betaTask] };
+      return { object: "list", data: [] };
+    });
+    vi.mocked(getTaskRuns).mockResolvedValue({ object: "list", data: [] });
+
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      projects: [projectA, projectB],
+      activeProjectID: projectA.id,
+    });
+
+    render(withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Task Alpha task" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Project Alpha" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Project Beta" })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Project Beta" }));
+
+    await waitFor(() => {
+      expect(vi.mocked(getTasks)).toHaveBeenCalledWith(30, projectB.id);
+      expect(screen.getByRole("button", { name: "Task Beta task" })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("button", { name: "Task Alpha task" })).toBeNull();
   });
 });
 

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -130,6 +130,7 @@ export function TasksView({
   useEnsureProviderPresetsLoaded();
   const providerPresets = useProvidersAndModels().state.providerPresets;
   const projects = useProjects();
+  const activeProjectID = projects.activeProjectID;
   const defaultTaskWorkspace = projectDefaultWorkspace(projects.activeProject);
 
   const streamCursorRef = useRef(0);
@@ -199,11 +200,15 @@ export function TasksView({
   );
 
   const loadTasks = useCallback(
-    async (preferredTaskID = "", preferredRunID = "") => {
+    async (
+      preferredTaskID = "",
+      preferredRunID = "",
+      projectID: string | null = activeProjectID,
+    ) => {
       // single-user: always authenticated
       setLoading(true);
       try {
-        const res = await getTasks(30);
+        const res = await getTasks(30, projectID);
         const nextTasks = res.data ?? [];
         setTasks(nextTasks);
         const currentTaskID = selectedTaskIDRef.current;
@@ -224,12 +229,12 @@ export function TasksView({
         setLoading(false);
       }
     },
-    [loadTaskDetail],
+    [activeProjectID, loadTaskDetail],
   );
 
   useEffect(() => {
     void loadTasks();
-  }, [loadTasks]);
+  }, [activeProjectID, loadTasks]);
 
   useEffect(() => {
     if (!focusRequest?.taskID) return;
@@ -547,10 +552,13 @@ export function TasksView({
   async function handleCreateTask(payload: CreateTaskPayload) {
     setBusyAction("create");
     try {
-      const created = await createTask(payload);
+      const created = await createTask({
+        ...payload,
+        project_id: activeProjectID || undefined,
+      });
       const started = await startTask(created.data.id);
       setNewTaskOpen(false);
-      await loadTasks(created.data.id, started.data.id);
+      await loadTasks(created.data.id, started.data.id, activeProjectID);
     } catch (err) {
       setNotice({
         tone: "error",
@@ -570,7 +578,7 @@ export function TasksView({
         busyAction={busyAction}
         projectScope={
           <ProjectScopePanel
-            noProjectDetail="Tasks stay ungrouped."
+            noProjectDetail="Unprojected tasks only."
             emptyHint="Add a folder when you want task defaults and workspace context."
             deleteMessage={(project) => (
               <>
@@ -578,6 +586,9 @@ export function TasksView({
                 project context and its defaults are removed.
               </>
             )}
+            onProjectSelected={(projectID) => {
+              void loadTasks("", "", projectID);
+            }}
           />
         }
         onSelect={(id) => void handleSelectTask(id)}

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -9,6 +9,7 @@ import {
   getProviders,
   getTaskApprovals,
   getTaskRunArtifacts,
+  getTaskRunContext,
   getTaskRunEvents,
   getTaskRuns,
   getTaskRunSteps,
@@ -614,6 +615,11 @@ export function TasksView({
           }
           onApplyPatch={(artifactID) => void handleApplyPatch(artifactID)}
           onRevertPatch={(artifactID) => void handleRevertPatch(artifactID)}
+          loadContext={
+            selectedTaskID && selectedRunID
+              ? async () => (await getTaskRunContext(selectedTaskID, selectedRunID)).data
+              : null
+          }
           onOpenTrace={onOpenTrace}
         />
       ) : (

--- a/ui/src/features/runs/taskDetailHelpers.test.ts
+++ b/ui/src/features/runs/taskDetailHelpers.test.ts
@@ -610,8 +610,16 @@ describe("taskActivityTitle", () => {
 
   it("renders the canonical type label for artifact / changed_files / final_answer / patch", () => {
     expect(taskActivityTitle(activity({ type: "artifact" }))).toBe("Artifact");
+    expect(
+      taskActivityTitle(activity({ type: "artifact", title: "git-stdout.txt", kind: "stdout" })),
+    ).toBe("Output");
+    expect(
+      taskActivityTitle(
+        activity({ type: "artifact", title: "agent-conversation.json", kind: "agent_conversation" }),
+      ),
+    ).toBe("Agent conversation");
     expect(taskActivityTitle(activity({ type: "changed_files" }))).toBe("Changed files");
-    expect(taskActivityTitle(activity({ type: "final_answer" }))).toBe("Final answer artifact");
+    expect(taskActivityTitle(activity({ type: "final_answer" }))).toBe("Final answer");
     expect(taskActivityTitle(activity({ type: "patch" }))).toBe("Patch");
   });
 

--- a/ui/src/features/runs/taskDetailHelpers.test.ts
+++ b/ui/src/features/runs/taskDetailHelpers.test.ts
@@ -615,7 +615,11 @@ describe("taskActivityTitle", () => {
     ).toBe("Output");
     expect(
       taskActivityTitle(
-        activity({ type: "artifact", title: "agent-conversation.json", kind: "agent_conversation" }),
+        activity({
+          type: "artifact",
+          title: "agent-conversation.json",
+          kind: "agent_conversation",
+        }),
       ),
     ).toBe("Agent conversation");
     expect(taskActivityTitle(activity({ type: "changed_files" }))).toBe("Changed files");

--- a/ui/src/features/runs/taskDetailHelpers.ts
+++ b/ui/src/features/runs/taskDetailHelpers.ts
@@ -321,11 +321,13 @@ export function taskActivityTitle(item: TaskActivityRecord): string {
       if (item.status === "rejected" || item.status === "denied") return "Approval rejected";
       return "Approval";
     case "artifact":
+      if ((item.kind ?? "").trim() === "agent_conversation") return "Agent conversation";
+      if (isOutputArtifactActivity(item)) return "Output";
       return "Artifact";
     case "changed_files":
       return "Changed files";
     case "final_answer":
-      return "Final answer artifact";
+      return "Final answer";
     case "patch":
       return "Patch";
     case "tool_call":

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { ApiError } from "../../lib/api";
 import type {
@@ -59,6 +59,11 @@ export function ContextInspectorModalTrigger({
   const [open, setOpen] = useState(false);
   const [reloadNonce, setReloadNonce] = useState(0);
   const [state, setState] = useState<RemoteState>({ status: "idle" });
+  const loadRef = useRef(loadPacket);
+  const unavailableDetailRef = useRef(unavailableDetail);
+
+  loadRef.current = loadPacket;
+  unavailableDetailRef.current = unavailableDetail;
 
   useEffect(() => {
     setReloadNonce(0);
@@ -66,10 +71,10 @@ export function ContextInspectorModalTrigger({
   }, [resourceKey]);
 
   useEffect(() => {
-    if (!open || !loadPacket) return;
+    if (!open || !loadRef.current) return;
     let cancelled = false;
     setState({ status: "loading" });
-    loadPacket()
+    loadRef.current()
       .then((packet) => {
         if (cancelled) return;
         setState({ status: "ready", packet });
@@ -77,7 +82,7 @@ export function ContextInspectorModalTrigger({
       .catch((error) => {
         if (cancelled) return;
         if (error instanceof ApiError && error.status === 404) {
-          setState({ status: "unavailable", detail: unavailableDetail });
+          setState({ status: "unavailable", detail: unavailableDetailRef.current });
           return;
         }
         setState({
@@ -88,7 +93,7 @@ export function ContextInspectorModalTrigger({
     return () => {
       cancelled = true;
     };
-  }, [loadPacket, open, reloadNonce, resourceKey, unavailableDetail]);
+  }, [open, reloadNonce, resourceKey]);
 
   const canInspect = Boolean(loadPacket);
   return (

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -74,7 +74,8 @@ export function ContextInspectorModalTrigger({
     if (!open || !loadRef.current) return;
     let cancelled = false;
     setState({ status: "loading" });
-    loadRef.current()
+    loadRef
+      .current()
       .then((packet) => {
         if (cancelled) return;
         setState({ status: "ready", packet });

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -290,10 +290,10 @@ function ContextSummary({ packet }: { packet: ContextPacketRecord }) {
       ? packet.system_prompt_included
         ? "Included"
         : "Not included"
-      : "Unknown";
+      : "Not captured";
   const messageCountValue =
     typeof packet.message_count === "number"
-      ? `${packet.message_count} message${packet.message_count === 1 ? "" : "s"}`
+      ? `${packet.message_count} chat message${packet.message_count === 1 ? "" : "s"} in scope`
       : "—";
 
   return (
@@ -373,8 +373,11 @@ function ContextSectionGroup({ group }: { group: ContextSectionGroupRecord }) {
 }
 
 function ContextItemRow({ item }: { item: ContextPacketItemRecord }) {
-  const detail = [item.origin, item.body_ref].filter(Boolean).join(" · ");
-  const note = item.body?.trim() || item.inclusion_reason?.trim();
+  const detail =
+    item.body_ref && item.body_ref !== item.origin
+      ? [item.origin, item.body_ref].filter(Boolean).join(" · ")
+      : item.origin;
+  const note = humanContextNote(item);
   return (
     <div
       style={{
@@ -474,6 +477,14 @@ function contextInspectorSummary(packet: ContextPacketRecord): string {
     modelLabel,
   ].filter(Boolean);
   return summaryParts.join(" · ");
+}
+
+function humanContextNote(item: ContextPacketItemRecord): string {
+  const note = item.body?.trim() || item.inclusion_reason?.trim() || "";
+  if (item.kind === "transcript" && note === "Current user message") {
+    return "Current turn input";
+  }
+  return note;
 }
 
 function groupContextItemsBySection(items: ContextPacketItemRecord[]): ContextSectionGroupRecord[] {

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -1,0 +1,559 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import { ApiError } from "../../lib/api";
+import type {
+  ContextPacketItemRecord,
+  ContextPacketRecord,
+  ContextPacketRefsRecord,
+  ContextPacketSourceRecord,
+} from "../../types/context";
+import { InlineError } from "./Atoms";
+import { Badge, Icon, Icons, Modal } from "./ui";
+
+type ContextInspectorModalTriggerProps = {
+  buttonLabel?: string;
+  buttonTitle?: string;
+  emptyDetail?: string;
+  loadPacket?: (() => Promise<ContextPacketRecord>) | null;
+  modalTitle: string;
+  resourceKey: string;
+  unavailableDetail?: string;
+};
+
+type RemoteState =
+  | { status: "idle" | "loading" }
+  | { status: "ready"; packet: ContextPacketRecord }
+  | { status: "unavailable"; detail: string }
+  | { status: "error"; detail: string };
+
+const sectionOrder = [
+  "instructions",
+  "project",
+  "project_work",
+  "memory",
+  "sources",
+  "workspace",
+  "runtime",
+] as const;
+
+const refOrder: Array<[keyof ContextPacketRefsRecord, string]> = [
+  ["project_id", "Project"],
+  ["work_item_id", "Work item"],
+  ["assignment_id", "Assignment"],
+  ["role_id", "Role"],
+  ["task_id", "Task"],
+  ["run_id", "Run"],
+  ["session_id", "Chat session"],
+  ["message_id", "Message"],
+];
+
+export function ContextInspectorModalTrigger({
+  buttonLabel = "Inspect context",
+  buttonTitle,
+  emptyDetail,
+  loadPacket,
+  modalTitle,
+  resourceKey,
+  unavailableDetail = "This snapshot may predate stored context packets or have no linked packet.",
+}: ContextInspectorModalTriggerProps) {
+  const [open, setOpen] = useState(false);
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const [state, setState] = useState<RemoteState>({ status: "idle" });
+
+  useEffect(() => {
+    setReloadNonce(0);
+    setState({ status: "idle" });
+  }, [resourceKey]);
+
+  useEffect(() => {
+    if (!open || !loadPacket) return;
+    let cancelled = false;
+    setState({ status: "loading" });
+    loadPacket()
+      .then((packet) => {
+        if (cancelled) return;
+        setState({ status: "ready", packet });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        if (error instanceof ApiError && error.status === 404) {
+          setState({ status: "unavailable", detail: unavailableDetail });
+          return;
+        }
+        setState({
+          status: "error",
+          detail: error instanceof Error ? error.message : "Failed to load context snapshot.",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPacket, open, reloadNonce, resourceKey, unavailableDetail]);
+
+  const canInspect = Boolean(loadPacket);
+  return (
+    <>
+      <button
+        className="btn btn-ghost btn-sm"
+        type="button"
+        disabled={!canInspect}
+        onClick={() => setOpen(true)}
+        title={
+          buttonTitle ||
+          (canInspect
+            ? "Inspect the stored context snapshot."
+            : "No context snapshot available yet.")
+        }
+      >
+        <Icon d={Icons.search} size={12} />
+        {buttonLabel}
+      </button>
+      {open && (
+        <Modal
+          title={modalTitle}
+          width={820}
+          onClose={() => setOpen(false)}
+          footer={
+            <>
+              <button className="btn btn-ghost" type="button" onClick={() => setOpen(false)}>
+                Close
+              </button>
+              {canInspect && (
+                <button
+                  className="btn btn-ghost"
+                  type="button"
+                  onClick={() => setReloadNonce((current) => current + 1)}
+                >
+                  Reload
+                </button>
+              )}
+            </>
+          }
+        >
+          <div style={{ padding: 16, overflowY: "auto" }}>
+            {state.status === "loading" || state.status === "idle" ? (
+              <ContextInspectorNotice
+                title="Loading context snapshot…"
+                detail="Fetching the persisted packet for this run or assignment."
+                tone="muted"
+              />
+            ) : null}
+            {state.status === "unavailable" ? (
+              <ContextInspectorNotice
+                title="Context snapshot unavailable"
+                detail={state.detail}
+                tone="warning"
+              />
+            ) : null}
+            {state.status === "error" ? (
+              <div style={{ display: "grid", gap: 10 }}>
+                <InlineError message={state.detail} />
+                <div style={{ color: "var(--t2)", fontSize: 12 }}>
+                  Try again after the linked run or chat packet finishes persisting.
+                </div>
+              </div>
+            ) : null}
+            {state.status === "ready" ? (
+              <ContextInspectorPanel packet={state.packet} emptyDetail={emptyDetail} />
+            ) : null}
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export function ContextInspectorDetails({ packet }: { packet: ContextPacketRecord }) {
+  return (
+    <details style={{ marginTop: 8 }}>
+      <summary
+        style={{
+          color: "var(--t3)",
+          cursor: "pointer",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          lineHeight: 1.6,
+        }}
+      >
+        {contextInspectorSummary(packet)}
+      </summary>
+      <div style={{ marginTop: 6 }}>
+        <ContextInspectorPanel packet={packet} compact />
+      </div>
+    </details>
+  );
+}
+
+export function contextPacketEmpty(packet: ContextPacketRecord): boolean {
+  return (
+    !packet.id &&
+    !packet.version &&
+    !packet.execution_mode &&
+    !packet.provider &&
+    !packet.model &&
+    !packet.execution_profile &&
+    !packet.workspace &&
+    !packet.system_prompt_included &&
+    !packet.message_count &&
+    !hasRefs(packet.refs) &&
+    (packet.sources ?? []).length === 0 &&
+    (packet.items ?? []).length === 0
+  );
+}
+
+function ContextInspectorPanel({
+  compact = false,
+  emptyDetail,
+  packet,
+}: {
+  compact?: boolean;
+  emptyDetail?: string;
+  packet: ContextPacketRecord;
+}) {
+  const items = packet.items ?? [];
+  const sources = packet.sources ?? [];
+  const groups = groupContextItemsBySection(items);
+  const refs = visibleRefs(packet.refs);
+  const legacyOnly = groups.length === 0 && sources.length > 0;
+  const empty = contextPacketEmpty(packet);
+
+  if (empty) {
+    return (
+      <ContextInspectorNotice
+        title="No context metadata captured"
+        detail={emptyDetail || "This snapshot does not include any itemized context metadata yet."}
+        tone="muted"
+      />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        background: "var(--bg1)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        display: "grid",
+        gap: 12,
+        padding: compact ? "8px 9px" : 12,
+      }}
+    >
+      <ContextSummary packet={packet} />
+      {!compact && refs.length > 0 && (
+        <section style={{ display: "grid", gap: 8 }}>
+          <div className="kicker">Linked refs</div>
+          <div
+            style={{
+              display: "grid",
+              gap: "8px 12px",
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            }}
+          >
+            {refs.map(([label, value]) => (
+              <ContextMetaCell key={label} label={label} value={value} />
+            ))}
+          </div>
+        </section>
+      )}
+      {groups.length > 0 && (
+        <div style={{ display: "grid", gap: 10 }}>
+          {groups.map((group) => (
+            <ContextSectionGroup key={group.section} group={group} />
+          ))}
+        </div>
+      )}
+      {legacyOnly && (
+        <section style={{ display: "grid", gap: 8 }}>
+          <div className="kicker">Legacy sources</div>
+          <div style={{ color: "var(--t3)", fontSize: 11 }}>
+            This older packet only exposes top-level sources. Newer packets render itemized
+            sections.
+          </div>
+          <div style={{ display: "grid", gap: 8 }}>
+            {sources.map((source, index) => (
+              <ContextSourceRow key={`${source.kind}-${source.label}-${index}`} source={source} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ContextSummary({ packet }: { packet: ContextPacketRecord }) {
+  const modelValue = [packet.provider, packet.model].filter(Boolean).join(" / ") || "—";
+  const modeValue = packet.execution_mode ? humanExecutionMode(packet.execution_mode) : "—";
+  const profileValue = packet.execution_profile || "—";
+  const workspaceValue = packet.workspace || "—";
+  const systemPromptValue =
+    typeof packet.system_prompt_included === "boolean"
+      ? packet.system_prompt_included
+        ? "Included"
+        : "Not included"
+      : "Unknown";
+  const messageCountValue =
+    typeof packet.message_count === "number"
+      ? `${packet.message_count} message${packet.message_count === 1 ? "" : "s"}`
+      : "—";
+
+  return (
+    <section style={{ display: "grid", gap: 8 }}>
+      <div className="kicker">Launch summary</div>
+      <div
+        style={{
+          display: "grid",
+          gap: "8px 12px",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+        }}
+      >
+        <ContextMetaCell label="Mode" value={modeValue} />
+        <ContextMetaCell label="Provider / model" value={modelValue} />
+        <ContextMetaCell label="Execution profile" value={profileValue} />
+        <ContextMetaCell label="Workspace" value={workspaceValue} />
+        <ContextMetaCell label="System prompt" value={systemPromptValue} />
+        <ContextMetaCell label="Transcript count" value={messageCountValue} />
+      </div>
+    </section>
+  );
+}
+
+function ContextMetaCell({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div>
+      <div className="kicker" style={{ marginBottom: 4 }}>
+        {label}
+      </div>
+      <div
+        style={{
+          color: "var(--t1)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          lineHeight: 1.5,
+          wordBreak: "break-word",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+type ContextSectionGroupRecord = {
+  section: string;
+  items: ContextPacketItemRecord[];
+};
+
+function ContextSectionGroup({ group }: { group: ContextSectionGroupRecord }) {
+  const includedCount = group.items.filter((item) => item.included).length;
+  const excludedCount = group.items.length - includedCount;
+  return (
+    <section
+      style={{
+        borderTop: "1px solid var(--border)",
+        display: "grid",
+        gap: 8,
+        paddingTop: 10,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <div className="kicker" style={{ margin: 0 }}>
+          {humanSectionLabel(group.section)}
+        </div>
+        <span className="badge badge-muted">{group.items.length}</span>
+        {includedCount > 0 && <Badge status="ok" label={`${includedCount} included`} />}
+        {excludedCount > 0 && <Badge status="disabled" label={`${excludedCount} inspect-only`} />}
+      </div>
+      <div style={{ display: "grid", gap: 8 }}>
+        {group.items.map((item, index) => (
+          <ContextItemRow key={`${item.kind}-${item.origin}-${index}`} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ContextItemRow({ item }: { item: ContextPacketItemRecord }) {
+  const detail = [item.origin, item.body_ref].filter(Boolean).join(" · ");
+  const note = item.body?.trim() || item.inclusion_reason?.trim();
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 5,
+        padding: "8px 10px",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        background: "var(--bg2)",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ color: "var(--t0)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
+          {item.title || item.kind}
+        </div>
+        <Badge
+          status={item.included ? "ok" : "disabled"}
+          label={item.included ? "included" : "inspect-only"}
+        />
+        <span className="badge badge-muted">{humanTrustLevel(item.trust_level)}</span>
+      </div>
+      {detail && (
+        <div style={{ color: "var(--t3)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
+          {detail}
+        </div>
+      )}
+      {note && (
+        <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.5, whiteSpace: "pre-wrap" }}>
+          {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ContextSourceRow({ source }: { source: ContextPacketSourceRecord }) {
+  const detail = source.detail?.trim();
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        background: "var(--bg2)",
+        display: "grid",
+        gap: 4,
+        padding: "8px 10px",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ color: "var(--t0)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
+          {source.label || source.kind}
+        </div>
+        {source.trust && <span className="badge badge-muted">{source.trust}</span>}
+      </div>
+      {detail && <div style={{ color: "var(--t3)", fontSize: 11 }}>{detail}</div>}
+    </div>
+  );
+}
+
+function ContextInspectorNotice({
+  title,
+  detail,
+  tone,
+}: {
+  title: string;
+  detail: string;
+  tone: "muted" | "warning";
+}) {
+  return (
+    <div
+      style={{
+        background: tone === "warning" ? "var(--amber-bg)" : "var(--bg2)",
+        border: `1px solid ${tone === "warning" ? "var(--amber-border)" : "var(--border)"}`,
+        borderRadius: "var(--radius-sm)",
+        display: "grid",
+        gap: 6,
+        padding: "10px 12px",
+      }}
+    >
+      <div style={{ color: tone === "warning" ? "var(--amber)" : "var(--t1)", fontWeight: 500 }}>
+        {title}
+      </div>
+      <div style={{ color: tone === "warning" ? "var(--amber-lo)" : "var(--t2)", fontSize: 12 }}>
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function contextInspectorSummary(packet: ContextPacketRecord): string {
+  const modelLabel = [packet.provider, packet.model].filter(Boolean).join(" · ");
+  const summaryParts = [
+    "what the agent saw",
+    packet.message_count
+      ? `${packet.message_count} message${packet.message_count === 1 ? "" : "s"}`
+      : "",
+    modelLabel,
+  ].filter(Boolean);
+  return summaryParts.join(" · ");
+}
+
+function groupContextItemsBySection(items: ContextPacketItemRecord[]): ContextSectionGroupRecord[] {
+  const groups = new Map<string, ContextPacketItemRecord[]>();
+  for (const item of items) {
+    const section = item.section || "runtime";
+    const group = groups.get(section) ?? [];
+    group.push(item);
+    groups.set(section, group);
+  }
+  return Array.from(groups.entries())
+    .sort(([left], [right]) => sectionSortIndex(left) - sectionSortIndex(right))
+    .map(([section, groupedItems]) => ({ section, items: groupedItems }));
+}
+
+function sectionSortIndex(section: string): number {
+  const index = sectionOrder.indexOf(section as (typeof sectionOrder)[number]);
+  return index === -1 ? sectionOrder.length + 1 : index;
+}
+
+function visibleRefs(refs?: ContextPacketRefsRecord): Array<[string, string]> {
+  if (!refs) return [];
+  return refOrder
+    .map(([key, label]) => [label, refs[key]?.trim() || ""] as [string, string])
+    .filter(([, value]) => value !== "");
+}
+
+function hasRefs(refs?: ContextPacketRefsRecord): boolean {
+  return visibleRefs(refs).length > 0;
+}
+
+function humanExecutionMode(mode: string): string {
+  switch (mode) {
+    case "external_agent":
+      return "External agent";
+    case "hecate_task":
+      return "Hecate task runtime";
+    default:
+      return mode;
+  }
+}
+
+function humanSectionLabel(section: string): string {
+  switch (section) {
+    case "instructions":
+      return "Instructions";
+    case "project":
+      return "Project";
+    case "project_work":
+      return "Launch context";
+    case "memory":
+      return "Memory";
+    case "sources":
+      return "Context sources";
+    case "workspace":
+      return "Workspace";
+    case "runtime":
+      return "Runtime";
+    default:
+      return section.replaceAll("_", " ");
+  }
+}
+
+function humanTrustLevel(level: string): string {
+  switch (level) {
+    case "system_instruction":
+      return "system instruction";
+    case "operator_memory":
+      return "operator memory";
+    case "workspace_guidance":
+      return "workspace guidance";
+    case "runtime_state":
+      return "runtime state";
+    case "tool_output":
+      return "tool output";
+    case "generated_summary":
+      return "generated summary";
+    case "external_untrusted":
+      return "external untrusted";
+    default:
+      return level.replaceAll("_", " ");
+  }
+}

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -529,12 +529,14 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getAllByText("Workspace").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Hecate task runtime").length).toBeGreaterThan(0);
     expect(screen.getAllByText("/tmp/hecate")).toHaveLength(2);
+    expect(screen.queryByText("/tmp/hecate · /tmp/hecate")).toBeNull();
     expect(screen.getByText("Not captured")).toBeInTheDocument();
     expect(screen.getByText("3 chat messages in scope")).toBeInTheDocument();
     expect(screen.getByText("system instruction")).toBeInTheDocument();
     expect(screen.getByText("workspace guidance")).toBeInTheDocument();
     expect(screen.getAllByText("System prompt").length).toBeGreaterThan(0);
     expect(screen.getByText("Current turn input")).toBeInTheDocument();
+    expect(screen.queryByText("Current user message")).toBeNull();
     expect(screen.getByText("Configured for this turn")).toBeInTheDocument();
   });
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -506,6 +506,15 @@ describe("TranscriptMessageRow", () => {
           included: true,
           inclusion_reason: "Workspace path selected",
         },
+        {
+          section: "runtime",
+          kind: "transcript",
+          trust_level: "runtime_state",
+          origin: "chat.transcript",
+          title: "Chat transcript",
+          body: "Current user message",
+          included: true,
+        },
       ],
     };
 
@@ -519,10 +528,13 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText("Instructions")).toBeInTheDocument();
     expect(screen.getAllByText("Workspace").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Hecate task runtime").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("/tmp/hecate")).toHaveLength(1);
+    expect(screen.getAllByText("/tmp/hecate")).toHaveLength(2);
+    expect(screen.getByText("Not captured")).toBeInTheDocument();
+    expect(screen.getByText("3 chat messages in scope")).toBeInTheDocument();
     expect(screen.getByText("system instruction")).toBeInTheDocument();
     expect(screen.getByText("workspace guidance")).toBeInTheDocument();
     expect(screen.getAllByText("System prompt").length).toBeGreaterThan(0);
+    expect(screen.getByText("Current turn input")).toBeInTheDocument();
     expect(screen.getByText("Configured for this turn")).toBeInTheDocument();
   });
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -487,6 +487,7 @@ describe("TranscriptMessageRow", () => {
       ],
       items: [
         {
+          section: "instructions",
           kind: "system_prompt",
           trust_level: "system_instruction",
           origin: "task.system_prompt",
@@ -496,6 +497,7 @@ describe("TranscriptMessageRow", () => {
           inclusion_reason: "Configured for this turn",
         },
         {
+          section: "workspace",
           kind: "workspace",
           trust_level: "workspace_guidance",
           origin: "/tmp/hecate",
@@ -513,11 +515,14 @@ describe("TranscriptMessageRow", () => {
 
     await user.click(summary);
 
-    expect(screen.getByText("Hecate task runtime")).toBeInTheDocument();
-    expect(screen.getAllByText("/tmp/hecate")).toHaveLength(2);
-    expect(screen.getByText("System instruction")).toBeInTheDocument();
-    expect(screen.getByText("Workspace guidance")).toBeInTheDocument();
-    expect(screen.getByText("System prompt")).toBeInTheDocument();
+    expect(screen.getByText("Launch summary")).toBeInTheDocument();
+    expect(screen.getByText("Instructions")).toBeInTheDocument();
+    expect(screen.getAllByText("Workspace").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Hecate task runtime").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("/tmp/hecate")).toHaveLength(1);
+    expect(screen.getByText("system instruction")).toBeInTheDocument();
+    expect(screen.getByText("workspace guidance")).toBeInTheDocument();
+    expect(screen.getAllByText("System prompt").length).toBeGreaterThan(0);
     expect(screen.getByText("Configured for this turn")).toBeInTheDocument();
   });
 
@@ -541,6 +546,7 @@ describe("TranscriptMessageRow", () => {
     const summary = screen.getByText(/what the agent saw · 2 messages/);
     await user.click(summary);
 
+    expect(screen.getByText("Legacy sources")).toBeInTheDocument();
     expect(screen.getByText("Cursor Agent ACP session")).toBeInTheDocument();
     expect(
       screen.getByText("The adapter owns model packing inside its native session"),

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -9,6 +9,7 @@ import type {
 import { formatDurationMs } from "../../lib/format";
 import { CodeBlock } from "../shared/Atoms";
 import { BrandAvatar } from "../shared/BrandAvatar";
+import { ContextInspectorDetails, contextPacketEmpty } from "../shared/ContextInspector";
 import { DiffViewer } from "../shared/DiffViewer";
 import { Icon, Icons } from "../shared/Icons";
 import { DiffStatList, TranscriptActivityTimeline } from "./TranscriptActivityTimeline";
@@ -317,7 +318,7 @@ export function TranscriptMessageRow({
             <AgentTiming timing={agentTiming} />
           )}
           {isAssistant && contextPacket && !contextPacketEmpty(contextPacket) && (
-            <ContextInspector packet={contextPacket} />
+            <ContextInspectorDetails packet={contextPacket} />
           )}
           {isAssistant && agentUsage && !agentUsageEmpty(agentUsage) && (
             <AgentUsage usage={agentUsage} />
@@ -858,200 +859,6 @@ function AgentUsage({ usage }: { usage: ChatUsageRecord }) {
   );
 }
 
-function ContextInspector({ packet }: { packet: ChatContextPacketRecord }) {
-  const modelLabel = [packet.provider, packet.model].filter(Boolean).join(" · ");
-  const sources = packet.sources ?? [];
-  const itemGroups = groupContextItemsByTrust(packet.items ?? []);
-  const summaryParts = [
-    "what the agent saw",
-    packet.message_count
-      ? `${packet.message_count} message${packet.message_count === 1 ? "" : "s"}`
-      : "",
-    modelLabel,
-  ].filter(Boolean);
-  return (
-    <details style={{ marginTop: 8 }}>
-      <summary
-        style={{
-          color: "var(--t3)",
-          cursor: "pointer",
-          fontFamily: "var(--font-mono)",
-          fontSize: 10,
-          lineHeight: 1.6,
-        }}
-      >
-        {summaryParts.join(" · ")}
-      </summary>
-      <div
-        style={{
-          background: "var(--bg1)",
-          border: "1px solid var(--border)",
-          borderRadius: "var(--radius-sm)",
-          display: "grid",
-          gap: 6,
-          marginTop: 6,
-          padding: "8px 9px",
-        }}
-      >
-        {packet.execution_mode && (
-          <ContextRow label="mode" value={humanExecutionMode(packet.execution_mode)} />
-        )}
-        {packet.workspace && <ContextRow label="workspace" value={packet.workspace} />}
-        {itemGroups.length > 0 && (
-          <div style={{ display: "grid", gap: 7 }}>
-            {itemGroups.map((group) => (
-              <ContextItemGroup key={group.trustLevel} group={group} />
-            ))}
-          </div>
-        )}
-        {itemGroups.length === 0 && sources.length > 0 && (
-          <div style={{ display: "grid", gap: 5 }}>
-            {sources.map((source, index) => (
-              <ContextSourceRow key={`${source.kind}-${source.label}-${index}`} source={source} />
-            ))}
-          </div>
-        )}
-      </div>
-    </details>
-  );
-}
-
-type ContextItemGroupRecord = {
-  trustLevel: string;
-  items: NonNullable<ChatContextPacketRecord["items"]>;
-};
-
-function ContextItemGroup({ group }: { group: ContextItemGroupRecord }) {
-  return (
-    <div
-      style={{
-        borderTop: "1px solid var(--border)",
-        display: "grid",
-        gap: 5,
-        paddingTop: 6,
-      }}
-    >
-      <div
-        style={{
-          color: "var(--t3)",
-          fontFamily: "var(--font-mono)",
-          fontSize: 10,
-          textTransform: "uppercase",
-        }}
-      >
-        {humanTrustLevel(group.trustLevel)}
-      </div>
-      <div style={{ display: "grid", gap: 6 }}>
-        {group.items.map((item, index) => (
-          <ContextItemRow key={`${item.kind}-${item.origin}-${index}`} item={item} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ContextItemRow({ item }: { item: NonNullable<ChatContextPacketRecord["items"]>[number] }) {
-  const detail = [item.origin, item.included ? "" : "excluded"].filter(Boolean).join(" · ");
-  const body = item.body?.trim() || item.inclusion_reason?.trim() || item.body_ref?.trim();
-  return (
-    <div style={{ display: "grid", gap: 2 }}>
-      <div style={{ color: "var(--t1)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-        {item.title || item.kind}
-      </div>
-      {detail && (
-        <div
-          style={{
-            color: "var(--t3)",
-            fontSize: 10,
-            lineHeight: 1.5,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-          title={detail}
-        >
-          {detail}
-        </div>
-      )}
-      {body && (
-        <div
-          style={{
-            color: "var(--t2)",
-            fontSize: 10,
-            lineHeight: 1.5,
-          }}
-        >
-          {body}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ContextRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div style={{ display: "grid", gridTemplateColumns: "96px minmax(0, 1fr)", gap: 8 }}>
-      <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-        {label}
-      </span>
-      <span
-        style={{
-          color: "var(--t1)",
-          fontFamily: "var(--font-mono)",
-          fontSize: 10,
-          minWidth: 0,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        }}
-        title={value}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function ContextSourceRow({
-  source,
-}: {
-  source: NonNullable<ChatContextPacketRecord["sources"]>[number];
-}) {
-  const detail = source.detail?.trim();
-  const label = source.label || source.kind;
-  const trust = source.trust ? ` · ${source.trust}` : "";
-  return (
-    <div
-      style={{
-        borderTop: "1px solid var(--border)",
-        display: "grid",
-        gap: 2,
-        paddingTop: 5,
-      }}
-    >
-      <div style={{ color: "var(--t1)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
-        {label}
-        <span style={{ color: "var(--t3)" }}>{trust}</span>
-      </div>
-      {detail && (
-        <div
-          style={{
-            color: "var(--t3)",
-            fontSize: 10,
-            lineHeight: 1.5,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-          title={detail}
-        >
-          {detail}
-        </div>
-      )}
-    </div>
-  );
-}
-
 function AgentTiming({ timing }: { timing: ChatTimingRecord }) {
   const bottleneck =
     timing.bottleneck && timing.bottleneck_ms
@@ -1098,68 +905,6 @@ function AgentTiming({ timing }: { timing: ChatTimingRecord }) {
       {counts && <span>{counts}</span>}
     </div>
   );
-}
-
-function contextPacketEmpty(packet: ChatContextPacketRecord): boolean {
-  return (
-    !packet.version &&
-    !packet.execution_mode &&
-    !packet.provider &&
-    !packet.model &&
-    !packet.workspace &&
-    !packet.system_prompt_included &&
-    !packet.message_count &&
-    (packet.sources ?? []).length === 0 &&
-    (packet.items ?? []).length === 0
-  );
-}
-
-function groupContextItemsByTrust(
-  items: NonNullable<ChatContextPacketRecord["items"]>,
-): ContextItemGroupRecord[] {
-  const groups = new Map<string, NonNullable<ChatContextPacketRecord["items"]>>();
-  for (const item of items) {
-    const trustLevel = item.trust_level || "runtime_state";
-    const group = groups.get(trustLevel) ?? [];
-    group.push(item);
-    groups.set(trustLevel, group);
-  }
-  return Array.from(groups.entries()).map(([trustLevel, groupItems]) => ({
-    trustLevel,
-    items: groupItems,
-  }));
-}
-
-function humanExecutionMode(mode: string): string {
-  switch (mode) {
-    case "external_agent":
-      return "External agent";
-    case "hecate_task":
-      return "Hecate task runtime";
-    default:
-      return mode;
-  }
-}
-
-function humanTrustLevel(level: string): string {
-  switch (level) {
-    case "system_instruction":
-      return "System instruction";
-    case "operator_memory":
-      return "Operator memory";
-    case "workspace_guidance":
-      return "Workspace guidance";
-    case "runtime_state":
-      return "Runtime state";
-    case "tool_output":
-      return "Tool output";
-    case "generated_summary":
-      return "Generated summary";
-    case "external_untrusted":
-      return "External untrusted";
-    default:
-      return level.replaceAll("_", " ");
-  }
 }
 
 function agentTimingEmpty(timing: ChatTimingRecord): boolean {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -19,11 +19,13 @@ import {
   deleteProjectWorkItem,
   discoverLocalProviders,
   dispatchChatStreamEvent,
+  getChatMessageContext,
   getChatMessageFileDiff,
   getChatWorkspaceDiff,
   getChatWorkspaceFileDiff,
   getChatWorkspaceFiles,
   getChatApproval,
+  getProjectAssignmentContext,
   getProjectAssignments,
   getProjectActivity,
   getProjectCollaborationArtifacts,
@@ -36,6 +38,7 @@ import {
   getUsageEvents,
   getUsageSummary,
   getSession,
+  getTaskRunContext,
   getTrace,
   listChatApprovals,
   listChatGrants,
@@ -533,6 +536,20 @@ describe("api client", () => {
         body: JSON.stringify({ driver_kind: "hecate_task" }),
       }),
     );
+  });
+
+  it("fetches project assignment context snapshots", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ object: "context_packet", data: { id: "ctx_1", version: "chat.context.v1" } }),
+    );
+
+    const result = await getProjectAssignmentContext("proj/1", "work/1", "asgn/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments/asgn%2F1/context",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.data.id).toBe("ctx_1");
   });
 
   it("creates project work items and assignments", async () => {
@@ -1275,6 +1292,23 @@ describe("api client", () => {
   });
 
   describe("chat changed-file endpoints", () => {
+    it("fetches a stored context packet for a chat message", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          object: "context_packet",
+          data: { id: "ctx_2", version: "chat.context.v1" },
+        }),
+      );
+
+      const result = await getChatMessageContext("s 1", "m/1");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/hecate/v1/chat/sessions/s%201/messages/m%2F1/context",
+        expect.anything(),
+      );
+      expect(result.data.id).toBe("ctx_2");
+    });
+
     it("lists changed files for an agent message", async () => {
       fetchMock.mockResolvedValue(
         jsonResponse({
@@ -1441,6 +1475,20 @@ describe("api client", () => {
       expect(result.data.reverted).toBe(true);
       expect(result.data.files[0]?.path).toBe("README.md");
     });
+  });
+
+  it("fetches task run context snapshots", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ object: "context_packet", data: { id: "ctx_3", version: "chat.context.v1" } }),
+    );
+
+    const result = await getTaskRunContext("task/1", "run/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/tasks/task%2F1/runs/run%2F1/context",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.data.id).toBe("ctx_3");
   });
 
   // ─── Agent-chat SSE dispatch ───────────────────────────────────────────────

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   SystemResetDataResponse,
 } from "../types/runtime";
 import type { ModelResponse } from "../types/model";
+import type { ContextPacketResponse } from "../types/context";
 import type {
   ConfiguredStateResponse,
   LocalProviderDiscoveryResponse,
@@ -561,6 +562,16 @@ export async function startProjectAssignment(
   );
 }
 
+export async function getProjectAssignmentContext(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+): Promise<ContextPacketResponse> {
+  return fetchJSON<ContextPacketResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/context`,
+  );
+}
+
 export async function getProjectCollaborationArtifacts(
   projectID: string,
   workItemID: string,
@@ -670,6 +681,15 @@ export async function createChatMessage(
   return fetchJSON<ChatSessionResponse>(
     `${HECATE_API}/chat/sessions/${encodeURIComponent(id)}/messages`,
     { method: "POST", body },
+  );
+}
+
+export async function getChatMessageContext(
+  sessionID: string,
+  messageID: string,
+): Promise<ContextPacketResponse> {
+  return fetchJSON<ContextPacketResponse>(
+    `${HECATE_API}/chat/sessions/${encodeURIComponent(sessionID)}/messages/${encodeURIComponent(messageID)}/context`,
   );
 }
 
@@ -1123,6 +1143,15 @@ export async function getTaskRunEvents(
 ): Promise<TaskRunEventsResponse> {
   return fetchJSON<TaskRunEventsResponse>(
     `${HECATE_API}/tasks/${encodeURIComponent(taskID)}/runs/${encodeURIComponent(runID)}/events?after_sequence=${encodeURIComponent(String(afterSequence))}`,
+  );
+}
+
+export async function getTaskRunContext(
+  taskID: string,
+  runID: string,
+): Promise<ContextPacketResponse> {
+  return fetchJSON<ContextPacketResponse>(
+    `${HECATE_API}/tasks/${encodeURIComponent(taskID)}/runs/${encodeURIComponent(runID)}/context`,
   );
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -206,6 +206,7 @@ export type CreateChatMessagePayload = {
 export type CreateTaskPayload = {
   title?: string;
   prompt: string;
+  project_id?: string;
   execution_kind?: string;
   shell_command?: string;
   git_command?: string;
@@ -1067,8 +1068,12 @@ export async function getRetentionRuns(limit = 10): Promise<RetentionRunsRespons
   );
 }
 
-export async function getTasks(limit = 20): Promise<TasksResponse> {
-  return fetchJSON<TasksResponse>(`${HECATE_API}/tasks?limit=${encodeURIComponent(String(limit))}`);
+export async function getTasks(limit = 20, projectID?: string | null): Promise<TasksResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (projectID !== undefined && projectID !== null) {
+    params.set("project_id", projectID);
+  }
+  return fetchJSON<TasksResponse>(`${HECATE_API}/tasks?${params.toString()}`);
 }
 
 export async function createTask(payload: CreateTaskPayload): Promise<TaskResponse> {

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -1,4 +1,10 @@
 import type { ModelCapabilitiesRecord } from "./model";
+import type {
+  ContextPacketItemRecord,
+  ContextPacketRecord,
+  ContextPacketRefsRecord,
+  ContextPacketSourceRecord,
+} from "./context";
 
 // PersistedContentBlock mirrors the Hecate-extension wire shape used to
 // persist Anthropic-aware content (thinking, tool_use, image with
@@ -78,35 +84,10 @@ export type ChatMessageRecord = {
   context_packet?: ChatContextPacketRecord;
 };
 
-export type ChatContextPacketRecord = {
-  version?: string;
-  execution_mode?: string;
-  provider?: string;
-  model?: string;
-  workspace?: string;
-  system_prompt_included?: boolean;
-  message_count?: number;
-  sources?: ChatContextSourceRecord[];
-  items?: ChatContextItemRecord[];
-};
-
-export type ChatContextSourceRecord = {
-  kind: string;
-  label: string;
-  detail?: string;
-  trust?: string;
-};
-
-export type ChatContextItemRecord = {
-  kind: string;
-  trust_level: string;
-  origin: string;
-  title: string;
-  body?: string;
-  body_ref?: string;
-  included: boolean;
-  inclusion_reason?: string;
-};
+export type ChatContextPacketRecord = ContextPacketRecord;
+export type ChatContextRefsRecord = ContextPacketRefsRecord;
+export type ChatContextSourceRecord = ContextPacketSourceRecord;
+export type ChatContextItemRecord = ContextPacketItemRecord;
 
 export type ChatSegmentRecord = {
   id: string;

--- a/ui/src/types/context.ts
+++ b/ui/src/types/context.ts
@@ -1,0 +1,49 @@
+export type ContextPacketRefsRecord = {
+  session_id?: string;
+  message_id?: string;
+  task_id?: string;
+  run_id?: string;
+  project_id?: string;
+  work_item_id?: string;
+  assignment_id?: string;
+  role_id?: string;
+};
+
+export type ContextPacketSourceRecord = {
+  kind: string;
+  label: string;
+  detail?: string;
+  trust?: string;
+};
+
+export type ContextPacketItemRecord = {
+  section?: string;
+  kind: string;
+  trust_level: string;
+  origin: string;
+  title: string;
+  body?: string;
+  body_ref?: string;
+  included: boolean;
+  inclusion_reason?: string;
+};
+
+export type ContextPacketRecord = {
+  id?: string;
+  version?: string;
+  execution_mode?: string;
+  provider?: string;
+  model?: string;
+  execution_profile?: string;
+  workspace?: string;
+  system_prompt_included?: boolean;
+  message_count?: number;
+  refs?: ContextPacketRefsRecord;
+  sources?: ContextPacketSourceRecord[];
+  items?: ContextPacketItemRecord[];
+};
+
+export type ContextPacketResponse = {
+  object: string;
+  data: ContextPacketRecord;
+};

--- a/ui/src/types/task.ts
+++ b/ui/src/types/task.ts
@@ -2,6 +2,7 @@ export type TaskRecord = {
   id: string;
   title: string;
   prompt: string;
+  project_id?: string;
   // Per-task agent_loop system prompt — narrowest layer in the
   // composition (global → workspace CLAUDE.md/AGENTS.md → this).
   system_prompt?: string;


### PR DESCRIPTION
## Summary
- add shared context-packet types and API helpers for chat messages, task runs, and project assignments
- introduce a reusable context inspector renderer with trust labels, linked refs, and legacy/unavailable states
- wire context inspection into chat transcript rows, task detail, and project assignment detail
- add UI tests for the new render paths and missing-context behavior

## Why
The runtime contract for context inspection has landed, but operators could only inspect assistant message packets inline in chats. Runs and project assignments needed the same visibility so operators can answer what each execution actually saw without leaving their workflow.

## Impact
Operators can now inspect launch context, memory and source metadata, assignment/work-item refs, and trust/provenance labels directly from the three main workflow surfaces. Older packets and missing snapshots degrade cleanly instead of failing silently.

## Validation
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx src/features/runs/TaskDetail.test.tsx src/features/projects/ProjectsView.test.tsx src/lib/api.test.ts