### PR TITLE
Add profile skill picker UI

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -25,7 +25,9 @@ teams of agents: project roles describe who should do the work, assignments and
 handoffs record collaboration state, Tasks and Chats remain the execution
 surfaces, project memory/context carries reviewed knowledge forward, and the
 project skills registry exposes local `SKILL.md` metadata for roles/profiles
-without granting tools, injecting bodies, or executing skill scripts.
+without granting tools, injecting bodies, or executing skill scripts. The
+operator UI can manage agent profiles and pick registered project skills for
+roles/profiles; those selections remain metadata until launch-time resolution.
 Model-backed assistant turns should carry a small context-inspector packet:
 execution mode, route/workspace metadata, source provenance, and visible
 transcript counts. Do not store full prompt bodies, raw transcript text, file

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -371,9 +371,9 @@ The next project-orchestration slices are:
 
 1. Finish durable task/run project linkage so native tasks, project assignments,
    and chat-origin work all expose the same `project_id` boundary.
-2. Add a profile-management UI and finish profile-driven memory/source
-   selection. Role/project defaults already resolve into assignment-start
-   provider/model/profile/context posture.
+2. Finish profile-driven memory/source selection. Profile-management UI,
+   role/project default profile selection, and project-skill pickers exist;
+   assignment starts already resolve provider/model/profile/context posture.
 3. Add focused end-to-end project journeys: create project, set defaults, add
    memory, create work item, create/start assignment, resolve approval or
    failure, inspect activity health, and follow a handoff.

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -2,14 +2,15 @@
 
 > **Status:** proposal; Agent Profiles V1 core, workspace-guidance discovery,
 > project skills registry core/UI, role skill ids, assignment skill resolution,
-> and Bootstrap V2 registry-based role suggestions are implemented.
+> profile-management UI, skill pickers, and Bootstrap V2 registry-based role
+> suggestions are implemented.
 > **Current source of truth:** [Context assembly and injection boundaries](context-assembly-and-injection-boundaries.md),
 > [Agent memory](agent-memory.md), [Projects](../accepted/projects.md), and
 > [Runtime API](../../runtime/runtime-api.md) for today's context-packet,
 > memory, project, and task behavior.
-> **Next action:** add profile-management UI polish, skill pickers, compatibility
-> warnings, and explicit source-content injection policy. Remote skill install
-> and skill execution remain separate later slices.
+> **Next action:** add compatibility warnings, profile-driven memory/source
+> activation, and explicit source-content injection policy. Remote skill
+> install and skill execution remain separate later slices.
 
 Hecate needs a clean vocabulary for several things that are easy to blur:
 workspace `AGENTS.md` files, other Markdown instruction files, reusable
@@ -386,6 +387,7 @@ Recommended sequence:
 1. **Agent Profiles V1 Core** — partially implemented.
    - Profile store with memory/SQLite parity.
    - CRUD/list API.
+   - Profile-management UI for creating, editing, and deleting saved profiles.
    - Resolution helper with explicit/role/project/fallback order.
    - `skill_ids` resolve against the project skills registry during project
      work starts.
@@ -424,12 +426,14 @@ Recommended sequence:
      assignment start.
    - Implemented: active/skipped skill metadata and warnings are snapshotted
      into context packets without bodies.
-   - Future: profile editor skill picker and permission-compatibility warnings.
+   - Implemented: project roles and the profile editor can select from the
+     project skills registry while preserving manual/unresolved IDs.
+   - Future: permission-compatibility warnings.
 
 5. **UI**
-   - Profile editor.
-   - Skill list/detail and skill picker.
-   - Workspace instruction source list.
+   - Implemented: profile editor.
+   - Implemented: Project Skills list/detail and role/profile skill pickers.
+   - Implemented: workspace instruction source list.
    - Context Inspector sections for instructions, skills, profile, memory, and
      runbook/workflow context.
 

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -103,10 +103,10 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   capability metadata; generic OpenAI-compatible local models often remain
   `unknown` until the provider reports richer metadata.
 - Workspace modes are available for task/project starts, and named agent
-  profiles now have a core API plus project/role default selection. A full
-  profile-management UI and profile-driven memory/source injection are still
-  beta-hardening work. Tools-on chat still uses the selected workspace with the
-  current chat runtime posture.
+  profiles now have a core API, profile-management UI, project/role default
+  selection, and project-skill pickers. Profile-driven memory/source injection
+  is still beta-hardening work. Tools-on chat still uses the selected workspace
+  with the current chat runtime posture.
 - Tasks remains canonical for full run history, retry/resume, artifacts, and
   patch review. Chats projects the high-signal run activity and approval
   controls, but it is not a replacement for every Task Detail inspection flow.

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -9,12 +9,14 @@ import { SettingsProvider } from "../../app/state/settings";
 import {
   ApiError,
   applyProjectAssistant,
+  createAgentProfile,
   createProjectAssignment,
   createProjectHandoff,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
+  deleteAgentProfile,
   deleteProjectHandoff,
   deleteProjectMemory,
   deleteProjectWorkRole,
@@ -39,6 +41,7 @@ import {
   rejectProjectMemoryCandidate,
   startProjectAssignment,
   updateProject,
+  updateAgentProfile,
   updateProjectAssignment,
   updateProjectHandoff,
   updateProjectHandoffStatus,
@@ -186,6 +189,9 @@ vi.mock("../../lib/api", async (importOriginal) => {
     })),
     getProjectSkills: vi.fn(async () => ({ object: "project_skills", data: [] })),
     getAgentProfiles: vi.fn(async () => ({ object: "agent_profiles", data: [] })),
+    createAgentProfile: vi.fn(async () => ({ object: "agent_profile", data: null })),
+    updateAgentProfile: vi.fn(async () => ({ object: "agent_profile", data: null })),
+    deleteAgentProfile: vi.fn(async () => undefined),
     draftProjectAssistant: vi.fn(async () => ({
       object: "project_assistant.proposal",
       data: {
@@ -676,6 +682,55 @@ function resetProjectWorkMocks() {
       },
     ],
   });
+  vi.mocked(createAgentProfile).mockImplementation(async (payload) => ({
+    object: "agent_profile",
+    data: {
+      id: payload.id || "profile_new",
+      name: payload.name,
+      description: payload.description ?? "",
+      instructions: payload.instructions ?? "",
+      surface: payload.surface || "any",
+      provider_hint: payload.provider_hint ?? "",
+      model_hint: payload.model_hint ?? "",
+      execution_profile: payload.execution_profile ?? "",
+      tools_enabled: payload.tools_enabled ?? true,
+      writes_allowed: payload.writes_allowed ?? false,
+      network_allowed: payload.network_allowed ?? false,
+      approval_policy: payload.approval_policy || "inherit",
+      project_memory_policy: payload.project_memory_policy || "inherit",
+      context_source_policy: payload.context_source_policy || "inherit",
+      skill_ids: payload.skill_ids ?? [],
+      external_agent_kind: payload.external_agent_kind ?? "",
+      external_agent_options: {},
+      created_at: "2026-06-04T12:00:00Z",
+      updated_at: "2026-06-04T12:00:00Z",
+    },
+  }));
+  vi.mocked(updateAgentProfile).mockImplementation(async (id, payload) => ({
+    object: "agent_profile",
+    data: {
+      id,
+      name: payload.name || "Implementation",
+      description: payload.description ?? "",
+      instructions: payload.instructions ?? "",
+      surface: payload.surface || "any",
+      provider_hint: payload.provider_hint ?? "",
+      model_hint: payload.model_hint ?? "",
+      execution_profile: payload.execution_profile ?? "",
+      tools_enabled: payload.tools_enabled ?? true,
+      writes_allowed: payload.writes_allowed ?? false,
+      network_allowed: payload.network_allowed ?? false,
+      approval_policy: payload.approval_policy || "inherit",
+      project_memory_policy: payload.project_memory_policy || "inherit",
+      context_source_policy: payload.context_source_policy || "inherit",
+      skill_ids: payload.skill_ids ?? [],
+      external_agent_kind: payload.external_agent_kind ?? "",
+      external_agent_options: {},
+      created_at: "2026-06-04T10:00:00Z",
+      updated_at: "2026-06-04T12:00:00Z",
+    },
+  }));
+  vi.mocked(deleteAgentProfile).mockResolvedValue(undefined);
   vi.mocked(draftProjectAssistant).mockResolvedValue({
     object: "project_assistant.proposal",
     data: {
@@ -888,6 +943,9 @@ afterEach(() => {
   vi.mocked(getProjectMemoryCandidates).mockReset();
   vi.mocked(getProjectSkills).mockReset();
   vi.mocked(getAgentProfiles).mockReset();
+  vi.mocked(createAgentProfile).mockReset();
+  vi.mocked(updateAgentProfile).mockReset();
+  vi.mocked(deleteAgentProfile).mockReset();
   vi.mocked(draftProjectAssistant).mockReset();
   vi.mocked(applyProjectAssistant).mockReset();
   vi.mocked(createProjectHandoff).mockReset();
@@ -995,7 +1053,12 @@ describe("ProjectsView index", () => {
       .getAllByRole("button")
       .map((button) => button.getAttribute("aria-label") ?? "");
     expect(actionLabels[0]).toMatch(/^Project attention/);
-    expect(actionLabels.slice(1)).toEqual(["Roles", "Project settings", "Refresh project work"]);
+    expect(actionLabels.slice(1)).toEqual([
+      "Roles",
+      "Agent profiles",
+      "Project settings",
+      "Refresh project work",
+    ]);
     expect(within(detail).queryByText("Cockpit")).toBeNull();
     expect(within(workPanel).getByRole("button", { name: "Work" })).toBeTruthy();
     expect(within(workPanel).getByText("Work Queue")).toBeTruthy();
@@ -3719,6 +3782,23 @@ describe("ProjectsView cockpit", () => {
 
   it("creates custom roles with execution defaults", async () => {
     resetProjectWorkMocks();
+    vi.mocked(getProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [
+        {
+          ...projectSkill,
+          id: "frontend",
+          title: "Frontend",
+          path: ".agents/skills/frontend/SKILL.md",
+        },
+        {
+          ...projectSkill,
+          id: "ui",
+          title: "UI",
+          path: ".agents/skills/ui/SKILL.md",
+        },
+      ],
+    });
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -3750,9 +3830,8 @@ describe("ProjectsView cockpit", () => {
     fireEvent.change(within(dialog).getByLabelText("Default model"), {
       target: { value: "ministral-3:latest" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Skill ids"), {
-      target: { value: "frontend, ui" },
-    });
+    await userEvent.click(await within(dialog).findByLabelText("Use skill Frontend"));
+    await userEvent.click(within(dialog).getByLabelText("Use skill UI"));
     await userEvent.click(within(dialog).getByRole("button", { name: "Create role" }));
 
     expect(createProjectWorkRole).toHaveBeenCalledWith(project.id, {
@@ -3769,6 +3848,109 @@ describe("ProjectsView cockpit", () => {
       expect(within(dialog).getByRole("button", { name: "Save role" })).toBeTruthy();
     });
     expect(within(dialog).getByRole("button", { name: "Delete role" })).toBeTruthy();
+  });
+
+  it("creates agent profiles with project skill selections", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [projectSkill],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Agent profiles" }));
+    const dialog = screen.getByRole("dialog", { name: "Agent profiles" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "New profile" }));
+    fireEvent.change(within(dialog).getByLabelText("Profile id"), {
+      target: { value: "reviewer" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Reviewer" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Description"), {
+      target: { value: "Reviews implementation assignments." },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Instructions"), {
+      target: { value: "Review the diff and surface risks." },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Surface"), {
+      target: { value: "hecate_task" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Execution profile"), {
+      target: { value: "review" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Provider hint"), {
+      target: { value: "ollama" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Model hint"), {
+      target: { value: "qwen2.5-coder" },
+    });
+    await userEvent.click(within(dialog).getByLabelText("Writes allowed"));
+    fireEvent.change(within(dialog).getByLabelText("Approval policy"), {
+      target: { value: "require" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Memory policy"), {
+      target: { value: "include" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Context source policy"), {
+      target: { value: "visible_only" },
+    });
+    await userEvent.click(await within(dialog).findByLabelText("Use skill Backend"));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create profile" }));
+
+    expect(createAgentProfile).toHaveBeenCalledWith({
+      id: "reviewer",
+      name: "Reviewer",
+      description: "Reviews implementation assignments.",
+      instructions: "Review the diff and surface risks.",
+      surface: "hecate_task",
+      provider_hint: "ollama",
+      model_hint: "qwen2.5-coder",
+      execution_profile: "review",
+      tools_enabled: true,
+      writes_allowed: true,
+      network_allowed: false,
+      approval_policy: "require",
+      project_memory_policy: "include",
+      context_source_policy: "visible_only",
+      skill_ids: ["backend"],
+      external_agent_kind: "",
+    });
+  });
+
+  it("updates and deletes agent profiles", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Agent profiles" }));
+    const dialog = screen.getByRole("dialog", { name: "Agent profiles" });
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Implementation reviewer" },
+    });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save profile" }));
+
+    expect(updateAgentProfile).toHaveBeenCalledWith(
+      "implementation",
+      expect.objectContaining({
+        name: "Implementation reviewer",
+        surface: "hecate_task",
+        project_memory_policy: "visible_only",
+        context_source_policy: "include_enabled",
+      }),
+    );
+
+    await userEvent.click(await within(dialog).findByRole("button", { name: "Delete profile" }));
+    expect(deleteAgentProfile).toHaveBeenCalledWith("implementation");
   });
 
   it("edits and deletes assignments from the selected work item", async () => {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -3950,6 +3950,9 @@ describe("ProjectsView cockpit", () => {
     );
 
     await userEvent.click(await within(dialog).findByRole("button", { name: "Delete profile" }));
+    expect(deleteAgentProfile).not.toHaveBeenCalled();
+    expect(screen.getByText(/Other projects may also reference this global profile/i)).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Delete agent profile" }));
     expect(deleteAgentProfile).toHaveBeenCalledWith("implementation");
   });
 

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1716,7 +1716,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             error={profilesError}
             pending={profilesPending}
             profiles={agentProfiles}
+            project={selectedProject}
             projectSkills={projectSkills}
+            roles={roles}
             onClose={() => setProfilesModalOpen(false)}
             onCreate={handleCreateAgentProfile}
             onDelete={handleDeleteAgentProfile}
@@ -4018,7 +4020,9 @@ function ProfilesModal({
   error,
   pending,
   profiles,
+  project,
   projectSkills,
+  roles,
   onClose,
   onCreate,
   onDelete,
@@ -4027,7 +4031,9 @@ function ProfilesModal({
   error: string;
   pending: boolean;
   profiles: AgentProfileRecord[];
+  project: ProjectRecord;
   projectSkills: ProjectSkillRecord[];
+  roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onCreate: (
     form: AgentProfileForm,
@@ -4041,6 +4047,7 @@ function ProfilesModal({
   const [selectedProfileID, setSelectedProfileID] = useState(profiles[0]?.id ?? "new");
   const selectedProfile = profiles.find((profile) => profile.id === selectedProfileID) ?? null;
   const editingNew = selectedProfileID === "new";
+  const [deleteProfile, setDeleteProfile] = useState<AgentProfileRecord | null>(null);
   const [form, setForm] = useState<AgentProfileForm>(() =>
     selectedProfile ? profileFormFromRecord(selectedProfile) : emptyAgentProfileForm(),
   );
@@ -4071,6 +4078,7 @@ function ProfilesModal({
   async function deleteSelectedProfile(profile: AgentProfileRecord) {
     const deleted = await onDelete(profile);
     if (!deleted) return;
+    setDeleteProfile(null);
     const nextProfile = profiles.find((item) => item.id !== profile.id) ?? null;
     if (nextProfile) {
       selectProfileRecord(nextProfile);
@@ -4081,281 +4089,304 @@ function ProfilesModal({
   }
 
   return (
-    <Modal
-      title="Agent profiles"
-      onClose={onClose}
-      width={840}
-      footer={
-        <div style={{ display: "flex", gap: 8, width: "100%" }}>
-          {selectedProfile && !editingNew && (
+    <>
+      <Modal
+        title="Agent profiles"
+        onClose={onClose}
+        width={840}
+        footer={
+          <div style={{ display: "flex", gap: 8, width: "100%" }}>
+            {selectedProfile && !editingNew && (
+              <button
+                className="btn btn-ghost"
+                type="button"
+                disabled={pending}
+                onClick={() => setDeleteProfile(selectedProfile)}
+                style={{ color: "var(--red)" }}
+              >
+                Delete profile
+              </button>
+            )}
             <button
-              className="btn btn-ghost"
+              className="btn btn-primary"
               type="button"
-              disabled={pending}
-              onClick={() => void deleteSelectedProfile(selectedProfile)}
-              style={{ color: "var(--red)" }}
+              disabled={pending || !canSave}
+              onClick={() => void submit()}
+              style={{ marginLeft: "auto" }}
             >
-              Delete profile
+              {pending ? "Saving..." : editingNew ? "Create profile" : "Save profile"}
             </button>
-          )}
-          <button
-            className="btn btn-primary"
-            type="button"
-            disabled={pending || !canSave}
-            onClick={() => void submit()}
-            style={{ marginLeft: "auto" }}
+          </div>
+        }
+      >
+        <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, minHeight: 470 }}>
+          <div
+            style={{
+              borderRight: "1px solid var(--border)",
+              paddingRight: 10,
+              display: "grid",
+              alignContent: "start",
+              gap: 6,
+            }}
           >
-            {pending ? "Saving..." : editingNew ? "Create profile" : "Save profile"}
-          </button>
-        </div>
-      }
-    >
-      <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, minHeight: 470 }}>
-        <div
-          style={{
-            borderRight: "1px solid var(--border)",
-            paddingRight: 10,
-            display: "grid",
-            alignContent: "start",
-            gap: 6,
-          }}
-        >
-          <button
-            className={
-              selectedProfileID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
-            }
-            type="button"
-            onClick={() => selectProfile("new")}
-            style={{ justifyContent: "flex-start" }}
-          >
-            <Icon d={Icons.plus} size={12} />
-            New profile
-          </button>
-          {profiles.map((profile) => (
             <button
-              key={profile.id}
               className={
-                selectedProfileID === profile.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
+                selectedProfileID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
               }
               type="button"
-              onClick={() => selectProfile(profile.id)}
-              style={{ justifyContent: "flex-start", minWidth: 0 }}
+              onClick={() => selectProfile("new")}
+              style={{ justifyContent: "flex-start" }}
             >
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-                {profile.name || profile.id}
-              </span>
+              <Icon d={Icons.plus} size={12} />
+              New profile
             </button>
-          ))}
+            {profiles.map((profile) => (
+              <button
+                key={profile.id}
+                className={
+                  selectedProfileID === profile.id
+                    ? "btn btn-primary btn-sm"
+                    : "btn btn-ghost btn-sm"
+                }
+                type="button"
+                onClick={() => selectProfile(profile.id)}
+                style={{ justifyContent: "flex-start", minWidth: 0 }}
+              >
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {profile.name || profile.id}
+                </span>
+              </button>
+            ))}
+          </div>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submit();
+            }}
+            style={{ display: "grid", gap: 12, alignContent: "start" }}
+          >
+            {error && <InlineError message={error} />}
+            <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Profile id</span>
+                <input
+                  className="input"
+                  value={form.id}
+                  disabled={!editingNew}
+                  placeholder="implementation"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, id: event.target.value }))
+                  }
+                />
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Name</span>
+                <input
+                  className="input"
+                  value={form.name}
+                  autoFocus={editingNew}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                />
+              </label>
+            </div>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Description</span>
+              <textarea
+                className="input"
+                value={form.description}
+                rows={2}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, description: event.target.value }))
+                }
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Instructions</span>
+              <textarea
+                className="input"
+                value={form.instructions}
+                rows={5}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, instructions: event.target.value }))
+                }
+              />
+            </label>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Surface</span>
+                <select
+                  className="input"
+                  value={form.surface}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, surface: event.target.value }))
+                  }
+                >
+                  {AGENT_PROFILE_SURFACES.map((surface) => (
+                    <option key={surface} value={surface}>
+                      {surface}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Execution profile</span>
+                <input
+                  className="input"
+                  value={form.executionProfile}
+                  placeholder="implementation"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, executionProfile: event.target.value }))
+                  }
+                />
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Provider hint</span>
+                <input
+                  className="input"
+                  value={form.providerHint}
+                  placeholder="ollama"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, providerHint: event.target.value }))
+                  }
+                />
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Model hint</span>
+                <input
+                  className="input"
+                  value={form.modelHint}
+                  placeholder="qwen2.5-coder"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, modelHint: event.target.value }))
+                  }
+                />
+              </label>
+            </div>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <label style={checkboxLabelStyle}>
+                <input
+                  type="checkbox"
+                  checked={form.toolsEnabled}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, toolsEnabled: event.target.checked }))
+                  }
+                />
+                Tools enabled
+              </label>
+              <label style={checkboxLabelStyle}>
+                <input
+                  type="checkbox"
+                  checked={form.writesAllowed}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
+                  }
+                />
+                Writes allowed
+              </label>
+              <label style={checkboxLabelStyle}>
+                <input
+                  type="checkbox"
+                  checked={form.networkAllowed}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
+                  }
+                />
+                Network allowed
+              </label>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Approval policy</span>
+                <select
+                  className="input"
+                  value={form.approvalPolicy}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
+                  }
+                >
+                  {AGENT_PROFILE_APPROVAL_POLICIES.map((policy) => (
+                    <option key={policy} value={policy}>
+                      {policy}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Memory policy</span>
+                <select
+                  className="input"
+                  value={form.projectMemoryPolicy}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
+                  }
+                >
+                  {AGENT_PROFILE_MEMORY_POLICIES.map((policy) => (
+                    <option key={policy} value={policy}>
+                      {policy}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>Context source policy</span>
+                <select
+                  className="input"
+                  value={form.contextSourcePolicy}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
+                  }
+                >
+                  {AGENT_PROFILE_CONTEXT_POLICIES.map((policy) => (
+                    <option key={policy} value={policy}>
+                      {policy}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={fieldStyle}>
+                <span style={fieldLabelStyle}>External agent kind</span>
+                <input
+                  className="input"
+                  value={form.externalAgentKind}
+                  placeholder="claude_code"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
+                  }
+                />
+              </label>
+            </div>
+            <SkillIDPicker
+              onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
+              skills={projectSkills}
+              value={form.skillIDs}
+            />
+            <div style={subtleTextStyle}>
+              Profiles set runtime posture and skill references. Skills do not grant tools, writes,
+              network, or approvals.
+            </div>
+          </form>
         </div>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            void submit();
-          }}
-          style={{ display: "grid", gap: 12, alignContent: "start" }}
-        >
-          {error && <InlineError message={error} />}
-          <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Profile id</span>
-              <input
-                className="input"
-                value={form.id}
-                disabled={!editingNew}
-                placeholder="implementation"
-                onChange={(event) => setForm((current) => ({ ...current, id: event.target.value }))}
-              />
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Name</span>
-              <input
-                className="input"
-                value={form.name}
-                autoFocus={editingNew}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, name: event.target.value }))
-                }
-              />
-            </label>
-          </div>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Description</span>
-            <textarea
-              className="input"
-              value={form.description}
-              rows={2}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, description: event.target.value }))
-              }
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Instructions</span>
-            <textarea
-              className="input"
-              value={form.instructions}
-              rows={5}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, instructions: event.target.value }))
-              }
-            />
-          </label>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Surface</span>
-              <select
-                className="input"
-                value={form.surface}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, surface: event.target.value }))
-                }
-              >
-                {AGENT_PROFILE_SURFACES.map((surface) => (
-                  <option key={surface} value={surface}>
-                    {surface}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Execution profile</span>
-              <input
-                className="input"
-                value={form.executionProfile}
-                placeholder="implementation"
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, executionProfile: event.target.value }))
-                }
-              />
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Provider hint</span>
-              <input
-                className="input"
-                value={form.providerHint}
-                placeholder="ollama"
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, providerHint: event.target.value }))
-                }
-              />
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Model hint</span>
-              <input
-                className="input"
-                value={form.modelHint}
-                placeholder="qwen2.5-coder"
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, modelHint: event.target.value }))
-                }
-              />
-            </label>
-          </div>
-          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-            <label style={checkboxLabelStyle}>
-              <input
-                type="checkbox"
-                checked={form.toolsEnabled}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, toolsEnabled: event.target.checked }))
-                }
-              />
-              Tools enabled
-            </label>
-            <label style={checkboxLabelStyle}>
-              <input
-                type="checkbox"
-                checked={form.writesAllowed}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
-                }
-              />
-              Writes allowed
-            </label>
-            <label style={checkboxLabelStyle}>
-              <input
-                type="checkbox"
-                checked={form.networkAllowed}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
-                }
-              />
-              Network allowed
-            </label>
-          </div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Approval policy</span>
-              <select
-                className="input"
-                value={form.approvalPolicy}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
-                }
-              >
-                {AGENT_PROFILE_APPROVAL_POLICIES.map((policy) => (
-                  <option key={policy} value={policy}>
-                    {policy}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Memory policy</span>
-              <select
-                className="input"
-                value={form.projectMemoryPolicy}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
-                }
-              >
-                {AGENT_PROFILE_MEMORY_POLICIES.map((policy) => (
-                  <option key={policy} value={policy}>
-                    {policy}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>Context source policy</span>
-              <select
-                className="input"
-                value={form.contextSourcePolicy}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
-                }
-              >
-                {AGENT_PROFILE_CONTEXT_POLICIES.map((policy) => (
-                  <option key={policy} value={policy}>
-                    {policy}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={fieldStyle}>
-              <span style={fieldLabelStyle}>External agent kind</span>
-              <input
-                className="input"
-                value={form.externalAgentKind}
-                placeholder="claude_code"
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
-                }
-              />
-            </label>
-          </div>
-          <SkillIDPicker
-            onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
-            skills={projectSkills}
-            value={form.skillIDs}
-          />
-          <div style={subtleTextStyle}>
-            Profiles set runtime posture and skill references. Skills do not grant tools, writes,
-            network, or approvals.
-          </div>
-        </form>
-      </div>
-    </Modal>
+      </Modal>
+      {deleteProfile && (
+        <ConfirmModal
+          title="Delete agent profile"
+          danger
+          pending={pending}
+          confirmLabel="Delete agent profile"
+          onClose={() => setDeleteProfile(null)}
+          onConfirm={() => void deleteSelectedProfile(deleteProfile)}
+          message={
+            <>
+              Delete <strong>{deleteProfile.name || deleteProfile.id}</strong>.{" "}
+              {profileReferenceSummary(deleteProfile, project, roles)} Other projects may also
+              reference this global profile.
+            </>
+          }
+        />
+      )}
+    </>
   );
 }
 
@@ -5964,6 +5995,27 @@ function profileUpdatePayloadFromForm(form: AgentProfileForm): UpdateAgentProfil
     skill_ids: uniqueSkillIDs(splitIDs(form.skillIDs)),
     external_agent_kind: form.externalAgentKind.trim(),
   };
+}
+
+function profileReferenceSummary(
+  profile: AgentProfileRecord,
+  project: ProjectRecord,
+  roles: ProjectWorkRoleRecord[],
+) {
+  const references: string[] = [];
+  if (project.default_agent_profile === profile.id) {
+    references.push("this project's default profile");
+  }
+  const roleNames = roles
+    .filter((role) => role.default_agent_profile === profile.id)
+    .map((role) => role.name || role.id);
+  if (roleNames.length > 0) {
+    references.push(`roles ${roleNames.join(", ")}`);
+  }
+  if (references.length === 0) {
+    return "No current project defaults or roles reference it.";
+  }
+  return `Referenced by ${references.join("; ")}. Those references will fall back until changed.`;
 }
 
 function roleFormFromRecord(role: ProjectWorkRoleRecord): RoleForm {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -14,6 +14,7 @@ import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
   applyProjectAssistant,
+  createAgentProfile,
   createProjectAssignment,
   createProjectHandoff,
   discoverProjectContextSources,
@@ -41,9 +42,11 @@ import {
   getProjectWorkItems,
   getProjectWorkRoles,
   startProjectAssignment,
+  deleteAgentProfile,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
   updateProject,
+  updateAgentProfile,
   updateProjectAssignment,
   updateProjectHandoff,
   updateProjectHandoffStatus,
@@ -99,7 +102,11 @@ import type {
   UpdateProjectSkillPayload,
   UpdateProjectWorkItemPayload,
 } from "../../types/project";
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type {
+  AgentProfileRecord,
+  CreateAgentProfilePayload,
+  UpdateAgentProfilePayload,
+} from "../../types/agent-profile";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderPresetRecord } from "../../types/provider";
 import type { ContextPacketRecord } from "../../types/context";
@@ -213,6 +220,25 @@ type SkillForm = {
   trustLabel: string;
 };
 
+type AgentProfileForm = {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  surface: string;
+  providerHint: string;
+  modelHint: string;
+  executionProfile: string;
+  toolsEnabled: boolean;
+  writesAllowed: boolean;
+  networkAllowed: boolean;
+  approvalPolicy: string;
+  projectMemoryPolicy: string;
+  contextSourcePolicy: string;
+  skillIDs: string;
+  externalAgentKind: string;
+};
+
 type RoleForm = {
   id: string;
   name: string;
@@ -251,6 +277,10 @@ const MEMORY_TRUST_LABELS = [
   "external_untrusted",
   "runtime_state",
 ];
+const AGENT_PROFILE_SURFACES = ["any", "hecate_chat", "hecate_task", "external_agent"];
+const AGENT_PROFILE_APPROVAL_POLICIES = ["inherit", "require", "block", "allow"];
+const AGENT_PROFILE_MEMORY_POLICIES = ["inherit", "include", "visible_only", "exclude"];
+const AGENT_PROFILE_CONTEXT_POLICIES = ["inherit", "include_enabled", "visible_only", "exclude"];
 const MEMORY_SOURCE_KINDS = [
   "operator",
   "generated",
@@ -389,6 +419,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [updatingSkillID, setUpdatingSkillID] = useState("");
   const [agentProfiles, setAgentProfiles] = useState<AgentProfileRecord[]>([]);
   const [agentProfilesError, setAgentProfilesError] = useState("");
+  const [profilesModalOpen, setProfilesModalOpen] = useState(false);
+  const [profilesPending, setProfilesPending] = useState(false);
+  const [profilesError, setProfilesError] = useState("");
   const [discoveringContext, setDiscoveringContext] = useState(false);
   const [memoryLoadState, setMemoryLoadState] = useState<LoadState>("idle");
   const [memoryError, setMemoryError] = useState("");
@@ -405,22 +438,26 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     () => projects.state.projects.find((project) => project.id === selectedProjectID) ?? null,
     [projects.state.projects, selectedProjectID],
   );
+
+  const loadAgentProfiles = useCallback(async (cancelled?: () => boolean) => {
+    try {
+      const payload = await getAgentProfiles();
+      if (cancelled?.()) return;
+      setAgentProfiles(payload.data ?? []);
+      setAgentProfilesError("");
+    } catch (error) {
+      if (cancelled?.()) return;
+      setAgentProfilesError(errorMessage(error, "Failed to load agent profiles."));
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    getAgentProfiles()
-      .then((payload) => {
-        if (cancelled) return;
-        setAgentProfiles(payload.data ?? []);
-        setAgentProfilesError("");
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setAgentProfilesError(errorMessage(error, "Failed to load agent profiles."));
-      });
+    void loadAgentProfiles(() => cancelled);
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadAgentProfiles]);
   const pendingDeleteProject =
     projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
   const roleByID = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
@@ -767,6 +804,55 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setSkillsError(errorMessage(error, "Failed to update project skill."));
     } finally {
       setUpdatingSkillID("");
+    }
+  }
+
+  async function handleCreateAgentProfile(form: AgentProfileForm) {
+    const name = form.name.trim();
+    if (!name) return undefined;
+    setProfilesPending(true);
+    setProfilesError("");
+    try {
+      const payload = await createAgentProfile(profileCreatePayloadFromForm(form));
+      setAgentProfiles((current) => upsertAgentProfile(current, payload.data));
+      return payload.data;
+    } catch (error) {
+      setProfilesError(errorMessage(error, "Failed to create agent profile."));
+      return undefined;
+    } finally {
+      setProfilesPending(false);
+    }
+  }
+
+  async function handleUpdateAgentProfile(profileID: string, form: AgentProfileForm) {
+    const name = form.name.trim();
+    if (!name) return undefined;
+    setProfilesPending(true);
+    setProfilesError("");
+    try {
+      const payload = await updateAgentProfile(profileID, profileUpdatePayloadFromForm(form));
+      setAgentProfiles((current) => upsertAgentProfile(current, payload.data));
+      return payload.data;
+    } catch (error) {
+      setProfilesError(errorMessage(error, "Failed to update agent profile."));
+      return undefined;
+    } finally {
+      setProfilesPending(false);
+    }
+  }
+
+  async function handleDeleteAgentProfile(profile: AgentProfileRecord) {
+    setProfilesPending(true);
+    setProfilesError("");
+    try {
+      await deleteAgentProfile(profile.id);
+      setAgentProfiles((current) => current.filter((item) => item.id !== profile.id));
+      return true;
+    } catch (error) {
+      setProfilesError(errorMessage(error, "Failed to delete agent profile."));
+      return false;
+    } finally {
+      setProfilesPending(false);
     }
   }
 
@@ -1380,6 +1466,10 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             setDefaultsError("");
             setSettingsPanelOpen((open) => !open);
           }}
+          onManageProfiles={() => {
+            setProfilesError("");
+            setProfilesModalOpen(true);
+          }}
           onManageRoles={() => {
             setRolesError("");
             setRolesModalOpen(true);
@@ -1612,11 +1702,25 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             agentProfiles={agentProfiles}
             error={rolesError}
             pending={rolesPending}
+            projectSkills={projectSkills}
             roles={roles}
             onClose={() => setRolesModalOpen(false)}
             onCreate={handleCreateRole}
             onDelete={handleDeleteRole}
             onUpdate={handleUpdateRole}
+          />
+        )}
+
+        {selectedProject && profilesModalOpen && (
+          <ProfilesModal
+            error={profilesError}
+            pending={profilesPending}
+            profiles={agentProfiles}
+            projectSkills={projectSkills}
+            onClose={() => setProfilesModalOpen(false)}
+            onCreate={handleCreateAgentProfile}
+            onDelete={handleDeleteAgentProfile}
+            onUpdate={handleUpdateAgentProfile}
           />
         )}
 
@@ -1944,6 +2048,7 @@ function ProjectHeader({
   onAttentionTask,
   onAttentionWorkItem,
   onEditDefaults,
+  onManageProfiles,
   onManageRoles,
   onRefresh,
 }: {
@@ -1958,6 +2063,7 @@ function ProjectHeader({
   onAttentionTask?: (taskID: string, runID?: string) => void;
   onAttentionWorkItem: (workItemID: string) => void;
   onEditDefaults: () => void;
+  onManageProfiles: () => void;
   onManageRoles: () => void;
   onRefresh: () => void;
 }) {
@@ -2075,6 +2181,17 @@ function ProjectHeader({
           style={projectHeaderActionButtonStyle}
         >
           <Icon d={Icons.user} size={13} />
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          aria-label="Agent profiles"
+          title="Agent profiles"
+          onClick={onManageProfiles}
+          disabled={!project}
+          style={projectHeaderActionButtonStyle}
+        >
+          <Icon d={Icons.model} size={13} />
         </button>
         <button
           className="btn btn-ghost btn-sm"
@@ -3897,10 +4014,443 @@ function normalizeWorkspaceMode(value: string) {
   return "in_place";
 }
 
+function ProfilesModal({
+  error,
+  pending,
+  profiles,
+  projectSkills,
+  onClose,
+  onCreate,
+  onDelete,
+  onUpdate,
+}: {
+  error: string;
+  pending: boolean;
+  profiles: AgentProfileRecord[];
+  projectSkills: ProjectSkillRecord[];
+  onClose: () => void;
+  onCreate: (
+    form: AgentProfileForm,
+  ) => AgentProfileRecord | undefined | Promise<AgentProfileRecord | undefined>;
+  onDelete: (profile: AgentProfileRecord) => boolean | Promise<boolean>;
+  onUpdate: (
+    profileID: string,
+    form: AgentProfileForm,
+  ) => AgentProfileRecord | undefined | Promise<AgentProfileRecord | undefined>;
+}) {
+  const [selectedProfileID, setSelectedProfileID] = useState(profiles[0]?.id ?? "new");
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileID) ?? null;
+  const editingNew = selectedProfileID === "new";
+  const [form, setForm] = useState<AgentProfileForm>(() =>
+    selectedProfile ? profileFormFromRecord(selectedProfile) : emptyAgentProfileForm(),
+  );
+
+  function selectProfile(profileID: string) {
+    setSelectedProfileID(profileID);
+    const profile = profiles.find((item) => item.id === profileID) ?? null;
+    setForm(profile ? profileFormFromRecord(profile) : emptyAgentProfileForm());
+  }
+
+  function selectProfileRecord(profile: AgentProfileRecord) {
+    setSelectedProfileID(profile.id);
+    setForm(profileFormFromRecord(profile));
+  }
+
+  const canSave = form.name.trim().length > 0;
+  const submit = async () => {
+    if (!canSave) return;
+    if (editingNew) {
+      const profile = await onCreate(form);
+      if (profile) selectProfileRecord(profile);
+      return;
+    }
+    const profile = await onUpdate(selectedProfileID, form);
+    if (profile) selectProfileRecord(profile);
+  };
+
+  async function deleteSelectedProfile(profile: AgentProfileRecord) {
+    const deleted = await onDelete(profile);
+    if (!deleted) return;
+    const nextProfile = profiles.find((item) => item.id !== profile.id) ?? null;
+    if (nextProfile) {
+      selectProfileRecord(nextProfile);
+      return;
+    }
+    setSelectedProfileID("new");
+    setForm(emptyAgentProfileForm());
+  }
+
+  return (
+    <Modal
+      title="Agent profiles"
+      onClose={onClose}
+      width={840}
+      footer={
+        <div style={{ display: "flex", gap: 8, width: "100%" }}>
+          {selectedProfile && !editingNew && (
+            <button
+              className="btn btn-ghost"
+              type="button"
+              disabled={pending}
+              onClick={() => void deleteSelectedProfile(selectedProfile)}
+              style={{ color: "var(--red)" }}
+            >
+              Delete profile
+            </button>
+          )}
+          <button
+            className="btn btn-primary"
+            type="button"
+            disabled={pending || !canSave}
+            onClick={() => void submit()}
+            style={{ marginLeft: "auto" }}
+          >
+            {pending ? "Saving..." : editingNew ? "Create profile" : "Save profile"}
+          </button>
+        </div>
+      }
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, minHeight: 470 }}>
+        <div
+          style={{
+            borderRight: "1px solid var(--border)",
+            paddingRight: 10,
+            display: "grid",
+            alignContent: "start",
+            gap: 6,
+          }}
+        >
+          <button
+            className={
+              selectedProfileID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
+            }
+            type="button"
+            onClick={() => selectProfile("new")}
+            style={{ justifyContent: "flex-start" }}
+          >
+            <Icon d={Icons.plus} size={12} />
+            New profile
+          </button>
+          {profiles.map((profile) => (
+            <button
+              key={profile.id}
+              className={
+                selectedProfileID === profile.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
+              }
+              type="button"
+              onClick={() => selectProfile(profile.id)}
+              style={{ justifyContent: "flex-start", minWidth: 0 }}
+            >
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                {profile.name || profile.id}
+              </span>
+            </button>
+          ))}
+        </div>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submit();
+          }}
+          style={{ display: "grid", gap: 12, alignContent: "start" }}
+        >
+          {error && <InlineError message={error} />}
+          <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Profile id</span>
+              <input
+                className="input"
+                value={form.id}
+                disabled={!editingNew}
+                placeholder="implementation"
+                onChange={(event) => setForm((current) => ({ ...current, id: event.target.value }))}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Name</span>
+              <input
+                className="input"
+                value={form.name}
+                autoFocus={editingNew}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, name: event.target.value }))
+                }
+              />
+            </label>
+          </div>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Description</span>
+            <textarea
+              className="input"
+              value={form.description}
+              rows={2}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, description: event.target.value }))
+              }
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Instructions</span>
+            <textarea
+              className="input"
+              value={form.instructions}
+              rows={5}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, instructions: event.target.value }))
+              }
+            />
+          </label>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Surface</span>
+              <select
+                className="input"
+                value={form.surface}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, surface: event.target.value }))
+                }
+              >
+                {AGENT_PROFILE_SURFACES.map((surface) => (
+                  <option key={surface} value={surface}>
+                    {surface}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Execution profile</span>
+              <input
+                className="input"
+                value={form.executionProfile}
+                placeholder="implementation"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, executionProfile: event.target.value }))
+                }
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Provider hint</span>
+              <input
+                className="input"
+                value={form.providerHint}
+                placeholder="ollama"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, providerHint: event.target.value }))
+                }
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Model hint</span>
+              <input
+                className="input"
+                value={form.modelHint}
+                placeholder="qwen2.5-coder"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, modelHint: event.target.value }))
+                }
+              />
+            </label>
+          </div>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={form.toolsEnabled}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, toolsEnabled: event.target.checked }))
+                }
+              />
+              Tools enabled
+            </label>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={form.writesAllowed}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
+                }
+              />
+              Writes allowed
+            </label>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={form.networkAllowed}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
+                }
+              />
+              Network allowed
+            </label>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Approval policy</span>
+              <select
+                className="input"
+                value={form.approvalPolicy}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
+                }
+              >
+                {AGENT_PROFILE_APPROVAL_POLICIES.map((policy) => (
+                  <option key={policy} value={policy}>
+                    {policy}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Memory policy</span>
+              <select
+                className="input"
+                value={form.projectMemoryPolicy}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
+                }
+              >
+                {AGENT_PROFILE_MEMORY_POLICIES.map((policy) => (
+                  <option key={policy} value={policy}>
+                    {policy}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>Context source policy</span>
+              <select
+                className="input"
+                value={form.contextSourcePolicy}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
+                }
+              >
+                {AGENT_PROFILE_CONTEXT_POLICIES.map((policy) => (
+                  <option key={policy} value={policy}>
+                    {policy}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldStyle}>
+              <span style={fieldLabelStyle}>External agent kind</span>
+              <input
+                className="input"
+                value={form.externalAgentKind}
+                placeholder="claude_code"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
+                }
+              />
+            </label>
+          </div>
+          <SkillIDPicker
+            onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
+            skills={projectSkills}
+            value={form.skillIDs}
+          />
+          <div style={subtleTextStyle}>
+            Profiles set runtime posture and skill references. Skills do not grant tools, writes,
+            network, or approvals.
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+}
+
+function SkillIDPicker({
+  disabled = false,
+  skills,
+  value,
+  onChange,
+}: {
+  disabled?: boolean;
+  skills: ProjectSkillRecord[];
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const selectedIDs = uniqueSkillIDs(splitIDs(value));
+  const selectedSet = new Set(selectedIDs);
+  const indexedSkills = new Map(skills.map((skill) => [skill.id, skill]));
+  const sortedSkills = sortProjectSkillsForPicker(skills);
+  const warnings = selectedIDs.flatMap((id) => projectSkillSelectionWarnings(id, indexedSkills));
+
+  function toggleSkill(skillID: string, checked: boolean) {
+    const next = checked
+      ? uniqueSkillIDs([...selectedIDs, skillID])
+      : selectedIDs.filter((id) => id !== skillID);
+    onChange(next.join(", "));
+  }
+
+  return (
+    <div style={fieldStyle}>
+      {sortedSkills.length > 0 && (
+        <div style={{ display: "grid", gap: 6 }}>
+          <span style={fieldLabelStyle}>Project skills</span>
+          <div style={{ display: "grid", gap: 6 }}>
+            {sortedSkills.map((skill) => (
+              <label
+                key={`${skill.id}:${skill.path}`}
+                style={{
+                  border: "1px solid var(--border)",
+                  borderRadius: 6,
+                  display: "grid",
+                  gap: 4,
+                  gridTemplateColumns: "auto 1fr",
+                  padding: "7px 8px",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedSet.has(skill.id)}
+                  disabled={disabled}
+                  aria-label={`Use skill ${skill.title || skill.id}`}
+                  onChange={(event) => toggleSkill(skill.id, event.target.checked)}
+                  style={{ marginTop: 2 }}
+                />
+                <span style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                  <span style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                    <span style={titleStyle}>{skill.title || skill.id}</span>
+                    <span className={projectSkillBadgeClass(skill)}>{skill.status}</span>
+                    {!skill.enabled && <span className="badge badge-muted">disabled</span>}
+                    <span className="badge badge-muted">{skill.id}</span>
+                  </span>
+                  <span style={subtleTextStyle}>{skill.path}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+      <label style={{ ...fieldStyle, marginTop: sortedSkills.length > 0 ? 8 : 0 }}>
+        <span style={fieldLabelStyle}>Skill ids</span>
+        <input
+          className="input"
+          value={value}
+          disabled={disabled}
+          placeholder="backend, qa"
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </label>
+      {warnings.length > 0 && (
+        <div style={{ display: "grid", gap: 3 }}>
+          {warnings.map((warning) => (
+            <div key={warning} style={{ ...subtleTextStyle, color: "var(--amber)" }}>
+              {warning}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function RolesModal({
   agentProfiles,
   error,
   pending,
+  projectSkills,
   roles,
   onClose,
   onCreate,
@@ -3910,6 +4460,7 @@ function RolesModal({
   agentProfiles: AgentProfileRecord[];
   error: string;
   pending: boolean;
+  projectSkills: ProjectSkillRecord[];
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onCreate: (
@@ -4144,18 +4695,12 @@ function RolesModal({
               />
             </label>
           </div>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Skill ids</span>
-            <input
-              className="input"
-              value={form.skillIDs}
-              disabled={editingBuiltIn}
-              placeholder="backend, qa"
-              onChange={(event) =>
-                setForm((current) => ({ ...current, skillIDs: event.target.value }))
-              }
-            />
-          </label>
+          <SkillIDPicker
+            disabled={editingBuiltIn}
+            onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
+            skills={projectSkills}
+            value={form.skillIDs}
+          />
           <div style={subtleTextStyle}>
             Role defaults are execution hints. Assignments can still override the driver, and
             project defaults remain the fallback.
@@ -5352,6 +5897,75 @@ function emptyRoleForm(): RoleForm {
   };
 }
 
+function emptyAgentProfileForm(): AgentProfileForm {
+  return {
+    id: "",
+    name: "",
+    description: "",
+    instructions: "",
+    surface: "any",
+    providerHint: "",
+    modelHint: "",
+    executionProfile: "",
+    toolsEnabled: true,
+    writesAllowed: false,
+    networkAllowed: false,
+    approvalPolicy: "inherit",
+    projectMemoryPolicy: "inherit",
+    contextSourcePolicy: "inherit",
+    skillIDs: "",
+    externalAgentKind: "",
+  };
+}
+
+function profileFormFromRecord(profile: AgentProfileRecord): AgentProfileForm {
+  return {
+    id: profile.id,
+    name: profile.name,
+    description: profile.description ?? "",
+    instructions: profile.instructions ?? "",
+    surface: profile.surface || "any",
+    providerHint: profile.provider_hint ?? "",
+    modelHint: profile.model_hint ?? "",
+    executionProfile: profile.execution_profile ?? "",
+    toolsEnabled: profile.tools_enabled,
+    writesAllowed: profile.writes_allowed,
+    networkAllowed: profile.network_allowed,
+    approvalPolicy: profile.approval_policy || "inherit",
+    projectMemoryPolicy: profile.project_memory_policy || "inherit",
+    contextSourcePolicy: profile.context_source_policy || "inherit",
+    skillIDs: (profile.skill_ids ?? []).join(", "),
+    externalAgentKind: profile.external_agent_kind ?? "",
+  };
+}
+
+function profileCreatePayloadFromForm(form: AgentProfileForm): CreateAgentProfilePayload {
+  const payload = profileUpdatePayloadFromForm(form) as CreateAgentProfilePayload;
+  const id = form.id.trim();
+  if (id) payload.id = id;
+  return payload;
+}
+
+function profileUpdatePayloadFromForm(form: AgentProfileForm): UpdateAgentProfilePayload {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    instructions: form.instructions.trim(),
+    surface: form.surface.trim() || "any",
+    provider_hint: form.providerHint.trim(),
+    model_hint: form.modelHint.trim(),
+    execution_profile: form.executionProfile.trim(),
+    tools_enabled: form.toolsEnabled,
+    writes_allowed: form.writesAllowed,
+    network_allowed: form.networkAllowed,
+    approval_policy: form.approvalPolicy.trim() || "inherit",
+    project_memory_policy: form.projectMemoryPolicy.trim() || "inherit",
+    context_source_policy: form.contextSourcePolicy.trim() || "inherit",
+    skill_ids: uniqueSkillIDs(splitIDs(form.skillIDs)),
+    external_agent_kind: form.externalAgentKind.trim(),
+  };
+}
+
 function roleFormFromRecord(role: ProjectWorkRoleRecord): RoleForm {
   return {
     id: role.id,
@@ -5375,7 +5989,7 @@ function rolePayloadFromForm(form: RoleForm) {
     default_provider: form.defaultProvider.trim(),
     default_model: form.defaultModel.trim(),
     default_agent_profile: form.defaultAgentProfile.trim(),
-    skill_ids: splitIDs(form.skillIDs),
+    skill_ids: uniqueSkillIDs(splitIDs(form.skillIDs)),
   };
 }
 
@@ -5696,6 +6310,15 @@ function upsertRole(items: ProjectWorkRoleRecord[], item: ProjectWorkRoleRecord)
   });
 }
 
+function upsertAgentProfile(items: AgentProfileRecord[], item: AgentProfileRecord) {
+  const index = items.findIndex((current) => current.id === item.id);
+  const next = index === -1 ? [item, ...items] : items.slice();
+  if (index !== -1) {
+    next[index] = item;
+  }
+  return next.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+}
+
 function upsertProjectSkill(items: ProjectSkillRecord[], item: ProjectSkillRecord) {
   const index = items.findIndex((current) => current.id === item.id);
   const next = index === -1 ? [item, ...items] : items.slice();
@@ -5712,6 +6335,37 @@ function upsertProjectSkill(items: ProjectSkillRecord[], item: ProjectSkillRecor
       a.id.localeCompare(b.id)
     );
   });
+}
+
+function sortProjectSkillsForPicker(skills: ProjectSkillRecord[]) {
+  return skills.slice().sort((a, b) => {
+    if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+    const rank = projectSkillStatusRank(a.status) - projectSkillStatusRank(b.status);
+    return (
+      rank ||
+      a.title.localeCompare(b.title) ||
+      a.path.localeCompare(b.path) ||
+      a.id.localeCompare(b.id)
+    );
+  });
+}
+
+function projectSkillBadgeClass(skill: ProjectSkillRecord) {
+  if (skill.status === "available" && skill.enabled) return "badge badge-green";
+  if (skill.status === "available") return "badge badge-muted";
+  return "badge badge-amber";
+}
+
+function projectSkillSelectionWarnings(
+  skillID: string,
+  indexedSkills: Map<string, ProjectSkillRecord>,
+) {
+  const skill = indexedSkills.get(skillID);
+  if (!skill) return [`Skill ${skillID} is not registered in this project.`];
+  const warnings: string[] = [];
+  if (!skill.enabled) warnings.push(`Skill ${skillID} is disabled.`);
+  if (skill.status !== "available") warnings.push(`Skill ${skillID} is ${skill.status}.`);
+  return warnings;
 }
 
 function projectSkillStatusRank(status: string): number {
@@ -5805,6 +6459,10 @@ function splitIDs(value: string): string[] {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function uniqueSkillIDs(ids: string[]): string[] {
+  return Array.from(new Set(ids));
 }
 
 function errorMessage(error: unknown, fallback: string): string {
@@ -5950,6 +6608,14 @@ const fieldLabelStyle: CSSProperties = {
   fontFamily: "var(--font-mono)",
   fontSize: 11,
   textTransform: "uppercase",
+};
+
+const checkboxLabelStyle: CSSProperties = {
+  alignItems: "center",
+  color: "var(--t1)",
+  display: "inline-flex",
+  fontSize: 12,
+  gap: 6,
 };
 
 const panelStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- add an Agent profiles modal in Projects with create, edit, and delete support
- add project skills registry pickers for roles and profiles while preserving manual skill ids
- update project/profile/skills docs to mark the UI slice as implemented

## Validation
- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx
- cd ui && bun run test
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- just agent-docs-check
- just docs-format-check
- just docs-check
- git diff --check