### PR TITLE
Clarify Projects authority boundaries

### DIFF
--- a/docs/contributor/beta-roadmap.md
+++ b/docs/contributor/beta-roadmap.md
@@ -46,8 +46,9 @@ is released in alpha tags only after it merges.
   patch review; Hecate Chat projections stay accurate and linked. One chat can
   have many historical segments but only one active task-backed loop.
 - **Project orchestration boundaries**: Projects coordinate roles,
-  assignments, handoffs, memory, and activity health; they do not become a
-  separate execution engine or hosted project-management system.
+  assignments, handoffs, memory, and activity health; Project Assistant drafts
+  bounded proposals; the orchestrator executes approved work. Projects do not
+  become a separate execution engine or hosted project-management system.
 - **Docs structure**: operator docs, runtime references, contributor docs,
   design records, and `docs-ai` guidance describe the same product and same
   caveats.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -266,6 +266,28 @@ The Projects UI should stay lightweight but operational:
 
 Avoid turning Projects into a heavy project-management product. This is a runtime identity and context boundary first.
 
+## Authority Model
+
+Projects is the operator cockpit for project-scoped work. It coordinates
+identity, roles, assignments, handoffs, memory, guidance, activity, approvals,
+artifacts, and context inspection, but it is not itself an execution engine.
+
+The product layers should stay separate:
+
+| Layer             | Scope               | Owns                                                                                                   |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| Operator          | Human control plane | Final authority over project setup, proposal apply, assignment start, approvals, cancellation, memory. |
+| Project Assistant | One project         | Bounded proposals for setup, work items, assignments, handoffs, and memory candidates.                 |
+| Planner           | Future project plan | Backlog, milestones, dependencies, roles, and context-bundle proposals.                                |
+| Manager           | Future project run  | Active-state monitoring, blocker detection, sequencing suggestions, follow-up proposals.               |
+| Orchestrator      | Runtime execution   | Approved task/agent coordination, waits, approvals, event emission, and state transitions.             |
+
+Project Assistant can help create a new project or draft a follow-up assignment,
+but it does not auto-start work, run agents, or write durable memory directly.
+Planner and Manager are future proposal/monitoring layers. The orchestrator is
+the runtime coordinator that executes approved work through Tasks, External
+Agents, approvals, artifacts, traces, and events.
+
 ## Storage Plan
 
 The first implementation adds `internal/projects/` with memory and SQLite

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -31,6 +31,34 @@ selected work item, the draft creates a new project work item. In both cases
 `Draft proposal` creates reviewable data only; it does not create a chat, task,
 run, assignment, or agent session.
 
+## Authority boundary
+
+Project Assistant is a proposal author, not the project orchestrator. It can
+help set up a project, attach roots, draft work items, queue assignments, draft
+handoffs, and create memory candidates, but it does not own runtime execution
+or ongoing project supervision.
+
+The intended authority ladder is:
+
+| Layer             | Responsibility                                                                 |
+| ----------------- | ------------------------------------------------------------------------------ |
+| Operator          | Final authority. Reviews, applies, starts, cancels, and approves durable work. |
+| Project Assistant | Produces one bounded project-scoped proposal when asked.                       |
+| Planner           | Future layer that turns goals and project state into backlog/plan proposals.   |
+| Manager           | Future layer that monitors active work and proposes next actions or gates.     |
+| Orchestrator      | Executes approved coordination through tasks, agents, approvals, and events.   |
+
+Project Assistant may propose orchestration-shaped work, such as "create an
+implementation assignment, then create a QA assignment", but applying that
+proposal only creates durable project records. Starting assignments, waiting on
+approvals, routing handoffs, and coordinating multiple agents belong to the
+orchestrator after explicit operator action.
+
+Project Assistant is also distinct from any future personal assistant. Project
+Assistant is scoped to one project and its project stores. A personal assistant
+would be operator-scoped across projects and would need a separate privacy and
+permission model.
+
 ## Safety model
 
 - Project Assistant actions are typed and allowlisted.


### PR DESCRIPTION
## Summary
- document the Project Assistant authority boundary and future Planner/Manager/Orchestrator hierarchy
- clarify Projects as the operator cockpit, not an execution engine
- align beta-roadmap wording around assistant proposals versus orchestrator execution

## Tests
- docs-only change
- git diff --check