### PR TITLE
Add Project Assistant context packet

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -103,12 +103,23 @@ Builds the same project-scoped context packet and role/driver selection that
 use this endpoint to show what `Auto` resolved to before asking the server to
 draft a proposal.
 
-The context packet is deliberately bounded. It includes project defaults and
-roots, the selected work item when present, loaded project roles, recent
-assignments, accepted project memory, pending memory candidates, recent
-activity, and a `selection` block explaining the chosen role and driver.
-The response below is abbreviated; timestamp fields are included in the live
-API response.
+The v0 context packet is item-limited and body-budgeted. It includes project
+defaults and roots, the selected work item when present, loaded project roles,
+recent assignments, accepted project memory, pending memory candidates, recent
+activity, and a `selection` block explaining the chosen role and driver. Memory
+and candidate `body` fields are truncated at per-body byte limits and carry
+`body_original_bytes`, `body_returned_bytes`, `body_tokens_estimate`, and
+`body_truncated` metadata. The top-level `budget` block summarizes the active
+limits and total returned body size.
+
+The token estimate is intentionally cheap and model-independent; provider
+tokenizers remain authoritative when a real LLM-backed Project Assistant
+consumer exists. Candidate bodies are lower-trust by construction, especially
+generated-summary candidates. Future prompt assembly must preserve that trust
+labeling instead of treating candidate bodies as accepted project memory.
+
+The response below is abbreviated; timestamp fields are included in the live API
+response.
 
 ```json
 POST /hecate/v1/project-assistant/context
@@ -145,6 +156,14 @@ POST /hecate/v1/project-assistant/context
     "memory": [],
     "memory_candidates": [],
     "recent_activity": [],
+    "budget": {
+      "memory_body_max_bytes": 4096,
+      "memory_candidate_body_max_bytes": 2048,
+      "body_original_bytes": 0,
+      "body_returned_bytes": 0,
+      "body_tokens_estimate": 0,
+      "body_truncated_count": 0
+    },
     "selection": {
       "role_id": "product_manager",
       "role_name": "Product Manager",

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -96,6 +96,70 @@ requiring it.
 
 ## Endpoints
 
+### `POST /hecate/v1/project-assistant/context`
+
+Builds the same project-scoped context packet and role/driver selection that
+`draft` uses, without creating proposal data or mutating project stores. Clients
+use this endpoint to show what `Auto` resolved to before asking the server to
+draft a proposal.
+
+The context packet is deliberately bounded. It includes project defaults and
+roots, the selected work item when present, loaded project roles, recent
+assignments, accepted project memory, pending memory candidates, recent
+activity, and a `selection` block explaining the chosen role and driver.
+The response below is abbreviated; timestamp fields are included in the live
+API response.
+
+```json
+POST /hecate/v1/project-assistant/context
+{
+  "project_id": "proj_hecate",
+  "work_item_id": "work_next",
+  "request": "Queue product planning\nPrefer a reviewable handoff."
+}
+→ 200
+{
+  "object": "project_assistant.context",
+  "data": {
+    "project": {
+      "id": "proj_hecate",
+      "name": "Hecate",
+      "default_model": "qwen2.5-coder"
+    },
+    "request": "Queue product planning\nPrefer a reviewable handoff.",
+    "selected_work": {
+      "id": "work_next",
+      "title": "Plan next work",
+      "status": "ready",
+      "owner_role_id": "product_manager"
+    },
+    "roles": [
+      {
+        "id": "product_manager",
+        "name": "Product Manager",
+        "default_driver_kind": "external_agent",
+        "built_in": true
+      }
+    ],
+    "assignments": [],
+    "memory": [],
+    "memory_candidates": [],
+    "recent_activity": [],
+    "selection": {
+      "role_id": "product_manager",
+      "role_name": "Product Manager",
+      "role_source": "selected_work_owner",
+      "driver_kind": "external_agent",
+      "driver_source": "role_default",
+      "reason": "Selected work item is owned by Product Manager. Using external_agent from the selected role default."
+    }
+  }
+}
+```
+
+Missing projects, work items, or explicit roles return `404 not_found`.
+Unsupported driver kinds return `400 invalid_request`.
+
 ### `POST /hecate/v1/project-assistant/draft`
 
 Builds a server-owned proposal from project context and a short operator
@@ -108,7 +172,8 @@ loaded project role, and the selected role's default driver, then
 
 Drafting creates proposal data only. It does not create a Hecate Chat session,
 append a chat message, create a task, create a run, queue an assignment, or
-start an external agent session.
+start an external agent session. It uses the same context and selection path as
+`/project-assistant/context`.
 
 ```json
 POST /hecate/v1/project-assistant/draft

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2159,9 +2159,12 @@ Endpoints:
 - `POST /hecate/v1/project-assistant/propose`
 - `POST /hecate/v1/project-assistant/apply`
 
-`context` returns the bounded project packet and inspectable Auto role/driver
-selection that `draft` will use. `draft` creates proposal data only; it does not
-create a chat message, task, run, assignment, or external agent session. See
+`context` returns the v0 item-limited and body-budgeted project packet plus the
+inspectable Auto role/driver selection that `draft` will use. Memory and
+memory-candidate bodies are truncated at per-body byte limits and carry returned
+byte counts, original byte counts, truncation flags, and cheap token estimates.
+`draft` creates proposal data only; it does not create a chat message, task,
+run, assignment, or external agent session. See
 [`project-assistant.md`](project-assistant.md) for the context and draft
 requests, proposal schema, supported action kinds, confirmation behavior, and
 safety model.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2154,14 +2154,17 @@ action set or reapplying a fully applied proposal returns `409 conflict`.
 
 Endpoints:
 
+- `POST /hecate/v1/project-assistant/context`
 - `POST /hecate/v1/project-assistant/draft`
 - `POST /hecate/v1/project-assistant/propose`
 - `POST /hecate/v1/project-assistant/apply`
 
-`draft` creates proposal data only; it does not create a chat message, task,
-run, assignment, or external agent session. See
-[`project-assistant.md`](project-assistant.md) for the draft request, proposal
-schema, supported action kinds, confirmation behavior, and safety model.
+`context` returns the bounded project packet and inspectable Auto role/driver
+selection that `draft` will use. `draft` creates proposal data only; it does not
+create a chat message, task, run, assignment, or external agent session. See
+[`project-assistant.md`](project-assistant.md) for the context and draft
+requests, proposal schema, supported action kinds, confirmation behavior, and
+safety model.
 
 ## Chat session endpoints
 

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -24,9 +24,40 @@ type projectAssistantDraftRequest struct {
 	DriverKind string `json:"driver_kind,omitempty"`
 }
 
+type projectAssistantContextRequest struct {
+	ProjectID  string `json:"project_id"`
+	WorkItemID string `json:"work_item_id,omitempty"`
+	Request    string `json:"request"`
+	RoleID     string `json:"role_id,omitempty"`
+	DriverKind string `json:"driver_kind,omitempty"`
+}
+
 type projectAssistantApplyRequest struct {
 	Proposal projectassistant.Proposal `json:"proposal"`
 	Confirm  bool                      `json:"confirm,omitempty"`
+}
+
+func (h *Handler) HandleProjectAssistantContext(w http.ResponseWriter, r *http.Request) {
+	var req projectAssistantContextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant context request")
+		return
+	}
+	context, err := h.projectAssistantService().Context(r.Context(), projectassistant.ContextInput{
+		ProjectID:  req.ProjectID,
+		WorkItemID: req.WorkItemID,
+		Request:    req.Request,
+		RoleID:     req.RoleID,
+		DriverKind: req.DriverKind,
+	})
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.context",
+		"data":   context,
+	})
 }
 
 func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Request) {
@@ -101,6 +132,7 @@ func (h *Handler) projectAssistantService() *projectassistant.Service {
 			Projects:         h.projects,
 			Chats:            h.agentChat,
 			Work:             h.projectWork,
+			Memory:           h.memory,
 			MemoryCandidates: h.memoryCandidates,
 		}, newOpaqueTaskResourceID)
 	}

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -26,6 +26,11 @@ type projectAssistantApplyResponse struct {
 	Data   projectassistant.ApplyResult `json:"data"`
 }
 
+type projectAssistantContextResponse struct {
+	Object string                        `json:"object"`
+	Data   projectassistant.DraftContext `json:"data"`
+}
+
 type projectAssistantErrorResponse struct {
 	Error struct {
 		Type              string                       `json:"type"`
@@ -47,6 +52,68 @@ func newProjectAssistantTestHandler() (*Handler, http.Handler) {
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
 	handler.SetMemoryStore(memory.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
+}
+
+func TestProjectAssistantAPI_ContextBuildsSelectionPacket(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_context", Name: "Context Project"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	role, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                "planner",
+		ProjectID:         project.ID,
+		Name:              "Planning Lead",
+		DefaultDriverKind: projectwork.AssignmentDriverExternalAgent,
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	workItem, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:          "work_context",
+		ProjectID:   project.ID,
+		Title:       "Plan context",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: role.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_context",
+		ProjectID:  project.ID,
+		Title:      "Context decision",
+		Body:       "Expose assistant context before model drafting.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader([]byte(`{
+		"project_id":"proj_context",
+		"work_item_id":"work_context",
+		"request":"Queue planning"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("context status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantContextResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode context response: %v", err)
+	}
+	if response.Object != "project_assistant.context" || response.Data.Project.ID != project.ID || response.Data.SelectedWork == nil || response.Data.SelectedWork.ID != workItem.ID {
+		t.Fatalf("context response = %+v, want project assistant context with selected work", response)
+	}
+	if response.Data.Selection.RoleID != role.ID || response.Data.Selection.DriverKind != projectwork.AssignmentDriverExternalAgent || response.Data.Selection.RoleSource != "selected_work_owner" {
+		t.Fatalf("selection = %+v, want owner role and external driver", response.Data.Selection)
+	}
+	if len(response.Data.Memory) != 1 || response.Data.Memory[0].ID != "mem_context" {
+		t.Fatalf("memory = %+v, want memory entry included", response.Data.Memory)
+	}
 }
 
 func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
@@ -113,6 +114,72 @@ func TestProjectAssistantAPI_ContextBuildsSelectionPacket(t *testing.T) {
 	}
 	if len(response.Data.Memory) != 1 || response.Data.Memory[0].ID != "mem_context" {
 		t.Fatalf("memory = %+v, want memory entry included", response.Data.Memory)
+	}
+}
+
+func TestProjectAssistantAPI_ContextBudgetsMemoryBodies(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_budget", Name: "Budget Project"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	memoryBody := strings.Repeat("é", 6000)
+	candidateBody := strings.Repeat("é", 3000)
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_budget",
+		ProjectID:  project.ID,
+		Title:      "Large context memory",
+		Body:       memoryBody,
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:                  "cand_budget",
+		ProjectID:           project.ID,
+		Title:               "Large context candidate",
+		Body:                candidateBody,
+		SuggestedTrustLabel: memory.TrustLabelGenerated,
+		SuggestedSourceKind: memory.SourceKindGenerated,
+		Status:              memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("Create candidate: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader([]byte(`{
+		"project_id":"proj_budget",
+		"request":"Inspect context budget"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("context status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantContextResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode context response: %v", err)
+	}
+	if len(response.Data.Memory) != 1 || len(response.Data.MemoryCandidates) != 1 {
+		t.Fatalf("memory/candidates = %+v/%+v, want one of each", response.Data.Memory, response.Data.MemoryCandidates)
+	}
+	gotMemory := response.Data.Memory[0]
+	if !gotMemory.BodyTruncated || gotMemory.BodyOriginalBytes != len(memoryBody) || gotMemory.BodyReturnedBytes != len(gotMemory.Body) {
+		t.Fatalf("memory budget = %+v, want truncated body with original and returned byte counts", gotMemory)
+	}
+	if !strings.HasSuffix(gotMemory.Body, "\n...[truncated]") || !utf8.ValidString(gotMemory.Body) {
+		t.Fatalf("memory body suffix/utf8 = %v/%v, want truncated suffix and valid utf8", strings.HasSuffix(gotMemory.Body, "\n...[truncated]"), utf8.ValidString(gotMemory.Body))
+	}
+	gotCandidate := response.Data.MemoryCandidates[0]
+	if !gotCandidate.BodyTruncated || gotCandidate.BodyOriginalBytes != len(candidateBody) || gotCandidate.BodyReturnedBytes != len(gotCandidate.Body) {
+		t.Fatalf("candidate budget = %+v, want truncated body with original and returned byte counts", gotCandidate)
+	}
+	if !strings.HasSuffix(gotCandidate.Body, "\n...[truncated]") || !utf8.ValidString(gotCandidate.Body) {
+		t.Fatalf("candidate body suffix/utf8 = %v/%v, want truncated suffix and valid utf8", strings.HasSuffix(gotCandidate.Body, "\n...[truncated]"), utf8.ValidString(gotCandidate.Body))
+	}
+	if response.Data.Budget.BodyTruncatedCount != 2 || response.Data.Budget.BodyOriginalBytes != gotMemory.BodyOriginalBytes+gotCandidate.BodyOriginalBytes || response.Data.Budget.BodyReturnedBytes != gotMemory.BodyReturnedBytes+gotCandidate.BodyReturnedBytes {
+		t.Fatalf("context budget = %+v, want aggregate body metadata", response.Data.Budget)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,6 +70,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	// to them for shared defaults, memory, and context assembly.
 	mux.HandleFunc("GET /hecate/v1/projects", handler.HandleProjects)
 	mux.HandleFunc("POST /hecate/v1/projects", handler.HandleCreateProject)
+	mux.HandleFunc("POST /hecate/v1/project-assistant/context", handler.HandleProjectAssistantContext)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/draft", handler.HandleProjectAssistantDraft)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/propose", handler.HandleProjectAssistantPropose)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/apply", handler.HandleProjectAssistantApply)

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -13,10 +13,13 @@ import (
 )
 
 const (
-	contextAssignmentLimit      = 12
-	contextMemoryLimit          = 12
-	contextMemoryCandidateLimit = 12
-	contextActivityLimit        = 16
+	contextAssignmentLimit       = 12
+	contextMemoryLimit           = 12
+	contextMemoryCandidateLimit  = 12
+	contextActivityLimit         = 16
+	contextMemoryBodyMaxBytes    = 4096
+	contextCandidateBodyMaxBytes = 2048
+	contextTruncatedSuffix       = "\n...[truncated]"
 )
 
 type DraftContext struct {
@@ -28,7 +31,17 @@ type DraftContext struct {
 	Memory           []MemoryContext          `json:"memory,omitempty"`
 	MemoryCandidates []MemoryCandidateContext `json:"memory_candidates,omitempty"`
 	RecentActivity   []ActivityContext        `json:"recent_activity,omitempty"`
+	Budget           ContextBudget            `json:"budget"`
 	Selection        DraftSelection           `json:"selection"`
+}
+
+type ContextBudget struct {
+	MemoryBodyMaxBytes          int `json:"memory_body_max_bytes"`
+	MemoryCandidateBodyMaxBytes int `json:"memory_candidate_body_max_bytes"`
+	BodyOriginalBytes           int `json:"body_original_bytes"`
+	BodyReturnedBytes           int `json:"body_returned_bytes"`
+	BodyTokensEstimate          int `json:"body_tokens_estimate"`
+	BodyTruncatedCount          int `json:"body_truncated_count"`
 }
 
 type ProjectContext struct {
@@ -97,21 +110,29 @@ type AssignmentContext struct {
 }
 
 type MemoryContext struct {
-	ID         string    `json:"id"`
-	Title      string    `json:"title"`
-	Body       string    `json:"body"`
-	TrustLabel string    `json:"trust_label"`
-	SourceKind string    `json:"source_kind"`
-	SourceID   string    `json:"source_id,omitempty"`
-	Enabled    bool      `json:"enabled"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID                 string    `json:"id"`
+	Title              string    `json:"title"`
+	Body               string    `json:"body"`
+	BodyOriginalBytes  int       `json:"body_original_bytes"`
+	BodyReturnedBytes  int       `json:"body_returned_bytes"`
+	BodyTokensEstimate int       `json:"body_tokens_estimate"`
+	BodyTruncated      bool      `json:"body_truncated"`
+	TrustLabel         string    `json:"trust_label"`
+	SourceKind         string    `json:"source_kind"`
+	SourceID           string    `json:"source_id,omitempty"`
+	Enabled            bool      `json:"enabled"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
 }
 
 type MemoryCandidateContext struct {
 	ID                  string                      `json:"id"`
 	Title               string                      `json:"title"`
 	Body                string                      `json:"body"`
+	BodyOriginalBytes   int                         `json:"body_original_bytes"`
+	BodyReturnedBytes   int                         `json:"body_returned_bytes"`
+	BodyTokensEstimate  int                         `json:"body_tokens_estimate"`
+	BodyTruncated       bool                        `json:"body_truncated"`
 	SuggestedKind       string                      `json:"suggested_kind,omitempty"`
 	SuggestedTrustLabel string                      `json:"suggested_trust_label,omitempty"`
 	SuggestedSourceKind string                      `json:"suggested_source_kind,omitempty"`
@@ -192,6 +213,7 @@ func (s *Service) Context(ctx context.Context, input ContextInput) (DraftContext
 		Memory:           memoryItems,
 		MemoryCandidates: candidates,
 		RecentActivity:   recentActivity(workItem, assignments, memoryItems, candidates),
+		Budget:           contextBudget(memoryItems, candidates),
 		Selection:        selection,
 	}, nil
 }
@@ -434,24 +456,34 @@ func assignmentContext(item projectwork.Assignment) AssignmentContext {
 }
 
 func memoryContext(item memory.Entry) MemoryContext {
+	body := budgetedBody(item.Body, contextMemoryBodyMaxBytes)
 	return MemoryContext{
-		ID:         item.ID,
-		Title:      item.Title,
-		Body:       item.Body,
-		TrustLabel: item.TrustLabel,
-		SourceKind: item.SourceKind,
-		SourceID:   item.SourceID,
-		Enabled:    item.Enabled,
-		CreatedAt:  item.CreatedAt,
-		UpdatedAt:  item.UpdatedAt,
+		ID:                 item.ID,
+		Title:              item.Title,
+		Body:               body.Text,
+		BodyOriginalBytes:  body.OriginalBytes,
+		BodyReturnedBytes:  body.ReturnedBytes,
+		BodyTokensEstimate: body.TokensEstimate,
+		BodyTruncated:      body.Truncated,
+		TrustLabel:         item.TrustLabel,
+		SourceKind:         item.SourceKind,
+		SourceID:           item.SourceID,
+		Enabled:            item.Enabled,
+		CreatedAt:          item.CreatedAt,
+		UpdatedAt:          item.UpdatedAt,
 	}
 }
 
 func memoryCandidateContext(item memory.Candidate) MemoryCandidateContext {
+	body := budgetedBody(item.Body, contextCandidateBodyMaxBytes)
 	return MemoryCandidateContext{
 		ID:                  item.ID,
 		Title:               item.Title,
-		Body:                item.Body,
+		Body:                body.Text,
+		BodyOriginalBytes:   body.OriginalBytes,
+		BodyReturnedBytes:   body.ReturnedBytes,
+		BodyTokensEstimate:  body.TokensEstimate,
+		BodyTruncated:       body.Truncated,
 		SuggestedKind:       item.SuggestedKind,
 		SuggestedTrustLabel: item.SuggestedTrustLabel,
 		SuggestedSourceKind: item.SuggestedSourceKind,
@@ -486,6 +518,96 @@ func recentActivity(workItem *projectwork.WorkItem, assignments []AssignmentCont
 		out = out[:contextActivityLimit]
 	}
 	return out
+}
+
+type contextBodyBudget struct {
+	Text           string
+	OriginalBytes  int
+	ReturnedBytes  int
+	TokensEstimate int
+	Truncated      bool
+}
+
+func budgetedBody(body string, maxBytes int) contextBodyBudget {
+	body = strings.TrimSpace(body)
+	originalBytes := len(body)
+	if originalBytes == 0 {
+		return contextBodyBudget{}
+	}
+	if maxBytes <= 0 {
+		return contextBodyBudget{
+			OriginalBytes:  originalBytes,
+			TokensEstimate: estimateTokensFromBytes(originalBytes),
+			Truncated:      true,
+		}
+	}
+	out := body
+	truncated := false
+	if len(out) > maxBytes {
+		truncated = true
+		if maxBytes <= len(contextTruncatedSuffix) {
+			out = contextTruncatedSuffix[:maxBytes]
+		} else {
+			end := truncateStringByteIndex(out, maxBytes-len(contextTruncatedSuffix))
+			out = strings.TrimRight(out[:end], "\r\n\t ") + contextTruncatedSuffix
+			if len(out) > maxBytes {
+				end = truncateStringByteIndex(out, maxBytes-len(contextTruncatedSuffix))
+				out = out[:end] + contextTruncatedSuffix
+			}
+		}
+	}
+	return contextBodyBudget{
+		Text:           out,
+		OriginalBytes:  originalBytes,
+		ReturnedBytes:  len(out),
+		TokensEstimate: estimateTokensFromBytes(len(out)),
+		Truncated:      truncated,
+	}
+}
+
+func contextBudget(memoryItems []MemoryContext, candidates []MemoryCandidateContext) ContextBudget {
+	budget := ContextBudget{
+		MemoryBodyMaxBytes:          contextMemoryBodyMaxBytes,
+		MemoryCandidateBodyMaxBytes: contextCandidateBodyMaxBytes,
+	}
+	for _, item := range memoryItems {
+		budget.BodyOriginalBytes += item.BodyOriginalBytes
+		budget.BodyReturnedBytes += item.BodyReturnedBytes
+		budget.BodyTokensEstimate += item.BodyTokensEstimate
+		if item.BodyTruncated {
+			budget.BodyTruncatedCount++
+		}
+	}
+	for _, item := range candidates {
+		budget.BodyOriginalBytes += item.BodyOriginalBytes
+		budget.BodyReturnedBytes += item.BodyReturnedBytes
+		budget.BodyTokensEstimate += item.BodyTokensEstimate
+		if item.BodyTruncated {
+			budget.BodyTruncatedCount++
+		}
+	}
+	return budget
+}
+
+func estimateTokensFromBytes(size int) int {
+	if size <= 0 {
+		return 0
+	}
+	return (size + 3) / 4
+}
+
+func truncateStringByteIndex(content string, maxBytes int) int {
+	if len(content) <= maxBytes {
+		return len(content)
+	}
+	end := 0
+	for index := range content {
+		if index > maxBytes {
+			break
+		}
+		end = index
+	}
+	return end
 }
 
 func roleDisplayName(role projectwork.AgentRoleProfile) string {

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -1,0 +1,511 @@
+package projectassistant
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+const (
+	contextAssignmentLimit      = 12
+	contextMemoryLimit          = 12
+	contextMemoryCandidateLimit = 12
+	contextActivityLimit        = 16
+)
+
+type DraftContext struct {
+	Project          ProjectContext           `json:"project"`
+	Request          string                   `json:"request"`
+	SelectedWork     *WorkItemContext         `json:"selected_work,omitempty"`
+	Roles            []RoleContext            `json:"roles"`
+	Assignments      []AssignmentContext      `json:"assignments,omitempty"`
+	Memory           []MemoryContext          `json:"memory,omitempty"`
+	MemoryCandidates []MemoryCandidateContext `json:"memory_candidates,omitempty"`
+	RecentActivity   []ActivityContext        `json:"recent_activity,omitempty"`
+	Selection        DraftSelection           `json:"selection"`
+}
+
+type ProjectContext struct {
+	ID                   string               `json:"id"`
+	Name                 string               `json:"name"`
+	Description          string               `json:"description,omitempty"`
+	Roots                []ProjectRootContext `json:"roots,omitempty"`
+	DefaultRootID        string               `json:"default_root_id,omitempty"`
+	DefaultProvider      string               `json:"default_provider,omitempty"`
+	DefaultModel         string               `json:"default_model,omitempty"`
+	DefaultAgentProfile  string               `json:"default_agent_profile,omitempty"`
+	DefaultWorkspaceMode string               `json:"default_workspace_mode,omitempty"`
+	CreatedAt            time.Time            `json:"created_at"`
+	UpdatedAt            time.Time            `json:"updated_at"`
+}
+
+type ProjectRootContext struct {
+	ID        string `json:"id"`
+	Path      string `json:"path"`
+	Kind      string `json:"kind"`
+	GitRemote string `json:"git_remote,omitempty"`
+	GitBranch string `json:"git_branch,omitempty"`
+	Active    bool   `json:"active"`
+}
+
+type WorkItemContext struct {
+	ID              string    `json:"id"`
+	Title           string    `json:"title"`
+	Brief           string    `json:"brief,omitempty"`
+	Status          string    `json:"status"`
+	Priority        string    `json:"priority,omitempty"`
+	OwnerRoleID     string    `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string  `json:"reviewer_role_ids,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+type RoleContext struct {
+	ID                  string    `json:"id"`
+	Name                string    `json:"name"`
+	Description         string    `json:"description,omitempty"`
+	DefaultDriverKind   string    `json:"default_driver_kind,omitempty"`
+	DefaultProvider     string    `json:"default_provider,omitempty"`
+	DefaultModel        string    `json:"default_model,omitempty"`
+	DefaultAgentProfile string    `json:"default_agent_profile,omitempty"`
+	BuiltIn             bool      `json:"built_in"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+type AssignmentContext struct {
+	ID                string     `json:"id"`
+	WorkItemID        string     `json:"work_item_id"`
+	RoleID            string     `json:"role_id"`
+	DriverKind        string     `json:"driver_kind"`
+	Status            string     `json:"status"`
+	TaskID            string     `json:"task_id,omitempty"`
+	RunID             string     `json:"run_id,omitempty"`
+	ChatSessionID     string     `json:"chat_session_id,omitempty"`
+	MessageID         string     `json:"message_id,omitempty"`
+	ContextSnapshotID string     `json:"context_snapshot_id,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	StartedAt         *time.Time `json:"started_at,omitempty"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+}
+
+type MemoryContext struct {
+	ID         string    `json:"id"`
+	Title      string    `json:"title"`
+	Body       string    `json:"body"`
+	TrustLabel string    `json:"trust_label"`
+	SourceKind string    `json:"source_kind"`
+	SourceID   string    `json:"source_id,omitempty"`
+	Enabled    bool      `json:"enabled"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type MemoryCandidateContext struct {
+	ID                  string                      `json:"id"`
+	Title               string                      `json:"title"`
+	Body                string                      `json:"body"`
+	SuggestedKind       string                      `json:"suggested_kind,omitempty"`
+	SuggestedTrustLabel string                      `json:"suggested_trust_label,omitempty"`
+	SuggestedSourceKind string                      `json:"suggested_source_kind,omitempty"`
+	SuggestedSourceID   string                      `json:"suggested_source_id,omitempty"`
+	SourceRefs          []memory.CandidateSourceRef `json:"source_refs,omitempty"`
+	Status              string                      `json:"status"`
+	StatusReason        string                      `json:"status_reason,omitempty"`
+	PromotedMemoryID    string                      `json:"promoted_memory_id,omitempty"`
+	CreatedAt           time.Time                   `json:"created_at"`
+	UpdatedAt           time.Time                   `json:"updated_at"`
+}
+
+type ActivityContext struct {
+	Kind      string    `json:"kind"`
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type DraftSelection struct {
+	RoleID       string `json:"role_id,omitempty"`
+	RoleName     string `json:"role_name,omitempty"`
+	RoleSource   string `json:"role_source,omitempty"`
+	DriverKind   string `json:"driver_kind"`
+	DriverSource string `json:"driver_source"`
+	Reason       string `json:"reason"`
+}
+
+func (s *Service) Context(ctx context.Context, input ContextInput) (DraftContext, error) {
+	if s == nil || s.projects == nil || s.work == nil {
+		return DraftContext{}, ErrStoreNotConfigured
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	if projectID == "" {
+		return DraftContext{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	project, ok, err := s.projects.Get(ctx, projectID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	if !ok {
+		return DraftContext{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
+	}
+	roles, err := s.work.ListRoles(ctx, project.ID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	workItem, err := s.contextWorkItem(ctx, project.ID, input.WorkItemID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	selection, err := draftSelection(input, roles, workItem)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	if workItem != nil && selection.RoleID == "" {
+		return DraftContext{}, fmt.Errorf("%w: role_id is required for assignment drafts", ErrInvalid)
+	}
+	assignments, err := s.contextAssignments(ctx, project.ID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	memoryItems, err := s.contextMemory(ctx, project.ID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	candidates, err := s.contextMemoryCandidates(ctx, project.ID)
+	if err != nil {
+		return DraftContext{}, err
+	}
+	return DraftContext{
+		Project:          projectContext(project),
+		Request:          strings.TrimSpace(input.Request),
+		SelectedWork:     workItemContextPtr(workItem),
+		Roles:            roleContexts(roles),
+		Assignments:      assignments,
+		Memory:           memoryItems,
+		MemoryCandidates: candidates,
+		RecentActivity:   recentActivity(workItem, assignments, memoryItems, candidates),
+		Selection:        selection,
+	}, nil
+}
+
+func (s *Service) contextWorkItem(ctx context.Context, projectID, workItemID string) (*projectwork.WorkItem, error) {
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return nil, nil
+	}
+	item, found, err := s.work.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("%w: project work item %q", ErrNotFound, workItemID)
+	}
+	return &item, nil
+}
+
+func (s *Service) contextAssignments(ctx context.Context, projectID string) ([]AssignmentContext, error) {
+	items, err := s.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+	if len(items) > contextAssignmentLimit {
+		items = items[:contextAssignmentLimit]
+	}
+	out := make([]AssignmentContext, 0, len(items))
+	for _, item := range items {
+		out = append(out, assignmentContext(item))
+	}
+	return out, nil
+}
+
+func (s *Service) contextMemory(ctx context.Context, projectID string) ([]MemoryContext, error) {
+	if s.memory == nil {
+		return nil, nil
+	}
+	items, err := s.memory.List(ctx, memory.Filter{ProjectID: projectID})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+	if len(items) > contextMemoryLimit {
+		items = items[:contextMemoryLimit]
+	}
+	out := make([]MemoryContext, 0, len(items))
+	for _, item := range items {
+		out = append(out, memoryContext(item))
+	}
+	return out, nil
+}
+
+func (s *Service) contextMemoryCandidates(ctx context.Context, projectID string) ([]MemoryCandidateContext, error) {
+	if s.memoryCandidates == nil {
+		return nil, nil
+	}
+	items, err := s.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+		ProjectID: projectID,
+		Status:    memory.CandidateStatusPending,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+	if len(items) > contextMemoryCandidateLimit {
+		items = items[:contextMemoryCandidateLimit]
+	}
+	out := make([]MemoryCandidateContext, 0, len(items))
+	for _, item := range items {
+		out = append(out, memoryCandidateContext(item))
+	}
+	return out, nil
+}
+
+func draftSelection(input ContextInput, roles []projectwork.AgentRoleProfile, workItem *projectwork.WorkItem) (DraftSelection, error) {
+	role, roleSource, roleReason := selectDraftRole(strings.TrimSpace(input.RoleID), roles, workItem)
+	if strings.TrimSpace(input.RoleID) != "" && role == nil {
+		return DraftSelection{}, fmt.Errorf("%w: role %q", ErrNotFound, strings.TrimSpace(input.RoleID))
+	}
+	driverKind, driverSource, driverReason := selectDraftDriver(strings.TrimSpace(input.DriverKind), role)
+	if !validDraftDriverKind(driverKind) {
+		return DraftSelection{}, fmt.Errorf("%w: unsupported assignment driver_kind %q", ErrInvalid, driverKind)
+	}
+	selection := DraftSelection{
+		DriverKind:   driverKind,
+		DriverSource: driverSource,
+		Reason:       strings.Join(nonEmptyStrings(roleReason, driverReason), " "),
+	}
+	if role != nil {
+		selection.RoleID = role.ID
+		selection.RoleName = role.Name
+		selection.RoleSource = roleSource
+	}
+	return selection, nil
+}
+
+func selectDraftRole(roleID string, roles []projectwork.AgentRoleProfile, workItem *projectwork.WorkItem) (*projectwork.AgentRoleProfile, string, string) {
+	if roleID != "" {
+		if role := findDraftRole(roleID, roles); role != nil {
+			return role, "explicit", fmt.Sprintf("Operator selected role %s.", roleDisplayName(*role))
+		}
+		return nil, "", ""
+	}
+	if workItem != nil && strings.TrimSpace(workItem.OwnerRoleID) != "" {
+		if role := findDraftRole(workItem.OwnerRoleID, roles); role != nil {
+			return role, "selected_work_owner", fmt.Sprintf("Selected work item is owned by %s.", roleDisplayName(*role))
+		}
+		if len(roles) > 0 {
+			role := roles[0]
+			return &role, "first_role", fmt.Sprintf("Selected work item owner role %q is not loaded; using first project role %s.", workItem.OwnerRoleID, roleDisplayName(role))
+		}
+		return nil, "", fmt.Sprintf("Selected work item owner role %q is not loaded and no project roles are available.", workItem.OwnerRoleID)
+	}
+	if len(roles) > 0 {
+		role := roles[0]
+		return &role, "first_role", fmt.Sprintf("No selected work owner role; using first project role %s.", roleDisplayName(role))
+	}
+	return nil, "", "No project roles are available; new work item drafts will be unowned."
+}
+
+func selectDraftDriver(driverKind string, role *projectwork.AgentRoleProfile) (string, string, string) {
+	if driverKind != "" {
+		return driverKind, "explicit", fmt.Sprintf("Operator selected driver %s.", driverKind)
+	}
+	if role != nil && strings.TrimSpace(role.DefaultDriverKind) != "" {
+		driver := strings.TrimSpace(role.DefaultDriverKind)
+		return driver, "role_default", fmt.Sprintf("Using %s from the selected role default.", driver)
+	}
+	return projectwork.AssignmentDriverHecateTask, "fallback", "No driver hint was set; using hecate_task."
+}
+
+func findDraftRole(roleID string, roles []projectwork.AgentRoleProfile) *projectwork.AgentRoleProfile {
+	roleID = strings.TrimSpace(roleID)
+	for _, role := range roles {
+		if role.ID == roleID {
+			found := role
+			return &found
+		}
+	}
+	return nil
+}
+
+func projectContext(project projects.Project) ProjectContext {
+	return ProjectContext{
+		ID:                   project.ID,
+		Name:                 project.Name,
+		Description:          project.Description,
+		Roots:                projectRootContexts(project.Roots),
+		DefaultRootID:        project.DefaultRootID,
+		DefaultProvider:      project.DefaultProvider,
+		DefaultModel:         project.DefaultModel,
+		DefaultAgentProfile:  project.DefaultAgentProfile,
+		DefaultWorkspaceMode: project.DefaultWorkspaceMode,
+		CreatedAt:            project.CreatedAt,
+		UpdatedAt:            project.UpdatedAt,
+	}
+}
+
+func projectRootContexts(items []projects.Root) []ProjectRootContext {
+	out := make([]ProjectRootContext, 0, len(items))
+	for _, item := range items {
+		out = append(out, ProjectRootContext{
+			ID:        item.ID,
+			Path:      item.Path,
+			Kind:      item.Kind,
+			GitRemote: item.GitRemote,
+			GitBranch: item.GitBranch,
+			Active:    item.Active,
+		})
+	}
+	return out
+}
+
+func workItemContextPtr(item *projectwork.WorkItem) *WorkItemContext {
+	if item == nil {
+		return nil
+	}
+	context := workItemContext(*item)
+	return &context
+}
+
+func workItemContext(item projectwork.WorkItem) WorkItemContext {
+	return WorkItemContext{
+		ID:              item.ID,
+		Title:           item.Title,
+		Brief:           item.Brief,
+		Status:          item.Status,
+		Priority:        item.Priority,
+		OwnerRoleID:     item.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func roleContexts(items []projectwork.AgentRoleProfile) []RoleContext {
+	out := make([]RoleContext, 0, len(items))
+	for _, item := range items {
+		out = append(out, RoleContext{
+			ID:                  item.ID,
+			Name:                item.Name,
+			Description:         item.Description,
+			DefaultDriverKind:   item.DefaultDriverKind,
+			DefaultProvider:     item.DefaultProvider,
+			DefaultModel:        item.DefaultModel,
+			DefaultAgentProfile: item.DefaultAgentProfile,
+			BuiltIn:             item.BuiltIn,
+			CreatedAt:           item.CreatedAt,
+			UpdatedAt:           item.UpdatedAt,
+		})
+	}
+	return out
+}
+
+func assignmentContext(item projectwork.Assignment) AssignmentContext {
+	return AssignmentContext{
+		ID:                item.ID,
+		WorkItemID:        item.WorkItemID,
+		RoleID:            item.RoleID,
+		DriverKind:        item.DriverKind,
+		Status:            item.Status,
+		TaskID:            item.TaskID,
+		RunID:             item.RunID,
+		ChatSessionID:     item.ChatSessionID,
+		MessageID:         item.MessageID,
+		ContextSnapshotID: item.ContextSnapshotID,
+		CreatedAt:         item.CreatedAt,
+		UpdatedAt:         item.UpdatedAt,
+		StartedAt:         timePtrIfSet(item.StartedAt),
+		CompletedAt:       timePtrIfSet(item.CompletedAt),
+	}
+}
+
+func memoryContext(item memory.Entry) MemoryContext {
+	return MemoryContext{
+		ID:         item.ID,
+		Title:      item.Title,
+		Body:       item.Body,
+		TrustLabel: item.TrustLabel,
+		SourceKind: item.SourceKind,
+		SourceID:   item.SourceID,
+		Enabled:    item.Enabled,
+		CreatedAt:  item.CreatedAt,
+		UpdatedAt:  item.UpdatedAt,
+	}
+}
+
+func memoryCandidateContext(item memory.Candidate) MemoryCandidateContext {
+	return MemoryCandidateContext{
+		ID:                  item.ID,
+		Title:               item.Title,
+		Body:                item.Body,
+		SuggestedKind:       item.SuggestedKind,
+		SuggestedTrustLabel: item.SuggestedTrustLabel,
+		SuggestedSourceKind: item.SuggestedSourceKind,
+		SuggestedSourceID:   item.SuggestedSourceID,
+		SourceRefs:          append([]memory.CandidateSourceRef(nil), item.SourceRefs...),
+		Status:              item.Status,
+		StatusReason:        item.StatusReason,
+		PromotedMemoryID:    item.PromotedMemoryID,
+		CreatedAt:           item.CreatedAt,
+		UpdatedAt:           item.UpdatedAt,
+	}
+}
+
+func recentActivity(workItem *projectwork.WorkItem, assignments []AssignmentContext, memoryItems []MemoryContext, candidates []MemoryCandidateContext) []ActivityContext {
+	var out []ActivityContext
+	if workItem != nil {
+		out = append(out, ActivityContext{Kind: "selected_work", ID: workItem.ID, Title: workItem.Title, Status: workItem.Status, UpdatedAt: workItem.UpdatedAt})
+	}
+	for _, item := range assignments {
+		out = append(out, ActivityContext{Kind: "assignment", ID: item.ID, Title: item.WorkItemID, Status: item.Status, UpdatedAt: item.UpdatedAt})
+	}
+	for _, item := range memoryItems {
+		out = append(out, ActivityContext{Kind: "memory", ID: item.ID, Title: item.Title, Status: item.TrustLabel, UpdatedAt: item.UpdatedAt})
+	}
+	for _, item := range candidates {
+		out = append(out, ActivityContext{Kind: "memory_candidate", ID: item.ID, Title: item.Title, Status: item.Status, UpdatedAt: item.UpdatedAt})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	if len(out) > contextActivityLimit {
+		out = out[:contextActivityLimit]
+	}
+	return out
+}
+
+func roleDisplayName(role projectwork.AgentRoleProfile) string {
+	return firstNonEmpty(role.Name, role.ID, "role")
+}
+
+func nonEmptyStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func timePtrIfSet(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	copy := value
+	return &copy
+}

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	projects         projects.Store
 	chats            chat.Store
 	work             projectwork.Store
+	memory           memory.Store
 	memoryCandidates memory.CandidateStore
 	idgen            IDGenerator
 	applyProgress    map[string]*applyProgress
@@ -55,6 +56,7 @@ type Stores struct {
 	Projects         projects.Store
 	Chats            chat.Store
 	Work             projectwork.Store
+	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
 }
 
@@ -73,6 +75,14 @@ type DraftInput struct {
 	RoleID     string
 	DriverKind string
 	TraceID    string
+}
+
+type ContextInput struct {
+	ProjectID  string
+	WorkItemID string
+	Request    string
+	RoleID     string
+	DriverKind string
 }
 
 type Proposal struct {
@@ -153,6 +163,7 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		projects:         stores.Projects,
 		chats:            stores.Chats,
 		work:             stores.Work,
+		memory:           stores.Memory,
 		memoryCandidates: stores.MemoryCandidates,
 		idgen:            idgen,
 		applyProgress:    make(map[string]*applyProgress),
@@ -191,63 +202,36 @@ func (s *Service) Propose(_ context.Context, input ProposalInput) (Proposal, err
 }
 
 func (s *Service) Draft(ctx context.Context, input DraftInput) (Proposal, error) {
-	if s == nil || s.projects == nil || s.work == nil {
-		return Proposal{}, ErrStoreNotConfigured
-	}
-	projectID := strings.TrimSpace(input.ProjectID)
-	if projectID == "" {
-		return Proposal{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
-	}
-	project, ok, err := s.projects.Get(ctx, projectID)
+	draftContext, err := s.Context(ctx, ContextInput{
+		ProjectID:  input.ProjectID,
+		WorkItemID: input.WorkItemID,
+		Request:    input.Request,
+		RoleID:     input.RoleID,
+		DriverKind: input.DriverKind,
+	})
 	if err != nil {
 		return Proposal{}, err
-	}
-	if !ok {
-		return Proposal{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
-	}
-	roles, err := s.work.ListRoles(ctx, project.ID)
-	if err != nil {
-		return Proposal{}, err
-	}
-	workItemID := strings.TrimSpace(input.WorkItemID)
-	var workItem *projectwork.WorkItem
-	if workItemID != "" {
-		item, found, err := s.work.GetWorkItem(ctx, project.ID, workItemID)
-		if err != nil {
-			return Proposal{}, err
-		}
-		if !found {
-			return Proposal{}, fmt.Errorf("%w: project work item %q", ErrNotFound, workItemID)
-		}
-		workItem = &item
-	}
-	role := draftRole(strings.TrimSpace(input.RoleID), roles, workItem)
-	if strings.TrimSpace(input.RoleID) != "" && role == nil {
-		return Proposal{}, fmt.Errorf("%w: role %q", ErrNotFound, strings.TrimSpace(input.RoleID))
-	}
-	driverKind := draftDriverKind(strings.TrimSpace(input.DriverKind), role)
-	if !validDraftDriverKind(driverKind) {
-		return Proposal{}, fmt.Errorf("%w: unsupported assignment driver_kind %q", ErrInvalid, driverKind)
 	}
 	request := draftRequestParts(input.Request)
+	roleLabel := firstNonEmpty(draftContext.Selection.RoleName, draftContext.Selection.RoleID, "role")
 	var proposalInput ProposalInput
-	if workItem != nil {
-		if role == nil {
+	if draftContext.SelectedWork != nil {
+		if draftContext.Selection.RoleID == "" {
 			return Proposal{}, fmt.Errorf("%w: role_id is required for assignment drafts", ErrInvalid)
 		}
 		patch := mustRawJSON(map[string]any{
-			"project_id":   project.ID,
-			"work_item_id": workItem.ID,
-			"role_id":      role.ID,
-			"driver_kind":  driverKind,
+			"project_id":   draftContext.Project.ID,
+			"work_item_id": draftContext.SelectedWork.ID,
+			"role_id":      draftContext.Selection.RoleID,
+			"driver_kind":  draftContext.Selection.DriverKind,
 			"status":       projectwork.AssignmentStatusQueued,
 		})
 		proposalInput = ProposalInput{
-			Title:   firstNonEmpty(request.title, fmt.Sprintf("Queue %s for %s", firstNonEmpty(role.Name, role.ID, "role"), workItem.Title)),
-			Summary: fmt.Sprintf("Create a queued %s assignment on the selected work item.", driverKind),
+			Title:   firstNonEmpty(request.title, fmt.Sprintf("Queue %s for %s", roleLabel, draftContext.SelectedWork.Title)),
+			Summary: fmt.Sprintf("Create a queued %s assignment on the selected work item.", draftContext.Selection.DriverKind),
 			Actions: []Action{{
 				Kind:   ActionCreateAssignment,
-				Target: map[string]string{"project_id": project.ID},
+				Target: map[string]string{"project_id": draftContext.Project.ID},
 				Patch:  patch,
 				Reason: "Queue a reviewable assignment without starting execution.",
 			}},
@@ -255,21 +239,21 @@ func (s *Service) Draft(ctx context.Context, input DraftInput) (Proposal, error)
 		}
 	} else {
 		patch := map[string]any{
-			"project_id": project.ID,
+			"project_id": draftContext.Project.ID,
 			"title":      firstNonEmpty(request.title, "Untitled project work"),
 			"brief":      request.brief,
 			"status":     projectwork.WorkItemStatusReady,
 			"priority":   "normal",
 		}
-		if role != nil {
-			patch["owner_role_id"] = role.ID
+		if draftContext.Selection.RoleID != "" {
+			patch["owner_role_id"] = draftContext.Selection.RoleID
 		}
 		proposalInput = ProposalInput{
 			Title:   firstNonEmpty(request.title, "Create project work item"),
 			Summary: "Create a ready work item from the current assistant draft.",
 			Actions: []Action{{
 				Kind:   ActionCreateWorkItem,
-				Target: map[string]string{"project_id": project.ID},
+				Target: map[string]string{"project_id": draftContext.Project.ID},
 				Patch:  mustRawJSON(patch),
 				Reason: "Create a reviewable project work item.",
 			}},
@@ -1106,46 +1090,6 @@ func draftRequestParts(request string) draftRequest {
 		return draftRequest{}
 	}
 	return draftRequest{title: parts[0], brief: strings.Join(parts[1:], "\n\n")}
-}
-
-func draftRole(roleID string, roles []projectwork.AgentRoleProfile, workItem *projectwork.WorkItem) *projectwork.AgentRoleProfile {
-	roleID = strings.TrimSpace(roleID)
-	if roleID != "" {
-		for _, role := range roles {
-			if role.ID == roleID {
-				found := role
-				return &found
-			}
-		}
-		return nil
-	}
-	if workItem != nil {
-		ownerID := strings.TrimSpace(workItem.OwnerRoleID)
-		if ownerID != "" {
-			for _, role := range roles {
-				if role.ID == ownerID {
-					found := role
-					return &found
-				}
-			}
-		}
-	}
-	if len(roles) == 0 {
-		return nil
-	}
-	found := roles[0]
-	return &found
-}
-
-func draftDriverKind(driverKind string, role *projectwork.AgentRoleProfile) string {
-	driverKind = strings.TrimSpace(driverKind)
-	if driverKind != "" {
-		return driverKind
-	}
-	if role != nil && strings.TrimSpace(role.DefaultDriverKind) != "" {
-		return strings.TrimSpace(role.DefaultDriverKind)
-	}
-	return projectwork.AssignmentDriverHecateTask
 }
 
 func validDraftDriverKind(kind string) bool {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -114,6 +114,169 @@ func TestService_DraftCreatesWorkItemProposalAcrossStores(t *testing.T) {
 	}
 }
 
+func TestService_ContextBuildsProjectAssistantPacketAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			role, err := fixture.work.CreateRole(ctx, projectwork.AgentRoleProfile{
+				ID:                "planner",
+				ProjectID:         project.ID,
+				Name:              "Planning Lead",
+				DefaultDriverKind: projectwork.AssignmentDriverExternalAgent,
+			})
+			if err != nil {
+				t.Fatalf("CreateRole: %v", err)
+			}
+			workItem, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+				ID:          "work_context",
+				ProjectID:   project.ID,
+				Title:       "Shape assistant context",
+				Brief:       "Define what the assistant sees.",
+				Status:      projectwork.WorkItemStatusReady,
+				OwnerRoleID: role.ID,
+			})
+			if err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
+			if _, err := fixture.work.CreateAssignment(ctx, projectwork.Assignment{
+				ID:         "asgn_context",
+				ProjectID:  project.ID,
+				WorkItemID: workItem.ID,
+				RoleID:     role.ID,
+				DriverKind: projectwork.AssignmentDriverExternalAgent,
+				Status:     projectwork.AssignmentStatusRunning,
+			}); err != nil {
+				t.Fatalf("CreateAssignment: %v", err)
+			}
+			if _, err := fixture.memoryEntries.Create(ctx, memory.Entry{
+				ID:         "mem_context",
+				ProjectID:  project.ID,
+				Title:      "Assistant context decision",
+				Body:       "Drafts inspect context before proposing durable changes.",
+				TrustLabel: memory.TrustLabelOperatorMemory,
+				SourceKind: memory.SourceKindOperator,
+				Enabled:    true,
+			}); err != nil {
+				t.Fatalf("Create memory: %v", err)
+			}
+			if _, err := fixture.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+				ID:                  "cand_context",
+				ProjectID:           project.ID,
+				Title:               "Candidate context note",
+				Body:                "Candidate memory is visible but still reviewable.",
+				SuggestedTrustLabel: memory.TrustLabelGenerated,
+				SuggestedSourceKind: memory.SourceKindGenerated,
+				Status:              memory.CandidateStatusPending,
+			}); err != nil {
+				t.Fatalf("CreateCandidate: %v", err)
+			}
+			if _, err := fixture.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+				ID:                  "cand_rejected",
+				ProjectID:           project.ID,
+				Title:               "Rejected context note",
+				Body:                "Rejected suggestions stay out of assistant context.",
+				SuggestedTrustLabel: memory.TrustLabelGenerated,
+				SuggestedSourceKind: memory.SourceKindGenerated,
+				Status:              memory.CandidateStatusRejected,
+			}); err != nil {
+				t.Fatalf("Create rejected candidate: %v", err)
+			}
+
+			packet, err := fixture.service.Context(ctx, ContextInput{
+				ProjectID:  project.ID,
+				WorkItemID: workItem.ID,
+				Request:    "Queue planning",
+			})
+			if err != nil {
+				t.Fatalf("Context: %v", err)
+			}
+			if packet.Project.ID != project.ID || packet.SelectedWork == nil || packet.SelectedWork.ID != workItem.ID {
+				t.Fatalf("context project/work = %+v/%+v, want selected project/work", packet.Project, packet.SelectedWork)
+			}
+			if packet.Selection.RoleID != role.ID || packet.Selection.RoleSource != "selected_work_owner" || packet.Selection.DriverKind != projectwork.AssignmentDriverExternalAgent || packet.Selection.DriverSource != "role_default" {
+				t.Fatalf("selection = %+v, want owner role and role default driver", packet.Selection)
+			}
+			if !strings.Contains(packet.Selection.Reason, "Selected work item is owned by Planning Lead") || !strings.Contains(packet.Selection.Reason, "Using external_agent") {
+				t.Fatalf("selection reason = %q, want owner/default explanation", packet.Selection.Reason)
+			}
+			if len(packet.Roles) == 0 || !contextRoleExists(packet.Roles, role.ID) {
+				t.Fatalf("roles = %+v, want custom role included", packet.Roles)
+			}
+			if len(packet.Assignments) != 1 || packet.Assignments[0].ID != "asgn_context" {
+				t.Fatalf("assignments = %+v, want recent assignment", packet.Assignments)
+			}
+			if len(packet.Memory) != 1 || packet.Memory[0].ID != "mem_context" {
+				t.Fatalf("memory = %+v, want enabled project memory", packet.Memory)
+			}
+			if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "cand_context" {
+				t.Fatalf("memory candidates = %+v, want candidate", packet.MemoryCandidates)
+			}
+			if len(packet.RecentActivity) == 0 {
+				t.Fatalf("recent activity is empty, want context timeline entries")
+			}
+		})
+	}
+}
+
+func TestService_ContextRejectsMissingExplicitRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newMemoryAssistantFixture(t)
+	project := createTestProject(t, ctx, fixture.projects)
+
+	_, err := fixture.service.Context(ctx, ContextInput{
+		ProjectID: project.ID,
+		Request:   "Draft with missing role",
+		RoleID:    "missing_role",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Context err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestService_DraftUsesContextSelection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newMemoryAssistantFixture(t)
+	project := createTestProject(t, ctx, fixture.projects)
+	role, err := fixture.work.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:                "planner",
+		ProjectID:         project.ID,
+		Name:              "Planning Lead",
+		DefaultDriverKind: projectwork.AssignmentDriverExternalAgent,
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	workItem, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:          "work_context_draft",
+		ProjectID:   project.ID,
+		Title:       "Draft from context",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: role.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+
+	proposal, err := fixture.service.Draft(ctx, DraftInput{
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		Request:    "Queue selected owner",
+	})
+	if err != nil {
+		t.Fatalf("Draft: %v", err)
+	}
+	patch := rawPatchMap(t, proposal.Actions[0].Patch)
+	if patch["role_id"] != role.ID || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent {
+		t.Fatalf("patch = %+v, want context-selected owner role and role default driver", patch)
+	}
+}
+
 func TestService_DraftRejectsUnsupportedDriverKind(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -829,12 +992,17 @@ func newSQLiteAssistantFixture(t *testing.T) assistantFixture {
 	}
 }
 
-func projectassistantService(projectStore projects.Store, chatStore chat.Store, workStore projectwork.Store, memoryStore memory.CandidateStore) *Service {
+func projectassistantService(projectStore projects.Store, chatStore chat.Store, workStore projectwork.Store, memoryStore memory.Store) *Service {
+	var candidateStore memory.CandidateStore
+	if candidates, ok := memoryStore.(memory.CandidateStore); ok {
+		candidateStore = candidates
+	}
 	return NewService(Stores{
 		Projects:         projectStore,
 		Chats:            chatStore,
 		Work:             workStore,
-		MemoryCandidates: memoryStore,
+		Memory:           memoryStore,
+		MemoryCandidates: candidateStore,
 	}, sequenceIDGenerator())
 }
 
@@ -862,6 +1030,15 @@ func rawPatchMap(t *testing.T, payload json.RawMessage) map[string]string {
 		t.Fatalf("decode patch: %v", err)
 	}
 	return decoded
+}
+
+func contextRoleExists(roles []RoleContext, id string) bool {
+	for _, role := range roles {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func createTestProject(t *testing.T, ctx context.Context, store projects.Store) projects.Project {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
@@ -235,6 +236,73 @@ func TestService_ContextRejectsMissingExplicitRole(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Context err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestService_ContextBudgetsMemoryBodiesAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			memoryBody := strings.Repeat("é", contextMemoryBodyMaxBytes)
+			candidateBody := strings.Repeat("é", contextCandidateBodyMaxBytes)
+			if _, err := fixture.memoryEntries.Create(ctx, memory.Entry{
+				ID:         "mem_budget",
+				ProjectID:  project.ID,
+				Title:      "Large project memory",
+				Body:       memoryBody,
+				TrustLabel: memory.TrustLabelOperatorMemory,
+				SourceKind: memory.SourceKindOperator,
+				Enabled:    true,
+			}); err != nil {
+				t.Fatalf("Create memory: %v", err)
+			}
+			if _, err := fixture.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+				ID:                  "cand_budget",
+				ProjectID:           project.ID,
+				Title:               "Large candidate memory",
+				Body:                candidateBody,
+				SuggestedTrustLabel: memory.TrustLabelGenerated,
+				SuggestedSourceKind: memory.SourceKindGenerated,
+				Status:              memory.CandidateStatusPending,
+			}); err != nil {
+				t.Fatalf("CreateCandidate: %v", err)
+			}
+
+			packet, err := fixture.service.Context(ctx, ContextInput{
+				ProjectID: project.ID,
+				Request:   "Inspect budgeted context",
+			})
+			if err != nil {
+				t.Fatalf("Context: %v", err)
+			}
+			if len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
+				t.Fatalf("memory/candidates = %+v/%+v, want one of each", packet.Memory, packet.MemoryCandidates)
+			}
+			gotMemory := packet.Memory[0]
+			if !gotMemory.BodyTruncated || len(gotMemory.Body) > contextMemoryBodyMaxBytes || !strings.HasSuffix(gotMemory.Body, contextTruncatedSuffix) || !utf8.ValidString(gotMemory.Body) {
+				t.Fatalf("memory body budget = len:%d truncated:%v suffix:%v valid:%v", len(gotMemory.Body), gotMemory.BodyTruncated, strings.HasSuffix(gotMemory.Body, contextTruncatedSuffix), utf8.ValidString(gotMemory.Body))
+			}
+			if gotMemory.BodyOriginalBytes != len(memoryBody) || gotMemory.BodyReturnedBytes != len(gotMemory.Body) || gotMemory.BodyTokensEstimate != estimateTokensFromBytes(len(gotMemory.Body)) {
+				t.Fatalf("memory budget metadata = %+v, want original/returned bytes and token estimate", gotMemory)
+			}
+			gotCandidate := packet.MemoryCandidates[0]
+			if !gotCandidate.BodyTruncated || len(gotCandidate.Body) > contextCandidateBodyMaxBytes || !strings.HasSuffix(gotCandidate.Body, contextTruncatedSuffix) || !utf8.ValidString(gotCandidate.Body) {
+				t.Fatalf("candidate body budget = len:%d truncated:%v suffix:%v valid:%v", len(gotCandidate.Body), gotCandidate.BodyTruncated, strings.HasSuffix(gotCandidate.Body, contextTruncatedSuffix), utf8.ValidString(gotCandidate.Body))
+			}
+			if gotCandidate.BodyOriginalBytes != len(candidateBody) || gotCandidate.BodyReturnedBytes != len(gotCandidate.Body) || gotCandidate.BodyTokensEstimate != estimateTokensFromBytes(len(gotCandidate.Body)) {
+				t.Fatalf("candidate budget metadata = %+v, want original/returned bytes and token estimate", gotCandidate)
+			}
+			if packet.Budget.MemoryBodyMaxBytes != contextMemoryBodyMaxBytes || packet.Budget.MemoryCandidateBodyMaxBytes != contextCandidateBodyMaxBytes || packet.Budget.BodyTruncatedCount != 2 {
+				t.Fatalf("context budget = %+v, want byte limits and two truncated bodies", packet.Budget)
+			}
+			if packet.Budget.BodyOriginalBytes != gotMemory.BodyOriginalBytes+gotCandidate.BodyOriginalBytes || packet.Budget.BodyReturnedBytes != gotMemory.BodyReturnedBytes+gotCandidate.BodyReturnedBytes || packet.Budget.BodyTokensEstimate != gotMemory.BodyTokensEstimate+gotCandidate.BodyTokensEstimate {
+				t.Fatalf("context budget totals = %+v, want memory + candidate totals", packet.Budget)
+			}
+		})
 	}
 }
 

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 
 import type {
   ProjectAssistantApplyResult,
+  ProjectAssistantContextRecord,
   ProjectAssistantProposal,
   ProjectRecord,
   ProjectWorkItemRecord,
@@ -18,12 +19,17 @@ export type ProjectAssistantDraftForm = {
 };
 
 export type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
+export type ProjectAssistantContextStatus = "idle" | "loading" | "loaded" | "error";
 
 type Props = {
   applyResult: ProjectAssistantApplyResult | null;
+  context: ProjectAssistantContextRecord | null;
+  contextError: string;
+  contextStatus: ProjectAssistantContextStatus;
   error: string;
   onApply: () => void;
   onDismiss: () => void;
+  onInspectContext: (form: ProjectAssistantDraftForm) => void;
   onPropose: (form: ProjectAssistantDraftForm) => void;
   project: ProjectRecord | null;
   proposal: ProjectAssistantProposal | null;
@@ -34,9 +40,13 @@ type Props = {
 
 export function ProjectAssistantPanel({
   applyResult,
+  context,
+  contextError,
+  contextStatus,
   error,
   onApply,
   onDismiss,
+  onInspectContext,
   onPropose,
   project,
   proposal,
@@ -60,6 +70,7 @@ export function ProjectAssistantPanel({
       : (roles.find((role) => role.id === form.roleID) ?? null);
   const valid = form.request.trim().length > 0 && (workItem ? Boolean(selectedRole) : true);
   const busy = status === "proposing" || status === "applying";
+  const contextBusy = contextStatus === "loading";
   const panelDetail = workItem ? `Selected work: ${workItem.title}` : "Project queue";
 
   return (
@@ -141,6 +152,15 @@ export function ProjectAssistantPanel({
             </label>
           </div>
           <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            disabled={!valid || busy || contextBusy}
+            onClick={() => onInspectContext(form)}
+          >
+            <Icon d={Icons.eye} size={13} />
+            {contextBusy ? "Inspecting..." : "Inspect context"}
+          </button>
+          <button
             className="btn btn-primary btn-sm"
             type="submit"
             disabled={!valid || busy}
@@ -151,6 +171,12 @@ export function ProjectAssistantPanel({
           </button>
         </div>
       </form>
+      {contextError && (
+        <div style={{ marginTop: 2 }}>
+          <InlineError message={contextError} />
+        </div>
+      )}
+      {context && <ProjectAssistantContextPanel context={context} />}
       {error && (
         <div style={{ marginTop: 10 }}>
           <InlineError message={error} />
@@ -217,6 +243,43 @@ export function ProjectAssistantPanel({
         </div>
       )}
     </section>
+  );
+}
+
+function ProjectAssistantContextPanel({ context }: { context: ProjectAssistantContextRecord }) {
+  const selection = context.selection;
+  return (
+    <details open style={assistantContextStyle} aria-label="Project Assistant context">
+      <summary style={assistantContextSummaryStyle}>
+        <span className="badge badge-muted">context</span>
+        <span>{projectAssistantSelectionLabel(context)}</span>
+      </summary>
+      <div style={assistantContextBodyStyle}>
+        <div style={subtleTextStyle}>{selection.reason}</div>
+        <div style={assistantContextGridStyle}>
+          <ProjectAssistantContextStat label="Selected work" value={context.selected_work?.title} />
+          <ProjectAssistantContextStat label="Roles" value={String(context.roles.length)} />
+          <ProjectAssistantContextStat
+            label="Assignments"
+            value={String(context.assignments?.length ?? 0)}
+          />
+          <ProjectAssistantContextStat label="Memory" value={String(context.memory?.length ?? 0)} />
+          <ProjectAssistantContextStat
+            label="Candidates"
+            value={String(context.memory_candidates?.length ?? 0)}
+          />
+        </div>
+      </div>
+    </details>
+  );
+}
+
+function ProjectAssistantContextStat({ label, value }: { label: string; value?: string }) {
+  return (
+    <div style={assistantContextStatStyle}>
+      <span style={fieldLabelStyle}>{label}</span>
+      <span style={assistantContextStatValueStyle}>{value || "none"}</span>
+    </div>
   );
 }
 
@@ -308,6 +371,22 @@ function projectAssistantAutoRole(
   roles: ProjectWorkRoleRecord[],
 ): ProjectWorkRoleRecord | null {
   return roles.find((item) => item.id === workItem?.owner_role_id) ?? roles[0] ?? null;
+}
+
+function projectAssistantSelectionLabel(context: ProjectAssistantContextRecord): string {
+  const role = context.selection.role_name || context.selection.role_id || "no role";
+  return `Auto selected ${role} via ${projectAssistantDriverLabel(context.selection.driver_kind)}`;
+}
+
+function projectAssistantDriverLabel(kind: string): string {
+  switch (kind) {
+    case "hecate_task":
+      return "Hecate task";
+    case "external_agent":
+      return "External agent";
+    default:
+      return kind.replace(/_/g, " ");
+  }
 }
 
 function projectAssistantActionLabel(kind: string): string {
@@ -422,6 +501,59 @@ const assistantProposalStyle: CSSProperties = {
   display: "grid",
   gap: 10,
   padding: 10,
+};
+
+const assistantContextStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  minWidth: 0,
+  padding: "8px 10px",
+};
+
+const assistantContextSummaryStyle: CSSProperties = {
+  alignItems: "center",
+  color: "var(--t1)",
+  cursor: "pointer",
+  display: "flex",
+  flexWrap: "wrap",
+  fontSize: 12,
+  gap: 8,
+  lineHeight: 1.4,
+  minWidth: 0,
+};
+
+const assistantContextBodyStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  marginTop: 8,
+  minWidth: 0,
+};
+
+const assistantContextGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 140px), 1fr))",
+  minWidth: 0,
+};
+
+const assistantContextStatStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 4,
+  minWidth: 0,
+  padding: "7px 8px",
+};
+
+const assistantContextStatValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
 };
 
 const assistantProposalHeaderStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -268,6 +268,14 @@ function ProjectAssistantContextPanel({ context }: { context: ProjectAssistantCo
             label="Candidates"
             value={String(context.memory_candidates?.length ?? 0)}
           />
+          <ProjectAssistantContextStat
+            label="Body tokens"
+            value={`~${context.budget.body_tokens_estimate}`}
+          />
+          <ProjectAssistantContextStat
+            label="Truncated"
+            value={String(context.budget.body_truncated_count)}
+          />
         </div>
       </div>
     </details>

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1159,6 +1159,78 @@ describe("ProjectsView cockpit", () => {
     expect(within(assistant).getAllByText("Build cockpit UI").length).toBeGreaterThan(0);
   });
 
+  it("renders Project Assistant context budget values", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectAssistantContext).mockResolvedValueOnce({
+      object: "project_assistant.context",
+      data: {
+        project: {
+          id: project.id,
+          name: project.name,
+          roots: [],
+          created_at: project.created_at,
+          updated_at: project.updated_at,
+        },
+        request: `Queue ${role.name} for ${workItem.title}`,
+        selected_work: {
+          id: workItem.id,
+          title: workItem.title,
+          status: workItem.status,
+          owner_role_id: workItem.owner_role_id,
+          created_at: workItem.created_at,
+          updated_at: workItem.updated_at,
+        },
+        roles: [
+          {
+            id: role.id,
+            name: role.name,
+            built_in: role.built_in,
+            created_at: "2026-06-01T10:00:00Z",
+            updated_at: "2026-06-01T10:00:00Z",
+          },
+        ],
+        assignments: [],
+        memory: [],
+        memory_candidates: [],
+        recent_activity: [],
+        budget: {
+          memory_body_max_bytes: 4096,
+          memory_candidate_body_max_bytes: 2048,
+          body_original_bytes: 12000,
+          body_returned_bytes: 6144,
+          body_tokens_estimate: 321,
+          body_truncated_count: 2,
+        },
+        selection: {
+          role_id: role.id,
+          role_name: role.name,
+          role_source: "selected_work_owner",
+          driver_kind: "hecate_task",
+          driver_source: "role_default",
+          reason:
+            "Selected work item is owned by Software developer. Using hecate_task from the selected role default.",
+        },
+      },
+    });
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Inspect context" }));
+
+    const context = await within(assistant).findByLabelText("Project Assistant context");
+    expect(within(context).getByText("Body tokens")).toBeTruthy();
+    expect(within(context).getByText("~321")).toBeTruthy();
+    expect(within(context).getByText("Truncated")).toBeTruthy();
+    expect(within(context).getByText("2")).toBeTruthy();
+  });
+
   it("surfaces Project Assistant context inspection errors", async () => {
     resetProjectWorkMocks();
     vi.mocked(getProjectAssistantContext).mockRejectedValueOnce(

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -24,6 +24,7 @@ import {
   getAgentProfiles,
   getProjectAssignmentContext,
   getProjectAssignments,
+  getProjectAssistantContext,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
   getProjectMemory,
@@ -110,6 +111,57 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
     getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
     getProjectAssignmentContext: vi.fn(async () => ({ object: "context_packet", data: null })),
+    getProjectAssistantContext: vi.fn(async () => ({
+      object: "project_assistant.context",
+      data: {
+        project: {
+          id: "proj_1",
+          name: "Hecate",
+          roots: [],
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T11:00:00Z",
+        },
+        request: "Queue Software developer for Build cockpit UI",
+        selected_work: {
+          id: "work_1",
+          title: "Build cockpit UI",
+          brief: "Expose project work and native starts.",
+          status: "ready",
+          priority: "high",
+          owner_role_id: "software_developer",
+          reviewer_role_ids: ["reviewer_qa"],
+          created_at: "2026-06-02T10:00:00Z",
+          updated_at: "2026-06-02T11:00:00Z",
+        },
+        roles: [
+          {
+            id: "software_developer",
+            name: "Software developer",
+            description: "Owns implementation work.",
+            default_driver_kind: "hecate_task",
+            default_provider: "anthropic",
+            default_model: "claude-sonnet-4",
+            default_agent_profile: "implementation",
+            built_in: true,
+            created_at: "2026-06-01T10:00:00Z",
+            updated_at: "2026-06-01T10:00:00Z",
+          },
+        ],
+        assignments: [],
+        memory: [],
+        memory_candidates: [],
+        recent_activity: [],
+        selection: {
+          role_id: "software_developer",
+          role_name: "Software developer",
+          role_source: "selected_work_owner",
+          driver_kind: "hecate_task",
+          driver_source: "role_default",
+          reason:
+            "Selected work item is owned by Software developer. Using hecate_task from the selected role default.",
+        },
+      },
+    })),
     getProjectCollaborationArtifacts: vi.fn(async () => ({
       object: "project_collaboration_artifacts",
       data: [],
@@ -427,6 +479,74 @@ function resetProjectWorkMocks() {
       ],
     },
   });
+  vi.mocked(getProjectAssistantContext).mockResolvedValue({
+    object: "project_assistant.context",
+    data: {
+      project: {
+        id: project.id,
+        name: project.name,
+        roots: project.roots.map(({ id, path, kind, git_remote, git_branch, active }) => ({
+          id,
+          path,
+          kind,
+          git_remote,
+          git_branch,
+          active,
+        })),
+        default_provider: project.default_provider,
+        default_model: project.default_model,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+      },
+      request: `Queue ${role.name} for ${workItem.title}`,
+      selected_work: {
+        id: workItem.id,
+        title: workItem.title,
+        brief: workItem.brief,
+        status: workItem.status,
+        priority: workItem.priority,
+        owner_role_id: workItem.owner_role_id,
+        reviewer_role_ids: workItem.reviewer_role_ids,
+        created_at: workItem.created_at,
+        updated_at: workItem.updated_at,
+      },
+      roles: [
+        {
+          id: role.id,
+          name: role.name,
+          description: role.description,
+          default_driver_kind: role.default_driver_kind,
+          default_provider: role.default_provider,
+          default_model: role.default_model,
+          default_agent_profile: role.default_agent_profile,
+          built_in: role.built_in,
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T10:00:00Z",
+        },
+      ],
+      assignments: [hecateAssignment],
+      memory: [memoryEntry],
+      memory_candidates: [memoryCandidate],
+      recent_activity: [
+        {
+          kind: "selected_work",
+          id: workItem.id,
+          title: workItem.title,
+          status: workItem.status,
+          updated_at: workItem.updated_at,
+        },
+      ],
+      selection: {
+        role_id: role.id,
+        role_name: role.name,
+        role_source: "selected_work_owner",
+        driver_kind: "hecate_task",
+        driver_source: "role_default",
+        reason:
+          "Selected work item is owned by Software developer. Using hecate_task from the selected role default.",
+      },
+    },
+  });
   vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
     object: "project_collaboration_artifacts",
     data: [],
@@ -669,6 +789,7 @@ afterEach(() => {
   vi.mocked(getProjectWorkItem).mockReset();
   vi.mocked(getProjectAssignments).mockReset();
   vi.mocked(getProjectAssignmentContext).mockReset();
+  vi.mocked(getProjectAssistantContext).mockReset();
   vi.mocked(getProjectCollaborationArtifacts).mockReset();
   vi.mocked(getProjectHandoffs).mockReset();
   vi.mocked(getProjectMemory).mockReset();
@@ -947,6 +1068,61 @@ describe("ProjectsView cockpit", () => {
     expect(await within(assistant).findByText("Applied 1 action from pa_test.")).toBeTruthy();
     expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
     expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
+  });
+
+  it("inspects Project Assistant context selection before drafting", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Inspect context" }));
+
+    await waitFor(() => {
+      expect(getProjectAssistantContext).toHaveBeenCalledWith({
+        project_id: project.id,
+        work_item_id: workItem.id,
+        request: "Queue Software developer for Build cockpit UI",
+      });
+    });
+    expect(
+      await within(assistant).findByText("Auto selected Software developer via Hecate task"),
+    ).toBeTruthy();
+    expect(
+      within(assistant).getByText(
+        "Selected work item is owned by Software developer. Using hecate_task from the selected role default.",
+      ),
+    ).toBeTruthy();
+    expect(within(assistant).getByText("context")).toBeTruthy();
+    expect(within(assistant).getByText("Candidates")).toBeTruthy();
+    expect(within(assistant).getAllByText("Build cockpit UI").length).toBeGreaterThan(0);
+  });
+
+  it("surfaces Project Assistant context inspection errors", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectAssistantContext).mockRejectedValueOnce(
+      new ApiError("project assistant target not found", 404, "not_found"),
+    );
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Inspect context" }));
+
+    expect(await within(assistant).findByText("project assistant target not found")).toBeTruthy();
+    expect(within(assistant).queryByLabelText("Project Assistant context")).toBeNull();
   });
 
   it("drafts Project Assistant work proposals without an owner role when none exists", async () => {
@@ -1567,7 +1743,11 @@ describe("ProjectsView cockpit", () => {
     await userEvent.click(within(detail).getByRole("button", { name: "Open task" }));
     expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
 
-    await userEvent.click(within(detail).getByRole("button", { name: "Inspect context" }));
+    await userEvent.click(
+      within(detail).getByTitle(
+        "Inspect the best available stored context snapshot for this assignment.",
+      ),
+    );
     expect(getProjectAssignmentContext).toHaveBeenCalledWith(
       project.id,
       workItem.id,

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -151,6 +151,14 @@ vi.mock("../../lib/api", async (importOriginal) => {
         memory: [],
         memory_candidates: [],
         recent_activity: [],
+        budget: {
+          memory_body_max_bytes: 4096,
+          memory_candidate_body_max_bytes: 2048,
+          body_original_bytes: 0,
+          body_returned_bytes: 0,
+          body_tokens_estimate: 0,
+          body_truncated_count: 0,
+        },
         selection: {
           role_id: "software_developer",
           role_name: "Software developer",
@@ -525,8 +533,44 @@ function resetProjectWorkMocks() {
         },
       ],
       assignments: [hecateAssignment],
-      memory: [memoryEntry],
-      memory_candidates: [memoryCandidate],
+      memory: [
+        {
+          id: memoryEntry.id,
+          title: memoryEntry.title,
+          body: memoryEntry.body,
+          body_original_bytes: memoryEntry.body.length,
+          body_returned_bytes: memoryEntry.body.length,
+          body_tokens_estimate: Math.ceil(memoryEntry.body.length / 4),
+          body_truncated: false,
+          trust_label: memoryEntry.trust_label,
+          source_kind: memoryEntry.source_kind,
+          source_id: memoryEntry.source_id,
+          enabled: memoryEntry.enabled,
+          created_at: memoryEntry.created_at,
+          updated_at: memoryEntry.updated_at,
+        },
+      ],
+      memory_candidates: [
+        {
+          id: memoryCandidate.id,
+          title: memoryCandidate.title,
+          body: memoryCandidate.body,
+          body_original_bytes: memoryCandidate.body.length,
+          body_returned_bytes: memoryCandidate.body.length,
+          body_tokens_estimate: Math.ceil(memoryCandidate.body.length / 4),
+          body_truncated: false,
+          suggested_kind: memoryCandidate.suggested_kind,
+          suggested_trust_label: memoryCandidate.suggested_trust_label,
+          suggested_source_kind: memoryCandidate.suggested_source_kind,
+          suggested_source_id: memoryCandidate.suggested_source_id,
+          source_refs: memoryCandidate.source_refs,
+          status: memoryCandidate.status,
+          status_reason: memoryCandidate.status_reason,
+          promoted_memory_id: memoryCandidate.promoted_memory_id,
+          created_at: memoryCandidate.created_at,
+          updated_at: memoryCandidate.updated_at,
+        },
+      ],
       recent_activity: [
         {
           kind: "selected_work",
@@ -536,6 +580,15 @@ function resetProjectWorkMocks() {
           updated_at: workItem.updated_at,
         },
       ],
+      budget: {
+        memory_body_max_bytes: 4096,
+        memory_candidate_body_max_bytes: 2048,
+        body_original_bytes: memoryEntry.body.length + memoryCandidate.body.length,
+        body_returned_bytes: memoryEntry.body.length + memoryCandidate.body.length,
+        body_tokens_estimate:
+          Math.ceil(memoryEntry.body.length / 4) + Math.ceil(memoryCandidate.body.length / 4),
+        body_truncated_count: 0,
+      },
       selection: {
         role_id: role.id,
         role_name: role.name,
@@ -1101,6 +1154,8 @@ describe("ProjectsView cockpit", () => {
     ).toBeTruthy();
     expect(within(assistant).getByText("context")).toBeTruthy();
     expect(within(assistant).getByText("Candidates")).toBeTruthy();
+    expect(within(assistant).getByText("Body tokens")).toBeTruthy();
+    expect(within(assistant).getByText("Truncated")).toBeTruthy();
     expect(within(assistant).getAllByText("Build cockpit UI").length).toBeGreaterThan(0);
   });
 

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -18,6 +18,7 @@ import {
   createProjectHandoff,
   discoverProjectContextSources,
   draftProjectAssistant,
+  getProjectAssistantContext,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
@@ -76,6 +77,8 @@ import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
   ProjectAssistantApplyResult,
+  ProjectAssistantContextPayload,
+  ProjectAssistantContextRecord,
   ProjectAssistantProposal,
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
@@ -352,6 +355,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [assistantProposal, setAssistantProposal] = useState<ProjectAssistantProposal | null>(null);
   const [assistantApplyResult, setAssistantApplyResult] =
     useState<ProjectAssistantApplyResult | null>(null);
+  const [assistantContext, setAssistantContext] = useState<ProjectAssistantContextRecord | null>(
+    null,
+  );
+  const [assistantContextStatus, setAssistantContextStatus] = useState<LoadState>("idle");
+  const [assistantContextError, setAssistantContextError] = useState("");
   const [assistantStatus, setAssistantStatus] = useState<ProjectAssistantStatus>("idle");
   const [assistantError, setAssistantError] = useState("");
 
@@ -610,6 +618,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   useEffect(() => {
     setAssistantProposal(null);
     setAssistantApplyResult(null);
+    setAssistantContext(null);
+    setAssistantContextError("");
+    setAssistantContextStatus("idle");
     setAssistantError("");
     setAssistantStatus("idle");
   }, [selectedProjectID, selectedWorkItemID]);
@@ -1109,20 +1120,31 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setAssistantError("");
     setAssistantApplyResult(null);
     try {
-      const roleID = form.roleID === PROJECT_ASSISTANT_AUTO ? "" : form.roleID.trim();
-      const driverKind = form.driverKind === PROJECT_ASSISTANT_AUTO ? "" : form.driverKind.trim();
-      const proposal = await draftProjectAssistant({
-        project_id: selectedProject.id,
-        work_item_id: selectedWorkItem?.id,
-        request: form.request,
-        ...(roleID ? { role_id: roleID } : {}),
-        ...(driverKind ? { driver_kind: driverKind } : {}),
-      });
+      const proposal = await draftProjectAssistant(
+        projectAssistantPayload(form, selectedProject.id, selectedWorkItem?.id),
+      );
       setAssistantProposal(proposal.data);
       setAssistantStatus("idle");
     } catch (error) {
       setAssistantStatus("idle");
       setAssistantError(errorMessage(error, "Failed to draft Project Assistant proposal."));
+    }
+  }
+
+  async function handleProjectAssistantContext(form: ProjectAssistantDraftForm) {
+    if (!selectedProject) return;
+    setAssistantContextStatus("loading");
+    setAssistantContextError("");
+    try {
+      const payload = await getProjectAssistantContext(
+        projectAssistantPayload(form, selectedProject.id, selectedWorkItem?.id),
+      );
+      setAssistantContext(payload.data);
+      setAssistantContextStatus("loaded");
+    } catch (error) {
+      setAssistantContext(null);
+      setAssistantContextStatus("error");
+      setAssistantContextError(errorMessage(error, "Failed to inspect Project Assistant context."));
     }
   }
 
@@ -1159,6 +1181,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   function dismissProjectAssistantProposal() {
     setAssistantProposal(null);
     setAssistantApplyResult(null);
+    setAssistantContext(null);
+    setAssistantContextError("");
+    setAssistantContextStatus("idle");
     setAssistantError("");
     setAssistantStatus("idle");
   }
@@ -1292,8 +1317,12 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
               <section style={domainSectionStyle} aria-label="Project workspace">
                 <ProjectAssistantPanel
                   applyResult={assistantApplyResult}
+                  context={assistantContext}
+                  contextError={assistantContextError}
+                  contextStatus={assistantContextStatus}
                   error={assistantError}
                   onApply={() => void handleProjectAssistantApply()}
+                  onInspectContext={(form) => void handleProjectAssistantContext(form)}
                   onDismiss={dismissProjectAssistantProposal}
                   onPropose={(form) => void handleProjectAssistantPropose(form)}
                   project={selectedProject}
@@ -4915,6 +4944,22 @@ function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): 
     if (workItemID) return workItemID;
   }
   return "";
+}
+
+function projectAssistantPayload(
+  form: ProjectAssistantDraftForm,
+  projectID: string,
+  workItemID?: string,
+): ProjectAssistantContextPayload {
+  const roleID = form.roleID === PROJECT_ASSISTANT_AUTO ? "" : form.roleID.trim();
+  const driverKind = form.driverKind === PROJECT_ASSISTANT_AUTO ? "" : form.driverKind.trim();
+  return {
+    project_id: projectID,
+    ...(workItemID ? { work_item_id: workItemID } : {}),
+    request: form.request,
+    ...(roleID ? { role_id: roleID } : {}),
+    ...(driverKind ? { driver_kind: driverKind } : {}),
+  };
 }
 
 function projectAssistantApplyErrorMessage(

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -64,6 +64,8 @@ import type {
   CreateProjectWorkItemPayload,
   ProjectAssistantApplyPayload,
   ProjectAssistantApplyResponse,
+  ProjectAssistantContextPayload,
+  ProjectAssistantContextResponse,
   ProjectAssistantDraftPayload,
   ProjectAssistantProposalResponse,
   ProjectAssistantProposePayload,
@@ -362,6 +364,15 @@ export async function proposeProjectAssistant(
   payload: ProjectAssistantProposePayload,
 ): Promise<ProjectAssistantProposalResponse> {
   return fetchJSON<ProjectAssistantProposalResponse>(`${HECATE_API}/project-assistant/propose`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function getProjectAssistantContext(
+  payload: ProjectAssistantContextPayload,
+): Promise<ProjectAssistantContextResponse> {
+  return fetchJSON<ProjectAssistantContextResponse>(`${HECATE_API}/project-assistant/context`, {
     method: "POST",
     body: payload,
   });

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -101,6 +101,15 @@ export type ProjectAssistantContextSelection = {
   reason: string;
 };
 
+export type ProjectAssistantContextBudget = {
+  memory_body_max_bytes: number;
+  memory_candidate_body_max_bytes: number;
+  body_original_bytes: number;
+  body_returned_bytes: number;
+  body_tokens_estimate: number;
+  body_truncated_count: number;
+};
+
 export type ProjectAssistantContextProjectRoot = {
   id: string;
   path: string;
@@ -170,6 +179,10 @@ export type ProjectAssistantContextMemory = {
   id: string;
   title: string;
   body: string;
+  body_original_bytes: number;
+  body_returned_bytes: number;
+  body_tokens_estimate: number;
+  body_truncated: boolean;
   trust_label: string;
   source_kind: string;
   source_id?: string;
@@ -182,6 +195,10 @@ export type ProjectAssistantContextMemoryCandidate = {
   id: string;
   title: string;
   body: string;
+  body_original_bytes: number;
+  body_returned_bytes: number;
+  body_tokens_estimate: number;
+  body_truncated: boolean;
   suggested_kind?: string;
   suggested_trust_label?: string;
   suggested_source_kind?: string;
@@ -216,6 +233,7 @@ export type ProjectAssistantContextRecord = {
   memory?: ProjectAssistantContextMemory[];
   memory_candidates?: ProjectAssistantContextMemoryCandidate[];
   recent_activity?: ProjectAssistantContextActivity[];
+  budget: ProjectAssistantContextBudget;
   selection: ProjectAssistantContextSelection;
 };
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -92,6 +92,138 @@ export type ProjectAssistantApplyResponse = {
   data: ProjectAssistantApplyResult;
 };
 
+export type ProjectAssistantContextSelection = {
+  role_id?: string;
+  role_name?: string;
+  role_source?: string;
+  driver_kind: string;
+  driver_source: string;
+  reason: string;
+};
+
+export type ProjectAssistantContextProjectRoot = {
+  id: string;
+  path: string;
+  kind: string;
+  git_remote?: string;
+  git_branch?: string;
+  active: boolean;
+};
+
+export type ProjectAssistantContextProject = {
+  id: string;
+  name: string;
+  description?: string;
+  roots?: ProjectAssistantContextProjectRoot[];
+  default_root_id?: string;
+  default_provider?: string;
+  default_model?: string;
+  default_agent_profile?: string;
+  default_workspace_mode?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextWorkItem = {
+  id: string;
+  title: string;
+  brief?: string;
+  status: string;
+  priority?: string;
+  owner_role_id?: string;
+  reviewer_role_ids?: string[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextRole = {
+  id: string;
+  name: string;
+  description?: string;
+  default_driver_kind?: string;
+  default_provider?: string;
+  default_model?: string;
+  default_agent_profile?: string;
+  built_in: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextAssignment = {
+  id: string;
+  work_item_id: string;
+  role_id: string;
+  driver_kind: string;
+  status: string;
+  task_id?: string;
+  run_id?: string;
+  chat_session_id?: string;
+  message_id?: string;
+  context_snapshot_id?: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+};
+
+export type ProjectAssistantContextMemory = {
+  id: string;
+  title: string;
+  body: string;
+  trust_label: string;
+  source_kind: string;
+  source_id?: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextMemoryCandidate = {
+  id: string;
+  title: string;
+  body: string;
+  suggested_kind?: string;
+  suggested_trust_label?: string;
+  suggested_source_kind?: string;
+  suggested_source_id?: string;
+  source_refs?: Array<{
+    kind: string;
+    id: string;
+    title?: string;
+    url?: string;
+  }>;
+  status: "pending" | "promoted" | "rejected" | (string & {});
+  status_reason?: string;
+  promoted_memory_id?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextActivity = {
+  kind: string;
+  id: string;
+  title: string;
+  status?: string;
+  updated_at: string;
+};
+
+export type ProjectAssistantContextRecord = {
+  project: ProjectAssistantContextProject;
+  request: string;
+  selected_work?: ProjectAssistantContextWorkItem;
+  roles: ProjectAssistantContextRole[];
+  assignments?: ProjectAssistantContextAssignment[];
+  memory?: ProjectAssistantContextMemory[];
+  memory_candidates?: ProjectAssistantContextMemoryCandidate[];
+  recent_activity?: ProjectAssistantContextActivity[];
+  selection: ProjectAssistantContextSelection;
+};
+
+export type ProjectAssistantContextResponse = {
+  object: string;
+  data: ProjectAssistantContextRecord;
+};
+
 export type ProjectAssistantProposePayload = {
   id?: string;
   title?: string;
@@ -99,13 +231,15 @@ export type ProjectAssistantProposePayload = {
   actions: ProjectAssistantAction[];
 };
 
-export type ProjectAssistantDraftPayload = {
+export type ProjectAssistantContextPayload = {
   project_id: string;
   work_item_id?: string;
   request: string;
   role_id?: string;
   driver_kind?: string;
 };
+
+export type ProjectAssistantDraftPayload = ProjectAssistantContextPayload;
 
 export type ProjectAssistantApplyPayload = {
   proposal: ProjectAssistantProposal;


### PR DESCRIPTION
## Summary

- Add a bounded Project Assistant context packet and `/hecate/v1/project-assistant/context` endpoint that shares draft role/driver selection.
- Add per-body byte budgeting for project memory and memory candidates, with truncation flags, original/returned byte counts, and cheap token estimates.
- Wire the Projects cockpit to inspect Auto context before drafting, including success/error UI coverage and compact budget metadata.
- Add HTTP and UI regressions for context budget metadata, truncated bodies, and rendered budget values.
- Document the context endpoint, selection behavior, body budgeting, and candidate trust posture.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/projectassistant ./internal/api -run 'TestService_Context|TestService_Draft|TestProjectAssistantAPI_Context|TestProjectAssistantAPI_Draft'`
- `go vet ./...`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `git diff --check`
