### PR TITLE
feat(projects): add Project Assistant action API

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -1,0 +1,163 @@
+# Project Assistant
+
+Project Assistant is Hecate's API-first foundation for supervised project
+operations. It is intentionally narrow: a client proposes typed actions, Hecate
+validates them, the operator inspects the exact change set, and apply
+revalidates current server state before any durable mutation.
+
+It is not a broad chat persona in v0. Hecate Chat can call the same proposal and
+apply API later, but the action system lives in core so every surface follows
+the same validation, confirmation, and audit rules.
+
+## Safety model
+
+- Project Assistant actions are typed and allowlisted.
+- Durable or destructive actions require explicit operator confirmation.
+- "No project" remains valid. Assistant proposals may suggest creating or
+  selecting a project, but they do not force every chat into a project.
+- The assistant never writes project stores directly. Proposals are structured
+  data; apply revalidates ids, current state, and project/workspace boundaries
+  server-side.
+- Memory actions create memory candidates only. They never create durable
+  memory entries directly.
+- Assistant code does not perform raw filesystem, shell, or Git access.
+  Workspace-bound behavior must use WorkspaceFS, ProcessRunner, GitRunner, or
+  existing task-runtime paths.
+- Proposals, traces, artifacts, and memory candidates must not store secrets.
+
+Apply is sequential across existing stores. A proposal id is an idempotency
+boundary: applying the same proposal again returns a conflict instead of
+duplicating mutations.
+
+## Endpoints
+
+### `POST /hecate/v1/project-assistant/propose`
+
+Validates a candidate proposal and returns a server-shaped proposal id,
+warnings, confirmation posture, and trace id.
+
+```json
+POST /hecate/v1/project-assistant/propose
+{
+  "title": "Create project",
+  "summary": "Create a Hecate project with the current workspace root.",
+  "actions": [
+    {
+      "kind": "create_project",
+      "target": { "project_id": "proj_hecate" },
+      "patch": {
+        "name": "Hecate",
+        "description": "Local AI operations console",
+        "workspace_path": "/Users/alice/src/hecate",
+        "workspace_kind": "git"
+      },
+      "reason": "Track chats, project work, and context under one project."
+    }
+  ]
+}
+→ 200
+{
+  "object": "project_assistant.proposal",
+  "data": {
+    "id": "pa_...",
+    "title": "Create project",
+    "summary": "Create a Hecate project with the current workspace root.",
+    "actions": [],
+    "warnings": [],
+    "requires_confirmation": true,
+    "trace_id": "..."
+  }
+}
+```
+
+Unknown action kinds return `400 invalid_request`.
+
+### `POST /hecate/v1/project-assistant/apply`
+
+Applies a previously proposed change set. Requests must send the proposal and
+`confirm: true` when `requires_confirmation` is true.
+
+```json
+POST /hecate/v1/project-assistant/apply
+{
+  "proposal": {
+    "id": "pa_...",
+    "title": "Create project",
+    "summary": "Create a Hecate project and attach the current workspace root.",
+    "actions": [],
+    "warnings": [],
+    "requires_confirmation": true
+  },
+  "confirm": true
+}
+→ 200
+{
+  "object": "project_assistant.apply_result",
+  "data": {
+    "proposal_id": "pa_...",
+    "applied": true,
+    "actions": [
+      {
+        "kind": "create_project",
+        "id": "proj_hecate",
+        "data": {
+          "project_id": "proj_hecate"
+        }
+      }
+    ]
+  }
+}
+```
+
+Repeated apply attempts for the same proposal id return `409 conflict`.
+Stale ids, missing projects, missing chats, missing work items, or missing
+memory candidates return `404 not_found` or `409 conflict` depending on the
+state transition.
+
+## Action shape
+
+Every action has the same envelope:
+
+```json
+{
+  "kind": "move_chat_session",
+  "target": {
+    "chat_session_id": "chat_...",
+    "project_id": "proj_..."
+  },
+  "patch": {},
+  "reason": "Keep this chat with the project it discusses."
+}
+```
+
+- `kind` selects the allowlisted operation.
+- `target` identifies the existing resource or requested id.
+- `patch` carries the proposed new fields.
+- `reason` is operator-facing context shown before apply.
+
+## Supported action kinds
+
+| Kind                      | Store path used        | Notes                                                                                                                                   |
+| ------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `create_project`          | `internal/projects`    | Creates a project with optional explicit id, `workspace_path`, roots, and defaults. Omit workspace fields for a workspace-less project. |
+| `update_project`          | `internal/projects`    | Updates metadata and whole-list roots/context-source fields.                                                                            |
+| `attach_project_root`     | `internal/projects`    | Adds a root to an existing project.                                                                                                     |
+| `remove_project_root`     | `internal/projects`    | Removes a root from an existing project.                                                                                                |
+| `set_project_defaults`    | `internal/projects`    | Updates provider/model/profile/tools/workspace/system-prompt defaults.                                                                  |
+| `move_chat_session`       | `internal/chat`        | Moves exactly one chat session into a project or back to no project.                                                                    |
+| `create_work_item`        | `internal/projectwork` | Creates a project-scoped work item; does not start a task.                                                                              |
+| `update_work_item`        | `internal/projectwork` | Updates one existing work item.                                                                                                         |
+| `create_assignment`       | `internal/projectwork` | Creates an assignment for existing project work.                                                                                        |
+| `create_handoff`          | `internal/projectwork` | Creates a handoff record; does not launch follow-up work.                                                                               |
+| `create_memory_candidate` | `internal/memory`      | Creates a candidate with provenance; never a durable memory entry.                                                                      |
+
+## UI contract
+
+The first visible UI should stay small and inspectable:
+
+- show proposal cards with exact actions before apply;
+- show `Apply`, `Dismiss`, and `Inspect`;
+- require explicit confirmation for durable/destructive proposals;
+- show stale-state failures as "State changed, refresh proposal";
+- keep Chat integration as a later caller of the same API, not a second action
+  system.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -24,10 +24,21 @@ the same validation, confirmation, and audit rules.
   Workspace-bound behavior must use WorkspaceFS, ProcessRunner, GitRunner, or
   existing task-runtime paths.
 - Proposals, traces, artifacts, and memory candidates must not store secrets.
+- Apply is human-gated. Do not expose `/project-assistant/apply` as a direct
+  model-callable tool; chat or agent integrations must route durable mutations
+  through an explicit blocking operator confirmation first.
 
-Apply is sequential across existing stores. A proposal id is an idempotency
-boundary: applying the same proposal again returns a conflict instead of
-duplicating mutations.
+Apply is sequential across existing stores. A proposal id plus its canonical
+action set is the in-process progress boundary. If action N fails after earlier
+actions have already mutated durable stores, the API returns the partial action
+results and `failed_action_index`. Retrying the exact same proposal resumes at
+the next unapplied action. Retrying the same proposal id with a changed action
+set returns `409 conflict`, and retrying a fully applied proposal also returns
+`409 conflict`.
+
+Future versions may persist proposal ids server-side so reviewed actions,
+confirmation, and resumable progress survive process restarts. The v0 API keeps
+that shape possible without requiring it.
 
 ## Endpoints
 
@@ -113,6 +124,37 @@ Repeated apply attempts for the same proposal id return `409 conflict`.
 Stale ids, missing projects, missing chats, missing work items, or missing
 memory candidates return `404 not_found` or `409 conflict` depending on the
 state transition.
+
+When a multi-action apply fails after earlier actions were committed, the error
+includes progress metadata:
+
+```json
+{
+  "error": {
+    "type": "not_found",
+    "message": "project assistant apply failed at action 1: project assistant target not found: project \"proj_missing\"",
+    "failed_action_index": 1,
+    "partial_result": {
+      "proposal_id": "pa_...",
+      "applied": false,
+      "actions": [
+        {
+          "kind": "create_project",
+          "id": "proj_hecate",
+          "data": {
+            "project_id": "proj_hecate"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Retry the unchanged proposal after fixing the missing target to resume from the
+first unapplied action. If the client changes `actions[]` while reusing the same
+proposal id, apply returns `409 conflict` so the operator can refresh the
+proposal instead of unknowingly applying a different change set.
 
 ## Action shape
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -117,6 +117,7 @@ object when available.
 - [Health and discovery endpoints](#health-and-discovery-endpoints)
 - [Agent profile endpoints](#agent-profile-endpoints)
 - [Project endpoints](#project-endpoints)
+- [Project Assistant endpoints](#project-assistant-endpoints)
 - [Chat session endpoints](#chat-session-endpoints)
 - [Rate-limit headers on chat / messages](#rate-limit-headers-on-chat--messages)
 
@@ -1192,20 +1193,20 @@ When supplied, `default_root_id` must match one of the supplied roots.
 Context source `id` values are optional; Hecate generates `ctxsrc_...` IDs for
 sources that omit them. Context sources are metadata only in this release.
 
+Projects may be created without a workspace by omitting both `workspace_path`
+and `roots`. For the common one-workspace case, send `workspace_path` and
+optionally `workspace_kind`; Hecate creates one active root and makes it the
+default root. For advanced multi-root setup, send `roots` directly.
+`workspace_path` cannot be combined with `roots` or an explicit
+`default_root_id`.
+
 ```json
 POST /hecate/v1/projects
 {
   "name": "Hecate",
   "description": "Gateway and agent runtime",
-  "roots": [
-    {
-      "path": "/Users/alice/src/hecate",
-      "kind": "git",
-      "git_remote": "git@github.com:hecatehq/hecate.git",
-      "git_branch": "master",
-      "active": true
-    }
-  ],
+  "workspace_path": "/Users/alice/src/hecate",
+  "workspace_kind": "git",
   "context_sources": [
     {
       "kind": "doc",
@@ -2058,6 +2059,22 @@ the same work item.
   "author_role_id": "software_developer"
 }
 ```
+
+## Project Assistant endpoints
+
+Project Assistant is the API-first assistant-action foundation for project
+operations. It does not expose an open-ended chat persona. Clients submit a
+typed, allowlisted proposal, inspect the exact changes, then explicitly apply
+the proposal. Apply revalidates current server state before mutating projects,
+chats, project work, or memory candidates.
+
+Endpoints:
+
+- `POST /hecate/v1/project-assistant/propose`
+- `POST /hecate/v1/project-assistant/apply`
+
+See [`project-assistant.md`](project-assistant.md) for the proposal schema,
+supported action kinds, confirmation behavior, and safety model.
 
 ## Chat session endpoints
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2068,6 +2068,13 @@ typed, allowlisted proposal, inspect the exact changes, then explicitly apply
 the proposal. Apply revalidates current server state before mutating projects,
 chats, project work, or memory candidates.
 
+Apply is a human-gated operation. Do not wire it as a direct model-callable tool
+without an explicit blocking operator confirmation. Multi-action apply is
+sequential and resumable within the current process: on a mid-sequence failure
+the error includes `failed_action_index` and `partial_result`; retrying the
+unchanged proposal id resumes after the committed actions, while changing the
+action set or reapplying a fully applied proposal returns `409 conflict`.
+
 Endpoints:
 
 - `POST /hecate/v1/project-assistant/propose`

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
@@ -22,6 +23,7 @@ import (
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/ratelimit"
@@ -47,6 +49,8 @@ type Handler struct {
 	memory                   memory.Store
 	memoryCandidates         memory.CandidateStore
 	projectWork              projectwork.Store
+	projectAssistantMu       sync.Mutex
+	projectAssistant         *projectassistant.Service
 	agentProfiles            agentprofiles.Store
 	agentChatRunner          agentadapters.Runner
 	agentChatLive            *agentChatLive
@@ -381,6 +385,9 @@ func (h *Handler) SetAgentChatStore(store chat.Store) {
 		return
 	}
 	h.agentChat = store
+	h.projectAssistantMu.Lock()
+	h.projectAssistant = nil
+	h.projectAssistantMu.Unlock()
 	h.reconcileAgentChatStore(context.Background())
 }
 
@@ -389,6 +396,9 @@ func (h *Handler) SetProjectStore(store projects.Store) {
 		return
 	}
 	h.projects = store
+	h.projectAssistantMu.Lock()
+	h.projectAssistant = nil
+	h.projectAssistantMu.Unlock()
 }
 
 func (h *Handler) SetMemoryStore(store memory.Store) {
@@ -401,6 +411,9 @@ func (h *Handler) SetMemoryStore(store memory.Store) {
 	} else {
 		h.memoryCandidates = nil
 	}
+	h.projectAssistantMu.Lock()
+	h.projectAssistant = nil
+	h.projectAssistantMu.Unlock()
 }
 
 func (h *Handler) SetProjectWorkStore(store projectwork.Store) {
@@ -408,6 +421,9 @@ func (h *Handler) SetProjectWorkStore(store projectwork.Store) {
 		return
 	}
 	h.projectWork = store
+	h.projectAssistantMu.Lock()
+	h.projectAssistant = nil
+	h.projectAssistantMu.Unlock()
 }
 
 func (h *Handler) SetAgentProfileStore(store agentprofiles.Store) {

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type projectAssistantProposeRequest struct {
+	ID      string                    `json:"id,omitempty"`
+	Title   string                    `json:"title,omitempty"`
+	Summary string                    `json:"summary,omitempty"`
+	Actions []projectassistant.Action `json:"actions"`
+}
+
+type projectAssistantApplyRequest struct {
+	Proposal projectassistant.Proposal `json:"proposal"`
+	Confirm  bool                      `json:"confirm,omitempty"`
+}
+
+func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.Request) {
+	var req projectAssistantProposeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant proposal request")
+		return
+	}
+	proposal, err := h.projectAssistantService().Propose(r.Context(), projectassistant.ProposalInput{
+		ID:      req.ID,
+		Title:   req.Title,
+		Summary: req.Summary,
+		Actions: req.Actions,
+		TraceID: requestTraceID(r),
+	})
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.proposal",
+		"data":   proposal,
+	})
+}
+
+func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Request) {
+	var req projectAssistantApplyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant apply request")
+		return
+	}
+	result, err := h.projectAssistantService().Apply(r.Context(), req.Proposal, req.Confirm)
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.apply_result",
+		"data":   result,
+	})
+}
+
+func (h *Handler) projectAssistantService() *projectassistant.Service {
+	h.projectAssistantMu.Lock()
+	defer h.projectAssistantMu.Unlock()
+	if h.projectAssistant == nil {
+		h.projectAssistant = projectassistant.NewService(projectassistant.Stores{
+			Projects:         h.projects,
+			Chats:            h.agentChat,
+			Work:             h.projectWork,
+			MemoryCandidates: h.memoryCandidates,
+		}, newOpaqueTaskResourceID)
+	}
+	return h.projectAssistant
+}
+
+func writeProjectAssistantError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, projectassistant.ErrUnknownActionKind), errors.Is(err, projectassistant.ErrInvalid):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, projectassistant.ErrNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
+	case errors.Is(err, projectassistant.ErrConfirmationRequired), errors.Is(err, projectassistant.ErrConflict):
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+	default:
+		WriteError(w, http.StatusInternalServerError, errCodeInternalError, err.Error())
+	}
+}
+
+func requestTraceID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	spanCtx := trace.SpanContextFromContext(r.Context())
+	if !spanCtx.HasTraceID() {
+		return ""
+	}
+	return spanCtx.TraceID().String()
+}

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -52,7 +52,7 @@ func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Req
 	}
 	result, err := h.projectAssistantService().Apply(r.Context(), req.Proposal, req.Confirm)
 	if err != nil {
-		writeProjectAssistantError(w, err)
+		writeProjectAssistantApplyError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, map[string]any{
@@ -75,16 +75,36 @@ func (h *Handler) projectAssistantService() *projectassistant.Service {
 	return h.projectAssistant
 }
 
+func writeProjectAssistantApplyError(w http.ResponseWriter, err error) {
+	var applyErr *projectassistant.ApplyError
+	if !errors.As(err, &applyErr) {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	status, code := projectAssistantErrorStatusCode(err)
+	WriteErrorDetails(w, status, code, err.Error(), ErrorDetails{
+		Fields: map[string]any{
+			"failed_action_index": applyErr.FailedActionIndex,
+			"partial_result":      applyErr.Result,
+		},
+	})
+}
+
 func writeProjectAssistantError(w http.ResponseWriter, err error) {
+	status, code := projectAssistantErrorStatusCode(err)
+	WriteError(w, status, code, err.Error())
+}
+
+func projectAssistantErrorStatusCode(err error) (int, string) {
 	switch {
 	case errors.Is(err, projectassistant.ErrUnknownActionKind), errors.Is(err, projectassistant.ErrInvalid):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return http.StatusBadRequest, errCodeInvalidRequest
 	case errors.Is(err, projectassistant.ErrNotFound):
-		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
+		return http.StatusNotFound, errCodeNotFound
 	case errors.Is(err, projectassistant.ErrConfirmationRequired), errors.Is(err, projectassistant.ErrConflict):
-		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return http.StatusConflict, errCodeConflict
 	default:
-		WriteError(w, http.StatusInternalServerError, errCodeInternalError, err.Error())
+		return http.StatusInternalServerError, errCodeInternalError
 	}
 }
 

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -26,6 +26,15 @@ type projectAssistantApplyResponse struct {
 	Data   projectassistant.ApplyResult `json:"data"`
 }
 
+type projectAssistantErrorResponse struct {
+	Error struct {
+		Type              string                       `json:"type"`
+		Message           string                       `json:"message"`
+		FailedActionIndex int                          `json:"failed_action_index"`
+		PartialResult     projectassistant.ApplyResult `json:"partial_result"`
+	} `json:"error"`
+}
+
 func newProjectAssistantTestServer() http.Handler {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
@@ -134,6 +143,54 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	root := project.Data.Roots[0]
 	if root.Path != "/tmp/hecate-api-project" || root.Kind != "git" || !root.Active || project.Data.DefaultRootID != root.ID {
 		t.Fatalf("root = %+v default_root_id=%q, want generated default workspace root", root, project.Data.DefaultRootID)
+	}
+}
+
+func TestProjectAssistantAPI_ApplyPartialFailureIncludesProgress(t *testing.T) {
+	t.Parallel()
+	server := newProjectAssistantTestServer()
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_partial_api",
+		Title:                "Partial apply",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind:  projectassistant.ActionCreateProject,
+				Patch: json.RawMessage(`{"id":"proj_partial_api","name":"Partial API"}`),
+			},
+			{
+				Kind: projectassistant.ActionCreateWorkItem,
+				Patch: json.RawMessage(`{
+					"id":"work_missing_project",
+					"project_id":"proj_missing_api",
+					"title":"Cannot create yet"
+				}`),
+			},
+		},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("partial apply status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	var payload projectAssistantErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode partial apply error: %v", err)
+	}
+	if payload.Error.Type != errCodeNotFound || payload.Error.FailedActionIndex != 1 {
+		t.Fatalf("error = %+v, want not_found at action index 1", payload.Error)
+	}
+	partial := payload.Error.PartialResult
+	if partial.ProposalID != "pa_partial_api" || partial.Applied || len(partial.Actions) != 1 {
+		t.Fatalf("partial_result = %+v, want one unapplied partial result", partial)
+	}
+	if partial.Actions[0].Kind != projectassistant.ActionCreateProject || partial.Actions[0].ID != "proj_partial_api" {
+		t.Fatalf("partial action = %+v, want created project action", partial.Actions[0])
 	}
 }
 

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type projectAssistantProposalResponse struct {
+	Object string                    `json:"object"`
+	Data   projectassistant.Proposal `json:"data"`
+}
+
+type projectAssistantApplyResponse struct {
+	Object string                       `json:"object"`
+	Data   projectassistant.ApplyResult `json:"data"`
+}
+
+func newProjectAssistantTestServer() http.Handler {
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetAgentChatStore(chat.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	return NewServer(quietLogger(), handler)
+}
+
+func TestProjectAssistantAPI_ProposeRejectsUnknownActionKind(t *testing.T) {
+	t.Parallel()
+	server := newProjectAssistantTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/propose", strings.NewReader(`{
+		"actions":[{"kind":"rewrite_the_world","patch":{"name":"bad"}}]
+	}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("propose status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unknown project assistant action kind") {
+		t.Fatalf("propose body = %s, want unknown action error", rec.Body.String())
+	}
+}
+
+func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
+	t.Parallel()
+	server := newProjectAssistantTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/propose", bytes.NewReader([]byte(`{
+		"id":"pa_api",
+		"title":"Create API project",
+		"summary":"Create a project from a typed assistant action.",
+		"actions":[{
+			"kind":"create_project",
+			"reason":"Operator asked for a new project.",
+			"patch":{
+				"id":"proj_api",
+				"name":"API Project",
+				"description":"Created through Project Assistant",
+				"workspace_path":"/tmp/hecate-api-project",
+				"workspace_kind":"git"
+			}
+		}]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("propose status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode propose response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || proposed.Data.ID != "pa_api" {
+		t.Fatalf("propose response = %+v, want project assistant proposal envelope", proposed)
+	}
+	if !proposed.Data.RequiresConfirmation {
+		t.Fatalf("requires_confirmation = false, want true")
+	}
+	if len(proposed.Data.Actions) != 1 || proposed.Data.Actions[0].Kind != projectassistant.ActionCreateProject {
+		t.Fatalf("proposal actions = %+v, want create_project action", proposed.Data.Actions)
+	}
+
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposed.Data})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("unconfirmed apply status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+
+	applyBody, err = json.Marshal(map[string]any{"proposal": proposed.Data, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal confirmed apply body: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("confirmed apply status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var applied projectAssistantApplyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("decode apply response: %v", err)
+	}
+	if applied.Object != "project_assistant.apply_result" || !applied.Data.Applied || applied.Data.ProposalID != "pa_api" {
+		t.Fatalf("apply response = %+v, want applied project assistant result", applied)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_api", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get project status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &project); err != nil {
+		t.Fatalf("decode project response: %v", err)
+	}
+	if project.Data.Name != "API Project" || project.Data.Description != "Created through Project Assistant" {
+		t.Fatalf("project = %+v, want assistant-created metadata", project.Data)
+	}
+	if len(project.Data.Roots) != 1 {
+		t.Fatalf("roots = %+v, want generated workspace root", project.Data.Roots)
+	}
+	root := project.Data.Roots[0]
+	if root.Path != "/tmp/hecate-api-project" || root.Kind != "git" || !root.Active || project.Data.DefaultRootID != root.ID {
+		t.Fatalf("root = %+v default_root_id=%q, want generated default workspace root", root, project.Data.DefaultRootID)
+	}
+}
+
+func TestProjectAssistantAPI_RepeatedApplyConflicts(t *testing.T) {
+	t.Parallel()
+	server := newProjectAssistantTestServer()
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_repeat_api",
+		Title:                "Create once",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind:  projectassistant.ActionCreateProject,
+			Patch: json.RawMessage(`{"id":"proj_repeat_api","name":"Repeat"}`),
+		}},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first apply status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("second apply status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -36,6 +36,8 @@ type projectContextSourceRequest struct {
 type createProjectRequest struct {
 	Name                     string                        `json:"name"`
 	Description              string                        `json:"description,omitempty"`
+	WorkspacePath            string                        `json:"workspace_path,omitempty"`
+	WorkspaceKind            string                        `json:"workspace_kind,omitempty"`
 	Roots                    []projectRootRequest          `json:"roots,omitempty"`
 	ContextSources           []projectContextSourceRequest `json:"context_sources,omitempty"`
 	DefaultRootID            string                        `json:"default_root_id,omitempty"`
@@ -340,6 +342,23 @@ func projectFromCreateRequest(req createProjectRequest) (projects.Project, error
 	roots, err := rootsFromRequest(req.Roots)
 	if err != nil {
 		return projects.Project{}, err
+	}
+	workspacePath := strings.TrimSpace(req.WorkspacePath)
+	workspaceKind := strings.TrimSpace(req.WorkspaceKind)
+	if workspacePath != "" {
+		if len(roots) > 0 {
+			return projects.Project{}, errors.New("workspace_path cannot be combined with roots")
+		}
+		if strings.TrimSpace(req.DefaultRootID) != "" {
+			return projects.Project{}, errors.New("default_root_id cannot be supplied with workspace_path")
+		}
+		roots = []projects.Root{{
+			Path:   workspacePath,
+			Kind:   workspaceKind,
+			Active: true,
+		}}
+	} else if workspaceKind != "" {
+		return projects.Project{}, errors.New("workspace_kind requires workspace_path")
 	}
 	contextSources, err := contextSourcesFromRequest(req.ContextSources)
 	if err != nil {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -137,6 +137,93 @@ func TestProjectsAPI_Validation(t *testing.T) {
 	}
 }
 
+func TestProjectsAPI_CreateWithWorkspacePathDefaultsRoot(t *testing.T) {
+	t.Parallel()
+	server := newProjectsTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Workspace project",
+		"workspace_path":"/tmp/hecate-workspace",
+		"workspace_kind":"git"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if len(created.Data.Roots) != 1 {
+		t.Fatalf("roots = %+v, want one generated workspace root", created.Data.Roots)
+	}
+	root := created.Data.Roots[0]
+	if root.ID == "" || root.Path != "/tmp/hecate-workspace" || root.Kind != "git" || !root.Active {
+		t.Fatalf("root = %+v, want generated active git workspace root", root)
+	}
+	if created.Data.DefaultRootID != root.ID {
+		t.Fatalf("default_root_id = %q, want generated root id %q", created.Data.DefaultRootID, root.ID)
+	}
+}
+
+func TestProjectsAPI_CreateWithoutWorkspace(t *testing.T) {
+	t.Parallel()
+	server := newProjectsTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"No workspace"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if len(created.Data.Roots) != 0 || created.Data.DefaultRootID != "" {
+		t.Fatalf("project = %+v, want workspace-less project", created.Data)
+	}
+}
+
+func TestProjectsAPI_CreateWorkspacePathRejectsConflictingRootFields(t *testing.T) {
+	t.Parallel()
+	server := newProjectsTestServer()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "explicit roots",
+			body: `{"name":"Broken","workspace_path":"/tmp/hecate","roots":[{"path":"/tmp/other"}]}`,
+			want: "workspace_path cannot be combined with roots",
+		},
+		{
+			name: "workspace kind without path",
+			body: `{"name":"Broken","workspace_kind":"git"}`,
+			want: "workspace_kind requires workspace_path",
+		},
+		{
+			name: "default root id",
+			body: `{"name":"Broken","workspace_path":"/tmp/hecate","default_root_id":"root_a"}`,
+			want: "default_root_id cannot be supplied with workspace_path",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(tc.body))))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("create status = %d body=%s, want 400", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.want) {
+				t.Fatalf("create body = %s, want %q", rec.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
 func TestProjectsAPI_InvalidDefaultRootPatchDoesNotMutate(t *testing.T) {
 	t.Parallel()
 	server := newProjectsTestServer()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,6 +70,8 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	// to them for shared defaults, memory, and context assembly.
 	mux.HandleFunc("GET /hecate/v1/projects", handler.HandleProjects)
 	mux.HandleFunc("POST /hecate/v1/projects", handler.HandleCreateProject)
+	mux.HandleFunc("POST /hecate/v1/project-assistant/propose", handler.HandleProjectAssistantPropose)
+	mux.HandleFunc("POST /hecate/v1/project-assistant/apply", handler.HandleProjectAssistantApply)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -1,6 +1,7 @@
 package projectassistant
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -47,7 +48,7 @@ type Service struct {
 	work             projectwork.Store
 	memoryCandidates memory.CandidateStore
 	idgen            IDGenerator
-	applied          map[string]struct{}
+	applyProgress    map[string]*applyProgress
 }
 
 type Stores struct {
@@ -94,6 +95,43 @@ type ActionResult struct {
 	Data map[string]string `json:"data,omitempty"`
 }
 
+type ApplyError struct {
+	ProposalID        string
+	FailedActionIndex int
+	Result            ApplyResult
+	Err               error
+}
+
+func (e *ApplyError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("project assistant apply failed at action %d", e.FailedActionIndex)
+	}
+	return fmt.Sprintf("project assistant apply failed at action %d: %v", e.FailedActionIndex, e.Err)
+}
+
+func (e *ApplyError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type applyProgress struct {
+	fingerprint string
+	complete    bool
+	results     []ActionResult
+}
+
+type actionFingerprint struct {
+	Kind   string            `json:"kind"`
+	Target map[string]string `json:"target,omitempty"`
+	Patch  json.RawMessage   `json:"patch,omitempty"`
+	Reason string            `json:"reason,omitempty"`
+}
+
 var defaultIDCounter atomic.Uint64
 
 func NewService(stores Stores, idgen IDGenerator) *Service {
@@ -108,7 +146,7 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		work:             stores.Work,
 		memoryCandidates: stores.MemoryCandidates,
 		idgen:            idgen,
-		applied:          make(map[string]struct{}),
+		applyProgress:    make(map[string]*applyProgress),
 	}
 }
 
@@ -159,27 +197,52 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 			return ApplyResult{}, err
 		}
 	}
+	fingerprint, err := actionSetFingerprint(proposal.Actions)
+	if err != nil {
+		return ApplyResult{}, err
+	}
 
 	// Hold the apply lock through the mutation sequence so a proposal ID cannot
-	// race itself into duplicate durable writes.
+	// race itself into duplicate durable writes. Progress is intentionally
+	// in-process for v0; retrying the exact same action set resumes after the
+	// last committed action instead of replaying earlier mutations.
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.applied[proposal.ID]; ok {
+
+	progress, ok := s.applyProgress[proposal.ID]
+	if !ok {
+		progress = &applyProgress{fingerprint: fingerprint}
+		s.applyProgress[proposal.ID] = progress
+	}
+	if progress.complete {
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q was already applied", ErrConflict, proposal.ID)
 	}
-
-	results := make([]ActionResult, 0, len(proposal.Actions))
-	for _, action := range proposal.Actions {
-		result, err := s.applyAction(ctx, action)
-		if err != nil {
-			return ApplyResult{}, err
-		}
-		results = append(results, result)
+	if progress.fingerprint != fingerprint {
+		return ApplyResult{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
 	}
 
-	s.applied[proposal.ID] = struct{}{}
+	for idx := len(progress.results); idx < len(proposal.Actions); idx++ {
+		action := proposal.Actions[idx]
+		result, err := s.applyAction(ctx, action)
+		if err != nil {
+			partial := ApplyResult{
+				ProposalID: proposal.ID,
+				Applied:    false,
+				Actions:    cloneActionResults(progress.results),
+			}
+			return partial, &ApplyError{
+				ProposalID:        proposal.ID,
+				FailedActionIndex: idx,
+				Result:            partial,
+				Err:               err,
+			}
+		}
+		progress.results = append(progress.results, result)
+	}
 
-	return ApplyResult{ProposalID: proposal.ID, Applied: true, Actions: results}, nil
+	progress.complete = true
+
+	return ApplyResult{ProposalID: proposal.ID, Applied: true, Actions: cloneActionResults(progress.results)}, nil
 }
 
 func (s *Service) applyAction(ctx context.Context, action Action) (ActionResult, error) {
@@ -865,6 +928,53 @@ func cloneActions(actions []Action) []Action {
 			Target: cloneStringMap(action.Target),
 			Patch:  append(json.RawMessage(nil), action.Patch...),
 			Reason: action.Reason,
+		}
+	}
+	return cloned
+}
+
+func actionSetFingerprint(actions []Action) (string, error) {
+	items := make([]actionFingerprint, 0, len(actions))
+	for _, action := range actions {
+		patch, err := compactPatch(action.Patch)
+		if err != nil {
+			return "", err
+		}
+		items = append(items, actionFingerprint{
+			Kind:   normalizeKind(action.Kind),
+			Target: cloneStringMap(action.Target),
+			Patch:  patch,
+			Reason: strings.TrimSpace(action.Reason),
+		})
+	}
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		return "", fmt.Errorf("%w: encode action fingerprint: %v", ErrInvalid, err)
+	}
+	return string(encoded), nil
+}
+
+func compactPatch(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return nil, fmt.Errorf("%w: invalid action patch json", ErrInvalid)
+	}
+	return append(json.RawMessage(nil), buf.Bytes()...), nil
+}
+
+func cloneActionResults(results []ActionResult) []ActionResult {
+	if results == nil {
+		return nil
+	}
+	cloned := make([]ActionResult, len(results))
+	for idx, result := range results {
+		cloned[idx] = ActionResult{
+			Kind: result.Kind,
+			ID:   result.ID,
+			Data: cloneStringMap(result.Data),
 		}
 	}
 	return cloned

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -1,0 +1,919 @@
+package projectassistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+const (
+	ActionCreateProject         = "create_project"
+	ActionUpdateProject         = "update_project"
+	ActionAttachProjectRoot     = "attach_project_root"
+	ActionRemoveProjectRoot     = "remove_project_root"
+	ActionSetProjectDefaults    = "set_project_defaults"
+	ActionMoveChatSession       = "move_chat_session"
+	ActionCreateWorkItem        = "create_work_item"
+	ActionUpdateWorkItem        = "update_work_item"
+	ActionCreateAssignment      = "create_assignment"
+	ActionCreateHandoff         = "create_handoff"
+	ActionCreateMemoryCandidate = "create_memory_candidate"
+)
+
+var (
+	ErrInvalid              = errors.New("invalid project assistant proposal")
+	ErrUnknownActionKind    = errors.New("unknown project assistant action kind")
+	ErrNotFound             = errors.New("project assistant target not found")
+	ErrConflict             = errors.New("project assistant conflict")
+	ErrConfirmationRequired = errors.New("project assistant confirmation required")
+	ErrStoreNotConfigured   = errors.New("project assistant store not configured")
+)
+
+type IDGenerator func(prefix string) string
+
+type Service struct {
+	mu               sync.Mutex
+	projects         projects.Store
+	chats            chat.Store
+	work             projectwork.Store
+	memoryCandidates memory.CandidateStore
+	idgen            IDGenerator
+	applied          map[string]struct{}
+}
+
+type Stores struct {
+	Projects         projects.Store
+	Chats            chat.Store
+	Work             projectwork.Store
+	MemoryCandidates memory.CandidateStore
+}
+
+type ProposalInput struct {
+	ID      string
+	Title   string
+	Summary string
+	Actions []Action
+	TraceID string
+}
+
+type Proposal struct {
+	ID                   string   `json:"id"`
+	Title                string   `json:"title"`
+	Summary              string   `json:"summary"`
+	Actions              []Action `json:"actions"`
+	Warnings             []string `json:"warnings,omitempty"`
+	RequiresConfirmation bool     `json:"requires_confirmation"`
+	TraceID              string   `json:"trace_id,omitempty"`
+}
+
+type Action struct {
+	Kind   string            `json:"kind"`
+	Target map[string]string `json:"target,omitempty"`
+	Patch  json.RawMessage   `json:"patch,omitempty"`
+	Reason string            `json:"reason,omitempty"`
+}
+
+type ApplyResult struct {
+	ProposalID string         `json:"proposal_id"`
+	Applied    bool           `json:"applied"`
+	Actions    []ActionResult `json:"actions"`
+}
+
+type ActionResult struct {
+	Kind string            `json:"kind"`
+	ID   string            `json:"id,omitempty"`
+	Data map[string]string `json:"data,omitempty"`
+}
+
+var defaultIDCounter atomic.Uint64
+
+func NewService(stores Stores, idgen IDGenerator) *Service {
+	if idgen == nil {
+		idgen = func(prefix string) string {
+			return fmt.Sprintf("%s_%d", strings.TrimSpace(prefix), defaultIDCounter.Add(1))
+		}
+	}
+	return &Service{
+		projects:         stores.Projects,
+		chats:            stores.Chats,
+		work:             stores.Work,
+		memoryCandidates: stores.MemoryCandidates,
+		idgen:            idgen,
+		applied:          make(map[string]struct{}),
+	}
+}
+
+func (s *Service) Propose(_ context.Context, input ProposalInput) (Proposal, error) {
+	if s == nil {
+		return Proposal{}, ErrStoreNotConfigured
+	}
+	actions := cloneActions(input.Actions)
+	if len(actions) == 0 {
+		return Proposal{}, fmt.Errorf("%w: actions are required", ErrInvalid)
+	}
+	for _, action := range actions {
+		if err := validateActionShape(action); err != nil {
+			return Proposal{}, err
+		}
+	}
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		id = s.idgen("pa")
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		title = "Project operation proposal"
+	}
+	return Proposal{
+		ID:                   id,
+		Title:                title,
+		Summary:              strings.TrimSpace(input.Summary),
+		Actions:              actions,
+		RequiresConfirmation: true,
+		TraceID:              strings.TrimSpace(input.TraceID),
+	}, nil
+}
+
+func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) (ApplyResult, error) {
+	if s == nil {
+		return ApplyResult{}, ErrStoreNotConfigured
+	}
+	proposal.ID = strings.TrimSpace(proposal.ID)
+	if proposal.ID == "" {
+		return ApplyResult{}, fmt.Errorf("%w: proposal id is required", ErrInvalid)
+	}
+	if proposal.RequiresConfirmation && !confirmed {
+		return ApplyResult{}, ErrConfirmationRequired
+	}
+	for _, action := range proposal.Actions {
+		if err := validateActionShape(action); err != nil {
+			return ApplyResult{}, err
+		}
+	}
+
+	// Hold the apply lock through the mutation sequence so a proposal ID cannot
+	// race itself into duplicate durable writes.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.applied[proposal.ID]; ok {
+		return ApplyResult{}, fmt.Errorf("%w: proposal %q was already applied", ErrConflict, proposal.ID)
+	}
+
+	results := make([]ActionResult, 0, len(proposal.Actions))
+	for _, action := range proposal.Actions {
+		result, err := s.applyAction(ctx, action)
+		if err != nil {
+			return ApplyResult{}, err
+		}
+		results = append(results, result)
+	}
+
+	s.applied[proposal.ID] = struct{}{}
+
+	return ApplyResult{ProposalID: proposal.ID, Applied: true, Actions: results}, nil
+}
+
+func (s *Service) applyAction(ctx context.Context, action Action) (ActionResult, error) {
+	switch normalizeKind(action.Kind) {
+	case ActionCreateProject:
+		return s.applyCreateProject(ctx, action)
+	case ActionUpdateProject:
+		return s.applyUpdateProject(ctx, action)
+	case ActionAttachProjectRoot:
+		return s.applyAttachProjectRoot(ctx, action)
+	case ActionRemoveProjectRoot:
+		return s.applyRemoveProjectRoot(ctx, action)
+	case ActionSetProjectDefaults:
+		return s.applySetProjectDefaults(ctx, action)
+	case ActionMoveChatSession:
+		return s.applyMoveChatSession(ctx, action)
+	case ActionCreateWorkItem:
+		return s.applyCreateWorkItem(ctx, action)
+	case ActionUpdateWorkItem:
+		return s.applyUpdateWorkItem(ctx, action)
+	case ActionCreateAssignment:
+		return s.applyCreateAssignment(ctx, action)
+	case ActionCreateHandoff:
+		return s.applyCreateHandoff(ctx, action)
+	case ActionCreateMemoryCandidate:
+		return s.applyCreateMemoryCandidate(ctx, action)
+	default:
+		return ActionResult{}, fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
+	}
+}
+
+func validateActionShape(action Action) error {
+	kind := normalizeKind(action.Kind)
+	switch kind {
+	case ActionCreateProject, ActionUpdateProject, ActionAttachProjectRoot, ActionRemoveProjectRoot,
+		ActionSetProjectDefaults, ActionMoveChatSession, ActionCreateWorkItem, ActionUpdateWorkItem,
+		ActionCreateAssignment, ActionCreateHandoff, ActionCreateMemoryCandidate:
+		if len(action.Patch) == 0 && kind != ActionRemoveProjectRoot {
+			return fmt.Errorf("%w: action %q patch is required", ErrInvalid, kind)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
+	}
+}
+
+func (s *Service) applyCreateProject(ctx context.Context, action Action) (ActionResult, error) {
+	if s.projects == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch projectPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("proj")
+	} else if _, ok, err := s.projects.Get(ctx, id); err != nil {
+		return ActionResult{}, err
+	} else if ok {
+		return ActionResult{}, fmt.Errorf("%w: project %q already exists", ErrConflict, id)
+	}
+	roots, err := rootsForProjectPatch(patch, s.idgen)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	project := projects.Project{
+		ID:                       id,
+		Name:                     patch.Name,
+		Description:              patch.Description,
+		Roots:                    roots,
+		DefaultProvider:          patch.DefaultProvider,
+		DefaultModel:             patch.DefaultModel,
+		DefaultAgentProfile:      patch.DefaultAgentProfile,
+		DefaultToolsEnabled:      patch.DefaultToolsEnabled,
+		DefaultWorkspaceMode:     patch.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      patch.DefaultSystemPrompt,
+		DefaultCompactToolOutput: patch.DefaultCompactToolOutput,
+	}
+	created, err := s.projects.Create(ctx, project)
+	if err != nil {
+		return ActionResult{}, mapProjectErr(err)
+	}
+	return ActionResult{Kind: ActionCreateProject, ID: created.ID, Data: map[string]string{"project_id": created.ID}}, nil
+}
+
+func (s *Service) applyUpdateProject(ctx context.Context, action Action) (ActionResult, error) {
+	projectID := targetValue(action, "project_id")
+	if projectID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return ActionResult{}, err
+	}
+	var patch updateProjectPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
+		if patch.Name != nil {
+			project.Name = *patch.Name
+		}
+		if patch.Description != nil {
+			project.Description = *patch.Description
+		}
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectErr(err)
+	}
+	return ActionResult{Kind: ActionUpdateProject, ID: updated.ID, Data: map[string]string{"project_id": updated.ID}}, nil
+}
+
+func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+	projectID := targetValue(action, "project_id")
+	if projectID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return ActionResult{}, err
+	}
+	var patch rootPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	root := rootFromPatch(patch, s.idgen)
+	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
+		project.Roots = append(project.Roots, root)
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectErr(err)
+	}
+	return ActionResult{Kind: ActionAttachProjectRoot, ID: root.ID, Data: map[string]string{"project_id": updated.ID, "root_id": root.ID}}, nil
+}
+
+func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+	projectID := targetValue(action, "project_id")
+	rootID := targetValue(action, "root_id")
+	if projectID == "" || rootID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.project_id and target.root_id are required", ErrInvalid)
+	}
+	project, err := s.requireProject(ctx, projectID)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	if !projectHasRoot(project, rootID) {
+		return ActionResult{}, fmt.Errorf("%w: root %q", ErrNotFound, rootID)
+	}
+	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
+		roots := project.Roots[:0]
+		for _, root := range project.Roots {
+			if root.ID != rootID {
+				roots = append(roots, root)
+			}
+		}
+		project.Roots = roots
+		if project.DefaultRootID == rootID {
+			project.DefaultRootID = ""
+		}
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectErr(err)
+	}
+	return ActionResult{Kind: ActionRemoveProjectRoot, ID: rootID, Data: map[string]string{"project_id": updated.ID, "root_id": rootID}}, nil
+}
+
+func (s *Service) applySetProjectDefaults(ctx context.Context, action Action) (ActionResult, error) {
+	projectID := targetValue(action, "project_id")
+	if projectID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
+	}
+	project, err := s.requireProject(ctx, projectID)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	var patch defaultsPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	if patch.DefaultRootID != nil && *patch.DefaultRootID != "" && !projectHasRoot(project, *patch.DefaultRootID) {
+		return ActionResult{}, fmt.Errorf("%w: root %q", ErrNotFound, *patch.DefaultRootID)
+	}
+	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
+		if patch.DefaultRootID != nil {
+			project.DefaultRootID = *patch.DefaultRootID
+		}
+		if patch.DefaultProvider != nil {
+			project.DefaultProvider = *patch.DefaultProvider
+		}
+		if patch.DefaultModel != nil {
+			project.DefaultModel = *patch.DefaultModel
+		}
+		if patch.DefaultAgentProfile != nil {
+			project.DefaultAgentProfile = *patch.DefaultAgentProfile
+		}
+		if patch.DefaultToolsEnabled != nil {
+			project.DefaultToolsEnabled = patch.DefaultToolsEnabled
+		}
+		if patch.DefaultWorkspaceMode != nil {
+			project.DefaultWorkspaceMode = *patch.DefaultWorkspaceMode
+		}
+		if patch.DefaultSystemPrompt != nil {
+			project.DefaultSystemPrompt = *patch.DefaultSystemPrompt
+		}
+		if patch.DefaultCompactToolOutput != nil {
+			project.DefaultCompactToolOutput = patch.DefaultCompactToolOutput
+		}
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectErr(err)
+	}
+	return ActionResult{Kind: ActionSetProjectDefaults, ID: updated.ID, Data: map[string]string{"project_id": updated.ID}}, nil
+}
+
+func (s *Service) applyMoveChatSession(ctx context.Context, action Action) (ActionResult, error) {
+	if s.chats == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	sessionID := targetValue(action, "chat_session_id")
+	if sessionID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.chat_session_id is required", ErrInvalid)
+	}
+	var patch moveChatSessionPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := strings.TrimSpace(patch.ProjectID)
+	if projectID != "" {
+		if _, err := s.requireProject(ctx, projectID); err != nil {
+			return ActionResult{}, err
+		}
+	}
+	if _, ok, err := s.chats.Get(ctx, sessionID); err != nil {
+		return ActionResult{}, err
+	} else if !ok {
+		return ActionResult{}, fmt.Errorf("%w: chat session %q", ErrNotFound, sessionID)
+	}
+	updated, err := s.chats.UpdateSession(ctx, sessionID, func(session *chat.Session) {
+		session.ProjectID = projectID
+	})
+	if err != nil {
+		return ActionResult{}, err
+	}
+	return ActionResult{Kind: ActionMoveChatSession, ID: updated.ID, Data: map[string]string{"chat_session_id": updated.ID, "project_id": updated.ProjectID}}, nil
+}
+
+func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
+	if s.work == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch workItemPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := patch.ProjectID
+	if projectID == "" {
+		projectID = targetValue(action, "project_id")
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("work")
+	}
+	item, err := s.work.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:              id,
+		ProjectID:       projectID,
+		Title:           patch.Title,
+		Brief:           patch.Brief,
+		Status:          patch.Status,
+		Priority:        patch.Priority,
+		OwnerRoleID:     patch.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), patch.ReviewerRoleIDs...),
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectWorkErr(err)
+	}
+	return ActionResult{Kind: ActionCreateWorkItem, ID: item.ID, Data: map[string]string{"project_id": item.ProjectID, "work_item_id": item.ID}}, nil
+}
+
+func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
+	if s.work == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	projectID := targetValue(action, "project_id")
+	workItemID := targetValue(action, "work_item_id")
+	if projectID == "" || workItemID == "" {
+		return ActionResult{}, fmt.Errorf("%w: target.project_id and target.work_item_id are required", ErrInvalid)
+	}
+	if _, err := s.requireWorkItem(ctx, projectID, workItemID); err != nil {
+		return ActionResult{}, err
+	}
+	var patch updateWorkItemPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	item, err := s.work.UpdateWorkItem(ctx, projectID, workItemID, func(item *projectwork.WorkItem) {
+		if patch.Title != nil {
+			item.Title = *patch.Title
+		}
+		if patch.Brief != nil {
+			item.Brief = *patch.Brief
+		}
+		if patch.Status != nil {
+			item.Status = *patch.Status
+		}
+		if patch.Priority != nil {
+			item.Priority = *patch.Priority
+		}
+		if patch.OwnerRoleID != nil {
+			item.OwnerRoleID = *patch.OwnerRoleID
+		}
+		if patch.ReviewerRoleIDs != nil {
+			item.ReviewerRoleIDs = append([]string(nil), patch.ReviewerRoleIDs...)
+		}
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectWorkErr(err)
+	}
+	return ActionResult{Kind: ActionUpdateWorkItem, ID: item.ID, Data: map[string]string{"project_id": item.ProjectID, "work_item_id": item.ID}}, nil
+}
+
+func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (ActionResult, error) {
+	if s.work == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch assignmentPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := patch.ProjectID
+	if projectID == "" {
+		projectID = targetValue(action, "project_id")
+	}
+	if _, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("asgn")
+	}
+	assignment, err := s.work.CreateAssignment(ctx, projectwork.Assignment{
+		ID:                id,
+		ProjectID:         projectID,
+		WorkItemID:        patch.WorkItemID,
+		RoleID:            patch.RoleID,
+		DriverKind:        patch.DriverKind,
+		Status:            patch.Status,
+		TaskID:            patch.TaskID,
+		RunID:             patch.RunID,
+		ChatSessionID:     patch.ChatSessionID,
+		MessageID:         patch.MessageID,
+		ContextSnapshotID: patch.ContextSnapshotID,
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectWorkErr(err)
+	}
+	return ActionResult{Kind: ActionCreateAssignment, ID: assignment.ID, Data: map[string]string{"project_id": assignment.ProjectID, "assignment_id": assignment.ID}}, nil
+}
+
+func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (ActionResult, error) {
+	if s.work == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch handoffPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := patch.ProjectID
+	if projectID == "" {
+		projectID = targetValue(action, "project_id")
+	}
+	if _, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("handoff")
+	}
+	handoff, err := s.work.CreateHandoff(ctx, projectwork.Handoff{
+		ID:                    id,
+		ProjectID:             projectID,
+		WorkItemID:            patch.WorkItemID,
+		SourceAssignmentID:    patch.SourceAssignmentID,
+		SourceRunID:           patch.SourceRunID,
+		SourceChatSessionID:   patch.SourceChatSessionID,
+		SourceMessageID:       patch.SourceMessageID,
+		TargetRoleID:          patch.TargetRoleID,
+		TargetAssignmentID:    patch.TargetAssignmentID,
+		TargetWorkItemID:      patch.TargetWorkItemID,
+		Title:                 patch.Title,
+		Summary:               patch.Summary,
+		RecommendedNextAction: patch.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), patch.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), patch.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), patch.ContextRefs...),
+		Status:                patch.Status,
+		ProvenanceKind:        patch.ProvenanceKind,
+		TrustLabel:            patch.TrustLabel,
+		CreatedByRoleID:       patch.CreatedByRoleID,
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectWorkErr(err)
+	}
+	return ActionResult{Kind: ActionCreateHandoff, ID: handoff.ID, Data: map[string]string{"project_id": handoff.ProjectID, "handoff_id": handoff.ID}}, nil
+}
+
+func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action) (ActionResult, error) {
+	if s.memoryCandidates == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch memoryCandidatePatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := patch.ProjectID
+	if projectID == "" {
+		projectID = targetValue(action, "project_id")
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("memcand")
+	}
+	candidate, err := s.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+		ID:                  id,
+		ProjectID:           projectID,
+		Title:               patch.Title,
+		Body:                patch.Body,
+		SuggestedKind:       patch.SuggestedKind,
+		SuggestedTrustLabel: patch.SuggestedTrustLabel,
+		SuggestedSourceKind: patch.SuggestedSourceKind,
+		SuggestedSourceID:   patch.SuggestedSourceID,
+		SourceRefs:          append([]memory.CandidateSourceRef(nil), patch.SourceRefs...),
+	})
+	if err != nil {
+		return ActionResult{}, mapMemoryErr(err)
+	}
+	return ActionResult{Kind: ActionCreateMemoryCandidate, ID: candidate.ID, Data: map[string]string{"project_id": candidate.ProjectID, "candidate_id": candidate.ID}}, nil
+}
+
+func (s *Service) requireProject(ctx context.Context, projectID string) (projects.Project, error) {
+	if s.projects == nil {
+		return projects.Project{}, ErrStoreNotConfigured
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return projects.Project{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	project, ok, err := s.projects.Get(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	if !ok {
+		return projects.Project{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
+	}
+	return project, nil
+}
+
+func (s *Service) requireWorkItem(ctx context.Context, projectID, workItemID string) (projectwork.WorkItem, error) {
+	if s.work == nil {
+		return projectwork.WorkItem{}, ErrStoreNotConfigured
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return projectwork.WorkItem{}, fmt.Errorf("%w: work_item_id is required", ErrInvalid)
+	}
+	item, ok, err := s.work.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	if !ok {
+		return projectwork.WorkItem{}, fmt.Errorf("%w: work item %q", ErrNotFound, workItemID)
+	}
+	return item, nil
+}
+
+type projectPatch struct {
+	ID                       string      `json:"id,omitempty"`
+	Name                     string      `json:"name,omitempty"`
+	Description              string      `json:"description,omitempty"`
+	WorkspacePath            string      `json:"workspace_path,omitempty"`
+	WorkspaceKind            string      `json:"workspace_kind,omitempty"`
+	Roots                    []rootPatch `json:"roots,omitempty"`
+	DefaultProvider          string      `json:"default_provider,omitempty"`
+	DefaultModel             string      `json:"default_model,omitempty"`
+	DefaultAgentProfile      string      `json:"default_agent_profile,omitempty"`
+	DefaultToolsEnabled      *bool       `json:"default_tools_enabled,omitempty"`
+	DefaultWorkspaceMode     string      `json:"default_workspace_mode,omitempty"`
+	DefaultSystemPrompt      string      `json:"default_system_prompt,omitempty"`
+	DefaultCompactToolOutput *bool       `json:"default_compact_tool_output,omitempty"`
+}
+
+type updateProjectPatch struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type rootPatch struct {
+	ID        string `json:"id,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	GitRemote string `json:"git_remote,omitempty"`
+	GitBranch string `json:"git_branch,omitempty"`
+	Active    *bool  `json:"active,omitempty"`
+}
+
+type defaultsPatch struct {
+	DefaultRootID            *string `json:"default_root_id,omitempty"`
+	DefaultProvider          *string `json:"default_provider,omitempty"`
+	DefaultModel             *string `json:"default_model,omitempty"`
+	DefaultAgentProfile      *string `json:"default_agent_profile,omitempty"`
+	DefaultToolsEnabled      *bool   `json:"default_tools_enabled,omitempty"`
+	DefaultWorkspaceMode     *string `json:"default_workspace_mode,omitempty"`
+	DefaultSystemPrompt      *string `json:"default_system_prompt,omitempty"`
+	DefaultCompactToolOutput *bool   `json:"default_compact_tool_output,omitempty"`
+}
+
+type moveChatSessionPatch struct {
+	ProjectID string `json:"project_id"`
+}
+
+type workItemPatch struct {
+	ID              string   `json:"id,omitempty"`
+	ProjectID       string   `json:"project_id,omitempty"`
+	Title           string   `json:"title,omitempty"`
+	Brief           string   `json:"brief,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	Priority        string   `json:"priority,omitempty"`
+	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+}
+
+type updateWorkItemPatch struct {
+	Title           *string  `json:"title,omitempty"`
+	Brief           *string  `json:"brief,omitempty"`
+	Status          *string  `json:"status,omitempty"`
+	Priority        *string  `json:"priority,omitempty"`
+	OwnerRoleID     *string  `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+}
+
+type assignmentPatch struct {
+	ID                string `json:"id,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
+	WorkItemID        string `json:"work_item_id,omitempty"`
+	RoleID            string `json:"role_id,omitempty"`
+	DriverKind        string `json:"driver_kind,omitempty"`
+	Status            string `json:"status,omitempty"`
+	TaskID            string `json:"task_id,omitempty"`
+	RunID             string `json:"run_id,omitempty"`
+	ChatSessionID     string `json:"chat_session_id,omitempty"`
+	MessageID         string `json:"message_id,omitempty"`
+	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
+}
+
+type handoffPatch struct {
+	ID                    string   `json:"id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
+	WorkItemID            string   `json:"work_item_id,omitempty"`
+	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       string   `json:"source_message_id,omitempty"`
+	TargetRoleID          string   `json:"target_role_id,omitempty"`
+	TargetAssignmentID    string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      string   `json:"target_work_item_id,omitempty"`
+	Title                 string   `json:"title,omitempty"`
+	Summary               string   `json:"summary,omitempty"`
+	RecommendedNextAction string   `json:"recommended_next_action,omitempty"`
+	LinkedArtifactIDs     []string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       []string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           []string `json:"context_refs,omitempty"`
+	Status                string   `json:"status,omitempty"`
+	ProvenanceKind        string   `json:"provenance_kind,omitempty"`
+	TrustLabel            string   `json:"trust_label,omitempty"`
+	CreatedByRoleID       string   `json:"created_by_role_id,omitempty"`
+}
+
+type memoryCandidatePatch struct {
+	ID                  string                      `json:"id,omitempty"`
+	ProjectID           string                      `json:"project_id,omitempty"`
+	Title               string                      `json:"title,omitempty"`
+	Body                string                      `json:"body,omitempty"`
+	SuggestedKind       string                      `json:"suggested_kind,omitempty"`
+	SuggestedTrustLabel string                      `json:"suggested_trust_label,omitempty"`
+	SuggestedSourceKind string                      `json:"suggested_source_kind,omitempty"`
+	SuggestedSourceID   string                      `json:"suggested_source_id,omitempty"`
+	SourceRefs          []memory.CandidateSourceRef `json:"source_refs,omitempty"`
+}
+
+func decodePatch(action Action, target any) error {
+	if len(action.Patch) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(action.Patch, target); err != nil {
+		return fmt.Errorf("%w: decode %s patch: %v", ErrInvalid, normalizeKind(action.Kind), err)
+	}
+	return nil
+}
+
+func rootFromPatch(patch rootPatch, idgen IDGenerator) projects.Root {
+	active := true
+	if patch.Active != nil {
+		active = *patch.Active
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = idgen("root")
+	}
+	return projects.Root{
+		ID:        id,
+		Path:      patch.Path,
+		Kind:      patch.Kind,
+		GitRemote: patch.GitRemote,
+		GitBranch: patch.GitBranch,
+		Active:    active,
+	}
+}
+
+func rootsFromPatch(patches []rootPatch, idgen IDGenerator) []projects.Root {
+	roots := make([]projects.Root, 0, len(patches))
+	for _, patch := range patches {
+		roots = append(roots, rootFromPatch(patch, idgen))
+	}
+	return roots
+}
+
+func rootsForProjectPatch(patch projectPatch, idgen IDGenerator) ([]projects.Root, error) {
+	roots := rootsFromPatch(patch.Roots, idgen)
+	workspacePath := strings.TrimSpace(patch.WorkspacePath)
+	workspaceKind := strings.TrimSpace(patch.WorkspaceKind)
+	if workspacePath != "" {
+		if len(roots) > 0 {
+			return nil, fmt.Errorf("%w: workspace_path cannot be combined with roots", ErrInvalid)
+		}
+		roots = []projects.Root{{
+			ID:     idgen("root"),
+			Path:   workspacePath,
+			Kind:   workspaceKind,
+			Active: true,
+		}}
+	} else if workspaceKind != "" {
+		return nil, fmt.Errorf("%w: workspace_kind requires workspace_path", ErrInvalid)
+	}
+	return roots, nil
+}
+
+func projectHasRoot(project projects.Project, rootID string) bool {
+	rootID = strings.TrimSpace(rootID)
+	for _, root := range project.Roots {
+		if root.ID == rootID {
+			return true
+		}
+	}
+	return false
+}
+
+func targetValue(action Action, key string) string {
+	if action.Target == nil {
+		return ""
+	}
+	return strings.TrimSpace(action.Target[key])
+}
+
+func normalizeKind(kind string) string {
+	return strings.TrimSpace(kind)
+}
+
+func cloneActions(actions []Action) []Action {
+	if actions == nil {
+		return nil
+	}
+	cloned := make([]Action, len(actions))
+	for idx, action := range actions {
+		cloned[idx] = Action{
+			Kind:   action.Kind,
+			Target: cloneStringMap(action.Target),
+			Patch:  append(json.RawMessage(nil), action.Patch...),
+			Reason: action.Reason,
+		}
+	}
+	return cloned
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func mapProjectErr(err error) error {
+	switch {
+	case errors.Is(err, projects.ErrNotFound):
+		return fmt.Errorf("%w: %v", ErrNotFound, err)
+	case errors.Is(err, projects.ErrInvalid):
+		return fmt.Errorf("%w: %v", ErrInvalid, err)
+	default:
+		return err
+	}
+}
+
+func mapProjectWorkErr(err error) error {
+	switch {
+	case errors.Is(err, projectwork.ErrNotFound):
+		return fmt.Errorf("%w: %v", ErrNotFound, err)
+	case errors.Is(err, projectwork.ErrInvalid):
+		return fmt.Errorf("%w: %v", ErrInvalid, err)
+	case errors.Is(err, projectwork.ErrDuplicate), errors.Is(err, projectwork.ErrDuplicateRole):
+		return fmt.Errorf("%w: %v", ErrConflict, err)
+	default:
+		return err
+	}
+}
+
+func mapMemoryErr(err error) error {
+	switch {
+	case errors.Is(err, memory.ErrNotFound):
+		return fmt.Errorf("%w: %v", ErrNotFound, err)
+	case errors.Is(err, memory.ErrInvalid):
+		return fmt.Errorf("%w: %v", ErrInvalid, err)
+	case errors.Is(err, memory.ErrAlreadyExists), errors.Is(err, memory.ErrConflict):
+		return fmt.Errorf("%w: %v", ErrConflict, err)
+	default:
+		return err
+	}
+}

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -551,6 +551,132 @@ func TestService_ApplyRepeatedProposalConflicts(t *testing.T) {
 	}
 }
 
+func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			proposal := Proposal{
+				ID:                   "pa_partial_resume",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind:  ActionCreateProject,
+						Patch: rawPatch(t, map[string]string{"id": "proj_partial", "name": "Partial"}),
+					},
+					{
+						Kind: ActionCreateWorkItem,
+						Patch: rawPatch(t, map[string]string{
+							"id":         "work_after_retry",
+							"project_id": "proj_after_retry",
+							"title":      "Resume after missing project",
+						}),
+					},
+				},
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("Apply err = %v, want ErrNotFound", err)
+			}
+			var applyErr *ApplyError
+			if !errors.As(err, &applyErr) {
+				t.Fatalf("Apply err = %T %v, want ApplyError", err, err)
+			}
+			if applyErr.FailedActionIndex != 1 {
+				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
+			}
+			if result.Applied || len(result.Actions) != 1 || result.Actions[0].ID != "proj_partial" {
+				t.Fatalf("partial result = %+v, want first action only", result)
+			}
+			if applyErr.Result.ProposalID != result.ProposalID || len(applyErr.Result.Actions) != len(result.Actions) {
+				t.Fatalf("apply error result = %+v, want returned partial result %+v", applyErr.Result, result)
+			}
+			if _, ok, err := fixture.projects.Get(ctx, "proj_partial"); err != nil || !ok {
+				t.Fatalf("get partially-created project ok=%v err=%v", ok, err)
+			}
+
+			if _, err := fixture.projects.Create(ctx, projects.Project{ID: "proj_after_retry", Name: "After retry"}); err != nil {
+				t.Fatalf("create missing project before retry: %v", err)
+			}
+			result, err = fixture.service.Apply(ctx, proposal, true)
+			if err != nil {
+				t.Fatalf("retry Apply: %v", err)
+			}
+			if !result.Applied || len(result.Actions) != 2 {
+				t.Fatalf("retry result = %+v, want both actions applied", result)
+			}
+			item, ok, err := fixture.work.GetWorkItem(ctx, "proj_after_retry", "work_after_retry")
+			if err != nil || !ok {
+				t.Fatalf("get work item ok=%v err=%v", ok, err)
+			}
+			if item.Title != "Resume after missing project" {
+				t.Fatalf("work item title = %q, want resumed action title", item.Title)
+			}
+
+			projectsAfterRetry, err := fixture.projects.List(ctx)
+			if err != nil {
+				t.Fatalf("list projects: %v", err)
+			}
+			var partialProjectCount int
+			for _, project := range projectsAfterRetry {
+				if project.ID == "proj_partial" {
+					partialProjectCount++
+				}
+			}
+			if partialProjectCount != 1 {
+				t.Fatalf("proj_partial count = %d, want one non-duplicated project", partialProjectCount)
+			}
+		})
+	}
+}
+
+func TestService_ApplyChangedProposalAfterPartialFailureConflictsAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			proposal := Proposal{
+				ID:                   "pa_partial_changed",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind:  ActionCreateProject,
+						Patch: rawPatch(t, map[string]string{"id": "proj_partial_changed", "name": "Partial"}),
+					},
+					{
+						Kind: ActionCreateWorkItem,
+						Patch: rawPatch(t, map[string]string{
+							"id":         "work_changed",
+							"project_id": "proj_missing_changed",
+							"title":      "Original title",
+						}),
+					},
+				},
+			}
+			if _, err := fixture.service.Apply(ctx, proposal, true); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("Apply err = %v, want ErrNotFound", err)
+			}
+
+			changed := proposal
+			changed.Actions = cloneActions(proposal.Actions)
+			changed.Actions[1].Patch = rawPatch(t, map[string]string{
+				"id":         "work_changed",
+				"project_id": "proj_missing_changed",
+				"title":      "Changed title",
+			})
+			_, err := fixture.service.Apply(ctx, changed, true)
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("changed Apply err = %v, want ErrConflict", err)
+			}
+		})
+	}
+}
+
 func assistantFixtureBuilders() []assistantFixtureBuilder {
 	return []assistantFixtureBuilder{
 		{name: "memory", build: newMemoryAssistantFixture},

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1,0 +1,669 @@
+package projectassistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+type assistantFixture struct {
+	service          *Service
+	projects         projects.Store
+	chats            chat.Store
+	work             projectwork.Store
+	memoryEntries    memory.Store
+	memoryCandidates memory.CandidateStore
+}
+
+type assistantFixtureBuilder struct {
+	name  string
+	build func(t *testing.T) assistantFixture
+}
+
+func TestService_ProposeRejectsUnknownActionKind(t *testing.T) {
+	t.Parallel()
+	fixture := newMemoryAssistantFixture(t)
+
+	_, err := fixture.service.Propose(context.Background(), ProposalInput{
+		Actions: []Action{{Kind: "rewrite_the_world", Patch: rawPatch(t, map[string]string{"name": "bad"})}},
+	})
+	if !errors.Is(err, ErrUnknownActionKind) {
+		t.Fatalf("Propose err = %v, want ErrUnknownActionKind", err)
+	}
+}
+
+func TestService_ApplyRequiresConfirmation(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			proposal := Proposal{
+				ID:                   "pa_confirm",
+				Title:                "Create project",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind:  ActionCreateProject,
+					Patch: rawPatch(t, map[string]string{"id": "proj_confirm", "name": "Confirm me"}),
+				}},
+			}
+
+			_, err := fixture.service.Apply(ctx, proposal, false)
+			if !errors.Is(err, ErrConfirmationRequired) {
+				t.Fatalf("Apply err = %v, want ErrConfirmationRequired", err)
+			}
+			items, err := fixture.projects.List(ctx)
+			if err != nil {
+				t.Fatalf("list projects: %v", err)
+			}
+			if len(items) != 0 {
+				t.Fatalf("projects = %+v, want none after unconfirmed apply", items)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreateAndUpdateProjectAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			toolsEnabled := true
+			compactToolOutput := true
+
+			proposal := Proposal{
+				ID:                   "pa_project",
+				Title:                "Project setup",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind: ActionCreateProject,
+						Patch: rawPatch(t, map[string]any{
+							"id":          "proj_alpha",
+							"name":        "Alpha",
+							"description": "main",
+							"roots": []map[string]any{{
+								"id":   "root_a",
+								"path": filepath.Join(t.TempDir(), "alpha"),
+								"kind": "local",
+							}},
+						}),
+					},
+					{
+						Kind:   ActionAttachProjectRoot,
+						Target: map[string]string{"project_id": "proj_alpha"},
+						Patch: rawPatch(t, map[string]any{
+							"id":   "root_b",
+							"path": filepath.Join(t.TempDir(), "beta"),
+							"kind": "local",
+						}),
+					},
+					{
+						Kind:   ActionSetProjectDefaults,
+						Target: map[string]string{"project_id": "proj_alpha"},
+						Patch: rawPatch(t, map[string]any{
+							"default_root_id":             "root_b",
+							"default_provider":            "ollama",
+							"default_model":               "llama3.1:8b",
+							"default_agent_profile":       "reviewer",
+							"default_tools_enabled":       toolsEnabled,
+							"default_workspace_mode":      "worktree",
+							"default_system_prompt":       "Stay crisp.",
+							"default_compact_tool_output": compactToolOutput,
+						}),
+					},
+					{
+						Kind:   ActionRemoveProjectRoot,
+						Target: map[string]string{"project_id": "proj_alpha", "root_id": "root_a"},
+					},
+				},
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if err != nil {
+				t.Fatalf("Apply setup: %v", err)
+			}
+			if !result.Applied || len(result.Actions) != len(proposal.Actions) {
+				t.Fatalf("result = %+v, want all actions applied", result)
+			}
+			project, ok, err := fixture.projects.Get(ctx, "proj_alpha")
+			if err != nil {
+				t.Fatalf("get project: %v", err)
+			}
+			if !ok {
+				t.Fatal("project not found after apply")
+			}
+			if project.Name != "Alpha" || project.Description != "main" {
+				t.Fatalf("project metadata = %+v, want created metadata", project)
+			}
+			if len(project.Roots) != 1 || project.Roots[0].ID != "root_b" {
+				t.Fatalf("project roots = %+v, want only root_b", project.Roots)
+			}
+			if project.DefaultRootID != "root_b" ||
+				project.DefaultProvider != "ollama" ||
+				project.DefaultModel != "llama3.1:8b" ||
+				project.DefaultAgentProfile != "reviewer" ||
+				project.DefaultWorkspaceMode != "worktree" ||
+				project.DefaultSystemPrompt != "Stay crisp." {
+				t.Fatalf("project defaults = %+v, want applied defaults", project)
+			}
+			if project.DefaultToolsEnabled == nil || !*project.DefaultToolsEnabled {
+				t.Fatalf("default tools enabled = %v, want true", project.DefaultToolsEnabled)
+			}
+			if project.DefaultCompactToolOutput == nil || !*project.DefaultCompactToolOutput {
+				t.Fatalf("default compact output = %v, want true", project.DefaultCompactToolOutput)
+			}
+
+			name := "Renamed"
+			description := "Updated"
+			_, err = fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_project_update",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind:   ActionUpdateProject,
+					Target: map[string]string{"project_id": "proj_alpha"},
+					Patch:  rawPatch(t, map[string]any{"name": name, "description": description}),
+				}},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply update: %v", err)
+			}
+			project, ok, err = fixture.projects.Get(ctx, "proj_alpha")
+			if err != nil || !ok {
+				t.Fatalf("get updated project ok=%v err=%v", ok, err)
+			}
+			if project.Name != name || project.Description != description {
+				t.Fatalf("updated project = %+v, want renamed/updated", project)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreateProjectWorkspacePathAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			workspacePath := filepath.Join(t.TempDir(), "workspace")
+
+			_, err := fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_workspace_project",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind: ActionCreateProject,
+					Patch: rawPatch(t, map[string]any{
+						"id":             "proj_workspace",
+						"name":           "Workspace",
+						"workspace_path": workspacePath,
+						"workspace_kind": "git",
+					}),
+				}},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply create workspace project: %v", err)
+			}
+
+			project, ok, err := fixture.projects.Get(ctx, "proj_workspace")
+			if err != nil || !ok {
+				t.Fatalf("get project ok=%v err=%v", ok, err)
+			}
+			if len(project.Roots) != 1 {
+				t.Fatalf("roots = %+v, want one generated workspace root", project.Roots)
+			}
+			root := project.Roots[0]
+			if root.ID == "" || root.Path != workspacePath || root.Kind != "git" || !root.Active {
+				t.Fatalf("root = %+v, want active git workspace root at %q", root, workspacePath)
+			}
+			if project.DefaultRootID != root.ID {
+				t.Fatalf("default_root_id = %q, want generated root id %q", project.DefaultRootID, root.ID)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreateProjectWithoutWorkspaceAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+
+			_, err := fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_no_workspace_project",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind: ActionCreateProject,
+					Patch: rawPatch(t, map[string]string{
+						"id":   "proj_no_workspace",
+						"name": "No workspace",
+					}),
+				}},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply create workspace-less project: %v", err)
+			}
+
+			project, ok, err := fixture.projects.Get(ctx, "proj_no_workspace")
+			if err != nil || !ok {
+				t.Fatalf("get project ok=%v err=%v", ok, err)
+			}
+			if len(project.Roots) != 0 || project.DefaultRootID != "" {
+				t.Fatalf("project = %+v, want workspace-less project", project)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreateProjectRejectsWorkspacePathWithRoots(t *testing.T) {
+	t.Parallel()
+	fixture := newMemoryAssistantFixture(t)
+
+	_, err := fixture.service.Apply(context.Background(), Proposal{
+		ID:                   "pa_workspace_conflict",
+		RequiresConfirmation: true,
+		Actions: []Action{{
+			Kind: ActionCreateProject,
+			Patch: rawPatch(t, map[string]any{
+				"id":             "proj_workspace_conflict",
+				"name":           "Broken",
+				"workspace_path": filepath.Join(t.TempDir(), "workspace"),
+				"roots": []map[string]string{{
+					"path": filepath.Join(t.TempDir(), "other"),
+				}},
+			}),
+		}},
+	}, true)
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Apply err = %v, want ErrInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "workspace_path cannot be combined with roots") {
+		t.Fatalf("Apply err = %v, want workspace_path conflict", err)
+	}
+}
+
+func TestService_ApplyRevalidatesStaleTargets(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+
+			cases := []struct {
+				name   string
+				action Action
+			}{
+				{
+					name: "missing project",
+					action: Action{
+						Kind:   ActionSetProjectDefaults,
+						Target: map[string]string{"project_id": "proj_missing"},
+						Patch:  rawPatch(t, map[string]string{"default_model": "llama3.1:8b"}),
+					},
+				},
+				{
+					name: "missing root",
+					action: Action{
+						Kind:   ActionRemoveProjectRoot,
+						Target: map[string]string{"project_id": project.ID, "root_id": "root_missing"},
+					},
+				},
+				{
+					name: "missing default root",
+					action: Action{
+						Kind:   ActionSetProjectDefaults,
+						Target: map[string]string{"project_id": project.ID},
+						Patch:  rawPatch(t, map[string]string{"default_root_id": "root_missing"}),
+					},
+				},
+				{
+					name: "missing chat",
+					action: Action{
+						Kind:   ActionMoveChatSession,
+						Target: map[string]string{"chat_session_id": "chat_missing"},
+						Patch:  rawPatch(t, map[string]string{"project_id": project.ID}),
+					},
+				},
+			}
+
+			for idx, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					_, err := fixture.service.Apply(ctx, Proposal{
+						ID:                   fmt.Sprintf("pa_stale_%d", idx),
+						RequiresConfirmation: true,
+						Actions:              []Action{tc.action},
+					}, true)
+					if !errors.Is(err, ErrNotFound) {
+						t.Fatalf("Apply err = %v, want ErrNotFound", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestService_ApplyMoveChatSessionUpdatesOnlyTarget(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			createTestChatSession(t, ctx, fixture.chats, "chat_a")
+			createTestChatSession(t, ctx, fixture.chats, "chat_b")
+
+			_, err := fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_move_chat",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind:   ActionMoveChatSession,
+					Target: map[string]string{"chat_session_id": "chat_a"},
+					Patch:  rawPatch(t, map[string]string{"project_id": project.ID}),
+				}},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply move chat: %v", err)
+			}
+
+			chatA, ok, err := fixture.chats.Get(ctx, "chat_a")
+			if err != nil || !ok {
+				t.Fatalf("get chat_a ok=%v err=%v", ok, err)
+			}
+			chatB, ok, err := fixture.chats.Get(ctx, "chat_b")
+			if err != nil || !ok {
+				t.Fatalf("get chat_b ok=%v err=%v", ok, err)
+			}
+			if chatA.ProjectID != project.ID {
+				t.Fatalf("chat_a project = %q, want %q", chatA.ProjectID, project.ID)
+			}
+			if chatB.ProjectID != "" {
+				t.Fatalf("chat_b project = %q, want unchanged empty project", chatB.ProjectID)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+
+			_, err := fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_project_work",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind: ActionCreateWorkItem,
+						Patch: rawPatch(t, map[string]any{
+							"id":         "work_a",
+							"project_id": project.ID,
+							"title":      "Build assistant",
+							"brief":      "Create typed project assistant actions.",
+						}),
+					},
+					{
+						Kind: ActionCreateAssignment,
+						Patch: rawPatch(t, map[string]any{
+							"id":           "asgn_a",
+							"project_id":   project.ID,
+							"work_item_id": "work_a",
+							"role_id":      "software_developer",
+							"driver_kind":  projectwork.AssignmentDriverHecateTask,
+							"task_id":      "task_a",
+						}),
+					},
+					{
+						Kind: ActionCreateHandoff,
+						Patch: rawPatch(t, map[string]any{
+							"id":                      "handoff_a",
+							"project_id":              project.ID,
+							"work_item_id":            "work_a",
+							"title":                   "Continue implementation",
+							"summary":                 "Project assistant core is ready for UI.",
+							"recommended_next_action": "Add project cockpit cards.",
+						}),
+					},
+				},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply project work: %v", err)
+			}
+
+			item, ok, err := fixture.work.GetWorkItem(ctx, project.ID, "work_a")
+			if err != nil || !ok {
+				t.Fatalf("get work item ok=%v err=%v", ok, err)
+			}
+			if item.Title != "Build assistant" || item.Status != projectwork.WorkItemStatusBacklog {
+				t.Fatalf("work item = %+v, want backlog item", item)
+			}
+			assignments, err := fixture.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: project.ID, WorkItemID: "work_a"})
+			if err != nil {
+				t.Fatalf("list assignments: %v", err)
+			}
+			if len(assignments) != 1 || assignments[0].ID != "asgn_a" || assignments[0].Status != projectwork.AssignmentStatusQueued {
+				t.Fatalf("assignments = %+v, want queued assignment", assignments)
+			}
+			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: "work_a"})
+			if err != nil {
+				t.Fatalf("list handoffs: %v", err)
+			}
+			if len(handoffs) != 1 || handoffs[0].ID != "handoff_a" || handoffs[0].Status != projectwork.HandoffStatusPending {
+				t.Fatalf("handoffs = %+v, want pending handoff", handoffs)
+			}
+		})
+	}
+}
+
+func TestService_ApplyCreatesMemoryCandidateOnly(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+
+			_, err := fixture.service.Apply(ctx, Proposal{
+				ID:                   "pa_memory_candidate",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind: ActionCreateMemoryCandidate,
+					Patch: rawPatch(t, map[string]any{
+						"id":             "memcand_a",
+						"project_id":     project.ID,
+						"title":          "Project assistant decision",
+						"body":           "Project Assistant creates candidates, not durable entries.",
+						"suggested_kind": "decision",
+					}),
+				}},
+			}, true)
+			if err != nil {
+				t.Fatalf("Apply memory candidate: %v", err)
+			}
+
+			candidates, err := fixture.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+				ProjectID: project.ID,
+				Status:    memory.CandidateStatusPending,
+			})
+			if err != nil {
+				t.Fatalf("list candidates: %v", err)
+			}
+			if len(candidates) != 1 || candidates[0].ID != "memcand_a" {
+				t.Fatalf("candidates = %+v, want one pending candidate", candidates)
+			}
+			entries, err := fixture.memoryEntries.List(ctx, memory.Filter{ProjectID: project.ID, IncludeDisabled: true})
+			if err != nil {
+				t.Fatalf("list memory entries: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("memory entries = %+v, want no durable entries", entries)
+			}
+		})
+	}
+}
+
+func TestService_ApplyRepeatedProposalConflicts(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			proposal := Proposal{
+				ID:                   "pa_repeat",
+				RequiresConfirmation: true,
+				Actions: []Action{{
+					Kind:  ActionCreateProject,
+					Patch: rawPatch(t, map[string]string{"id": "proj_repeat", "name": "Repeat"}),
+				}},
+			}
+
+			if _, err := fixture.service.Apply(ctx, proposal, true); err != nil {
+				t.Fatalf("first Apply: %v", err)
+			}
+			_, err := fixture.service.Apply(ctx, proposal, true)
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("second Apply err = %v, want ErrConflict", err)
+			}
+		})
+	}
+}
+
+func assistantFixtureBuilders() []assistantFixtureBuilder {
+	return []assistantFixtureBuilder{
+		{name: "memory", build: newMemoryAssistantFixture},
+		{name: "sqlite", build: newSQLiteAssistantFixture},
+	}
+}
+
+func newMemoryAssistantFixture(t *testing.T) assistantFixture {
+	t.Helper()
+	projectStore := projects.NewMemoryStore()
+	chatStore := chat.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	memoryStore := memory.NewMemoryStore()
+	return assistantFixture{
+		service:          projectassistantService(projectStore, chatStore, workStore, memoryStore),
+		projects:         projectStore,
+		chats:            chatStore,
+		work:             workStore,
+		memoryEntries:    memoryStore,
+		memoryCandidates: memoryStore,
+	}
+}
+
+func newSQLiteAssistantFixture(t *testing.T) assistantFixture {
+	t.Helper()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "hecate.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("new sqlite client: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("close sqlite client: %v", err)
+		}
+	})
+	projectStore, err := projects.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new project sqlite store: %v", err)
+	}
+	chatStore, err := chat.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new chat sqlite store: %v", err)
+	}
+	workStore, err := projectwork.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new project work sqlite store: %v", err)
+	}
+	memoryStore, err := memory.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new memory sqlite store: %v", err)
+	}
+	return assistantFixture{
+		service:          projectassistantService(projectStore, chatStore, workStore, memoryStore),
+		projects:         projectStore,
+		chats:            chatStore,
+		work:             workStore,
+		memoryEntries:    memoryStore,
+		memoryCandidates: memoryStore,
+	}
+}
+
+func projectassistantService(projectStore projects.Store, chatStore chat.Store, workStore projectwork.Store, memoryStore memory.CandidateStore) *Service {
+	return NewService(Stores{
+		Projects:         projectStore,
+		Chats:            chatStore,
+		Work:             workStore,
+		MemoryCandidates: memoryStore,
+	}, sequenceIDGenerator())
+}
+
+func sequenceIDGenerator() IDGenerator {
+	var seq int
+	return func(prefix string) string {
+		seq++
+		return fmt.Sprintf("%s_%02d", prefix, seq)
+	}
+}
+
+func rawPatch(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal patch: %v", err)
+	}
+	return payload
+}
+
+func createTestProject(t *testing.T, ctx context.Context, store projects.Store) projects.Project {
+	t.Helper()
+	project, err := store.Create(ctx, projects.Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		Roots: []projects.Root{{
+			ID:     "root_a",
+			Path:   filepath.Join(t.TempDir(), "alpha"),
+			Kind:   "local",
+			Active: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return project
+}
+
+func createTestChatSession(t *testing.T, ctx context.Context, store chat.Store, id string) chat.Session {
+	t.Helper()
+	session, err := store.Create(ctx, chat.Session{ID: id, Title: id})
+	if err != nil {
+		t.Fatalf("create chat session %q: %v", id, err)
+	}
+	return session
+}


### PR DESCRIPTION
## Summary
- Add the Project Assistant propose/apply API for typed, allowlisted project operations.
- Implement the core action engine for project metadata, roots/defaults, chat moves, work items, assignments, and memory candidates.
- Support creating projects either without a workspace or with a one-shot workspace_path root in the Projects API and Project Assistant actions.
- Document the Project Assistant API, confirmation model, supported actions, and safety boundaries.

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/projectassistant ./internal/api ./internal/projects ./internal/projectwork ./internal/memory ./internal/chat
- /Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md docs/runtime/project-assistant.md
- git diff --check origin/master...HEAD

Note: the focused Go suite was run outside the command sandbox because internal/api uses httptest loopback listeners.