### PR TITLE
Add project agent profiles and guidance discovery

### DIFF
--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/api"
 	"github.com/hecatehq/hecate/internal/bootstrap"
 	"github.com/hecatehq/hecate/internal/catalog"
@@ -200,6 +201,7 @@ func runServe() {
 	projectStore := buildProjectStore(cfg, logger, sqliteClient)
 	memoryStore := buildMemoryStore(cfg, logger, sqliteClient)
 	projectWorkStore := buildProjectWorkStore(cfg, logger, sqliteClient)
+	agentProfileStore := buildAgentProfileStore(cfg, logger, sqliteClient)
 	// Approval state follows HECATE_BACKEND so chat transcripts, grants,
 	// and pending approval rows move together across memory/sqlite modes.
 	// Startup reconcile fires before the gateway accepts any request:
@@ -270,6 +272,7 @@ func runServe() {
 	handler.SetProjectStore(projectStore)
 	handler.SetMemoryStore(memoryStore)
 	handler.SetProjectWorkStore(projectWorkStore)
+	handler.SetAgentProfileStore(agentProfileStore)
 	handler.SetAgentApprovalStore(approvalStore)
 	handler.SetStateCleaner(sqliteClient)
 	// Wire the cipher into the handler and its underlying runner so MCP
@@ -749,6 +752,20 @@ func buildProjectWorkStore(cfg config.Config, logger *slog.Logger, sqliteClient 
 		return store
 	default:
 		return projectwork.NewMemoryStore()
+	}
+}
+
+func buildAgentProfileStore(cfg config.Config, logger *slog.Logger, sqliteClient *storage.SQLiteClient) agentprofiles.Store {
+	switch cfg.Projects.Backend {
+	case "sqlite":
+		store, err := agentprofiles.NewSQLiteStore(context.Background(), sqliteClient)
+		if err != nil {
+			logger.Error("agent profile store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	default:
+		return agentprofiles.NewMemoryStore()
 	}
 }
 

--- a/docs/design/accepted/hecate-chat-model-capabilities.md
+++ b/docs/design/accepted/hecate-chat-model-capabilities.md
@@ -3,8 +3,8 @@
 > **Status:** accepted; partially implemented alpha direction.
 > **Current source of truth:** [Chat sessions](../../runtime/chat-sessions.md),
 > [Agent runtime](../../runtime/agent-runtime.md), and [Runtime API](../../runtime/runtime-api.md).
-> **Next action:** implement workspace modes, named agent profiles, automatic
-> capability probes, and broader e2e hardening.
+> **Next action:** wire workspace modes and named agent profiles into Hecate
+> Chat setup, implement automatic capability probes, and broaden e2e hardening.
 >
 > **Terminology note:** this design record was written while "Hecate Agent" was the
 > proposed product label for Hecate-owned tools-on chat. Current UI and
@@ -42,7 +42,7 @@ requirements after the baseline bridge are:
 - streamed assistant text for task-backed Hecate Agent turns _(implemented)_
 - local composer queueing while a backing task is busy _(implemented)_
 - task workspace modes exposed in Hecate Chat setup
-- named agent profiles
+- named agent profiles consumed by Hecate Chat setup
 - richer automatic capability detection with visible status
 
 ## Why
@@ -455,7 +455,8 @@ Done in the core bridge:
 Still required for a complete Hecate Chat tools-on experience:
 
 - workspace modes in the chat setup
-- named agent profiles
+- named agent profiles in the chat setup; profile Core/API exists, but Chat
+  does not yet select or snapshot a named chat profile
 - automatic capability probing
 - broader e2e/product hardening around workspace modes, profiles, automatic
   capability detection, and mixed long-running sessions

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -5,9 +5,9 @@
 Current source of truth: [Agent runtime](../../runtime/agent-runtime.md), [Chat sessions](../../runtime/chat-sessions.md), [Architecture](../../contributor/architecture.md)
 
 Next action: make Projects the operational cockpit for project-scoped agent
-teams: finish task/run project linkage, wire agent profiles into defaults and
-memory-source selection, and harden the activity/health/timeline UI with
-end-to-end project journeys.
+teams: add profile-management UI, finish profile-driven memory/source
+selection, and harden the activity/health/timeline UI with end-to-end project
+journeys.
 
 ## Summary
 
@@ -334,7 +334,8 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 7. Add agent-profile memory-source selection.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.
    Partial: provider, model, workspace mode, and agent profile defaults are
-   project defaults; profile-driven activation remains future.
+   project defaults; assignment starts resolve role/project/fallback profiles,
+   but profile-driven memory/source activation remains future.
 9. Add project activity aggregation. Done for the read-only V1 inbox.
 10. Add structured handoffs. Done for memory + SQLite store parity, API, UI
     actions, and activity projection signals.
@@ -348,9 +349,9 @@ The next project-orchestration slices are:
 
 1. Finish durable task/run project linkage so native tasks, project assignments,
    and chat-origin work all expose the same `project_id` boundary.
-2. Wire agent profiles into project defaults and memory-source selection so a
-   role/assignment can launch with a known provider/model/profile/context
-   posture instead of only a provider/model/workspace default.
+2. Add a profile-management UI and finish profile-driven memory/source
+   selection. Role/project defaults already resolve into assignment-start
+   provider/model/profile/context posture.
 3. Add focused end-to-end project journeys: create project, set defaults, add
    memory, create work item, create/start assignment, resolve approval or
    failure, inspect activity health, and follow a handoff.

--- a/docs/design/proposals/adk-a2a-alignment.md
+++ b/docs/design/proposals/adk-a2a-alignment.md
@@ -60,15 +60,15 @@ Facts, accessed 2026-06-08:
 
 Hecate already separates the pieces that ADK and A2A tend to bundle together:
 
-| Hecate concept | Current role | ADK / A2A alignment |
-| -------------- | ------------ | ------------------- |
-| Model provider | OpenAI, Anthropic, Ollama, LM Studio, and compatible backends answer LLM calls. | Keep separate. ADK and A2A agents are not model providers. |
-| Native runtime | `agent_loop` runs Hecate-owned tool loops with approvals, artifacts, events, cost accounting, and sandboxed tool calls. | Borrow ADK concepts for profiles, workflow graphs, and evaluation; do not replace this runtime. |
-| Agent adapter | ACP-backed Codex, Claude Code, Cursor Agent, Grok Build, and future opaque coding agents. | A remote A2A agent can become another External Agent target. |
-| Protocol adapter | ACP, MCP, OpenAI-compatible HTTP, Anthropic Messages. | A2A belongs here. |
-| MCP | Hecate as an MCP server and as an MCP client for external tools. | Keep MCP as the agent-to-tool/control-plane protocol. A2A should not displace MCP. |
-| Agent profile | Saved runtime posture: model/provider hints, tools, approvals, skills, memory/context activation, and system/profile instructions. | Align profile fields with ADK's agent/tool/session vocabulary where useful. |
-| Runbook | Named workflow pattern with inputs, evidence, approvals, and stop conditions. | Borrow ADK graph/workflow and evaluation ideas as Hecate-native runbooks. |
+| Hecate concept   | Current role                                                                                                                       | ADK / A2A alignment                                                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Model provider   | OpenAI, Anthropic, Ollama, LM Studio, and compatible backends answer LLM calls.                                                    | Keep separate. ADK and A2A agents are not model providers.                                      |
+| Native runtime   | `agent_loop` runs Hecate-owned tool loops with approvals, artifacts, events, cost accounting, and sandboxed tool calls.            | Borrow ADK concepts for profiles, workflow graphs, and evaluation; do not replace this runtime. |
+| Agent adapter    | ACP-backed Codex, Claude Code, Cursor Agent, Grok Build, and future opaque coding agents.                                          | A remote A2A agent can become another External Agent target.                                    |
+| Protocol adapter | ACP, MCP, OpenAI-compatible HTTP, Anthropic Messages.                                                                              | A2A belongs here.                                                                               |
+| MCP              | Hecate as an MCP server and as an MCP client for external tools.                                                                   | Keep MCP as the agent-to-tool/control-plane protocol. A2A should not displace MCP.              |
+| Agent profile    | Saved runtime posture: model/provider hints, tools, approvals, skills, memory/context activation, and system/profile instructions. | Align profile fields with ADK's agent/tool/session vocabulary where useful.                     |
+| Runbook          | Named workflow pattern with inputs, evidence, approvals, and stop conditions.                                                      | Borrow ADK graph/workflow and evaluation ideas as Hecate-native runbooks.                       |
 
 This keeps the accepted external-agent distinction intact: providers answer LLM
 calls, agent adapters drive coding-agent loops, and protocol adapters define
@@ -87,17 +87,17 @@ Hecate-specific storage and API shapes.
 
 Suggested mapping:
 
-| ADK concept | Hecate-native shape |
-| ----------- | ------------------- |
-| Agent | Hecate agent profile, Hecate-owned `agent_loop`, or External Agent adapter depending on context. |
-| Tool | Built-in task tool or namespaced MCP tool. |
-| Runner | Orchestrator plus task runner. |
-| Session | Chat session, task context, or External Agent native session metadata. |
-| State | Context packet, run state, session metadata, and runtime records. |
-| Memory | Operator-approved Hecate memory scoped by project/profile. |
-| Artifact | Hecate task artifact, chat diff artifact, or future portable artifact storage record. |
-| Workflow / graph | Hecate runbook steps and evidence requirements. |
-| Evaluation | Hecate replay/eval suites for `agent_loop`, chat, and External Agent turns. |
+| ADK concept      | Hecate-native shape                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| Agent            | Hecate agent profile, Hecate-owned `agent_loop`, or External Agent adapter depending on context. |
+| Tool             | Built-in task tool or namespaced MCP tool.                                                       |
+| Runner           | Orchestrator plus task runner.                                                                   |
+| Session          | Chat session, task context, or External Agent native session metadata.                           |
+| State            | Context packet, run state, session metadata, and runtime records.                                |
+| Memory           | Operator-approved Hecate memory scoped by project/profile.                                       |
+| Artifact         | Hecate task artifact, chat diff artifact, or future portable artifact storage record.            |
+| Workflow / graph | Hecate runbook steps and evidence requirements.                                                  |
+| Evaluation       | Hecate replay/eval suites for `agent_loop`, chat, and External Agent turns.                      |
 
 ### Agent Profiles
 
@@ -189,14 +189,14 @@ APIs and stores.
 
 Candidate method mapping:
 
-| A2A method | Hecate behavior |
-| ---------- | --------------- |
-| `SendMessage` | Create or continue a Hecate task/chat turn and return either a message or a task snapshot. |
-| `SendStreamingMessage` | Start the same work and project existing task/chat SSE updates into A2A stream events. |
-| `GetTask` | Return a run/task snapshot using A2A task state and artifact shapes. |
-| `ListTasks` | Return recent Hecate runs/tasks scoped by context or status. |
-| `CancelTask` | Cancel the mapped Hecate run. |
-| `SubscribeToTask` | Reattach to a non-terminal run stream using Hecate's replayable event sequence. |
+| A2A method             | Hecate behavior                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| `SendMessage`          | Create or continue a Hecate task/chat turn and return either a message or a task snapshot. |
+| `SendStreamingMessage` | Start the same work and project existing task/chat SSE updates into A2A stream events.     |
+| `GetTask`              | Return a run/task snapshot using A2A task state and artifact shapes.                       |
+| `ListTasks`            | Return recent Hecate runs/tasks scoped by context or status.                               |
+| `CancelTask`           | Cancel the mapped Hecate run.                                                              |
+| `SubscribeToTask`      | Reattach to a non-terminal run stream using Hecate's replayable event sequence.            |
 
 V1 should skip A2A push notifications. Webhook callbacks introduce SSRF,
 authentication, replay, and lifecycle concerns that Hecate does not need for
@@ -259,31 +259,31 @@ Do not adopt an SDK if it forces:
 A2A's lifecycle should map to Hecate without pretending the two models are the
 same.
 
-| A2A concept | Hecate mapping |
-| ----------- | -------------- |
-| Agent Card | Hecate capability document for local/authenticated clients, or remote External Agent descriptor when consumed. |
-| AgentSkill | Hecate actions such as create task, continue chat, inspect run, cancel run, resolve approval, inspect traces. |
-| `contextId` | Hecate chat session id, project-scoped conversation id, or future task context id. |
-| `taskId` | Prefer Hecate run id for protocol identity; include Hecate task id as metadata. |
-| Task | A snapshot of one unit of work. Terminal A2A tasks are immutable; Hecate retries/follow-ups should produce new A2A task ids. |
-| Message | Chat or task turn message. |
-| Part | Hecate content block or artifact part. |
-| Artifact | Hecate task artifact, final answer, stdout/stderr artifact, file/diff artifact, or future portable artifact record. |
-| `input-required` | Hecate `awaiting_approval` or explicit clarification-needed state, depending on source. |
-| `auth-required` | Provider, adapter, MCP, or remote-agent auth failure surfaced as a stable state/error. |
-| SSE stream | Existing task-run or chat-session SSE projected into A2A `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent`. |
+| A2A concept      | Hecate mapping                                                                                                               |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Agent Card       | Hecate capability document for local/authenticated clients, or remote External Agent descriptor when consumed.               |
+| AgentSkill       | Hecate actions such as create task, continue chat, inspect run, cancel run, resolve approval, inspect traces.                |
+| `contextId`      | Hecate chat session id, project-scoped conversation id, or future task context id.                                           |
+| `taskId`         | Prefer Hecate run id for protocol identity; include Hecate task id as metadata.                                              |
+| Task             | A snapshot of one unit of work. Terminal A2A tasks are immutable; Hecate retries/follow-ups should produce new A2A task ids. |
+| Message          | Chat or task turn message.                                                                                                   |
+| Part             | Hecate content block or artifact part.                                                                                       |
+| Artifact         | Hecate task artifact, final answer, stdout/stderr artifact, file/diff artifact, or future portable artifact record.          |
+| `input-required` | Hecate `awaiting_approval` or explicit clarification-needed state, depending on source.                                      |
+| `auth-required`  | Provider, adapter, MCP, or remote-agent auth failure surfaced as a stable state/error.                                       |
+| SSE stream       | Existing task-run or chat-session SSE projected into A2A `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent`.              |
 
 Status mapping sketch:
 
-| Hecate status | A2A task state |
-| ------------- | -------------- |
-| `queued` | submitted / working |
-| `running` | working |
-| `awaiting_approval` | input-required |
-| `completed` | completed |
-| `cancelled` | canceled |
-| `failed` | failed |
-| approval rejected | rejected |
+| Hecate status       | A2A task state      |
+| ------------------- | ------------------- |
+| `queued`            | submitted / working |
+| `running`           | working             |
+| `awaiting_approval` | input-required      |
+| `completed`         | completed           |
+| `cancelled`         | canceled            |
+| `failed`            | failed              |
+| approval rejected   | rejected            |
 
 The exact enum spelling should follow the current A2A SDK/spec at
 implementation time.

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -1,13 +1,14 @@
 # Workspace Instructions, Skills, And Profiles
 
-> **Status:** proposed.
+> **Status:** proposal; Agent Profiles V1 core and workspace-guidance discovery
+> are partially implemented.
 > **Current source of truth:** [Context assembly and injection boundaries](context-assembly-and-injection-boundaries.md),
 > [Agent memory](agent-memory.md), [Projects](../accepted/projects.md), and
 > [Runtime API](../../runtime/runtime-api.md) for today's context-packet,
 > memory, project, and task behavior.
-> **Next action:** implement Agent Profiles V1 core with room for skill
-> references, then add workspace-instruction discovery and local skill registry
-> support as separate slices.
+> **Next action:** add profile-management UI and profile skill/source
+> resolution. Local skill registry support and source-content injection remain
+> separate later slices.
 
 Hecate needs a clean vocabulary for several things that are easy to blur:
 workspace `AGENTS.md` files, other Markdown instruction files, reusable
@@ -15,8 +16,8 @@ workspace `AGENTS.md` files, other Markdown instruction files, reusable
 They are all "context" in the broad sense, but they have different authority,
 lifecycle, safety, and UI needs.
 
-This proposal defines the layering Hecate should use before implementing Agent
-Profiles V1, Skills V1, and planner/runbook features.
+This proposal defines the layering Hecate should use while finishing Agent
+Profiles V1 and before implementing Skills V1 and planner/runbook features.
 
 ## External Alignment
 
@@ -364,27 +365,29 @@ but the operator approves before anything is created or started.
 
 Recommended sequence:
 
-1. **Agent Profiles V1 Core**
+1. **Agent Profiles V1 Core** — partially implemented.
    - Profile store with memory/SQLite parity.
    - CRUD/list API.
    - Resolution helper with explicit/role/project/fallback order.
    - `skill_ids` as unresolved references or best-effort metadata.
    - Context packet fields for resolved profile metadata.
 
-2. **Skills Registry V1 Core**
+2. **Workspace Instructions V1 Core** — partially implemented.
+   - Discover `AGENTS.md` and nested `AGENTS.md` under project workspace roots.
+   - Save/refresh them as project context-source metadata.
+   - Label host-specific files as metadata-only context sources.
+   - Future: include relevant Hecate-owned instruction content in context packets
+     after explicit injection policy is designed.
+   - Future: label external-agent behavior as "available to adapter" or "not
+     injected" when Hecate does not own the adapter prompt.
+
+3. **Skills Registry V1 Core**
    - Built-in skill registry.
    - Project-local `.hecate/skills/*/SKILL.md` discovery.
    - Frontmatter validation.
    - List/get API.
    - Trust/source labels.
    - No script execution or remote install.
-
-3. **Workspace Instructions V1 Core**
-   - Discover `AGENTS.md` and nested `AGENTS.md` under project workspace roots.
-   - Save/refresh them as project context-source metadata.
-   - Include relevant Hecate-owned instruction content in context packets.
-   - Label external-agent behavior as "available to adapter" or "not injected"
-     when Hecate does not own the adapter prompt.
 
 4. **Profile Skill Resolution**
    - Resolve `skill_ids` to active skill metadata.

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -102,8 +102,11 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   capability repair hint. Ollama models can be enriched from their native
   capability metadata; generic OpenAI-compatible local models often remain
   `unknown` until the provider reports richer metadata.
-- Workspace modes and named agent profiles are still roadmap items.
-  Tools-on chat uses the selected workspace with the current built-in profile.
+- Workspace modes are available for task/project starts, and named agent
+  profiles now have a core API plus project/role default selection. A full
+  profile-management UI and profile-driven memory/source injection are still
+  beta-hardening work. Tools-on chat still uses the selected workspace with the
+  current chat runtime posture.
 - Tasks remains canonical for full run history, retry/resume, artifacts, and
   patch review. Chats projects the high-signal run activity and approval
   controls, but it is not a replacement for every Task Detail inspection flow.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1079,12 +1079,12 @@ Supported endpoints:
 
 Enums:
 
-| Field                   | Values                                                        |
-| ----------------------- | ------------------------------------------------------------- |
-| `surface`               | `hecate_chat`, `hecate_task`, `external_agent`, `any`         |
-| `approval_policy`       | `inherit`, `require`, `block`, `allow`                        |
-| `project_memory_policy` | `inherit`, `include`, `visible_only`, `exclude`               |
-| `context_source_policy` | `inherit`, `include_enabled`, `visible_only`, `exclude`       |
+| Field                   | Values                                                  |
+| ----------------------- | ------------------------------------------------------- |
+| `surface`               | `hecate_chat`, `hecate_task`, `external_agent`, `any`   |
+| `approval_policy`       | `inherit`, `require`, `block`, `allow`                  |
+| `project_memory_policy` | `inherit`, `include`, `visible_only`, `exclude`         |
+| `context_source_policy` | `inherit`, `include_enabled`, `visible_only`, `exclude` |
 
 Project assignment starts resolve profiles in this order: role default,
 project default, built-in `project_assignment` fallback. The start path

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -115,6 +115,7 @@ object when available.
 - [Runtime backend and queue configuration](#runtime-backend-and-queue-configuration)
 - [Usage endpoints](#usage-endpoints)
 - [Health and discovery endpoints](#health-and-discovery-endpoints)
+- [Agent profile endpoints](#agent-profile-endpoints)
 - [Project endpoints](#project-endpoints)
 - [Chat session endpoints](#chat-session-endpoints)
 - [Rate-limit headers on chat / messages](#rate-limit-headers-on-chat--messages)
@@ -436,7 +437,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -445,6 +446,7 @@ Tool names come back un-namespaced — the operator wants to see what the upstre
   "data": {
     "projects_deleted": 1,
     "project_work_rows_deleted": 3,
+    "agent_profiles_deleted": 1,
     "chat_sessions_deleted": 2,
     "tasks_deleted": 1,
     "providers_deleted": 1,
@@ -1024,6 +1026,72 @@ Status codes:
 - `409 conflict` when the adapter is not managed or the launcher cannot be
   recreated.
 
+## Agent profile endpoints
+
+Agent profiles are reusable runtime postures for project work, Hecate Chat,
+task-backed runs, and external-agent launches. They describe defaults and
+constraints such as instructions, surface, provider/model hints, tool/write/
+network posture, approval policy, project-memory policy, context-source
+policy, skill ids, and external-agent options. In this release, `skill_ids` are
+unresolved references for operators and future launch code; Hecate does not
+install or execute skills from an agent profile.
+
+Profile responses use the normal Hecate envelope:
+
+```json
+GET /hecate/v1/agent-profiles
+→ 200
+{
+  "object": "agent_profiles",
+  "data": [
+    {
+      "id": "prof_...",
+      "name": "Backend implementer",
+      "description": "Go runtime work",
+      "instructions": "Prefer narrow, tested patches.",
+      "surface": "hecate_task",
+      "provider_hint": "anthropic",
+      "model_hint": "claude-sonnet-4",
+      "execution_profile": "implementation",
+      "tools_enabled": true,
+      "writes_allowed": true,
+      "network_allowed": false,
+      "approval_policy": "require",
+      "project_memory_policy": "visible_only",
+      "context_source_policy": "include_enabled",
+      "skill_ids": ["backend", "providers"],
+      "external_agent_kind": "codex",
+      "external_agent_options": { "effort": "high" },
+      "created_at": "2026-06-08T12:00:00Z",
+      "updated_at": "2026-06-08T12:00:00Z"
+    }
+  ]
+}
+```
+
+Supported endpoints:
+
+- `GET /hecate/v1/agent-profiles`
+- `POST /hecate/v1/agent-profiles`
+- `GET /hecate/v1/agent-profiles/{id}`
+- `PATCH /hecate/v1/agent-profiles/{id}`
+- `DELETE /hecate/v1/agent-profiles/{id}`
+
+Enums:
+
+| Field                   | Values                                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| `surface`               | `hecate_chat`, `hecate_task`, `external_agent`, `any`         |
+| `approval_policy`       | `inherit`, `require`, `block`, `allow`                        |
+| `project_memory_policy` | `inherit`, `include`, `visible_only`, `exclude`               |
+| `context_source_policy` | `inherit`, `include_enabled`, `visible_only`, `exclude`       |
+
+Project assignment starts resolve profiles in this order: role default,
+project default, built-in `project_assignment` fallback. The start path
+snapshots the resolved profile, provider/model hints, execution profile,
+memory policy, context-source policy, skill ids, and warnings into the task/run
+context packet.
+
 ## Project endpoints
 
 Projects are the durable Hecate identity for a codebase or work area. A project
@@ -1038,10 +1106,11 @@ The project catalog implementation is intentionally lightweight:
 a project-work assignment creates a project-scoped Hecate Chat session and
 pre-fills the editable composer with a concise launch-context draft; the draft
 is not submitted automatically. Projects can also remember context-source
-metadata (`path`, `kind`, `title`, and whether the
-source is enabled). Chat message context packets include enabled sources as
-itemized `workspace_guidance` metadata for inspection, but Hecate does not
-inject those files into prompts yet. Project work-coordination endpoints can
+metadata (`path`, `kind`, `title`, `format`, `scope`, `trust_label`,
+`source_category`, arbitrary string metadata, and whether the source is
+enabled). Chat message context packets include enabled sources as itemized
+`workspace_guidance` metadata for inspection, but Hecate does not inject those
+files into prompts yet. Project work-coordination endpoints can
 persist roles, work items, assignments, and collaboration artifacts under a
 project. Assignments may record links to existing task runs or chat messages,
 but creating an assignment does not start a task, open a chat, inject context,
@@ -1054,8 +1123,7 @@ Markdown-compatible `body` text; they are not Markdown files, and they are
 written only through explicit operator API/UI actions. Enabled project memory
 entries appear as itemized chat context-packet metadata with their
 `trust_label`, but Hecate still does not perform automatic memory extraction,
-embeddings, retrieval ranking, or source-content injection. Profiles, presets,
-and source-content injection are not linked to `project_id` yet.
+embeddings, retrieval ranking, or source-content injection.
 
 ### `GET /hecate/v1/projects`
 
@@ -1090,6 +1158,11 @@ GET /hecate/v1/projects
           "title": "README",
           "path": "README.md",
           "enabled": true,
+          "format": "",
+          "scope": "",
+          "trust_label": "",
+          "source_category": "",
+          "metadata": {},
           "created_at": "2026-05-20T12:00:00Z",
           "updated_at": "2026-05-20T12:00:00Z"
         }
@@ -1138,7 +1211,8 @@ POST /hecate/v1/projects
       "kind": "doc",
       "title": "README",
       "path": "README.md",
-      "enabled": true
+      "enabled": true,
+      "metadata": {}
     }
   ],
   "default_provider": "ollama",
@@ -1186,6 +1260,49 @@ PATCH /hecate/v1/projects/proj_...
   "name": "Hecate runtime",
   "last_opened_at": "2026-05-20T12:45:00Z",
   "default_compact_tool_output": true
+}
+```
+
+### `POST /hecate/v1/projects/{id}/context-sources/discover`
+
+Discovers workspace guidance metadata from active absolute project roots and
+merges it into `context_sources`. Discovery is an explicit operator action: it
+does not read discovered file bodies into prompts and does not change Hecate
+policy, approvals, sandboxing, or profile settings.
+
+V1 enables portable `AGENTS.md` sources as `kind=workspace_instruction`,
+`format=agents_md`, and `trust_label=workspace_guidance`. Host-specific files
+are labelled for visibility but remain metadata-only: `CLAUDE.md`,
+`.claude/CLAUDE.md`, `GEMINI.md`, `.cursor/rules`, `.github/instructions`,
+`.devin/rules`, `.windsurf/rules`, and `.gemini/commands`.
+
+Discovery skips common vendor/build directories such as `.git`, `node_modules`,
+`vendor`, `dist`, `build`, `.next`, `.turbo`, `.cache`, `target`, and
+`coverage`. Existing sources are matched by `(kind,path)` so operator disabled
+state and source IDs are preserved on rediscovery.
+
+```json
+POST /hecate/v1/projects/proj_.../context-sources/discover
+→ 200
+{
+  "object": "project",
+  "data": {
+    "id": "proj_...",
+    "context_sources": [
+      {
+        "id": "ctxsrc_...",
+        "kind": "workspace_instruction",
+        "title": "AGENTS.md",
+        "path": "AGENTS.md",
+        "enabled": true,
+        "format": "agents_md",
+        "scope": "workspace",
+        "trust_label": "workspace_guidance",
+        "source_category": "workspace_guidance",
+        "metadata": { "root_id": "root_..." }
+      }
+    ]
+  }
 }
 ```
 

--- a/internal/agentprofiles/sqlite.go
+++ b/internal/agentprofiles/sqlite.go
@@ -1,0 +1,268 @@
+package agentprofiles
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+type SQLiteStore struct {
+	client *storage.SQLiteClient
+	table  string
+}
+
+func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
+	if client == nil {
+		return nil, errors.New("sqlite client is required")
+	}
+	store := &SQLiteStore{
+		client: client,
+		table:  client.QualifiedTable("agent_profiles"),
+	}
+	if err := store.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLiteStore) Backend() string { return "sqlite" }
+
+func (s *SQLiteStore) migrate(ctx context.Context) error {
+	_, err := s.client.DB().ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS `+s.table+` (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    instructions TEXT NOT NULL DEFAULT '',
+    surface TEXT NOT NULL DEFAULT 'any',
+    provider_hint TEXT NOT NULL DEFAULT '',
+    model_hint TEXT NOT NULL DEFAULT '',
+    execution_profile TEXT NOT NULL DEFAULT '',
+    tools_enabled INTEGER NOT NULL DEFAULT 0,
+    writes_allowed INTEGER NOT NULL DEFAULT 0,
+    network_allowed INTEGER NOT NULL DEFAULT 0,
+    approval_policy TEXT NOT NULL DEFAULT 'inherit',
+    project_memory_policy TEXT NOT NULL DEFAULT 'inherit',
+    context_source_policy TEXT NOT NULL DEFAULT 'inherit',
+    skill_ids TEXT NOT NULL DEFAULT '[]',
+    external_agent_kind TEXT NOT NULL DEFAULT '',
+    external_agent_options TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)`)
+	return err
+}
+
+func (s *SQLiteStore) Create(ctx context.Context, profile Profile) (Profile, error) {
+	profile = normalizeProfile(profile, time.Now().UTC())
+	if err := validateProfile(profile); err != nil {
+		return Profile{}, err
+	}
+	if err := s.upsert(ctx, profile); err != nil {
+		return Profile{}, err
+	}
+	return cloneProfile(profile), nil
+}
+
+func (s *SQLiteStore) Get(ctx context.Context, id string) (Profile, bool, error) {
+	row := s.client.DB().QueryRowContext(ctx, selectAgentProfileSQL(s.table)+" WHERE id = ?", strings.TrimSpace(id))
+	profile, err := scanAgentProfile(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Profile{}, false, nil
+	}
+	if err != nil {
+		return Profile{}, false, err
+	}
+	return cloneProfile(profile), true, nil
+}
+
+func (s *SQLiteStore) List(ctx context.Context) ([]Profile, error) {
+	rows, err := s.client.DB().QueryContext(ctx, selectAgentProfileSQL(s.table)+" ORDER BY updated_at DESC, name ASC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Profile
+	for rows.Next() {
+		item, err := scanAgentProfile(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Profile)) (Profile, error) {
+	profile, ok, err := s.Get(ctx, id)
+	if err != nil {
+		return Profile{}, err
+	}
+	if !ok {
+		return Profile{}, ErrNotFound
+	}
+	createdAt := profile.CreatedAt
+	originalID := profile.ID
+	if update != nil {
+		update(&profile)
+	}
+	profile.ID = originalID
+	profile.CreatedAt = createdAt
+	profile.UpdatedAt = time.Now().UTC()
+	profile = normalizeProfile(profile, profile.UpdatedAt)
+	if err := validateProfile(profile); err != nil {
+		return Profile{}, err
+	}
+	if err := s.upsert(ctx, profile); err != nil {
+		return Profile{}, err
+	}
+	return cloneProfile(profile), nil
+}
+
+func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
+	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.table+` WHERE id = ?`, strings.TrimSpace(id))
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) upsert(ctx context.Context, profile Profile) error {
+	skills, err := json.Marshal(profile.SkillIDs)
+	if err != nil {
+		return err
+	}
+	options, err := json.Marshal(profile.ExternalAgentOptions)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.DB().ExecContext(ctx, `
+INSERT INTO `+s.table+` (
+    id, name, description, instructions, surface, provider_hint, model_hint,
+    execution_profile, tools_enabled, writes_allowed, network_allowed,
+    approval_policy, project_memory_policy, context_source_policy, skill_ids,
+    external_agent_kind, external_agent_options, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    description = excluded.description,
+    instructions = excluded.instructions,
+    surface = excluded.surface,
+    provider_hint = excluded.provider_hint,
+    model_hint = excluded.model_hint,
+    execution_profile = excluded.execution_profile,
+    tools_enabled = excluded.tools_enabled,
+    writes_allowed = excluded.writes_allowed,
+    network_allowed = excluded.network_allowed,
+    approval_policy = excluded.approval_policy,
+    project_memory_policy = excluded.project_memory_policy,
+    context_source_policy = excluded.context_source_policy,
+    skill_ids = excluded.skill_ids,
+    external_agent_kind = excluded.external_agent_kind,
+    external_agent_options = excluded.external_agent_options,
+    updated_at = excluded.updated_at`,
+		profile.ID,
+		profile.Name,
+		profile.Description,
+		profile.Instructions,
+		profile.Surface,
+		profile.ProviderHint,
+		profile.ModelHint,
+		profile.ExecutionProfile,
+		boolInt(profile.ToolsEnabled),
+		boolInt(profile.WritesAllowed),
+		boolInt(profile.NetworkAllowed),
+		profile.ApprovalPolicy,
+		profile.ProjectMemoryPolicy,
+		profile.ContextSourcePolicy,
+		string(skills),
+		profile.ExternalAgentKind,
+		string(options),
+		formatTime(profile.CreatedAt),
+		formatTime(profile.UpdatedAt),
+	)
+	return err
+}
+
+func selectAgentProfileSQL(table string) string {
+	return `SELECT id, name, description, instructions, surface, provider_hint, model_hint,
+execution_profile, tools_enabled, writes_allowed, network_allowed, approval_policy,
+project_memory_policy, context_source_policy, skill_ids, external_agent_kind,
+external_agent_options, created_at, updated_at FROM ` + table
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgentProfile(row scanner) (Profile, error) {
+	var profile Profile
+	var tools, writes, network int
+	var skillsRaw, optionsRaw string
+	var createdAt, updatedAt string
+	if err := row.Scan(
+		&profile.ID,
+		&profile.Name,
+		&profile.Description,
+		&profile.Instructions,
+		&profile.Surface,
+		&profile.ProviderHint,
+		&profile.ModelHint,
+		&profile.ExecutionProfile,
+		&tools,
+		&writes,
+		&network,
+		&profile.ApprovalPolicy,
+		&profile.ProjectMemoryPolicy,
+		&profile.ContextSourcePolicy,
+		&skillsRaw,
+		&profile.ExternalAgentKind,
+		&optionsRaw,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Profile{}, err
+	}
+	profile.ToolsEnabled = tools != 0
+	profile.WritesAllowed = writes != 0
+	profile.NetworkAllowed = network != 0
+	_ = json.Unmarshal([]byte(skillsRaw), &profile.SkillIDs)
+	_ = json.Unmarshal([]byte(optionsRaw), &profile.ExternalAgentOptions)
+	profile.CreatedAt = parseTime(createdAt)
+	profile.UpdatedAt = parseTime(updatedAt)
+	return normalizeProfile(profile, profile.UpdatedAt), nil
+}
+
+func boolInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTime(raw string) time.Time {
+	t, _ := time.Parse(time.RFC3339Nano, raw)
+	return t
+}

--- a/internal/agentprofiles/sqlite_test.go
+++ b/internal/agentprofiles/sqlite_test.go
@@ -1,0 +1,86 @@
+package agentprofiles
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+func newSQLiteProfileTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	client, err := storage.NewSQLiteClient(context.Background(), storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "profiles.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	store, err := NewSQLiteStore(context.Background(), client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	return store
+}
+
+func TestSQLiteStore_ProfileRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteProfileTestStore(t)
+
+	created, err := store.Create(ctx, Profile{
+		ID:                  "prof_reviewer",
+		Name:                "Reviewer",
+		Description:         "Production-risk review",
+		Instructions:        "Call out risk first.",
+		Surface:             SurfaceHecateTask,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-4.1",
+		ExecutionProfile:    "review",
+		ToolsEnabled:        true,
+		ApprovalPolicy:      ApprovalRequire,
+		ProjectMemoryPolicy: MemoryVisibleOnly,
+		ContextSourcePolicy: ContextIncludeEnabled,
+		SkillIDs:            []string{"review", "security-audit"},
+		ExternalAgentKind:   "claude",
+		ExternalAgentOptions: map[string]string{
+			"permission_mode": "plan",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatalf("timestamps were not initialized: %+v", created)
+	}
+
+	got, ok, err := store.Get(ctx, "prof_reviewer")
+	if err != nil || !ok {
+		t.Fatalf("Get ok=%v err=%v, want profile", ok, err)
+	}
+	if got.Name != "Reviewer" || got.ExternalAgentOptions["permission_mode"] != "plan" {
+		t.Fatalf("profile = %+v, want persisted profile", got)
+	}
+
+	updated, err := store.Update(ctx, "prof_reviewer", func(profile *Profile) {
+		profile.Name = "Reviewer V2"
+		profile.NetworkAllowed = true
+		profile.ExternalAgentOptions = map[string]string{"permission_mode": "accept_edits"}
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Name != "Reviewer V2" || !updated.NetworkAllowed || updated.ExternalAgentOptions["permission_mode"] != "accept_edits" {
+		t.Fatalf("updated = %+v, want patched profile", updated)
+	}
+
+	items, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "prof_reviewer" {
+		t.Fatalf("items = %+v, want one profile", items)
+	}
+}

--- a/internal/agentprofiles/store.go
+++ b/internal/agentprofiles/store.go
@@ -1,0 +1,282 @@
+package agentprofiles
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrNotFound = errors.New("agent profile not found")
+	ErrInvalid  = errors.New("invalid agent profile")
+)
+
+const (
+	SurfaceAny           = "any"
+	SurfaceHecateChat    = "hecate_chat"
+	SurfaceHecateTask    = "hecate_task"
+	SurfaceExternalAgent = "external_agent"
+
+	ApprovalInherit = "inherit"
+	ApprovalRequire = "require"
+	ApprovalBlock   = "block"
+	ApprovalAllow   = "allow"
+
+	MemoryInherit     = "inherit"
+	MemoryInclude     = "include"
+	MemoryVisibleOnly = "visible_only"
+	MemoryExclude     = "exclude"
+
+	ContextInherit        = "inherit"
+	ContextIncludeEnabled = "include_enabled"
+	ContextVisibleOnly    = "visible_only"
+	ContextExclude        = "exclude"
+)
+
+type Profile struct {
+	ID                   string
+	Name                 string
+	Description          string
+	Instructions         string
+	Surface              string
+	ProviderHint         string
+	ModelHint            string
+	ExecutionProfile     string
+	ToolsEnabled         bool
+	WritesAllowed        bool
+	NetworkAllowed       bool
+	ApprovalPolicy       string
+	ProjectMemoryPolicy  string
+	ContextSourcePolicy  string
+	SkillIDs             []string
+	ExternalAgentKind    string
+	ExternalAgentOptions map[string]string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+type Store interface {
+	Backend() string
+	Create(ctx context.Context, profile Profile) (Profile, error)
+	Get(ctx context.Context, id string) (Profile, bool, error)
+	List(ctx context.Context) ([]Profile, error)
+	Update(ctx context.Context, id string, update func(*Profile)) (Profile, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type MemoryStore struct {
+	mu       sync.Mutex
+	profiles map[string]Profile
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{profiles: make(map[string]Profile)}
+}
+
+func (s *MemoryStore) Backend() string { return "memory" }
+
+func (s *MemoryStore) Create(_ context.Context, profile Profile) (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	profile = normalizeProfile(profile, time.Now().UTC())
+	if err := validateProfile(profile); err != nil {
+		return Profile{}, err
+	}
+	s.profiles[profile.ID] = cloneProfile(profile)
+	return cloneProfile(profile), nil
+}
+
+func (s *MemoryStore) Get(_ context.Context, id string) (Profile, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	profile, ok := s.profiles[strings.TrimSpace(id)]
+	if !ok {
+		return Profile{}, false, nil
+	}
+	return cloneProfile(profile), true, nil
+}
+
+func (s *MemoryStore) List(_ context.Context) ([]Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := make([]Profile, 0, len(s.profiles))
+	for _, profile := range s.profiles {
+		items = append(items, cloneProfile(profile))
+	}
+	sortProfiles(items)
+	return items, nil
+}
+
+func (s *MemoryStore) Update(_ context.Context, id string, update func(*Profile)) (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id = strings.TrimSpace(id)
+	profile, ok := s.profiles[id]
+	if !ok {
+		return Profile{}, ErrNotFound
+	}
+	profile = cloneProfile(profile)
+	originalID := profile.ID
+	createdAt := profile.CreatedAt
+	if update != nil {
+		update(&profile)
+	}
+	profile.ID = originalID
+	profile.CreatedAt = createdAt
+	profile.UpdatedAt = time.Now().UTC()
+	profile = normalizeProfile(profile, profile.UpdatedAt)
+	if err := validateProfile(profile); err != nil {
+		return Profile{}, err
+	}
+	s.profiles[id] = cloneProfile(profile)
+	return cloneProfile(profile), nil
+}
+
+func (s *MemoryStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id = strings.TrimSpace(id)
+	if _, ok := s.profiles[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.profiles, id)
+	return nil
+}
+
+func normalizeProfile(profile Profile, now time.Time) Profile {
+	profile.ID = strings.TrimSpace(profile.ID)
+	profile.Name = strings.TrimSpace(profile.Name)
+	profile.Description = strings.TrimSpace(profile.Description)
+	profile.Instructions = strings.TrimSpace(profile.Instructions)
+	profile.Surface = strings.TrimSpace(profile.Surface)
+	profile.ProviderHint = strings.TrimSpace(profile.ProviderHint)
+	profile.ModelHint = strings.TrimSpace(profile.ModelHint)
+	profile.ExecutionProfile = strings.TrimSpace(profile.ExecutionProfile)
+	profile.ApprovalPolicy = strings.TrimSpace(profile.ApprovalPolicy)
+	profile.ProjectMemoryPolicy = strings.TrimSpace(profile.ProjectMemoryPolicy)
+	profile.ContextSourcePolicy = strings.TrimSpace(profile.ContextSourcePolicy)
+	profile.ExternalAgentKind = strings.TrimSpace(profile.ExternalAgentKind)
+	if profile.Surface == "" {
+		profile.Surface = SurfaceAny
+	}
+	if profile.ApprovalPolicy == "" {
+		profile.ApprovalPolicy = ApprovalInherit
+	}
+	if profile.ProjectMemoryPolicy == "" {
+		profile.ProjectMemoryPolicy = MemoryInherit
+	}
+	if profile.ContextSourcePolicy == "" {
+		profile.ContextSourcePolicy = ContextInherit
+	}
+	profile.SkillIDs = normalizeStringSlice(profile.SkillIDs)
+	profile.ExternalAgentOptions = normalizeStringMap(profile.ExternalAgentOptions)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if profile.CreatedAt.IsZero() {
+		profile.CreatedAt = now
+	}
+	if profile.UpdatedAt.IsZero() {
+		profile.UpdatedAt = profile.CreatedAt
+	}
+	return profile
+}
+
+func validateProfile(profile Profile) error {
+	if profile.ID == "" {
+		return ErrInvalid
+	}
+	if profile.Name == "" {
+		return ErrInvalid
+	}
+	if !oneOf(profile.Surface, SurfaceAny, SurfaceHecateChat, SurfaceHecateTask, SurfaceExternalAgent) {
+		return ErrInvalid
+	}
+	if !oneOf(profile.ApprovalPolicy, ApprovalInherit, ApprovalRequire, ApprovalBlock, ApprovalAllow) {
+		return ErrInvalid
+	}
+	if !oneOf(profile.ProjectMemoryPolicy, MemoryInherit, MemoryInclude, MemoryVisibleOnly, MemoryExclude) {
+		return ErrInvalid
+	}
+	if !oneOf(profile.ContextSourcePolicy, ContextInherit, ContextIncludeEnabled, ContextVisibleOnly, ContextExclude) {
+		return ErrInvalid
+	}
+	return nil
+}
+
+func cloneProfile(profile Profile) Profile {
+	profile.SkillIDs = append([]string(nil), profile.SkillIDs...)
+	profile.ExternalAgentOptions = cloneStringMap(profile.ExternalAgentOptions)
+	return profile
+}
+
+func sortProfiles(items []Profile) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+}
+
+func normalizeStringSlice(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func normalizeStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, item := range allowed {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agentprofiles/store_test.go
+++ b/internal/agentprofiles/store_test.go
@@ -1,0 +1,95 @@
+package agentprofiles
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMemoryStore_ProfileRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	created, err := store.Create(ctx, Profile{
+		ID:                  "prof_backend",
+		Name:                "Backend reviewer",
+		Description:         "Reviews backend changes",
+		Instructions:        "Prefer small, tested changes.",
+		Surface:             SurfaceHecateTask,
+		ProviderHint:        "anthropic",
+		ModelHint:           "claude-sonnet-4",
+		ExecutionProfile:    "review",
+		ToolsEnabled:        true,
+		WritesAllowed:       false,
+		NetworkAllowed:      false,
+		ApprovalPolicy:      ApprovalRequire,
+		ProjectMemoryPolicy: MemoryVisibleOnly,
+		ContextSourcePolicy: ContextIncludeEnabled,
+		SkillIDs:            []string{"review", "review"},
+		ExternalAgentKind:   "codex",
+		ExternalAgentOptions: map[string]string{
+			"effort": "high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatalf("timestamps were not initialized: %+v", created)
+	}
+	if len(created.SkillIDs) != 1 || created.SkillIDs[0] != "review" {
+		t.Fatalf("skill ids = %+v, want normalized unique list", created.SkillIDs)
+	}
+
+	got, ok, err := store.Get(ctx, "prof_backend")
+	if err != nil || !ok {
+		t.Fatalf("Get ok=%v err=%v, want profile", ok, err)
+	}
+	if got.Name != "Backend reviewer" || got.ExecutionProfile != "review" || !got.ToolsEnabled {
+		t.Fatalf("profile = %+v, want persisted fields", got)
+	}
+
+	updated, err := store.Update(ctx, "prof_backend", func(profile *Profile) {
+		profile.Name = "Backend implementer"
+		profile.WritesAllowed = true
+		profile.ProjectMemoryPolicy = MemoryInclude
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Name != "Backend implementer" || !updated.WritesAllowed || updated.ProjectMemoryPolicy != MemoryInclude {
+		t.Fatalf("updated = %+v, want patched fields", updated)
+	}
+
+	items, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "prof_backend" {
+		t.Fatalf("items = %+v, want created profile", items)
+	}
+
+	if err := store.Delete(ctx, "prof_backend"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := store.Delete(ctx, "prof_backend"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete missing error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemoryStore_Validation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	if _, err := store.Create(ctx, Profile{ID: "prof_missing_name"}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create missing name error = %v, want ErrInvalid", err)
+	}
+	if _, err := store.Create(ctx, Profile{ID: "prof_bad_surface", Name: "Bad", Surface: "terminal"}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create bad surface error = %v, want ErrInvalid", err)
+	}
+	if _, err := store.Create(ctx, Profile{ID: "prof_bad_policy", Name: "Bad", ApprovalPolicy: "sometimes"}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create bad policy error = %v, want ErrInvalid", err)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
@@ -46,6 +47,7 @@ type Handler struct {
 	memory                   memory.Store
 	memoryCandidates         memory.CandidateStore
 	projectWork              projectwork.Store
+	agentProfiles            agentprofiles.Store
 	agentChatRunner          agentadapters.Runner
 	agentChatLive            *agentChatLive
 	agentChatIdleSweepCancel context.CancelFunc
@@ -316,6 +318,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		memory:              memoryStore,
 		memoryCandidates:    memoryStore,
 		projectWork:         projectwork.NewMemoryStore(),
+		agentProfiles:       agentprofiles.NewMemoryStore(),
 		agentChatRunner:     agentChatRunner,
 		agentChatLive:       agentChatLive,
 		orchestratorMetrics: orchestratorMetrics,
@@ -405,6 +408,13 @@ func (h *Handler) SetProjectWorkStore(store projectwork.Store) {
 		return
 	}
 	h.projectWork = store
+}
+
+func (h *Handler) SetAgentProfileStore(store agentprofiles.Store) {
+	if store == nil {
+		return
+	}
+	h.agentProfiles = store
 }
 
 func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {

--- a/internal/api/handler_agent_profiles.go
+++ b/internal/api/handler_agent_profiles.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+)
+
+func (h *Handler) HandleAgentProfiles(w http.ResponseWriter, r *http.Request) {
+	items, err := h.agentProfiles.List(r.Context())
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	data := make([]AgentProfileResponseItem, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderAgentProfile(item))
+	}
+	WriteJSON(w, http.StatusOK, AgentProfilesResponse{Object: "agent_profiles", Data: data})
+}
+
+func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Request) {
+	var req CreateAgentProfileRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	profile := agentProfileFromCreate(req)
+	if profile.ID == "" {
+		profile.ID = newOpaqueTaskResourceID("prof")
+	}
+	profile, err := h.agentProfiles.Create(r.Context(), profile)
+	if errors.Is(err, agentprofiles.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusCreated, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
+}
+
+func (h *Handler) HandleAgentProfile(w http.ResponseWriter, r *http.Request) {
+	profile, ok, err := h.agentProfiles.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
+}
+
+func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Request) {
+	var req UpdateAgentProfileRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	profile, err := h.agentProfiles.Update(r.Context(), r.PathValue("id"), func(item *agentprofiles.Profile) {
+		applyAgentProfileUpdate(item, req)
+	})
+	if errors.Is(err, agentprofiles.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+		return
+	}
+	if errors.Is(err, agentprofiles.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
+}
+
+func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Request) {
+	if err := h.agentProfiles.Delete(r.Context(), r.PathValue("id")); errors.Is(err, agentprofiles.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+		return
+	} else if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func agentProfileFromCreate(req CreateAgentProfileRequest) agentprofiles.Profile {
+	return agentprofiles.Profile{
+		ID:                   req.ID,
+		Name:                 req.Name,
+		Description:          req.Description,
+		Instructions:         req.Instructions,
+		Surface:              req.Surface,
+		ProviderHint:         req.ProviderHint,
+		ModelHint:            req.ModelHint,
+		ExecutionProfile:     req.ExecutionProfile,
+		ToolsEnabled:         req.ToolsEnabled,
+		WritesAllowed:        req.WritesAllowed,
+		NetworkAllowed:       req.NetworkAllowed,
+		ApprovalPolicy:       req.ApprovalPolicy,
+		ProjectMemoryPolicy:  req.ProjectMemoryPolicy,
+		ContextSourcePolicy:  req.ContextSourcePolicy,
+		SkillIDs:             req.SkillIDs,
+		ExternalAgentKind:    req.ExternalAgentKind,
+		ExternalAgentOptions: req.ExternalAgentOptions,
+	}
+}
+
+func applyAgentProfileUpdate(profile *agentprofiles.Profile, req UpdateAgentProfileRequest) {
+	if req.Name != nil {
+		profile.Name = *req.Name
+	}
+	if req.Description != nil {
+		profile.Description = *req.Description
+	}
+	if req.Instructions != nil {
+		profile.Instructions = *req.Instructions
+	}
+	if req.Surface != nil {
+		profile.Surface = *req.Surface
+	}
+	if req.ProviderHint != nil {
+		profile.ProviderHint = *req.ProviderHint
+	}
+	if req.ModelHint != nil {
+		profile.ModelHint = *req.ModelHint
+	}
+	if req.ExecutionProfile != nil {
+		profile.ExecutionProfile = *req.ExecutionProfile
+	}
+	if req.ToolsEnabled != nil {
+		profile.ToolsEnabled = *req.ToolsEnabled
+	}
+	if req.WritesAllowed != nil {
+		profile.WritesAllowed = *req.WritesAllowed
+	}
+	if req.NetworkAllowed != nil {
+		profile.NetworkAllowed = *req.NetworkAllowed
+	}
+	if req.ApprovalPolicy != nil {
+		profile.ApprovalPolicy = *req.ApprovalPolicy
+	}
+	if req.ProjectMemoryPolicy != nil {
+		profile.ProjectMemoryPolicy = *req.ProjectMemoryPolicy
+	}
+	if req.ContextSourcePolicy != nil {
+		profile.ContextSourcePolicy = *req.ContextSourcePolicy
+	}
+	if req.SkillIDs != nil {
+		profile.SkillIDs = req.SkillIDs
+	}
+	if req.ExternalAgentKind != nil {
+		profile.ExternalAgentKind = *req.ExternalAgentKind
+	}
+	if req.ExternalAgentOptions != nil {
+		profile.ExternalAgentOptions = req.ExternalAgentOptions
+	}
+}
+
+func renderAgentProfile(profile agentprofiles.Profile) AgentProfileResponseItem {
+	return AgentProfileResponseItem{
+		ID:                   profile.ID,
+		Name:                 profile.Name,
+		Description:          profile.Description,
+		Instructions:         profile.Instructions,
+		Surface:              profile.Surface,
+		ProviderHint:         profile.ProviderHint,
+		ModelHint:            profile.ModelHint,
+		ExecutionProfile:     profile.ExecutionProfile,
+		ToolsEnabled:         profile.ToolsEnabled,
+		WritesAllowed:        profile.WritesAllowed,
+		NetworkAllowed:       profile.NetworkAllowed,
+		ApprovalPolicy:       profile.ApprovalPolicy,
+		ProjectMemoryPolicy:  profile.ProjectMemoryPolicy,
+		ContextSourcePolicy:  profile.ContextSourcePolicy,
+		SkillIDs:             append([]string(nil), profile.SkillIDs...),
+		ExternalAgentKind:    profile.ExternalAgentKind,
+		ExternalAgentOptions: cloneAgentProfileOptions(profile.ExternalAgentOptions),
+		CreatedAt:            formatOptionalTime(profile.CreatedAt),
+		UpdatedAt:            formatOptionalTime(profile.UpdatedAt),
+	}
+}
+
+func cloneAgentProfileOptions(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/api/handler_agent_profiles_test.go
+++ b/internal/api/handler_agent_profiles_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+)
+
+func newAgentProfilesTestServer() http.Handler {
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	return NewServer(quietLogger(), handler)
+}
+
+func TestAgentProfilesAPI_CRUD(t *testing.T) {
+	t.Parallel()
+	server := newAgentProfilesTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{
+		"id":"prof_backend",
+		"name":"Backend implementer",
+		"description":"Go runtime work",
+		"instructions":"Prefer narrow tests.",
+		"surface":"hecate_task",
+		"provider_hint":"anthropic",
+		"model_hint":"claude-sonnet-4",
+		"execution_profile":"implementation",
+		"tools_enabled":true,
+		"writes_allowed":true,
+		"network_allowed":false,
+		"approval_policy":"require",
+		"project_memory_policy":"visible_only",
+		"context_source_policy":"include_enabled",
+		"skill_ids":["backend","providers"],
+		"external_agent_kind":"codex",
+		"external_agent_options":{"effort":"high"}
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Object != "agent_profile" || created.Data.ID != "prof_backend" || created.Data.ExecutionProfile != "implementation" {
+		t.Fatalf("created = %+v, want profile envelope", created)
+	}
+	if !created.Data.ToolsEnabled || !created.Data.WritesAllowed || created.Data.NetworkAllowed {
+		t.Fatalf("posture = tools=%v writes=%v network=%v, want true/true/false", created.Data.ToolsEnabled, created.Data.WritesAllowed, created.Data.NetworkAllowed)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/agent-profiles/prof_backend", bytes.NewReader([]byte(`{
+		"name":"Backend reviewer",
+		"writes_allowed":false,
+		"approval_policy":"block"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if updated.Data.Name != "Backend reviewer" || updated.Data.WritesAllowed || updated.Data.ApprovalPolicy != "block" {
+		t.Fatalf("updated = %+v, want patched profile", updated.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/agent-profiles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed AgentProfilesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if listed.Object != "agent_profiles" || len(listed.Data) != 1 || listed.Data[0].ID != "prof_backend" {
+		t.Fatalf("listed = %+v, want created profile", listed)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_backend", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentProfilesAPI_RejectsInvalidEnums(t *testing.T) {
+	t.Parallel()
+	server := newAgentProfilesTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{
+		"id":"prof_bad",
+		"name":"Bad",
+		"surface":"terminal"
+	}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create bad enum status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentProfilesAPI_GeneratesIDsAndReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	server := newAgentProfilesTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{"name":"Generated"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if !strings.HasPrefix(created.Data.ID, "prof_") {
+		t.Fatalf("generated id = %q, want prof_ prefix", created.Data.ID)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/agent-profiles/prof_missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("get missing status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("delete missing status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -19,11 +19,13 @@ const chatContextPacketVersion = "chat.context.v1"
 const (
 	contextTrustSystemInstruction = "system_instruction"
 	contextTrustOperatorMemory    = "operator_memory"
+	contextTrustProject           = "project"
 	contextTrustWorkspaceGuidance = "workspace_guidance"
 	contextTrustRuntimeState      = "runtime_state"
 )
 
 const (
+	contextSectionProfile      = "profile"
 	contextSectionInstructions = "instructions"
 	contextSectionMemory       = "memory"
 	contextSectionWorkspace    = "workspace"
@@ -399,7 +401,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	return packet
 }
 
-func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string) chat.ContextPacket {
+func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string, profile resolvedAgentProfile) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
 	packet.ID = newChatID("ctx")
 	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
@@ -490,6 +492,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 		Included:        true,
 		InclusionReason: "Included in the native project assignment launch context",
 	})
+	appendResolvedAgentProfile(&packet, profile)
 	if packet.SystemPromptIncluded {
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
@@ -561,11 +564,12 @@ func projectContextSourcesFromProject(project projects.Project) []chat.ContextSo
 		if label == "" {
 			continue
 		}
+		trust := firstNonEmptyString(strings.TrimSpace(source.TrustLabel), contextTrustProject)
 		sources = append(sources, chat.ContextSource{
 			Kind:   projectContextSourceKind(source.Kind),
 			Label:  label,
 			Detail: strings.TrimSpace(source.Path),
-			Trust:  "project",
+			Trust:  trust,
 		})
 	}
 	return sources
@@ -676,6 +680,70 @@ func appendProjectContextSourcesWithInclusion(packet *chat.ContextPacket, source
 	}
 }
 
+func appendResolvedAgentProfile(packet *chat.ContextPacket, profile resolvedAgentProfile) {
+	if strings.TrimSpace(profile.ID) == "" {
+		return
+	}
+	body := []string{
+		"ID: " + profile.ID,
+		"Name: " + firstNonEmptyString(profile.Name, profile.ID),
+		"Source: " + firstNonEmptyString(profile.Source, "unknown"),
+		"Surface: " + firstNonEmptyString(profile.Surface, "any"),
+		"Execution profile: " + firstNonEmptyString(profile.ExecutionProfile, profile.ID),
+		"Provider hint: " + firstNonEmptyString(profile.ProviderHint, "inherit"),
+		"Model hint: " + firstNonEmptyString(profile.ModelHint, "inherit"),
+		"Tools enabled: " + boolLabel(profile.ToolsEnabled),
+		"Writes allowed: " + boolLabel(profile.WritesAllowed),
+		"Network allowed: " + boolLabel(profile.NetworkAllowed),
+		"Approval policy: " + firstNonEmptyString(profile.ApprovalPolicy, "inherit"),
+		"Project memory policy: " + firstNonEmptyString(profile.ProjectMemoryPolicy, "inherit"),
+		"Context source policy: " + firstNonEmptyString(profile.ContextSourcePolicy, "inherit"),
+	}
+	if len(profile.SkillIDs) > 0 {
+		body = append(body, "Skills: "+strings.Join(profile.SkillIDs, ", "))
+	}
+	if len(profile.Warnings) > 0 {
+		body = append(body, "Warnings: "+strings.Join(profile.Warnings, " "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
+		Kind:   "agent_profile",
+		Label:  firstNonEmptyString(profile.Name, profile.ID),
+		Detail: profile.ID,
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "agent_profile",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          profile.ID,
+		Title:           firstNonEmptyString(profile.Name, profile.ID),
+		Body:            strings.Join(body, "\n"),
+		Included:        !profile.Missing,
+		InclusionReason: firstNonEmptyString(profile.Source, "resolved profile"),
+	})
+	for _, warning := range profile.Warnings {
+		appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
+			Kind:   "profile_warning",
+			Label:  "Profile warning",
+			Detail: profile.ID,
+			Trust:  contextTrustRuntimeState,
+		}, chat.ContextItem{
+			Kind:            "profile_warning",
+			TrustLevel:      contextTrustRuntimeState,
+			Origin:          profile.ID,
+			Title:           "Profile warning",
+			Body:            warning,
+			Included:        false,
+			InclusionReason: "Profile resolution warning",
+		})
+	}
+}
+
+func boolLabel(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
 func appendProjectAssignmentHandoffs(packet *chat.ContextPacket, items []projectwork.Handoff, included bool, reason string) {
 	for _, item := range items {
 		trust := firstNonEmptyString(strings.TrimSpace(item.TrustLabel), contextTrustRuntimeState)
@@ -784,6 +852,8 @@ func projectContextSourceKind(kind string) string {
 		// Operator-configured docs should render beside native workspace
 		// sources; other project kinds stay namespaced to avoid collisions.
 		return "workspace_doc"
+	case "workspace_instruction", "host_instruction", "path_instruction", "host_rule", "host_command", "host_agent_definition":
+		return kind
 	default:
 		return "project_" + strings.NewReplacer(" ", "_", "-", "_").Replace(kind)
 	}

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -405,7 +405,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
 	packet.ID = newChatID("ctx")
 	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
-	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role)) != ""
+	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role, profile)) != ""
 	packet.Refs = &chat.ContextRefs{
 		TaskID:       strings.TrimSpace(assignment.TaskID),
 		RunID:        strings.TrimSpace(assignment.RunID),
@@ -698,6 +698,9 @@ func appendResolvedAgentProfile(packet *chat.ContextPacket, profile resolvedAgen
 		"Approval policy: " + firstNonEmptyString(profile.ApprovalPolicy, "inherit"),
 		"Project memory policy: " + firstNonEmptyString(profile.ProjectMemoryPolicy, "inherit"),
 		"Context source policy: " + firstNonEmptyString(profile.ContextSourcePolicy, "inherit"),
+	}
+	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" && !profile.Missing {
+		body = append(body, "Instructions:\n"+instructions)
 	}
 	if len(profile.SkillIDs) > 0 {
 		body = append(body, "Skills: "+strings.Join(profile.SkillIDs, ", "))

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -747,6 +747,15 @@ func findRenderedContextItemByOrigin(packet ChatContextPacketItem, origin string
 	return nil
 }
 
+func findRenderedContextItemByKind(packet ChatContextPacketItem, kind string) *ChatContextItem {
+	for idx := range packet.Items {
+		if packet.Items[idx].Kind == kind {
+			return &packet.Items[idx]
+		}
+	}
+	return nil
+}
+
 func sourceKinds(packet chat.ContextPacket) []string {
 	kinds := make([]string, 0, len(packet.Sources))
 	for _, source := range packet.Sources {

--- a/internal/api/handler_project_context_discovery.go
+++ b/internal/api/handler_project_context_discovery.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"errors"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+const maxProjectInstructionDiscoveryDepth = 8
+
+func (h *Handler) HandleDiscoverProjectContextSources(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	project, ok, err := h.projects.Get(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	discovered, err := discoverProjectInstructionSources(project)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	project, err = h.projects.Update(r.Context(), projectID, func(item *projects.Project) {
+		item.ContextSources = mergeDiscoveredContextSources(item.ContextSources, discovered)
+	})
+	if errors.Is(err, projects.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+}
+
+func discoverProjectInstructionSources(project projects.Project) ([]projects.ContextSource, error) {
+	var out []projects.ContextSource
+	for _, root := range project.Roots {
+		if !root.Active {
+			continue
+		}
+		rootPath := strings.TrimSpace(root.Path)
+		if rootPath == "" {
+			continue
+		}
+		if !filepath.IsAbs(rootPath) {
+			return nil, errors.New("project context discovery requires absolute project root paths")
+		}
+		info, err := os.Stat(rootPath)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			return nil, errors.New("project context discovery requires directory roots")
+		}
+		rootID := strings.TrimSpace(root.ID)
+		err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			rel, relErr := filepath.Rel(rootPath, path)
+			if relErr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if rel == "." {
+				return nil
+			}
+			depth := pathDepth(rel)
+			if d.IsDir() {
+				if shouldSkipInstructionDiscoveryDir(d.Name()) || depth > maxProjectInstructionDiscoveryDepth {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if depth > maxProjectInstructionDiscoveryDepth+1 {
+				return nil
+			}
+			if source, ok := classifyInstructionSource(rel, rootID); ok {
+				out = append(out, source)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out, nil
+}
+
+func classifyInstructionSource(rel, rootID string) (projects.ContextSource, bool) {
+	base := pathBase(rel)
+	lower := strings.ToLower(rel)
+	source := projects.ContextSource{
+		ID:             newOpaqueTaskResourceID("ctxsrc"),
+		Path:           rel,
+		Title:          rel,
+		Enabled:        true,
+		TrustLabel:     contextTrustWorkspaceGuidance,
+		SourceCategory: "workspace_guidance",
+		Metadata: map[string]string{
+			"root_id": rootID,
+		},
+	}
+	switch {
+	case base == "AGENTS.md":
+		source.Kind = "workspace_instruction"
+		source.Format = "agents_md"
+		source.Scope = instructionScopeForPath(rel)
+	case rel == "CLAUDE.md" || rel == ".claude/CLAUDE.md" || base == "CLAUDE.local.md":
+		source.Kind = "host_instruction"
+		source.Format = "claude_md"
+		source.Scope = instructionScopeForPath(rel)
+		source.Metadata["host"] = "claude"
+	case rel == "GEMINI.md":
+		source.Kind = "host_instruction"
+		source.Format = "gemini_md"
+		source.Scope = "workspace"
+		source.Metadata["host"] = "gemini"
+	case strings.HasPrefix(lower, ".cursor/rules/"):
+		source.Kind = "host_rule"
+		source.Format = "cursor_rule"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "cursor"
+	case strings.HasPrefix(lower, ".github/instructions/") && strings.HasSuffix(lower, ".instructions.md"):
+		source.Kind = "path_instruction"
+		source.Format = "copilot_instruction"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "github_copilot"
+	case strings.HasPrefix(lower, ".devin/rules/"):
+		source.Kind = "host_rule"
+		source.Format = "devin_rule"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "devin"
+	case strings.HasPrefix(lower, ".windsurf/rules/"):
+		source.Kind = "host_rule"
+		source.Format = "windsurf_rule"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "windsurf"
+	case strings.HasPrefix(lower, ".gemini/commands/") && strings.HasSuffix(lower, ".toml"):
+		source.Kind = "host_command"
+		source.Format = "gemini_command"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "gemini"
+	default:
+		return projects.ContextSource{}, false
+	}
+	return source, true
+}
+
+func mergeDiscoveredContextSources(existing, discovered []projects.ContextSource) []projects.ContextSource {
+	byKey := make(map[string]projects.ContextSource, len(existing)+len(discovered))
+	order := make([]string, 0, len(existing)+len(discovered))
+	add := func(source projects.ContextSource) {
+		key := strings.TrimSpace(source.Kind) + "\x00" + strings.TrimSpace(source.Path)
+		if key == "\x00" {
+			return
+		}
+		if previous, ok := byKey[key]; ok {
+			source.ID = firstNonEmptyString(previous.ID, source.ID)
+			source.Enabled = previous.Enabled
+			source.CreatedAt = previous.CreatedAt
+		} else {
+			order = append(order, key)
+		}
+		byKey[key] = source
+	}
+	for _, source := range existing {
+		add(source)
+	}
+	for _, source := range discovered {
+		add(source)
+	}
+	out := make([]projects.ContextSource, 0, len(order))
+	for _, key := range order {
+		out = append(out, byKey[key])
+	}
+	return out
+}
+
+func instructionScopeForPath(rel string) string {
+	dir := filepath.ToSlash(filepath.Dir(rel))
+	if dir == "." || dir == "" {
+		return "workspace"
+	}
+	return "path:" + dir
+}
+
+func shouldSkipInstructionDiscoveryDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "dist", "build", ".next", ".turbo", ".cache", ".gomodcache", "target", "coverage":
+		return true
+	default:
+		return false
+	}
+}
+
+func pathDepth(rel string) int {
+	if rel == "" || rel == "." {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(rel), "/")
+}
+
+func pathBase(rel string) string {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	return parts[len(parts)-1]
+}

--- a/internal/api/handler_project_context_discovery.go
+++ b/internal/api/handler_project_context_discovery.go
@@ -139,6 +139,11 @@ func classifyInstructionSource(rel, rootID string) (projects.ContextSource, bool
 		source.Format = "cursor_rule"
 		source.Scope = "metadata_only"
 		source.Metadata["host"] = "cursor"
+	case lower == ".github/copilot-instructions.md":
+		source.Kind = "host_instruction"
+		source.Format = "copilot_instruction"
+		source.Scope = "metadata_only"
+		source.Metadata["host"] = "github_copilot"
 	case strings.HasPrefix(lower, ".github/instructions/") && strings.HasSuffix(lower, ".instructions.md"):
 		source.Kind = "path_instruction"
 		source.Format = "copilot_instruction"
@@ -169,9 +174,26 @@ func mergeDiscoveredContextSources(existing, discovered []projects.ContextSource
 	byKey := make(map[string]projects.ContextSource, len(existing)+len(discovered))
 	order := make([]string, 0, len(existing)+len(discovered))
 	add := func(source projects.ContextSource) {
-		key := strings.TrimSpace(source.Kind) + "\x00" + strings.TrimSpace(source.Path)
-		if key == "\x00" {
+		key := contextSourceMergeKey(source)
+		if key == "\x00\x00" {
 			return
+		}
+		if _, ok := byKey[key]; !ok {
+			legacyKey := contextSourceLegacyMergeKey(source)
+			if legacyKey != key {
+				if previous, ok := byKey[legacyKey]; ok {
+					delete(byKey, legacyKey)
+					for i, item := range order {
+						if item == legacyKey {
+							order[i] = key
+							break
+						}
+					}
+					source.ID = firstNonEmptyString(previous.ID, source.ID)
+					source.Enabled = previous.Enabled
+					source.CreatedAt = previous.CreatedAt
+				}
+			}
 		}
 		if previous, ok := byKey[key]; ok {
 			source.ID = firstNonEmptyString(previous.ID, source.ID)
@@ -193,6 +215,18 @@ func mergeDiscoveredContextSources(existing, discovered []projects.ContextSource
 		out = append(out, byKey[key])
 	}
 	return out
+}
+
+func contextSourceMergeKey(source projects.ContextSource) string {
+	rootID := ""
+	if source.Metadata != nil {
+		rootID = strings.TrimSpace(source.Metadata["root_id"])
+	}
+	return contextSourceLegacyMergeKey(source) + "\x00" + rootID
+}
+
+func contextSourceLegacyMergeKey(source projects.ContextSource) string {
+	return strings.TrimSpace(source.Kind) + "\x00" + strings.TrimSpace(source.Path)
 }
 
 func instructionScopeForPath(rel string) string {

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+func TestProjectContextDiscovery_FindsWorkspaceGuidanceMetadata(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeDiscoveryFile(t, root, "AGENTS.md")
+	writeDiscoveryFile(t, root, "internal/api/AGENTS.md")
+	writeDiscoveryFile(t, root, "CLAUDE.md")
+	writeDiscoveryFile(t, root, ".cursor/rules/backend.mdc")
+	writeDiscoveryFile(t, root, ".github/instructions/go.instructions.md")
+	writeDiscoveryFile(t, root, "vendor/AGENTS.md")
+	writeDiscoveryFile(t, root, "node_modules/pkg/AGENTS.md")
+
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:   "proj_guidance",
+		Name: "Guidance",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   root,
+			Kind:   "local",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents_existing",
+			Kind:    "workspace_instruction",
+			Path:    "AGENTS.md",
+			Title:   "AGENTS.md",
+			Enabled: false,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_guidance/context-sources/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discovery response: %v", err)
+	}
+
+	sources := map[string]ProjectContextSourceResponseItem{}
+	for _, source := range resp.Data.ContextSources {
+		sources[source.Path] = source
+	}
+	if got := sources["AGENTS.md"]; got.ID != "ctx_agents_existing" || got.Enabled {
+		t.Fatalf("root AGENTS source = %+v, want existing disabled source preserved", got)
+	}
+	if got := sources["internal/api/AGENTS.md"]; got.Kind != "workspace_instruction" || got.Format != "agents_md" || got.Scope != "path:internal/api" || got.TrustLabel != contextTrustWorkspaceGuidance {
+		t.Fatalf("nested AGENTS source = %+v, want workspace guidance metadata", got)
+	}
+	if got := sources["CLAUDE.md"]; got.Kind != "host_instruction" || got.Metadata["host"] != "claude" {
+		t.Fatalf("CLAUDE source = %+v, want labelled host instruction", got)
+	}
+	if got := sources[".cursor/rules/backend.mdc"]; got.Kind != "host_rule" || got.Metadata["host"] != "cursor" || got.Scope != "metadata_only" {
+		t.Fatalf("Cursor source = %+v, want metadata-only host rule", got)
+	}
+	if _, ok := sources["vendor/AGENTS.md"]; ok {
+		t.Fatalf("vendor AGENTS.md was discovered: %+v", sources["vendor/AGENTS.md"])
+	}
+	if _, ok := sources["node_modules/pkg/AGENTS.md"]; ok {
+		t.Fatalf("node_modules AGENTS.md was discovered: %+v", sources["node_modules/pkg/AGENTS.md"])
+	}
+}
+
+func TestProjectContextDiscovery_RejectsRelativeRoot(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:   "proj_relative",
+		Name: "Relative",
+		Roots: []projects.Root{{
+			ID:     "root_relative",
+			Path:   "relative/path",
+			Kind:   "local",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_relative/context-sources/discover", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("discover relative status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+}
+
+func writeDiscoveryFile(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("# guidance\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -20,6 +20,7 @@ func TestProjectContextDiscovery_FindsWorkspaceGuidanceMetadata(t *testing.T) {
 	writeDiscoveryFile(t, root, "internal/api/AGENTS.md")
 	writeDiscoveryFile(t, root, "CLAUDE.md")
 	writeDiscoveryFile(t, root, ".cursor/rules/backend.mdc")
+	writeDiscoveryFile(t, root, ".github/copilot-instructions.md")
 	writeDiscoveryFile(t, root, ".github/instructions/go.instructions.md")
 	writeDiscoveryFile(t, root, "vendor/AGENTS.md")
 	writeDiscoveryFile(t, root, "node_modules/pkg/AGENTS.md")
@@ -75,11 +76,58 @@ func TestProjectContextDiscovery_FindsWorkspaceGuidanceMetadata(t *testing.T) {
 	if got := sources[".cursor/rules/backend.mdc"]; got.Kind != "host_rule" || got.Metadata["host"] != "cursor" || got.Scope != "metadata_only" {
 		t.Fatalf("Cursor source = %+v, want metadata-only host rule", got)
 	}
+	if got := sources[".github/copilot-instructions.md"]; got.Kind != "host_instruction" || got.Metadata["host"] != "github_copilot" || got.Scope != "metadata_only" {
+		t.Fatalf("Copilot source = %+v, want metadata-only host instruction", got)
+	}
 	if _, ok := sources["vendor/AGENTS.md"]; ok {
 		t.Fatalf("vendor AGENTS.md was discovered: %+v", sources["vendor/AGENTS.md"])
 	}
 	if _, ok := sources["node_modules/pkg/AGENTS.md"]; ok {
 		t.Fatalf("node_modules AGENTS.md was discovered: %+v", sources["node_modules/pkg/AGENTS.md"])
+	}
+}
+
+func TestProjectContextDiscovery_KeepsSamePathSourcesFromDifferentRoots(t *testing.T) {
+	t.Parallel()
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeDiscoveryFile(t, rootA, "AGENTS.md")
+	writeDiscoveryFile(t, rootB, "AGENTS.md")
+
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:   "proj_multi_root",
+		Name: "Multi-root",
+		Roots: []projects.Root{
+			{ID: "root_a", Path: rootA, Kind: "local", Active: true},
+			{ID: "root_b", Path: rootB, Kind: "local", Active: true},
+		},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_multi_root/context-sources/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discovery response: %v", err)
+	}
+
+	roots := make(map[string]bool)
+	for _, source := range resp.Data.ContextSources {
+		if source.Path == "AGENTS.md" && source.Kind == "workspace_instruction" {
+			roots[source.Metadata["root_id"]] = true
+		}
+	}
+	if !roots["root_a"] || !roots["root_b"] || len(roots) != 2 {
+		t.Fatalf("discovered AGENTS roots = %+v, want root_a and root_b", roots)
 	}
 }
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -864,15 +864,16 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
-	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel, h.config.Router.DefaultModel))
+	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel))
 	profile := h.resolveProjectAssignmentProfile(ctx, role, project)
 	executionProfile := strings.TrimSpace(firstNonEmpty(profile.ExecutionProfile, role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
 	if profile.ProviderHint != "" && requestedProvider == "" {
 		requestedProvider = profile.ProviderHint
 	}
-	if profile.ModelHint != "" && (requestedModel == "" || requestedModel == h.config.Router.DefaultModel) {
+	if profile.ModelHint != "" && requestedModel == "" {
 		requestedModel = profile.ModelHint
 	}
+	requestedModel = strings.TrimSpace(firstNonEmpty(requestedModel, h.config.Router.DefaultModel))
 	if requestedModel == "" {
 		WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, "project assignment start requires a default model")
 		return

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -864,12 +865,19 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	}
 	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
 	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel, h.config.Router.DefaultModel))
+	profile := h.resolveProjectAssignmentProfile(ctx, role, project)
+	executionProfile := strings.TrimSpace(firstNonEmpty(profile.ExecutionProfile, role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
+	if profile.ProviderHint != "" && requestedProvider == "" {
+		requestedProvider = profile.ProviderHint
+	}
+	if profile.ModelHint != "" && (requestedModel == "" || requestedModel == h.config.Router.DefaultModel) {
+		requestedModel = profile.ModelHint
+	}
 	if requestedModel == "" {
 		WriteError(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, "project assignment start requires a default model")
 		return
 	}
-	executionProfile := strings.TrimSpace(firstNonEmpty(role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
-	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workingDirectory, requestedProvider, requestedModel, executionProfile)
+	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workingDirectory, requestedProvider, requestedModel, executionProfile, profile)
 	if contextPacket.ID == "" {
 		contextPacket.ID = newChatID("ctx")
 	}
@@ -1204,6 +1212,87 @@ func projectAssignmentSystemPrompt(project projects.Project, role projectwork.Ag
 type assignmentHint struct {
 	label string
 	value string
+}
+
+type resolvedAgentProfile struct {
+	ID                  string
+	Name                string
+	Source              string
+	Missing             bool
+	Surface             string
+	ProviderHint        string
+	ModelHint           string
+	ExecutionProfile    string
+	ToolsEnabled        bool
+	WritesAllowed       bool
+	NetworkAllowed      bool
+	ApprovalPolicy      string
+	ProjectMemoryPolicy string
+	ContextSourcePolicy string
+	SkillIDs            []string
+	Warnings            []string
+}
+
+func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) resolvedAgentProfile {
+	for _, candidate := range []struct {
+		id     string
+		source string
+	}{
+		{strings.TrimSpace(role.DefaultAgentProfile), "role_default"},
+		{strings.TrimSpace(project.DefaultAgentProfile), "project_default"},
+	} {
+		if candidate.id == "" {
+			continue
+		}
+		if h != nil && h.agentProfiles != nil {
+			profile, ok, err := h.agentProfiles.Get(ctx, candidate.id)
+			if err == nil && ok {
+				return resolvedProfileFromStore(profile, candidate.source)
+			}
+		}
+		return resolvedAgentProfile{
+			ID:                  candidate.id,
+			Name:                candidate.id,
+			Source:              candidate.source,
+			Missing:             true,
+			ExecutionProfile:    candidate.id,
+			ApprovalPolicy:      agentprofiles.ApprovalInherit,
+			ProjectMemoryPolicy: agentprofiles.MemoryInherit,
+			ContextSourcePolicy: agentprofiles.ContextInherit,
+			Warnings:            []string{fmt.Sprintf("Referenced agent profile %q was not found; using stored profile id as execution_profile hint.", candidate.id)},
+		}
+	}
+	return resolvedAgentProfile{
+		ID:                  "project_assignment",
+		Name:                "Project Assignment",
+		Source:              "built_in_fallback",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ExecutionProfile:    "project_assignment",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		ApprovalPolicy:      agentprofiles.ApprovalInherit,
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}
+}
+
+func resolvedProfileFromStore(profile agentprofiles.Profile, source string) resolvedAgentProfile {
+	return resolvedAgentProfile{
+		ID:                  profile.ID,
+		Name:                profile.Name,
+		Source:              source,
+		Surface:             profile.Surface,
+		ProviderHint:        profile.ProviderHint,
+		ModelHint:           profile.ModelHint,
+		ExecutionProfile:    firstNonEmptyString(profile.ExecutionProfile, profile.ID),
+		ToolsEnabled:        profile.ToolsEnabled,
+		WritesAllowed:       profile.WritesAllowed,
+		NetworkAllowed:      profile.NetworkAllowed,
+		ApprovalPolicy:      profile.ApprovalPolicy,
+		ProjectMemoryPolicy: profile.ProjectMemoryPolicy,
+		ContextSourcePolicy: profile.ContextSourcePolicy,
+		SkillIDs:            append([]string(nil), profile.SkillIDs...),
+	}
 }
 
 func formatAssignmentHints(items []assignmentHint) string {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -865,7 +865,11 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	}
 	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
 	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel))
-	profile := h.resolveProjectAssignmentProfile(ctx, role, project)
+	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	executionProfile := strings.TrimSpace(firstNonEmpty(profile.ExecutionProfile, role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
 	if profile.ProviderHint != "" && requestedProvider == "" {
 		requestedProvider = profile.ProviderHint
@@ -910,7 +914,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	task, err := h.createProjectAssignmentTask(ctx, taskID, project, workItem, assignment, role, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile)
+	task, err := h.createProjectAssignmentTask(ctx, taskID, project, workItem, assignment, role, profile, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile)
 	if err != nil {
 		assignment, updateErr := h.projectWork.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 			if item.TaskID == taskID && item.RunID == "" {
@@ -1106,14 +1110,14 @@ func selectProjectAssignmentRoot(project projects.Project) (projects.Root, bool)
 	return projects.Root{}, false
 }
 
-func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile string) (types.Task, error) {
+func (h *Handler) createProjectAssignmentTask(ctx context.Context, taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, profile resolvedAgentProfile, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile string) (types.Task, error) {
 	now := time.Now().UTC()
 	task := types.Task{
 		ID:                 taskID,
 		Title:              projectAssignmentTaskTitle(workItem, role),
 		Prompt:             projectAssignmentPrompt(project, workItem, assignment, role),
 		ProjectID:          project.ID,
-		SystemPrompt:       projectAssignmentSystemPrompt(project, role),
+		SystemPrompt:       projectAssignmentSystemPrompt(project, role, profile),
 		ExecutionKind:      "agent_loop",
 		ExecutionProfile:   executionProfile,
 		OriginKind:         "project_work_item",
@@ -1197,10 +1201,13 @@ func projectAssignmentPrompt(project projects.Project, workItem projectwork.Work
 	return strings.Join(sections, "\n\n")
 }
 
-func projectAssignmentSystemPrompt(project projects.Project, role projectwork.AgentRoleProfile) string {
+func projectAssignmentSystemPrompt(project projects.Project, role projectwork.AgentRoleProfile, profile resolvedAgentProfile) string {
 	var parts []string
 	if prompt := strings.TrimSpace(project.DefaultSystemPrompt); prompt != "" {
 		parts = append(parts, "Project system prompt:\n"+prompt)
+	}
+	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" && !profile.Missing {
+		parts = append(parts, "Agent profile instructions:\n"+instructions)
 	}
 	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
 		parts = append(parts, "Role instructions:\n"+instructions)
@@ -1219,6 +1226,7 @@ type resolvedAgentProfile struct {
 	ID                  string
 	Name                string
 	Source              string
+	Instructions        string
 	Missing             bool
 	Surface             string
 	ProviderHint        string
@@ -1234,7 +1242,7 @@ type resolvedAgentProfile struct {
 	Warnings            []string
 }
 
-func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) resolvedAgentProfile {
+func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) (resolvedAgentProfile, error) {
 	for _, candidate := range []struct {
 		id     string
 		source string
@@ -1247,8 +1255,11 @@ func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role proj
 		}
 		if h != nil && h.agentProfiles != nil {
 			profile, ok, err := h.agentProfiles.Get(ctx, candidate.id)
-			if err == nil && ok {
-				return resolvedProfileFromStore(profile, candidate.source)
+			if err != nil {
+				return resolvedAgentProfile{}, err
+			}
+			if ok {
+				return resolvedProfileFromStore(profile, candidate.source), nil
 			}
 		}
 		return resolvedAgentProfile{
@@ -1261,7 +1272,7 @@ func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role proj
 			ProjectMemoryPolicy: agentprofiles.MemoryInherit,
 			ContextSourcePolicy: agentprofiles.ContextInherit,
 			Warnings:            []string{fmt.Sprintf("Referenced agent profile %q was not found; using stored profile id as execution_profile hint.", candidate.id)},
-		}
+		}, nil
 	}
 	return resolvedAgentProfile{
 		ID:                  "project_assignment",
@@ -1274,7 +1285,7 @@ func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role proj
 		ApprovalPolicy:      agentprofiles.ApprovalInherit,
 		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
 		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
-	}
+	}, nil
 }
 
 func resolvedProfileFromStore(profile agentprofiles.Profile, source string) resolvedAgentProfile {
@@ -1282,6 +1293,7 @@ func resolvedProfileFromStore(profile agentprofiles.Profile, source string) reso
 		ID:                  profile.ID,
 		Name:                profile.Name,
 		Source:              source,
+		Instructions:        profile.Instructions,
 		Surface:             profile.Surface,
 		ProviderHint:        profile.ProviderHint,
 		ModelHint:           profile.ModelHint,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -685,6 +685,7 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
 		ID:                  "prof_role",
 		Name:                "Role profile",
+		Instructions:        "Use the profile-specific review checklist.",
 		Surface:             agentprofiles.SurfaceHecateTask,
 		ProviderHint:        "anthropic",
 		ModelHint:           "claude-sonnet-4",
@@ -737,6 +738,9 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "role_profile" {
 		t.Fatalf("task provider/model/profile = %q/%q/%q, want role profile hints", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
 	}
+	if !strings.Contains(task.SystemPrompt, "Agent profile instructions:\nUse the profile-specific review checklist.") {
+		t.Fatalf("task system prompt = %q, want profile instructions", task.SystemPrompt)
+	}
 
 	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
 	if packetResp.Data.ExecutionProfile != "role_profile" {
@@ -752,6 +756,7 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 		"Provider hint: anthropic",
 		"Model hint: claude-sonnet-4",
 		"Execution profile: role_profile",
+		"Instructions:\nUse the profile-specific review checklist.",
 		"Skills: backend, review",
 	} {
 		if !strings.Contains(profileItem.Body, want) {
@@ -798,6 +803,29 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentReturnsErrorWhenProfileStoreFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultAgentProfile = "prof_project"
+	}); err != nil {
+		t.Fatalf("Update project profile: %v", err)
+	}
+	handler.SetAgentProfileStore(failingAgentProfileStore{err: errors.New("profile store unavailable")})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("start assignment status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentKeepsExplicitModelEqualToRouterDefault(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -838,6 +866,54 @@ func TestProjectWorkAPI_StartAssignmentKeepsExplicitModelEqualToRouterDefault(t 
 	}
 	if task.RequestedModel != "qwen2.5-coder" {
 		t.Fatalf("task requested model = %q, want explicit project default", task.RequestedModel)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentKeepsExplicitRoleModelEqualToRouterDefault(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	handler.config.Router.DefaultModel = "qwen2.5-coder"
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:        "prof_role",
+		Name:      "Role profile",
+		Surface:   agentprofiles.SurfaceHecateTask,
+		ModelHint: "claude-sonnet-4",
+	}); err != nil {
+		t.Fatalf("Create role profile: %v", err)
+	}
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultModel = ""
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_role"
+		role.DefaultModel = "qwen2.5-coder"
+	}); err != nil {
+		t.Fatalf("Update role defaults: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+	}
+	if task.RequestedModel != "qwen2.5-coder" {
+		t.Fatalf("task requested model = %q, want explicit role default", task.RequestedModel)
 	}
 }
 
@@ -1423,6 +1499,32 @@ type failingCreateTaskStore struct {
 
 func (s failingCreateTaskStore) CreateTask(context.Context, types.Task) (types.Task, error) {
 	return types.Task{}, errors.New("create task failed")
+}
+
+type failingAgentProfileStore struct {
+	err error
+}
+
+func (s failingAgentProfileStore) Backend() string { return "failing" }
+
+func (s failingAgentProfileStore) Create(context.Context, agentprofiles.Profile) (agentprofiles.Profile, error) {
+	return agentprofiles.Profile{}, s.err
+}
+
+func (s failingAgentProfileStore) Get(context.Context, string) (agentprofiles.Profile, bool, error) {
+	return agentprofiles.Profile{}, false, s.err
+}
+
+func (s failingAgentProfileStore) List(context.Context) ([]agentprofiles.Profile, error) {
+	return nil, s.err
+}
+
+func (s failingAgentProfileStore) Update(context.Context, string, func(*agentprofiles.Profile)) (agentprofiles.Profile, error) {
+	return agentprofiles.Profile{}, s.err
+}
+
+func (s failingAgentProfileStore) Delete(context.Context, string) error {
+	return s.err
 }
 
 type projectWorkAssignmentStartSeed struct {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
@@ -669,6 +670,131 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	assignmentPacket := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
 	if assignmentPacket.Data.ID != assignment.Data.ContextSnapshotID {
 		t.Fatalf("assignment context id = %q, want %q", assignmentPacket.Data.ID, assignment.Data.ContextSnapshotID)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "prof_role",
+		Name:                "Role profile",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProviderHint:        "anthropic",
+		ModelHint:           "claude-sonnet-4",
+		ExecutionProfile:    "role_profile",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		NetworkAllowed:      false,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		SkillIDs:            []string{"backend", "review"},
+	}); err != nil {
+		t.Fatalf("Create role profile: %v", err)
+	}
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:               "prof_project",
+		Name:             "Project profile",
+		Surface:          agentprofiles.SurfaceHecateTask,
+		ModelHint:        "qwen2.5-coder",
+		ExecutionProfile: "project_profile",
+	}); err != nil {
+		t.Fatalf("Create project profile: %v", err)
+	}
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultAgentProfile = "prof_project"
+		project.DefaultProvider = ""
+		project.DefaultModel = ""
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_role"
+	}); err != nil {
+		t.Fatalf("Update role defaults: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+	}
+	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "role_profile" {
+		t.Fatalf("task provider/model/profile = %q/%q/%q, want role profile hints", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	if packetResp.Data.ExecutionProfile != "role_profile" {
+		t.Fatalf("packet execution_profile = %q, want role_profile", packetResp.Data.ExecutionProfile)
+	}
+	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_role")
+	if profileItem == nil || !profileItem.Included || profileItem.Section != contextSectionProfile {
+		t.Fatalf("profile item = %+v, want included profile section item", profileItem)
+	}
+	for _, want := range []string{
+		"ID: prof_role",
+		"Source: role_default",
+		"Provider hint: anthropic",
+		"Model hint: claude-sonnet-4",
+		"Execution profile: role_profile",
+		"Skills: backend, review",
+	} {
+		if !strings.Contains(profileItem.Body, want) {
+			t.Fatalf("profile body = %q, want %q", profileItem.Body, want)
+		}
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultAgentProfile = "prof_missing"
+	}); err != nil {
+		t.Fatalf("Update project profile: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_missing")
+	if profileItem == nil || profileItem.Included || profileItem.Section != contextSectionProfile {
+		t.Fatalf("profile item = %+v, want excluded missing profile item", profileItem)
+	}
+	if !strings.Contains(profileItem.Body, "profile \"prof_missing\" was not found") {
+		t.Fatalf("profile body = %q, want missing profile warning", profileItem.Body)
+	}
+	warning := findRenderedContextItemByKind(packetResp.Data, "profile_warning")
+	if warning == nil || warning.Included || !strings.Contains(warning.Body, "profile \"prof_missing\" was not found") {
+		t.Fatalf("profile warning = %+v, want excluded warning item", warning)
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -798,6 +798,49 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentKeepsExplicitModelEqualToRouterDefault(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	handler.config.Router.DefaultModel = "qwen2.5-coder"
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:        "prof_project",
+		Name:      "Project profile",
+		Surface:   agentprofiles.SurfaceHecateTask,
+		ModelHint: "claude-sonnet-4",
+	}); err != nil {
+		t.Fatalf("Create project profile: %v", err)
+	}
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultAgentProfile = "prof_project"
+		project.DefaultModel = "qwen2.5-coder"
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+	}
+	if task.RequestedModel != "qwen2.5-coder" {
+		t.Fatalf("task requested model = %q, want explicit project default", task.RequestedModel)
+	}
+}
+
 func TestProjectWorkAPI_AssignmentContextFallsBackToLinkedChatPacket(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -21,11 +21,16 @@ type projectRootRequest struct {
 }
 
 type projectContextSourceRequest struct {
-	ID      string `json:"id,omitempty"`
-	Kind    string `json:"kind,omitempty"`
-	Title   string `json:"title,omitempty"`
-	Path    string `json:"path"`
-	Enabled *bool  `json:"enabled,omitempty"`
+	ID             string            `json:"id,omitempty"`
+	Kind           string            `json:"kind,omitempty"`
+	Title          string            `json:"title,omitempty"`
+	Path           string            `json:"path"`
+	Enabled        *bool             `json:"enabled,omitempty"`
+	Format         string            `json:"format,omitempty"`
+	Scope          string            `json:"scope,omitempty"`
+	TrustLabel     string            `json:"trust_label,omitempty"`
+	SourceCategory string            `json:"source_category,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
 }
 
 type createProjectRequest struct {
@@ -391,11 +396,16 @@ func contextSourcesFromRequest(req []projectContextSourceRequest) ([]projects.Co
 			enabled = *item.Enabled
 		}
 		sources = append(sources, projects.ContextSource{
-			ID:      strings.TrimSpace(item.ID),
-			Kind:    strings.TrimSpace(item.Kind),
-			Title:   strings.TrimSpace(item.Title),
-			Path:    path,
-			Enabled: enabled,
+			ID:             strings.TrimSpace(item.ID),
+			Kind:           strings.TrimSpace(item.Kind),
+			Title:          strings.TrimSpace(item.Title),
+			Path:           path,
+			Enabled:        enabled,
+			Format:         strings.TrimSpace(item.Format),
+			Scope:          strings.TrimSpace(item.Scope),
+			TrustLabel:     strings.TrimSpace(item.TrustLabel),
+			SourceCategory: strings.TrimSpace(item.SourceCategory),
+			Metadata:       item.Metadata,
 		})
 	}
 	return sources, nil
@@ -470,13 +480,18 @@ func renderProject(project projects.Project) ProjectResponseItem {
 	contextSources := make([]ProjectContextSourceResponseItem, 0, len(project.ContextSources))
 	for _, source := range project.ContextSources {
 		contextSources = append(contextSources, ProjectContextSourceResponseItem{
-			ID:        source.ID,
-			Kind:      source.Kind,
-			Title:     source.Title,
-			Path:      source.Path,
-			Enabled:   source.Enabled,
-			CreatedAt: formatOptionalTime(source.CreatedAt),
-			UpdatedAt: formatOptionalTime(source.UpdatedAt),
+			ID:             source.ID,
+			Kind:           source.Kind,
+			Title:          source.Title,
+			Path:           source.Path,
+			Enabled:        source.Enabled,
+			Format:         source.Format,
+			Scope:          source.Scope,
+			TrustLabel:     source.TrustLabel,
+			SourceCategory: source.SourceCategory,
+			Metadata:       cloneProjectContextMetadata(source.Metadata),
+			CreatedAt:      formatOptionalTime(source.CreatedAt),
+			UpdatedAt:      formatOptionalTime(source.UpdatedAt),
 		})
 	}
 	return ProjectResponseItem{
@@ -497,6 +512,17 @@ func renderProject(project projects.Project) ProjectResponseItem {
 		UpdatedAt:                formatOptionalTime(project.UpdatedAt),
 		LastOpenedAt:             formatOptionalTime(project.LastOpenedAt),
 	}
+}
+
+func cloneProjectContextMetadata(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
 }
 
 func cloneBool(value *bool) *bool {

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -53,6 +53,12 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 	}
 	stats.ProjectWorkRowsDeleted = projectWorkRowsDeleted
 
+	agentProfilesDeleted, err := h.resetAgentProfiles(ctx)
+	if err != nil {
+		return stats, err
+	}
+	stats.AgentProfilesDeleted = agentProfilesDeleted
+
 	tasksDeleted, err := h.resetTasks(ctx)
 	if err != nil {
 		return stats, err
@@ -139,6 +145,24 @@ func (h *Handler) resetProjectWork(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return h.projectWork.Clear(ctx)
+}
+
+func (h *Handler) resetAgentProfiles(ctx context.Context) (int, error) {
+	if h.agentProfiles == nil {
+		return 0, nil
+	}
+	items, err := h.agentProfiles.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, item := range items {
+		if err := h.agentProfiles.Delete(ctx, item.ID); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
 }
 
 func (h *Handler) resetTasks(ctx context.Context) (int, error) {

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
@@ -26,6 +27,7 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	runtime := &fakeProviderRuntime{store: cpStore}
 	handler := NewHandler(config.Config{}, logger, nil, cpStore, taskstate.NewMemoryStore(), nil, runtime)
 	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
 	chatStore := chat.NewMemoryStore()
 	handler.SetAgentChatStore(chatStore)
 	runner := &fakeAgentChatRunner{}
@@ -91,6 +93,9 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if _, err := handler.taskStore.CreateTask(ctx, types.Task{ID: "task_reset", Title: "Reset me", Status: "queued"}); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
+	if _, err := handler.agentProfiles.Create(ctx, agentprofiles.Profile{ID: "prof_reset", Name: "Reset profile"}); err != nil {
+		t.Fatalf("create agent profile: %v", err)
+	}
 	if _, err := cpStore.UpsertProvider(ctx, controlplane.Provider{
 		ID:       "openai",
 		Name:     "OpenAI",
@@ -121,8 +126,8 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &reset); err != nil {
 		t.Fatalf("decode reset response: %v", err)
 	}
-	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
-		t.Fatalf("reset stats = %+v, want one project, two project-work rows, one task, provider, rule and two chats", reset.Data)
+	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.AgentProfilesDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
+		t.Fatalf("reset stats = %+v, want one project, one profile, two project-work rows, one task, provider, rule and two chats", reset.Data)
 	}
 	if len(runner.closedSessions) != 2 {
 		t.Fatalf("closed sessions = %#v, want two external chats closed", runner.closedSessions)
@@ -141,6 +146,13 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	}
 	if len(projectList) != 0 {
 		t.Fatalf("projects after reset = %#v, want none", projectList)
+	}
+	profiles, err := handler.agentProfiles.List(ctx)
+	if err != nil {
+		t.Fatalf("list agent profiles: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Fatalf("agent profiles after reset = %#v, want none", profiles)
 	}
 	workItems, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID)
 	if err != nil {
@@ -223,6 +235,10 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(projectwork): %v", err)
 	}
+	agentProfileStore, err := agentprofiles.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(agentprofiles): %v", err)
+	}
 	taskStore, err := taskstate.NewSQLiteStore(ctx, client)
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(taskstate): %v", err)
@@ -241,6 +257,7 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	handler.SetProjectStore(projectStore)
 	handler.SetMemoryStore(memoryStore)
 	handler.SetProjectWorkStore(projectWorkStore)
+	handler.SetAgentProfileStore(agentProfileStore)
 	handler.SetStateCleaner(client)
 	runner := &fakeAgentChatRunner{}
 	handler.SetAgentChatRunner(runner)
@@ -281,6 +298,9 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if _, err := taskStore.CreateTask(ctx, types.Task{ID: "task_sqlite_reset", Title: "SQLite task", Status: "queued"}); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
+	if _, err := agentProfileStore.Create(ctx, agentprofiles.Profile{ID: "prof_sqlite_reset", Name: "SQLite profile"}); err != nil {
+		t.Fatalf("create agent profile: %v", err)
+	}
 	if _, err := cpStore.UpsertProvider(ctx, controlplane.Provider{
 		ID:       "openai",
 		Name:     "OpenAI",
@@ -309,10 +329,14 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if reset.Data.ProjectWorkRowsDeleted != 1 {
 		t.Fatalf("project work rows deleted = %d, want 1", reset.Data.ProjectWorkRowsDeleted)
 	}
+	if reset.Data.AgentProfilesDeleted != 1 {
+		t.Fatalf("agent profiles deleted = %d, want 1", reset.Data.AgentProfilesDeleted)
+	}
 	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_sqlite_external" {
 		t.Fatalf("closed sessions = %#v, want sqlite external chat closed", runner.closedSessions)
 	}
 	assertSQLiteTableCount(t, client, client.QualifiedTable("memory_entries"), 0)
+	assertSQLiteTableCount(t, client, client.QualifiedTable("agent_profiles"), 0)
 	assertSQLiteTableCount(t, client, client.QualifiedTable("reset_scratch"), 0)
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -261,6 +261,77 @@ type ProjectResponse struct {
 	Data   ProjectResponseItem `json:"data"`
 }
 
+type AgentProfileResponse struct {
+	Object string                   `json:"object"`
+	Data   AgentProfileResponseItem `json:"data"`
+}
+
+type AgentProfilesResponse struct {
+	Object string                     `json:"object"`
+	Data   []AgentProfileResponseItem `json:"data"`
+}
+
+type AgentProfileResponseItem struct {
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description,omitempty"`
+	Instructions         string            `json:"instructions,omitempty"`
+	Surface              string            `json:"surface"`
+	ProviderHint         string            `json:"provider_hint,omitempty"`
+	ModelHint            string            `json:"model_hint,omitempty"`
+	ExecutionProfile     string            `json:"execution_profile,omitempty"`
+	ToolsEnabled         bool              `json:"tools_enabled"`
+	WritesAllowed        bool              `json:"writes_allowed"`
+	NetworkAllowed       bool              `json:"network_allowed"`
+	ApprovalPolicy       string            `json:"approval_policy"`
+	ProjectMemoryPolicy  string            `json:"project_memory_policy"`
+	ContextSourcePolicy  string            `json:"context_source_policy"`
+	SkillIDs             []string          `json:"skill_ids,omitempty"`
+	ExternalAgentKind    string            `json:"external_agent_kind,omitempty"`
+	ExternalAgentOptions map[string]string `json:"external_agent_options,omitempty"`
+	CreatedAt            string            `json:"created_at,omitempty"`
+	UpdatedAt            string            `json:"updated_at,omitempty"`
+}
+
+type CreateAgentProfileRequest struct {
+	ID                   string            `json:"id,omitempty"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description,omitempty"`
+	Instructions         string            `json:"instructions,omitempty"`
+	Surface              string            `json:"surface,omitempty"`
+	ProviderHint         string            `json:"provider_hint,omitempty"`
+	ModelHint            string            `json:"model_hint,omitempty"`
+	ExecutionProfile     string            `json:"execution_profile,omitempty"`
+	ToolsEnabled         bool              `json:"tools_enabled,omitempty"`
+	WritesAllowed        bool              `json:"writes_allowed,omitempty"`
+	NetworkAllowed       bool              `json:"network_allowed,omitempty"`
+	ApprovalPolicy       string            `json:"approval_policy,omitempty"`
+	ProjectMemoryPolicy  string            `json:"project_memory_policy,omitempty"`
+	ContextSourcePolicy  string            `json:"context_source_policy,omitempty"`
+	SkillIDs             []string          `json:"skill_ids,omitempty"`
+	ExternalAgentKind    string            `json:"external_agent_kind,omitempty"`
+	ExternalAgentOptions map[string]string `json:"external_agent_options,omitempty"`
+}
+
+type UpdateAgentProfileRequest struct {
+	Name                 *string           `json:"name,omitempty"`
+	Description          *string           `json:"description,omitempty"`
+	Instructions         *string           `json:"instructions,omitempty"`
+	Surface              *string           `json:"surface,omitempty"`
+	ProviderHint         *string           `json:"provider_hint,omitempty"`
+	ModelHint            *string           `json:"model_hint,omitempty"`
+	ExecutionProfile     *string           `json:"execution_profile,omitempty"`
+	ToolsEnabled         *bool             `json:"tools_enabled,omitempty"`
+	WritesAllowed        *bool             `json:"writes_allowed,omitempty"`
+	NetworkAllowed       *bool             `json:"network_allowed,omitempty"`
+	ApprovalPolicy       *string           `json:"approval_policy,omitempty"`
+	ProjectMemoryPolicy  *string           `json:"project_memory_policy,omitempty"`
+	ContextSourcePolicy  *string           `json:"context_source_policy,omitempty"`
+	SkillIDs             []string          `json:"skill_ids,omitempty"`
+	ExternalAgentKind    *string           `json:"external_agent_kind,omitempty"`
+	ExternalAgentOptions map[string]string `json:"external_agent_options,omitempty"`
+}
+
 type ProjectResponseItem struct {
 	ID                       string                             `json:"id"`
 	Name                     string                             `json:"name"`
@@ -292,13 +363,18 @@ type ProjectRootResponseItem struct {
 }
 
 type ProjectContextSourceResponseItem struct {
-	ID        string `json:"id"`
-	Kind      string `json:"kind"`
-	Title     string `json:"title,omitempty"`
-	Path      string `json:"path"`
-	Enabled   bool   `json:"enabled"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID             string            `json:"id"`
+	Kind           string            `json:"kind"`
+	Title          string            `json:"title,omitempty"`
+	Path           string            `json:"path"`
+	Enabled        bool              `json:"enabled"`
+	Format         string            `json:"format,omitempty"`
+	Scope          string            `json:"scope,omitempty"`
+	TrustLabel     string            `json:"trust_label,omitempty"`
+	SourceCategory string            `json:"source_category,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at"`
 }
 
 type ProjectMemoryResponse struct {
@@ -1087,6 +1163,7 @@ type SystemResetDataResponse struct {
 type SystemResetDataResponseItem struct {
 	ProjectsDeleted            int `json:"projects_deleted"`
 	ProjectWorkRowsDeleted     int `json:"project_work_rows_deleted"`
+	AgentProfilesDeleted       int `json:"agent_profiles_deleted"`
 	ChatSessionsDeleted        int `json:"chat_sessions_deleted"`
 	TasksDeleted               int `json:"tasks_deleted"`
 	ProvidersDeleted           int `json:"providers_deleted"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/context-sources/discover", handler.HandleDiscoverProjectContextSources)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/memory", handler.HandleProjectMemoryEntries)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/memory", handler.HandleCreateProjectMemoryEntry)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/memory/candidates", handler.HandleProjectMemoryCandidates)
@@ -110,6 +111,11 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	// External-agent adapters and agent-chat sessions are Hecate-native state:
 	// approvals, grants, launcher refresh, diffs, and session streams.
+	mux.HandleFunc("GET /hecate/v1/agent-profiles", handler.HandleAgentProfiles)
+	mux.HandleFunc("POST /hecate/v1/agent-profiles", handler.HandleCreateAgentProfile)
+	mux.HandleFunc("GET /hecate/v1/agent-profiles/{id}", handler.HandleAgentProfile)
+	mux.HandleFunc("PATCH /hecate/v1/agent-profiles/{id}", handler.HandleUpdateAgentProfile)
+	mux.HandleFunc("DELETE /hecate/v1/agent-profiles/{id}", handler.HandleDeleteAgentProfile)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters", handler.HandleAgentAdapters)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/probe", handler.HandleAgentAdapterProbe)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/refresh-launcher", handler.HandleAgentAdapterRefreshLauncher)

--- a/internal/projects/sqlite.go
+++ b/internal/projects/sqlite.go
@@ -84,12 +84,31 @@ CREATE TABLE IF NOT EXISTS %s (
 	title TEXT NOT NULL DEFAULT '',
 	path TEXT NOT NULL,
 	enabled INTEGER NOT NULL DEFAULT 1,
+	format TEXT NOT NULL DEFAULT '',
+	scope TEXT NOT NULL DEFAULT '',
+	trust_label TEXT NOT NULL DEFAULT '',
+	source_category TEXT NOT NULL DEFAULT '',
+	metadata TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY(project_id, id),
 	FOREIGN KEY(project_id) REFERENCES %s(id) ON DELETE CASCADE
 )`, s.sourcesTbl, s.projectsTbl)); err != nil {
 		return fmt.Errorf("create project context sources table: %w", err)
+	}
+	for _, column := range []struct {
+		name string
+		ddl  string
+	}{
+		{"format", "TEXT NOT NULL DEFAULT ''"},
+		{"scope", "TEXT NOT NULL DEFAULT ''"},
+		{"trust_label", "TEXT NOT NULL DEFAULT ''"},
+		{"source_category", "TEXT NOT NULL DEFAULT ''"},
+		{"metadata", "TEXT NOT NULL DEFAULT '{}'"},
+	} {
+		if err := s.addColumnIfMissing(ctx, s.sourcesTbl, column.name, column.ddl); err != nil {
+			return fmt.Errorf("migrate project context source column %s: %w", column.name, err)
+		}
 	}
 	rootsProjectIndex := strings.Trim(s.rootsTbl, `"`) + "_project_idx"
 	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (project_id)`, rootsProjectIndex, s.rootsTbl)); err != nil {
@@ -100,6 +119,32 @@ CREATE TABLE IF NOT EXISTS %s (
 		return fmt.Errorf("create project context sources project index: %w", err)
 	}
 	return nil
+}
+
+func (s *SQLiteStore) addColumnIfMissing(ctx context.Context, table, column, ddl string) error {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if name == column {
+			return rows.Err()
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, ddl))
+	return err
 }
 
 func (s *SQLiteStore) Create(ctx context.Context, project Project) (Project, error) {
@@ -381,13 +426,19 @@ func (s *SQLiteStore) upsertProjectContextSources(ctx context.Context, tx *sql.T
 	for _, source := range project.ContextSources {
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, kind, title, path, enabled, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	id, project_id, kind, title, path, enabled, format, scope, trust_label,
+	source_category, metadata, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(project_id, id) DO UPDATE SET
 	kind = excluded.kind,
 	title = excluded.title,
 	path = excluded.path,
 	enabled = excluded.enabled,
+	format = excluded.format,
+	scope = excluded.scope,
+	trust_label = excluded.trust_label,
+	source_category = excluded.source_category,
+	metadata = excluded.metadata,
 	updated_at = excluded.updated_at`, s.sourcesTbl),
 			source.ID,
 			project.ID,
@@ -395,6 +446,11 @@ ON CONFLICT(project_id, id) DO UPDATE SET
 			source.Title,
 			source.Path,
 			boolToDB(source.Enabled),
+			source.Format,
+			source.Scope,
+			source.TrustLabel,
+			source.SourceCategory,
+			encodeContextMetadata(source.Metadata),
 			formatTime(source.CreatedAt),
 			formatTime(source.UpdatedAt),
 		); err != nil {
@@ -519,7 +575,7 @@ ORDER BY active DESC, path ASC, id ASC`, s.rootsTbl), projectID)
 
 func (s *SQLiteStore) loadContextSourcesWith(ctx context.Context, q sqliteQuerier, projectID string) ([]ContextSource, error) {
 	rows, err := q.QueryContext(ctx, fmt.Sprintf(`
-SELECT id, kind, title, path, enabled, created_at, updated_at
+SELECT id, kind, title, path, enabled, format, scope, trust_label, source_category, metadata, created_at, updated_at
 FROM %s
 WHERE project_id = ?
 ORDER BY enabled DESC, path ASC, id ASC`, s.sourcesTbl), projectID)
@@ -531,6 +587,7 @@ ORDER BY enabled DESC, path ASC, id ASC`, s.sourcesTbl), projectID)
 	for rows.Next() {
 		var source ContextSource
 		var enabled int
+		var metadataRaw string
 		var createdAt, updatedAt string
 		if err := rows.Scan(
 			&source.ID,
@@ -538,12 +595,18 @@ ORDER BY enabled DESC, path ASC, id ASC`, s.sourcesTbl), projectID)
 			&source.Title,
 			&source.Path,
 			&enabled,
+			&source.Format,
+			&source.Scope,
+			&source.TrustLabel,
+			&source.SourceCategory,
+			&metadataRaw,
 			&createdAt,
 			&updatedAt,
 		); err != nil {
 			return nil, err
 		}
 		source.Enabled = enabled != 0
+		source.Metadata = decodeContextMetadata(metadataRaw)
 		var err error
 		if source.CreatedAt, err = parseTime(createdAt); err != nil {
 			return nil, err

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -2,6 +2,7 @@ package projects
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -46,13 +47,18 @@ type Root struct {
 }
 
 type ContextSource struct {
-	ID        string
-	Kind      string
-	Title     string
-	Path      string
-	Enabled   bool
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID             string
+	Kind           string
+	Title          string
+	Path           string
+	Enabled        bool
+	Format         string
+	Scope          string
+	TrustLabel     string
+	SourceCategory string
+	Metadata       map[string]string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 type Store interface {
@@ -213,6 +219,11 @@ func normalizeContextSource(source ContextSource, now time.Time) ContextSource {
 	source.Kind = strings.TrimSpace(source.Kind)
 	source.Title = strings.TrimSpace(source.Title)
 	source.Path = strings.TrimSpace(source.Path)
+	source.Format = strings.TrimSpace(source.Format)
+	source.Scope = strings.TrimSpace(source.Scope)
+	source.TrustLabel = strings.TrimSpace(source.TrustLabel)
+	source.SourceCategory = strings.TrimSpace(source.SourceCategory)
+	source.Metadata = normalizeStringMap(source.Metadata)
 	if source.Kind == "" {
 		source.Kind = "doc"
 	}
@@ -318,6 +329,11 @@ func contextSourceMetadataEqual(next, previous ContextSource) bool {
 		strings.TrimSpace(next.Path) == strings.TrimSpace(previous.Path) &&
 		normalizeContextSourceKind(next.Kind) == normalizeContextSourceKind(previous.Kind) &&
 		strings.TrimSpace(next.Title) == strings.TrimSpace(previous.Title) &&
+		strings.TrimSpace(next.Format) == strings.TrimSpace(previous.Format) &&
+		strings.TrimSpace(next.Scope) == strings.TrimSpace(previous.Scope) &&
+		strings.TrimSpace(next.TrustLabel) == strings.TrimSpace(previous.TrustLabel) &&
+		strings.TrimSpace(next.SourceCategory) == strings.TrimSpace(previous.SourceCategory) &&
+		stringMapsEqual(next.Metadata, previous.Metadata) &&
 		next.Enabled == previous.Enabled
 }
 
@@ -394,6 +410,9 @@ func hasRootID(roots []Root, id string) bool {
 func cloneProject(project Project) Project {
 	project.Roots = append([]Root(nil), project.Roots...)
 	project.ContextSources = append([]ContextSource(nil), project.ContextSources...)
+	for idx := range project.ContextSources {
+		project.ContextSources[idx].Metadata = cloneStringMap(project.ContextSources[idx].Metadata)
+	}
 	project.DefaultToolsEnabled = cloneBoolPtr(project.DefaultToolsEnabled)
 	project.DefaultCompactToolOutput = cloneBoolPtr(project.DefaultCompactToolOutput)
 	return project
@@ -405,6 +424,70 @@ func cloneBoolPtr(value *bool) *bool {
 	}
 	copied := *value
 	return &copied
+}
+
+func normalizeStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
+}
+
+func stringMapsEqual(left, right map[string]string) bool {
+	left = normalizeStringMap(left)
+	right = normalizeStringMap(right)
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftValue := range left {
+		if right[key] != leftValue {
+			return false
+		}
+	}
+	return true
+}
+
+func encodeContextMetadata(metadata map[string]string) string {
+	metadata = normalizeStringMap(metadata)
+	if len(metadata) == 0 {
+		return "{}"
+	}
+	raw, err := json.Marshal(metadata)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func decodeContextMetadata(raw string) map[string]string {
+	var out map[string]string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return normalizeStringMap(out)
 }
 
 func sortProjects(items []Project) {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2804,6 +2804,68 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("preserves inherited project model defaults when saving settings", async () => {
+    resetProjectWorkMocks();
+    const projectWithInheritedModel = {
+      ...project,
+      default_provider: "ollama",
+      default_model: undefined,
+    };
+    window.localStorage.setItem("hecate.project", projectWithInheritedModel.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [projectWithInheritedModel],
+      activeProjectID: projectWithInheritedModel.id,
+      settingsConfig: {
+        backend: "memory",
+        providers: [
+          {
+            id: "ollama",
+            name: "Ollama",
+            kind: "local",
+            protocol: "openai",
+            base_url: "http://127.0.0.1:11434/v1",
+            credential_configured: false,
+          },
+        ],
+        policy_rules: [],
+        events: [],
+      },
+      providerPresets: [
+        {
+          id: "ollama",
+          name: "Ollama",
+          kind: "local",
+          protocol: "openai",
+          base_url: "http://127.0.0.1:11434/v1",
+        },
+      ],
+      models: [
+        {
+          id: "qwen2.5-coder",
+          owned_by: "ollama",
+          metadata: { provider: "ollama", provider_kind: "local", default: true },
+        },
+      ],
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Project settings" }));
+    expect(
+      screen.getByRole("button", { name: /Model picker: inherit runtime default/i }),
+    ).toBeTruthy();
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "Workspace mode" }), [
+      "ephemeral",
+    ]);
+    await userEvent.click(screen.getByRole("button", { name: "Save defaults" }));
+
+    expect(updateProject).toHaveBeenCalledWith(projectWithInheritedModel.id, {
+      default_provider: "ollama",
+      default_model: "",
+      default_agent_profile: "",
+      default_workspace_mode: "ephemeral",
+    });
+  });
+
   it("starts native Hecate assignments and refreshes detail state", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -17,7 +17,9 @@ import {
   deleteProjectMemory,
   deleteProjectWorkRole,
   deleteProjectWorkItem,
+  discoverProjectContextSources,
   getProjectActivity,
+  getAgentProfiles,
   getProjectAssignmentContext,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
@@ -115,6 +117,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
       object: "project_memory_candidates",
       data: [],
     })),
+    getAgentProfiles: vi.fn(async () => ({ object: "agent_profiles", data: [] })),
     createProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
     updateProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
     updateProjectHandoffStatus: vi.fn(async () => ({ object: "project_handoff", data: null })),
@@ -141,6 +144,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
     updateProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
     deleteProjectAssignment: vi.fn(async () => undefined),
     updateProject: vi.fn(async () => ({ object: "project", data: null })),
+    discoverProjectContextSources: vi.fn(async () => ({ object: "project", data: null })),
   };
 });
 
@@ -352,6 +356,32 @@ function resetProjectWorkMocks() {
     object: "project_memory_candidates",
     data: [],
   });
+  vi.mocked(getAgentProfiles).mockResolvedValue({
+    object: "agent_profiles",
+    data: [
+      {
+        id: "implementation",
+        name: "Implementation",
+        description: "Build project assignments",
+        instructions: "",
+        surface: "hecate_task",
+        provider_hint: "",
+        model_hint: "",
+        execution_profile: "implementation",
+        tools_enabled: true,
+        writes_allowed: true,
+        network_allowed: false,
+        approval_policy: "inherit",
+        project_memory_policy: "visible_only",
+        context_source_policy: "include_enabled",
+        skill_ids: [],
+        external_agent_kind: "",
+        external_agent_options: {},
+        created_at: "2026-06-04T10:00:00Z",
+        updated_at: "2026-06-04T10:00:00Z",
+      },
+    ],
+  });
   vi.mocked(createProjectHandoff).mockResolvedValue({
     object: "project_handoff",
     data: {
@@ -476,6 +506,10 @@ function resetProjectWorkMocks() {
       default_workspace_mode: "in_place",
     },
   });
+  vi.mocked(discoverProjectContextSources).mockResolvedValue({
+    object: "project",
+    data: project,
+  });
 }
 
 function directWrapper(initialState: Parameters<typeof ProjectsProvider>[0]["initialState"]) {
@@ -514,6 +548,7 @@ afterEach(() => {
   vi.mocked(getProjectHandoffs).mockReset();
   vi.mocked(getProjectMemory).mockReset();
   vi.mocked(getProjectMemoryCandidates).mockReset();
+  vi.mocked(getAgentProfiles).mockReset();
   vi.mocked(createProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoffStatus).mockReset();
@@ -534,6 +569,7 @@ afterEach(() => {
   vi.mocked(updateProjectAssignment).mockReset();
   vi.mocked(deleteProjectAssignment).mockReset();
   vi.mocked(updateProject).mockReset();
+  vi.mocked(discoverProjectContextSources).mockReset();
 });
 
 describe("ProjectsView index", () => {
@@ -791,6 +827,47 @@ describe("ProjectsView cockpit", () => {
     await user.click(screen.getByRole("button", { name: "Delete memory Commit style" }));
     await user.click(screen.getByRole("button", { name: "Delete memory" }));
     expect(deleteProjectMemory).toHaveBeenCalledWith(project.id, memoryEntry.id);
+  });
+
+  it("discovers workspace guidance sources from the memory context panel", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(discoverProjectContextSources).mockResolvedValue({
+      object: "project",
+      data: {
+        ...project,
+        context_sources: [
+          {
+            id: "ctx_agents",
+            kind: "workspace_instruction",
+            title: "AGENTS.md",
+            path: "AGENTS.md",
+            enabled: true,
+            format: "agents_md",
+            scope: "workspace",
+            trust_label: "workspace_guidance",
+            source_category: "workspace_guidance",
+            metadata: { host: "portable" },
+            created_at: "2026-06-08T10:00:00Z",
+            updated_at: "2026-06-08T10:00:00Z",
+          },
+        ],
+      },
+    });
+    const user = userEvent.setup();
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await openProjectWorkspaceTab(/Memory \/ Context/);
+    await user.click(screen.getByRole("button", { name: "Discover" }));
+
+    expect(discoverProjectContextSources).toHaveBeenCalledWith(project.id);
+    expect((await screen.findAllByText("AGENTS.md")).length).toBeGreaterThan(0);
+    expect(screen.getByText("workspace_instruction")).toBeTruthy();
+    expect(screen.getByText("agents_md")).toBeTruthy();
+    expect(screen.getAllByText("workspace").length).toBeGreaterThan(0);
   });
 
   it("reviews project memory candidates before promotion", async () => {
@@ -2722,6 +2799,7 @@ describe("ProjectsView cockpit", () => {
     expect(updateProject).toHaveBeenCalledWith(projectWithUpdatedDefaults.id, {
       default_provider: "ollama",
       default_model: "qwen2.5-coder",
+      default_agent_profile: "",
       default_workspace_mode: "ephemeral",
     });
   });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -14,6 +14,7 @@ import {
   ApiError,
   createProjectAssignment,
   createProjectHandoff,
+  discoverProjectContextSources,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
@@ -23,6 +24,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
+  getAgentProfiles,
   getProjectAssignmentContext,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
@@ -66,6 +68,7 @@ import type {
   ProjectActivityItemRecord,
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
+  ProjectContextSourceRecord,
   CreateProjectHandoffPayload,
   ProjectHandoffRecord,
   ProjectMemoryRecord,
@@ -76,6 +79,7 @@ import type {
   UpdateProjectPayload,
   UpdateProjectWorkItemPayload,
 } from "../../types/project";
+import type { AgentProfileRecord } from "../../types/agent-profile";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderPresetRecord } from "../../types/provider";
 import type { ContextPacketRecord } from "../../types/context";
@@ -166,6 +170,7 @@ type HandoffForm = {
 type ProjectDefaultsForm = {
   provider: string;
   model: string;
+  defaultAgentProfile: string;
   workspaceMode: string;
 };
 
@@ -334,6 +339,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   }
   const [memoryEntries, setMemoryEntries] = useState<ProjectMemoryRecord[]>([]);
   const [memoryCandidates, setMemoryCandidates] = useState<ProjectMemoryCandidateRecord[]>([]);
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfileRecord[]>([]);
+  const [agentProfilesError, setAgentProfilesError] = useState("");
+  const [discoveringContext, setDiscoveringContext] = useState(false);
   const [memoryLoadState, setMemoryLoadState] = useState<LoadState>("idle");
   const [memoryError, setMemoryError] = useState("");
   const [editingMemory, setEditingMemory] = useState<ProjectMemoryRecord | "new" | null>(null);
@@ -349,6 +357,22 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     () => projects.state.projects.find((project) => project.id === selectedProjectID) ?? null,
     [projects.state.projects, selectedProjectID],
   );
+  useEffect(() => {
+    let cancelled = false;
+    getAgentProfiles()
+      .then((payload) => {
+        if (cancelled) return;
+        setAgentProfiles(payload.data ?? []);
+        setAgentProfilesError("");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setAgentProfilesError(errorMessage(error, "Failed to load agent profiles."));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const pendingDeleteProject =
     projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
   const roleByID = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
@@ -594,6 +618,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     const patch: UpdateProjectPayload = {
       default_provider: form.provider.trim(),
       default_model: form.model.trim(),
+      default_agent_profile: form.defaultAgentProfile.trim(),
       default_workspace_mode: form.workspaceMode.trim(),
     };
     try {
@@ -604,6 +629,20 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setDefaultsError(errorMessage(error, "Failed to update project defaults."));
     } finally {
       setDefaultsPending(false);
+    }
+  }
+
+  async function handleDiscoverContextSources() {
+    if (!selectedProjectID) return;
+    setDiscoveringContext(true);
+    setMemoryError("");
+    try {
+      const payload = await discoverProjectContextSources(selectedProjectID);
+      projects.actions.setProjects((current) => upsertProject(current, payload.data));
+    } catch (error) {
+      setMemoryError(errorMessage(error, "Failed to discover workspace guidance."));
+    } finally {
+      setDiscoveringContext(false);
     }
   }
 
@@ -1272,9 +1311,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                 {workspaceTab === "memory" && (
                   <ProjectMemoryPanel
                     candidates={memoryCandidates}
+                    discoveringContext={discoveringContext}
                     entries={memoryEntries}
                     error={memoryError}
                     loading={memoryLoadState === "loading"}
+                    onDiscoverContextSources={handleDiscoverContextSources}
                     onPromoteCandidate={setPromotingCandidate}
                     onRejectCandidate={handleRejectCandidate}
                     onDelete={setDeleteMemory}
@@ -1296,6 +1337,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
               onWidthChange={updateRightPanelWidth}
             >
               <ProjectSettingsPanel
+                agentProfiles={agentProfiles}
+                agentProfilesError={agentProfilesError}
                 error={defaultsError}
                 models={providersAndModels.state.models}
                 pending={defaultsPending}
@@ -1310,6 +1353,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
 
         {selectedProject && rolesModalOpen && (
           <RolesModal
+            agentProfiles={agentProfiles}
             error={rolesError}
             pending={rolesPending}
             roles={roles}
@@ -2421,9 +2465,11 @@ function ProjectDecisionRow({
 
 function ProjectMemoryPanel({
   candidates,
+  discoveringContext,
   entries,
   error,
   loading,
+  onDiscoverContextSources,
   onPromoteCandidate,
   onRejectCandidate,
   onDelete,
@@ -2434,9 +2480,11 @@ function ProjectMemoryPanel({
   rejectingCandidateID,
 }: {
   candidates: ProjectMemoryCandidateRecord[];
+  discoveringContext: boolean;
   entries: ProjectMemoryRecord[];
   error: string;
   loading: boolean;
+  onDiscoverContextSources: () => void;
   onPromoteCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
   onRejectCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
   onDelete: (entry: ProjectMemoryRecord) => void;
@@ -2449,6 +2497,7 @@ function ProjectMemoryPanel({
   if (!project) return null;
   const enabledCount = entries.filter((entry) => entry.enabled).length;
   const pendingCount = candidates.filter((candidate) => candidate.status === "pending").length;
+  const contextSources = project.context_sources ?? [];
   return (
     <div>
       <div style={panelStyle}>
@@ -2471,6 +2520,15 @@ function ProjectMemoryPanel({
           >
             <Icon d={Icons.refresh} size={12} />
           </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            disabled={discoveringContext}
+            onClick={onDiscoverContextSources}
+          >
+            <Icon d={Icons.search} size={12} />
+            {discoveringContext ? "Discovering…" : "Discover"}
+          </button>
           <button className="btn btn-primary btn-sm" type="button" onClick={onNew}>
             <Icon d={Icons.plus} size={12} />
             Memory
@@ -2481,6 +2539,14 @@ function ProjectMemoryPanel({
             <InlineError message={error} />
           </div>
         )}
+        <div style={{ display: "grid", gap: 8, marginBottom: 12 }}>
+          <div style={sectionLabelStyle}>Workspace guidance</div>
+          {contextSources.length === 0 ? (
+            <div style={subtleTextStyle}>No context sources discovered or configured yet.</div>
+          ) : (
+            contextSources.map((source) => <ProjectContextSourceRow key={source.id} source={source} />)
+          )}
+        </div>
         {candidates.length > 0 && (
           <div style={{ display: "grid", gap: 8, marginBottom: 12 }}>
             <div style={sectionLabelStyle}>Candidates</div>
@@ -2509,6 +2575,33 @@ function ProjectMemoryPanel({
             ))}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectContextSourceRow({ source }: { source: ProjectContextSourceRecord }) {
+  const host = source.metadata?.host;
+  return (
+    <div style={memoryEntryStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <span
+          className={
+            source.kind === "workspace_instruction" ? "badge badge-green" : "badge badge-muted"
+          }
+        >
+          {source.kind}
+        </span>
+        <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{source.title || source.path}</div>
+        <span className={source.enabled ? "badge badge-muted" : "badge badge-amber"}>
+          {source.enabled ? "enabled" : "disabled"}
+        </span>
+      </div>
+      <div style={metaLineStyle}>
+        <span>{source.path}</span>
+        {source.format && <span>{source.format}</span>}
+        {source.scope && <span>{source.scope}</span>}
+        {host && <span>{host}</span>}
       </div>
     </div>
   );
@@ -3007,6 +3100,8 @@ function WorkItemDetail({
 }
 
 function ProjectSettingsPanel({
+  agentProfiles,
+  agentProfilesError,
   error,
   models,
   pending,
@@ -3015,6 +3110,8 @@ function ProjectSettingsPanel({
   project,
   onSave,
 }: {
+  agentProfiles: AgentProfileRecord[];
+  agentProfilesError: string;
   error: string;
   models: ModelRecord[];
   pending: boolean;
@@ -3026,6 +3123,7 @@ function ProjectSettingsPanel({
   const [form, setForm] = useState<ProjectDefaultsForm>({
     provider: project.default_provider ?? "",
     model: project.default_model ?? "",
+    defaultAgentProfile: project.default_agent_profile ?? "",
     workspaceMode: project.default_workspace_mode || "in_place",
   });
   const scopedModels = useMemo(() => {
@@ -3036,6 +3134,10 @@ function ProjectSettingsPanel({
     if (form.model) return form.model;
     return defaultModelID(scopedModels);
   }, [form.model, scopedModels]);
+  const selectedProfile = useMemo(
+    () => agentProfiles.find((profile) => profile.id === form.defaultAgentProfile) ?? null,
+    [agentProfiles, form.defaultAgentProfile],
+  );
 
   function handleProviderChange(provider: string) {
     setForm((current) => {
@@ -3104,6 +3206,7 @@ function ProjectSettingsPanel({
           style={{ display: "grid", gap: 14 }}
         >
           {error && <InlineError message={error} />}
+          {agentProfilesError && <InlineError message={agentProfilesError} />}
           <ProjectSettingsSection title="Assignment defaults">
             <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
               Native Hecate assignments copy these defaults when creating the backing task.
@@ -3128,6 +3231,29 @@ function ProjectSettingsPanel({
                     showProvider={!form.provider}
                   />
                 </div>
+              </div>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Agent profile</span>
+                <select
+                  aria-label="Default agent profile"
+                  className="input"
+                  value={form.defaultAgentProfile}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      defaultAgentProfile: event.target.value,
+                    }))
+                  }
+                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+                >
+                  <option value="">built-in project_assignment</option>
+                  {agentProfiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name || profile.id} ({profile.id})
+                    </option>
+                  ))}
+                </select>
+                <ProfilePosturePreview profile={selectedProfile} />
               </div>
               <div style={fieldStyle}>
                 <span style={fieldLabelStyle}>Workspace mode</span>
@@ -3222,12 +3348,41 @@ function ProjectSettingsSection({ title, children }: { title: string; children: 
   );
 }
 
+function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null }) {
+  if (!profile) {
+    return (
+      <div style={{ ...subtleTextStyle, marginTop: 4 }}>
+        Uses the built-in project_assignment posture until a saved profile is selected.
+      </div>
+    );
+  }
+  const details = [
+    profile.surface,
+    profile.execution_profile ? `profile ${profile.execution_profile}` : "",
+    profile.provider_hint || profile.model_hint
+      ? `hints ${[profile.provider_hint, profile.model_hint].filter(Boolean).join("/")}`
+      : "",
+    `tools ${profile.tools_enabled ? "on" : "off"}`,
+    `writes ${profile.writes_allowed ? "on" : "off"}`,
+    `network ${profile.network_allowed ? "on" : "off"}`,
+    `approval ${profile.approval_policy}`,
+    `memory ${profile.project_memory_policy}`,
+    `sources ${profile.context_source_policy}`,
+  ].filter(Boolean);
+  return (
+    <div style={{ ...subtleTextStyle, marginTop: 4 }}>
+      {details.join(" · ")}
+    </div>
+  );
+}
+
 function normalizeWorkspaceMode(value: string) {
   if (value === "persistent" || value === "ephemeral") return value;
   return "in_place";
 }
 
 function RolesModal({
+  agentProfiles,
   error,
   pending,
   roles,
@@ -3236,6 +3391,7 @@ function RolesModal({
   onDelete,
   onUpdate,
 }: {
+  agentProfiles: AgentProfileRecord[];
   error: string;
   pending: boolean;
   roles: ProjectWorkRoleRecord[];
@@ -3428,18 +3584,24 @@ function RolesModal({
             </label>
             <label style={fieldStyle}>
               <span style={fieldLabelStyle}>Default profile</span>
-              <input
+              <select
                 className="input"
                 value={form.defaultAgentProfile}
                 disabled={editingBuiltIn}
-                placeholder="implementation"
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
                     defaultAgentProfile: event.target.value,
                   }))
                 }
-              />
+              >
+                <option value="">inherit project default</option>
+                {agentProfiles.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.name || profile.id} ({profile.id})
+                  </option>
+                ))}
+              </select>
             </label>
             <label style={fieldStyle}>
               <span style={fieldLabelStyle}>Default provider</span>

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -2544,7 +2544,9 @@ function ProjectMemoryPanel({
           {contextSources.length === 0 ? (
             <div style={subtleTextStyle}>No context sources discovered or configured yet.</div>
           ) : (
-            contextSources.map((source) => <ProjectContextSourceRow key={source.id} source={source} />)
+            contextSources.map((source) => (
+              <ProjectContextSourceRow key={source.id} source={source} />
+            ))
           )}
         </div>
         {candidates.length > 0 && (
@@ -3369,11 +3371,7 @@ function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null
     `memory ${profile.project_memory_policy}`,
     `sources ${profile.context_source_policy}`,
   ].filter(Boolean);
-  return (
-    <div style={{ ...subtleTextStyle, marginTop: 4 }}>
-      {details.join(" · ")}
-    </div>
-  );
+  return <div style={{ ...subtleTextStyle, marginTop: 4 }}>{details.join(" · ")}</div>;
 }
 
 function normalizeWorkspaceMode(value: string) {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -3132,10 +3132,6 @@ function ProjectSettingsPanel({
     if (!form.provider) return models;
     return models.filter((model) => model.metadata?.provider === form.provider);
   }, [form.provider, models]);
-  const selectedModel = useMemo(() => {
-    if (form.model) return form.model;
-    return defaultModelID(scopedModels);
-  }, [form.model, scopedModels]);
   const selectedProfile = useMemo(
     () => agentProfiles.find((profile) => profile.id === form.defaultAgentProfile) ?? null,
     [agentProfiles, form.defaultAgentProfile],
@@ -3155,11 +3151,11 @@ function ProjectSettingsPanel({
       return {
         ...current,
         provider,
-        model: modelStillValid ? current.model : defaultModelID(nextModels),
+        model: modelStillValid ? current.model : "",
       };
     });
   }
-  const submitForm = () => onSave({ ...form, model: selectedModel });
+  const submitForm = () => onSave(form);
 
   const workspace = projectDefaultWorkspace(project);
 
@@ -3226,10 +3222,12 @@ function ProjectSettingsPanel({
                     }
                   />
                   <ModelPicker
-                    value={selectedModel}
+                    value={form.model}
                     onChange={(model) => setForm((current) => ({ ...current, model }))}
                     models={scopedModels}
                     presets={providerPresets}
+                    includeAll
+                    allLabel="inherit runtime default"
                     showProvider={!form.provider}
                   />
                 </div>
@@ -4627,10 +4625,6 @@ function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemS
     },
     { assignmentCount: 0, activeCount: 0, failedCount: 0, completedCount: 0 },
   );
-}
-
-function defaultModelID(models: ModelRecord[]): string {
-  return models.find((model) => model.metadata?.default)?.id || models[0]?.id || "";
 }
 
 function emptyRoleForm(): RoleForm {

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -23,9 +23,7 @@ describe("projectInsights", () => {
 
     const health = buildProjectHealthSummary(project, null, [], [], []);
 
-    expect(health.attention.some((item) => item.title === "No project root configured")).toBe(
-      true,
-    );
+    expect(health.attention.some((item) => item.title === "No project root configured")).toBe(true);
   });
 
   it("labels handoff health metrics as recent when they come from bounded activity handoffs", () => {

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -9,6 +9,25 @@ import type {
 } from "../../types/project";
 
 describe("projectInsights", () => {
+  it("calls out projects without an active root", () => {
+    const project = {
+      id: "proj_no_root",
+      name: "Project",
+      roots: [],
+      default_provider: "openai",
+      default_model: "gpt-4.1",
+      context_sources: [],
+      created_at: "2026-06-04T10:00:00Z",
+      updated_at: "2026-06-04T10:00:00Z",
+    } satisfies ProjectRecord;
+
+    const health = buildProjectHealthSummary(project, null, [], [], []);
+
+    expect(health.attention.some((item) => item.title === "No project root configured")).toBe(
+      true,
+    );
+  });
+
   it("labels handoff health metrics as recent when they come from bounded activity handoffs", () => {
     const project = {
       id: "proj_1",

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -208,7 +208,18 @@ export function buildProjectHealthSummary(
   const memoryCandidateSummary = summarizeProjectMemoryCandidates(memoryCandidates);
   const handoffSummary = summarizeProjectHandoffs(activityItems);
   const missingDefaults = Boolean(project && (!project.default_provider || !project.default_model));
+  const missingProjectRoot = Boolean(
+    project && (project.roots ?? []).filter((root) => root.active !== false && root.path).length === 0,
+  );
   const attention: ProjectHealthAttention[] = [];
+  if (missingProjectRoot && project) {
+    attention.push({
+      id: `${project.id}:root`,
+      title: "No project root configured",
+      detail: "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
+      status: "stale_unknown",
+    });
+  }
   if (missingDefaults && project) {
     attention.push({
       id: `${project.id}:defaults`,

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -209,14 +209,16 @@ export function buildProjectHealthSummary(
   const handoffSummary = summarizeProjectHandoffs(activityItems);
   const missingDefaults = Boolean(project && (!project.default_provider || !project.default_model));
   const missingProjectRoot = Boolean(
-    project && (project.roots ?? []).filter((root) => root.active !== false && root.path).length === 0,
+    project &&
+    (project.roots ?? []).filter((root) => root.active !== false && root.path).length === 0,
   );
   const attention: ProjectHealthAttention[] = [];
   if (missingProjectRoot && project) {
     attention.push({
       id: `${project.id}:root`,
       title: "No project root configured",
-      detail: "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
+      detail:
+        "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
       status: "stale_unknown",
     });
   }

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -27,6 +27,7 @@ type RemoteState =
   | { status: "error"; detail: string };
 
 const sectionOrder = [
+  "profile",
   "instructions",
   "project",
   "project_work",
@@ -535,6 +536,8 @@ function humanExecutionMode(mode: string): string {
 
 function humanSectionLabel(section: string): string {
   switch (section) {
+    case "profile":
+      return "Profile";
     case "instructions":
       return "Instructions";
     case "project":
@@ -544,7 +547,7 @@ function humanSectionLabel(section: string): string {
     case "memory":
       return "Memory";
     case "sources":
-      return "Context sources";
+      return "Project sources";
     case "workspace":
       return "Workspace";
     case "runtime":

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -16,6 +16,12 @@ import type {
 } from "../types/provider";
 import type { AgentAdapterProbeResponse, AgentAdapterResponse } from "../types/agent-adapter";
 import type {
+  AgentProfileResponse,
+  AgentProfilesResponse,
+  CreateAgentProfilePayload,
+  UpdateAgentProfilePayload,
+} from "../types/agent-profile";
+import type {
   ChatApprovalRequestedEvent,
   ChatApprovalResolvedEvent,
   ChatApprovalResponse,
@@ -571,6 +577,42 @@ export async function getProjectAssignmentContext(
   return fetchJSON<ContextPacketResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/context`,
   );
+}
+
+export async function discoverProjectContextSources(projectID: string): Promise<ProjectResponse> {
+  return fetchJSON<ProjectResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/context-sources/discover`,
+    { method: "POST", body: {} },
+  );
+}
+
+export async function getAgentProfiles(): Promise<AgentProfilesResponse> {
+  return fetchJSON<AgentProfilesResponse>(`${HECATE_API}/agent-profiles`);
+}
+
+export async function createAgentProfile(
+  payload: CreateAgentProfilePayload,
+): Promise<AgentProfileResponse> {
+  return fetchJSON<AgentProfileResponse>(`${HECATE_API}/agent-profiles`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function updateAgentProfile(
+  id: string,
+  payload: UpdateAgentProfilePayload,
+): Promise<AgentProfileResponse> {
+  return fetchJSON<AgentProfileResponse>(`${HECATE_API}/agent-profiles/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export async function deleteAgentProfile(id: string): Promise<void> {
+  return fetchJSON<void>(`${HECATE_API}/agent-profiles/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
 }
 
 export async function getProjectCollaborationArtifacts(

--- a/ui/src/types/agent-profile.ts
+++ b/ui/src/types/agent-profile.ts
@@ -1,0 +1,60 @@
+export type AgentProfileSurface = "any" | "hecate_chat" | "hecate_task" | "external_agent";
+
+export type AgentProfileRecord = {
+  id: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  surface: AgentProfileSurface | string;
+  provider_hint?: string;
+  model_hint?: string;
+  execution_profile?: string;
+  tools_enabled: boolean;
+  writes_allowed: boolean;
+  network_allowed: boolean;
+  approval_policy: "inherit" | "require" | "block" | "allow" | string;
+  project_memory_policy: "inherit" | "include" | "visible_only" | "exclude" | string;
+  context_source_policy:
+    | "inherit"
+    | "include_enabled"
+    | "visible_only"
+    | "exclude"
+    | string;
+  skill_ids?: string[];
+  external_agent_kind?: string;
+  external_agent_options?: Record<string, string>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type AgentProfileResponse = {
+  object: string;
+  data: AgentProfileRecord;
+};
+
+export type AgentProfilesResponse = {
+  object: string;
+  data: AgentProfileRecord[];
+};
+
+export type CreateAgentProfilePayload = {
+  id?: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  surface?: string;
+  provider_hint?: string;
+  model_hint?: string;
+  execution_profile?: string;
+  tools_enabled?: boolean;
+  writes_allowed?: boolean;
+  network_allowed?: boolean;
+  approval_policy?: string;
+  project_memory_policy?: string;
+  context_source_policy?: string;
+  skill_ids?: string[];
+  external_agent_kind?: string;
+  external_agent_options?: Record<string, string>;
+};
+
+export type UpdateAgentProfilePayload = Partial<CreateAgentProfilePayload>;

--- a/ui/src/types/agent-profile.ts
+++ b/ui/src/types/agent-profile.ts
@@ -14,12 +14,7 @@ export type AgentProfileRecord = {
   network_allowed: boolean;
   approval_policy: "inherit" | "require" | "block" | "allow" | string;
   project_memory_policy: "inherit" | "include" | "visible_only" | "exclude" | string;
-  context_source_policy:
-    | "inherit"
-    | "include_enabled"
-    | "visible_only"
-    | "exclude"
-    | string;
+  context_source_policy: "inherit" | "include_enabled" | "visible_only" | "exclude" | string;
   skill_ids?: string[];
   external_agent_kind?: string;
   external_agent_options?: Record<string, string>;

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -15,6 +15,11 @@ export type ProjectContextSourceRecord = {
   title?: string;
   path: string;
   enabled: boolean;
+  format?: string;
+  scope?: string;
+  trust_label?: string;
+  source_category?: string;
+  metadata?: Record<string, string>;
   created_at: string;
   updated_at: string;
 };
@@ -155,6 +160,11 @@ export type ProjectContextSourcePayload = {
   title?: string;
   path: string;
   enabled?: boolean;
+  format?: string;
+  scope?: string;
+  trust_label?: string;
+  source_category?: string;
+  metadata?: Record<string, string>;
 };
 
 export type CreateProjectPayload = {


### PR DESCRIPTION
## Summary

- Add Agent Profiles V1 storage, API endpoints, startup wiring, and reset cleanup.
- Resolve project assignment profiles from role default, project default, then built-in fallback, and snapshot the effective profile posture into context packets.
- Add workspace guidance discovery for AGENTS.md and metadata-only host-specific instruction files.
- Update Projects UI for profile defaults, role profile selection, guidance discovery, context source display, and Context Inspector grouping.
- Refresh runtime, operator, and design docs to reflect the implemented slice and remaining gaps.

## Validation

- `go test ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/projectInsights.test.ts src/features/projects/ProjectsView.test.tsx`

## Notes

This lands profile Core/API and project/role selection. A full profile-management UI, skill resolution, and source-content injection remain follow-up work.