### PR TITLE
Add Project Assistant review UI

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -282,13 +282,14 @@ between direct model turns and new task-backed segments in one transcript.
 Project assignments can also prepare External Agent sessions. Starting a
 `driver_kind="external_agent"` assignment from Projects creates and prepares the
 linked External Agent chat session, records assignment/profile/workspace context,
-and stores the session link on the assignment. It does not send the assignment
-prompt automatically; the operator stays in control of the first turn from the
-linked chat. Project activity rows project the linked chat's session status,
-latest message status, adapter identity, and missing-session diagnostics so the
-Projects cockpit can show follow-through state without embedding the full chat
-transcript. Handoffs created from these assignments can carry the source
-assignment, chat session, message, run, and context refs for provenance.
+and stores the session link on the assignment. It does not append a visible chat
+message, create a `message_id`, or send the assignment prompt automatically; the
+operator stays in control of the first turn from the linked chat. Project
+activity rows project the linked chat's session status, latest message status,
+adapter identity, and missing-session diagnostics so the Projects cockpit can
+show follow-through state without embedding the full chat transcript. Handoffs
+created from these assignments can carry the source assignment, chat session,
+message, run, and context refs for provenance.
 
 Hecate validates the workspace before creating a session, sanitizes the
 environment passed to the ACP agent process, applies timeout/cancel behavior,

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -9,6 +9,28 @@ It is not a broad chat persona in v0. Hecate Chat can call the same proposal and
 apply API later, but the action system lives in core so every surface follows
 the same validation, confirmation, and audit rules.
 
+## Current decisions
+
+Project Assistant v0 is a project-level proposal and review surface, not a
+replacement for simple chat. The Projects UI owns a compact composer above the
+workspace tabs; Chats remains the place for conversational turns. A future real
+assistant may offer a chat-like project surface, but durable changes should
+still land as typed proposals that the operator reviews and applies.
+
+The current composer is intentionally deterministic. `Auto` for `Run as`
+resolves to the selected work item's owner role, then the first loaded project
+role. `Auto` for `Via` resolves to the selected role's default driver, then
+`hecate_task`. No model is choosing a delegate yet. When Hecate grows a real
+project assistant loop, it can use richer project context to recommend or select
+roles and drivers, but that decision still needs to be inspectable before work
+is queued or launched.
+
+The UI supports both project-level planning and selected-work context. With a
+selected work item, the draft queues an assignment for that work. Without a
+selected work item, the draft creates a new project work item. In both cases
+`Draft proposal` creates reviewable data only; it does not create a chat, task,
+run, assignment, or agent session.
+
 ## Safety model
 
 - Project Assistant actions are typed and allowlisted.
@@ -197,9 +219,42 @@ Every action has the same envelope:
 
 The first visible UI should stay small and inspectable:
 
-- show proposal cards with exact actions before apply;
-- show `Apply`, `Dismiss`, and `Inspect`;
+- start from a compact request composer, not a wide operational form;
+- place the composer at the top of the project workspace because the assistant
+  is project-scoped, above workspace tabs and tab panels even when it uses the
+  selected work item as context;
+- keep route controls contextual, with an automatic choice for the common path;
+- show proposal cards with exact actions before apply, either inline or behind
+  an inspect affordance;
+- show `Apply` and `Dismiss`;
 - require explicit confirmation for durable/destructive proposals;
 - show stale-state failures as "State changed, refresh proposal";
 - keep Chat integration as a later caller of the same API, not a second action
   system.
+
+The Projects cockpit exposes this contract at the top of the project workspace.
+V0 uses a composer-style request box that drafts typed proposals from the
+selected project/work item. Later Hecate Chat can call the same proposal API,
+but durable mutations should still stop at the same explicit review/apply card.
+Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
+after the operator reviews the action rows. A successful apply refreshes the
+project list, project work, selected work-item detail, and project memory.
+`404 not_found` and `409 conflict` apply responses are treated as stale review
+state: refresh the current work view and draft a fresh proposal instead of
+retrying blindly.
+
+Drafting a proposal does not create a chat session, task, run, or assignment.
+Applying a proposal may create durable project records such as work items or
+queued assignments, but a queued assignment still does not start execution.
+Task/chat execution starts only through the assignment start flow, which may
+then attach `task_id`, `run_id`, or `chat_session_id` links to the assignment.
+For `external_agent` assignments, "start" means "prepare the linked chat":
+Hecate creates and prepares the External Agent session, stores the assignment
+context packet, and links `chat_session_id`, but it does not append a visible
+chat message or send the first prompt. The operator sends that first prompt
+from Chats after reviewing the prepared session.
+
+Project-launched Hecate chat drafts reuse an existing matching 0-message idle
+chat instead of creating another empty chat row. Once the operator sends a
+message, the transcript is no longer reusable and a later launch may create a
+new chat.

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
@@ -847,6 +848,89 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_external")
 	if profileItem == nil || profileItem.Section != contextSectionProfile || !strings.Contains(profileItem.Body, "External agent: codex") {
 		t.Fatalf("profile item = %+v, want external profile metadata", profileItem)
+	}
+}
+
+func TestProjectWorkAPI_StartExternalAgentAssignmentConcurrentRequestsCreateOneChat(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	runner := newConcurrentProjectExternalPrepareRunner()
+	handler.SetAgentChatRunner(runner)
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                "prof_external",
+		Name:              "External implementer",
+		Surface:           agentprofiles.SurfaceExternalAgent,
+		ExternalAgentKind: "claude_code",
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	statuses := make(chan int, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+			statuses <- rec.Code
+		}()
+	}
+	released := false
+	defer func() {
+		if !released {
+			close(runner.releasePrepare)
+		}
+	}()
+	for range 2 {
+		select {
+		case <-runner.prepareStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for concurrent external-agent prepares")
+		}
+	}
+	close(runner.releasePrepare)
+	released = true
+	wg.Wait()
+	close(statuses)
+
+	counts := map[int]int{}
+	for status := range statuses {
+		counts[status]++
+	}
+	if counts[http.StatusOK] != 1 || counts[http.StatusConflict] != 1 {
+		t.Fatalf("concurrent external start statuses = %+v, want one 200 and one 409", counts)
+	}
+	sessions, err := handler.agentChat.List(t.Context())
+	if err != nil {
+		t.Fatalf("List chats: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("chat session count = %d, want one surviving linked chat: %+v", len(sessions), sessions)
+	}
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_start", WorkItemID: "work_start"})
+	if err != nil {
+		t.Fatalf("ListAssignments: %v", err)
+	}
+	if len(assignments) != 1 || assignments[0].ChatSessionID != sessions[0].ID {
+		t.Fatalf("assignment/chat link = %+v / %+v, want one linked surviving chat", assignments, sessions)
+	}
+	if got := runner.prepareCount(); got != 2 {
+		t.Fatalf("prepare requests = %d, want both requests to reach prepare", got)
+	}
+	if got := runner.closedCount(); got != 1 {
+		t.Fatalf("closed sessions = %d, want losing prepared chat closed", got)
 	}
 }
 
@@ -2255,6 +2339,70 @@ func assertStoredProjectWorkAssignmentStatusForTest(t *testing.T, handler *Handl
 		}
 	}
 	t.Fatalf("stored assignment %s not found in %+v", assignmentID, assignments)
+}
+
+type concurrentProjectExternalPrepareRunner struct {
+	mu              sync.Mutex
+	prepareStarted  chan struct{}
+	releasePrepare  chan struct{}
+	prepareRequests []agentadapters.PrepareSessionRequest
+	closedSessions  []string
+}
+
+func newConcurrentProjectExternalPrepareRunner() *concurrentProjectExternalPrepareRunner {
+	return &concurrentProjectExternalPrepareRunner{
+		prepareStarted: make(chan struct{}, 2),
+		releasePrepare: make(chan struct{}),
+	}
+}
+
+func (r *concurrentProjectExternalPrepareRunner) PrepareSession(ctx context.Context, req agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error) {
+	r.mu.Lock()
+	r.prepareRequests = append(r.prepareRequests, req)
+	r.mu.Unlock()
+	r.prepareStarted <- struct{}{}
+	select {
+	case <-r.releasePrepare:
+	case <-ctx.Done():
+		return agentadapters.PrepareSessionResult{}, ctx.Err()
+	}
+	adapter, _ := agentadapters.BuiltInByID(req.AdapterID)
+	return agentadapters.PrepareSessionResult{
+		Adapter:         adapter,
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_" + req.SessionID,
+	}, nil
+}
+
+func (r *concurrentProjectExternalPrepareRunner) Run(_ context.Context, _ agentadapters.RunRequest) (agentadapters.RunResult, error) {
+	return agentadapters.RunResult{}, nil
+}
+
+func (r *concurrentProjectExternalPrepareRunner) SetSessionConfigOption(_ context.Context, _ agentadapters.SetSessionConfigOptionRequest) (agentadapters.SetSessionConfigOptionResult, error) {
+	return agentadapters.SetSessionConfigOptionResult{ConfigOptions: []agentcontrols.ConfigOption{}}, nil
+}
+
+func (r *concurrentProjectExternalPrepareRunner) CloseSession(_ context.Context, sessionID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closedSessions = append(r.closedSessions, sessionID)
+	return nil
+}
+
+func (r *concurrentProjectExternalPrepareRunner) Shutdown(context.Context) error {
+	return nil
+}
+
+func (r *concurrentProjectExternalPrepareRunner) prepareCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.prepareRequests)
+}
+
+func (r *concurrentProjectExternalPrepareRunner) closedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.closedSessions)
 }
 
 func findProjectActivityItemForTest(t *testing.T, items []ProjectActivityItemResponse, assignmentID string) ProjectActivityItemResponse {

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -630,6 +630,7 @@ describe("ConsoleShell navigation", () => {
         provider: "ollama",
         model: "qwen2.5-coder",
         title: "Build cockpit UI - Software developer",
+        reuseEmptyDraft: true,
       }),
     );
     const request = createChatSession.mock.calls[0]?.[0];

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -333,6 +333,7 @@ function AuthenticatedShell({
       model: request.model,
       title: request.title,
       draft: request.draft,
+      reuseEmptyDraft: Boolean(request.draft),
     });
     onSelectWorkspace("chats");
   }

--- a/ui/src/app/state/coordinators/chat.test.ts
+++ b/ui/src/app/state/coordinators/chat.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { findReusableEmptyDraftSession } from "./chat";
+
+import type { ChatSessionSummaryRecord } from "../../../types/chat";
+
+describe("findReusableEmptyDraftSession", () => {
+  it("matches empty idle Hecate project draft sessions", () => {
+    const sessions: ChatSessionSummaryRecord[] = [
+      {
+        id: "chat_used",
+        title: "Plan next work - Product Manager",
+        project_id: "proj_1",
+        agent_id: "hecate",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        workspace: "/tmp/hecate",
+        status: "idle",
+        message_count: 1,
+      },
+      {
+        id: "chat_empty",
+        title: "Plan next work - Product Manager",
+        project_id: "proj_1",
+        agent_id: "hecate",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        workspace: "/tmp/hecate",
+        status: "idle",
+        message_count: 0,
+      },
+    ];
+
+    expect(
+      findReusableEmptyDraftSession(sessions, {
+        agentID: "hecate",
+        projectID: "proj_1",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        title: "Plan next work - Product Manager",
+      })?.id,
+    ).toBe("chat_empty");
+  });
+
+  it("does not match active, messaged, or differently routed sessions", () => {
+    const sessions: ChatSessionSummaryRecord[] = [
+      {
+        id: "chat_running",
+        title: "Plan next work - Product Manager",
+        project_id: "proj_1",
+        agent_id: "hecate",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        workspace: "/tmp/hecate",
+        status: "running",
+        message_count: 0,
+      },
+      {
+        id: "chat_other_model",
+        title: "Plan next work - Product Manager",
+        project_id: "proj_1",
+        agent_id: "hecate",
+        provider: "ollama",
+        model: "qwen2.5-coder",
+        workspace: "/tmp/hecate",
+        status: "idle",
+        message_count: 0,
+      },
+      {
+        id: "chat_external",
+        title: "Plan next work - Product Manager",
+        project_id: "proj_1",
+        agent_id: "claude_code",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        workspace: "/tmp/hecate",
+        status: "idle",
+        message_count: 0,
+      },
+    ];
+
+    expect(
+      findReusableEmptyDraftSession(sessions, {
+        agentID: "hecate",
+        projectID: "proj_1",
+        provider: "ollama",
+        model: "ministral-3:latest",
+        title: "Plan next work - Product Manager",
+      }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -75,6 +75,7 @@ import type {
   ChatWorkspaceDiffRecord,
   ChatWorkspaceFilesRecord,
   ChatResponse,
+  ChatSessionSummaryRecord,
   ChatSessionRecord,
 } from "../../../types/chat";
 import type { SettingsActions } from "./settings";
@@ -179,6 +180,49 @@ function modelAvailableForProviderFilter(
 
 export { chatSessionIsExternal, chatSessionIsBusy };
 
+export function findReusableEmptyDraftSession(
+  sessions: ChatSessionSummaryRecord[],
+  {
+    agentID,
+    model,
+    projectID,
+    provider,
+    title,
+  }: {
+    agentID: string;
+    model: string;
+    projectID: string;
+    provider: string;
+    title: string;
+  },
+): ChatSessionSummaryRecord | null {
+  const expectedAgentID = agentID.trim() || "hecate";
+  const expectedProjectID = projectID.trim();
+  const expectedProvider = provider.trim();
+  const expectedModel = model.trim();
+  const expectedTitle = title.trim();
+  if (!expectedTitle) return null;
+  return (
+    sessions.find((session) => {
+      const sessionAgentID = (session.agent_id ?? "hecate").trim() || "hecate";
+      const sessionProjectID = (session.project_id ?? "").trim();
+      const sessionProvider = (session.provider ?? "").trim();
+      const sessionModel = (session.model ?? "").trim();
+      const sessionTitle = (session.title ?? "").trim();
+      const sessionStatus = (session.status ?? "").trim();
+      return (
+        sessionAgentID === expectedAgentID &&
+        sessionProjectID === expectedProjectID &&
+        sessionProvider === expectedProvider &&
+        sessionModel === expectedModel &&
+        sessionTitle === expectedTitle &&
+        (session.message_count ?? 0) === 0 &&
+        (!sessionStatus || sessionStatus === "idle")
+      );
+    }) ?? null
+  );
+}
+
 export type CreateChatSessionOptions = {
   agentID?: string;
   projectID?: string;
@@ -186,6 +230,7 @@ export type CreateChatSessionOptions = {
   model?: string;
   title?: string;
   draft?: string;
+  reuseEmptyDraft?: boolean;
 };
 
 type ChatActionsReturn = {
@@ -814,6 +859,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const requestedAgentID = options?.agentID?.trim();
     const requestedTitle = options?.title?.trim() || "";
     const requestedDraft = options?.draft ?? "";
+    const requestedReuseEmptyDraft = Boolean(options?.reuseEmptyDraft && requestedDraft.trim());
     const createProjectID =
       options && "projectID" in options ? options.projectID?.trim() || "" : activeProjectID;
     const requestedProviderFilter = (
@@ -893,6 +939,31 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       setActiveChatSession(null);
       return;
     }
+    const createProvider = requestedProviderFilter === "auto" ? "" : requestedProviderFilter;
+    if (requestedReuseEmptyDraft) {
+      const reusable = findReusableEmptyDraftSession(chat.state.chatSessions, {
+        agentID: "hecate",
+        projectID: createProjectID,
+        provider: createProvider,
+        model: requestedModel,
+        title: requestedTitle,
+      });
+      if (reusable) {
+        setChatTargetBySessionID((current) => {
+          const next = new Map(current);
+          next.set(reusable.id, "agent");
+          return next;
+        });
+        setChatToolsEnabledBySessionID((current) => {
+          const next = new Map(current);
+          next.set(reusable.id, toolsEnabled);
+          return next;
+        });
+        await selectChatSession(reusable.id);
+        setMessage(requestedDraft);
+        return;
+      }
+    }
     setChatLoading(true);
     clearChatErrorState();
     try {
@@ -900,7 +971,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ...(requestedTitle ? { title: requestedTitle } : {}),
         ...(createProjectID ? { project_id: createProjectID } : {}),
         agent_id: "hecate",
-        provider: requestedProviderFilter === "auto" ? "" : requestedProviderFilter,
+        provider: createProvider,
         model: requestedModel,
         ...(toolsEnabled && workspace ? { workspace } : {}),
         ...(toolsEnabled ? { rtk_enabled: hecateRTKEnabled } : {}),

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -1,0 +1,594 @@
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+
+import type {
+  ProjectAssistantApplyResult,
+  ProjectAssistantProposal,
+  ProjectRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { CopyableID, Icon, Icons, InlineError } from "../shared/ui";
+
+export const PROJECT_ASSISTANT_AUTO = "__auto__";
+
+export type ProjectAssistantDraftForm = {
+  request: string;
+  roleID: string;
+  driverKind: string;
+};
+
+export type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
+
+type Props = {
+  applyResult: ProjectAssistantApplyResult | null;
+  error: string;
+  onApply: () => void;
+  onDismiss: () => void;
+  onPropose: (form: ProjectAssistantDraftForm) => void;
+  project: ProjectRecord | null;
+  proposal: ProjectAssistantProposal | null;
+  roles: ProjectWorkRoleRecord[];
+  status: ProjectAssistantStatus;
+  workItem: ProjectWorkItemRecord | null;
+};
+
+export function ProjectAssistantPanel({
+  applyResult,
+  error,
+  onApply,
+  onDismiss,
+  onPropose,
+  project,
+  proposal,
+  roles,
+  status,
+  workItem,
+}: Props) {
+  const [form, setForm] = useState<ProjectAssistantDraftForm>(() =>
+    projectAssistantDraftForm(project, workItem, roles),
+  );
+
+  useEffect(() => {
+    setForm(projectAssistantDraftForm(project, workItem, roles));
+  }, [project, roles, workItem]);
+
+  if (!project) return null;
+
+  const selectedRole =
+    form.roleID === PROJECT_ASSISTANT_AUTO
+      ? projectAssistantAutoRole(workItem, roles)
+      : (roles.find((role) => role.id === form.roleID) ?? null);
+  const valid = form.request.trim().length > 0 && (workItem ? Boolean(selectedRole) : true);
+  const busy = status === "proposing" || status === "applying";
+  const panelDetail = workItem ? `Selected work: ${workItem.title}` : "Project queue";
+
+  return (
+    <section style={assistantPanelStyle} aria-label="Project Assistant">
+      <MiniSectionHeader
+        title="Project Assistant"
+        detail={panelDetail}
+        action={
+          proposal || applyResult ? (
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onDismiss}>
+              <Icon d={Icons.x} size={12} />
+              Dismiss
+            </button>
+          ) : null
+        }
+      />
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!valid || busy) return;
+          onPropose(form);
+        }}
+        style={assistantComposerStyle}
+      >
+        <label style={requestFieldStyle}>
+          <span style={fieldLabelStyle}>Request</span>
+          <textarea
+            className="input"
+            rows={workItem ? 2 : 3}
+            value={form.request}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, request: event.target.value }))
+            }
+            style={assistantRequestInputStyle}
+          />
+        </label>
+        <div style={assistantRouteBarStyle}>
+          <div style={assistantRouteFieldsStyle}>
+            <label style={routeFieldStyle}>
+              <span style={fieldLabelStyle}>Run as</span>
+              <select
+                className="input"
+                value={form.roleID}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    roleID: event.target.value,
+                  }))
+                }
+                disabled={roles.length === 0}
+              >
+                {roles.length === 0 ? (
+                  <option value="">No roles</option>
+                ) : (
+                  <>
+                    <option value={PROJECT_ASSISTANT_AUTO}>Auto</option>
+                    {roles.map((role) => (
+                      <option key={role.id} value={role.id}>
+                        {role.name || role.id}
+                      </option>
+                    ))}
+                  </>
+                )}
+              </select>
+            </label>
+            <label style={routeFieldStyle}>
+              <span style={fieldLabelStyle}>Via</span>
+              <select
+                className="input"
+                value={form.driverKind}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, driverKind: event.target.value }))
+                }
+              >
+                <option value={PROJECT_ASSISTANT_AUTO}>Auto</option>
+                <option value="hecate_task">Hecate task</option>
+                <option value="external_agent">External agent</option>
+              </select>
+            </label>
+          </div>
+          <button
+            className="btn btn-primary btn-sm"
+            type="submit"
+            disabled={!valid || busy}
+            style={assistantSubmitStyle}
+          >
+            <Icon d={Icons.send} size={13} />
+            {status === "proposing" ? "Drafting..." : "Draft proposal"}
+          </button>
+        </div>
+      </form>
+      {error && (
+        <div style={{ marginTop: 10 }}>
+          <InlineError message={error} />
+        </div>
+      )}
+      {proposal && (
+        <div style={assistantProposalStyle}>
+          <div style={assistantProposalHeaderStyle}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={titleStyle}>{proposal.title}</div>
+              {proposal.summary && (
+                <div style={assistantProposalSummaryStyle}>{proposal.summary}</div>
+              )}
+            </div>
+            <span className="badge badge-amber">
+              {proposal.requires_confirmation ? "confirmation required" : "ready"}
+            </span>
+            <span className="badge badge-muted">
+              {proposal.actions.length} action{proposal.actions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          {proposal.trace_id && (
+            <div style={metaLineStyle}>
+              <span>Trace</span>
+              <CopyableID text={proposal.trace_id} compact />
+            </div>
+          )}
+          {proposal.warnings && proposal.warnings.length > 0 && (
+            <div style={assistantWarningsStyle}>
+              {proposal.warnings.map((warning) => (
+                <div key={warning}>{warning}</div>
+              ))}
+            </div>
+          )}
+          <div style={assistantActionListStyle}>
+            {proposal.actions.map((action, index) => (
+              <ProjectAssistantActionRow key={`${action.kind}-${index}`} action={action} />
+            ))}
+          </div>
+          <div style={assistantProposalActionsStyle}>
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onDismiss}>
+              <Icon d={Icons.x} size={12} />
+              Dismiss proposal
+            </button>
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              disabled={status === "applying"}
+              onClick={onApply}
+            >
+              <Icon d={Icons.check} size={12} />
+              {status === "applying" ? "Applying..." : "Apply proposal"}
+            </button>
+          </div>
+        </div>
+      )}
+      {applyResult && (
+        <div style={assistantResultStyle} role="status">
+          <span className="badge badge-green">applied</span>
+          <span>
+            Applied {applyResult.actions.length} action
+            {applyResult.actions.length === 1 ? "" : "s"} from {applyResult.proposal_id}.
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MiniSectionHeader({
+  action,
+  detail,
+  title,
+}: {
+  action: ReactNode;
+  detail: string;
+  title: string;
+}) {
+  return (
+    <div style={domainHeaderStyle}>
+      <div style={{ minWidth: 0 }}>
+        <div style={sectionLabelStyle}>{title}</div>
+        <div style={{ ...subtleTextStyle, marginTop: 3 }}>{detail}</div>
+      </div>
+      {action && <div style={domainHeaderActionsStyle}>{action}</div>}
+    </div>
+  );
+}
+
+function ProjectAssistantActionRow({
+  action,
+}: {
+  action: ProjectAssistantProposal["actions"][number];
+}) {
+  const targetEntries = Object.entries(action.target ?? {});
+  const patchEntries = Object.entries(action.patch ?? {});
+  return (
+    <div style={assistantActionStyle}>
+      <div style={assistantActionHeaderStyle}>
+        <span className="badge badge-muted">{projectAssistantActionLabel(action.kind)}</span>
+        {action.reason && <span style={subtleTextStyle}>{action.reason}</span>}
+      </div>
+      <div style={assistantPatchGridStyle}>
+        {targetEntries.length > 0 && (
+          <ProjectAssistantFieldGroup title="Target" entries={targetEntries} />
+        )}
+        {patchEntries.length > 0 && (
+          <ProjectAssistantFieldGroup title="Patch" entries={patchEntries} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectAssistantFieldGroup({
+  entries,
+  title,
+}: {
+  entries: Array<[string, unknown]>;
+  title: string;
+}) {
+  return (
+    <div style={assistantFieldGroupStyle}>
+      <div style={sectionLabelStyle}>{title}</div>
+      <dl style={assistantFieldsStyle}>
+        {entries.map(([key, value]) => (
+          <div key={key} style={assistantFieldRowStyle}>
+            <dt style={assistantFieldTermStyle}>{key}</dt>
+            <dd style={assistantFieldValueStyle}>{formatAssistantValue(value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function projectAssistantDraftForm(
+  project: ProjectRecord | null,
+  workItem: ProjectWorkItemRecord | null,
+  roles: ProjectWorkRoleRecord[],
+): ProjectAssistantDraftForm {
+  const role = roles.find((item) => item.id === workItem?.owner_role_id) ?? roles[0] ?? null;
+  const request = workItem
+    ? `Queue ${role?.name || role?.id || "role"} for ${workItem.title}`
+    : `Plan next work for ${project?.name ?? "project"}\nCapture the next reviewable project task.`;
+  return {
+    request,
+    roleID: roles.length > 0 ? PROJECT_ASSISTANT_AUTO : "",
+    driverKind: PROJECT_ASSISTANT_AUTO,
+  };
+}
+
+function projectAssistantAutoRole(
+  workItem: ProjectWorkItemRecord | null,
+  roles: ProjectWorkRoleRecord[],
+): ProjectWorkRoleRecord | null {
+  return roles.find((item) => item.id === workItem?.owner_role_id) ?? roles[0] ?? null;
+}
+
+function projectAssistantActionLabel(kind: string): string {
+  switch (kind) {
+    case "create_project":
+      return "Create project";
+    case "update_project":
+      return "Update project";
+    case "attach_project_root":
+      return "Attach root";
+    case "remove_project_root":
+      return "Remove root";
+    case "set_project_defaults":
+      return "Set defaults";
+    case "move_chat_session":
+      return "Move chat";
+    case "create_work_item":
+      return "Create work item";
+    case "update_work_item":
+      return "Update work item";
+    case "create_assignment":
+      return "Create assignment";
+    case "create_handoff":
+      return "Create handoff";
+    case "create_memory_candidate":
+      return "Create memory candidate";
+    default:
+      return kind.replace(/_/g, " ");
+  }
+}
+
+function formatAssistantValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map(formatAssistantValue).join(", ");
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+const assistantPanelStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  boxSizing: "border-box",
+  display: "grid",
+  gap: 10,
+  maxWidth: "100%",
+  minWidth: 0,
+  padding: 12,
+};
+
+const assistantComposerStyle: CSSProperties = {
+  display: "grid",
+  gap: 10,
+  minWidth: 0,
+};
+
+const requestFieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+const assistantRequestInputStyle: CSSProperties = {
+  lineHeight: 1.45,
+  minHeight: 78,
+  resize: "vertical",
+};
+
+const assistantRouteBarStyle: CSSProperties = {
+  alignItems: "end",
+  borderTop: "1px solid var(--border)",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "space-between",
+  minWidth: 0,
+  paddingTop: 10,
+};
+
+const assistantRouteFieldsStyle: CSSProperties = {
+  display: "flex",
+  flex: "1 1 320px",
+  flexWrap: "wrap",
+  gap: 8,
+  minWidth: 0,
+};
+
+const routeFieldStyle: CSSProperties = {
+  display: "grid",
+  flex: "1 1 150px",
+  gap: 5,
+  maxWidth: 260,
+  minWidth: 140,
+};
+
+const assistantSubmitStyle: CSSProperties = {
+  flex: "0 0 auto",
+  justifyContent: "center",
+  minWidth: 150,
+};
+
+const assistantProposalStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 10,
+  padding: 10,
+};
+
+const assistantProposalHeaderStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  minWidth: 0,
+};
+
+const assistantProposalSummaryStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 12,
+  lineHeight: 1.45,
+  marginTop: 4,
+  overflowWrap: "anywhere",
+};
+
+const assistantWarningsStyle: CSSProperties = {
+  background: "var(--amber-bg)",
+  border: "1px solid var(--amber-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--amber)",
+  display: "grid",
+  fontSize: 12,
+  gap: 4,
+  padding: "8px 9px",
+};
+
+const assistantActionListStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+};
+
+const assistantActionStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 8,
+  minWidth: 0,
+  padding: 10,
+};
+
+const assistantActionHeaderStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  minWidth: 0,
+};
+
+const assistantPatchGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 240px), 1fr))",
+  minWidth: 0,
+};
+
+const assistantFieldGroupStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+  minWidth: 0,
+};
+
+const assistantFieldsStyle: CSSProperties = {
+  display: "grid",
+  gap: 4,
+  margin: 0,
+  minWidth: 0,
+};
+
+const assistantFieldRowStyle: CSSProperties = {
+  color: "var(--t2)",
+  display: "grid",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  gap: 6,
+  gridTemplateColumns: "minmax(90px, 0.45fr) minmax(0, 1fr)",
+  minWidth: 0,
+};
+
+const assistantFieldTermStyle: CSSProperties = {
+  color: "var(--t3)",
+  margin: 0,
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const assistantFieldValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  margin: 0,
+  minWidth: 0,
+  overflowWrap: "anywhere",
+};
+
+const assistantProposalActionsStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "flex-end",
+};
+
+const assistantResultStyle: CSSProperties = {
+  alignItems: "center",
+  background: "var(--green-bg)",
+  border: "1px solid var(--green-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--green)",
+  display: "flex",
+  flexWrap: "wrap",
+  fontSize: 12,
+  gap: 8,
+  padding: "8px 9px",
+};
+
+const domainHeaderStyle: CSSProperties = {
+  alignItems: "flex-start",
+  display: "flex",
+  gap: 10,
+  justifyContent: "space-between",
+  minWidth: 0,
+};
+
+const domainHeaderActionsStyle: CSSProperties = {
+  display: "flex",
+  flexShrink: 0,
+  gap: 8,
+};
+
+const sectionLabelStyle: CSSProperties = {
+  color: "var(--teal)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  letterSpacing: 0,
+  textTransform: "uppercase",
+};
+
+const titleStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: 13,
+  fontWeight: 600,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const subtleTextStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.4,
+};
+
+const metaLineStyle: CSSProperties = {
+  color: "var(--t3)",
+  display: "flex",
+  flexWrap: "wrap",
+  fontSize: 11,
+  gap: 8,
+  marginTop: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -7,6 +7,8 @@ import { ProvidersAndModelsProvider } from "../../app/state/providersAndModels";
 import { ProjectsProvider } from "../../app/state/projects";
 import { SettingsProvider } from "../../app/state/settings";
 import {
+  ApiError,
+  applyProjectAssistant,
   createProjectAssignment,
   createProjectHandoff,
   createProjectMemory,
@@ -29,6 +31,7 @@ import {
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
+  proposeProjectAssistant,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
   startProjectAssignment,
@@ -118,6 +121,47 @@ vi.mock("../../lib/api", async (importOriginal) => {
       data: [],
     })),
     getAgentProfiles: vi.fn(async () => ({ object: "agent_profiles", data: [] })),
+    proposeProjectAssistant: vi.fn(async () => ({
+      object: "project_assistant.proposal",
+      data: {
+        id: "pa_test",
+        title: "Queue Software developer for Build cockpit UI",
+        summary: "Create a queued hecate_task assignment on the selected work item.",
+        requires_confirmation: true,
+        actions: [
+          {
+            kind: "create_assignment",
+            target: { project_id: "proj_1" },
+            patch: {
+              project_id: "proj_1",
+              work_item_id: "work_1",
+              role_id: "software_developer",
+              driver_kind: "hecate_task",
+              status: "queued",
+            },
+            reason: "Queue a reviewable assignment without starting execution.",
+          },
+        ],
+        trace_id: "trace_project_assistant",
+      },
+    })),
+    applyProjectAssistant: vi.fn(async () => ({
+      object: "project_assistant.apply_result",
+      data: {
+        proposal_id: "pa_test",
+        applied: true,
+        actions: [
+          {
+            kind: "create_assignment",
+            id: "asgn_assistant",
+            data: {
+              project_id: "proj_1",
+              assignment_id: "asgn_assistant",
+            },
+          },
+        ],
+      },
+    })),
     createProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
     updateProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
     updateProjectHandoffStatus: vi.fn(async () => ({ object: "project_handoff", data: null })),
@@ -422,6 +466,47 @@ function resetProjectWorkMocks() {
       },
     ],
   });
+  vi.mocked(proposeProjectAssistant).mockResolvedValue({
+    object: "project_assistant.proposal",
+    data: {
+      id: "pa_test",
+      title: "Queue Software developer for Build cockpit UI",
+      summary: "Create a queued hecate_task assignment on the selected work item.",
+      requires_confirmation: true,
+      actions: [
+        {
+          kind: "create_assignment",
+          target: { project_id: project.id },
+          patch: {
+            project_id: project.id,
+            work_item_id: workItem.id,
+            role_id: role.id,
+            driver_kind: "hecate_task",
+            status: "queued",
+          },
+          reason: "Queue a reviewable assignment without starting execution.",
+        },
+      ],
+      trace_id: "trace_project_assistant",
+    },
+  });
+  vi.mocked(applyProjectAssistant).mockResolvedValue({
+    object: "project_assistant.apply_result",
+    data: {
+      proposal_id: "pa_test",
+      applied: true,
+      actions: [
+        {
+          kind: "create_assignment",
+          id: "asgn_assistant",
+          data: {
+            project_id: project.id,
+            assignment_id: "asgn_assistant",
+          },
+        },
+      ],
+    },
+  });
   vi.mocked(createProjectHandoff).mockResolvedValue({
     object: "project_handoff",
     data: {
@@ -589,6 +674,8 @@ afterEach(() => {
   vi.mocked(getProjectMemory).mockReset();
   vi.mocked(getProjectMemoryCandidates).mockReset();
   vi.mocked(getAgentProfiles).mockReset();
+  vi.mocked(proposeProjectAssistant).mockReset();
+  vi.mocked(applyProjectAssistant).mockReset();
   vi.mocked(createProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoffStatus).mockReset();
@@ -716,7 +803,9 @@ describe("ProjectsView index", () => {
 
     expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
     const workspace = screen.getByRole("region", { name: "Project workspace" });
+    const assistant = within(workspace).getByRole("region", { name: "Project Assistant" });
     const tabs = within(workspace).getByRole("tablist", { name: "Project workspace views" });
+    expect(assistant.compareDocumentPosition(tabs) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByRole("region", { name: "Work queue" })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Project attention/ })).toBeTruthy();
     expect(screen.queryByRole("region", { name: "Needs attention" })).toBeNull();
@@ -817,6 +906,147 @@ describe("ProjectsView cockpit", () => {
     });
     expect(actions.selectProject).toHaveBeenCalledWith(project.id);
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
+  });
+
+  it("reviews and applies Project Assistant assignment proposals", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+
+    await waitFor(() => {
+      expect(proposeProjectAssistant).toHaveBeenCalledWith({
+        title: "Queue Software developer for Build cockpit UI",
+        summary: "Create a queued hecate_task assignment on the selected work item.",
+        actions: [
+          {
+            kind: "create_assignment",
+            target: { project_id: project.id },
+            patch: {
+              project_id: project.id,
+              work_item_id: workItem.id,
+              role_id: role.id,
+              driver_kind: "hecate_task",
+              status: "queued",
+            },
+            reason: "Queue a reviewable assignment without starting execution.",
+          },
+        ],
+      });
+    });
+    expect(await within(assistant).findByText("Create assignment")).toBeTruthy();
+    expect(within(assistant).getByText("work_item_id")).toBeTruthy();
+    expect(within(assistant).getByText(workItem.id)).toBeTruthy();
+    expect(
+      within(assistant).getByRole("button", { name: "Copy trace_project_assistant" }),
+    ).toBeTruthy();
+
+    await user.click(within(assistant).getByRole("button", { name: "Apply proposal" }));
+
+    await waitFor(() => {
+      expect(applyProjectAssistant).toHaveBeenCalledWith({
+        proposal: expect.objectContaining({ id: "pa_test" }),
+        confirm: true,
+      });
+    });
+    expect(await within(assistant).findByText("Applied 1 action from pa_test.")).toBeTruthy();
+    expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
+    expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
+  });
+
+  it("drafts Project Assistant work proposals without an owner role when none exists", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_work_roles", data: [] });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await screen.findByText("No work items for this project.");
+    expect(within(assistant).getByText("Project queue")).toBeTruthy();
+    fireEvent.change(within(assistant).getByLabelText("Request"), {
+      target: { value: "Write project brief\nCapture the next operator task." },
+    });
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+
+    await waitFor(() => {
+      expect(proposeProjectAssistant).toHaveBeenCalledWith({
+        title: "Write project brief",
+        summary: "Create a ready work item from the current assistant draft.",
+        actions: [
+          {
+            kind: "create_work_item",
+            target: { project_id: project.id },
+            patch: {
+              project_id: project.id,
+              title: "Write project brief",
+              brief: "Capture the next operator task.",
+              status: "ready",
+              priority: "normal",
+            },
+            reason: "Create a reviewable project work item.",
+          },
+        ],
+      });
+    });
+  });
+
+  it("dismisses Project Assistant proposals without applying", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+    expect(await within(assistant).findByText("Create assignment")).toBeTruthy();
+
+    await user.click(within(assistant).getByRole("button", { name: "Dismiss proposal" }));
+
+    expect(within(assistant).queryByText("Create assignment")).toBeNull();
+    expect(applyProjectAssistant).not.toHaveBeenCalled();
+  });
+
+  it("surfaces stale Project Assistant proposal conflicts and refreshes work", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(applyProjectAssistant).mockRejectedValueOnce(
+      new ApiError("project assistant conflict", 409, "conflict"),
+    );
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+    await within(assistant).findByText("Create assignment");
+    await user.click(within(assistant).getByRole("button", { name: "Apply proposal" }));
+
+    expect(await within(assistant).findByText(/proposal is stale, conflicts/)).toBeTruthy();
+    expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
+    expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
   });
 
   it("manages project memory entries in the cockpit", async () => {
@@ -1310,7 +1540,7 @@ describe("ProjectsView cockpit", () => {
     expect(screen.getByRole("article", { name: "Build cockpit UI work item" })).toBeTruthy();
   });
 
-  it("starts queued external-agent assignments from the selected work item", async () => {
+  it("prepares queued external-agent assignment chats from the selected work item", async () => {
     resetProjectWorkMocks();
     const externalAssignment: ProjectAssignmentRecord = {
       ...hecateAssignment,
@@ -1328,15 +1558,14 @@ describe("ProjectsView cockpit", () => {
       object: "project_assignments",
       data: [externalAssignment],
     });
-    vi.mocked(startProjectAssignment).mockResolvedValue({
-      object: "project_assignment",
-      data: {
-        ...externalAssignment,
-        status: "running",
-        chat_session_id: "chat_external_1",
-        context_snapshot_id: "ctx_external_1",
-      },
-    });
+    let resolveStartAssignment: (
+      value: Awaited<ReturnType<typeof startProjectAssignment>>,
+    ) => void = () => {};
+    vi.mocked(startProjectAssignment).mockReturnValue(
+      new Promise((resolve) => {
+        resolveStartAssignment = resolve;
+      }),
+    );
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -1348,7 +1577,8 @@ describe("ProjectsView cockpit", () => {
       await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
     );
     const detail = await screen.findByRole("region", { name: "Selected work item" });
-    await userEvent.click(within(detail).getByRole("button", { name: "Start" }));
+    const prepareButton = within(detail).getByRole("button", { name: "Prepare chat" });
+    await userEvent.dblClick(prepareButton);
 
     expect(startProjectAssignment).toHaveBeenCalledWith(
       project.id,
@@ -1356,6 +1586,19 @@ describe("ProjectsView cockpit", () => {
       externalAssignment.id,
       "external_agent",
     );
+    expect(startProjectAssignment).toHaveBeenCalledTimes(1);
+    resolveStartAssignment({
+      object: "project_assignment",
+      data: {
+        ...externalAssignment,
+        status: "running",
+        chat_session_id: "chat_external_1",
+        context_snapshot_id: "ctx_external_1",
+      },
+    });
+    await waitFor(() => {
+      expect(prepareButton).not.toBeDisabled();
+    });
   });
 
   it("opens linked external-agent assignment chat sessions directly", async () => {
@@ -3275,7 +3518,7 @@ describe("ProjectsView cockpit", () => {
     expect(screen.queryByText(/^Started\s*$/)).toBeNull();
   });
 
-  it("exposes start for queued external-agent assignments", async () => {
+  it("exposes chat preparation for queued external-agent assignments", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);
     vi.mocked(getProjectAssignments).mockResolvedValue({
@@ -3300,7 +3543,7 @@ describe("ProjectsView cockpit", () => {
       await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
     );
     const detail = await screen.findByRole("region", { name: "Selected work item" });
-    expect(within(detail).getByRole("button", { name: "Start" })).toBeTruthy();
-    expect(screen.queryByText("Start in Chats")).toBeNull();
+    expect(within(detail).getByRole("button", { name: "Prepare chat" })).toBeTruthy();
+    expect(screen.queryByText("Chat not prepared")).toBeNull();
   });
 });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
   type ReactNode,
@@ -12,6 +13,7 @@ import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
+  applyProjectAssistant,
   createProjectAssignment,
   createProjectHandoff,
   discoverProjectContextSources,
@@ -34,6 +36,7 @@ import {
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
+  proposeProjectAssistant,
   startProjectAssignment,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
@@ -62,10 +65,19 @@ import {
   type ProjectHealthAttention,
   type ProjectTimelineItem,
 } from "./projectInsights";
+import {
+  PROJECT_ASSISTANT_AUTO,
+  ProjectAssistantPanel,
+  type ProjectAssistantDraftForm,
+  type ProjectAssistantStatus,
+} from "./ProjectAssistantPanel";
 import type {
   ProjectAssignmentRecord,
   ProjectActivityData,
   ProjectActivityItemRecord,
+  ProjectAssistantApplyResult,
+  ProjectAssistantProposal,
+  ProjectAssistantProposePayload,
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
@@ -337,6 +349,12 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [detailError, setDetailError] = useState("");
   const [assignmentErrors, setAssignmentErrors] = useState<Record<string, string>>({});
   const [startingAssignmentID, setStartingAssignmentID] = useState("");
+  const startingAssignmentIDsRef = useRef<Set<string>>(new Set());
+  const [assistantProposal, setAssistantProposal] = useState<ProjectAssistantProposal | null>(null);
+  const [assistantApplyResult, setAssistantApplyResult] =
+    useState<ProjectAssistantApplyResult | null>(null);
+  const [assistantStatus, setAssistantStatus] = useState<ProjectAssistantStatus>("idle");
+  const [assistantError, setAssistantError] = useState("");
 
   function updateRightPanelWidth(width: number) {
     setRightPanelWidth(width);
@@ -589,6 +607,13 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!selectedProjectID || !selectedWorkItemID) return;
     void loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
   }, [loadWorkItemDetail, selectedProjectID, selectedWorkItemID]);
+
+  useEffect(() => {
+    setAssistantProposal(null);
+    setAssistantApplyResult(null);
+    setAssistantError("");
+    setAssistantStatus("idle");
+  }, [selectedProjectID, selectedWorkItemID]);
 
   function openProject(projectID: string) {
     if (projectID !== selectedProjectID) {
@@ -1079,11 +1104,71 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
+  async function handleProjectAssistantPropose(form: ProjectAssistantDraftForm) {
+    if (!selectedProject) return;
+    setAssistantStatus("proposing");
+    setAssistantError("");
+    setAssistantApplyResult(null);
+    try {
+      const payload = buildProjectAssistantProposalPayload({
+        form,
+        project: selectedProject,
+        role: projectAssistantResolvedRole(form, roles, selectedWorkItem),
+        workItem: selectedWorkItem,
+      });
+      const proposal = await proposeProjectAssistant(payload);
+      setAssistantProposal(proposal.data);
+      setAssistantStatus("idle");
+    } catch (error) {
+      setAssistantStatus("idle");
+      setAssistantError(errorMessage(error, "Failed to draft Project Assistant proposal."));
+    }
+  }
+
+  async function handleProjectAssistantApply() {
+    if (!selectedProjectID || !assistantProposal) return;
+    const proposal = assistantProposal;
+    setAssistantStatus("applying");
+    setAssistantError("");
+    try {
+      const payload = await applyProjectAssistant({ proposal, confirm: true });
+      setAssistantApplyResult(payload.data);
+      setAssistantProposal(null);
+      setAssistantStatus("applied");
+      await projects.actions.loadProjects();
+      const preferredWorkItemID =
+        projectAssistantResultWorkItemID(payload.data) || selectedWorkItemID;
+      const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, preferredWorkItemID);
+      if (refreshedWorkItemID) {
+        await loadWorkItemDetail(selectedProjectID, refreshedWorkItemID);
+      }
+      await loadProjectMemory(selectedProjectID);
+    } catch (error) {
+      setAssistantStatus("idle");
+      setAssistantError(projectAssistantApplyErrorMessage(error));
+      if (error instanceof ApiError && (error.status === 404 || error.status === 409)) {
+        const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+        if (refreshedWorkItemID) {
+          await loadWorkItemDetail(selectedProjectID, refreshedWorkItemID);
+        }
+      }
+    }
+  }
+
+  function dismissProjectAssistantProposal() {
+    setAssistantProposal(null);
+    setAssistantApplyResult(null);
+    setAssistantError("");
+    setAssistantStatus("idle");
+  }
+
   async function handleStartAssignment(
     assignment: ProjectAssignmentRecord,
     workItemID = selectedWorkItemID,
   ) {
     if (!selectedProjectID || !workItemID) return;
+    if (startingAssignmentIDsRef.current.has(assignment.id)) return;
+    startingAssignmentIDsRef.current.add(assignment.id);
     setStartingAssignmentID(assignment.id);
     setAssignmentErrors((current) => ({ ...current, [assignment.id]: "" }));
     try {
@@ -1106,6 +1191,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
         await loadWorkItemDetail(selectedProjectID, workItemID);
       }
     } finally {
+      startingAssignmentIDsRef.current.delete(assignment.id);
       setStartingAssignmentID("");
     }
   }
@@ -1203,6 +1289,18 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           <section style={detailStyle} aria-label="Selected work item">
             <div className="project-cockpit-workspace" style={cockpitWorkspaceStyle}>
               <section style={domainSectionStyle} aria-label="Project workspace">
+                <ProjectAssistantPanel
+                  applyResult={assistantApplyResult}
+                  error={assistantError}
+                  onApply={() => void handleProjectAssistantApply()}
+                  onDismiss={dismissProjectAssistantProposal}
+                  onPropose={(form) => void handleProjectAssistantPropose(form)}
+                  project={selectedProject}
+                  proposal={assistantProposal}
+                  roles={roles}
+                  status={assistantStatus}
+                  workItem={selectedWorkItem}
+                />
                 <ProjectWorkspaceTabs
                   activeTab={workspaceTab}
                   memoryCandidateCount={memoryCandidates.length}
@@ -4459,6 +4557,8 @@ function AssignmentRow({
     (assignment.driver_kind === "hecate_task" || assignment.driver_kind === "external_agent") &&
     projectedStatus === "queued";
   const external = assignment.driver_kind === "external_agent";
+  const startActionLabel = external ? "Prepare chat" : "Start";
+  const startingLabel = external ? "Preparing…" : "Starting…";
   const startedAt = execution?.started_at || assignment.started_at;
   const finishedAt = execution?.finished_at || assignment.completed_at;
   return (
@@ -4494,17 +4594,22 @@ function AssignmentRow({
             type="button"
             onClick={onStart}
             disabled={starting}
+            title={
+              external
+                ? "Prepare a linked External Agent chat. The first prompt is sent from Chats."
+                : "Start this assignment."
+            }
           >
-            <Icon d={Icons.send} size={12} />
-            {starting ? "Starting…" : "Start"}
+            <Icon d={external ? Icons.chat : Icons.send} size={12} />
+            {starting ? startingLabel : startActionLabel}
           </button>
         )}
         {external && !startable && !assignment.chat_session_id && (
           <span
             style={subtleTextStyle}
-            title="Start this assignment to prepare a supervised External Agent chat session."
+            title="Prepare this assignment to create a supervised External Agent chat session."
           >
-            Start in Chats
+            Chat not prepared
           </span>
         )}
       </div>
@@ -4537,7 +4642,9 @@ function AssignmentRow({
           disabled={!onOpenChat || (!chatSessionID && !chatModel)}
           title={
             chatSessionID
-              ? "Open linked External Agent chat"
+              ? external
+                ? "Open the prepared External Agent chat. The first prompt is sent from Chats."
+                : "Open linked External Agent chat"
               : chatModel
                 ? `Open chat with ${chatModel}`
                 : "Set project defaults before opening chat."
@@ -4768,6 +4875,113 @@ function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemS
     },
     { assignmentCount: 0, activeCount: 0, failedCount: 0, completedCount: 0 },
   );
+}
+
+function buildProjectAssistantProposalPayload({
+  form,
+  project,
+  role,
+  workItem,
+}: {
+  form: ProjectAssistantDraftForm;
+  project: ProjectRecord;
+  role: ProjectWorkRoleRecord | null;
+  workItem: ProjectWorkItemRecord | null;
+}): ProjectAssistantProposePayload {
+  const roleID =
+    form.roleID === PROJECT_ASSISTANT_AUTO
+      ? role?.id || ""
+      : (form.roleID || role?.id || "").trim();
+  const driverKind =
+    form.driverKind === PROJECT_ASSISTANT_AUTO
+      ? role?.default_driver_kind || "hecate_task"
+      : (form.driverKind || role?.default_driver_kind || "hecate_task").trim();
+  const request = projectAssistantRequestParts(form.request);
+  if (workItem) {
+    return {
+      title: request.title || `Queue ${role?.name || roleID || "role"} for ${workItem.title}`,
+      summary: `Create a queued ${driverKind} assignment on the selected work item.`,
+      actions: [
+        {
+          kind: "create_assignment",
+          target: { project_id: project.id },
+          patch: {
+            project_id: project.id,
+            work_item_id: workItem.id,
+            role_id: roleID,
+            driver_kind: driverKind,
+            status: "queued",
+          },
+          reason: "Queue a reviewable assignment without starting execution.",
+        },
+      ],
+    };
+  }
+  const patch: Record<string, unknown> = {
+    project_id: project.id,
+    title: request.title || "Untitled project work",
+    brief: request.brief,
+    status: "ready",
+    priority: "normal",
+  };
+  if (roleID) {
+    patch.owner_role_id = roleID;
+  }
+  return {
+    title: request.title || "Create project work item",
+    summary: "Create a ready work item from the current assistant draft.",
+    actions: [
+      {
+        kind: "create_work_item",
+        target: { project_id: project.id },
+        patch,
+        reason: "Create a reviewable project work item.",
+      },
+    ],
+  };
+}
+
+function projectAssistantResolvedRole(
+  form: ProjectAssistantDraftForm,
+  roles: ProjectWorkRoleRecord[],
+  workItem: ProjectWorkItemRecord | null,
+): ProjectWorkRoleRecord | null {
+  if (form.roleID && form.roleID !== PROJECT_ASSISTANT_AUTO) {
+    return roles.find((role) => role.id === form.roleID) ?? null;
+  }
+  return roles.find((role) => role.id === workItem?.owner_role_id) ?? roles[0] ?? null;
+}
+
+function projectAssistantRequestParts(request: string): { title: string; brief: string } {
+  const lines = request
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const title = lines[0] ?? "";
+  return {
+    title,
+    brief: lines.slice(1).join("\n\n"),
+  };
+}
+
+function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): string {
+  for (const action of result.actions) {
+    const workItemID = action.data?.work_item_id;
+    if (workItemID) return workItemID;
+  }
+  return "";
+}
+
+function projectAssistantApplyErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 404) {
+      return "Project Assistant could not find a proposal target. The project may have changed; refresh project work and draft the proposal again.";
+    }
+    if (error.status === 409) {
+      return "Project Assistant could not apply because the proposal is stale, conflicts with current project state, or was already applied. Refresh project work and draft it again.";
+    }
+  }
+  return errorMessage(error, "Failed to apply Project Assistant proposal.");
 }
 
 function emptyRoleForm(): RoleForm {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -62,6 +62,10 @@ import type {
   CreateProjectHandoffPayload,
   CreateProjectWorkRolePayload,
   CreateProjectWorkItemPayload,
+  ProjectAssistantApplyPayload,
+  ProjectAssistantApplyResponse,
+  ProjectAssistantProposalResponse,
+  ProjectAssistantProposePayload,
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
   ProjectActivityResponse,
@@ -349,6 +353,24 @@ export async function updateProject(
 export async function deleteProject(id: string): Promise<void> {
   return fetchJSON<void>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",
+  });
+}
+
+export async function proposeProjectAssistant(
+  payload: ProjectAssistantProposePayload,
+): Promise<ProjectAssistantProposalResponse> {
+  return fetchJSON<ProjectAssistantProposalResponse>(`${HECATE_API}/project-assistant/propose`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function applyProjectAssistant(
+  payload: ProjectAssistantApplyPayload,
+): Promise<ProjectAssistantApplyResponse> {
+  return fetchJSON<ProjectAssistantApplyResponse>(`${HECATE_API}/project-assistant/apply`, {
+    method: "POST",
+    body: payload,
   });
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -53,6 +53,57 @@ export type ProjectResponse = {
   data: ProjectRecord;
 };
 
+export type ProjectAssistantAction = {
+  kind: string;
+  target?: Record<string, string>;
+  patch?: Record<string, unknown>;
+  reason?: string;
+};
+
+export type ProjectAssistantProposal = {
+  id: string;
+  title: string;
+  summary: string;
+  actions: ProjectAssistantAction[];
+  warnings?: string[];
+  requires_confirmation: boolean;
+  trace_id?: string;
+};
+
+export type ProjectAssistantActionResult = {
+  kind: string;
+  id?: string;
+  data?: Record<string, string>;
+};
+
+export type ProjectAssistantApplyResult = {
+  proposal_id: string;
+  applied: boolean;
+  actions: ProjectAssistantActionResult[];
+};
+
+export type ProjectAssistantProposalResponse = {
+  object: string;
+  data: ProjectAssistantProposal;
+};
+
+export type ProjectAssistantApplyResponse = {
+  object: string;
+  data: ProjectAssistantApplyResult;
+};
+
+export type ProjectAssistantProposePayload = {
+  id?: string;
+  title?: string;
+  summary?: string;
+  actions: ProjectAssistantAction[];
+};
+
+export type ProjectAssistantApplyPayload = {
+  proposal: ProjectAssistantProposal;
+  confirm?: boolean;
+};
+
 export type ProjectMemoryRecord = {
   id: string;
   scope: "project" | (string & {});


### PR DESCRIPTION
## Summary

- Add a project-level Project Assistant review panel above the Projects workspace tabs.
- Wire the UI to `/hecate/v1/project-assistant/propose` and `/hecate/v1/project-assistant/apply` with explicit `confirm: true` on apply.
- Render exact action target/patch details, warnings, trace ids, apply/dismiss states, and stale-conflict refresh handling.
- Clarify external-agent assignment preparation and prevent duplicate empty chat rows from repeat project launches.
- Document the current Project Assistant decisions and v0 boundaries.

## Current decisions

- Project Assistant v0 is a project-level proposal/review surface, not a replacement for simple chat.
- Simple chat remains in Chats; future real-assistant behavior can call the same proposal/apply API.
- `Auto` role/driver selection is deterministic for now: selected work owner role, then first project role; role default driver, then `hecate_task`.
- `Draft proposal` creates reviewable proposal data only. It does not create chats, tasks, runs, assignments, or agent sessions.
- Applying proposals may create project records, but execution still starts from the assignment start/prepare flow.
- External-agent assignment start prepares a linked chat and context packet, but does not send a first message.

## Validation

- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx src/app/AppShell.test.tsx src/app/state/coordinators/chat.test.ts`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `git diff --check`

## Notes

Remaining real-assistant behavior is intentionally deferred. This PR establishes the reviewable action surface and records the product contract for the next iteration.