### PR TITLE
Create follow-up assignments from handoffs

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2065,6 +2065,13 @@ required. `status` defaults to `pending`, `provenance_kind` defaults to
 assignment IDs, if supplied, must belong to the same work item. Linked artifact
 IDs, memory IDs, and context refs are stored as references only; creating a
 handoff does not write memory, inject context, start a task, or open a chat.
+The Projects UI can use a handoff's target role/work-item hints to create a
+queued follow-up assignment. That operation remains operator-controlled: the UI
+creates the assignment, records `target_assignment_id` on the handoff, and marks
+the handoff accepted, but it does not start the assignment automatically. Source
+assignment/run/chat/message/context refs remain on the handoff as provenance
+rather than being copied into the new assignment as if they were the new
+assignment's own execution links.
 
 ```json
 {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2782,6 +2782,20 @@ describe("ProjectsView cockpit", () => {
 
   it("creates target assignments from handoffs without starting them", async () => {
     resetProjectWorkMocks();
+    const qaRole: ProjectWorkRoleRecord = {
+      id: "reviewer_qa",
+      project_id: project.id,
+      name: "QA reviewer",
+      default_driver_kind: "external_agent",
+      default_provider: "anthropic",
+      default_model: "claude-sonnet-4",
+      default_agent_profile: "qa_external",
+      built_in: false,
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [role, qaRole],
+    });
     vi.mocked(getProjectHandoffs).mockResolvedValue({
       object: "project_handoffs",
       data: [
@@ -2789,11 +2803,16 @@ describe("ProjectsView cockpit", () => {
           id: "handoff_1",
           project_id: project.id,
           work_item_id: workItem.id,
+          source_assignment_id: "asgn_1",
+          source_run_id: "run_1",
+          source_chat_session_id: "chat_1",
+          source_message_id: "msg_1",
           title: "QA handoff",
           summary: "Ready for review.",
           recommended_next_action: "Create a QA assignment.",
           target_role_id: "reviewer_qa",
           target_work_item_id: "work_followup",
+          context_refs: ["ctx_1"],
           status: "pending",
           provenance_kind: "agent_draft",
           trust_label: "operator_reviewed",
@@ -2810,6 +2829,7 @@ describe("ProjectsView cockpit", () => {
         id: "asgn_new",
         work_item_id: "work_followup",
         role_id: "reviewer_qa",
+        driver_kind: "external_agent",
         status: "queued",
       },
     });
@@ -2824,12 +2844,17 @@ describe("ProjectsView cockpit", () => {
     await waitFor(() => {
       expect(within(detail).getAllByText("QA handoff").length).toBeGreaterThan(0);
     });
-    await userEvent.click(within(detail).getByRole("button", { name: "Target assignment" }));
+    expect(within(detail).getByText(/Source refs: assignment asgn_1/)).toBeTruthy();
+    expect(within(detail).getByText(/chat chat_1/)).toBeTruthy();
+    expect(within(detail).getByText(/context ctx_1/)).toBeTruthy();
+    await userEvent.click(
+      within(detail).getByRole("button", { name: "Create follow-up assignment" }),
+    );
 
     await waitFor(() => {
       expect(createProjectAssignment).toHaveBeenCalledWith(project.id, "work_followup", {
         role_id: "reviewer_qa",
-        driver_kind: "hecate_task",
+        driver_kind: "external_agent",
       });
     });
     expect(updateProjectHandoff).toHaveBeenCalledWith(

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2870,6 +2870,82 @@ describe("ProjectsView cockpit", () => {
     expect(startProjectAssignment).not.toHaveBeenCalled();
   });
 
+  it("falls back to Hecate task follow-up assignments when the target role has no default driver", async () => {
+    resetProjectWorkMocks();
+    const reviewRole: ProjectWorkRoleRecord = {
+      id: "role_review",
+      project_id: project.id,
+      name: "Review",
+      built_in: false,
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [role, reviewRole],
+    });
+    vi.mocked(getProjectHandoffs).mockResolvedValue({
+      object: "project_handoffs",
+      data: [
+        {
+          id: "handoff_driver_fallback",
+          project_id: project.id,
+          work_item_id: workItem.id,
+          title: "Review handoff",
+          summary: "Ready for review.",
+          recommended_next_action: "Create a review assignment.",
+          target_role_id: "role_review",
+          status: "pending",
+          provenance_kind: "agent_draft",
+          trust_label: "operator_reviewed",
+          created_at: "2026-06-02T12:00:00Z",
+          updated_at: "2026-06-02T12:00:00Z",
+          status_changed_at: "2026-06-02T12:00:00Z",
+        },
+      ],
+    });
+    vi.mocked(createProjectAssignment).mockResolvedValueOnce({
+      object: "project_assignment",
+      data: {
+        ...hecateAssignment,
+        id: "asgn_review",
+        role_id: "role_review",
+        driver_kind: "hecate_task",
+        status: "queued",
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const detail = screen.getByLabelText("Selected work item");
+    await waitFor(() => {
+      expect(within(detail).getAllByText("Review handoff").length).toBeGreaterThan(0);
+    });
+    await userEvent.click(
+      within(detail).getByRole("button", { name: "Create follow-up assignment" }),
+    );
+
+    await waitFor(() => {
+      expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
+        role_id: "role_review",
+        driver_kind: "hecate_task",
+      });
+    });
+    expect(updateProjectHandoff).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      "handoff_driver_fallback",
+      expect.objectContaining({
+        target_assignment_id: "asgn_review",
+        target_role_id: "role_review",
+        status: "accepted",
+      }),
+    );
+    expect(startProjectAssignment).not.toHaveBeenCalled();
+  });
+
   it("uses a role default driver when adding assignments", async () => {
     const externalRole: ProjectWorkRoleRecord = {
       id: "role_external",

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1027,12 +1027,14 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!roleID) return;
     const targetWorkItemID = (handoff.target_work_item_id || selectedWorkItemID).trim();
     if (!targetWorkItemID) return;
+    const targetRole = roleByID.get(roleID);
+    const driverKind = targetRole?.default_driver_kind || "hecate_task";
     setHandoffActionID(handoff.id);
     setHandoffError("");
     try {
       const assignment = await createProjectAssignment(selectedProjectID, targetWorkItemID, {
         role_id: roleID,
-        driver_kind: "hecate_task",
+        driver_kind: driverKind,
       });
       if (targetWorkItemID === selectedWorkItemID) {
         setAssignments((current) => upsertAssignment(current, assignment.data));
@@ -4638,6 +4640,7 @@ function ProjectHandoffRow({
     (assignment?.driver_kind === "hecate_task" || assignment?.driver_kind === "external_agent") &&
     (assignment.execution?.status || assignment.status) === "queued";
   const canCreateAssignment = !assignment && handoff.status !== "dismissed";
+  const sourceRefs = handoffSourceRefs(handoff);
   return (
     <div style={artifactStyle}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -4673,6 +4676,11 @@ function ProjectHandoffRow({
         <span>{handoff.trust_label}</span>
         {handoff.updated_at && <span>Updated {formatAbsoluteTime(handoff.updated_at)}</span>}
       </div>
+      {sourceRefs.length > 0 && (
+        <div style={{ ...subtleTextStyle, marginTop: 7 }}>
+          Source refs: {sourceRefs.join(" · ")}
+        </div>
+      )}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 9 }}>
         {handoff.status === "pending" && (
           <>
@@ -4713,7 +4721,7 @@ function ProjectHandoffRow({
             disabled={actionPending}
           >
             <Icon d={Icons.plus} size={12} />
-            Target assignment
+            Create follow-up assignment
           </button>
         )}
         {assignment && (
@@ -4872,6 +4880,23 @@ function linkedChatStatusTitle(linkedChat: NonNullable<ProjectActivityItemRecord
   ]
     .filter(Boolean)
     .join(" · ");
+}
+
+function handoffSourceRefs(handoff: ProjectHandoffRecord): string[] {
+  const refs = [
+    ["assignment", handoff.source_assignment_id],
+    ["run", handoff.source_run_id],
+    ["chat", handoff.source_chat_session_id],
+    ["message", handoff.source_message_id],
+  ]
+    .map(([label, value]) => (value ? `${label} ${shortID(value)}` : ""))
+    .filter(Boolean);
+  for (const ref of handoff.context_refs ?? []) {
+    if (ref && !refs.some((item) => item.endsWith(shortID(ref)))) {
+      refs.push(`context ${shortID(ref)}`);
+    }
+  }
+  return refs;
 }
 
 function memoryFormFromRecord(entry: ProjectMemoryRecord | null): MemoryForm {


### PR DESCRIPTION
## Summary
- create follow-up assignments from accepted handoffs without auto-starting work
- honor the target role's default driver when creating the follow-up assignment
- keep source assignment/run/chat/message/context refs on the handoff as provenance instead of copying them onto the new assignment

## Tests
- `cd ui && ./node_modules/.bin/oxfmt --write src/features/projects/ProjectsView.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `git diff --check`