### PR TITLE
fix(ui): align external agent setup readiness copy

### DIFF
--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -28,12 +28,12 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 		if ok, checked := detectClaudeCLIAuthStatus(); ok {
 			return AuthStatusOK, ""
 		} else if checked {
-			return AuthStatusUnauthenticated, "Run `claude /login` in Terminal, then test Claude Code again. Hecate uses Claude Code's local auth; it does not store Claude tokens."
+			return AuthStatusUnauthenticated, adapterSignInHint(adapter)
 		}
 		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
 			return AuthStatusUnknown, "Claude Code config is present on disk. Hecate has not verified CLI auth yet. Open Connections and test Claude Code."
 		}
-		return AuthStatusUnknown, "Open Connections and test Claude Code. If it reports a sign-in error, run `claude /login` in Terminal."
+		return AuthStatusUnknown, "Open Connections and test Claude Code. If it reports a sign-in error, run `claude /login` in Terminal or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment."
 	case "cursor_agent":
 		if envAny("CURSOR_API_KEY") || fileAny("${HOME}/.cursor", "${HOME}/Library/Application Support/Cursor") {
 			return AuthStatusOK, ""
@@ -54,7 +54,7 @@ func adapterSignInHint(adapter Adapter) string {
 	case "codex":
 		return "Run codex login, or set OPENAI_API_KEY for the adapter environment."
 	case "claude_code":
-		return "Run `claude /login` in Terminal, then test Claude Code again. Hecate uses Claude Code's local auth; it does not store Claude tokens."
+		return "Run `claude /login` in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment."
 	case "cursor_agent":
 		return "Run cursor-agent login, or set CURSOR_API_KEY for the adapter environment."
 	case "grok_build":
@@ -87,7 +87,7 @@ func adapterAppMissingHint(adapter Adapter) string {
 // trailing marker from visible copy; ChatView uses it to decide whether to show
 // the button.
 func claudeCodeAuthErrorMessage() string {
-	return "Claude Code isn't signed in. This is separate from the Anthropic key in the Providers tab — Claude Code runs as its own program and uses the operator's local Claude CLI auth. Run `claude /login`, then test Claude Code in Connections. (claude_code_auth_required)"
+	return "Claude Code isn't signed in. This is separate from the Anthropic key in the Providers tab — Claude Code runs as its own program and uses the operator's local Claude auth. Run `claude /login`, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment, then test Claude Code in Connections. (claude_code_auth_required)"
 }
 
 var runClaudeAuthStatus = defaultRunClaudeAuthStatus

--- a/internal/agentadapters/auth_status_test.go
+++ b/internal/agentadapters/auth_status_test.go
@@ -85,6 +85,9 @@ func TestDetectAuthStatusClaudeUnknownWithoutMarker(t *testing.T) {
 	if !strings.Contains(hint, "claude /login") {
 		t.Fatalf("hint = %q, want the `claude /login` command callout", hint)
 	}
+	if !strings.Contains(hint, "ANTHROPIC_API_KEY") || !strings.Contains(hint, "ANTHROPIC_AUTH_TOKEN") {
+		t.Fatalf("hint = %q, want Anthropic env auth alternatives", hint)
+	}
 }
 
 func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
@@ -126,6 +129,9 @@ func TestDetectAuthStatusClaudeReportsUnauthenticatedFromCLI(t *testing.T) {
 	if !strings.Contains(hint, "claude /login") {
 		t.Fatalf("hint = %q, want claude /login guidance", hint)
 	}
+	if !strings.Contains(hint, "ANTHROPIC_API_KEY") || !strings.Contains(hint, "ANTHROPIC_AUTH_TOKEN") {
+		t.Fatalf("hint = %q, want Anthropic env auth alternatives", hint)
+	}
 }
 
 func TestDetectAuthStatusClaudeParsesStatusOutputOnNonZeroExit(t *testing.T) {
@@ -138,6 +144,9 @@ func TestDetectAuthStatusClaudeParsesStatusOutputOnNonZeroExit(t *testing.T) {
 	}
 	if !strings.Contains(hint, "claude /login") {
 		t.Fatalf("hint = %q, want claude /login guidance", hint)
+	}
+	if !strings.Contains(hint, "ANTHROPIC_API_KEY") || !strings.Contains(hint, "ANTHROPIC_AUTH_TOKEN") {
+		t.Fatalf("hint = %q, want Anthropic env auth alternatives", hint)
 	}
 }
 

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -203,7 +203,7 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
 		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
-			res.Hint = "Claude Code isn't signed in. Run `claude /login` in Terminal, then test Claude Code again from Connections."
+			res.Hint = adapterSignInHint(adapter)
 		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)
@@ -221,7 +221,7 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 		res.Stderr = strings.TrimSpace(stderr.String())
 		res.Status, res.Hint = classifyAdapterError(err.Error(), res.Stderr)
 		if adapterID == "claude_code" && claudeCodeErrorNeedsAdapterVisibleAuth(err.Error(), res.Stderr) {
-			res.Hint = "Claude Code isn't signed in. Run `claude /login` in Terminal, then test Claude Code again from Connections."
+			res.Hint = adapterSignInHint(adapter)
 		}
 		res.Error = err.Error()
 		res.DurationMS = elapsedMS(start)

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -3375,7 +3375,7 @@ test("Claude Code setup stays visible when the probe requires local auth", async
   });
 
   await expect(page.getByText("Set up Claude Code")).toBeVisible();
-  await expect(page.getByText(/Claude Code needs local CLI sign-in/)).toBeVisible();
+  await expect(page.getByText(/claude \/login/)).toBeVisible();
   await page.locator("textarea").fill("hello from Claude Code");
   await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
 });
@@ -3396,9 +3396,7 @@ test("Cursor Agent setup explains CLI sign-in without launching the CLI", async 
   await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
 });
 
-test("Grok Build setup mentions CLI sign-in and model selection without launching the CLI", async ({
-  page,
-}) => {
+test("Grok Build setup mentions CLI sign-in without launching the CLI", async ({ page }) => {
   await openExternalAgentReadinessFixture(page, {
     id: "grok_build",
     name: "Grok Build",
@@ -3411,7 +3409,6 @@ test("Grok Build setup mentions CLI sign-in and model selection without launchin
 
   await expect(page.getByText("Set up Grok Build")).toBeVisible();
   await expect(page.getByText(/grok login/)).toBeVisible();
-  await expect(page.getByText(/model selected/)).toBeVisible();
   await page.locator("textarea").fill("hello from Grok Build");
   await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
 });

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3568,7 +3568,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
 
     expect(screen.getByText("Set up Claude Code")).toBeTruthy();
-    expect(screen.getByText(/local CLI sign-in/)).toBeTruthy();
+    expect(screen.getByText(/ANTHROPIC_API_KEY/)).toBeTruthy();
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Open setup" }));
@@ -3612,7 +3612,7 @@ describe("ChatView external-agent target", () => {
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     expect(screen.getByText("Set up Claude Code")).toBeTruthy();
-    expect(screen.getByText(/local CLI sign-in/)).toBeTruthy();
+    expect(screen.getByText(/ANTHROPIC_API_KEY/)).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -268,10 +268,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     ? (state.agentAdapterHealthByID.get(activeAgentAdapterID) ?? null)
     : null;
 
-  const externalAgentSetupRequired = resolveExternalAgentReadiness(
-    selectedAgent,
-    selectedAgentHealth,
-  ).needsRepair;
+  const selectedAgentReadiness = resolveExternalAgentReadiness(selectedAgent, selectedAgentHealth);
+  const externalAgentSetupRequired = selectedAgentReadiness.needsRepair;
   const availableAgents = state.agentAdapters.filter((adapter) => adapter.available);
   const configuredProviders = state.settingsConfig?.providers ?? [];
   const providerConfigLoaded = state.settingsConfig !== null;
@@ -447,6 +445,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     selectedAgentAvailable: Boolean(selectedAgent?.available),
     anyAgentAvailable: availableAgents.length > 0,
     externalAgentSetupRequired,
+    selectedAgentReadiness,
   });
   const externalAgentModelRequired = externalAgentRequiresModelSelection(
     externalAgentConfigOptions,

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -157,6 +157,36 @@ describe("resolveChatSetupRepairState", () => {
     expect(repair?.message).toContain("cursor-agent login");
   });
 
+  it("uses shared readiness sign-in copy for external-agent setup repairs", () => {
+    const repair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentID: "claude_code",
+      selectedAgentName: "Claude Code",
+      externalAgentSetupRequired: true,
+      selectedAgentReadiness: {
+        kind: "sign_in",
+        tone: "amber",
+        label: "sign in",
+        needsRepair: true,
+        loginCommand: "claude /login",
+        setupHint: "Install Claude Code and ensure claude is on PATH.",
+        signInHint:
+          "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment.",
+        detail: "Run `claude /login` in Terminal.",
+        verifiedByProbe: false,
+      },
+    });
+
+    expect(repair).toMatchObject({
+      kind: "external_agent_setup",
+      title: "Set up Claude Code",
+      message:
+        "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment.",
+      action: "open_agent_setup",
+    });
+  });
+
   it("uses Grok Build setup copy that mentions sign-in and model selection", () => {
     const repair = resolveChatSetupRepairState({
       ...base,

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -1,4 +1,5 @@
 import type { SelectedModelIssue } from "./provider-issues";
+import type { ExternalAgentReadiness } from "./external-agent-readiness";
 import type { ModelRecord } from "../types/model";
 import type { ProviderFilter } from "../types/provider";
 
@@ -40,6 +41,7 @@ export function resolveChatSetupRepairState({
   selectedAgentAvailable,
   anyAgentAvailable,
   externalAgentSetupRequired,
+  selectedAgentReadiness,
 }: {
   target: ChatSetupTarget;
   hasConfiguredProviders: boolean;
@@ -52,6 +54,7 @@ export function resolveChatSetupRepairState({
   selectedAgentAvailable: boolean;
   anyAgentAvailable: boolean;
   externalAgentSetupRequired: boolean;
+  selectedAgentReadiness?: ExternalAgentReadiness;
 }): ChatSetupRepairState | null {
   if (target === "external_agent") {
     if (!anyAgentAvailable || !selectedAgentAvailable) {
@@ -71,8 +74,8 @@ export function resolveChatSetupRepairState({
       const agent = selectedAgentName || "Selected agent";
       return {
         kind: "external_agent_setup",
-        title: `Set up ${agent}`,
-        message: externalAgentSetupMessage(selectedAgentID, agent),
+        title: externalAgentSetupTitle(agent, selectedAgentReadiness),
+        message: externalAgentSetupMessage(selectedAgentID, agent, selectedAgentReadiness),
         action: "open_agent_setup",
         actionLabel: "Open setup",
         tone: "amber",
@@ -124,7 +127,40 @@ export function resolveChatSetupRepairState({
   return null;
 }
 
-function externalAgentSetupMessage(agentID: string | undefined, agent: string): string {
+function externalAgentSetupTitle(agent: string, readiness?: ExternalAgentReadiness): string {
+  switch (readiness?.kind) {
+    case "billing":
+      return `Check ${agent} billing`;
+    case "issue":
+      return `Check ${agent}`;
+    default:
+      return `Set up ${agent}`;
+  }
+}
+
+function externalAgentSetupMessage(
+  agentID: string | undefined,
+  agent: string,
+  readiness?: ExternalAgentReadiness,
+): string {
+  if (readiness) {
+    switch (readiness.kind) {
+      case "sign_in":
+        return readiness.signInHint || readiness.detail || `${agent} needs local CLI sign-in.`;
+      case "setup":
+        return readiness.detail || readiness.setupHint;
+      case "billing":
+        return (
+          readiness.detail ||
+          `Check ${agent}'s billing or subscription, then test the adapter again in Connections.`
+        );
+      case "issue":
+        return readiness.detail || `Open Connections and test ${agent} again.`;
+      default:
+        break;
+    }
+  }
+
   switch (agentID) {
     case "cursor_agent":
       return "Cursor Agent needs the local CLI installed, available on PATH, and signed in with cursor-agent login before Hecate can start a session.";


### PR DESCRIPTION
## Summary
- Port the remaining useful commit from origin/fix/external-agent-polish-followups onto current master.
- Align external-agent auth/setup readiness copy across adapter probing and chat launch UI.
- Keep the old already-applied branch history out of this PR.

## Verification
- go test ./internal/agentadapters
- cd ui && bun run test -- src/lib/chat-setup-readiness.test.ts src/features/chats/ChatView.test.tsx
- cd ui && bun run typecheck