### PR TITLE
fix(ui): polish transcript output readability

### DIFF
--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -876,6 +876,27 @@ describe("TranscriptMessageRow", () => {
     expect(output).not.toHaveTextContent(/\d+\s*\|/);
   });
 
+  it("strips padded read-context gutters without leaving stray spacing", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "tool_call",
+        title: "call_read",
+        status: "completed",
+        kind: "read",
+        detail: "read · output:   42 | const answer = 42;\n  43 | return answer;",
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    await user.click(screen.getByText("Output"));
+
+    const output = screen.getByText(/const answer = 42/);
+    expect(output.textContent).toBe("const answer = 42;\nreturn answer;");
+    expect(output).not.toHaveTextContent(/\d+\s*\|/);
+  });
+
   it("strips box-drawing line gutters from read-context output", async () => {
     const user = userEvent.setup();
     const activities: ChatActivityRecord[] = [

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -453,7 +453,10 @@ function isAdapterContextReadFailure(activity: ChatActivityRecord): boolean {
 }
 
 function toolDetailHasOutput(activity: ChatActivityRecord): boolean {
-  return Boolean(capturedToolOutput(activity));
+  return (
+    Boolean(capturedToolOutput(activity)) ||
+    /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
+  );
 }
 
 function hasFailureLikeToolOutput(activity: ChatActivityRecord): boolean {


### PR DESCRIPTION
## Summary
- Port the useful remaining transcript readability changes onto current master without carrying stale branch history.
- Broaden captured-output parsing for output captured details that omit the separator after the marker.
- Add a regression test for padded read-context line gutters leaving no stray spacing in cleaned output.

## Verification
- cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx src/features/transcript/TranscriptActivityTimeline.test.tsx src/features/transcript/transcriptActivityHelpers.test.ts
- cd ui && bun run typecheck
- git diff --check