### PR TITLE
Surface project skills in Needs Attention

### DIFF
--- a/docs-ai/skills/maintenance/SKILL.md
+++ b/docs-ai/skills/maintenance/SKILL.md
@@ -28,8 +28,7 @@ when the task is maintenance-shaped rather than feature-shaped.
 
 ## Default flow
 
-1. Start from current `master`, preferably in
-   `/Users/chicoxyzzy/dev/hecate-maintainance`.
+1. Start from current `master`, preferably in a fresh maintenance worktree.
 2. Run `git fetch origin master --prune` before starting a new maintenance PR.
 3. Run `just branches-report` when cleanup might involve branches or worktrees.
 4. Make only maintenance-scoped edits. Keep behavior changes and dependency

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -375,9 +375,13 @@ When the Go side adds a required prop (e.g. `streamTurnCosts`), update the `setu
 - **Project cockpit action ownership** — project-global actions live in the
   project header. Needs Attention is a dropdown, Project Settings opens the
   shared right-side inspector pattern, and Work Coordination / Timeline /
-  Memory are workspace tabs. Work Coordination uses one Work Queue with All /
-  activity filters plus one selected work-item card; don't split the same work
-  state across a separate Activity Inbox, Work Items list, and detail card.
+  Memory / Skills are workspace tabs. Needs Attention rows should route to the
+  matching operator surface: settings for setup gaps, Memory for context and
+  candidates, Skills for project skill registry issues, Profiles/Roles for
+  broken references, and Work Coordination for assignment/activity issues. Work
+  Coordination uses one Work Queue with All / activity filters plus one selected
+  work-item card; don't split the same work state across a separate Activity
+  Inbox, Work Items list, and detail card.
   Keep the Projects index as a fixed left panel; don't add or restore a
   collapsed mini-rail until the navigation pattern is redesigned.
 - **`render1()` + `render2()` in the same `it` block** — don't. React Testing Library cleanup runs between tests, not within. Split into two `it`s if you need fresh mounts.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -239,7 +239,8 @@ The Projects UI should stay lightweight but operational:
 - Show compact activity and needs-attention surfaces in the project cockpit that
   derive operational status from existing activity, assignment execution
   rollups, handoff summaries, project defaults, memory entries, memory
-  candidates, and context-source metadata.
+  candidates, context-source metadata, agent profile references, and project
+  skills registry status.
 - Keep the project details surface focused on defaults, memory, trusted docs,
   activity, and assignment drill-downs.
 - Use the cockpit as the first screen for project orchestration. The project

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1583,9 +1583,10 @@ plus the project defaults, memory candidates, and memory/context-source lists.
 Activity Inbox stays focused on live assignment buckets; Needs Attention
 surfaces actionable setup gaps, blocked/failed/cancelled assignments, pending
 handoffs, stale or missing linked execution, memory candidates awaiting review,
-missing provider/model defaults, and memory/context readiness. These views do
-not add a separate recommendation engine, dependency model, persisted health
-record, or new API contract.
+missing provider/model defaults, missing profile references, skill registry
+conflicts or unresolved/disabled referenced skills, and memory/context
+readiness. These views do not add a separate recommendation engine, dependency
+model, persisted health record, or new API contract.
 
 The top-level envelope follows the Hecate-native convention:
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -3090,6 +3090,37 @@ describe("ProjectsView cockpit", () => {
     expect(screen.getByRole("dialog", { name: "New project memory" })).toBeTruthy();
   });
 
+  it("opens project skills from skill-related needs attention rows", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [{ ...role, skill_ids: ["backend"] }],
+    });
+    vi.mocked(getProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [{ ...projectSkill, enabled: false }],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Work Queue");
+    const health = await openProjectAttentionMenu();
+    const skillsAttentionItem = within(health).getByRole("button", {
+      name: "Open attention item Project skills need review",
+    });
+
+    await userEvent.click(skillsAttentionItem);
+
+    expect(screen.getByRole("tab", { name: /Skills/ })).toHaveAttribute("aria-selected", "true");
+    expect(await screen.findByText("Project Skills")).toBeTruthy();
+    expect(screen.getByRole("checkbox", { name: "Enable skill Backend" })).toBeTruthy();
+    expect(screen.getByDisplayValue("Backend")).toBeTruthy();
+  });
+
   it("surfaces stale and missing linked execution in needs attention", async () => {
     resetProjectWorkMocks();
     const staleAssignment: ProjectAssignmentRecord = {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -479,8 +479,22 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
         workItems,
         memoryEntries,
         memoryCandidates,
+        {
+          agentProfiles,
+          roles,
+          skills: projectSkills,
+        },
       ),
-    [activity, memoryCandidates, memoryEntries, selectedProject, workItems],
+    [
+      activity,
+      agentProfiles,
+      memoryCandidates,
+      memoryEntries,
+      projectSkills,
+      roles,
+      selectedProject,
+      workItems,
+    ],
   );
   const providerPresets = providersAndModels.state.providerPresets;
   const providerOptions = useMemo<ProviderOption[]>(() => {
@@ -1454,7 +1468,16 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             setSettingsPanelOpen(true);
           }}
           onAttentionMemory={() => setWorkspaceTab("memory")}
+          onAttentionProfiles={() => {
+            setProfilesError("");
+            setProfilesModalOpen(true);
+          }}
           onAttentionReviewCandidate={setPromotingCandidate}
+          onAttentionRoles={() => {
+            setRolesError("");
+            setRolesModalOpen(true);
+          }}
+          onAttentionSkills={() => setWorkspaceTab("skills")}
           onAttentionTask={onOpenTask}
           onAttentionWorkItem={(workItemID) => {
             setWorkspaceTab("work");
@@ -2046,7 +2069,10 @@ function ProjectHeader({
   onAttentionBucket,
   onAttentionDefaults,
   onAttentionMemory,
+  onAttentionProfiles,
   onAttentionReviewCandidate,
+  onAttentionRoles,
+  onAttentionSkills,
   onAttentionTask,
   onAttentionWorkItem,
   onEditDefaults,
@@ -2061,7 +2087,10 @@ function ProjectHeader({
   onAttentionBucket: (bucket: ProjectActivityBucketKey) => void;
   onAttentionDefaults: () => void;
   onAttentionMemory: () => void;
+  onAttentionProfiles: () => void;
   onAttentionReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
+  onAttentionRoles: () => void;
+  onAttentionSkills: () => void;
   onAttentionTask?: (taskID: string, runID?: string) => void;
   onAttentionWorkItem: (workItemID: string) => void;
   onEditDefaults: () => void;
@@ -2078,8 +2107,14 @@ function ProjectHeader({
     : "";
   const attentionCount = attentionItems.length;
   const handleAttentionAction = (item: ProjectHealthAttention) => {
-    if (item.id.endsWith(":defaults")) {
+    if (item.action === "settings" || item.id.endsWith(":defaults")) {
       onAttentionDefaults();
+    } else if (item.action === "skills") {
+      onAttentionSkills();
+    } else if (item.action === "profiles") {
+      onAttentionProfiles();
+    } else if (item.action === "roles") {
+      onAttentionRoles();
     } else if (item.candidateID) {
       const candidate = memoryCandidates.find((candidate) => candidate.id === item.candidateID);
       if (candidate) onAttentionReviewCandidate(candidate);
@@ -2090,7 +2125,7 @@ function ProjectHeader({
       onAttentionTask?.(item.taskID, item.runID);
     } else if (item.bucket) {
       onAttentionBucket(item.bucket);
-    } else if (item.id.endsWith(":context")) {
+    } else if (item.action === "memory" || item.id.endsWith(":context")) {
       onAttentionMemory();
     }
     attentionMenu.close();

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { buildProjectHealthSummary, projectHealthMetrics } from "./projectInsights";
+import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
   ProjectHandoffRecord,
   ProjectRecord,
+  ProjectSkillRecord,
+  ProjectWorkRoleRecord,
 } from "../../types/project";
 
 describe("projectInsights", () => {
@@ -24,6 +27,78 @@ describe("projectInsights", () => {
     const health = buildProjectHealthSummary(project, null, [], [], []);
 
     expect(health.attention.some((item) => item.title === "No project root configured")).toBe(true);
+  });
+
+  it("surfaces unresolved and disabled project skill references", () => {
+    const project = readyProject();
+    const role = projectRole({
+      skill_ids: ["backend", "review"],
+    });
+    const skills = [
+      projectSkill({
+        id: "backend",
+        enabled: false,
+      }),
+    ];
+
+    const health = buildProjectHealthSummary(project, null, [], [], [], {
+      roles: [role],
+      skills,
+    });
+
+    expect(health.attention).toContainEqual(
+      expect.objectContaining({
+        title: "Project skills need review",
+        detail: expect.stringContaining("unresolved: review"),
+        action: "skills",
+      }),
+    );
+    expect(health.attention).toContainEqual(
+      expect.objectContaining({
+        title: "Project skills need review",
+        detail: expect.stringContaining("disabled: backend"),
+        action: "skills",
+      }),
+    );
+  });
+
+  it("surfaces enabled project skills that are not available", () => {
+    const project = readyProject();
+    const health = buildProjectHealthSummary(project, null, [], [], [], {
+      skills: [
+        projectSkill({
+          id: "backend",
+          status: "conflict",
+        }),
+      ],
+    });
+
+    expect(health.attention).toContainEqual(
+      expect.objectContaining({
+        title: "Project skills need review",
+        detail: expect.stringContaining("backend"),
+        action: "skills",
+      }),
+    );
+  });
+
+  it("surfaces missing agent profile references when the profile catalog is loaded", () => {
+    const project = {
+      ...readyProject(),
+      default_agent_profile: "missing_profile",
+    };
+    const health = buildProjectHealthSummary(project, null, [], [], [], {
+      agentProfiles: [agentProfile("implementation")],
+      roles: [projectRole({ default_agent_profile: "implementation" })],
+    });
+
+    expect(health.attention).toContainEqual(
+      expect.objectContaining({
+        title: "Agent profile reference missing",
+        detail: expect.stringContaining("missing_profile"),
+        action: "profiles",
+      }),
+    );
   });
 
   it("labels handoff health metrics as recent when they come from bounded activity handoffs", () => {
@@ -131,6 +206,86 @@ describe("projectInsights", () => {
     expect(attention?.actionLabel).toBe("View blocked");
   });
 });
+
+function readyProject(): ProjectRecord {
+  return {
+    id: "proj_ready",
+    name: "Project",
+    roots: [
+      {
+        id: "root_1",
+        path: "/tmp/project",
+        kind: "git",
+        active: true,
+        created_at: "2026-06-04T10:00:00Z",
+        updated_at: "2026-06-04T10:00:00Z",
+      },
+    ],
+    default_provider: "openai",
+    default_model: "gpt-4.1",
+    context_sources: [
+      {
+        id: "ctx_1",
+        kind: "workspace_instruction",
+        title: "AGENTS.md",
+        path: "AGENTS.md",
+        enabled: true,
+        created_at: "2026-06-04T10:00:00Z",
+        updated_at: "2026-06-04T10:00:00Z",
+      },
+    ],
+    created_at: "2026-06-04T10:00:00Z",
+    updated_at: "2026-06-04T10:00:00Z",
+  };
+}
+
+function projectRole(patch: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRecord {
+  return {
+    id: "role_1",
+    project_id: "proj_ready",
+    name: "Developer",
+    built_in: false,
+    created_at: "2026-06-04T10:00:00Z",
+    updated_at: "2026-06-04T10:00:00Z",
+    ...patch,
+  };
+}
+
+function projectSkill(patch: Partial<ProjectSkillRecord> = {}): ProjectSkillRecord {
+  return {
+    id: "backend",
+    project_id: "proj_ready",
+    title: "Backend",
+    description: "Backend project skill.",
+    path: ".hecate/skills/backend/SKILL.md",
+    root_id: "root_1",
+    format: "skill_md",
+    enabled: true,
+    status: "available",
+    trust_label: "workspace_skill",
+    source_context_source_ids: ["ctx_1"],
+    warnings: [],
+    discovered_at: "2026-06-04T10:00:00Z",
+    created_at: "2026-06-04T10:00:00Z",
+    updated_at: "2026-06-04T10:00:00Z",
+    ...patch,
+  };
+}
+
+function agentProfile(id: string): AgentProfileRecord {
+  return {
+    id,
+    name: id,
+    surface: "any",
+    tools_enabled: true,
+    writes_allowed: true,
+    network_allowed: false,
+    approval_policy: "inherit",
+    project_memory_policy: "inherit",
+    context_source_policy: "inherit",
+    skill_ids: [],
+  };
+}
 
 function activityItem(
   projectID: string,

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -1,4 +1,5 @@
 import { formatAbsoluteTime } from "../../lib/format";
+import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
@@ -8,6 +9,7 @@ import type {
   ProjectMemoryCandidateRecord,
   ProjectMemoryRecord,
   ProjectRecord,
+  ProjectSkillRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
@@ -61,6 +63,7 @@ export type ProjectHealthAttention = {
   title: string;
   detail: string;
   status: string;
+  action?: "memory" | "profiles" | "roles" | "settings" | "skills";
   bucket?: ProjectActivityBucketKey;
   workItemID?: string;
   taskID?: string;
@@ -89,6 +92,12 @@ export type ProjectHealthSummary = {
     dismissed: number;
   };
   attention: ProjectHealthAttention[];
+};
+
+export type ProjectHealthSummaryOptions = {
+  agentProfiles?: AgentProfileRecord[];
+  roles?: ProjectWorkRoleRecord[];
+  skills?: ProjectSkillRecord[];
 };
 
 export function buildProjectTimelineItems({
@@ -186,6 +195,7 @@ export function buildProjectHealthSummary(
   workItems: ProjectWorkItemRecord[],
   memoryEntries: ProjectMemoryRecord[],
   memoryCandidates: ProjectMemoryCandidateRecord[],
+  options: ProjectHealthSummaryOptions = {},
 ): ProjectHealthSummary {
   const activityItems = uniqueActivityItems(activity);
   const projectedAssignments = workItems.flatMap((item) =>
@@ -221,6 +231,7 @@ export function buildProjectHealthSummary(
       detail:
         "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
       status: "stale_unknown",
+      action: "settings",
     });
   }
   if (missingDefaults && project) {
@@ -229,7 +240,21 @@ export function buildProjectHealthSummary(
       title: "Provider/model defaults missing",
       detail: "Native project starts and assignment chats need a default provider and model.",
       status: "awaiting_approval",
+      action: "settings",
     });
+  }
+  if (project) {
+    attention.push(
+      ...profileAttentionItems(project, options.roles ?? [], options.agentProfiles ?? []),
+    );
+    attention.push(
+      ...skillAttentionItems(
+        project,
+        options.roles ?? [],
+        options.agentProfiles ?? [],
+        options.skills ?? [],
+      ),
+    );
   }
   const firstPendingHandoff = activityItems.find((item) => hasPendingHandoff(item));
   if (firstPendingHandoff) {
@@ -285,6 +310,7 @@ export function buildProjectHealthSummary(
       title: "No project memory or context sources enabled",
       detail: "Project-scoped context is empty for new chats and linked context packets.",
       status: "stale_unknown",
+      action: "memory",
     });
   }
   const firstPendingCandidate = memoryCandidates.find(
@@ -297,6 +323,7 @@ export function buildProjectHealthSummary(
       detail: `${firstPendingCandidate.title} · ${firstPendingCandidate.suggested_trust_label}`,
       status: "awaiting_approval",
       candidateID: firstPendingCandidate.id,
+      action: "memory",
     });
   }
 
@@ -457,6 +484,106 @@ function addHandoffStatus(summary: ProjectHealthSummary["handoffs"], status: str
   if (status === "accepted") summary.accepted += 1;
   if (status === "superseded") summary.superseded += 1;
   if (status === "dismissed") summary.dismissed += 1;
+}
+
+function profileAttentionItems(
+  project: ProjectRecord,
+  roles: ProjectWorkRoleRecord[],
+  profiles: AgentProfileRecord[],
+): ProjectHealthAttention[] {
+  if (profiles.length === 0) return [];
+  const profileIDs = new Set(profiles.map((profile) => profile.id));
+  const missing = new Set<string>();
+  if (project.default_agent_profile && !profileIDs.has(project.default_agent_profile)) {
+    missing.add(project.default_agent_profile);
+  }
+  for (const role of roles) {
+    if (role.default_agent_profile && !profileIDs.has(role.default_agent_profile)) {
+      missing.add(role.default_agent_profile);
+    }
+  }
+  if (missing.size === 0) return [];
+  const missingList = Array.from(missing).slice(0, 3).join(", ");
+  return [
+    {
+      id: `${project.id}:profiles:missing`,
+      title: "Agent profile reference missing",
+      detail: `Project or role defaults reference ${missingList}${
+        missing.size > 3 ? ` and ${missing.size - 3} more` : ""
+      }.`,
+      status: "stale_unknown",
+      action: "profiles",
+    },
+  ];
+}
+
+function skillAttentionItems(
+  project: ProjectRecord,
+  roles: ProjectWorkRoleRecord[],
+  profiles: AgentProfileRecord[],
+  skills: ProjectSkillRecord[],
+): ProjectHealthAttention[] {
+  const skillsByID = new Map(skills.map((skill) => [skill.id, skill]));
+  const referencedSkillIDs = referencedProjectSkillIDs(project, roles, profiles);
+  const unresolved = referencedSkillIDs.filter((skillID) => !skillsByID.has(skillID));
+  const disabledReferenced = referencedSkillIDs.filter((skillID) => {
+    const skill = skillsByID.get(skillID);
+    return skill && !skill.enabled;
+  });
+  const unavailable = skills.filter(
+    (skill) =>
+      skill.status !== "available" && (skill.enabled || referencedSkillIDs.includes(skill.id)),
+  );
+  const details: string[] = [];
+  if (unresolved.length > 0) {
+    details.push(`unresolved: ${summarizeIDs(unresolved)}`);
+  }
+  if (disabledReferenced.length > 0) {
+    details.push(`disabled: ${summarizeIDs(disabledReferenced)}`);
+  }
+  if (unavailable.length > 0) {
+    details.push(`unavailable: ${summarizeIDs(unavailable.map((skill) => skill.id))}`);
+  }
+  if (details.length === 0) return [];
+  return [
+    {
+      id: `${project.id}:skills`,
+      title: "Project skills need review",
+      detail: `${details.join("; ")}.`,
+      status: disabledReferenced.length > 0 ? "awaiting_approval" : "stale_unknown",
+      action: "skills",
+    },
+  ];
+}
+
+function referencedProjectSkillIDs(
+  project: ProjectRecord,
+  roles: ProjectWorkRoleRecord[],
+  profiles: AgentProfileRecord[],
+): string[] {
+  const referenced = new Set<string>();
+  const relevantProfileIDs = new Set<string>();
+  if (project.default_agent_profile) relevantProfileIDs.add(project.default_agent_profile);
+  for (const role of roles) {
+    for (const skillID of role.skill_ids ?? []) {
+      if (skillID.trim()) referenced.add(skillID.trim());
+    }
+    if (role.default_agent_profile) relevantProfileIDs.add(role.default_agent_profile);
+  }
+  for (const profile of profiles) {
+    if (!relevantProfileIDs.has(profile.id)) continue;
+    for (const skillID of profile.skill_ids ?? []) {
+      if (skillID.trim()) referenced.add(skillID.trim());
+    }
+  }
+  return Array.from(referenced);
+}
+
+function summarizeIDs(ids: string[]): string {
+  const unique = Array.from(new Set(ids));
+  const shown = unique.slice(0, 3).join(", ");
+  if (unique.length <= 3) return shown;
+  return `${shown}, and ${unique.length - 3} more`;
 }
 
 function hasPendingHandoff(item: ProjectActivityItemRecord): boolean {


### PR DESCRIPTION
## Summary

- Add project health attention for project skill registry issues and missing agent profile references.
- Route Needs Attention rows to the matching operator surface, including Skills and Profiles.
- Update Projects, runtime API, and AI guidance docs for the expanded attention behavior.
- Remove a hardcoded local maintenance worktree path from AI guidance.

## Validation

- `bun run test -- src/features/projects/projectInsights.test.ts src/features/projects/ProjectsView.test.tsx`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `just docs-check`
- `git diff --check`