### PR TITLE
Add assistant-backed project drafting

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -60,8 +60,11 @@ set returns `409 conflict`, and retrying a fully applied proposal also returns
 `409 conflict`.
 
 Future versions may persist proposal ids server-side so reviewed actions,
-confirmation, and resumable progress survive process restarts. The v0 API keeps
-that shape possible without requiring it.
+confirmation, and resumable progress survive process restarts. In v0 the
+progress map is process-local; a runtime restart between a partial apply and a
+retry loses that resume point, so clients should refresh the proposal before
+retrying after restart. The v0 API keeps the persisted shape possible without
+requiring it.
 
 ## Endpoints
 

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -1,9 +1,10 @@
 # Project Assistant
 
 Project Assistant is Hecate's API-first foundation for supervised project
-operations. It is intentionally narrow: a client proposes typed actions, Hecate
-validates them, the operator inspects the exact change set, and apply
-revalidates current server state before any durable mutation.
+operations. It is intentionally narrow: a client can ask Hecate to draft a
+reviewable project proposal or submit typed actions directly, Hecate validates
+the proposal, the operator inspects the exact change set, and apply revalidates
+current server state before any durable mutation.
 
 It is not a broad chat persona in v0. Hecate Chat can call the same proposal and
 apply API later, but the action system lives in core so every surface follows
@@ -63,6 +64,58 @@ confirmation, and resumable progress survive process restarts. The v0 API keeps
 that shape possible without requiring it.
 
 ## Endpoints
+
+### `POST /hecate/v1/project-assistant/draft`
+
+Builds a server-owned proposal from project context and a short operator
+request. The v0 draft path is deterministic: with `work_item_id` it proposes a
+queued assignment for the selected work; without `work_item_id` it proposes a
+new ready work item. `role_id` and `driver_kind` are optional hints; omitting
+them lets the server choose the selected work item's owner role, then the first
+loaded project role, and the selected role's default driver, then
+`hecate_task`.
+
+Drafting creates proposal data only. It does not create a Hecate Chat session,
+append a chat message, create a task, create a run, queue an assignment, or
+start an external agent session.
+
+```json
+POST /hecate/v1/project-assistant/draft
+{
+  "project_id": "proj_hecate",
+  "work_item_id": "work_next",
+  "request": "Queue product planning\nPrefer a reviewable handoff.",
+  "driver_kind": "external_agent"
+}
+→ 200
+{
+  "object": "project_assistant.proposal",
+  "data": {
+    "id": "pa_...",
+    "title": "Queue product planning",
+    "summary": "Create a queued external_agent assignment on the selected work item.",
+    "actions": [
+      {
+        "kind": "create_assignment",
+        "target": { "project_id": "proj_hecate" },
+        "patch": {
+          "project_id": "proj_hecate",
+          "work_item_id": "work_next",
+          "role_id": "product_manager",
+          "driver_kind": "external_agent",
+          "status": "queued"
+        },
+        "reason": "Queue a reviewable assignment without starting execution."
+      }
+    ],
+    "requires_confirmation": true,
+    "trace_id": "..."
+  }
+}
+```
+
+Missing projects, work items, or explicit roles return `404 not_found`.
+Unsupported driver kinds return `400 invalid_request`.
 
 ### `POST /hecate/v1/project-assistant/propose`
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2139,10 +2139,11 @@ the same work item.
 ## Project Assistant endpoints
 
 Project Assistant is the API-first assistant-action foundation for project
-operations. It does not expose an open-ended chat persona. Clients submit a
-typed, allowlisted proposal, inspect the exact changes, then explicitly apply
-the proposal. Apply revalidates current server state before mutating projects,
-chats, project work, or memory candidates.
+operations. It does not expose an open-ended chat persona. Clients can ask the
+server to draft a reviewable proposal from project context, or submit a typed,
+allowlisted proposal directly. Operators inspect the exact changes, then
+explicitly apply the proposal. Apply revalidates current server state before
+mutating projects, chats, project work, or memory candidates.
 
 Apply is a human-gated operation. Do not wire it as a direct model-callable tool
 without an explicit blocking operator confirmation. Multi-action apply is
@@ -2153,11 +2154,14 @@ action set or reapplying a fully applied proposal returns `409 conflict`.
 
 Endpoints:
 
+- `POST /hecate/v1/project-assistant/draft`
 - `POST /hecate/v1/project-assistant/propose`
 - `POST /hecate/v1/project-assistant/apply`
 
-See [`project-assistant.md`](project-assistant.md) for the proposal schema,
-supported action kinds, confirmation behavior, and safety model.
+`draft` creates proposal data only; it does not create a chat message, task,
+run, assignment, or external agent session. See
+[`project-assistant.md`](project-assistant.md) for the draft request, proposal
+schema, supported action kinds, confirmation behavior, and safety model.
 
 ## Chat session endpoints
 

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -16,9 +16,41 @@ type projectAssistantProposeRequest struct {
 	Actions []projectassistant.Action `json:"actions"`
 }
 
+type projectAssistantDraftRequest struct {
+	ProjectID  string `json:"project_id"`
+	WorkItemID string `json:"work_item_id,omitempty"`
+	Request    string `json:"request"`
+	RoleID     string `json:"role_id,omitempty"`
+	DriverKind string `json:"driver_kind,omitempty"`
+}
+
 type projectAssistantApplyRequest struct {
 	Proposal projectassistant.Proposal `json:"proposal"`
 	Confirm  bool                      `json:"confirm,omitempty"`
+}
+
+func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Request) {
+	var req projectAssistantDraftRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant draft request")
+		return
+	}
+	proposal, err := h.projectAssistantService().Draft(r.Context(), projectassistant.DraftInput{
+		ProjectID:  req.ProjectID,
+		WorkItemID: req.WorkItemID,
+		Request:    req.Request,
+		RoleID:     req.RoleID,
+		DriverKind: req.DriverKind,
+		TraceID:    requestTraceID(r),
+	})
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.proposal",
+		"data":   proposal,
+	})
 }
 
 func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -36,12 +36,65 @@ type projectAssistantErrorResponse struct {
 }
 
 func newProjectAssistantTestServer() http.Handler {
+	_, server := newProjectAssistantTestHandler()
+	return server
+}
+
+func newProjectAssistantTestHandler() (*Handler, http.Handler) {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	handler.SetAgentChatStore(chat.NewMemoryStore())
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
 	handler.SetMemoryStore(memory.NewMemoryStore())
-	return NewServer(quietLogger(), handler)
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_api", Name: "API Project"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	workItem, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:          "work_api",
+		ProjectID:   project.ID,
+		Title:       "Plan next work",
+		Brief:       "Pick the next reviewable task.",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: "product_manager",
+	})
+	if err != nil {
+		t.Fatalf("Create work item: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader([]byte(`{
+		"project_id":"proj_api",
+		"work_item_id":"work_api",
+		"request":"Queue Product Manager\nPrepare acceptance criteria.",
+		"driver_kind":"external_agent"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || proposed.Data.ID == "" {
+		t.Fatalf("draft response = %+v, want proposal envelope with id", proposed)
+	}
+	if proposed.Data.Title != "Queue Product Manager" || len(proposed.Data.Actions) != 1 || proposed.Data.Actions[0].Kind != projectassistant.ActionCreateAssignment {
+		t.Fatalf("proposal = %+v, want one assignment proposal with request title", proposed.Data)
+	}
+	var patch map[string]string
+	if err := json.Unmarshal(proposed.Data.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patch["project_id"] != project.ID || patch["work_item_id"] != workItem.ID || patch["role_id"] != "product_manager" || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent {
+		t.Fatalf("patch = %+v, want selected project/work/owner role/external driver", patch)
+	}
 }
 
 func TestProjectAssistantAPI_ProposeRejectsUnknownActionKind(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,6 +70,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	// to them for shared defaults, memory, and context assembly.
 	mux.HandleFunc("GET /hecate/v1/projects", handler.HandleProjects)
 	mux.HandleFunc("POST /hecate/v1/projects", handler.HandleCreateProject)
+	mux.HandleFunc("POST /hecate/v1/project-assistant/draft", handler.HandleProjectAssistantDraft)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/propose", handler.HandleProjectAssistantPropose)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/apply", handler.HandleProjectAssistantApply)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -66,6 +66,15 @@ type ProposalInput struct {
 	TraceID string
 }
 
+type DraftInput struct {
+	ProjectID  string
+	WorkItemID string
+	Request    string
+	RoleID     string
+	DriverKind string
+	TraceID    string
+}
+
 type Proposal struct {
 	ID                   string   `json:"id"`
 	Title                string   `json:"title"`
@@ -179,6 +188,95 @@ func (s *Service) Propose(_ context.Context, input ProposalInput) (Proposal, err
 		RequiresConfirmation: true,
 		TraceID:              strings.TrimSpace(input.TraceID),
 	}, nil
+}
+
+func (s *Service) Draft(ctx context.Context, input DraftInput) (Proposal, error) {
+	if s == nil || s.projects == nil || s.work == nil {
+		return Proposal{}, ErrStoreNotConfigured
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	if projectID == "" {
+		return Proposal{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	project, ok, err := s.projects.Get(ctx, projectID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	if !ok {
+		return Proposal{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
+	}
+	roles, err := s.work.ListRoles(ctx, project.ID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	workItemID := strings.TrimSpace(input.WorkItemID)
+	var workItem *projectwork.WorkItem
+	if workItemID != "" {
+		item, found, err := s.work.GetWorkItem(ctx, project.ID, workItemID)
+		if err != nil {
+			return Proposal{}, err
+		}
+		if !found {
+			return Proposal{}, fmt.Errorf("%w: project work item %q", ErrNotFound, workItemID)
+		}
+		workItem = &item
+	}
+	role := draftRole(strings.TrimSpace(input.RoleID), roles, workItem)
+	if strings.TrimSpace(input.RoleID) != "" && role == nil {
+		return Proposal{}, fmt.Errorf("%w: role %q", ErrNotFound, strings.TrimSpace(input.RoleID))
+	}
+	driverKind := draftDriverKind(strings.TrimSpace(input.DriverKind), role)
+	if !validDraftDriverKind(driverKind) {
+		return Proposal{}, fmt.Errorf("%w: unsupported assignment driver_kind %q", ErrInvalid, driverKind)
+	}
+	request := draftRequestParts(input.Request)
+	var proposalInput ProposalInput
+	if workItem != nil {
+		if role == nil {
+			return Proposal{}, fmt.Errorf("%w: role_id is required for assignment drafts", ErrInvalid)
+		}
+		patch := mustRawJSON(map[string]any{
+			"project_id":   project.ID,
+			"work_item_id": workItem.ID,
+			"role_id":      role.ID,
+			"driver_kind":  driverKind,
+			"status":       projectwork.AssignmentStatusQueued,
+		})
+		proposalInput = ProposalInput{
+			Title:   firstNonEmpty(request.title, fmt.Sprintf("Queue %s for %s", firstNonEmpty(role.Name, role.ID, "role"), workItem.Title)),
+			Summary: fmt.Sprintf("Create a queued %s assignment on the selected work item.", driverKind),
+			Actions: []Action{{
+				Kind:   ActionCreateAssignment,
+				Target: map[string]string{"project_id": project.ID},
+				Patch:  patch,
+				Reason: "Queue a reviewable assignment without starting execution.",
+			}},
+			TraceID: strings.TrimSpace(input.TraceID),
+		}
+	} else {
+		patch := map[string]any{
+			"project_id": project.ID,
+			"title":      firstNonEmpty(request.title, "Untitled project work"),
+			"brief":      request.brief,
+			"status":     projectwork.WorkItemStatusReady,
+			"priority":   "normal",
+		}
+		if role != nil {
+			patch["owner_role_id"] = role.ID
+		}
+		proposalInput = ProposalInput{
+			Title:   firstNonEmpty(request.title, "Create project work item"),
+			Summary: "Create a ready work item from the current assistant draft.",
+			Actions: []Action{{
+				Kind:   ActionCreateWorkItem,
+				Target: map[string]string{"project_id": project.ID},
+				Patch:  mustRawJSON(patch),
+				Reason: "Create a reviewable project work item.",
+			}},
+			TraceID: strings.TrimSpace(input.TraceID),
+		}
+	}
+	return s.Propose(ctx, proposalInput)
 }
 
 func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) (ApplyResult, error) {
@@ -989,6 +1087,91 @@ func cloneStringMap(input map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+type draftRequest struct {
+	title string
+	brief string
+}
+
+func draftRequestParts(request string) draftRequest {
+	lines := strings.Split(strings.ReplaceAll(strings.ReplaceAll(request, "\r\n", "\n"), "\r", "\n"), "\n")
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	if len(parts) == 0 {
+		return draftRequest{}
+	}
+	return draftRequest{title: parts[0], brief: strings.Join(parts[1:], "\n\n")}
+}
+
+func draftRole(roleID string, roles []projectwork.AgentRoleProfile, workItem *projectwork.WorkItem) *projectwork.AgentRoleProfile {
+	roleID = strings.TrimSpace(roleID)
+	if roleID != "" {
+		for _, role := range roles {
+			if role.ID == roleID {
+				found := role
+				return &found
+			}
+		}
+		return nil
+	}
+	if workItem != nil {
+		ownerID := strings.TrimSpace(workItem.OwnerRoleID)
+		if ownerID != "" {
+			for _, role := range roles {
+				if role.ID == ownerID {
+					found := role
+					return &found
+				}
+			}
+		}
+	}
+	if len(roles) == 0 {
+		return nil
+	}
+	found := roles[0]
+	return &found
+}
+
+func draftDriverKind(driverKind string, role *projectwork.AgentRoleProfile) string {
+	driverKind = strings.TrimSpace(driverKind)
+	if driverKind != "" {
+		return driverKind
+	}
+	if role != nil && strings.TrimSpace(role.DefaultDriverKind) != "" {
+		return strings.TrimSpace(role.DefaultDriverKind)
+	}
+	return projectwork.AssignmentDriverHecateTask
+}
+
+func validDraftDriverKind(kind string) bool {
+	switch kind {
+	case projectwork.AssignmentDriverHecateTask, projectwork.AssignmentDriverExternalAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+func mustRawJSON(value any) json.RawMessage {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func mapProjectErr(err error) error {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -42,6 +42,94 @@ func TestService_ProposeRejectsUnknownActionKind(t *testing.T) {
 	}
 }
 
+func TestService_DraftCreatesAssignmentProposalAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			workItem, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+				ID:          "work_plan",
+				ProjectID:   project.ID,
+				Title:       "Plan next work",
+				Brief:       "Pick the next reviewable task.",
+				Status:      projectwork.WorkItemStatusReady,
+				OwnerRoleID: "product_manager",
+			})
+			if err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
+
+			proposal, err := fixture.service.Draft(ctx, DraftInput{
+				ProjectID:  project.ID,
+				WorkItemID: workItem.ID,
+				Request:    "Queue product planning\nPrefer a reviewable handoff.",
+				DriverKind: projectwork.AssignmentDriverExternalAgent,
+				TraceID:    "trace_draft",
+			})
+			if err != nil {
+				t.Fatalf("Draft assignment: %v", err)
+			}
+			if proposal.Title != "Queue product planning" || proposal.TraceID != "trace_draft" {
+				t.Fatalf("proposal title/trace = %q/%q, want request title and trace", proposal.Title, proposal.TraceID)
+			}
+			if len(proposal.Actions) != 1 || proposal.Actions[0].Kind != ActionCreateAssignment {
+				t.Fatalf("actions = %+v, want one create_assignment", proposal.Actions)
+			}
+			patch := rawPatchMap(t, proposal.Actions[0].Patch)
+			if patch["project_id"] != project.ID || patch["work_item_id"] != workItem.ID || patch["role_id"] != "product_manager" || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent || patch["status"] != projectwork.AssignmentStatusQueued {
+				t.Fatalf("assignment patch = %+v, want project/work/owner-role/external queued", patch)
+			}
+		})
+	}
+}
+
+func TestService_DraftCreatesWorkItemProposalAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+
+			proposal, err := fixture.service.Draft(ctx, DraftInput{
+				ProjectID: project.ID,
+				Request:   "Write rollout notes\nCapture release caveats.",
+				RoleID:    "architect",
+			})
+			if err != nil {
+				t.Fatalf("Draft work item: %v", err)
+			}
+			if len(proposal.Actions) != 1 || proposal.Actions[0].Kind != ActionCreateWorkItem {
+				t.Fatalf("actions = %+v, want one create_work_item", proposal.Actions)
+			}
+			patch := rawPatchMap(t, proposal.Actions[0].Patch)
+			if patch["project_id"] != project.ID || patch["title"] != "Write rollout notes" || patch["brief"] != "Capture release caveats." || patch["owner_role_id"] != "architect" {
+				t.Fatalf("work item patch = %+v, want project/title/brief/owner role", patch)
+			}
+		})
+	}
+}
+
+func TestService_DraftRejectsUnsupportedDriverKind(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newMemoryAssistantFixture(t)
+	project := createTestProject(t, ctx, fixture.projects)
+
+	_, err := fixture.service.Draft(ctx, DraftInput{
+		ProjectID:  project.ID,
+		Request:    "Queue speculative work",
+		DriverKind: "spreadsheet_macro",
+	})
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Draft err = %v, want ErrInvalid", err)
+	}
+}
+
 func TestService_ApplyRequiresConfirmation(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {
@@ -765,6 +853,15 @@ func rawPatch(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("marshal patch: %v", err)
 	}
 	return payload
+}
+
+func rawPatchMap(t *testing.T, payload json.RawMessage) map[string]string {
+	t.Helper()
+	var decoded map[string]string
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	return decoded
 }
 
 func createTestProject(t *testing.T, ctx context.Context, store projects.Store) projects.Project {

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -257,187 +257,193 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
               >
                 {group.label}
               </div>
-              {group.sessions.map((s) => (
-                <div
-                  key={s.id}
-                  role="button"
-                  tabIndex={renamingId === s.id ? -1 : 0}
-                  aria-current={activeSessionID === s.id ? "true" : undefined}
-                  aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
-                  onClick={() => {
-                    if (renamingId === s.id) return;
-                    onSelectSession(s.id);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.target !== e.currentTarget) return;
-                    if (renamingId === s.id) return;
-                    if (e.key !== "Enter" && e.key !== " ") return;
-                    e.preventDefault();
-                    onSelectSession(s.id);
-                  }}
-                  onFocus={() => setHoveredChatId(s.id)}
-                  onBlur={(e) => {
-                    const nextFocus = e.relatedTarget;
-                    if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
-                      setHoveredChatId(null);
-                    }
-                  }}
-                  onMouseEnter={() => setHoveredChatId(s.id)}
-                  onMouseLeave={() => setHoveredChatId(null)}
-                  style={{
-                    padding: "8px 12px",
-                    cursor: "pointer",
-                    background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
-                    borderLeft:
-                      activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
-                    transition: "background 0.1s",
-                  }}
-                >
-                  <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
-                    {renamingId === s.id ? (
-                      <input
-                        autoFocus
-                        value={renameValue}
-                        onChange={(e) => setRenameValue(e.target.value)}
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
+              {group.sessions.map((s) => {
+                const isDraftAgentChat = isAgentChat && sidebarSessionIsDraft(s);
+                return (
+                  <div
+                    key={s.id}
+                    role="button"
+                    tabIndex={renamingId === s.id ? -1 : 0}
+                    aria-current={activeSessionID === s.id ? "true" : undefined}
+                    aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
+                    onClick={() => {
+                      if (renamingId === s.id) return;
+                      onSelectSession(s.id);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (renamingId === s.id) return;
+                      if (e.key !== "Enter" && e.key !== " ") return;
+                      e.preventDefault();
+                      onSelectSession(s.id);
+                    }}
+                    onFocus={() => setHoveredChatId(s.id)}
+                    onBlur={(e) => {
+                      const nextFocus = e.relatedTarget;
+                      if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
+                        setHoveredChatId(null);
+                      }
+                    }}
+                    onMouseEnter={() => setHoveredChatId(s.id)}
+                    onMouseLeave={() => setHoveredChatId(null)}
+                    style={{
+                      padding: "8px 12px",
+                      cursor: "pointer",
+                      background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
+                      borderLeft:
+                        activeSessionID === s.id
+                          ? "2px solid var(--teal)"
+                          : "2px solid transparent",
+                      transition: "background 0.1s",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
+                      {renamingId === s.id ? (
+                        <input
+                          autoFocus
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              void chatActions.renameChatSession(s.id, renameValue);
+                              setRenamingId(null);
+                            }
+                            if (e.key === "Escape") setRenamingId(null);
+                          }}
+                          onBlur={() => {
                             void chatActions.renameChatSession(s.id, renameValue);
                             setRenamingId(null);
-                          }
-                          if (e.key === "Escape") setRenamingId(null);
-                        }}
-                        onBlur={() => {
-                          void chatActions.renameChatSession(s.id, renameValue);
-                          setRenamingId(null);
-                        }}
-                        style={{
-                          flex: 1,
-                          minWidth: 0,
-                          height: 18,
-                          boxSizing: "border-box",
-                          fontSize: 12,
-                          background: "var(--bg3)",
-                          border: "1px solid var(--teal)",
-                          borderRadius: "var(--radius-sm)",
-                          color: "var(--t0)",
-                          padding: "0 4px",
-                          outline: "none",
-                          fontFamily: "var(--font-sans)",
-                          lineHeight: "16px",
-                        }}
-                      />
-                    ) : (
-                      <>
-                        <div
+                          }}
                           style={{
                             flex: 1,
                             minWidth: 0,
+                            height: 18,
+                            boxSizing: "border-box",
                             fontSize: 12,
-                            lineHeight: "18px",
-                            color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)",
-                            fontWeight: activeSessionID === s.id ? 500 : 400,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
+                            background: "var(--bg3)",
+                            border: "1px solid var(--teal)",
+                            borderRadius: "var(--radius-sm)",
+                            color: "var(--t0)",
+                            padding: "0 4px",
+                            outline: "none",
+                            fontFamily: "var(--font-sans)",
+                            lineHeight: "16px",
                           }}
-                        >
-                          {s.title || "Untitled"}
-                        </div>
-                        {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
-                          <span
-                            title={formatAbsoluteTime(s.updated_at || s.created_at)}
+                        />
+                      ) : (
+                        <>
+                          <div
                             style={{
-                              color: "var(--t3)",
-                              flexShrink: 0,
-                              fontFamily: "var(--font-mono)",
-                              fontSize: 9,
+                              flex: 1,
+                              minWidth: 0,
+                              fontSize: 12,
                               lineHeight: "18px",
+                              color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)",
+                              fontWeight: activeSessionID === s.id ? 500 : 400,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
                             }}
                           >
-                            {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
-                          </span>
-                        )}
-                        <div
-                          style={{
-                            display: "flex",
-                            gap: 1,
-                            opacity: hoveredChatId === s.id ? 1 : 0,
-                            transition: "opacity 0.15s",
-                            flexShrink: 0,
-                          }}
-                        >
-                          <button
-                            className="btn btn-ghost btn-sm"
-                            aria-label={`Rename chat ${s.title || "Untitled"}`}
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setRenamingId(s.id);
-                              setRenameValue(s.title || "");
+                            {s.title || "Untitled"}
+                          </div>
+                          {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
+                            <span
+                              title={formatAbsoluteTime(s.updated_at || s.created_at)}
+                              style={{
+                                color: "var(--t3)",
+                                flexShrink: 0,
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 9,
+                                lineHeight: "18px",
+                              }}
+                            >
+                              {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
+                            </span>
+                          )}
+                          <div
+                            style={{
+                              display: "flex",
+                              gap: 1,
+                              opacity: hoveredChatId === s.id ? 1 : 0,
+                              transition: "opacity 0.15s",
+                              flexShrink: 0,
                             }}
-                            style={{ padding: "1px 3px" }}
-                            title="Rename"
                           >
-                            <Icon d={Icons.edit} size={10} />
-                          </button>
-                          <button
-                            className="btn btn-ghost btn-sm"
-                            aria-label={`Delete chat ${s.title || "Untitled"}`}
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setDeleteChatID(s.id);
-                            }}
-                            style={{ padding: "1px 3px", color: "var(--red)" }}
-                            title="Delete"
-                          >
-                            <Icon d={Icons.trash} size={10} />
-                          </button>
-                        </div>
-                      </>
-                    )}
-                  </div>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 6,
-                      fontSize: 10,
-                      color: "var(--t3)",
-                      marginTop: 1,
-                      fontFamily: "var(--font-mono)",
-                    }}
-                  >
-                    {isAgentChat && s.agent_brand && renamingId !== s.id && (
-                      <BrandAvatar
-                        brand={s.agent_brand}
-                        fallback={s.agent_label || s.agent_brand}
-                        title={s.agent_label || s.agent_brand}
-                        boxed={false}
-                        size={13}
-                        style={{ flexShrink: 0 }}
-                      />
-                    )}
-                    <span>{s.message_count} msg</span>
-                    {isAgentChat ? (
-                      s.status_label && (
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              aria-label={`Rename chat ${s.title || "Untitled"}`}
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setRenamingId(s.id);
+                                setRenameValue(s.title || "");
+                              }}
+                              style={{ padding: "1px 3px" }}
+                              title="Rename"
+                            >
+                              <Icon d={Icons.edit} size={10} />
+                            </button>
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              aria-label={`Delete chat ${s.title || "Untitled"}`}
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeleteChatID(s.id);
+                              }}
+                              style={{ padding: "1px 3px", color: "var(--red)" }}
+                              title="Delete"
+                            >
+                              <Icon d={Icons.trash} size={10} />
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                        fontSize: 10,
+                        color: "var(--t3)",
+                        marginTop: 1,
+                        fontFamily: "var(--font-mono)",
+                      }}
+                    >
+                      {isAgentChat && s.agent_brand && renamingId !== s.id && (
+                        <BrandAvatar
+                          brand={s.agent_brand}
+                          fallback={s.agent_label || s.agent_brand}
+                          title={s.agent_label || s.agent_brand}
+                          boxed={false}
+                          size={13}
+                          style={{ flexShrink: 0 }}
+                        />
+                      )}
+                      <span>{isDraftAgentChat ? "draft" : `${s.message_count} msg`}</span>
+                      {isAgentChat ? (
+                        !isDraftAgentChat &&
+                        s.status_label && (
+                          <>
+                            <span style={{ color: "var(--t4)" }}>·</span>
+                            <span>{s.status_label}</span>
+                          </>
+                        )
+                      ) : (
                         <>
                           <span style={{ color: "var(--t4)" }}>·</span>
-                          <span>{s.status_label}</span>
+                          <span>
+                            {s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}
+                          </span>
                         </>
-                      )
-                    ) : (
-                      <>
-                        <span style={{ color: "var(--t4)" }}>·</span>
-                        <span>
-                          {s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}
-                        </span>
-                      </>
-                    )}
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           ))}
         </div>
@@ -491,6 +497,13 @@ export function filterSidebarSessions(sessions: SidebarSession[], query: string)
       .toLowerCase();
     return searchable.includes(needle);
   });
+}
+
+export function sidebarSessionIsDraft(
+  session: Pick<SidebarSession, "message_count" | "status_label">,
+): boolean {
+  const status = (session.status_label ?? "").trim();
+  return session.message_count === 0 && (status === "" || status === "idle");
 }
 
 export function sidebarSessionBrand(session: ChatSessionRecord): string | undefined {

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -257,193 +257,190 @@ export function ChatSidebar({ isAgentChat, onSelectSession, onCreateChat }: Prop
               >
                 {group.label}
               </div>
-              {group.sessions.map((s) => {
-                const isDraftAgentChat = isAgentChat && sidebarSessionIsDraft(s);
-                return (
-                  <div
-                    key={s.id}
-                    role="button"
-                    tabIndex={renamingId === s.id ? -1 : 0}
-                    aria-current={activeSessionID === s.id ? "true" : undefined}
-                    aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
-                    onClick={() => {
-                      if (renamingId === s.id) return;
-                      onSelectSession(s.id);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.target !== e.currentTarget) return;
-                      if (renamingId === s.id) return;
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      onSelectSession(s.id);
-                    }}
-                    onFocus={() => setHoveredChatId(s.id)}
-                    onBlur={(e) => {
-                      const nextFocus = e.relatedTarget;
-                      if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
-                        setHoveredChatId(null);
-                      }
-                    }}
-                    onMouseEnter={() => setHoveredChatId(s.id)}
-                    onMouseLeave={() => setHoveredChatId(null)}
-                    style={{
-                      padding: "8px 12px",
-                      cursor: "pointer",
-                      background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
-                      borderLeft:
-                        activeSessionID === s.id
-                          ? "2px solid var(--teal)"
-                          : "2px solid transparent",
-                      transition: "background 0.1s",
-                    }}
-                  >
-                    <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
-                      {renamingId === s.id ? (
-                        <input
-                          autoFocus
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                          onClick={(e) => e.stopPropagation()}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              void chatActions.renameChatSession(s.id, renameValue);
-                              setRenamingId(null);
-                            }
-                            if (e.key === "Escape") setRenamingId(null);
-                          }}
-                          onBlur={() => {
+              {group.sessions.map((s) => (
+                <div
+                  key={s.id}
+                  role="button"
+                  tabIndex={renamingId === s.id ? -1 : 0}
+                  aria-current={activeSessionID === s.id ? "true" : undefined}
+                  aria-label={`Chat ${s.title || "Untitled"}${s.agent_label ? `, ${s.agent_label}` : ""}`}
+                  onClick={() => {
+                    if (renamingId === s.id) return;
+                    onSelectSession(s.id);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return;
+                    if (renamingId === s.id) return;
+                    if (e.key !== "Enter" && e.key !== " ") return;
+                    e.preventDefault();
+                    onSelectSession(s.id);
+                  }}
+                  onFocus={() => setHoveredChatId(s.id)}
+                  onBlur={(e) => {
+                    const nextFocus = e.relatedTarget;
+                    if (!(nextFocus instanceof Node) || !e.currentTarget.contains(nextFocus)) {
+                      setHoveredChatId(null);
+                    }
+                  }}
+                  onMouseEnter={() => setHoveredChatId(s.id)}
+                  onMouseLeave={() => setHoveredChatId(null)}
+                  style={{
+                    padding: "8px 12px",
+                    cursor: "pointer",
+                    background: activeSessionID === s.id ? "var(--teal-bg)" : "transparent",
+                    borderLeft:
+                      activeSessionID === s.id ? "2px solid var(--teal)" : "2px solid transparent",
+                    transition: "background 0.1s",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 7, minHeight: 22 }}>
+                    {renamingId === s.id ? (
+                      <input
+                        autoFocus
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
                             void chatActions.renameChatSession(s.id, renameValue);
                             setRenamingId(null);
-                          }}
+                          }
+                          if (e.key === "Escape") setRenamingId(null);
+                        }}
+                        onBlur={() => {
+                          void chatActions.renameChatSession(s.id, renameValue);
+                          setRenamingId(null);
+                        }}
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          height: 18,
+                          boxSizing: "border-box",
+                          fontSize: 12,
+                          background: "var(--bg3)",
+                          border: "1px solid var(--teal)",
+                          borderRadius: "var(--radius-sm)",
+                          color: "var(--t0)",
+                          padding: "0 4px",
+                          outline: "none",
+                          fontFamily: "var(--font-sans)",
+                          lineHeight: "16px",
+                        }}
+                      />
+                    ) : (
+                      <>
+                        <div
                           style={{
                             flex: 1,
                             minWidth: 0,
-                            height: 18,
-                            boxSizing: "border-box",
                             fontSize: 12,
-                            background: "var(--bg3)",
-                            border: "1px solid var(--teal)",
-                            borderRadius: "var(--radius-sm)",
-                            color: "var(--t0)",
-                            padding: "0 4px",
-                            outline: "none",
-                            fontFamily: "var(--font-sans)",
-                            lineHeight: "16px",
+                            lineHeight: "18px",
+                            color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)",
+                            fontWeight: activeSessionID === s.id ? 500 : 400,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
                           }}
-                        />
-                      ) : (
-                        <>
-                          <div
+                        >
+                          {s.title || "Untitled"}
+                        </div>
+                        {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
+                          <span
+                            title={formatAbsoluteTime(s.updated_at || s.created_at)}
                             style={{
-                              flex: 1,
-                              minWidth: 0,
-                              fontSize: 12,
-                              lineHeight: "18px",
-                              color: activeSessionID === s.id ? "var(--t0)" : "var(--t1)",
-                              fontWeight: activeSessionID === s.id ? 500 : 400,
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {s.title || "Untitled"}
-                          </div>
-                          {sidebarSessionTimeLabel(s.updated_at || s.created_at) && (
-                            <span
-                              title={formatAbsoluteTime(s.updated_at || s.created_at)}
-                              style={{
-                                color: "var(--t3)",
-                                flexShrink: 0,
-                                fontFamily: "var(--font-mono)",
-                                fontSize: 9,
-                                lineHeight: "18px",
-                              }}
-                            >
-                              {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
-                            </span>
-                          )}
-                          <div
-                            style={{
-                              display: "flex",
-                              gap: 1,
-                              opacity: hoveredChatId === s.id ? 1 : 0,
-                              transition: "opacity 0.15s",
+                              color: "var(--t3)",
                               flexShrink: 0,
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 9,
+                              lineHeight: "18px",
                             }}
                           >
-                            <button
-                              className="btn btn-ghost btn-sm"
-                              aria-label={`Rename chat ${s.title || "Untitled"}`}
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setRenamingId(s.id);
-                                setRenameValue(s.title || "");
-                              }}
-                              style={{ padding: "1px 3px" }}
-                              title="Rename"
-                            >
-                              <Icon d={Icons.edit} size={10} />
-                            </button>
-                            <button
-                              className="btn btn-ghost btn-sm"
-                              aria-label={`Delete chat ${s.title || "Untitled"}`}
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeleteChatID(s.id);
-                              }}
-                              style={{ padding: "1px 3px", color: "var(--red)" }}
-                              title="Delete"
-                            >
-                              <Icon d={Icons.trash} size={10} />
-                            </button>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
-                        fontSize: 10,
-                        color: "var(--t3)",
-                        marginTop: 1,
-                        fontFamily: "var(--font-mono)",
-                      }}
-                    >
-                      {isAgentChat && s.agent_brand && renamingId !== s.id && (
-                        <BrandAvatar
-                          brand={s.agent_brand}
-                          fallback={s.agent_label || s.agent_brand}
-                          title={s.agent_label || s.agent_brand}
-                          boxed={false}
-                          size={13}
-                          style={{ flexShrink: 0 }}
-                        />
-                      )}
-                      <span>{isDraftAgentChat ? "draft" : `${s.message_count} msg`}</span>
-                      {isAgentChat ? (
-                        !isDraftAgentChat &&
-                        s.status_label && (
-                          <>
-                            <span style={{ color: "var(--t4)" }}>·</span>
-                            <span>{s.status_label}</span>
-                          </>
-                        )
-                      ) : (
+                            {sidebarSessionTimeLabel(s.updated_at || s.created_at)}
+                          </span>
+                        )}
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: 1,
+                            opacity: hoveredChatId === s.id ? 1 : 0,
+                            transition: "opacity 0.15s",
+                            flexShrink: 0,
+                          }}
+                        >
+                          <button
+                            className="btn btn-ghost btn-sm"
+                            aria-label={`Rename chat ${s.title || "Untitled"}`}
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setRenamingId(s.id);
+                              setRenameValue(s.title || "");
+                            }}
+                            style={{ padding: "1px 3px" }}
+                            title="Rename"
+                          >
+                            <Icon d={Icons.edit} size={10} />
+                          </button>
+                          <button
+                            className="btn btn-ghost btn-sm"
+                            aria-label={`Delete chat ${s.title || "Untitled"}`}
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteChatID(s.id);
+                            }}
+                            style={{ padding: "1px 3px", color: "var(--red)" }}
+                            title="Delete"
+                          >
+                            <Icon d={Icons.trash} size={10} />
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      fontSize: 10,
+                      color: "var(--t3)",
+                      marginTop: 1,
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  >
+                    {isAgentChat && s.agent_brand && renamingId !== s.id && (
+                      <BrandAvatar
+                        brand={s.agent_brand}
+                        fallback={s.agent_label || s.agent_brand}
+                        title={s.agent_label || s.agent_brand}
+                        boxed={false}
+                        size={13}
+                        style={{ flexShrink: 0 }}
+                      />
+                    )}
+                    <span>
+                      {isAgentChat && sidebarSessionIsDraft(s) ? "draft" : `${s.message_count} msg`}
+                    </span>
+                    {isAgentChat ? (
+                      !sidebarSessionIsDraft(s) &&
+                      s.status_label && (
                         <>
                           <span style={{ color: "var(--t4)" }}>·</span>
-                          <span>
-                            {s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}
-                          </span>
+                          <span>{s.status_label}</span>
                         </>
-                      )}
-                    </div>
+                      )
+                    ) : (
+                      <>
+                        <span style={{ color: "var(--t4)" }}>·</span>
+                        <span>
+                          {s.provider_call_count} call{s.provider_call_count === 1 ? "" : "s"}
+                        </span>
+                      </>
+                    )}
                   </div>
-                );
-              })}
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3092,6 +3092,27 @@ describe("ChatView chats sidebar", () => {
     expect(screen.getByText("Second chat")).toBeTruthy();
   });
 
+  it("labels empty idle assistant chats as drafts", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      chatSessions: [
+        {
+          id: "a1",
+          title: "Plan next work for hecate",
+          agent_id: "hecate",
+          status: "idle",
+          message_count: 0,
+          updated_at: daysAgo(0),
+        } as any,
+      ],
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+    const row = screen.getByRole("button", { name: /^Chat Plan next work for hecate/ });
+    expect(within(row).getByText("draft")).toBeTruthy();
+    expect(within(row).queryByText("0 msg")).toBeNull();
+    expect(within(row).queryByText("idle")).toBeNull();
+  });
+
   it("filters chat history by title and route metadata", async () => {
     const { state, actions } = setup({
       chatTarget: "agent",

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1022,6 +1022,84 @@ describe("ProjectsView cockpit", () => {
     expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
   });
 
+  it("surfaces partial Project Assistant apply progress", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(draftProjectAssistant).mockResolvedValueOnce({
+      object: "project_assistant.proposal",
+      data: {
+        id: "pa_partial",
+        title: "Apply two changes",
+        summary: "Create an assignment and a memory candidate.",
+        requires_confirmation: true,
+        actions: [
+          {
+            kind: "create_assignment",
+            target: { project_id: project.id },
+            patch: {
+              project_id: project.id,
+              work_item_id: workItem.id,
+              role_id: role.id,
+              driver_kind: "hecate_task",
+              status: "queued",
+            },
+            reason: "Queue the selected work.",
+          },
+          {
+            kind: "create_memory_candidate",
+            target: { project_id: project.id },
+            patch: {
+              project_id: project.id,
+              title: "Decision",
+              body: "Keep the apply flow resumable.",
+              source_kind: "operator_note",
+            },
+            reason: "Capture the decision.",
+          },
+        ],
+        trace_id: "trace_partial_apply",
+      },
+    });
+    vi.mocked(applyProjectAssistant).mockRejectedValueOnce(
+      new ApiError("project assistant apply failed at action 1", 409, "conflict", {
+        fields: {
+          failed_action_index: 1,
+          partial_result: {
+            proposal_id: "pa_partial",
+            applied: false,
+            actions: [
+              {
+                kind: "create_assignment",
+                id: "asgn_partial",
+                data: { project_id: project.id, assignment_id: "asgn_partial" },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+    await within(assistant).findByText("Create memory candidate");
+    await user.click(within(assistant).getByRole("button", { name: "Apply proposal" }));
+
+    expect(
+      await within(assistant).findByText(
+        "Project Assistant applied 1 of 2 actions, then failed at action 2. Apply the same proposal again after fixing the target state to resume from the next unapplied action.",
+      ),
+    ).toBeTruthy();
+    expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
+    expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
+  });
+
   it("manages project memory entries in the cockpit", async () => {
     resetProjectWorkMocks();
     vi.mocked(getProjectMemory).mockResolvedValue({

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -31,7 +31,7 @@ import {
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
-  proposeProjectAssistant,
+  draftProjectAssistant,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
   startProjectAssignment,
@@ -121,7 +121,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
       data: [],
     })),
     getAgentProfiles: vi.fn(async () => ({ object: "agent_profiles", data: [] })),
-    proposeProjectAssistant: vi.fn(async () => ({
+    draftProjectAssistant: vi.fn(async () => ({
       object: "project_assistant.proposal",
       data: {
         id: "pa_test",
@@ -466,7 +466,7 @@ function resetProjectWorkMocks() {
       },
     ],
   });
-  vi.mocked(proposeProjectAssistant).mockResolvedValue({
+  vi.mocked(draftProjectAssistant).mockResolvedValue({
     object: "project_assistant.proposal",
     data: {
       id: "pa_test",
@@ -674,7 +674,7 @@ afterEach(() => {
   vi.mocked(getProjectMemory).mockReset();
   vi.mocked(getProjectMemoryCandidates).mockReset();
   vi.mocked(getAgentProfiles).mockReset();
-  vi.mocked(proposeProjectAssistant).mockReset();
+  vi.mocked(draftProjectAssistant).mockReset();
   vi.mocked(applyProjectAssistant).mockReset();
   vi.mocked(createProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoff).mockReset();
@@ -923,23 +923,10 @@ describe("ProjectsView cockpit", () => {
     await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
 
     await waitFor(() => {
-      expect(proposeProjectAssistant).toHaveBeenCalledWith({
-        title: "Queue Software developer for Build cockpit UI",
-        summary: "Create a queued hecate_task assignment on the selected work item.",
-        actions: [
-          {
-            kind: "create_assignment",
-            target: { project_id: project.id },
-            patch: {
-              project_id: project.id,
-              work_item_id: workItem.id,
-              role_id: role.id,
-              driver_kind: "hecate_task",
-              status: "queued",
-            },
-            reason: "Queue a reviewable assignment without starting execution.",
-          },
-        ],
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        work_item_id: workItem.id,
+        request: "Queue Software developer for Build cockpit UI",
       });
     });
     expect(await within(assistant).findByText("Create assignment")).toBeTruthy();
@@ -983,23 +970,9 @@ describe("ProjectsView cockpit", () => {
     await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
 
     await waitFor(() => {
-      expect(proposeProjectAssistant).toHaveBeenCalledWith({
-        title: "Write project brief",
-        summary: "Create a ready work item from the current assistant draft.",
-        actions: [
-          {
-            kind: "create_work_item",
-            target: { project_id: project.id },
-            patch: {
-              project_id: project.id,
-              title: "Write project brief",
-              brief: "Capture the next operator task.",
-              status: "ready",
-              priority: "normal",
-            },
-            reason: "Create a reviewable project work item.",
-          },
-        ],
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        request: "Write project brief\nCapture the next operator task.",
       });
     });
   });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -17,6 +17,7 @@ import {
   createProjectAssignment,
   createProjectHandoff,
   discoverProjectContextSources,
+  draftProjectAssistant,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
@@ -36,7 +37,6 @@ import {
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
-  proposeProjectAssistant,
   startProjectAssignment,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
@@ -77,7 +77,6 @@ import type {
   ProjectActivityItemRecord,
   ProjectAssistantApplyResult,
   ProjectAssistantProposal,
-  ProjectAssistantProposePayload,
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
@@ -1110,13 +1109,15 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setAssistantError("");
     setAssistantApplyResult(null);
     try {
-      const payload = buildProjectAssistantProposalPayload({
-        form,
-        project: selectedProject,
-        role: projectAssistantResolvedRole(form, roles, selectedWorkItem),
-        workItem: selectedWorkItem,
+      const roleID = form.roleID === PROJECT_ASSISTANT_AUTO ? "" : form.roleID.trim();
+      const driverKind = form.driverKind === PROJECT_ASSISTANT_AUTO ? "" : form.driverKind.trim();
+      const proposal = await draftProjectAssistant({
+        project_id: selectedProject.id,
+        work_item_id: selectedWorkItem?.id,
+        request: form.request,
+        ...(roleID ? { role_id: roleID } : {}),
+        ...(driverKind ? { driver_kind: driverKind } : {}),
       });
-      const proposal = await proposeProjectAssistant(payload);
       setAssistantProposal(proposal.data);
       setAssistantStatus("idle");
     } catch (error) {
@@ -4906,93 +4907,6 @@ function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemS
     },
     { assignmentCount: 0, activeCount: 0, failedCount: 0, completedCount: 0 },
   );
-}
-
-function buildProjectAssistantProposalPayload({
-  form,
-  project,
-  role,
-  workItem,
-}: {
-  form: ProjectAssistantDraftForm;
-  project: ProjectRecord;
-  role: ProjectWorkRoleRecord | null;
-  workItem: ProjectWorkItemRecord | null;
-}): ProjectAssistantProposePayload {
-  const roleID =
-    form.roleID === PROJECT_ASSISTANT_AUTO
-      ? role?.id || ""
-      : (form.roleID || role?.id || "").trim();
-  const driverKind =
-    form.driverKind === PROJECT_ASSISTANT_AUTO
-      ? role?.default_driver_kind || "hecate_task"
-      : (form.driverKind || role?.default_driver_kind || "hecate_task").trim();
-  const request = projectAssistantRequestParts(form.request);
-  if (workItem) {
-    return {
-      title: request.title || `Queue ${role?.name || roleID || "role"} for ${workItem.title}`,
-      summary: `Create a queued ${driverKind} assignment on the selected work item.`,
-      actions: [
-        {
-          kind: "create_assignment",
-          target: { project_id: project.id },
-          patch: {
-            project_id: project.id,
-            work_item_id: workItem.id,
-            role_id: roleID,
-            driver_kind: driverKind,
-            status: "queued",
-          },
-          reason: "Queue a reviewable assignment without starting execution.",
-        },
-      ],
-    };
-  }
-  const patch: Record<string, unknown> = {
-    project_id: project.id,
-    title: request.title || "Untitled project work",
-    brief: request.brief,
-    status: "ready",
-    priority: "normal",
-  };
-  if (roleID) {
-    patch.owner_role_id = roleID;
-  }
-  return {
-    title: request.title || "Create project work item",
-    summary: "Create a ready work item from the current assistant draft.",
-    actions: [
-      {
-        kind: "create_work_item",
-        target: { project_id: project.id },
-        patch,
-        reason: "Create a reviewable project work item.",
-      },
-    ],
-  };
-}
-
-function projectAssistantResolvedRole(
-  form: ProjectAssistantDraftForm,
-  roles: ProjectWorkRoleRecord[],
-  workItem: ProjectWorkItemRecord | null,
-): ProjectWorkRoleRecord | null {
-  if (form.roleID && form.roleID !== PROJECT_ASSISTANT_AUTO) {
-    return roles.find((role) => role.id === form.roleID) ?? null;
-  }
-  return roles.find((role) => role.id === workItem?.owner_role_id) ?? roles[0] ?? null;
-}
-
-function projectAssistantRequestParts(request: string): { title: string; brief: string } {
-  const lines = request
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const title = lines[0] ?? "";
-  return {
-    title,
-    brief: lines.slice(1).join("\n\n"),
-  };
 }
 
 function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): string {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1146,7 +1146,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       await loadProjectMemory(selectedProjectID);
     } catch (error) {
       setAssistantStatus("idle");
-      setAssistantError(projectAssistantApplyErrorMessage(error));
+      setAssistantError(projectAssistantApplyErrorMessage(error, proposal));
       if (error instanceof ApiError && (error.status === 404 || error.status === 409)) {
         const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, selectedWorkItemID);
         if (refreshedWorkItemID) {
@@ -4917,8 +4917,13 @@ function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): 
   return "";
 }
 
-function projectAssistantApplyErrorMessage(error: unknown): string {
+function projectAssistantApplyErrorMessage(
+  error: unknown,
+  proposal?: ProjectAssistantProposal,
+): string {
   if (error instanceof ApiError) {
+    const partialMessage = projectAssistantPartialApplyErrorMessage(error, proposal);
+    if (partialMessage) return partialMessage;
     if (error.status === 404) {
       return "Project Assistant could not find a proposal target. The project may have changed; refresh project work and draft the proposal again.";
     }
@@ -4927,6 +4932,39 @@ function projectAssistantApplyErrorMessage(error: unknown): string {
     }
   }
   return errorMessage(error, "Failed to apply Project Assistant proposal.");
+}
+
+function projectAssistantPartialApplyErrorMessage(
+  error: ApiError,
+  proposal?: ProjectAssistantProposal,
+): string {
+  const failedActionIndex = projectAssistantFailedActionIndex(error.fields.failed_action_index);
+  const partialResult = projectAssistantPartialResult(error.fields.partial_result);
+  if (failedActionIndex === null || !partialResult) return "";
+  const appliedCount = partialResult.actions.length;
+  const totalCount = proposal?.actions.length ?? Math.max(appliedCount, failedActionIndex + 1);
+  return `Project Assistant applied ${appliedCount} of ${totalCount} actions, then failed at action ${failedActionIndex + 1}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
+}
+
+function projectAssistantFailedActionIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyResult | null {
+  if (!value || typeof value !== "object") return null;
+  const result = value as Partial<ProjectAssistantApplyResult>;
+  if (
+    typeof result.proposal_id !== "string" ||
+    typeof result.applied !== "boolean" ||
+    !Array.isArray(result.actions)
+  ) {
+    return null;
+  }
+  return {
+    proposal_id: result.proposal_id,
+    applied: result.applied,
+    actions: result.actions,
+  };
 }
 
 function emptyRoleForm(): RoleForm {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1014,6 +1014,37 @@ describe("api client", () => {
       } satisfies Partial<ApiError>);
     });
 
+    it("preserves nonstandard error fields from the gateway envelope", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              type: "conflict",
+              message: "project assistant apply failed",
+              failed_action_index: 1,
+              partial_result: {
+                proposal_id: "pa_partial",
+                applied: false,
+                actions: [{ kind: "create_assignment", id: "asgn_1" }],
+              },
+            },
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(getUsageSummary("?scope=global")).rejects.toMatchObject({
+        fields: {
+          failed_action_index: 1,
+          partial_result: {
+            proposal_id: "pa_partial",
+            applied: false,
+            actions: [{ kind: "create_assignment", id: "asgn_1" }],
+          },
+        },
+      } satisfies Partial<ApiError>);
+    });
+
     it("falls back to request and trace headers when the error body omits correlation IDs", async () => {
       fetchMock.mockResolvedValue(
         new Response(

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -64,6 +64,7 @@ import type {
   CreateProjectWorkItemPayload,
   ProjectAssistantApplyPayload,
   ProjectAssistantApplyResponse,
+  ProjectAssistantDraftPayload,
   ProjectAssistantProposalResponse,
   ProjectAssistantProposePayload,
   ProjectAssignmentResponse,
@@ -360,6 +361,15 @@ export async function proposeProjectAssistant(
   payload: ProjectAssistantProposePayload,
 ): Promise<ProjectAssistantProposalResponse> {
   return fetchJSON<ProjectAssistantProposalResponse>(`${HECATE_API}/project-assistant/propose`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function draftProjectAssistant(
+  payload: ProjectAssistantDraftPayload,
+): Promise<ProjectAssistantProposalResponse> {
+  return fetchJSON<ProjectAssistantProposalResponse>(`${HECATE_API}/project-assistant/draft`, {
     method: "POST",
     body: payload,
   });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -109,6 +109,7 @@ type ErrorPayload = {
     status?: string;
     stage?: string;
     hint?: string;
+    [key: string]: unknown;
   };
 };
 
@@ -1580,13 +1581,14 @@ export class ApiError extends Error {
   operatorAction: string;
   requestId: string;
   traceId: string;
+  fields: Record<string, unknown>;
   constructor(
     message: string,
     status: number,
     code = "",
-    details: Partial<
-      Pick<ApiError, "userMessage" | "operatorAction" | "requestId" | "traceId">
-    > = {},
+    details: Partial<Pick<ApiError, "userMessage" | "operatorAction" | "requestId" | "traceId">> & {
+      fields?: Record<string, unknown>;
+    } = {},
   ) {
     super(message);
     this.name = "ApiError";
@@ -1596,6 +1598,7 @@ export class ApiError extends Error {
     this.operatorAction = details.operatorAction ?? "";
     this.requestId = details.requestId ?? "";
     this.traceId = details.traceId ?? "";
+    this.fields = details.fields ?? {};
   }
 }
 
@@ -1637,6 +1640,7 @@ async function apiError(response: Response, fallback: string): Promise<ApiError>
     operatorAction: payload.operatorAction,
     requestId: payload.requestId || response.headers.get("X-Request-Id") || "",
     traceId: payload.traceId || response.headers.get("X-Trace-Id") || "",
+    fields: payload.fields,
   });
 }
 
@@ -1650,6 +1654,7 @@ async function errorPayload(
   operatorAction: string;
   requestId: string;
   traceId: string;
+  fields: Record<string, unknown>;
 }> {
   try {
     const payload = (await response.clone().json()) as ErrorPayload;
@@ -1660,6 +1665,7 @@ async function errorPayload(
       operatorAction: payload.error?.operator_action ?? "",
       requestId: payload.error?.request_id ?? "",
       traceId: payload.error?.trace_id ?? "",
+      fields: payload.error ? extraErrorFields(payload.error) : {},
     };
   } catch {
     const text = await response.text().catch(() => "");
@@ -1671,6 +1677,32 @@ async function errorPayload(
       operatorAction: "",
       requestId: "",
       traceId: "",
+      fields: {},
     };
   }
+}
+
+function extraErrorFields(error: NonNullable<ErrorPayload["error"]>): Record<string, unknown> {
+  const {
+    type,
+    message,
+    user_message,
+    operator_action,
+    request_id,
+    trace_id,
+    status,
+    stage,
+    hint,
+    ...fields
+  } = error;
+  void type;
+  void message;
+  void user_message;
+  void operator_action;
+  void request_id;
+  void trace_id;
+  void status;
+  void stage;
+  void hint;
+  return fields;
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -99,6 +99,14 @@ export type ProjectAssistantProposePayload = {
   actions: ProjectAssistantAction[];
 };
 
+export type ProjectAssistantDraftPayload = {
+  project_id: string;
+  work_item_id?: string;
+  request: string;
+  role_id?: string;
+  driver_kind?: string;
+};
+
 export type ProjectAssistantApplyPayload = {
   proposal: ProjectAssistantProposal;
   confirm?: boolean;


### PR DESCRIPTION
## Summary
- Add a server-backed Project Assistant draft endpoint that turns project/work context into reviewable proposals.
- Update the Projects UI to send draft intent instead of building action payloads in the browser.
- Surface partial apply progress from `failed_action_index` / `partial_result` so the operator sees how many actions committed before failure.
- Label empty idle assistant chat rows as drafts and document the draft/propose/apply boundary, including the v0 in-process resume caveat.

## Validation
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `go vet ./...`
- `cd ui && bun run test -- src/lib/api.test.ts src/features/projects/ProjectsView.test.tsx src/features/chats/ChatView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `git diff --check`
