### PR TITLE
Clarify assignment context inspector

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1912,7 +1912,10 @@ linked Task/Run packets first, then falls back to the assignment-stored packet
 created by an External Agent start, then to a linked Chat `chat_session_id` +
 `message_id` packet when present. Unstarted assignments, legacy rows without a
 stored packet or execution link, or older runs that predate snapshots return
-`404 not_found`.
+`404 not_found`. The Projects cockpit uses this endpoint for the assignment
+`Inspect context` action so operators can inspect the resolved profile, launch
+instructions, memory, project sources, work context, runtime refs, and skipped
+or inspect-only items without reopening the raw task or chat transcript.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start`
 
@@ -2754,10 +2757,11 @@ text, file contents, or external-agent private prompt packing.
 Operator UI note: the current React console renders these packets as a compact
 "what the agent saw" inspector. Chats expose it inline on assistant transcript
 rows; Task Detail and Project assignment detail expose it behind an
-`Inspect context` modal. The UI groups rows by `section`, keeps trust labels on
-each item, falls back to legacy `sources` when `items` are absent, and uses
-operator-facing copy such as `Not captured` when a snapshot does not expose the
-full system prompt text.
+`Inspect context` modal. The UI groups rows by `section` using labels such as
+Profile, Instructions, Memory, Project sources, Work context, and Runtime
+evidence; keeps trust labels on each item; falls back to legacy `sources` when
+`items` are absent; and uses operator-facing copy such as `Not captured` when a
+snapshot does not expose the full system prompt text.
 
 Section values currently used by the runtime are:
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -325,12 +325,43 @@ function resetProjectWorkMocks() {
       provider: "ollama",
       model: "qwen2.5-coder",
       execution_profile: "implementation",
+      workspace: "/tmp/hecate-project",
       refs: {
         project_id: project.id,
         work_item_id: workItem.id,
         assignment_id: hecateAssignment.id,
+        task_id: "task_1",
+        run_id: "run_1",
       },
       items: [
+        {
+          section: "profile",
+          kind: "agent_profile",
+          trust_level: "runtime_state",
+          origin: "implementation",
+          title: "Implementation profile",
+          body: "Tools enabled. Writes allowed.",
+          included: true,
+        },
+        {
+          section: "memory",
+          kind: "memory",
+          trust_level: "operator_memory",
+          origin: "mem_backend",
+          title: "Backend preference",
+          body: "Prefer Go-first changes.",
+          included: false,
+          inclusion_reason: "Visible to operator, not injected into assignment launch context.",
+        },
+        {
+          section: "sources",
+          kind: "workspace_instruction",
+          trust_level: "workspace_guidance",
+          origin: "AGENTS.md",
+          title: "Workspace instructions",
+          body: "Discovered project guidance.",
+          included: false,
+        },
         {
           section: "project_work",
           kind: "work_item",
@@ -338,6 +369,15 @@ function resetProjectWorkMocks() {
           origin: workItem.id,
           title: workItem.title,
           body: workItem.brief,
+          included: true,
+        },
+        {
+          section: "runtime",
+          kind: "trace",
+          trust_level: "runtime_state",
+          origin: "run_1",
+          title: "Run evidence",
+          body: "Trace and run identifiers captured.",
           included: true,
         },
       ],
@@ -1247,6 +1287,13 @@ describe("ProjectsView cockpit", () => {
     );
     const dialog = await screen.findByRole("dialog", { name: "Assignment asgn_1 context" });
     expect(dialog).toBeTruthy();
+    expect(within(dialog).getByText("Profile")).toBeTruthy();
+    expect(within(dialog).getByText("Memory")).toBeTruthy();
+    expect(within(dialog).getByText("Project sources")).toBeTruthy();
+    expect(within(dialog).getByText("Work context")).toBeTruthy();
+    expect(within(dialog).getByText("Runtime evidence")).toBeTruthy();
+    expect(within(dialog).getByText("Task")).toBeTruthy();
+    expect(within(dialog).getByText("task_1")).toBeTruthy();
     expect(within(dialog).getByText("Expose project work and native starts.")).toBeTruthy();
 
     await userEvent.click(within(detail).getByRole("button", { name: "Open chat" }));

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -29,12 +29,12 @@ type RemoteState =
 const sectionOrder = [
   "profile",
   "instructions",
-  "project",
-  "project_work",
   "memory",
   "sources",
-  "workspace",
+  "project_work",
   "runtime",
+  "project",
+  "workspace",
 ] as const;
 
 const refOrder: Array<[keyof ContextPacketRefsRecord, string]> = [
@@ -543,7 +543,7 @@ function humanSectionLabel(section: string): string {
     case "project":
       return "Project";
     case "project_work":
-      return "Launch context";
+      return "Work context";
     case "memory":
       return "Memory";
     case "sources":
@@ -551,7 +551,7 @@ function humanSectionLabel(section: string): string {
     case "workspace":
       return "Workspace";
     case "runtime":
-      return "Runtime";
+      return "Runtime evidence";
     default:
       return section.replaceAll("_", " ");
   }


### PR DESCRIPTION
## Summary
- Align Context Inspector section labels/order with the Projects cockpit language: Profile, Memory, Project sources, Work context, and Runtime evidence.
- Strengthen the Projects assignment inspector test to assert grouped context sections and linked task refs.
- Document the assignment context endpoint as the Projects cockpit Inspect context path for profile, memory, project sources, work context, runtime refs, and inspect-only items.

## Tests
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `git diff --check`