### PR TITLE
Split skills in context inspector

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2871,14 +2871,15 @@ Operator UI note: the current React console renders these packets as a compact
 "what the agent saw" inspector. Chats expose it inline on assistant transcript
 rows; Task Detail and Project assignment detail expose it behind an
 `Inspect context` modal. The UI groups rows by `section` using labels such as
-Profile, Instructions, Memory, Project sources, Work context, and Runtime
-evidence; keeps trust labels on each item; falls back to legacy `sources` when
+Profile, Instructions, Skills, Memory, Project sources, Work context, and
+Runtime evidence; keeps trust labels on each item; falls back to legacy `sources` when
 `items` are absent; and uses operator-facing copy such as `Not captured` when a
 snapshot does not expose the full system prompt text.
 
 Section values currently used by the runtime are:
 
 - `instructions` for system-prompt and instruction-layer metadata
+- `skills` for resolved and skipped project skill metadata; `SKILL.md` bodies are not included
 - `memory` for project memory entries
 - `workspace` for the selected workspace path
 - `project` for project identity metadata

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -28,6 +28,7 @@ const (
 const (
 	contextSectionProfile      = "profile"
 	contextSectionInstructions = "instructions"
+	contextSectionSkills       = "skills"
 	contextSectionMemory       = "memory"
 	contextSectionWorkspace    = "workspace"
 	contextSectionProject      = "project"
@@ -847,7 +848,7 @@ func appendResolvedProjectSkills(packet *chat.ContextPacket, skills resolvedProj
 	if len(skills.Warnings) > 0 {
 		body = append(body, "Warnings: "+strings.Join(skills.Warnings, " "))
 	}
-	appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
+	appendContextPacketSourceWithSection(packet, contextSectionSkills, chat.ContextSource{
 		Kind:   "project_skills",
 		Label:  "Project skills",
 		Detail: strings.Join(skills.Requested, ","),
@@ -1068,6 +1069,8 @@ func defaultContextItemSection(kind string) string {
 	switch {
 	case kind == "system_prompt":
 		return contextSectionInstructions
+	case kind == "project_skills":
+		return contextSectionSkills
 	case kind == "memory":
 		return contextSectionMemory
 	case kind == "workspace":

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -794,8 +794,8 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 		}
 	}
 	skillsItem := findRenderedContextItemByOrigin(packetResp.Data, "project_skills")
-	if skillsItem == nil || !skillsItem.Included || skillsItem.Section != contextSectionProfile {
-		t.Fatalf("project skills item = %+v, want included profile section item", skillsItem)
+	if skillsItem == nil || !skillsItem.Included || skillsItem.Section != contextSectionSkills {
+		t.Fatalf("project skills item = %+v, want included skills section item", skillsItem)
 	}
 	for _, want := range []string{
 		"Requested: backend, review",

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -474,6 +474,17 @@ function resetProjectWorkMocks() {
           included: true,
         },
         {
+          section: "skills",
+          kind: "project_skills",
+          trust_level: "workspace_skill",
+          origin: "project_skills",
+          title: "Project skills",
+          body: "Requested: backend\nResolved enabled skills: backend (.hecate/skills/backend/SKILL.md)",
+          included: true,
+          inclusion_reason:
+            "Skill metadata resolved for this assignment; skill bodies are not injected",
+        },
+        {
           section: "memory",
           kind: "memory",
           trust_level: "operator_memory",
@@ -2001,12 +2012,14 @@ describe("ProjectsView cockpit", () => {
     const dialog = await screen.findByRole("dialog", { name: "Assignment asgn_1 context" });
     expect(dialog).toBeTruthy();
     expect(within(dialog).getByText("Profile")).toBeTruthy();
+    expect(within(dialog).getByText("Skills")).toBeTruthy();
     expect(within(dialog).getByText("Memory")).toBeTruthy();
     expect(within(dialog).getByText("Project sources")).toBeTruthy();
     expect(within(dialog).getByText("Work context")).toBeTruthy();
     expect(within(dialog).getByText("Runtime evidence")).toBeTruthy();
     expect(within(dialog).getByText("Task")).toBeTruthy();
     expect(within(dialog).getByText("task_1")).toBeTruthy();
+    expect(within(dialog).getByText("Project skills")).toBeTruthy();
     expect(within(dialog).getByText("Expose project work and native starts.")).toBeTruthy();
 
     await userEvent.click(within(detail).getByRole("button", { name: "Open chat" }));

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -29,6 +29,7 @@ type RemoteState =
 const sectionOrder = [
   "profile",
   "instructions",
+  "skills",
   "memory",
   "sources",
   "project_work",
@@ -540,6 +541,8 @@ function humanSectionLabel(section: string): string {
       return "Profile";
     case "instructions":
       return "Instructions";
+    case "skills":
+      return "Skills";
     case "project":
       return "Project";
     case "project_work":


### PR DESCRIPTION
## Summary

Moves project skill metadata into its own context packet section and teaches the shared Context Inspector to render Skills as a first-class group.

## Changes

- Add a backend `skills` context section for project skill resolution snapshots.
- Render `Skills` between Instructions and Memory in the shared inspector.
- Update Projects inspector coverage to assert the Skills group and Project skills item.
- Document the `skills` context packet section in the runtime API reference.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `go vet ./internal/api`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx src/features/transcript/TranscriptMessageRow.test.tsx src/features/runs/TaskDetail.test.tsx`
- `cd ui && bun run format:check`
- `cd ui && bun run typecheck`
- `just docs-format-check`
- `git diff --check`