### PR TITLE
Show memory candidate provenance

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1419,6 +1419,12 @@ Lists pending memory candidates by default. Pass `include_resolved=true` to
 include promoted and rejected candidates, or `status=pending|promoted|rejected`
 to filter explicitly.
 
+Candidates are review artifacts, not durable memory. Operators should inspect
+the candidate body, suggested trust/source fields, and `source_refs` before
+promotion. `source_refs` point back to evidence such as task runs, handoffs,
+chat messages, or artifacts so the UI can show where the candidate came from
+without injecting unapproved text into future context packets.
+
 ```json
 GET /hecate/v1/projects/proj_.../memory/candidates
 → 200
@@ -1457,6 +1463,8 @@ Promotes a pending candidate into a durable project memory entry. The request
 may include edited `title`, `body`, `trust_label`, `source_kind`, `source_id`,
 and `enabled`; omitted fields use the candidate's suggested values. Promotion
 sets the candidate status to `promoted` and records `promoted_memory_id`.
+Only the created memory entry participates in future project-memory context
+selection; the candidate remains a provenance/audit record.
 Promoting an already-promoted candidate is idempotent when the linked
 `promoted_memory_id` still exists and returns the existing promoted candidate.
 Promoting a rejected candidate returns `409 conflict`.

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -951,6 +951,9 @@ describe("ProjectsView cockpit", () => {
     expect(await screen.findByText("Generated summary")).toBeTruthy();
     expect(screen.getByText("Temporary note")).toBeTruthy();
     expect(screen.getAllByText("generated_summary").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Source refs: task_run Implementation run/).length).toBeGreaterThan(
+      0,
+    );
 
     await user.click(
       screen.getByRole("button", { name: "Reject memory candidate Temporary note" }),
@@ -961,6 +964,10 @@ describe("ProjectsView cockpit", () => {
       screen.getByRole("button", { name: "Promote memory candidate Generated summary" }),
     );
     expect(screen.getByRole("button", { name: "Promote memory" })).toBeTruthy();
+    expect(screen.getByText("Candidate provenance")).toBeTruthy();
+    expect(screen.getAllByText(/Source refs: task_run Implementation run/).length).toBeGreaterThan(
+      0,
+    );
     fireEvent.change(screen.getByLabelText("Trust label"), {
       target: { value: "operator_memory" },
     });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -2713,6 +2713,7 @@ function ProjectMemoryCandidateRow({
   pendingReject: boolean;
 }) {
   const source = formatCandidateSource(candidate);
+  const sourceRefs = formatCandidateSourceRefs(candidate);
   const pending = candidate.status === "pending";
   return (
     <div style={memoryEntryStyle}>
@@ -2753,6 +2754,11 @@ function ProjectMemoryCandidateRow({
         <span>Suggested {formatAbsoluteTime(candidate.created_at)}</span>
         <CopyableID text={candidate.id} compact />
       </div>
+      {sourceRefs.length > 0 && (
+        <div style={{ ...subtleTextStyle, marginTop: 6 }}>
+          Source refs: {sourceRefs.join(" · ")}
+        </div>
+      )}
     </div>
   );
 }
@@ -2777,6 +2783,7 @@ function ProjectMemoryModal({
   );
   const valid = form.title.trim().length > 0 && form.body.trim().length > 0;
   const isCandidate = Boolean(candidate);
+  const candidateSourceRefs = candidate ? formatCandidateSourceRefs(candidate) : [];
   return (
     <Modal
       title={
@@ -2814,6 +2821,30 @@ function ProjectMemoryModal({
         style={{ display: "grid", gap: 12 }}
       >
         {error && <InlineError message={error} />}
+        {candidate && (
+          <div
+            style={{
+              background: "var(--bg2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-sm)",
+              display: "grid",
+              gap: 6,
+              padding: "9px 10px",
+            }}
+          >
+            <div style={sectionLabelStyle}>Candidate provenance</div>
+            <div style={metaLineStyle}>
+              <span>{formatCandidateSource(candidate)}</span>
+              <span>{candidate.suggested_trust_label}</span>
+              <span>{candidate.status}</span>
+            </div>
+            {candidateSourceRefs.length > 0 && (
+              <div style={{ ...subtleTextStyle }}>
+                Source refs: {candidateSourceRefs.join(" · ")}
+              </div>
+            )}
+          </div>
+        )}
         <label style={fieldStyle}>
           <span style={fieldLabelStyle}>Title</span>
           <input
@@ -4938,6 +4969,16 @@ function formatCandidateSource(candidate: ProjectMemoryCandidateRecord): string 
   return candidate.suggested_source_id
     ? `${sourceKind}:${candidate.suggested_source_id}`
     : sourceKind;
+}
+
+function formatCandidateSourceRefs(candidate: ProjectMemoryCandidateRecord): string[] {
+  return (candidate.source_refs ?? [])
+    .map((ref) => {
+      const label = ref.title || (ref.id ? shortID(ref.id) : ref.url || "");
+      if (!label) return ref.kind;
+      return `${ref.kind} ${label}`;
+    })
+    .filter(Boolean);
 }
 
 function buildProjectAssignmentChatLaunchRequest({


### PR DESCRIPTION
## Summary
- show memory candidate source refs in the Project Memory / Context panel
- show candidate provenance in the promote-memory dialog before operator approval
- document that candidates are review artifacts and only promoted entries enter future project-memory context selection

## Tests
- cd ui && ./node_modules/.bin/oxfmt --write src/features/projects/ProjectsView.tsx src/features/projects/ProjectsView.test.tsx
- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run format:check
- git diff --check