### PR TITLE
Start external agent assignments from Projects

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -279,6 +279,13 @@ the ACP native session, workspace, or agent selection.
 Hecate-owned chats are different: their provider/model selection can change
 between direct model turns and new task-backed segments in one transcript.
 
+Project assignments can also prepare External Agent sessions. Starting a
+`driver_kind="external_agent"` assignment from Projects creates and prepares the
+linked External Agent chat session, records assignment/profile/workspace context,
+and stores the session link on the assignment. It does not send the assignment
+prompt automatically; the operator stays in control of the first turn from the
+linked chat.
+
 Hecate validates the workspace before creating a session, sanitizes the
 environment passed to the ACP agent process, applies timeout/cancel behavior,
 captures ACP updates with an output cap, and records Git diff / diff stat after

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1499,8 +1499,10 @@ reviewer_qa
 Supported work-item statuses are `backlog`, `ready`, `running`, `review`,
 `blocked`, `done`, and `cancelled`. Supported assignment statuses are `queued`,
 `running`, `awaiting_approval`, `completed`, `failed`, and `cancelled`.
-Supported assignment driver kinds are `hecate_task` and `external_agent`, but
-native assignment start V1 only dispatches `hecate_task`.
+Supported assignment driver kinds are `hecate_task` and `external_agent`.
+Assignment start dispatches `hecate_task` assignments through the native task
+runtime and prepares `external_agent` assignments as supervised External Agent
+chat sessions.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
 Supported structured handoff statuses are `pending`, `accepted`, `superseded`,
@@ -1877,18 +1879,16 @@ or external-agent execution.
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/context`
 
 Returns the best available context packet for the assignment. Hecate resolves
-linked Task/Run packets first, then falls back to a linked Chat
-`chat_session_id` + `message_id` packet when present. Unstarted assignments,
-legacy rows without either link, or older runs that predate snapshots return
+linked Task/Run packets first, then falls back to the assignment-stored packet
+created by an External Agent start, then to a linked Chat `chat_session_id` +
+`message_id` packet when present. Unstarted assignments, legacy rows without a
+stored packet or execution link, or older runs that predate snapshots return
 `404 not_found`.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start`
 
-Starts a native Hecate assignment. V1 supports only assignments whose
-`driver_kind` is `hecate_task`; `external_agent` assignments return
-`409 conflict` and must still be run through the external-agent chat/session
-surface. The request body is optional. When present, `driver_kind` must match
-the stored assignment driver.
+Starts a project assignment through its stored driver. The request body is
+optional. When present, `driver_kind` must match the stored assignment driver.
 
 ```json
 {
@@ -1896,7 +1896,8 @@ the stored assignment driver.
 }
 ```
 
-Starting verifies that the project, work item, assignment, and role exist, then
+For `driver_kind="hecate_task"`, starting verifies that the project, work item,
+assignment, and role exist, then
 creates a normal Task with `execution_kind="agent_loop"`,
 `origin_kind="project_work_item"`, and `origin_id` set to the work item ID. The
 task title, prompt, and system prompt are composed from a visible launch-context
@@ -1937,6 +1938,35 @@ assignment:
       "run_status": "queued",
       "status": "queued"
     },
+    "created_at": "2026-06-03T12:00:00Z",
+    "updated_at": "2026-06-03T12:00:01Z",
+    "started_at": "2026-06-03T12:00:01Z"
+  }
+}
+```
+
+For `driver_kind="external_agent"`, starting prepares a supervised External
+Agent chat session without sending the assignment prompt. The resolved Agent
+Profile must name an `external_agent_kind` such as `codex`, `claude_code`,
+`cursor_agent`, or `grok_build`; profile `external_agent_options` may set
+Hecate-owned launch controls for that adapter. Hecate validates the project
+workspace root, creates and prepares the chat session through the External Agent
+supervisor, stores a project assignment context packet on the assignment, and
+links `chat_session_id` plus `context_snapshot_id`. `task_id`, `run_id`, and
+`message_id` remain empty until the operator sends a turn in the linked chat.
+
+```json
+{
+  "object": "project_assignment",
+  "data": {
+    "id": "asgn_...",
+    "project_id": "proj_...",
+    "work_item_id": "work_...",
+    "role_id": "software_developer",
+    "driver_kind": "external_agent",
+    "status": "running",
+    "chat_session_id": "chat_...",
+    "context_snapshot_id": "ctx_...",
     "created_at": "2026-06-03T12:00:00Z",
     "updated_at": "2026-06-03T12:00:01Z",
     "started_at": "2026-06-03T12:00:01Z"

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -202,6 +202,15 @@ func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignm
 			}
 		}
 	}
+	if len(assignment.ContextPacket) > 0 {
+		var packet chat.ContextPacket
+		if err := json.Unmarshal(assignment.ContextPacket, &packet); err != nil {
+			return chat.ContextPacket{}, false, fmt.Errorf("decode project assignment context packet: %w", err)
+		}
+		if !packet.Empty() {
+			return packet, true, nil
+		}
+	}
 	if h == nil || h.agentChat == nil || strings.TrimSpace(assignment.ChatSessionID) == "" || strings.TrimSpace(assignment.MessageID) == "" {
 		return chat.ContextPacket{}, false, nil
 	}
@@ -403,6 +412,11 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 
 func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string, profile resolvedAgentProfile) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
+	driverKind := firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
+	includedReason := "Included in the native project assignment launch context"
+	if driverKind == projectwork.AssignmentDriverExternalAgent {
+		includedReason = "Included in the external-agent assignment launch context"
+	}
 	packet.ID = newChatID("ctx")
 	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
 	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role, profile)) != ""
@@ -415,7 +429,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 		RoleID:       strings.TrimSpace(role.ID),
 	}
 
-	appendProjectSummary(&packet, &project, true, "Included in the native project assignment launch context")
+	appendProjectSummary(&packet, &project, true, includedReason)
 	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "work_item",
 		Label:  firstNonEmptyString(strings.TrimSpace(workItem.Title), strings.TrimSpace(workItem.ID)),
@@ -428,21 +442,21 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 		Title:           firstNonEmptyString(strings.TrimSpace(workItem.Title), strings.TrimSpace(workItem.ID)),
 		Body:            firstNonEmptyString(strings.TrimSpace(workItem.Brief), "No brief recorded."),
 		Included:        true,
-		InclusionReason: "Included in the native project assignment launch context",
+		InclusionReason: includedReason,
 	})
 	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "assignment",
 		Label:  firstNonEmptyString(strings.TrimSpace(assignment.ID), "Assignment"),
-		Detail: firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask),
+		Detail: driverKind,
 		Trust:  "runtime",
 	}, chat.ContextItem{
 		Kind:            "assignment",
 		TrustLevel:      contextTrustRuntimeState,
 		Origin:          strings.TrimSpace(assignment.ID),
 		Title:           "Assignment",
-		Body:            fmt.Sprintf("Status: %s\nDriver: %s", firstNonEmptyString(strings.TrimSpace(assignment.Status), projectwork.AssignmentStatusQueued), firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)),
+		Body:            fmt.Sprintf("Status: %s\nDriver: %s", firstNonEmptyString(strings.TrimSpace(assignment.Status), projectwork.AssignmentStatusQueued), driverKind),
 		Included:        true,
-		InclusionReason: "Included in the native project assignment launch context",
+		InclusionReason: includedReason,
 	})
 	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "role",
@@ -459,7 +473,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			"Instructions: " + firstNonEmptyString(strings.TrimSpace(role.Instructions), "No role instructions recorded."),
 		}, "\n"),
 		Included:        true,
-		InclusionReason: "Included in the native project assignment launch context",
+		InclusionReason: includedReason,
 	})
 	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "execution_hints",
@@ -472,7 +486,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 		Origin:     "project_assignment.execution_hints",
 		Title:      "Execution hints",
 		Body: strings.Join([]string{
-			"Driver: " + firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask),
+			"Driver: " + driverKind,
 			"Provider: " + firstNonEmptyString(strings.TrimSpace(provider), "auto"),
 			"Model: " + firstNonEmptyString(strings.TrimSpace(model), "project/runtime default"),
 			"Profile: " + firstNonEmptyString(strings.TrimSpace(executionProfile), "none"),
@@ -490,23 +504,31 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			}),
 		}, "\n"),
 		Included:        true,
-		InclusionReason: "Included in the native project assignment launch context",
+		InclusionReason: includedReason,
 	})
 	appendResolvedAgentProfile(&packet, profile)
 	if packet.SystemPromptIncluded {
+		promptOrigin := "task.system_prompt"
+		promptBodyRef := "task_system_prompt"
+		promptReason := "Stored on the native assignment task"
+		if driverKind == projectwork.AssignmentDriverExternalAgent {
+			promptOrigin = "external_agent.assignment_instructions"
+			promptBodyRef = "external_agent_assignment_instructions"
+			promptReason = "Stored on the external-agent assignment context packet"
+		}
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
 			Label:  "System prompt",
-			Detail: "Stored on the native assignment task",
+			Detail: promptReason,
 			Trust:  "system",
 		}, chat.ContextItem{
 			Kind:            "system_prompt",
 			TrustLevel:      contextTrustSystemInstruction,
-			Origin:          "task.system_prompt",
+			Origin:          promptOrigin,
 			Title:           "System prompt",
-			BodyRef:         "task_system_prompt",
+			BodyRef:         promptBodyRef,
 			Included:        true,
-			InclusionReason: "Stored on the native assignment task",
+			InclusionReason: promptReason,
 		})
 	}
 	if strings.TrimSpace(workingDirectory) != "" {
@@ -522,13 +544,13 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			Title:           "Workspace",
 			BodyRef:         strings.TrimSpace(workingDirectory),
 			Included:        true,
-			InclusionReason: "Selected as the native assignment workspace",
+			InclusionReason: "Selected as the project assignment workspace",
 		})
 	}
-	appendProjectMemoryWithInclusion(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), false, "Stored project memory is not injected into native project assignment launch context v1")
-	appendProjectContextSourcesWithInclusion(&packet, projectContextSourcesFromProject(project), false, "Stored project sources are not injected into native project assignment launch context v1")
-	appendProjectAssignmentHandoffs(&packet, h.assignmentRelevantHandoffs(ctx, assignment, role.ID), false, "Handoff references are inspectable metadata only in native project assignment launch context v1")
-	appendProjectAssignmentArtifacts(&packet, h.assignmentRelevantArtifacts(ctx, assignment), false, "Artifact references are inspectable metadata only in native project assignment launch context v1")
+	appendProjectMemoryWithInclusion(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), false, "Stored project memory is not injected into project assignment launch context v1")
+	appendProjectContextSourcesWithInclusion(&packet, projectContextSourcesFromProject(project), false, "Stored project sources are not injected into project assignment launch context v1")
+	appendProjectAssignmentHandoffs(&packet, h.assignmentRelevantHandoffs(ctx, assignment, role.ID), false, "Handoff references are inspectable metadata only in project assignment launch context v1")
+	appendProjectAssignmentArtifacts(&packet, h.assignmentRelevantArtifacts(ctx, assignment), false, "Artifact references are inspectable metadata only in project assignment launch context v1")
 	return packet
 }
 
@@ -704,6 +726,9 @@ func appendResolvedAgentProfile(packet *chat.ContextPacket, profile resolvedAgen
 	}
 	if len(profile.SkillIDs) > 0 {
 		body = append(body, "Skills: "+strings.Join(profile.SkillIDs, ", "))
+	}
+	if externalAgent := strings.TrimSpace(profile.ExternalAgentKind); externalAgent != "" {
+		body = append(body, "External agent: "+externalAgent)
 	}
 	if len(profile.Warnings) > 0 {
 		body = append(body, "Warnings: "+strings.Join(profile.Warnings, " "))

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/orchestrator"
@@ -830,10 +832,6 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("assignment driver_kind is %q, not %q", assignment.DriverKind, driver))
 		return
 	}
-	if assignment.DriverKind != projectwork.AssignmentDriverHecateTask {
-		WriteError(w, http.StatusConflict, errCodeConflict, fmt.Sprintf("assignment driver_kind %q is not supported by native start; V1 supports %q only", assignment.DriverKind, projectwork.AssignmentDriverHecateTask))
-		return
-	}
 	if projectWorkAssignmentIsTerminal(assignment.Status) {
 		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
 		if projectErr != nil {
@@ -841,6 +839,14 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 			return
 		}
 		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+		return
+	}
+	if assignment.DriverKind == projectwork.AssignmentDriverExternalAgent {
+		h.startProjectExternalAgentAssignment(w, r, project, workItem, assignment, role)
+		return
+	}
+	if assignment.DriverKind != projectwork.AssignmentDriverHecateTask {
+		WriteError(w, http.StatusConflict, errCodeConflict, fmt.Sprintf("assignment driver_kind %q is not supported; V1 supports %q and %q", assignment.DriverKind, projectwork.AssignmentDriverHecateTask, projectwork.AssignmentDriverExternalAgent))
 		return
 	}
 	active, err := projectWorkAssignmentHasActiveExecution(ctx, h.taskStore, assignment)
@@ -978,6 +984,157 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+}
+
+func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *http.Request, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) {
+	ctx := r.Context()
+	if h.agentChat == nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, "agent chat store is not configured")
+		return
+	}
+	if h.agentChatRunner == nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, "agent chat runner is not configured")
+		return
+	}
+	if strings.TrimSpace(assignment.ChatSessionID) != "" {
+		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if projectErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+			return
+		}
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+		return
+	}
+	workingDirectory, _, err := resolveProjectAssignmentWorkspace(project)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
+	if adapterID == "" {
+		WriteError(w, http.StatusUnprocessableEntity, errCodeInvalidRequest, "external-agent assignment requires an agent profile with external_agent_kind")
+		return
+	}
+	adapter, ok := agentadapters.BuiltInByID(adapterID)
+	if !ok {
+		writeAgentChatAdapterNotFound(w, adapterID)
+		return
+	}
+	configOptions, err := projectExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	sessionID := newChatID("chat")
+	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workspace, "", "", firstNonEmptyString(profile.ExecutionProfile, "external_agent_assignment"), profile)
+	contextPacket.ID = firstNonEmptyString(contextPacket.ID, newChatID("ctx"))
+	contextPacket.ExecutionMode = chat.ExecutionModeExternalAgent
+	contextPacket.Provider = ""
+	contextPacket.Model = ""
+	contextPacket.Workspace = workspace
+	contextPacket.Refs.SessionID = sessionID
+	contextPacket.Refs.TaskID = ""
+	contextPacket.Refs.RunID = ""
+
+	session := chat.Session{
+		ID:              sessionID,
+		Title:           projectExternalAgentAssignmentTitle(workItem, role, adapter),
+		ProjectID:       project.ID,
+		AgentID:         adapterID,
+		DriverKind:      agentadapters.DriverKindACP,
+		Workspace:       workspace,
+		WorkspaceBranch: workspaceGitBranch(workspace),
+		ConfigOptions:   configOptions,
+	}
+	session, err = h.agentChat.Create(ctx, session)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	prepareCtx, cancel := context.WithTimeout(ctx, agentChatPrepareTimeout)
+	result, prepareErr := h.agentChatRunner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
+		SessionID:     session.ID,
+		AdapterID:     session.AgentID,
+		Workspace:     session.Workspace,
+		ConfigOptions: session.ConfigOptions,
+	})
+	cancel()
+	if prepareErr != nil {
+		_ = h.agentChat.Delete(context.Background(), session.ID)
+		writeAgentChatPrepareError(w, adapter.Name, prepareErr)
+		return
+	}
+	session, err = h.agentChat.UpdateSession(ctx, session.ID, func(item *chat.Session) {
+		item.DriverKind = result.DriverKind
+		item.NativeSessionID = result.NativeSessionID
+		item.ConfigOptions = result.ConfigOptions
+	})
+	if err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
+		_ = h.agentChatRunner.CloseSession(cleanupCtx, session.ID)
+		cleanupCancel()
+		_ = h.agentChat.Delete(context.Background(), session.ID)
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	contextPacket.Refs.SessionID = session.ID
+	contextPacket = normalizeContextPacket(contextPacket, chat.ContextRefs{
+		SessionID:    session.ID,
+		ProjectID:    project.ID,
+		WorkItemID:   workItem.ID,
+		AssignmentID: assignment.ID,
+		RoleID:       role.ID,
+	})
+	packetBytes := marshalContextPacket(contextPacket)
+	assignment, err = h.projectWork.UpdateAssignment(ctx, project.ID, assignment.ID, func(item *projectwork.Assignment) {
+		if item.ChatSessionID != "" || projectWorkAssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverExternalAgent {
+			return
+		}
+		item.ChatSessionID = session.ID
+		item.ContextSnapshotID = contextPacket.ID
+		item.ContextPacket = packetBytes
+		item.Status = projectwork.AssignmentStatusRunning
+		if item.StartedAt.IsZero() {
+			item.StartedAt = time.Now().UTC()
+		}
+	})
+	if err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
+		_ = h.agentChatRunner.CloseSession(cleanupCtx, session.ID)
+		cleanupCancel()
+		_ = h.agentChat.Delete(context.Background(), session.ID)
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if assignment.ChatSessionID != session.ID {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
+		_ = h.agentChatRunner.CloseSession(cleanupCtx, session.ID)
+		cleanupCancel()
+		_ = h.agentChat.Delete(context.Background(), session.ID)
+		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if projectErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+			return
+		}
+		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
@@ -1223,23 +1380,25 @@ type assignmentHint struct {
 }
 
 type resolvedAgentProfile struct {
-	ID                  string
-	Name                string
-	Source              string
-	Instructions        string
-	Missing             bool
-	Surface             string
-	ProviderHint        string
-	ModelHint           string
-	ExecutionProfile    string
-	ToolsEnabled        bool
-	WritesAllowed       bool
-	NetworkAllowed      bool
-	ApprovalPolicy      string
-	ProjectMemoryPolicy string
-	ContextSourcePolicy string
-	SkillIDs            []string
-	Warnings            []string
+	ID                   string
+	Name                 string
+	Source               string
+	Instructions         string
+	Missing              bool
+	Surface              string
+	ProviderHint         string
+	ModelHint            string
+	ExecutionProfile     string
+	ToolsEnabled         bool
+	WritesAllowed        bool
+	NetworkAllowed       bool
+	ApprovalPolicy       string
+	ProjectMemoryPolicy  string
+	ContextSourcePolicy  string
+	SkillIDs             []string
+	ExternalAgentKind    string
+	ExternalAgentOptions map[string]string
+	Warnings             []string
 }
 
 func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) (resolvedAgentProfile, error) {
@@ -1290,22 +1449,75 @@ func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role proj
 
 func resolvedProfileFromStore(profile agentprofiles.Profile, source string) resolvedAgentProfile {
 	return resolvedAgentProfile{
-		ID:                  profile.ID,
-		Name:                profile.Name,
-		Source:              source,
-		Instructions:        profile.Instructions,
-		Surface:             profile.Surface,
-		ProviderHint:        profile.ProviderHint,
-		ModelHint:           profile.ModelHint,
-		ExecutionProfile:    firstNonEmptyString(profile.ExecutionProfile, profile.ID),
-		ToolsEnabled:        profile.ToolsEnabled,
-		WritesAllowed:       profile.WritesAllowed,
-		NetworkAllowed:      profile.NetworkAllowed,
-		ApprovalPolicy:      profile.ApprovalPolicy,
-		ProjectMemoryPolicy: profile.ProjectMemoryPolicy,
-		ContextSourcePolicy: profile.ContextSourcePolicy,
-		SkillIDs:            append([]string(nil), profile.SkillIDs...),
+		ID:                   profile.ID,
+		Name:                 profile.Name,
+		Source:               source,
+		Instructions:         profile.Instructions,
+		Surface:              profile.Surface,
+		ProviderHint:         profile.ProviderHint,
+		ModelHint:            profile.ModelHint,
+		ExecutionProfile:     firstNonEmptyString(profile.ExecutionProfile, profile.ID),
+		ToolsEnabled:         profile.ToolsEnabled,
+		WritesAllowed:        profile.WritesAllowed,
+		NetworkAllowed:       profile.NetworkAllowed,
+		ApprovalPolicy:       profile.ApprovalPolicy,
+		ProjectMemoryPolicy:  profile.ProjectMemoryPolicy,
+		ContextSourcePolicy:  profile.ContextSourcePolicy,
+		SkillIDs:             append([]string(nil), profile.SkillIDs...),
+		ExternalAgentKind:    profile.ExternalAgentKind,
+		ExternalAgentOptions: cloneStringMap(profile.ExternalAgentOptions),
 	}
+}
+
+func projectExternalAgentConfigOptions(adapterID string, options map[string]string) ([]agentcontrols.ConfigOption, error) {
+	if len(options) == 0 {
+		return nil, nil
+	}
+	out := make([]agentcontrols.ConfigOption, 0, len(options))
+	for key, value := range options {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		option, ok := agentadapters.LaunchConfigOptionForSet(adapterID, key, value)
+		if !ok {
+			return nil, fmt.Errorf("external_agent_options.%s is not a launch option for %s", key, adapterID)
+		}
+		out = append(out, option)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+func projectExternalAgentAssignmentTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile, adapter agentadapters.Adapter) string {
+	parts := []string{}
+	if title := strings.TrimSpace(workItem.Title); title != "" {
+		parts = append(parts, title)
+	}
+	if roleName := strings.TrimSpace(role.Name); roleName != "" {
+		parts = append(parts, roleName)
+	}
+	if adapter.Name != "" {
+		parts = append(parts, adapter.Name)
+	}
+	if len(parts) == 0 {
+		return "External Agent assignment"
+	}
+	return strings.Join(parts, " - ")
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
 }
 
 func formatAssignmentHints(items []assignmentHint) string {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
@@ -765,6 +766,126 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 	}
 }
 
+func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	runner := &fakeAgentChatRunner{nativeSessionID: "native_project_external"}
+	handler.SetAgentChatRunner(runner)
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "prof_external",
+		Name:                "External implementer",
+		Instructions:        "Use the linked project context before editing.",
+		Surface:             agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:    "external_implementation",
+		ExternalAgentKind:   "codex",
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+		SkillIDs:            []string{"project-handoff"},
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	if assignment.Data.ChatSessionID == "" || assignment.Data.ContextSnapshotID == "" {
+		t.Fatalf("assignment links = chat %q context %q, want linked session and context", assignment.Data.ChatSessionID, assignment.Data.ContextSnapshotID)
+	}
+	if assignment.Data.TaskID != "" || assignment.Data.RunID != "" || assignment.Data.MessageID != "" {
+		t.Fatalf("assignment task/run/message links = %q/%q/%q, want no task run or dispatched message", assignment.Data.TaskID, assignment.Data.RunID, assignment.Data.MessageID)
+	}
+	if assignment.Data.Status != projectwork.AssignmentStatusRunning {
+		t.Fatalf("assignment status = %q, want running", assignment.Data.Status)
+	}
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
+	}
+	if len(runner.runRequests) != 0 {
+		t.Fatalf("run requests = %d, want no automatic external-agent turn", len(runner.runRequests))
+	}
+	prepare := runner.prepareRequests[0]
+	resolvedWorkspace, err := agentadapters.ValidateWorkspace(workspace)
+	if err != nil {
+		t.Fatalf("ValidateWorkspace: %v", err)
+	}
+	if prepare.AdapterID != "codex" || prepare.SessionID != assignment.Data.ChatSessionID || prepare.Workspace != resolvedWorkspace {
+		t.Fatalf("prepare request = %+v, want codex session in workspace", prepare)
+	}
+	session, ok, err := handler.agentChat.Get(t.Context(), assignment.Data.ChatSessionID)
+	if err != nil || !ok {
+		t.Fatalf("Get chat session found=%v err=%v, want linked session", ok, err)
+	}
+	if session.AgentID != "codex" || session.DriverKind != agentadapters.DriverKindACP || session.NativeSessionID != "native_project_external" || session.ProjectID != "proj_start" {
+		t.Fatalf("session = %+v, want prepared codex project session", session)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
+	if packetResp.Data.ID != assignment.Data.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want %q", packetResp.Data.ID, assignment.Data.ContextSnapshotID)
+	}
+	if packetResp.Data.ExecutionMode != chat.ExecutionModeExternalAgent || packetResp.Data.Refs == nil || packetResp.Data.Refs.SessionID != assignment.Data.ChatSessionID {
+		t.Fatalf("packet execution/refs = %q/%+v, want external agent session refs", packetResp.Data.ExecutionMode, packetResp.Data.Refs)
+	}
+	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_external")
+	if profileItem == nil || profileItem.Section != contextSectionProfile || !strings.Contains(profileItem.Body, "External agent: codex") {
+		t.Fatalf("profile item = %+v, want external profile metadata", profileItem)
+	}
+}
+
+func TestProjectWorkAPI_StartExternalAgentAssignmentRejectsUnsupportedProfileOptions(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	runner := &fakeAgentChatRunner{}
+	handler.SetAgentChatRunner(runner)
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           t.TempDir(),
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                   "prof_external_bad_options",
+		Name:                 "External implementer",
+		Surface:              agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:     "external_implementation",
+		ExternalAgentKind:    "codex",
+		ExternalAgentOptions: map[string]string{"unsupported": "value"},
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external_bad_options"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("start assignment status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if len(runner.prepareRequests) != 0 || len(runner.runRequests) != 0 {
+		t.Fatalf("external agent requests = prepare %d run %d, want none when profile launch options are invalid", len(runner.prepareRequests), len(runner.runRequests))
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -1100,9 +1221,10 @@ func TestProjectWorkAPI_StartAssignmentRejectsMissingWorkspaceRoot(t *testing.T)
 	}
 }
 
-func TestProjectWorkAPI_StartAssignmentRejectsUnsupportedDriver(t *testing.T) {
+func TestProjectWorkAPI_StartExternalAgentAssignmentRequiresProfileKind(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
+	handler.SetAgentChatRunner(&fakeAgentChatRunner{})
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
 		Workspace: t.TempDir(),
 		Driver:    projectwork.AssignmentDriverExternalAgent,
@@ -1110,8 +1232,8 @@ func TestProjectWorkAPI_StartAssignmentRejectsUnsupportedDriver(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("start external assignment status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("start external assignment status = %d body=%s, want 422", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -102,6 +102,7 @@ CREATE TABLE IF NOT EXISTS %s (
 	chat_session_id TEXT NOT NULL DEFAULT '',
 	message_id TEXT NOT NULL DEFAULT '',
 	context_snapshot_id TEXT NOT NULL DEFAULT '',
+	context_packet TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	started_at TEXT NOT NULL DEFAULT '',
@@ -156,6 +157,9 @@ CREATE TABLE IF NOT EXISTS %s (
 		return fmt.Errorf("create project handoffs table: %w", err)
 	}
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "driver_kind", `TEXT NOT NULL DEFAULT 'hecate_task'`); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, s.assignmentsTbl, "context_packet", `TEXT NOT NULL DEFAULT ''`); err != nil {
 		return err
 	}
 	for _, column := range []string{"default_driver_kind", "default_provider", "default_model", "default_agent_profile"} {
@@ -480,7 +484,7 @@ func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilt
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ?`, s.assignmentsTbl)
 	args := []any{filter.ProjectID}
@@ -520,11 +524,11 @@ func (s *SQLiteStore) CreateAssignment(ctx context.Context, assignment Assignmen
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
 	id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id,
-	message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
+	message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
 		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID, assignment.DriverKind,
 		assignment.Status, assignment.TaskID, assignment.RunID, assignment.ChatSessionID,
-		assignment.MessageID, assignment.ContextSnapshotID, formatTime(assignment.CreatedAt),
+		assignment.MessageID, assignment.ContextSnapshotID, string(assignment.ContextPacket), formatTime(assignment.CreatedAt),
 		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
 	)
 	if err != nil {
@@ -569,10 +573,10 @@ func (s *SQLiteStore) UpdateAssignment(ctx context.Context, projectID, id string
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
 SET role_id = ?, driver_kind = ?, status = ?, task_id = ?, run_id = ?, chat_session_id = ?, message_id = ?,
-	context_snapshot_id = ?, updated_at = ?, started_at = ?, completed_at = ?
+	context_snapshot_id = ?, context_packet = ?, updated_at = ?, started_at = ?, completed_at = ?
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
 		item.RoleID, item.DriverKind, item.Status, item.TaskID, item.RunID, item.ChatSessionID,
-		item.MessageID, item.ContextSnapshotID, formatTime(item.UpdatedAt),
+		item.MessageID, item.ContextSnapshotID, string(item.ContextPacket), formatTime(item.UpdatedAt),
 		formatTime(item.StartedAt), formatTime(item.CompletedAt), projectID, id,
 	)
 	if err != nil {
@@ -1010,7 +1014,7 @@ WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID),
 
 func (s *SQLiteStore) getRequiredAssignment(ctx context.Context, projectID, id string) (Assignment, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanAssignment(row)
@@ -1126,7 +1130,7 @@ func scanAssignment(row scanner) (Assignment, error) {
 	if err := row.Scan(
 		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.DriverKind, &item.Status,
 		&item.TaskID, &item.RunID, &item.ChatSessionID, &item.MessageID,
-		&item.ContextSnapshotID, &createdAt, &updatedAt, &startedAt, &completedAt,
+		&item.ContextSnapshotID, &item.ContextPacket, &createdAt, &updatedAt, &startedAt, &completedAt,
 	); err != nil {
 		return Assignment{}, err
 	}

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -88,6 +88,7 @@ type Assignment struct {
 	ChatSessionID     string
 	MessageID         string
 	ContextSnapshotID string
+	ContextPacket     []byte
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 	StartedAt         time.Time
@@ -782,6 +783,7 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 	item.ChatSessionID = strings.TrimSpace(item.ChatSessionID)
 	item.MessageID = strings.TrimSpace(item.MessageID)
 	item.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
+	item.ContextPacket = append([]byte(nil), item.ContextPacket...)
 	if item.Status == "" {
 		item.Status = AssignmentStatusQueued
 	}
@@ -1072,6 +1074,7 @@ func cloneWorkItem(item WorkItem) WorkItem {
 }
 
 func cloneAssignment(item Assignment) Assignment {
+	item.ContextPacket = append([]byte(nil), item.ContextPacket...)
 	return item
 }
 

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -124,6 +124,7 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				TaskID:            "task_123",
 				RunID:             "run_123",
 				ContextSnapshotID: "ctx_123",
+				ContextPacket:     []byte(`{"id":"ctx_123","version":"chat.context.v1"}`),
 			})
 			if err != nil {
 				t.Fatalf("CreateAssignment: %v", err)
@@ -134,18 +135,25 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if assignment.DriverKind != AssignmentDriverHecateTask {
 				t.Fatalf("assignment driver_kind = %q, want hecate_task", assignment.DriverKind)
 			}
+			if string(assignment.ContextPacket) != `{"id":"ctx_123","version":"chat.context.v1"}` {
+				t.Fatalf("assignment context packet = %s, want stored packet", string(assignment.ContextPacket))
+			}
 
 			startedAt := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 			updatedAssignment, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
 				item.DriverKind = AssignmentDriverExternalAgent
 				item.Status = AssignmentStatusRunning
 				item.StartedAt = startedAt
+				item.ContextPacket = []byte(`{"id":"ctx_456","version":"chat.context.v1"}`)
 			})
 			if err != nil {
 				t.Fatalf("UpdateAssignment: %v", err)
 			}
 			if updatedAssignment.DriverKind != AssignmentDriverExternalAgent || updatedAssignment.Status != AssignmentStatusRunning || !updatedAssignment.StartedAt.Equal(startedAt) {
 				t.Fatalf("updated assignment = %+v, want running with start time", updatedAssignment)
+			}
+			if string(updatedAssignment.ContextPacket) != `{"id":"ctx_456","version":"chat.context.v1"}` {
+				t.Fatalf("updated assignment context packet = %s, want updated packet", string(updatedAssignment.ContextPacket))
 			}
 			if _, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
 				item.DriverKind = "unsupported"

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -645,6 +645,88 @@ describe("ConsoleShell navigation", () => {
     expect(onSelectWorkspace).toHaveBeenCalledWith("chats");
   });
 
+  it("selects linked External Agent chats when opening a started project assignment", async () => {
+    const createChatSession = vi.fn<RuntimeConsoleFixtureActions["createChatSession"]>(
+      async () => undefined,
+    );
+    const selectChatSession = vi.fn<RuntimeConsoleFixtureActions["selectChatSession"]>(
+      async () => undefined,
+    );
+    const onSelectWorkspace = vi.fn();
+    const project = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [],
+      created_at: "2026-05-21T10:00:00Z",
+      updated_at: "2026-05-21T10:00:00Z",
+    };
+    const workItem: ProjectWorkItemRecord = {
+      id: "work_1",
+      project_id: project.id,
+      title: "Build cockpit UI",
+      brief: "Open the linked external agent chat.",
+      status: "ready",
+      priority: "high",
+      owner_role_id: "software_developer",
+      created_at: "2026-06-02T10:00:00Z",
+      updated_at: "2026-06-02T11:00:00Z",
+    };
+    const assignment: ProjectAssignmentRecord = {
+      id: "asgn_external",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      role_id: "software_developer",
+      driver_kind: "external_agent",
+      status: "running",
+      chat_session_id: "chat_external_1",
+      context_snapshot_id: "ctx_external_1",
+      created_at: "2026-06-02T10:00:00Z",
+      updated_at: "2026-06-02T11:00:00Z",
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [
+        {
+          id: "software_developer",
+          project_id: project.id,
+          name: "Software developer",
+          built_in: true,
+        },
+      ],
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [assignment] }],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: workItem,
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [assignment],
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="projects" onSelectWorkspace={onSelectWorkspace} />,
+        {
+          state,
+          actions: { ...createRuntimeConsoleActions(), createChatSession, selectChatSession },
+        },
+      ),
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open chat" }));
+
+    expect(selectChatSession).toHaveBeenCalledWith("chat_external_1");
+    expect(createChatSession).not.toHaveBeenCalled();
+    expect(onSelectWorkspace).toHaveBeenCalledWith("chats");
+  });
+
   it("moves the active chat when selecting a different project", () => {
     const selectProject = vi.fn(async () => undefined);
     const selectChatSession = vi.fn(async () => undefined);

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -72,6 +72,7 @@ type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
 type TraceFocusRequest = { requestID: string; nonce: number };
 type ProjectChatRequest = {
   projectID: string;
+  chatSessionID?: string;
   provider?: string;
   model?: string;
   title?: string;
@@ -313,6 +314,11 @@ function AuthenticatedShell({
   function openChatFromProject(request: ProjectChatRequest) {
     if (request.projectID) {
       void projects.actions.selectProject(request.projectID);
+    }
+    if (request.chatSessionID) {
+      void chatActions.selectChatSession(request.chatSessionID);
+      onSelectWorkspace("chats");
+      return;
     }
     if (request.provider) {
       chatActions.selectProviderRoute(request.provider as ProviderFilter);

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1263,6 +1263,99 @@ describe("ProjectsView cockpit", () => {
     expect(screen.getByRole("article", { name: "Build cockpit UI work item" })).toBeTruthy();
   });
 
+  it("starts queued external-agent assignments from the selected work item", async () => {
+    resetProjectWorkMocks();
+    const externalAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      driver_kind: "external_agent",
+      status: "queued",
+      task_id: "",
+      run_id: "",
+      execution: undefined,
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [externalAssignment] }],
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [externalAssignment],
+    });
+    vi.mocked(startProjectAssignment).mockResolvedValue({
+      object: "project_assignment",
+      data: {
+        ...externalAssignment,
+        status: "running",
+        chat_session_id: "chat_external_1",
+        context_snapshot_id: "ctx_external_1",
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await userEvent.click(within(detail).getByRole("button", { name: "Start" }));
+
+    expect(startProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      externalAssignment.id,
+      "external_agent",
+    );
+  });
+
+  it("opens linked external-agent assignment chat sessions directly", async () => {
+    resetProjectWorkMocks();
+    const onOpenChat = vi.fn();
+    const linkedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      driver_kind: "external_agent",
+      status: "running",
+      task_id: "",
+      run_id: "",
+      chat_session_id: "chat_external_1",
+      context_snapshot_id: "ctx_external_1",
+      execution: undefined,
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [linkedAssignment] }],
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [linkedAssignment],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(<ProjectsView onOpenChat={onOpenChat} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await userEvent.click(within(detail).getByRole("button", { name: "Open chat" }));
+
+    expect(onOpenChat).toHaveBeenCalledWith({
+      projectID: project.id,
+      chatSessionID: "chat_external_1",
+    });
+  });
+
   it("renders a project timeline from activity, decisions, artifacts, and memory", async () => {
     resetProjectWorkMocks();
     const onOpenTask = vi.fn();
@@ -2298,6 +2391,7 @@ describe("ProjectsView cockpit", () => {
       project.id,
       workItem.id,
       notStartedAssignment.id,
+      "hecate_task",
     );
   });
 
@@ -2890,6 +2984,7 @@ describe("ProjectsView cockpit", () => {
       project.id,
       workItem.id,
       queuedAssignment.id,
+      "hecate_task",
     );
     await waitFor(() => {
       expect(getProjectWorkItem).toHaveBeenCalledTimes(2);
@@ -2926,7 +3021,7 @@ describe("ProjectsView cockpit", () => {
     expect(screen.queryByText(/^Started\s*$/)).toBeNull();
   });
 
-  it("does not expose native start for external-agent assignments", async () => {
+  it("exposes start for queued external-agent assignments", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);
     vi.mocked(getProjectAssignments).mockResolvedValue({
@@ -2947,7 +3042,11 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    expect(await screen.findByText("Start in Chats")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Start" })).toBeNull();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    expect(within(detail).getByRole("button", { name: "Start" })).toBeTruthy();
+    expect(screen.queryByText("Start in Chats")).toBeNull();
   });
 });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -106,6 +106,7 @@ const DEFAULT_RIGHT_PANEL_WIDTH = 380;
 
 export type ProjectAssignmentChatLaunchRequest = {
   projectID: string;
+  chatSessionID?: string;
   provider?: string;
   model?: string;
   title?: string;
@@ -1066,7 +1067,12 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setStartingAssignmentID(assignment.id);
     setAssignmentErrors((current) => ({ ...current, [assignment.id]: "" }));
     try {
-      const res = await startProjectAssignment(selectedProjectID, workItemID, assignment.id);
+      const res = await startProjectAssignment(
+        selectedProjectID,
+        workItemID,
+        assignment.id,
+        assignment.driver_kind || "hecate_task",
+      );
       setAssignments((current) => upsertAssignment(current, res.data));
       await loadWorkForProject(selectedProjectID, workItemID);
       await loadWorkItemDetail(selectedProjectID, workItemID);
@@ -3006,12 +3012,17 @@ function WorkItemDetail({
                     project
                       ? () =>
                           onOpenChat?.(
-                            buildProjectAssignmentChatLaunchRequest({
-                              project,
-                              workItem,
-                              assignment,
-                              role: roleByID.get(assignment.role_id) ?? null,
-                            }),
+                            assignment.chat_session_id
+                              ? {
+                                  projectID: project.id,
+                                  chatSessionID: assignment.chat_session_id,
+                                }
+                              : buildProjectAssignmentChatLaunchRequest({
+                                  project,
+                                  workItem,
+                                  assignment,
+                                  role: roleByID.get(assignment.role_id) ?? null,
+                                }),
                           )
                       : undefined
                   }
@@ -4348,8 +4359,11 @@ function AssignmentRow({
   const execution = assignment.execution;
   const taskID = execution?.task_id || assignment.task_id || "";
   const runID = execution?.run_id || assignment.run_id || "";
+  const chatSessionID = assignment.chat_session_id || "";
   const projectedStatus = execution?.status || assignment.status;
-  const startable = assignment.driver_kind === "hecate_task" && projectedStatus === "queued";
+  const startable =
+    (assignment.driver_kind === "hecate_task" || assignment.driver_kind === "external_agent") &&
+    projectedStatus === "queued";
   const external = assignment.driver_kind === "external_agent";
   const startedAt = execution?.started_at || assignment.started_at;
   const finishedAt = execution?.finished_at || assignment.completed_at;
@@ -4391,10 +4405,10 @@ function AssignmentRow({
             {starting ? "Starting…" : "Start"}
           </button>
         )}
-        {external && (
+        {external && !startable && !assignment.chat_session_id && (
           <span
             style={subtleTextStyle}
-            title="External assignment execution is not implemented yet."
+            title="Start this assignment to prepare a supervised External Agent chat session."
           >
             Start in Chats
           </span>
@@ -4426,9 +4440,13 @@ function AssignmentRow({
           className="btn btn-ghost btn-sm"
           type="button"
           onClick={onOpenChat}
-          disabled={!onOpenChat || !chatModel}
+          disabled={!onOpenChat || (!chatSessionID && !chatModel)}
           title={
-            chatModel ? `Open chat with ${chatModel}` : "Set project defaults before opening chat."
+            chatSessionID
+              ? "Open linked External Agent chat"
+              : chatModel
+                ? `Open chat with ${chatModel}`
+                : "Set project defaults before opening chat."
           }
         >
           <Icon d={Icons.chat} size={12} />

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -523,17 +523,28 @@ describe("api client", () => {
   });
 
   it("starts native project assignments with the hecate driver kind", async () => {
-    fetchMock.mockResolvedValue(
-      jsonResponse({ object: "project_assignment", data: { id: "asgn_1" } }),
-    );
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ object: "project_assignment", data: { id: "asgn_1" } }))
+      .mockResolvedValueOnce(
+        jsonResponse({ object: "project_assignment", data: { id: "asgn_2" } }),
+      );
 
     await startProjectAssignment("proj_1", "work_1", "asgn_1");
+    await startProjectAssignment("proj_1", "work_1", "asgn_2", "external_agent");
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/hecate/v1/projects/proj_1/work-items/work_1/assignments/asgn_1/start",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ driver_kind: "hecate_task" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj_1/work-items/work_1/assignments/asgn_2/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ driver_kind: "external_agent" }),
       }),
     );
   });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -562,10 +562,11 @@ export async function startProjectAssignment(
   projectID: string,
   workItemID: string,
   assignmentID: string,
+  driverKind = "hecate_task",
 ): Promise<ProjectAssignmentResponse> {
   return fetchJSON<ProjectAssignmentResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/start`,
-    { method: "POST", body: { driver_kind: "hecate_task" } },
+    { method: "POST", body: { driver_kind: driverKind } },
   );
 }
 


### PR DESCRIPTION
## Summary

- Add Projects assignment start support for `driver_kind: external_agent`.
- Prepare supervised External Agent chat sessions, link `chat_session_id`, and persist assignment context snapshots without auto-running the first turn.
- Let Projects UI start queued external-agent assignments and open linked sessions directly in Chats.
- Update runtime API and External Agents docs for the new project-assignment behavior.

## Validation

- `go test ./...`
- `go vet ./internal/projectwork ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `git diff --check`
