### PR TITLE
feat(ui): refresh workspace changes after agent turns

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -142,7 +142,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   workspace changes panel's Review tab owns changed-file diffs, copy, and
   discard actions; the Files tab owns the full workspace tree. Keep the full
   tree collapsed by default and expand matching directories only when the
-  operator searches or opens them.
+  operator searches or opens them. When the workspace panel is visible, refresh
+  it after an active chat/agent turn settles so the operator sees live changes
+  without pressing Refresh; keep the explicit Refresh action for manual
+  rechecks and recovery.
 - External Agent sessions store their workspace and native ACP session id. New
   UI affordances should preserve that continuity instead of treating every
   prompt as a one-off subprocess.

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -161,6 +161,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const workspaceDialogOpenRef = useRef(false);
   const [chatSettingsOpen, setChatSettingsOpen] = useState(false);
   const [workspaceChangesOpen, setWorkspaceChangesOpen] = useState(false);
+  const [workspaceRefreshSignal, setWorkspaceRefreshSignal] = useState(0);
   const [rightPanelWidth, setRightPanelWidth] = useState(() => readStoredRightPanelWidth());
   const [draftChatStarted, setDraftChatStarted] = useState(false);
   const [rtkOnboardingDismissed, setRTKOnboardingDismissed] = useState(false);
@@ -180,6 +181,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const [taskApprovalBusyID, setTaskApprovalBusyID] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const focusComposerAfterNewChatRef = useRef(false);
+  const workspaceRefreshStateRef = useRef({ agentBusy: false, sessionID: "" });
 
   const activeSessionIsExternal = Boolean(
     state.activeChatSession?.agent_id && state.activeChatSession.agent_id !== "hecate",
@@ -544,6 +546,19 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       setWorkspaceChangesOpen(false);
     }
   }, [activeWorkspacePath, selectedChatReady]);
+
+  useEffect(() => {
+    const previous = workspaceRefreshStateRef.current;
+    workspaceRefreshStateRef.current = { agentBusy, sessionID: activeSessionID };
+    if (
+      workspaceChangesPanelOpen &&
+      previous.sessionID === activeSessionID &&
+      previous.agentBusy &&
+      !agentBusy
+    ) {
+      setWorkspaceRefreshSignal((current) => current + 1);
+    }
+  }, [activeSessionID, agentBusy, workspaceChangesPanelOpen]);
 
   useEffect(() => {
     if (!focusComposerAfterNewChatRef.current || !composerVisible) return;
@@ -996,6 +1011,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                 <ChatWorkspaceChangesPanel
                   sessionID={activeSessionID}
                   workspace={activeWorkspacePath}
+                  refreshSignal={workspaceRefreshSignal}
                   onGetWorkspaceDiff={chatActions.getChatWorkspaceDiff}
                   onGetWorkspaceFiles={chatActions.getChatWorkspaceFiles}
                   onGetWorkspaceFileDiff={chatActions.getChatWorkspaceFileDiff}

--- a/ui/src/features/chats/ChatWorkspaceChangesPanel.test.tsx
+++ b/ui/src/features/chats/ChatWorkspaceChangesPanel.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatWorkspaceChangesPanel } from "./ChatWorkspaceChangesPanel";
+
+const readmePatch = [
+  "diff --git a/README.md b/README.md",
+  "index 1111111..2222222 100644",
+  "--- a/README.md",
+  "+++ b/README.md",
+  "@@ -1 +1 @@",
+  "-old readme",
+  "+live workspace line",
+].join("\n");
+
+describe("ChatWorkspaceChangesPanel", () => {
+  it("refreshes review and loaded file tree when refresh signal changes", async () => {
+    const getWorkspaceDiff = vi
+      .fn()
+      .mockResolvedValueOnce({
+        workspace: "/tmp/hecate",
+        diff_stat: "",
+        diff: "",
+        has_changes: false,
+        files: [],
+      })
+      .mockResolvedValue({
+        workspace: "/tmp/hecate",
+        diff_stat: "README.md | 1 +\n1 file changed, 1 insertion(+)",
+        diff: readmePatch,
+        has_changes: true,
+        files: [{ path: "README.md", additions: 1, deletions: 0, status: "modified" }],
+      });
+    const getWorkspaceFiles = vi
+      .fn()
+      .mockResolvedValueOnce({
+        workspace: "/tmp/hecate",
+        files: [{ path: "README.md", kind: "file", size_bytes: 12, status: "clean" }],
+        truncated: false,
+      })
+      .mockResolvedValue({
+        workspace: "/tmp/hecate",
+        files: [
+          { path: "README.md", kind: "file", size_bytes: 12, status: "modified" },
+          { path: "docs/notes.md", kind: "file", size_bytes: 10, status: "clean" },
+        ],
+        truncated: false,
+      });
+    const getWorkspaceFileDiff = vi.fn(async () => ({
+      path: "README.md",
+      additions: 1,
+      deletions: 0,
+      status: "modified",
+      diff: readmePatch,
+    }));
+    const revertWorkspaceFiles = vi.fn();
+
+    const view = render(
+      <ChatWorkspaceChangesPanel
+        sessionID="chat_1"
+        workspace="/tmp/hecate"
+        refreshSignal={0}
+        onGetWorkspaceDiff={getWorkspaceDiff}
+        onGetWorkspaceFiles={getWorkspaceFiles}
+        onGetWorkspaceFileDiff={getWorkspaceFileDiff}
+        onRevertWorkspaceFiles={revertWorkspaceFiles}
+      />,
+    );
+
+    expect(await screen.findByText("The current workspace is clean.")).toBeTruthy();
+    expect(getWorkspaceDiff).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("tab", { name: /Files/i }));
+    expect(await screen.findByText("README.md")).toBeTruthy();
+    expect(getWorkspaceFiles).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <ChatWorkspaceChangesPanel
+        sessionID="chat_1"
+        workspace="/tmp/hecate"
+        refreshSignal={1}
+        onGetWorkspaceDiff={getWorkspaceDiff}
+        onGetWorkspaceFiles={getWorkspaceFiles}
+        onGetWorkspaceFileDiff={getWorkspaceFileDiff}
+        onRevertWorkspaceFiles={revertWorkspaceFiles}
+      />,
+    );
+
+    await waitFor(() => expect(getWorkspaceDiff).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getWorkspaceFiles).toHaveBeenCalledTimes(2));
+    await userEvent.click(await screen.findByRole("button", { name: "Expand folder docs" }));
+    expect(await screen.findByText("notes.md")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("tab", { name: /Review/i }));
+    expect(await screen.findByText("1 file changed, 1 insertion(+)")).toBeTruthy();
+    expect(await screen.findByRole("region", { name: "Diff README.md" })).toBeTruthy();
+  });
+});

--- a/ui/src/features/chats/ChatWorkspaceChangesPanel.tsx
+++ b/ui/src/features/chats/ChatWorkspaceChangesPanel.tsx
@@ -104,6 +104,7 @@ export function compactWorkspaceChangeLabel(diffStat?: string): string {
 export function ChatWorkspaceChangesPanel({
   sessionID,
   workspace,
+  refreshSignal = 0,
   onGetWorkspaceDiff,
   onGetWorkspaceFiles,
   onGetWorkspaceFileDiff,
@@ -111,6 +112,7 @@ export function ChatWorkspaceChangesPanel({
 }: {
   sessionID: string;
   workspace: string;
+  refreshSignal?: number;
   onGetWorkspaceDiff: (sessionID: string) => Promise<ChatWorkspaceDiffRecord | null>;
   onGetWorkspaceFiles: (sessionID: string) => Promise<ChatWorkspaceFilesRecord | null>;
   onGetWorkspaceFileDiff: (
@@ -146,6 +148,7 @@ export function ChatWorkspaceChangesPanel({
   const filesLoadedRef = useRef(false);
   const fileDiffsRef = useRef<Record<string, ChatChangedFileDiffRecord>>({});
   const failedFileDiffPathsRef = useRef<Set<string>>(new Set());
+  const refreshSignalRef = useRef(refreshSignal);
 
   function replaceFileDiffs(next: Record<string, ChatChangedFileDiffRecord>) {
     fileDiffsRef.current = next;
@@ -303,6 +306,7 @@ export function ChatWorkspaceChangesPanel({
         setExpandedDiffPaths((current) =>
           paths.length === 0 ? [] : current.filter((path) => !paths.includes(path)),
         );
+        if (filesLoadedRef.current) void refreshFiles();
       } else {
         setLocalError("Could not discard those workspace changes.");
       }
@@ -345,6 +349,14 @@ export function ChatWorkspaceChangesPanel({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeView, sessionID, workspace]);
+
+  useEffect(() => {
+    if (refreshSignalRef.current === refreshSignal) return;
+    refreshSignalRef.current = refreshSignal;
+    void refreshReview();
+    if (filesLoadedRef.current) void refreshFiles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshSignal]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- refresh the Workspace changes panel when the active chat/agent turn settles
- refresh the loaded workspace file tree alongside the review diff
- document the UI invariant and add panel-level regression coverage

## Self-review
- refresh only fires for the same active session after a busy-to-idle transition
- opening the panel after a turn still uses the existing initial load path
- Files refresh only runs after the file tree has already been loaded, avoiding extra fetches for Review-only usage
- manual Refresh remains unchanged

## Tests
- `cd ui && bun run test`
- `cd ui && bun run typecheck`
- `cd ui && bun run format:check`
- `just docs-format-check`
- `git diff --check`