### PR TITLE
Apply profile context policies to project context packets

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -28,6 +28,9 @@ project skills registry exposes local `SKILL.md` metadata for roles/profiles
 without granting tools, injecting bodies, or executing skill scripts. The
 operator UI can manage agent profiles and pick registered project skills for
 roles/profiles; those selections remain metadata until launch-time resolution.
+Profile memory/source policies now control whether assignment context packets
+mark project memory and source metadata active, visible-only, or omitted. They
+do not load source file bodies or skill bodies into prompts.
 Model-backed assistant turns should carry a small context-inspector packet:
 execution mode, route/workspace metadata, source provenance, and visible
 transcript counts. Do not store full prompt bodies, raw transcript text, file

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -371,9 +371,11 @@ The next project-orchestration slices are:
 
 1. Finish durable task/run project linkage so native tasks, project assignments,
    and chat-origin work all expose the same `project_id` boundary.
-2. Finish profile-driven memory/source selection. Profile-management UI,
-   role/project default profile selection, and project-skill pickers exist;
-   assignment starts already resolve provider/model/profile/context posture.
+2. Design explicit prompt/source-content injection policy for project memory and
+   Hecate-owned workspace instructions. Profile-management UI, role/project
+   default profile selection, project-skill pickers, and profile-driven
+   assignment context-packet memory/source activation exist; source file bodies
+   are still not loaded by profile policy.
 3. Add focused end-to-end project journeys: create project, set defaults, add
    memory, create work item, create/start assignment, resolve approval or
    failure, inspect activity health, and follow a handoff.

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -8,9 +8,9 @@
 > [Agent memory](agent-memory.md), [Projects](../accepted/projects.md), and
 > [Runtime API](../../runtime/runtime-api.md) for today's context-packet,
 > memory, project, and task behavior.
-> **Next action:** add compatibility warnings, profile-driven memory/source
-> activation, and explicit source-content injection policy. Remote skill
-> install and skill execution remain separate later slices.
+> **Next action:** add compatibility warnings, profile-driven prompt/source
+> content injection policy, and broader chat/external-agent profile selection.
+> Remote skill install and skill execution remain separate later slices.
 
 Hecate needs a clean vocabulary for several things that are easy to blur:
 workspace `AGENTS.md` files, other Markdown instruction files, reusable
@@ -392,6 +392,8 @@ Recommended sequence:
    - `skill_ids` resolve against the project skills registry during project
      work starts.
    - Context packet fields for resolved profile metadata.
+   - Implemented: profile memory/source policies drive project-assignment
+     context packet active / visible-only / omitted state.
 
 2. **Workspace Instructions V1 Core** — partially implemented.
    - Discover `AGENTS.md` and nested `AGENTS.md` under project workspace roots.

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -104,9 +104,11 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   `unknown` until the provider reports richer metadata.
 - Workspace modes are available for task/project starts, and named agent
   profiles now have a core API, profile-management UI, project/role default
-  selection, and project-skill pickers. Profile-driven memory/source injection
-  is still beta-hardening work. Tools-on chat still uses the selected workspace
-  with the current chat runtime posture.
+  selection, project-skill pickers, and profile-driven assignment context-packet
+  memory/source activation. Prompt injection of project memory, source file
+  bodies, and Hecate-owned workspace instructions is still beta-hardening work.
+  Tools-on chat still uses the selected workspace with the current chat runtime
+  posture.
 - Tasks remains canonical for full run history, retry/resume, artifacts, and
   patch review. Chats projects the high-signal run activity and approval
   controls, but it is not a replacement for every Task Detail inspection flow.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1093,7 +1093,14 @@ Project assignment starts resolve profiles in this order: role default,
 project default, built-in `project_assignment` fallback. The start path
 snapshots the resolved profile, provider/model hints, execution profile,
 memory policy, context-source policy, skill ids, and warnings into the task/run
-context packet.
+context packet. For project assignments, `project_memory_policy=include` marks
+enabled project memory active in the context packet, `visible_only` and
+`inherit` keep enabled memory as inspect-only context, and `exclude` omits
+memory records from the packet. For context sources,
+`context_source_policy=include_enabled` marks enabled source metadata active,
+`visible_only` and `inherit` keep it inspect-only, and `exclude` omits it.
+Hecate still does not load workspace instruction/source file bodies or
+`SKILL.md` bodies through these policies.
 
 ## Project endpoints
 
@@ -2031,6 +2038,13 @@ success it also persists a structured context packet on the created run, updates
 `context_snapshot_id` to that packet id, then updates the assignment with
 `task_id`, latest `run_id`, status, and timestamps before returning the updated
 assignment:
+
+The persisted context packet records the resolved profile and applies its
+project memory/context-source policies. `include` / `include_enabled` make the
+enabled project records active in the packet, `visible_only` / `inherit` keep
+them inspect-only, and `exclude` omits them so memory bodies are not snapshotted.
+Source-content loading remains explicit future work; source records are still
+metadata and `BodyRef` values, not file bodies.
 
 ```json
 {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -550,8 +551,8 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			InclusionReason: "Selected as the project assignment workspace",
 		})
 	}
-	appendProjectMemoryWithInclusion(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), false, "Stored project memory is not injected into project assignment launch context v1")
-	appendProjectContextSourcesWithInclusion(&packet, projectContextSourcesFromProject(project), false, "Stored project sources are not injected into project assignment launch context v1")
+	appendProjectMemoryForProfilePolicy(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), profile)
+	appendProjectContextSourcesForProfilePolicy(&packet, projectContextSourcesFromProject(project), profile)
 	appendProjectAssignmentHandoffs(&packet, h.assignmentRelevantHandoffs(ctx, assignment, role.ID), false, "Handoff references are inspectable metadata only in project assignment launch context v1")
 	appendProjectAssignmentArtifacts(&packet, h.assignmentRelevantArtifacts(ctx, assignment), false, "Artifact references are inspectable metadata only in project assignment launch context v1")
 	return packet
@@ -659,6 +660,18 @@ func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
 	appendProjectMemoryWithInclusion(packet, entries, true, "Enabled project memory entry")
 }
 
+func appendProjectMemoryForProfilePolicy(packet *chat.ContextPacket, entries []memory.Entry, profile resolvedAgentProfile) {
+	policy := effectiveProjectMemoryPolicy(profile.ProjectMemoryPolicy)
+	switch policy {
+	case agentprofiles.MemoryExclude:
+		return
+	case agentprofiles.MemoryInclude:
+		appendProjectMemoryWithInclusion(packet, entries, true, "Activated by agent profile project_memory_policy=include")
+	default:
+		appendProjectMemoryWithInclusion(packet, entries, false, "Visible only by agent profile project_memory_policy="+firstNonEmptyString(strings.TrimSpace(profile.ProjectMemoryPolicy), agentprofiles.MemoryInherit))
+	}
+}
+
 func appendProjectMemoryWithInclusion(packet *chat.ContextPacket, entries []memory.Entry, included bool, reason string) {
 	for _, entry := range entries {
 		trust := strings.TrimSpace(entry.TrustLabel)
@@ -690,6 +703,18 @@ func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.Cont
 	appendProjectContextSourcesWithInclusion(packet, sources, true, "Enabled project context source metadata")
 }
 
+func appendProjectContextSourcesForProfilePolicy(packet *chat.ContextPacket, sources []chat.ContextSource, profile resolvedAgentProfile) {
+	policy := effectiveContextSourcePolicy(profile.ContextSourcePolicy)
+	switch policy {
+	case agentprofiles.ContextExclude:
+		return
+	case agentprofiles.ContextIncludeEnabled:
+		appendProjectContextSourcesWithInclusion(packet, sources, true, "Activated by agent profile context_source_policy=include_enabled; source bodies are not loaded")
+	default:
+		appendProjectContextSourcesWithInclusion(packet, sources, false, "Visible only by agent profile context_source_policy="+firstNonEmptyString(strings.TrimSpace(profile.ContextSourcePolicy), agentprofiles.ContextInherit))
+	}
+}
+
 func appendProjectContextSourcesWithInclusion(packet *chat.ContextPacket, sources []chat.ContextSource, included bool, reason string) {
 	for _, source := range sources {
 		item := chat.ContextItem{
@@ -702,6 +727,32 @@ func appendProjectContextSourcesWithInclusion(packet *chat.ContextPacket, source
 			InclusionReason: reason,
 		}
 		appendContextPacketSourceWithSection(packet, contextSectionSources, source, item)
+	}
+}
+
+func effectiveProjectMemoryPolicy(policy string) string {
+	switch strings.TrimSpace(policy) {
+	case agentprofiles.MemoryInclude:
+		return agentprofiles.MemoryInclude
+	case agentprofiles.MemoryExclude:
+		return agentprofiles.MemoryExclude
+	case agentprofiles.MemoryVisibleOnly:
+		return agentprofiles.MemoryVisibleOnly
+	default:
+		return agentprofiles.MemoryVisibleOnly
+	}
+}
+
+func effectiveContextSourcePolicy(policy string) string {
+	switch strings.TrimSpace(policy) {
+	case agentprofiles.ContextIncludeEnabled:
+		return agentprofiles.ContextIncludeEnabled
+	case agentprofiles.ContextExclude:
+		return agentprofiles.ContextExclude
+	case agentprofiles.ContextVisibleOnly:
+		return agentprofiles.ContextVisibleOnly
+	default:
+		return agentprofiles.ContextVisibleOnly
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -676,6 +676,133 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentAppliesProfileContextPolicies(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name             string
+		memoryPolicy     string
+		sourcePolicy     string
+		wantMemoryItem   bool
+		wantMemoryActive bool
+		wantSourceItem   bool
+		wantSourceActive bool
+		wantMemoryReason string
+		wantSourceReason string
+	}{
+		{
+			name:             "include",
+			memoryPolicy:     agentprofiles.MemoryInclude,
+			sourcePolicy:     agentprofiles.ContextIncludeEnabled,
+			wantMemoryItem:   true,
+			wantMemoryActive: true,
+			wantSourceItem:   true,
+			wantSourceActive: true,
+			wantMemoryReason: "project_memory_policy=include",
+			wantSourceReason: "context_source_policy=include_enabled",
+		},
+		{
+			name:             "visible only",
+			memoryPolicy:     agentprofiles.MemoryVisibleOnly,
+			sourcePolicy:     agentprofiles.ContextVisibleOnly,
+			wantMemoryItem:   true,
+			wantMemoryActive: false,
+			wantSourceItem:   true,
+			wantSourceActive: false,
+			wantMemoryReason: "project_memory_policy=visible_only",
+			wantSourceReason: "context_source_policy=visible_only",
+		},
+		{
+			name:             "inherit keeps visible only default",
+			memoryPolicy:     agentprofiles.MemoryInherit,
+			sourcePolicy:     agentprofiles.ContextInherit,
+			wantMemoryItem:   true,
+			wantSourceItem:   true,
+			wantMemoryReason: "project_memory_policy=inherit",
+			wantSourceReason: "context_source_policy=inherit",
+		},
+		{
+			name:         "exclude",
+			memoryPolicy: agentprofiles.MemoryExclude,
+			sourcePolicy: agentprofiles.ContextExclude,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handler, server := newProjectWorkTestServer()
+			handler.SetMemoryStore(memory.NewMemoryStore())
+			workspace := t.TempDir()
+			seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+				Workspace: workspace,
+				Driver:    projectwork.AssignmentDriverHecateTask,
+			})
+			if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+				ID:                  "implementation",
+				Name:                "Implementation",
+				Surface:             agentprofiles.SurfaceHecateTask,
+				ExecutionProfile:    "implementation",
+				ToolsEnabled:        true,
+				WritesAllowed:       true,
+				ProjectMemoryPolicy: tc.memoryPolicy,
+				ContextSourcePolicy: tc.sourcePolicy,
+			}); err != nil {
+				t.Fatalf("Create profile: %v", err)
+			}
+			if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+				project.ContextSources = []projects.ContextSource{{
+					ID:         "ctx_agents",
+					Kind:       "workspace_instruction",
+					Title:      "AGENTS.md",
+					Path:       "AGENTS.md",
+					Enabled:    true,
+					TrustLabel: "workspace_guidance",
+				}}
+			}); err != nil {
+				t.Fatalf("Update project context sources: %v", err)
+			}
+			if _, err := handler.memory.Create(t.Context(), memory.Entry{
+				ID:         "mem_runtime",
+				ProjectID:  "proj_start",
+				Title:      "Runtime preference",
+				Body:       "Keep context policy changes explicit.",
+				TrustLabel: memory.TrustLabelOperatorMemory,
+				SourceKind: memory.SourceKindOperator,
+				Enabled:    true,
+			}); err != nil {
+				t.Fatalf("Create project memory: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+			}
+			var assignment ProjectWorkAssignmentEnvelope
+			if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+				t.Fatalf("decode assignment: %v", err)
+			}
+			packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+
+			memoryItem := findRenderedContextItemByOrigin(packetResp.Data, "mem_runtime")
+			if tc.wantMemoryItem {
+				if memoryItem == nil || memoryItem.Included != tc.wantMemoryActive || memoryItem.Section != contextSectionMemory || !strings.Contains(memoryItem.InclusionReason, tc.wantMemoryReason) {
+					t.Fatalf("memory item = %+v, want present included=%v reason containing %q", memoryItem, tc.wantMemoryActive, tc.wantMemoryReason)
+				}
+			} else if memoryItem != nil {
+				t.Fatalf("memory item = %+v, want omitted by profile policy", memoryItem)
+			}
+
+			sourceItem := findRenderedContextItemByOrigin(packetResp.Data, "AGENTS.md")
+			if tc.wantSourceItem {
+				if sourceItem == nil || sourceItem.Included != tc.wantSourceActive || sourceItem.Section != contextSectionSources || !strings.Contains(sourceItem.InclusionReason, tc.wantSourceReason) {
+					t.Fatalf("source item = %+v, want present included=%v reason containing %q", sourceItem, tc.wantSourceActive, tc.wantSourceReason)
+				}
+			} else if sourceItem != nil {
+				t.Fatalf("source item = %+v, want omitted by profile policy", sourceItem)
+			}
+		})
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()


### PR DESCRIPTION
## Summary
- apply resolved agent profile memory and context-source policies to project assignment context packets
- keep inherit and visible-only behavior inspectable by default, omit records for exclude, and mark include policies active
- preserve the current boundary that source files and skill bodies are not loaded by these policies
- update runtime, operator, design, and agent guidance docs

## Tests
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestProjectWorkAPI_StartAssignment(AppliesProfileContextPolicies|PersistsInspectableContextPacket|SnapshotsResolvedAgentProfile|PreparesLinkedSession)|TestChatContextPackets'
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api
- go vet ./internal/api
- just docs-format-check
- just agent-docs-check
- just docs-check
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...
