### PR TITLE
Surface external assignment follow-through

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -284,7 +284,11 @@ Project assignments can also prepare External Agent sessions. Starting a
 linked External Agent chat session, records assignment/profile/workspace context,
 and stores the session link on the assignment. It does not send the assignment
 prompt automatically; the operator stays in control of the first turn from the
-linked chat.
+linked chat. Project activity rows project the linked chat's session status,
+latest message status, adapter identity, and missing-session diagnostics so the
+Projects cockpit can show follow-through state without embedding the full chat
+transcript. Handoffs created from these assignments can carry the source
+assignment, chat session, message, run, and context refs for provenance.
 
 Hecate validates the workspace before creating a session, sanitizes the
 environment passed to the ACP agent process, applies timeout/cancel behavior,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1693,8 +1693,9 @@ The top-level envelope follows the Hecate-native convention:
 `awaiting_approval`, `failed`, `cancelled`, `not_started`, `running`,
 `completed`, and `stale_unknown`. `not_started` means a queued assignment has
 no linked task, run, or chat identifiers. `stale_unknown` covers missing linked
-task/run/chat records, run-only links without enough task context, and unknown
-status values.
+task/run/chat records, run-only links without enough task context, unknown
+status values, wrong-project linked chats, and transient linked-chat lookup
+failures.
 Rows are sorted by most recent assignment/work/artifact update, then assignment
 ID. Each bucket is capped at 20 rows; `recent` mirrors
 `buckets.recent`. The example above leaves the mirrored recent arrays empty for

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1613,6 +1613,20 @@ The top-level envelope follows the Hecate-native convention:
           "status_summary": "1 approval pending",
           "linked_task_id": "task_...",
           "linked_run_id": "run_...",
+          "linked_chat_id": "chat_...",
+          "linked_chat": {
+            "id": "chat_...",
+            "title": "Backend substrate - External implementer",
+            "agent_id": "codex",
+            "driver_kind": "acp",
+            "native_session_id": "native_...",
+            "status": "running",
+            "latest_message_id": "msg_...",
+            "latest_role": "assistant",
+            "latest_status": "completed",
+            "message_count": 2,
+            "updated_at": "2026-06-03T12:02:00Z"
+          },
           "artifact_summary": {
             "count": 1,
             "latest_kind": "handoff",
@@ -1649,6 +1663,8 @@ The top-level envelope follows the Hecate-native convention:
               "project_id": "proj_...",
               "work_item_id": "work_...",
               "source_assignment_id": "asgn_...",
+              "source_chat_session_id": "chat_...",
+              "source_message_id": "msg_...",
               "target_role_id": "reviewer_qa",
               "title": "QA handoff",
               "summary": "Implementation is ready for review.",
@@ -1674,16 +1690,27 @@ The top-level envelope follows the Hecate-native convention:
 ```
 
 `blocking_signal` is the compact V1 operator signal. Known values are
-`awaiting_approval`, `failed`, `not_started`, `running`, `completed`, and
-`stale_unknown`. `not_started` means a queued assignment has no linked task,
-run, or chat identifiers. `stale_unknown` covers missing linked task/run
-records, run-only links without enough task context, and unknown status values.
+`awaiting_approval`, `failed`, `cancelled`, `not_started`, `running`,
+`completed`, and `stale_unknown`. `not_started` means a queued assignment has
+no linked task, run, or chat identifiers. `stale_unknown` covers missing linked
+task/run/chat records, run-only links without enough task context, and unknown
+status values.
 Rows are sorted by most recent assignment/work/artifact update, then assignment
 ID. Each bucket is capped at 20 rows; `recent` mirrors
 `buckets.recent`. The example above leaves the mirrored recent arrays empty for
 brevity; real responses include the same item shape there when `recent_count`
 is non-zero. `artifact_summary.assignment_id` is present only when the latest
 summarized artifact is assignment-scoped; work-item-level artifacts omit it.
+`linked_chat` is present when an assignment points at a Chat or External Agent
+session. It is a compact activity projection, not a full chat transcript:
+clients use it for session status, last-message status/error,
+adapter/session identity, and missing linked-session diagnostics, then open the
+chat endpoint for full transcript state. When a handoff is created from an
+assignment, clients may copy the assignment, run, chat, message, and context
+refs into the handoff source fields so later follow-up assignments preserve
+provenance without auto-dispatching work.
+An `idle` linked chat with a running/queued external assignment is a prepared
+session waiting for the operator's first or next turn, not stale execution.
 `handoff_summary` and `recent_handoffs` are activity projections over
 structured handoff records attached to the same work item and, when present,
 the same source or target assignment. Handoffs that are not assignment-linked

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -344,12 +344,30 @@ type ProjectActivityItemResponse struct {
 	LinkedTaskID    string                                 `json:"linked_task_id,omitempty"`
 	LinkedRunID     string                                 `json:"linked_run_id,omitempty"`
 	LinkedChatID    string                                 `json:"linked_chat_id,omitempty"`
+	LinkedChat      *ProjectActivityLinkedChatResponse     `json:"linked_chat,omitempty"`
 	LinkedMessageID string                                 `json:"linked_message_id,omitempty"`
 	RecentArtifacts []ProjectWorkArtifactResponse          `json:"recent_artifacts,omitempty"`
 	ArtifactSummary ProjectActivityArtifactSummaryResponse `json:"artifact_summary"`
 	RecentHandoffs  []ProjectHandoffResponse               `json:"recent_handoffs,omitempty"`
 	HandoffSummary  ProjectActivityHandoffSummaryResponse  `json:"handoff_summary"`
 	UpdatedAt       string                                 `json:"updated_at"`
+}
+
+type ProjectActivityLinkedChatResponse struct {
+	ID              string `json:"id"`
+	Title           string `json:"title,omitempty"`
+	AgentID         string `json:"agent_id,omitempty"`
+	DriverKind      string `json:"driver_kind,omitempty"`
+	NativeSessionID string `json:"native_session_id,omitempty"`
+	Status          string `json:"status,omitempty"`
+	LatestMessageID string `json:"latest_message_id,omitempty"`
+	LatestRole      string `json:"latest_role,omitempty"`
+	LatestStatus    string `json:"latest_status,omitempty"`
+	LatestError     string `json:"latest_error,omitempty"`
+	MessageCount    int    `json:"message_count,omitempty"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	Missing         bool   `json:"missing,omitempty"`
 }
 
 type ProjectActivityWorkItemResponse struct {
@@ -2086,6 +2104,70 @@ func groupProjectWorkAssignmentsByWorkItem(assignments []projectwork.Assignment)
 	return grouped
 }
 
+func (h *Handler) projectActivityLinkedChats(ctx context.Context, assignments []projectwork.Assignment) (map[string]*ProjectActivityLinkedChatResponse, error) {
+	linked := make(map[string]*ProjectActivityLinkedChatResponse)
+	if h == nil || h.agentChat == nil {
+		return linked, nil
+	}
+	for _, assignment := range assignments {
+		chatID := strings.TrimSpace(assignment.ChatSessionID)
+		if chatID == "" {
+			continue
+		}
+		session, ok, err := h.agentChat.Get(ctx, chatID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			linked[assignment.ID] = &ProjectActivityLinkedChatResponse{
+				ID:      chatID,
+				Missing: true,
+			}
+			continue
+		}
+		linked[assignment.ID] = renderProjectActivityLinkedChat(session)
+	}
+	return linked, nil
+}
+
+func renderProjectActivityLinkedChat(session chat.Session) *ProjectActivityLinkedChatResponse {
+	item := &ProjectActivityLinkedChatResponse{
+		ID:              session.ID,
+		Title:           session.Title,
+		AgentID:         renderChatAgentID(session),
+		DriverKind:      session.DriverKind,
+		NativeSessionID: session.NativeSessionID,
+		Status:          session.Status,
+		MessageCount:    len(session.Messages),
+		CreatedAt:       formatOptionalTime(session.CreatedAt),
+		UpdatedAt:       formatOptionalTime(session.UpdatedAt),
+	}
+	if latest := latestProjectActivityChatMessage(session.Messages); latest != nil {
+		item.LatestMessageID = latest.ID
+		item.LatestRole = latest.Role
+		item.LatestStatus = latest.Status
+		item.LatestError = latest.Error
+		if !latest.CompletedAt.IsZero() {
+			item.UpdatedAt = formatOptionalTime(latest.CompletedAt)
+		} else if !latest.StartedAt.IsZero() {
+			item.UpdatedAt = formatOptionalTime(latest.StartedAt)
+		} else if !latest.CreatedAt.IsZero() {
+			item.UpdatedAt = formatOptionalTime(latest.CreatedAt)
+		}
+	}
+	return item
+}
+
+func latestProjectActivityChatMessage(messages []chat.Message) *chat.Message {
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if strings.TrimSpace(message.ID) != "" {
+			return &messages[i]
+		}
+	}
+	return nil
+}
+
 func projectWorkProjectedAssignmentStatus(assignment projectwork.Assignment, projectedStatus string, projectedAt time.Time) string {
 	projectedStatus = strings.TrimSpace(projectedStatus)
 	if projectedStatus == "" {
@@ -2163,6 +2245,10 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 		roleByID[role.ID] = role
 	}
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	linkedChats, err := h.projectActivityLinkedChats(ctx, assignments)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
 	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
 	for _, item := range workItems {
 		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
@@ -2186,7 +2272,7 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 				activityHandoffs = handoffsByWorkItem[projected.WorkItemID]
 			}
 			role, _ := roleByID[projected.RoleID]
-			items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts, activityHandoffs))
+			items = append(items, renderProjectActivityItem(workItem, projected, role, activityArtifacts, activityHandoffs, linkedChats[projected.ID]))
 		}
 	}
 	sortProjectActivityItems(items)
@@ -2218,14 +2304,14 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 	return response, nil
 }
 
-func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) ProjectActivityItemResponse {
+func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, linkedChat *ProjectActivityLinkedChatResponse) ProjectActivityItemResponse {
 	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts)
 	handoffSummary, recentHandoffs := renderProjectActivityHandoffSignals(handoffs)
-	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
+	status := strings.TrimSpace(projectActivityProjectedStatus(assignment, linkedChat))
 	if status == "" {
 		status = "unknown"
 	}
-	signal := projectActivityBlockingSignal(assignment)
+	signal := projectActivityBlockingSignal(assignment, linkedChat)
 	return ProjectActivityItemResponse{
 		ID:              assignment.ID,
 		ProjectID:       assignment.ProjectID,
@@ -2234,16 +2320,17 @@ func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment Proj
 		Role:            renderProjectWorkRole(role),
 		Status:          status,
 		BlockingSignal:  signal,
-		StatusSummary:   projectActivityStatusSummary(assignment, signal, artifactSummary.Count),
+		StatusSummary:   projectActivityStatusSummary(assignment, linkedChat, signal, artifactSummary.Count),
 		LinkedTaskID:    firstNonEmpty(projectActivityExecutionTaskID(assignment), assignment.TaskID),
 		LinkedRunID:     firstNonEmpty(projectActivityExecutionRunID(assignment), assignment.RunID),
 		LinkedChatID:    assignment.ChatSessionID,
+		LinkedChat:      linkedChat,
 		LinkedMessageID: assignment.MessageID,
 		RecentArtifacts: recentArtifacts,
 		ArtifactSummary: artifactSummary,
 		RecentHandoffs:  recentHandoffs,
 		HandoffSummary:  handoffSummary,
-		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, artifactSummary, handoffSummary),
+		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, linkedChat, artifactSummary, handoffSummary),
 	}
 }
 
@@ -2389,7 +2476,7 @@ func boundedProjectActivityItems(items []ProjectActivityItemResponse, limit int)
 
 func projectActivityBucket(item ProjectActivityItemResponse) string {
 	switch item.BlockingSignal {
-	case "awaiting_approval", "failed", "not_started", "stale_unknown":
+	case "awaiting_approval", "failed", "cancelled", "not_started", "stale_unknown":
 		return "blocked"
 	case "completed":
 		return "completed"
@@ -2400,13 +2487,18 @@ func projectActivityBucket(item ProjectActivityItemResponse) string {
 	}
 }
 
-func projectActivityBlockingSignal(assignment ProjectWorkAssignmentResponse) string {
-	status := strings.TrimSpace(firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status))
+func projectActivityBlockingSignal(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse) string {
+	if linkedChat != nil && linkedChat.Missing {
+		return "stale_unknown"
+	}
+	status := strings.TrimSpace(projectActivityProjectedStatus(assignment, linkedChat))
 	switch status {
 	case projectwork.AssignmentStatusAwaitingApproval:
 		return "awaiting_approval"
 	case projectwork.AssignmentStatusFailed:
 		return "failed"
+	case projectwork.AssignmentStatusCancelled, "closed":
+		return "cancelled"
 	case projectwork.AssignmentStatusCompleted:
 		return "completed"
 	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusQueued:
@@ -2428,7 +2520,7 @@ func projectActivityBlockingSignal(assignment ProjectWorkAssignmentResponse) str
 	}
 }
 
-func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, signal string, artifactCount int) string {
+func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, signal string, artifactCount int) string {
 	switch signal {
 	case "awaiting_approval":
 		count := 0
@@ -2440,13 +2532,27 @@ func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, sign
 		}
 		return "awaiting approval"
 	case "failed":
+		if linkedChat != nil && linkedChat.LatestError != "" {
+			return linkedChat.LatestError
+		}
 		if assignment.Execution != nil && assignment.Execution.LastError != "" {
 			return assignment.Execution.LastError
 		}
+		if linkedChat != nil {
+			return "linked chat failed"
+		}
 		return "failed run"
+	case "cancelled":
+		if linkedChat != nil {
+			return "linked chat cancelled"
+		}
+		return "cancelled"
 	case "not_started":
 		return "not started"
 	case "running":
+		if linkedChat != nil {
+			return projectActivityLinkedChatSummary(linkedChat)
+		}
 		return "running"
 	case "completed":
 		if artifactCount > 0 {
@@ -2454,8 +2560,46 @@ func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, sign
 		}
 		return "completed"
 	default:
+		if linkedChat != nil && linkedChat.Missing {
+			return "linked chat missing"
+		}
 		return "stale or unknown"
 	}
+}
+
+func projectActivityProjectedStatus(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse) string {
+	if linkedChat != nil {
+		if linkedChat.Missing {
+			return "stale_unknown"
+		}
+		if status := strings.TrimSpace(linkedChat.Status); status != "" && status != "idle" {
+			return status
+		}
+		if status := strings.TrimSpace(linkedChat.LatestStatus); status != "" {
+			return status
+		}
+		if strings.TrimSpace(linkedChat.Status) == "idle" {
+			return firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status, projectwork.AssignmentStatusRunning)
+		}
+	}
+	return firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status)
+}
+
+func projectActivityLinkedChatSummary(linkedChat *ProjectActivityLinkedChatResponse) string {
+	if linkedChat == nil {
+		return ""
+	}
+	parts := []string{"linked chat"}
+	if linkedChat.Status != "" {
+		parts = append(parts, linkedChat.Status)
+	}
+	if linkedChat.LatestRole != "" && linkedChat.LatestStatus != "" {
+		parts = append(parts, linkedChat.LatestRole+" "+linkedChat.LatestStatus)
+	}
+	if linkedChat.MessageCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d message%s", linkedChat.MessageCount, pluralSuffix(linkedChat.MessageCount)))
+	}
+	return strings.Join(parts, " · ")
 }
 
 func projectActivityExecutionStatus(assignment ProjectWorkAssignmentResponse) string {
@@ -2479,13 +2623,20 @@ func projectActivityExecutionRunID(assignment ProjectWorkAssignmentResponse) str
 	return assignment.Execution.RunID
 }
 
-func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, artifacts ProjectActivityArtifactSummaryResponse, handoffs ProjectActivityHandoffSummaryResponse) string {
+func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, artifacts ProjectActivityArtifactSummaryResponse, handoffs ProjectActivityHandoffSummaryResponse) string {
 	latest := parseProjectActivityTime(firstNonEmpty(assignment.CompletedAt, assignment.StartedAt, assignment.UpdatedAt, assignment.CreatedAt))
 	workUpdated := parseProjectActivityTime(workItem.UpdatedAt)
+	chatUpdated := time.Time{}
+	if linkedChat != nil {
+		chatUpdated = parseProjectActivityTime(linkedChat.UpdatedAt)
+	}
 	artifactUpdated := parseProjectActivityTime(artifacts.LatestAt)
 	handoffUpdated := parseProjectActivityTime(handoffs.LatestAt)
 	if workUpdated.After(latest) {
 		latest = workUpdated
+	}
+	if chatUpdated.After(latest) {
+		latest = chatUpdated
 	}
 	if artifactUpdated.After(latest) {
 		latest = artifactUpdated

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -2104,10 +2104,10 @@ func groupProjectWorkAssignmentsByWorkItem(assignments []projectwork.Assignment)
 	return grouped
 }
 
-func (h *Handler) projectActivityLinkedChats(ctx context.Context, assignments []projectwork.Assignment) (map[string]*ProjectActivityLinkedChatResponse, error) {
+func (h *Handler) projectActivityLinkedChats(ctx context.Context, projectID string, assignments []projectwork.Assignment) map[string]*ProjectActivityLinkedChatResponse {
 	linked := make(map[string]*ProjectActivityLinkedChatResponse)
 	if h == nil || h.agentChat == nil {
-		return linked, nil
+		return linked
 	}
 	for _, assignment := range assignments {
 		chatID := strings.TrimSpace(assignment.ChatSessionID)
@@ -2115,19 +2115,20 @@ func (h *Handler) projectActivityLinkedChats(ctx context.Context, assignments []
 			continue
 		}
 		session, ok, err := h.agentChat.Get(ctx, chatID)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			linked[assignment.ID] = &ProjectActivityLinkedChatResponse{
-				ID:      chatID,
-				Missing: true,
-			}
+		if err != nil || !ok || strings.TrimSpace(session.ProjectID) != strings.TrimSpace(projectID) {
+			linked[assignment.ID] = missingProjectActivityLinkedChat(chatID)
 			continue
 		}
 		linked[assignment.ID] = renderProjectActivityLinkedChat(session)
 	}
-	return linked, nil
+	return linked
+}
+
+func missingProjectActivityLinkedChat(chatID string) *ProjectActivityLinkedChatResponse {
+	return &ProjectActivityLinkedChatResponse{
+		ID:      chatID,
+		Missing: true,
+	}
 }
 
 func renderProjectActivityLinkedChat(session chat.Session) *ProjectActivityLinkedChatResponse {
@@ -2245,10 +2246,7 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 		roleByID[role.ID] = role
 	}
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
-	linkedChats, err := h.projectActivityLinkedChats(ctx, assignments)
-	if err != nil {
-		return ProjectActivityDataResponse{}, err
-	}
+	linkedChats := h.projectActivityLinkedChats(ctx, projectID, assignments)
 	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
 	for _, item := range workItems {
 		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1547,6 +1547,7 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			t.Parallel()
 			handler, server := newProjectWorkProjectionTestServer(t, backend)
 			seedProjectWorkProjectionTest(t, handler)
+			handler.agentChat = failingChatGetStore{Store: handler.agentChat, failingID: "chat_external_error"}
 
 			rec := httptest.NewRecorder()
 			server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/activity", nil))
@@ -1626,6 +1627,16 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 				t.Fatalf("missing chat activity = %+v, want stale linked chat signal", missingChat)
 			}
 
+			crossProjectChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_cross_project_chat")
+			if crossProjectChat.LinkedChat == nil || !crossProjectChat.LinkedChat.Missing || crossProjectChat.LinkedChat.Title != "" || crossProjectChat.LinkedChat.LatestMessageID != "" {
+				t.Fatalf("cross-project chat activity = %+v, want missing without foreign chat metadata", crossProjectChat)
+			}
+
+			errorChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_error_chat")
+			if errorChat.LinkedChat == nil || !errorChat.LinkedChat.Missing || errorChat.BlockingSignal != "stale_unknown" || errorChat.StatusSummary != "linked chat missing" {
+				t.Fatalf("error chat activity = %+v, want degraded missing linked chat", errorChat)
+			}
+
 			preparedChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_prepared_chat")
 			if preparedChat.BlockingSignal != "running" || preparedChat.LinkedChat == nil || preparedChat.LinkedChat.Status != "idle" {
 				t.Fatalf("prepared chat activity = %+v, want idle linked chat treated as running assignment", preparedChat)
@@ -1675,6 +1686,18 @@ func (s failingAgentProfileStore) Update(context.Context, string, func(*agentpro
 
 func (s failingAgentProfileStore) Delete(context.Context, string) error {
 	return s.err
+}
+
+type failingChatGetStore struct {
+	chat.Store
+	failingID string
+}
+
+func (s failingChatGetStore) Get(ctx context.Context, id string) (chat.Session, bool, error) {
+	if id == s.failingID {
+		return chat.Session{}, false, errors.New("chat get failed")
+	}
+	return s.Store.Get(ctx, id)
 }
 
 type projectWorkAssignmentStartSeed struct {
@@ -1888,6 +1911,32 @@ func seedProjectWorkExternalChatProjectionCase(t *testing.T, handler *Handler) {
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_prepared_chat): %v", err)
 	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_cross_project_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_other_project",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_cross_project_chat): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_error_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_error",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_error_chat): %v", err)
+	}
 	if _, err := handler.agentChat.Create(ctx, chat.Session{
 		ID:              "chat_external_projection",
 		Title:           "External projection",
@@ -1934,6 +1983,23 @@ func seedProjectWorkExternalChatProjectionCase(t *testing.T, handler *Handler) {
 		CreatedAt:       createdAt,
 	}); err != nil {
 		t.Fatalf("Create prepared chat session: %v", err)
+	}
+	if _, err := handler.agentChat.Create(ctx, chat.Session{
+		ID:              "chat_external_other_project",
+		Title:           "Foreign external projection",
+		ProjectID:       "proj_other",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_external_other_project",
+		Workspace:       t.TempDir(),
+		Status:          "completed",
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt.Add(5 * time.Minute),
+		Messages: []chat.Message{
+			{ID: "msg_foreign_done", Role: "assistant", Content: "Other project", Status: "completed", CreatedAt: createdAt.Add(5 * time.Minute)},
+		},
+	}); err != nil {
+		t.Fatalf("Create cross-project chat session: %v", err)
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1577,6 +1577,11 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 				t.Fatalf("failed activity = %+v, want failed signal and compact error", failed)
 			}
 
+			cancelled := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_cancelled")
+			if cancelled.BlockingSignal != "cancelled" || cancelled.StatusSummary != "cancelled" {
+				t.Fatalf("cancelled activity = %+v, want cancelled signal without chat-specific summary", cancelled)
+			}
+
 			missing := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_missing")
 			if missing.BlockingSignal != "stale_unknown" || missing.LinkedTaskID == "" {
 				t.Fatalf("missing activity = %+v, want stale/unknown with linked task id", missing)
@@ -1606,6 +1611,29 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			queued := findProjectActivityItemForTest(t, response.Data.Buckets.Active, "asgn_queued")
 			if queued.HandoffSummary.Count != 1 || queued.HandoffSummary.LatestTitle != "Review follow-up" || queued.HandoffSummary.TargetWorkItem != "work_queued" {
 				t.Fatalf("target handoff summary = %+v, want target assignment handoff signal", queued.HandoffSummary)
+			}
+
+			external := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_external_chat")
+			if external.LinkedChat == nil || external.LinkedChat.ID != "chat_external_projection" || external.LinkedChat.LatestMessageID != "msg_external_done" {
+				t.Fatalf("external linked chat = %+v, want chat summary with latest message", external.LinkedChat)
+			}
+			if external.BlockingSignal != "running" || external.StatusSummary != "linked chat · running · assistant completed · 2 messages" {
+				t.Fatalf("external activity = %+v, want linked chat running summary", external)
+			}
+
+			missingChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_missing_chat")
+			if missingChat.LinkedChat == nil || !missingChat.LinkedChat.Missing || missingChat.BlockingSignal != "stale_unknown" || missingChat.StatusSummary != "linked chat missing" {
+				t.Fatalf("missing chat activity = %+v, want stale linked chat signal", missingChat)
+			}
+
+			preparedChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_prepared_chat")
+			if preparedChat.BlockingSignal != "running" || preparedChat.LinkedChat == nil || preparedChat.LinkedChat.Status != "idle" {
+				t.Fatalf("prepared chat activity = %+v, want idle linked chat treated as running assignment", preparedChat)
+			}
+
+			failedChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_failed_chat")
+			if failedChat.BlockingSignal != "failed" || failedChat.StatusSummary != "adapter auth failed" {
+				t.Fatalf("failed chat activity = %+v, want linked chat error surfaced", failedChat)
 			}
 
 			if len(response.Data.Recent) == 0 || len(response.Data.Buckets.Recent) != len(response.Data.Recent) {
@@ -1790,8 +1818,123 @@ func seedProjectWorkProjectionTest(t *testing.T, handler *Handler) {
 	}
 	seedProjectWorkRunOnlyProjectionCase(t, handler)
 	seedProjectWorkNotStartedProjectionCase(t, handler)
+	seedProjectWorkExternalChatProjectionCase(t, handler)
 	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_completed", "", "completed", base.Add(12*time.Minute), base.Add(13*time.Minute), time.Time{}, "", false, false)
 	seedProjectWorkProjectionCase(t, handler, "work_mixed", "asgn_mixed_failed", "", "failed", base.Add(14*time.Minute), base.Add(15*time.Minute), time.Time{}, "review failed", false, false)
+}
+
+func seedProjectWorkExternalChatProjectionCase(t *testing.T, handler *Handler) {
+	t.Helper()
+	ctx := t.Context()
+	createdAt := time.Date(2026, 6, 3, 12, 16, 0, 0, time.UTC)
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_external_chat",
+		ProjectID: "proj_projection",
+		Title:     "work_external_chat",
+		Status:    projectwork.WorkItemStatusRunning,
+		UpdatedAt: createdAt,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_external_chat): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_external_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_projection",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_external_chat): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_missing_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_missing",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_missing_chat): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_failed_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_failed",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_failed_chat): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:            "asgn_prepared_chat",
+		ProjectID:     "proj_projection",
+		WorkItemID:    "work_external_chat",
+		RoleID:        "role_projection",
+		DriverKind:    projectwork.AssignmentDriverExternalAgent,
+		Status:        projectwork.AssignmentStatusRunning,
+		ChatSessionID: "chat_external_prepared",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_prepared_chat): %v", err)
+	}
+	if _, err := handler.agentChat.Create(ctx, chat.Session{
+		ID:              "chat_external_projection",
+		Title:           "External projection",
+		ProjectID:       "proj_projection",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_external_projection",
+		Workspace:       t.TempDir(),
+		Status:          "running",
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt.Add(2 * time.Minute),
+		Messages: []chat.Message{
+			{ID: "msg_external_user", Role: "user", Content: "Continue", Status: "completed", CreatedAt: createdAt.Add(time.Minute)},
+			{ID: "msg_external_done", Role: "assistant", Content: "Done", Status: "completed", CreatedAt: createdAt.Add(2 * time.Minute), CompletedAt: createdAt.Add(3 * time.Minute)},
+		},
+	}); err != nil {
+		t.Fatalf("Create chat session: %v", err)
+	}
+	if _, err := handler.agentChat.Create(ctx, chat.Session{
+		ID:              "chat_external_failed",
+		Title:           "External failed projection",
+		ProjectID:       "proj_projection",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_external_failed",
+		Workspace:       t.TempDir(),
+		Status:          "failed",
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt.Add(4 * time.Minute),
+		Messages: []chat.Message{
+			{ID: "msg_external_failed", Role: "assistant", Content: "", Status: "failed", Error: "adapter auth failed", CreatedAt: createdAt.Add(4 * time.Minute)},
+		},
+	}); err != nil {
+		t.Fatalf("Create failed chat session: %v", err)
+	}
+	if _, err := handler.agentChat.Create(ctx, chat.Session{
+		ID:              "chat_external_prepared",
+		Title:           "External prepared projection",
+		ProjectID:       "proj_projection",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_external_prepared",
+		Workspace:       t.TempDir(),
+		CreatedAt:       createdAt,
+	}); err != nil {
+		t.Fatalf("Create prepared chat session: %v", err)
+	}
 }
 
 func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
@@ -2057,6 +2200,16 @@ func findProjectActivityItemForTest(t *testing.T, items []ProjectActivityItemRes
 	}
 	t.Fatalf("activity assignment %s not found in %+v", assignmentID, items)
 	return ProjectActivityItemResponse{}
+}
+
+func allProjectActivityItemsForTest(data ProjectActivityDataResponse) []ProjectActivityItemResponse {
+	items := make([]ProjectActivityItemResponse, 0, len(data.Buckets.Active)+len(data.Buckets.Blocked)+len(data.Buckets.Completed)+len(data.Buckets.Recent)+len(data.Recent))
+	items = append(items, data.Buckets.Active...)
+	items = append(items, data.Buckets.Blocked...)
+	items = append(items, data.Buckets.Completed...)
+	items = append(items, data.Buckets.Recent...)
+	items = append(items, data.Recent...)
+	return items
 }
 
 func boolToInt(value bool) int {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1361,14 +1361,14 @@ describe("ProjectsView cockpit", () => {
     const linkedAssignment: ProjectAssignmentRecord = {
       ...hecateAssignment,
       driver_kind: "external_agent",
-	      status: "running",
-	      task_id: "",
-	      run_id: "",
-	      chat_session_id: "chat_external_1",
-	      message_id: "",
-	      context_snapshot_id: "ctx_external_1",
-	      execution: undefined,
-	    };
+      status: "running",
+      task_id: "",
+      run_id: "",
+      chat_session_id: "chat_external_1",
+      message_id: "",
+      context_snapshot_id: "ctx_external_1",
+      execution: undefined,
+    };
     vi.mocked(getProjectActivity).mockResolvedValue({
       object: "project_activity",
       data: {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1356,6 +1356,112 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("prefills handoffs from linked external-agent assignment context", async () => {
+    resetProjectWorkMocks();
+    const linkedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      driver_kind: "external_agent",
+	      status: "running",
+	      task_id: "",
+	      run_id: "",
+	      chat_session_id: "chat_external_1",
+	      message_id: "",
+	      context_snapshot_id: "ctx_external_1",
+	      execution: undefined,
+	    };
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: {
+        project_id: project.id,
+        summary: {
+          work_item_count: 1,
+          assignment_count: 1,
+          active_count: 1,
+          blocked_count: 0,
+          completed_count: 0,
+          recent_count: 1,
+        },
+        buckets: {
+          active: [
+            {
+              id: linkedAssignment.id,
+              project_id: project.id,
+              work_item: {
+                id: workItem.id,
+                title: workItem.title,
+                status: "running",
+                priority: workItem.priority,
+              },
+              assignment: linkedAssignment,
+              role,
+              status: "running",
+              blocking_signal: "running",
+              status_summary: "linked chat · running · assistant completed · 2 messages",
+              linked_chat_id: "chat_external_1",
+              linked_message_id: "msg_external_1",
+              linked_chat: {
+                id: "chat_external_1",
+                title: "External implementation",
+                agent_id: "codex",
+                driver_kind: "acp",
+                native_session_id: "native_external_1",
+                status: "running",
+                latest_message_id: "msg_external_1",
+                latest_role: "assistant",
+                latest_status: "completed",
+                message_count: 2,
+                updated_at: "2026-06-02T11:20:00Z",
+              },
+              artifact_summary: { count: 0 },
+              handoff_summary: { count: 0 },
+              updated_at: "2026-06-02T11:20:00Z",
+            },
+          ],
+          blocked: [],
+          completed: [],
+          recent: [],
+        },
+        recent: [],
+      },
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [linkedAssignment] }],
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [linkedAssignment],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    expect(within(detail).getByText("chat completed")).toBeTruthy();
+    expect(
+      within(detail).getByText("linked chat · running · assistant completed · 2 messages"),
+    ).toBeTruthy();
+
+    await userEvent.click(
+      within(detail).getByRole("button", {
+        name: `Create handoff from assignment ${linkedAssignment.id}`,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "New handoff" });
+    expect(within(dialog).getByLabelText("Source assignment")).toHaveValue(linkedAssignment.id);
+    expect(within(dialog).getByLabelText("Source chat")).toHaveValue("chat_external_1");
+    expect(within(dialog).getByLabelText("Source message")).toHaveValue("msg_external_1");
+    expect(within(dialog).getByLabelText("Context refs")).toHaveValue(
+      "ctx_external_1, chat_external_1, msg_external_1",
+    );
+  });
+
   it("renders a project timeline from activity, decisions, artifacts, and memory", async () => {
     resetProjectWorkMocks();
     const onOpenTask = vi.fn();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -3073,7 +3073,10 @@ function WorkItemDetail({
                   onOpenTask={onOpenTask}
                   onStart={() => onStartAssignment(assignment)}
                   onCreateHandoff={() =>
-                    onAddHandoffFromAssignment(assignment, activityByAssignmentID.get(assignment.id))
+                    onAddHandoffFromAssignment(
+                      assignment,
+                      activityByAssignmentID.get(assignment.id),
+                    )
                   }
                   role={roleByID.get(assignment.role_id)}
                   starting={startingAssignmentID === assignment.id}

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -155,6 +155,9 @@ type EditAssignmentForm = NewAssignmentForm & {
 type HandoffForm = {
   id: string;
   sourceAssignmentID: string;
+  sourceRunID: string;
+  sourceChatSessionID: string;
+  sourceMessageID: string;
   targetRoleID: string;
   targetAssignmentID: string;
   title: string;
@@ -324,6 +327,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [artifacts, setArtifacts] = useState<ProjectCollaborationArtifactRecord[]>([]);
   const [handoffs, setHandoffs] = useState<ProjectHandoffRecord[]>([]);
   const [editingHandoff, setEditingHandoff] = useState<ProjectHandoffRecord | "new" | null>(null);
+  const [newHandoffDraft, setNewHandoffDraft] = useState<HandoffForm | null>(null);
   const [handoffPending, setHandoffPending] = useState(false);
   const [handoffError, setHandoffError] = useState("");
   const [handoffActionID, setHandoffActionID] = useState("");
@@ -377,6 +381,16 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const pendingDeleteProject =
     projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
   const roleByID = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
+  const activityByAssignmentID = useMemo(() => {
+    const items = [
+      ...(activity?.buckets.blocked ?? []),
+      ...(activity?.buckets.active ?? []),
+      ...(activity?.buckets.completed ?? []),
+      ...(activity?.buckets.recent ?? []),
+      ...(activity?.recent ?? []),
+    ];
+    return new Map(items.map((item) => [item.assignment.id, item]));
+  }, [activity]);
   const projectHealth = useMemo(
     () =>
       buildProjectHealthSummary(
@@ -939,6 +953,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!title || !summary || !recommendedNextAction) return;
     const payload: CreateProjectHandoffPayload = {
       source_assignment_id: form.sourceAssignmentID.trim(),
+      source_run_id: form.sourceRunID.trim(),
+      source_chat_session_id: form.sourceChatSessionID.trim(),
+      source_message_id: form.sourceMessageID.trim(),
       target_role_id: form.targetRoleID.trim(),
       target_assignment_id: form.targetAssignmentID.trim(),
       title,
@@ -960,6 +977,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           : await updateProjectHandoff(selectedProjectID, selectedWorkItemID, form.id, payload);
       setHandoffs((current) => upsertHandoff(current, res.data));
       setEditingHandoff(null);
+      setNewHandoffDraft(null);
       await loadWorkForProject(selectedProjectID, selectedWorkItemID);
     } catch (error) {
       setHandoffError(errorMessage(error, "Failed to save handoff."));
@@ -1252,10 +1270,12 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                             onOpenTask={onOpenTask}
                             onRefresh={refreshSelectedWorkItem}
                             onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
+                            activityByAssignmentID={activityByAssignmentID}
                             onDeleteHandoff={(handoff) => void handleDeleteHandoff(handoff)}
                             onDeleteWorkItem={(item) => setDeleteWorkItem(item)}
                             onEditHandoff={(handoff) => {
                               setHandoffError("");
+                              setNewHandoffDraft(null);
                               setEditingHandoff(handoff);
                             }}
                             onEditAssignment={(assignment) => {
@@ -1283,6 +1303,18 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                             }}
                             onAddHandoff={() => {
                               setHandoffError("");
+                              setNewHandoffDraft(null);
+                              setEditingHandoff("new");
+                            }}
+                            onAddHandoffFromAssignment={(assignment, activityItem) => {
+                              setHandoffError("");
+                              setNewHandoffDraft(
+                                handoffFormFromAssignment(
+                                  assignment,
+                                  roleByID.get(assignment.role_id) ?? null,
+                                  activityItem,
+                                ),
+                              );
                               setEditingHandoff("new");
                             }}
                           />
@@ -1439,10 +1471,14 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             key={editingHandoff === "new" ? "new" : editingHandoff.id}
             assignments={assignments}
             handoff={editingHandoff === "new" ? null : editingHandoff}
+            draft={editingHandoff === "new" ? newHandoffDraft : null}
             error={handoffError}
             pending={handoffPending}
             roles={roles}
-            onClose={() => setEditingHandoff(null)}
+            onClose={() => {
+              setEditingHandoff(null);
+              setNewHandoffDraft(null);
+            }}
             onSave={handleSaveHandoff}
           />
         )}
@@ -2856,6 +2892,7 @@ function ProjectMemoryModal({
 }
 
 function WorkItemDetail({
+  activityByAssignmentID,
   assignments,
   artifacts,
   handoffActionID,
@@ -2866,6 +2903,7 @@ function WorkItemDetail({
   loading,
   onAddAssignment,
   onAddHandoff,
+  onAddHandoffFromAssignment,
   onCreateAssignmentFromHandoff,
   onDeleteAssignment,
   onDeleteHandoff,
@@ -2884,6 +2922,7 @@ function WorkItemDetail({
   startingAssignmentID,
   workItem,
 }: {
+  activityByAssignmentID: Map<string, ProjectActivityItemRecord>;
   assignments: ProjectAssignmentRecord[];
   artifacts: ProjectCollaborationArtifactRecord[];
   handoffActionID: string;
@@ -2894,6 +2933,10 @@ function WorkItemDetail({
   loading: boolean;
   onAddAssignment: () => void;
   onAddHandoff: () => void;
+  onAddHandoffFromAssignment: (
+    assignment: ProjectAssignmentRecord,
+    activityItem?: ProjectActivityItemRecord,
+  ) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
   onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
   onDeleteHandoff: (handoff: ProjectHandoffRecord) => void;
@@ -2998,6 +3041,7 @@ function WorkItemDetail({
               {assignments.map((assignment) => (
                 <AssignmentRow
                   key={assignment.id}
+                  activityItem={activityByAssignmentID.get(assignment.id)}
                   assignment={assignment}
                   chatModel={
                     assignment.execution?.model ||
@@ -3028,6 +3072,9 @@ function WorkItemDetail({
                   }
                   onOpenTask={onOpenTask}
                   onStart={() => onStartAssignment(assignment)}
+                  onCreateHandoff={() =>
+                    onAddHandoffFromAssignment(assignment, activityByAssignmentID.get(assignment.id))
+                  }
                   role={roleByID.get(assignment.role_id)}
                   starting={startingAssignmentID === assignment.id}
                   loadContext={
@@ -4140,6 +4187,7 @@ function EditAssignmentModal({
 
 function ProjectHandoffModal({
   assignments,
+  draft,
   error,
   handoff,
   pending,
@@ -4148,6 +4196,7 @@ function ProjectHandoffModal({
   onSave,
 }: {
   assignments: ProjectAssignmentRecord[];
+  draft?: HandoffForm | null;
   error: string;
   handoff: ProjectHandoffRecord | null;
   pending: boolean;
@@ -4155,7 +4204,7 @@ function ProjectHandoffModal({
   onClose: () => void;
   onSave: (form: HandoffForm) => void | Promise<void>;
 }) {
-  const [form, setForm] = useState<HandoffForm>(() => handoffFormFromRecord(handoff));
+  const [form, setForm] = useState<HandoffForm>(() => draft ?? handoffFormFromRecord(handoff));
   const valid =
     form.title.trim().length > 0 &&
     form.summary.trim().length > 0 &&
@@ -4293,6 +4342,41 @@ function ProjectHandoffModal({
         </div>
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
           <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Source run</span>
+            <input
+              className="input"
+              value={form.sourceRunID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceRunID: event.target.value }))
+              }
+              placeholder="run_..."
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Source chat</span>
+            <input
+              className="input"
+              value={form.sourceChatSessionID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceChatSessionID: event.target.value }))
+              }
+              placeholder="chat_..."
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Source message</span>
+            <input
+              className="input"
+              value={form.sourceMessageID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceMessageID: event.target.value }))
+              }
+              placeholder="msg_..."
+            />
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
             <span style={fieldLabelStyle}>Artifact IDs</span>
             <input
               className="input"
@@ -4332,10 +4416,12 @@ function ProjectHandoffModal({
 }
 
 function AssignmentRow({
+  activityItem,
   assignment,
   chatModel,
   error,
   loadContext,
+  onCreateHandoff,
   onDelete,
   onEdit,
   onOpenChat,
@@ -4344,10 +4430,12 @@ function AssignmentRow({
   role,
   starting,
 }: {
+  activityItem?: ProjectActivityItemRecord;
   assignment: ProjectAssignmentRecord;
   chatModel: string;
   error: string;
   loadContext?: (() => Promise<ContextPacketRecord>) | null;
+  onCreateHandoff: () => void;
   onDelete: () => void;
   onEdit: () => void;
   onOpenChat?: () => void;
@@ -4360,6 +4448,7 @@ function AssignmentRow({
   const taskID = execution?.task_id || assignment.task_id || "";
   const runID = execution?.run_id || assignment.run_id || "";
   const chatSessionID = assignment.chat_session_id || "";
+  const linkedChat = activityItem?.linked_chat;
   const projectedStatus = execution?.status || assignment.status;
   const startable =
     (assignment.driver_kind === "hecate_task" || assignment.driver_kind === "external_agent") &&
@@ -4454,6 +4543,17 @@ function AssignmentRow({
         </button>
         {taskID && <CopyableID text={taskID} compact />}
         {runID && <CopyableID text={runID} compact />}
+        {chatSessionID && <CopyableID text={chatSessionID} compact />}
+        {linkedChat && (
+          <span
+            className={linkedChat.missing ? "badge badge-amber" : "badge badge-muted"}
+            title={linkedChatStatusTitle(linkedChat)}
+          >
+            {linkedChat.missing
+              ? "linked chat missing"
+              : `chat ${linkedChat.latest_status || linkedChat.status || "active"}`}
+          </span>
+        )}
         {execution?.pending_approval_count ? (
           <span className="badge badge-amber">
             {execution.pending_approval_count} approval pending
@@ -4471,7 +4571,23 @@ function AssignmentRow({
           </span>
         ) : null}
         {execution?.missing && <span className="badge badge-amber">linked run missing</span>}
+        {(taskID || runID || chatSessionID || assignment.context_snapshot_id) && (
+          <button
+            aria-label={`Create handoff from assignment ${assignment.id}`}
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={onCreateHandoff}
+          >
+            <Icon d={Icons.plus} size={12} />
+            Handoff
+          </button>
+        )}
       </div>
+      {activityItem?.status_summary &&
+        activityItem.status_summary !== projectedStatus &&
+        activityItem.status_summary !== "linked run missing" && (
+          <div style={{ ...subtleTextStyle, marginTop: 8 }}>{activityItem.status_summary}</div>
+        )}
       {(startedAt || finishedAt) && (
         <div style={{ ...metaLineStyle, marginTop: 8 }}>
           {startedAt && <span>Started {formatAbsoluteTime(startedAt)}</span>}
@@ -4516,7 +4632,7 @@ function ProjectHandoffRow({
   starting: boolean;
 }) {
   const startable =
-    assignment?.driver_kind === "hecate_task" &&
+    (assignment?.driver_kind === "hecate_task" || assignment?.driver_kind === "external_agent") &&
     (assignment.execution?.status || assignment.status) === "queued";
   const canCreateAssignment = !assignment && handoff.status !== "dismissed";
   return (
@@ -4603,9 +4719,7 @@ function ProjectHandoffRow({
             type="button"
             onClick={onStart}
             disabled={!startable || starting}
-            title={
-              startable ? "Start linked native assignment" : "Linked assignment is not queued."
-            }
+            title={startable ? "Start linked assignment" : "Linked assignment is not queued."}
           >
             <Icon d={Icons.send} size={12} />
             {starting ? "Starting…" : "Start from handoff"}
@@ -4687,6 +4801,9 @@ function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): HandoffFor
   return {
     id: handoff?.id ?? "",
     sourceAssignmentID: handoff?.source_assignment_id ?? "",
+    sourceRunID: handoff?.source_run_id ?? "",
+    sourceChatSessionID: handoff?.source_chat_session_id ?? "",
+    sourceMessageID: handoff?.source_message_id ?? "",
     targetRoleID: handoff?.target_role_id ?? "",
     targetAssignmentID: handoff?.target_assignment_id ?? "",
     title: handoff?.title ?? "",
@@ -4699,6 +4816,59 @@ function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): HandoffFor
     provenanceKind: handoff?.provenance_kind ?? "operator",
     trustLabel: handoff?.trust_label ?? "operator_reviewed",
   };
+}
+
+function handoffFormFromAssignment(
+  assignment: ProjectAssignmentRecord,
+  role: ProjectWorkRoleRecord | null,
+  activityItem?: ProjectActivityItemRecord,
+): HandoffForm {
+  const sourceChatSessionID = assignment.chat_session_id ?? "";
+  const sourceRunID = assignment.execution?.run_id || assignment.run_id || "";
+  const sourceMessageID =
+    assignment.message_id ||
+    activityItem?.linked_message_id ||
+    activityItem?.linked_chat?.latest_message_id ||
+    "";
+  const contextRefs = [
+    assignment.context_snapshot_id,
+    assignment.execution?.task_id || assignment.task_id,
+    sourceRunID,
+    sourceChatSessionID,
+    sourceMessageID,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return {
+    id: "",
+    sourceAssignmentID: assignment.id,
+    sourceRunID,
+    sourceChatSessionID,
+    sourceMessageID,
+    targetRoleID: "",
+    targetAssignmentID: "",
+    title: `${role?.name || assignment.role_id} handoff`,
+    summary: "",
+    recommendedNextAction: "",
+    linkedArtifactIDs: "",
+    linkedMemoryIDs: "",
+    contextRefs,
+    status: "pending",
+    provenanceKind: "operator",
+    trustLabel: "operator_reviewed",
+  };
+}
+
+function linkedChatStatusTitle(linkedChat: NonNullable<ProjectActivityItemRecord["linked_chat"]>) {
+  return [
+    linkedChat.title,
+    linkedChat.agent_id,
+    linkedChat.status ? `session ${linkedChat.status}` : "",
+    linkedChat.latest_status ? `latest ${linkedChat.latest_status}` : "",
+    linkedChat.latest_error,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function memoryFormFromRecord(entry: ProjectMemoryRecord | null): MemoryForm {

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -77,6 +77,59 @@ describe("projectInsights", () => {
     expect(metric?.value).toBe(1);
     expect(metric?.detail).toBe("1 recent accepted, 1 superseded, 1 dismissed");
   });
+
+  it("surfaces blocked external-agent assignments with chat refs", () => {
+    const project = {
+      id: "proj_external",
+      name: "Project",
+      roots: [
+        {
+          id: "root_1",
+          path: "/tmp/project",
+          kind: "git",
+          active: true,
+          created_at: "2026-06-04T10:00:00Z",
+          updated_at: "2026-06-04T10:00:00Z",
+        },
+      ],
+      default_provider: "openai",
+      default_model: "gpt-4.1",
+      context_sources: [],
+      created_at: "2026-06-04T10:00:00Z",
+      updated_at: "2026-06-04T10:00:00Z",
+    } satisfies ProjectRecord;
+    const item = activityItem(project.id, []);
+    item.assignment.driver_kind = "external_agent";
+    item.assignment.chat_session_id = "chat_failed";
+    item.blocking_signal = "failed";
+    item.linked_chat_id = "chat_failed";
+    const activity = {
+      project_id: project.id,
+      summary: {
+        work_item_count: 1,
+        assignment_count: 1,
+        active_count: 0,
+        blocked_count: 1,
+        completed_count: 0,
+        recent_count: 1,
+      },
+      buckets: {
+        active: [],
+        blocked: [item],
+        completed: [],
+        recent: [],
+      },
+      recent: [],
+    } as ProjectActivityData;
+
+    const health = buildProjectHealthSummary(project, activity, [], [], []);
+    const attention = health.attention.find((entry) =>
+      entry.title.startsWith("External assignment needs review"),
+    );
+
+    expect(attention?.chatID).toBe("chat_failed");
+    expect(attention?.actionLabel).toBe("View blocked");
+  });
 });
 
 function activityItem(

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -65,6 +65,7 @@ export type ProjectHealthAttention = {
   workItemID?: string;
   taskID?: string;
   runID?: string;
+  chatID?: string;
   candidateID?: string;
   actionLabel?: string;
 };
@@ -261,6 +262,21 @@ export function buildProjectHealthSummary(
   if (firstStale) {
     attention.push(
       activityAttention(firstStale, "Stale or unknown assignment", "View blocked", "blocked"),
+    );
+  }
+  const firstFailedExternal = activityItems.find(
+    (item) =>
+      item.assignment.driver_kind === "external_agent" &&
+      (item.blocking_signal === "failed" || item.blocking_signal === "cancelled"),
+  );
+  if (firstFailedExternal) {
+    attention.push(
+      activityAttention(
+        firstFailedExternal,
+        "External assignment needs review",
+        "View blocked",
+        "blocked",
+      ),
     );
   }
   if (enabledMemory === 0 && enabledContextSources === 0 && project) {
@@ -572,6 +588,7 @@ function projectAssignmentToActivityAttention(
     status_summary: "active assignment has not changed recently",
     linked_task_id: assignment.execution?.task_id || assignment.task_id,
     linked_run_id: assignment.execution?.run_id || assignment.run_id,
+    linked_chat_id: assignment.chat_session_id,
     artifact_summary: { count: assignment.execution?.artifact_count ?? 0 },
     updated_at: assignment.updated_at,
   };
@@ -586,6 +603,7 @@ function activityAttention(
   const taskID =
     item.linked_task_id || item.assignment.execution?.task_id || item.assignment.task_id;
   const runID = item.linked_run_id || item.assignment.execution?.run_id || item.assignment.run_id;
+  const chatID = item.linked_chat_id || item.assignment.chat_session_id;
   return {
     id: item.id,
     title: `${title}: ${item.work_item.title}`,
@@ -601,6 +619,7 @@ function activityAttention(
     workItemID: item.work_item.id,
     taskID,
     runID,
+    chatID,
     actionLabel,
   };
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -384,6 +384,7 @@ export type UpdateProjectHandoffPayload = Partial<CreateProjectHandoffPayload>;
 export type ProjectActivitySignal =
   | "awaiting_approval"
   | "failed"
+  | "cancelled"
   | "not_started"
   | "running"
   | "completed"
@@ -417,6 +418,23 @@ export type ProjectActivityHandoffSummary = {
   target_work_item_id?: string;
 };
 
+export type ProjectActivityLinkedChatRecord = {
+  id: string;
+  title?: string;
+  agent_id?: string;
+  driver_kind?: string;
+  native_session_id?: string;
+  status?: string;
+  latest_message_id?: string;
+  latest_role?: string;
+  latest_status?: string;
+  latest_error?: string;
+  message_count?: number;
+  created_at?: string;
+  updated_at?: string;
+  missing?: boolean;
+};
+
 export type ProjectActivityItemRecord = {
   id: string;
   project_id: string;
@@ -429,6 +447,7 @@ export type ProjectActivityItemRecord = {
   linked_task_id?: string;
   linked_run_id?: string;
   linked_chat_id?: string;
+  linked_chat?: ProjectActivityLinkedChatRecord;
   linked_message_id?: string;
   recent_artifacts?: ProjectCollaborationArtifactRecord[];
   artifact_summary: ProjectActivityArtifactSummary;


### PR DESCRIPTION
## Summary
- Project activity now includes linked chat projections for External Agent assignments, including latest message, adapter/session details, missing-session diagnostics, and prepared idle sessions.
- Project assignment rows expose linked chat status and can prefill handoffs with assignment/run/chat/message/context provenance.
- Needs Attention flags failed or cancelled External Agent assignments, and runtime docs describe the new activity and handoff source metadata.

## Tests
- `go test ./internal/api -run TestProjectWorkAPI_ProjectActivity`
- `go test ./...`
- `go vet ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/projectInsights.test.ts src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test`
- `git diff --check`