### PR TITLE
Bootstrap project guidance and skill roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,9 @@ Full ladder: [`docs-ai/core/verification.md`](docs-ai/core/verification.md).
 - **Before creating or updating PRs**: identify and run the related tests for
   every touched surface first. If a required check cannot run, say why in the
   PR/update summary.
+- **PR readiness includes coverage and docs**: before opening or updating a PR,
+  confirm production-code changes added or updated the right tests, and confirm
+  user/AI/runtime docs and related diagrams are updated or explicitly unchanged.
 - **Written production code needs tests**: new behavior gets new tests, bug
   fixes get regression tests, and refactors keep behavior tests passing before
   and after the reshape.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -75,6 +75,9 @@ Details and update rules: [`core/agent-guidance.md`](core/agent-guidance.md).
   `docs/operator/`, `docs/runtime/`, `docs/contributor/`, or `docs/design/`
   page. New event type → event-protocol taxonomy check +
   `docs/runtime/events.md`. Not as a follow-up.
+- **PR readiness check.** Before opening or updating a PR, confirm tests were
+  added/updated for production-code changes and confirm user/AI/runtime docs
+  and related diagrams are updated or intentionally unchanged.
 - **Race suite is the floor** for backend/runtime changes — not a nice-to-have. Use `just test-race` or `go test -race -timeout 10m ./...`.
 - **No plan labels** (`Phase 1`, `P0`, `#15`, `Milestone N`) in commit messages or code comments.
 - **Probe before assuming paths.** `grep`, `ls`, `go build` before writing file paths from memory. Wrong paths compound.

--- a/docs-ai/core/verification.md
+++ b/docs-ai/core/verification.md
@@ -28,6 +28,12 @@ neighboring unit tests, integration tests for crossed seams, UI view tests, and
 e2e tests for real-binary behavior. Run the relevant set locally first; if a
 test cannot be run, say which one and why in the PR/update summary.
 
+Also explicitly check documentation before changing PR state. If behavior,
+operator workflow, public API, runtime events, configuration, agent guidance, or
+architecture shape changed, update the relevant user docs, AI guidance, runtime
+reference, and related Mermaid diagrams in the same change. If no docs need to
+change, say that in the PR/update summary instead of leaving it implicit.
+
 Written production code needs automated coverage in the same change. New
 behavior gets a new test, bug fixes get a regression test, and refactors keep
 the existing behavior tests passing before and after the reshape. If automated

--- a/docs-ai/core/workflow.md
+++ b/docs-ai/core/workflow.md
@@ -22,7 +22,9 @@ The default operating loop, when to stop and plan, and how to propose commits.
    commits to a PR, marking it ready, or asking for merge, this is mandatory by
    touched surface: TypeScript/UI changes require the UI checks and Go changes
    require the Go checks. If a PR touches both, run both. State exactly what
-   was run.
+   was run. Also confirm tests were added or updated for production-code
+   changes, and confirm user/AI/runtime docs plus related diagrams were updated
+   or are intentionally unchanged.
 7. **Summarize.** What changed, what risks remain, what the operator should know — including manual smoke steps if any.
 
 ## When to ask clarifying questions

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -376,6 +376,9 @@ Recommended sequence:
    - Discover `AGENTS.md` and nested `AGENTS.md` under project workspace roots.
    - Save/refresh them as project context-source metadata.
    - Label host-specific files as metadata-only context sources.
+   - Project Assistant context exposes context-source metadata, and Bootstrap
+     drafting can turn enabled guidance metadata into reviewable memory
+     candidates with source refs.
    - Future: include relevant Hecate-owned instruction content in context packets
      after explicit injection policy is designed.
    - Future: label external-agent behavior as "available to adapter" or "not
@@ -384,6 +387,10 @@ Recommended sequence:
 3. **Skills Registry V1 Core**
    - Built-in skill registry.
    - Project-local `.hecate/skills/*/SKILL.md` discovery.
+   - Current Bootstrap drafting can suggest project roles from local
+     `.agents/skills`, `.hecate/skills`, and local skill roots explicitly linked
+     from discovered `AGENTS.md` or `CLAUDE.md` guidance without installing,
+     interpreting, or executing skills.
    - Frontmatter validation.
    - List/get API.
    - Trust/source labels.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -22,11 +22,14 @@ The current composer defaults to deterministic drafting. `Auto` for `Run as`
 resolves to the selected work item's owner role, then the first loaded project
 role. `Auto` for `Via` resolves to the selected role's default driver, then
 `hecate_task`. Operators can also choose model-backed drafting when the project
-has a default model. In that mode the model may author only typed proposal
-actions from the same context packet, and the server still validates those
-actions before the operator can apply them. A future real project assistant loop
-can use richer project context to recommend or select roles and drivers, but
-that decision still needs to be inspectable before work is queued or launched.
+has a default model, or deterministic Bootstrap drafting to turn discovered
+guidance metadata and project-local skill files into reviewable setup proposals.
+In model mode the model may author only typed proposal actions from the same
+context packet, and the server still validates those actions before the operator
+can apply them. Bootstrap mode does not call a model and does not start work.
+A future real project assistant loop can use richer project context to recommend
+or select roles and drivers, but that decision still needs to be inspectable
+before work is queued or launched.
 
 The UI supports both project-level planning and selected-work context. With a
 selected work item, the draft queues an assignment for that work. Without a
@@ -76,6 +79,15 @@ permission model.
   with generated provenance: `suggested_trust_label: "generated_summary"` and
   `suggested_source_kind: "generated"` when provided; operator-authored trust or
   source labels require later operator promotion or editing.
+- Bootstrap drafts may create memory candidates from project context-source
+  metadata, using `suggested_source_kind: "context_source"` and source refs back
+  to the discovered source. Those candidates record provenance only; operators
+  must review and edit/promote them before they become durable memory.
+- Bootstrap drafts may suggest project roles from local
+  `.agents/skills/*/SKILL.md` or `.hecate/skills/*/SKILL.md` files, plus local
+  skill roots explicitly referenced from discovered `AGENTS.md` or `CLAUDE.md`
+  guidance. Applying the proposal creates role records only; it does not install
+  skills, run scripts, grant tools, or change approval policy.
 - Assignment proposals create unstarted queued assignments. They cannot attach
   execution evidence or links such as `task_id`, `run_id`, `chat_session_id`,
   `message_id`, or `context_snapshot_id`; linking existing execution later
@@ -113,9 +125,10 @@ use this endpoint to show what `Auto` resolved to before asking the server to
 draft a proposal.
 
 The v0 context packet is item-limited and body-budgeted. It includes project
-defaults and roots, the selected work item when present, loaded project roles,
-recent assignments, accepted project memory, pending memory candidates, recent
-activity, and a `selection` block explaining the chosen role and driver. Memory
+defaults, roots, context-source metadata, the selected work item when present,
+loaded project roles, recent assignments, accepted project memory, pending
+memory candidates, recent activity, and a `selection` block explaining the chosen
+role and driver. Memory
 and candidate `body` fields are truncated at per-body byte limits and carry
 `body_original_bytes`, `body_returned_bytes`, `body_tokens_estimate`, and
 `body_truncated` metadata. The top-level `budget` block summarizes the active
@@ -197,6 +210,17 @@ proposes a new ready work item. `role_id` and `driver_kind` are optional hints;
 omitting them lets the server choose the selected work item's owner role, then
 the first loaded project role, and the selected role's default driver, then
 `hecate_task`.
+
+`draft_mode: "bootstrap"` creates a deterministic project setup proposal. It
+uses enabled `workspace_guidance` context-source metadata to propose memory
+candidates with source provenance, and scans active absolute project roots for
+local skill folders at `.agents/skills`, `.hecate/skills`, and any local skill
+roots explicitly linked from discovered `AGENTS.md` or `CLAUDE.md` files. It
+deduplicates against existing role ids and existing memory/candidate source refs.
+It may read those guidance files through the workspace filesystem with a byte cap
+to find skill paths, but it does not treat host-specific guidance as Hecate
+policy authority, call a model, create durable memory, start tasks, or launch
+agents.
 
 `draft_mode: "model"` asks the configured gateway model to author the proposal
 from the same context packet. The request may provide `model` and `provider`;
@@ -410,6 +434,7 @@ Every action has the same envelope:
 | `remove_project_root`     | `internal/projects`    | Removes a root from an existing project.                                                                                                |
 | `set_project_defaults`    | `internal/projects`    | Updates provider/model/profile/tools/workspace/system-prompt defaults.                                                                  |
 | `move_chat_session`       | `internal/chat`        | Moves exactly one chat session into a project or back to no project.                                                                    |
+| `create_role`             | `internal/projectwork` | Creates a custom project role; built-in role ids remain immutable.                                                                      |
 | `create_work_item`        | `internal/projectwork` | Creates a project-scoped work item; does not start a task.                                                                              |
 | `update_work_item`        | `internal/projectwork` | Updates one existing work item.                                                                                                         |
 | `create_assignment`       | `internal/projectwork` | Creates an assignment for existing project work.                                                                                        |
@@ -436,9 +461,10 @@ The first visible UI should stay small and inspectable:
 The Projects cockpit exposes this contract at the top of the project workspace.
 V0 uses a composer-style request box that drafts typed proposals from the
 selected project/work item. The `Rules` draft option uses deterministic server
-logic; the `Assistant` draft option asks the project default model to author the
-same typed proposal shape. Later Hecate Chat can call the same proposal API, but
-durable mutations should still stop at the same explicit review/apply card.
+logic; `Bootstrap` proposes project setup records from guidance and skill
+metadata; the `Assistant` draft option asks the project default model to author
+the same typed proposal shape. Later Hecate Chat can call the same proposal API,
+but durable mutations should still stop at the same explicit review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
 project list, project work, selected work-item detail, and project memory.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2160,13 +2160,18 @@ Endpoints:
 - `POST /hecate/v1/project-assistant/apply`
 
 `context` returns the v0 item-limited and body-budgeted project packet plus the
-inspectable Auto role/driver selection that `draft` will use. Memory and
+inspectable Auto role/driver selection that `draft` will use. It includes
+project context-source metadata, but not source file bodies. Memory and
 memory-candidate bodies are truncated at per-body byte limits and carry returned
 byte counts, original byte counts, truncation flags, and cheap token estimates.
 `draft` creates proposal data only; it does not create a chat message, task,
 run, assignment, or external agent session. `draft_mode` defaults to
-`deterministic`; `draft_mode: "model"` can use the project default model or
-explicit request model to author typed proposal actions, but those actions are
+`deterministic`; `draft_mode: "bootstrap"` deterministically proposes memory
+candidates from enabled guidance-source metadata and project roles from local
+`.agents/skills` or `.hecate/skills` folders, plus local skill roots explicitly
+linked from discovered `AGENTS.md` or `CLAUDE.md` guidance; `draft_mode: "model"`
+can use the project default model or explicit request model to author typed
+proposal actions, but those actions are
 still project-scoped, allowlisted, server-validated, and explicitly applied by
 the operator. Model-backed drafts use the normal model gateway path and send the
 item-limited, body-budgeted context packet, including accepted memory and

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -228,6 +230,80 @@ func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {
 	}
 	if patch["project_id"] != project.ID || patch["work_item_id"] != workItem.ID || patch["role_id"] != "product_manager" || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent {
 		t.Fatalf("patch = %+v, want selected project/work/owner role/external driver", patch)
+	}
+}
+
+func TestProjectAssistantAPI_DraftBootstrapProposal(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".hecate", "skills", "research"), 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".hecate", "skills", "research", "SKILL.md"), []byte("# Research\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	_, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_bootstrap_api",
+		Name: "Bootstrap API Project",
+		Roots: []projects.Root{{
+			ID:     "root_bootstrap_api",
+			Path:   root,
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:             "ctx_agents_api",
+			Kind:           "workspace_instruction",
+			Title:          "AGENTS.md",
+			Path:           "AGENTS.md",
+			Enabled:        true,
+			Format:         "agents_md",
+			Scope:          "workspace",
+			TrustLabel:     "workspace_guidance",
+			SourceCategory: "workspace_guidance",
+			Metadata:       map[string]string{"root_id": "root_bootstrap_api"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader([]byte(`{
+		"project_id":"proj_bootstrap_api",
+		"request":"Bootstrap project guidance",
+		"draft_mode":"bootstrap"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft bootstrap status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || proposed.Data.ID == "" {
+		t.Fatalf("draft response = %+v, want proposal envelope with id", proposed)
+	}
+	if len(proposed.Data.Actions) != 2 {
+		t.Fatalf("actions = %+v, want guidance candidate and skill role", proposed.Data.Actions)
+	}
+	if proposed.Data.Actions[0].Kind != projectassistant.ActionCreateMemoryCandidate || proposed.Data.Actions[1].Kind != projectassistant.ActionCreateRole {
+		t.Fatalf("action kinds = %s/%s, want memory candidate then role", proposed.Data.Actions[0].Kind, proposed.Data.Actions[1].Kind)
+	}
+	var memoryPatch map[string]any
+	if err := json.Unmarshal(proposed.Data.Actions[0].Patch, &memoryPatch); err != nil {
+		t.Fatalf("decode memory patch: %v", err)
+	}
+	if memoryPatch["suggested_source_kind"] != "context_source" || memoryPatch["suggested_source_id"] != "ctx_agents_api" {
+		t.Fatalf("memory patch = %+v, want context-source provenance", memoryPatch)
+	}
+	var rolePatch map[string]any
+	if err := json.Unmarshal(proposed.Data.Actions[1].Patch, &rolePatch); err != nil {
+		t.Fatalf("decode role patch: %v", err)
+	}
+	if rolePatch["id"] != "skill_research" || rolePatch["name"] != "Research" {
+		t.Fatalf("role patch = %+v, want skill-derived role", rolePatch)
 	}
 }
 

--- a/internal/projectassistant/bootstrap.go
+++ b/internal/projectassistant/bootstrap.go
@@ -1,0 +1,441 @@
+package projectassistant
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/workspacefs"
+)
+
+const (
+	bootstrapGuidanceActionLimit = 8
+	bootstrapSkillActionLimit    = 8
+	bootstrapGuidanceMaxBytes    = 64 * 1024
+)
+
+type bootstrapSkillSource struct {
+	ID   string
+	Path string
+}
+
+func (s *Service) draftBootstrap(ctx context.Context, input DraftInput, draftContext DraftContext) (Proposal, error) {
+	projectID := draftContext.Project.ID
+	actions, warnings := bootstrapGuidanceActions(projectID, draftContext)
+
+	skillActions, skillWarnings := bootstrapSkillRoleActions(projectID, draftContext)
+	actions = append(actions, skillActions...)
+	warnings = append(warnings, skillWarnings...)
+	if draftContext.SelectedWork != nil {
+		warnings = append(warnings, "Bootstrap drafts are project-scoped; selected work context was ignored.")
+	}
+	if len(actions) == 0 {
+		return Proposal{}, fmt.Errorf("%w: no enabled guidance sources or local skill files found for bootstrap", ErrInvalid)
+	}
+
+	proposal, err := s.Propose(ctx, ProposalInput{
+		Title:   fmt.Sprintf("Bootstrap %s guidance", firstNonEmpty(draftContext.Project.Name, projectID)),
+		Summary: "Create reviewable memory candidates from discovered guidance metadata and suggest project roles from local skill files.",
+		Actions: actions,
+		TraceID: strings.TrimSpace(input.TraceID),
+	})
+	if err != nil {
+		return Proposal{}, err
+	}
+	proposal.Warnings = warnings
+	return proposal, nil
+}
+
+func bootstrapGuidanceActions(projectID string, draftContext DraftContext) ([]Action, []string) {
+	existing := existingMemorySourceRefs(draftContext)
+	var actions []Action
+	var warnings []string
+	for _, source := range draftContext.Project.ContextSources {
+		if !source.Enabled || strings.TrimSpace(source.ID) == "" {
+			continue
+		}
+		if strings.TrimSpace(source.SourceCategory) != "workspace_guidance" {
+			continue
+		}
+		refKey := memorySourceRefKey("context_source", source.ID)
+		if existing[refKey] {
+			continue
+		}
+		if len(actions) >= bootstrapGuidanceActionLimit {
+			warnings = append(warnings, fmt.Sprintf("Skipped additional guidance sources after %d bootstrap memory candidates.", bootstrapGuidanceActionLimit))
+			break
+		}
+		actions = append(actions, bootstrapGuidanceAction(projectID, source))
+	}
+	return actions, warnings
+}
+
+func bootstrapGuidanceAction(projectID string, source ContextSource) Action {
+	trustLabel := firstNonEmpty(source.TrustLabel, "workspace_guidance")
+	title := firstNonEmpty(source.Title, source.Path, source.ID)
+	reason := "Prepare a reviewable memory candidate from discovered workspace guidance metadata."
+	if source.Kind != "workspace_instruction" {
+		reason = "Record host-specific guidance as reviewable metadata without importing host policy."
+	}
+	return Action{
+		Kind:   ActionCreateMemoryCandidate,
+		Target: map[string]string{"project_id": projectID},
+		Patch: mustRawJSON(memoryCandidatePatch{
+			ProjectID:           projectID,
+			Title:               "Guidance source: " + title,
+			Body:                bootstrapGuidanceBody(source),
+			SuggestedKind:       "workspace_guidance",
+			SuggestedTrustLabel: trustLabel,
+			SuggestedSourceKind: "context_source",
+			SuggestedSourceID:   source.ID,
+			SourceRefs: []memory.CandidateSourceRef{{
+				Kind:  "context_source",
+				ID:    source.ID,
+				Title: title,
+			}},
+		}),
+		Reason: reason,
+	}
+}
+
+func bootstrapGuidanceBody(source ContextSource) string {
+	var lines []string
+	lines = append(lines,
+		"Discovered project guidance source.",
+		"",
+		"Source: "+firstNonEmpty(source.Path, source.ID),
+		"Kind: "+firstNonEmpty(source.Kind, "unknown"),
+		"Format: "+firstNonEmpty(source.Format, "unknown"),
+		"Scope: "+firstNonEmpty(source.Scope, "unknown"),
+		"Trust label: "+firstNonEmpty(source.TrustLabel, "workspace_guidance"),
+	)
+	if rootID := strings.TrimSpace(source.Metadata["root_id"]); rootID != "" {
+		lines = append(lines, "Root: "+rootID)
+	}
+	if host := strings.TrimSpace(source.Metadata["host"]); host != "" {
+		lines = append(lines, "Host: "+host)
+	}
+	lines = append(lines,
+		"",
+		"This candidate records source provenance only. Review the source file before promoting or editing durable project memory from it.",
+	)
+	if source.Kind != "workspace_instruction" {
+		lines = append(lines, "Host-specific guidance is labelled for visibility only; it does not override Hecate policy, approvals, sandboxing, or project profile settings.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func existingMemorySourceRefs(draftContext DraftContext) map[string]bool {
+	out := make(map[string]bool)
+	for _, item := range draftContext.Memory {
+		if item.SourceKind != "" && item.SourceID != "" {
+			out[memorySourceRefKey(item.SourceKind, item.SourceID)] = true
+		}
+	}
+	for _, item := range draftContext.MemoryCandidates {
+		if item.SuggestedSourceKind != "" && item.SuggestedSourceID != "" {
+			out[memorySourceRefKey(item.SuggestedSourceKind, item.SuggestedSourceID)] = true
+		}
+		for _, ref := range item.SourceRefs {
+			if ref.Kind != "" && ref.ID != "" {
+				out[memorySourceRefKey(ref.Kind, ref.ID)] = true
+			}
+		}
+	}
+	return out
+}
+
+func memorySourceRefKey(kind, id string) string {
+	return strings.TrimSpace(kind) + "\x00" + strings.TrimSpace(id)
+}
+
+func bootstrapSkillRoleActions(projectID string, draftContext DraftContext) ([]Action, []string) {
+	existingRoles := existingRoleIDs(draftContext.Roles)
+	skills, warnings := discoverBootstrapSkills(draftContext.Project, existingRoles)
+	var actions []Action
+	for _, skill := range skills {
+		if len(actions) >= bootstrapSkillActionLimit {
+			warnings = append(warnings, fmt.Sprintf("Skipped additional local skills after %d bootstrap role suggestions.", bootstrapSkillActionLimit))
+			break
+		}
+		actions = append(actions, bootstrapSkillRoleAction(projectID, skill))
+	}
+	return actions, warnings
+}
+
+func bootstrapSkillRoleAction(projectID string, skill bootstrapSkillSource) Action {
+	roleID := "skill_" + skill.ID
+	roleName := bootstrapTitle(skill.ID)
+	return Action{
+		Kind:   ActionCreateRole,
+		Target: map[string]string{"project_id": projectID},
+		Patch: mustRawJSON(rolePatch{
+			ID:                roleID,
+			ProjectID:         projectID,
+			Name:              roleName,
+			Description:       fmt.Sprintf("Suggested from local skill metadata at %s.", skill.Path),
+			Instructions:      fmt.Sprintf("Use local skill guidance at %s when this project role owns work. This role is a suggestion only; it does not install skills, execute scripts, change approvals, or grant tools.", skill.Path),
+			DefaultDriverKind: projectwork.AssignmentDriverHecateTask,
+		}),
+		Reason: fmt.Sprintf("Suggest a project role from local skill metadata at %s.", skill.Path),
+	}
+}
+
+func discoverBootstrapSkills(project ProjectContext, existingRoles map[string]bool) ([]bootstrapSkillSource, []string) {
+	var out []bootstrapSkillSource
+	var warnings []string
+	seen := make(map[string]bool)
+	for _, root := range project.Roots {
+		if !root.Active || strings.TrimSpace(root.Path) == "" {
+			continue
+		}
+		if !filepath.IsAbs(root.Path) {
+			warnings = append(warnings, fmt.Sprintf("Skipped skill discovery for non-absolute project root %s.", root.ID))
+			continue
+		}
+		fsys, err := workspacefs.New(root.Path)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("Skipped skill discovery for root %s: %v.", root.ID, err))
+			continue
+		}
+		baseDirs := bootstrapSkillBaseDirs(fsys, root, project.ContextSources, &warnings)
+		for _, base := range baseDirs {
+			skills := discoverBootstrapSkillsInDir(fsys, base, seen, existingRoles)
+			out = append(out, skills...)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out, warnings
+}
+
+func bootstrapSkillBaseDirs(fsys *workspacefs.FS, root ProjectRootContext, sources []ContextSource, warnings *[]string) []string {
+	dirs := []string{".agents/skills", ".hecate/skills"}
+	seen := map[string]bool{
+		".agents/skills": true,
+		".hecate/skills": true,
+	}
+	for _, source := range sources {
+		if !bootstrapGuidanceSourceForRoot(source, root.ID) {
+			continue
+		}
+		body, ok := readBootstrapGuidanceSource(fsys, source, warnings)
+		if !ok {
+			continue
+		}
+		for _, dir := range skillBaseDirsFromGuidance(source.Path, body) {
+			if seen[dir] {
+				continue
+			}
+			seen[dir] = true
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
+func bootstrapGuidanceSourceForRoot(source ContextSource, rootID string) bool {
+	if !source.Enabled || strings.TrimSpace(source.Path) == "" {
+		return false
+	}
+	if source.Metadata != nil {
+		sourceRootID := strings.TrimSpace(source.Metadata["root_id"])
+		if sourceRootID != "" && rootID != "" && sourceRootID != rootID {
+			return false
+		}
+	}
+	if source.Kind == "workspace_instruction" || source.Format == "agents_md" || source.Format == "claude_md" {
+		return true
+	}
+	base := strings.ToLower(path.Base(filepath.ToSlash(source.Path)))
+	return base == "agents.md" || base == "claude.md" || base == "claude.local.md"
+}
+
+func readBootstrapGuidanceSource(fsys *workspacefs.FS, source ContextSource, warnings *[]string) (string, bool) {
+	info, _, err := fsys.Stat(source.Path)
+	if err != nil {
+		return "", false
+	}
+	if info.IsDir() {
+		return "", false
+	}
+	if info.Size() > bootstrapGuidanceMaxBytes {
+		if warnings != nil {
+			*warnings = append(*warnings, fmt.Sprintf("Skipped skill-reference discovery from %s because it is larger than %d bytes.", source.Path, bootstrapGuidanceMaxBytes))
+		}
+		return "", false
+	}
+	raw, _, err := fsys.ReadFile(source.Path)
+	if err != nil {
+		return "", false
+	}
+	return string(raw), true
+}
+
+func discoverBootstrapSkillsInDir(fsys *workspacefs.FS, base string, seen, existingRoles map[string]bool) []bootstrapSkillSource {
+	entries, _, err := fsys.ReadDir(base)
+	if err != nil {
+		return nil
+	}
+	var out []bootstrapSkillSource
+	for _, entry := range entries {
+		if !entry.IsDir || strings.HasPrefix(entry.Name, ".") {
+			continue
+		}
+		skillID := normalizeBootstrapID(entry.Name)
+		roleID := "skill_" + skillID
+		if skillID == "" || seen[skillID] || existingRoles[skillID] || existingRoles[roleID] {
+			continue
+		}
+		skillPath := path.Join(base, entry.Name, "SKILL.md")
+		info, _, err := fsys.Stat(skillPath)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		seen[skillID] = true
+		out = append(out, bootstrapSkillSource{
+			ID:   skillID,
+			Path: skillPath,
+		})
+	}
+	return out
+}
+
+func skillBaseDirsFromGuidance(sourcePath, body string) []string {
+	sourceDir := path.Dir(filepath.ToSlash(strings.TrimSpace(sourcePath)))
+	if sourceDir == "." {
+		sourceDir = ""
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, token := range guidancePathTokens(body) {
+		for _, dir := range skillBaseDirsFromToken(sourceDir, token) {
+			if seen[dir] {
+				continue
+			}
+			seen[dir] = true
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+func guidancePathTokens(body string) []string {
+	var out []string
+	var builder strings.Builder
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		token := strings.Trim(builder.String(), "`'\"()[]{}<>.,;:")
+		builder.Reset()
+		if token != "" {
+			out = append(out, token)
+		}
+	}
+	for _, r := range body {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-', r == '/', r == '*', r == '@':
+			builder.WriteRune(r)
+		default:
+			flush()
+		}
+	}
+	flush()
+	return out
+}
+
+func skillBaseDirsFromToken(sourceDir, token string) []string {
+	token = strings.TrimSpace(strings.TrimPrefix(token, "@"))
+	if token == "" || strings.Contains(token, "://") || strings.HasPrefix(token, "#") {
+		return nil
+	}
+	token = filepath.ToSlash(token)
+	token = strings.TrimPrefix(token, "./")
+	if path.IsAbs(token) {
+		return nil
+	}
+	cleaned := path.Clean(token)
+	if sourceDir != "" && !strings.HasPrefix(cleaned, ".agents/") && !strings.HasPrefix(cleaned, ".hecate/") {
+		cleaned = path.Clean(path.Join(sourceDir, cleaned))
+	}
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return nil
+	}
+	lower := strings.ToLower(cleaned)
+	switch {
+	case strings.Contains(lower, "/*/skill.md"):
+		idx := strings.Index(lower, "/*/skill.md")
+		base := cleaned[:idx]
+		if base != "" && base != "." {
+			return []string{base}
+		}
+	case strings.HasSuffix(lower, "/skill.md"):
+		skillDir := path.Dir(cleaned)
+		base := path.Dir(skillDir)
+		if base != "." && base != "/" {
+			return []string{base}
+		}
+	case strings.HasSuffix(lower, "/skills/readme.md"):
+		return []string{path.Dir(cleaned)}
+	case strings.HasSuffix(lower, "/skills"):
+		return []string{cleaned}
+	default:
+		if idx := strings.Index(lower, "/skills/"); idx >= 0 {
+			return []string{cleaned[:idx+len("/skills")]}
+		}
+	}
+	return nil
+}
+
+func existingRoleIDs(roles []RoleContext) map[string]bool {
+	out := make(map[string]bool, len(roles))
+	for _, role := range roles {
+		if role.ID != "" {
+			out[role.ID] = true
+		}
+	}
+	return out
+}
+
+func normalizeBootstrapID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			builder.WriteRune(r)
+			lastUnderscore = false
+		case r == '-' || r == '_' || r == ' ' || r == '.':
+			if !lastUnderscore && builder.Len() > 0 {
+				builder.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
+func bootstrapTitle(id string) string {
+	parts := strings.Split(normalizeBootstrapID(id), "_")
+	for idx, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[idx] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -49,6 +49,7 @@ type ProjectContext struct {
 	Name                 string               `json:"name"`
 	Description          string               `json:"description,omitempty"`
 	Roots                []ProjectRootContext `json:"roots,omitempty"`
+	ContextSources       []ContextSource      `json:"context_sources,omitempty"`
 	DefaultRootID        string               `json:"default_root_id,omitempty"`
 	DefaultProvider      string               `json:"default_provider,omitempty"`
 	DefaultModel         string               `json:"default_model,omitempty"`
@@ -65,6 +66,21 @@ type ProjectRootContext struct {
 	GitRemote string `json:"git_remote,omitempty"`
 	GitBranch string `json:"git_branch,omitempty"`
 	Active    bool   `json:"active"`
+}
+
+type ContextSource struct {
+	ID             string            `json:"id"`
+	Kind           string            `json:"kind"`
+	Title          string            `json:"title,omitempty"`
+	Path           string            `json:"path"`
+	Enabled        bool              `json:"enabled"`
+	Format         string            `json:"format,omitempty"`
+	Scope          string            `json:"scope,omitempty"`
+	TrustLabel     string            `json:"trust_label,omitempty"`
+	SourceCategory string            `json:"source_category,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
 }
 
 type WorkItemContext struct {
@@ -370,6 +386,7 @@ func projectContext(project projects.Project) ProjectContext {
 		Name:                 project.Name,
 		Description:          project.Description,
 		Roots:                projectRootContexts(project.Roots),
+		ContextSources:       contextSources(project.ContextSources),
 		DefaultRootID:        project.DefaultRootID,
 		DefaultProvider:      project.DefaultProvider,
 		DefaultModel:         project.DefaultModel,
@@ -391,6 +408,38 @@ func projectRootContexts(items []projects.Root) []ProjectRootContext {
 			GitBranch: item.GitBranch,
 			Active:    item.Active,
 		})
+	}
+	return out
+}
+
+func contextSources(items []projects.ContextSource) []ContextSource {
+	out := make([]ContextSource, 0, len(items))
+	for _, item := range items {
+		out = append(out, ContextSource{
+			ID:             item.ID,
+			Kind:           item.Kind,
+			Title:          item.Title,
+			Path:           item.Path,
+			Enabled:        item.Enabled,
+			Format:         item.Format,
+			Scope:          item.Scope,
+			TrustLabel:     item.TrustLabel,
+			SourceCategory: item.SourceCategory,
+			Metadata:       cloneContextMetadata(item.Metadata),
+			CreatedAt:      item.CreatedAt,
+			UpdatedAt:      item.UpdatedAt,
+		})
+	}
+	return out
+}
+
+func cloneContextMetadata(input map[string]string) map[string]string {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		out[key] = value
 	}
 	return out
 }

--- a/internal/projectassistant/model_draft.go
+++ b/internal/projectassistant/model_draft.go
@@ -14,6 +14,7 @@ import (
 const (
 	DraftModeDeterministic = "deterministic"
 	DraftModeModel         = "model"
+	DraftModeBootstrap     = "bootstrap"
 
 	modelDraftMaxTokens = 1600
 )

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -23,6 +23,7 @@ const (
 	ActionRemoveProjectRoot     = "remove_project_root"
 	ActionSetProjectDefaults    = "set_project_defaults"
 	ActionMoveChatSession       = "move_chat_session"
+	ActionCreateRole            = "create_role"
 	ActionCreateWorkItem        = "create_work_item"
 	ActionUpdateWorkItem        = "update_work_item"
 	ActionCreateAssignment      = "create_assignment"
@@ -222,6 +223,8 @@ func (s *Service) Draft(ctx context.Context, input DraftInput) (Proposal, error)
 	switch normalizeDraftMode(input.DraftMode) {
 	case "", DraftModeDeterministic:
 		return s.draftDeterministic(ctx, input, draftContext)
+	case DraftModeBootstrap:
+		return s.draftBootstrap(ctx, input, draftContext)
 	case DraftModeModel:
 		return s.draftWithModel(ctx, input, draftContext)
 	default:
@@ -359,6 +362,8 @@ func (s *Service) applyAction(ctx context.Context, action Action) (ActionResult,
 		return s.applySetProjectDefaults(ctx, action)
 	case ActionMoveChatSession:
 		return s.applyMoveChatSession(ctx, action)
+	case ActionCreateRole:
+		return s.applyCreateRole(ctx, action)
 	case ActionCreateWorkItem:
 		return s.applyCreateWorkItem(ctx, action)
 	case ActionUpdateWorkItem:
@@ -378,7 +383,7 @@ func validateActionShape(action Action) error {
 	kind := normalizeKind(action.Kind)
 	switch kind {
 	case ActionCreateProject, ActionUpdateProject, ActionAttachProjectRoot, ActionRemoveProjectRoot,
-		ActionSetProjectDefaults, ActionMoveChatSession, ActionCreateWorkItem, ActionUpdateWorkItem,
+		ActionSetProjectDefaults, ActionMoveChatSession, ActionCreateRole, ActionCreateWorkItem, ActionUpdateWorkItem,
 		ActionCreateAssignment, ActionCreateHandoff, ActionCreateMemoryCandidate:
 		if len(action.Patch) == 0 && kind != ActionRemoveProjectRoot {
 			return fmt.Errorf("%w: action %q patch is required", ErrInvalid, kind)
@@ -605,6 +610,42 @@ func (s *Service) applyMoveChatSession(ctx context.Context, action Action) (Acti
 		return ActionResult{}, err
 	}
 	return ActionResult{Kind: ActionMoveChatSession, ID: updated.ID, Data: map[string]string{"chat_session_id": updated.ID, "project_id": updated.ProjectID}}, nil
+}
+
+func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionResult, error) {
+	if s.work == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
+	var patch rolePatch
+	if err := decodePatch(action, &patch); err != nil {
+		return ActionResult{}, err
+	}
+	projectID := patch.ProjectID
+	if projectID == "" {
+		projectID = targetValue(action, "project_id")
+	}
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return ActionResult{}, err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		id = s.idgen("role")
+	}
+	role, err := s.work.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:                  id,
+		ProjectID:           projectID,
+		Name:                patch.Name,
+		Description:         patch.Description,
+		Instructions:        patch.Instructions,
+		DefaultDriverKind:   patch.DefaultDriverKind,
+		DefaultProvider:     patch.DefaultProvider,
+		DefaultModel:        patch.DefaultModel,
+		DefaultAgentProfile: patch.DefaultAgentProfile,
+	})
+	if err != nil {
+		return ActionResult{}, mapProjectWorkErr(err)
+	}
+	return ActionResult{Kind: ActionCreateRole, ID: role.ID, Data: map[string]string{"project_id": role.ProjectID, "role_id": role.ID}}, nil
 }
 
 func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
@@ -887,6 +928,18 @@ type defaultsPatch struct {
 
 type moveChatSessionPatch struct {
 	ProjectID string `json:"project_id"`
+}
+
+type rolePatch struct {
+	ID                  string `json:"id,omitempty"`
+	ProjectID           string `json:"project_id,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Description         string `json:"description,omitempty"`
+	Instructions        string `json:"instructions,omitempty"`
+	DefaultDriverKind   string `json:"default_driver_kind,omitempty"`
+	DefaultProvider     string `json:"default_provider,omitempty"`
+	DefaultModel        string `json:"default_model,omitempty"`
+	DefaultAgentProfile string `json:"default_agent_profile,omitempty"`
 }
 
 type workItemPatch struct {
@@ -1174,6 +1227,8 @@ func mapProjectWorkErr(err error) error {
 		return fmt.Errorf("%w: %v", ErrInvalid, err)
 	case errors.Is(err, projectwork.ErrDuplicate), errors.Is(err, projectwork.ErrDuplicateRole):
 		return fmt.Errorf("%w: %v", ErrConflict, err)
+	case errors.Is(err, projectwork.ErrBuiltInRole):
+		return fmt.Errorf("%w: %v", ErrInvalid, err)
 	default:
 		return err
 	}

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -131,6 +132,264 @@ func TestService_DraftCreatesWorkItemProposalAcrossStores(t *testing.T) {
 				t.Fatalf("work item patch = %+v, want project/title/brief/owner role", patch)
 			}
 		})
+	}
+}
+
+func TestService_DraftBootstrapCreatesGuidanceAndSkillRoleProposalAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, ".hecate", "skills", "research"), 0o755); err != nil {
+				t.Fatalf("mkdir skill: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(root, ".hecate", "skills", "research", "SKILL.md"), []byte("# Research\n"), 0o644); err != nil {
+				t.Fatalf("write skill: %v", err)
+			}
+			project, err := fixture.projects.Create(ctx, projects.Project{
+				ID:   "proj_bootstrap",
+				Name: "Bootstrap Project",
+				Roots: []projects.Root{{
+					ID:     "root_bootstrap",
+					Path:   root,
+					Kind:   "git",
+					Active: true,
+				}},
+				ContextSources: []projects.ContextSource{{
+					ID:             "ctx_agents",
+					Kind:           "workspace_instruction",
+					Title:          "AGENTS.md",
+					Path:           "AGENTS.md",
+					Enabled:        true,
+					Format:         "agents_md",
+					Scope:          "workspace",
+					TrustLabel:     "workspace_guidance",
+					SourceCategory: "workspace_guidance",
+					Metadata:       map[string]string{"root_id": "root_bootstrap"},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("Create project: %v", err)
+			}
+
+			proposal, err := fixture.service.Draft(ctx, DraftInput{
+				ProjectID: project.ID,
+				Request:   "Bootstrap project guidance",
+				DraftMode: DraftModeBootstrap,
+				TraceID:   "trace_bootstrap",
+			})
+			if err != nil {
+				t.Fatalf("Draft bootstrap: %v", err)
+			}
+			if proposal.TraceID != "trace_bootstrap" || !proposal.RequiresConfirmation {
+				t.Fatalf("proposal trace/confirmation = %q/%v, want trace and confirmation", proposal.TraceID, proposal.RequiresConfirmation)
+			}
+			if len(proposal.Actions) != 2 {
+				t.Fatalf("actions = %+v, want guidance candidate and skill role", proposal.Actions)
+			}
+			if proposal.Actions[0].Kind != ActionCreateMemoryCandidate || proposal.Actions[1].Kind != ActionCreateRole {
+				t.Fatalf("action kinds = %s/%s, want memory candidate then role", proposal.Actions[0].Kind, proposal.Actions[1].Kind)
+			}
+			var memoryPatch memoryCandidatePatch
+			if err := json.Unmarshal(proposal.Actions[0].Patch, &memoryPatch); err != nil {
+				t.Fatalf("decode memory patch: %v", err)
+			}
+			if memoryPatch.SuggestedSourceKind != "context_source" || memoryPatch.SuggestedSourceID != "ctx_agents" || memoryPatch.SuggestedTrustLabel != "workspace_guidance" {
+				t.Fatalf("memory patch = %+v, want context-source provenance", memoryPatch)
+			}
+			if !strings.Contains(memoryPatch.Body, "provenance only") {
+				t.Fatalf("memory body = %q, want provenance-only warning", memoryPatch.Body)
+			}
+			var rolePatch rolePatch
+			if err := json.Unmarshal(proposal.Actions[1].Patch, &rolePatch); err != nil {
+				t.Fatalf("decode role patch: %v", err)
+			}
+			if rolePatch.ID != "skill_research" || rolePatch.Name != "Research" || rolePatch.DefaultDriverKind != projectwork.AssignmentDriverHecateTask {
+				t.Fatalf("role patch = %+v, want skill-derived role", rolePatch)
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if err != nil {
+				t.Fatalf("Apply bootstrap: %v", err)
+			}
+			if !result.Applied || len(result.Actions) != 2 {
+				t.Fatalf("apply result = %+v, want two applied actions", result)
+			}
+			candidates, err := fixture.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+				ProjectID: project.ID,
+				Status:    memory.CandidateStatusPending,
+			})
+			if err != nil {
+				t.Fatalf("ListCandidates: %v", err)
+			}
+			if len(candidates) != 1 || candidates[0].SuggestedSourceKind != "context_source" || candidates[0].SuggestedSourceID != "ctx_agents" {
+				t.Fatalf("candidates = %+v, want context-source memory candidate", candidates)
+			}
+			roles, err := fixture.work.ListRoles(ctx, project.ID)
+			if err != nil {
+				t.Fatalf("ListRoles: %v", err)
+			}
+			if !contextRoleExists(roleContexts(roles), "skill_research") {
+				t.Fatalf("roles = %+v, want skill_research custom role", roles)
+			}
+		})
+	}
+}
+
+func TestService_DraftBootstrapIgnoresRepoSpecificDocsAISkills(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newMemoryAssistantFixture(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs-ai", "skills", "research"), 0o755); err != nil {
+		t.Fatalf("mkdir docs-ai skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs-ai", "skills", "research", "SKILL.md"), []byte("# Research\n"), 0o644); err != nil {
+		t.Fatalf("write docs-ai skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# Instructions\n\nNo skill registry is declared here.\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	project, err := fixture.projects.Create(ctx, projects.Project{
+		ID:   "proj_docs_ai_bootstrap",
+		Name: "Docs AI Bootstrap",
+		Roots: []projects.Root{{
+			ID:     "root_docs_ai",
+			Path:   root,
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:             "ctx_docs_ai_agents",
+			Kind:           "workspace_instruction",
+			Title:          "AGENTS.md",
+			Path:           "AGENTS.md",
+			Enabled:        true,
+			Format:         "agents_md",
+			Scope:          "workspace",
+			TrustLabel:     "workspace_guidance",
+			SourceCategory: "workspace_guidance",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposal, err := fixture.service.Draft(ctx, DraftInput{
+		ProjectID: project.ID,
+		Request:   "Bootstrap project guidance",
+		DraftMode: DraftModeBootstrap,
+	})
+	if err != nil {
+		t.Fatalf("Draft bootstrap: %v", err)
+	}
+	for _, action := range proposal.Actions {
+		if action.Kind == ActionCreateRole {
+			t.Fatalf("actions = %+v, want docs-ai skills ignored for generic bootstrap", proposal.Actions)
+		}
+	}
+}
+
+func TestService_DraftBootstrapDiscoversSkillDirsFromGuidanceReferences(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newMemoryAssistantFixture(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs-ai", "skills", "research"), 0o755); err != nil {
+		t.Fatalf("mkdir docs-ai skill: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "claude-skills", "review"), 0o755); err != nil {
+		t.Fatalf("mkdir review claude skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs-ai", "skills", "research", "SKILL.md"), []byte("# Research\n"), 0o644); err != nil {
+		t.Fatalf("write docs-ai skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "claude-skills", "review", "SKILL.md"), []byte("# Review\n"), 0o644); err != nil {
+		t.Fatalf("write review claude skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("Canonical skill registry: [`docs-ai/skills/README.md`](docs-ai/skills/README.md).\nUse [`docs-ai/skills/research/SKILL.md`](docs-ai/skills/research/SKILL.md).\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte("Claude-compatible entrypoint. Use [`claude-skills/review/SKILL.md`](claude-skills/review/SKILL.md).\n"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+	project, err := fixture.projects.Create(ctx, projects.Project{
+		ID:   "proj_guidance_skill_refs",
+		Name: "Guidance Skill Refs",
+		Roots: []projects.Root{{
+			ID:     "root_guidance_skill_refs",
+			Path:   root,
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{
+			{
+				ID:             "ctx_guidance_agents",
+				Kind:           "workspace_instruction",
+				Title:          "AGENTS.md",
+				Path:           "AGENTS.md",
+				Enabled:        true,
+				Format:         "agents_md",
+				Scope:          "workspace",
+				TrustLabel:     "workspace_guidance",
+				SourceCategory: "workspace_guidance",
+				Metadata:       map[string]string{"root_id": "root_guidance_skill_refs"},
+			},
+			{
+				ID:             "ctx_guidance_claude",
+				Kind:           "host_instruction",
+				Title:          "CLAUDE.md",
+				Path:           "CLAUDE.md",
+				Enabled:        true,
+				Format:         "claude_md",
+				Scope:          "workspace",
+				TrustLabel:     "workspace_guidance",
+				SourceCategory: "workspace_guidance",
+				Metadata:       map[string]string{"root_id": "root_guidance_skill_refs", "host": "claude"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposal, err := fixture.service.Draft(ctx, DraftInput{
+		ProjectID: project.ID,
+		Request:   "Bootstrap project guidance",
+		DraftMode: DraftModeBootstrap,
+	})
+	if err != nil {
+		t.Fatalf("Draft bootstrap: %v", err)
+	}
+	found := map[string]bool{}
+	for _, action := range proposal.Actions {
+		if action.Kind != ActionCreateRole {
+			continue
+		}
+		var patch rolePatch
+		if err := json.Unmarshal(action.Patch, &patch); err != nil {
+			t.Fatalf("decode role patch: %v", err)
+		}
+		switch patch.ID {
+		case "skill_research":
+			found[patch.ID] = true
+			if !strings.Contains(patch.Instructions, "docs-ai/skills/research/SKILL.md") {
+				t.Fatalf("role instructions = %q, want guidance-derived skill path", patch.Instructions)
+			}
+		case "skill_review":
+			found[patch.ID] = true
+			if !strings.Contains(patch.Instructions, "claude-skills/review/SKILL.md") {
+				t.Fatalf("role instructions = %q, want Claude guidance-derived skill path", patch.Instructions)
+			}
+		}
+	}
+	for _, id := range []string{"skill_research", "skill_review"} {
+		if !found[id] {
+			t.Fatalf("actions = %+v, want role %s from guidance skill reference", proposal.Actions, id)
+		}
 	}
 }
 

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -16,7 +16,7 @@ export type ProjectAssistantDraftForm = {
   request: string;
   roleID: string;
   driverKind: string;
-  draftMode: "deterministic" | "model";
+  draftMode: "deterministic" | "model" | "bootstrap";
 };
 
 export type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
@@ -119,14 +119,12 @@ export function ProjectAssistantPanel({
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
-                    draftMode:
-                      event.target.value === "model" && modelDraftAvailable
-                        ? "model"
-                        : "deterministic",
+                    draftMode: projectAssistantDraftMode(event.target.value, modelDraftAvailable),
                   }))
                 }
               >
                 <option value="deterministic">Rules</option>
+                <option value="bootstrap">Bootstrap</option>
                 <option value="model" disabled={!modelDraftAvailable}>
                   Assistant{modelDraftAvailable ? "" : " (set model)"}
                 </option>
@@ -283,6 +281,10 @@ function ProjectAssistantContextPanel({ context }: { context: ProjectAssistantCo
           <ProjectAssistantContextStat label="Selected work" value={context.selected_work?.title} />
           <ProjectAssistantContextStat label="Roles" value={String(context.roles.length)} />
           <ProjectAssistantContextStat
+            label="Sources"
+            value={String(context.project.context_sources?.length ?? 0)}
+          />
+          <ProjectAssistantContextStat
             label="Assignments"
             value={String(context.assignments?.length ?? 0)}
           />
@@ -398,6 +400,15 @@ function projectAssistantDraftForm(
   };
 }
 
+function projectAssistantDraftMode(
+  value: string,
+  modelDraftAvailable: boolean,
+): ProjectAssistantDraftForm["draftMode"] {
+  if (value === "bootstrap") return "bootstrap";
+  if (value === "model" && modelDraftAvailable) return "model";
+  return "deterministic";
+}
+
 function projectAssistantAutoRole(
   workItem: ProjectWorkItemRecord | null,
   roles: ProjectWorkRoleRecord[],
@@ -435,6 +446,8 @@ function projectAssistantActionLabel(kind: string): string {
       return "Set defaults";
     case "move_chat_session":
       return "Move chat";
+    case "create_role":
+      return "Create role";
     case "create_work_item":
       return "Create work item";
     case "update_work_item":

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1148,6 +1148,31 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("can request bootstrap Project Assistant drafts", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.selectOptions(within(assistant).getByLabelText("Draft"), "bootstrap");
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+
+    await waitFor(() => {
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        work_item_id: workItem.id,
+        request: "Queue Software developer for Build cockpit UI",
+        draft_mode: "bootstrap",
+      });
+    });
+  });
+
   it("inspects Project Assistant context selection before drafting", async () => {
     resetProjectWorkMocks();
     const user = userEvent.setup();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -4973,8 +4973,8 @@ function projectAssistantDraftPayload(
     projectID,
     workItemID,
   );
-  if (form.draftMode === "model") {
-    payload.draft_mode = "model";
+  if (form.draftMode !== "deterministic") {
+    payload.draft_mode = form.draftMode;
   }
   return payload;
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -124,6 +124,7 @@ export type ProjectAssistantContextProject = {
   name: string;
   description?: string;
   roots?: ProjectAssistantContextProjectRoot[];
+  context_sources?: ProjectContextSourceRecord[];
   default_root_id?: string;
   default_provider?: string;
   default_model?: string;
@@ -257,7 +258,7 @@ export type ProjectAssistantContextPayload = {
   driver_kind?: string;
 };
 
-export type ProjectAssistantDraftMode = "deterministic" | "model";
+export type ProjectAssistantDraftMode = "deterministic" | "model" | "bootstrap";
 
 export type ProjectAssistantDraftPayload = ProjectAssistantContextPayload & {
   draft_mode?: ProjectAssistantDraftMode;


### PR DESCRIPTION
## Summary

- Add deterministic Project Assistant bootstrap drafts from discovered workspace guidance metadata.
- Suggest project roles from local skill files in .agents/skills, .hecate/skills, or skill roots explicitly linked from AGENTS.md / CLAUDE.md.
- Expose project context-source metadata to assistant context packets and add the create_role proposal action.
- Wire the Projects UI to request bootstrap drafts and show source counts.
- Make the pre-PR rule explicit: production-code changes need tests, and user/AI/runtime docs plus diagrams must be checked before PR updates.

## Safety

- Bootstrap mode is deterministic and does not call a model.
- Guidance files are read through WorkspaceFS with a byte cap only to discover local skill-path references.
- Applying bootstrap proposals creates memory candidates and role records only. It does not install skills, execute scripts, grant tools, create durable memory, start tasks, or launch agents.

## Tests

- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/projectassistant ./internal/api
- go vet ./internal/projectassistant ./internal/api
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx
- just agent-docs-check

## Docs

Updated runtime API docs, Project Assistant docs, the workspace-instructions / skills / profiles proposal, and the canonical agent guidance. No Mermaid diagrams needed changes for this diff.