### PR TITLE
Add Project Assistant bootstrap prep

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -379,9 +379,12 @@ When the Go side adds a required prop (e.g. `streamTurnCosts`), update the `setu
   matching operator surface: settings for setup gaps, Memory for context and
   candidates, Skills for project skill registry issues, Profiles/Roles for
   broken references, and Work Coordination for assignment/activity issues. Work
-  Coordination uses one Work Queue with All / activity filters plus one selected
-  work-item card; don't split the same work state across a separate Activity
-  Inbox, Work Items list, and detail card.
+  with Project Assistant Bootstrap through one reviewable proposal path: UI
+  helpers may refresh guidance/skills first, but they should still call the
+  normal draft/apply flow rather than mutating setup directly. Work Coordination
+  uses one Work Queue with All / activity filters plus one selected work-item
+  card; don't split the same work state across a separate Activity Inbox, Work
+  Items list, and detail card.
   Keep the Projects index as a fixed left panel; don't add or restore a
   collapsed mini-rail until the navigation pattern is redesigned.
 - **`render1()` + `render2()` in the same `it` block** — don't. React Testing Library cleanup runs between tests, not within. Split into two `it`s if you need fresh mounts.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -284,7 +284,9 @@ The product layers should stay separate:
 | Orchestrator      | Runtime execution   | Approved task/agent coordination, waits, approvals, event emission, and state transitions.             |
 
 Project Assistant can help create a new project or draft a follow-up assignment,
-but it does not auto-start work, run agents, or write durable memory directly.
+and the Projects UI can prepare Bootstrap proposals by refreshing workspace
+guidance and project skills before drafting. It does not auto-start work, run
+agents, or write durable memory directly.
 Planner and Manager are future proposal/monitoring layers. The orchestrator is
 the runtime coordinator that executes approved work through Tasks, External
 Agents, approvals, artifacts, traces, and events.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -224,6 +224,12 @@ memory/candidate source refs. It does not treat host-specific guidance as
 Hecate policy authority, call a model, create durable memory, start tasks, or
 launch agents.
 
+In the operator UI, **Bootstrap project** is a convenience command around the
+same API contract: it refreshes workspace guidance context sources, refreshes
+the project skills registry, then requests a project-scoped Bootstrap draft.
+The resulting proposal is still review/apply gated and does not attach to the
+currently selected work item.
+
 `draft_mode: "model"` asks the configured gateway model to author the proposal
 from the same context packet. The request may provide `model` and `provider`;
 otherwise Hecate uses the project's `default_model` and optional

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -29,12 +29,14 @@ type Props = {
   contextStatus: ProjectAssistantContextStatus;
   error: string;
   onApply: () => void;
+  onBootstrap: () => void;
   onDismiss: () => void;
   onInspectContext: (form: ProjectAssistantDraftForm) => void;
   onPropose: (form: ProjectAssistantDraftForm) => void;
   project: ProjectRecord | null;
   proposal: ProjectAssistantProposal | null;
   roles: ProjectWorkRoleRecord[];
+  bootstrapPending: boolean;
   status: ProjectAssistantStatus;
   workItem: ProjectWorkItemRecord | null;
 };
@@ -46,12 +48,14 @@ export function ProjectAssistantPanel({
   contextStatus,
   error,
   onApply,
+  onBootstrap,
   onDismiss,
   onInspectContext,
   onPropose,
   project,
   proposal,
   roles,
+  bootstrapPending,
   status,
   workItem,
 }: Props) {
@@ -72,6 +76,7 @@ export function ProjectAssistantPanel({
   const valid = form.request.trim().length > 0 && (workItem ? Boolean(selectedRole) : true);
   const busy = status === "proposing" || status === "applying";
   const contextBusy = contextStatus === "loading";
+  const bootstrapBusy = bootstrapPending || busy;
   const panelDetail = workItem ? `Selected work: ${workItem.title}` : "Project queue";
   const modelDraftAvailable = Boolean(project.default_model?.trim());
 
@@ -180,6 +185,15 @@ export function ProjectAssistantPanel({
           >
             <Icon d={Icons.eye} size={13} />
             {contextBusy ? "Inspecting..." : "Inspect context"}
+          </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            disabled={bootstrapBusy || contextBusy}
+            onClick={onBootstrap}
+          >
+            <Icon d={Icons.refresh} size={13} />
+            {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
           </button>
           <button
             className="btn btn-primary btn-sm"

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1315,6 +1315,62 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("discovers guidance and skills before drafting project bootstrap proposals", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    const discoveredProject: ProjectRecord = {
+      ...project,
+      context_sources: [
+        {
+          id: "ctx_agents",
+          kind: "workspace_instruction",
+          title: "AGENTS.md",
+          path: "AGENTS.md",
+          enabled: true,
+          source_category: "workspace_guidance",
+          trust_label: "workspace_guidance",
+          created_at: "2026-06-02T09:00:00Z",
+          updated_at: "2026-06-02T09:00:00Z",
+        },
+      ],
+    };
+    vi.mocked(discoverProjectContextSources).mockResolvedValue({
+      object: "project",
+      data: discoveredProject,
+    });
+    vi.mocked(discoverProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [projectSkill],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Selected work: Build cockpit UI");
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await user.click(within(assistant).getByRole("button", { name: "Bootstrap project" }));
+
+    await waitFor(() => {
+      expect(discoverProjectContextSources).toHaveBeenCalledWith(project.id);
+      expect(discoverProjectSkills).toHaveBeenCalledWith(project.id);
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        request: "Bootstrap project guidance",
+        draft_mode: "bootstrap",
+      });
+    });
+    expect(vi.mocked(discoverProjectContextSources).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(discoverProjectSkills).mock.invocationCallOrder[0],
+    );
+    expect(vi.mocked(discoverProjectSkills).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(draftProjectAssistant).mock.invocationCallOrder[0],
+    );
+    expect(screen.getByRole("tab", { name: /Skills/ })).toHaveTextContent("1");
+  });
+
   it("inspects Project Assistant context selection before drafting", async () => {
     resetProjectWorkMocks();
     const user = userEvent.setup();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -405,6 +405,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [assistantContextError, setAssistantContextError] = useState("");
   const [assistantStatus, setAssistantStatus] = useState<ProjectAssistantStatus>("idle");
   const [assistantError, setAssistantError] = useState("");
+  const [assistantBootstrapPending, setAssistantBootstrapPending] = useState(false);
 
   function updateRightPanelWidth(width: number) {
     setRightPanelWidth(width);
@@ -1305,6 +1306,49 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
+  async function handleProjectAssistantBootstrap() {
+    if (!selectedProjectID) return;
+    const projectID = selectedProjectID;
+    setAssistantBootstrapPending(true);
+    setAssistantStatus("proposing");
+    setAssistantError("");
+    setAssistantProposal(null);
+    setAssistantApplyResult(null);
+    setMemoryError("");
+    setSkillsError("");
+    setDiscoveringContext(true);
+    setDiscoveringSkills(true);
+    try {
+      const projectPayload = await discoverProjectContextSources(projectID);
+      projects.actions.setProjects((current) => upsertProject(current, projectPayload.data));
+      const skillsPayload = await discoverProjectSkills(projectID);
+      setProjectSkills(skillsPayload.data ?? []);
+      setSkillsLoadState("loaded");
+      const proposal = await draftProjectAssistant(
+        projectAssistantDraftPayload(
+          {
+            request: "Bootstrap project guidance",
+            roleID: PROJECT_ASSISTANT_AUTO,
+            driverKind: PROJECT_ASSISTANT_AUTO,
+            draftMode: "bootstrap",
+          },
+          projectID,
+        ),
+      );
+      setAssistantProposal(proposal.data);
+      setAssistantContext(null);
+      setAssistantContextError("");
+      setAssistantContextStatus("idle");
+    } catch (error) {
+      setAssistantError(errorMessage(error, "Failed to bootstrap project assistant context."));
+    } finally {
+      setDiscoveringContext(false);
+      setDiscoveringSkills(false);
+      setAssistantBootstrapPending(false);
+      setAssistantStatus("idle");
+    }
+  }
+
   async function handleProjectAssistantContext(form: ProjectAssistantDraftForm) {
     if (!selectedProject) return;
     setAssistantContextStatus("loading");
@@ -1504,11 +1548,13 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
               <section style={domainSectionStyle} aria-label="Project workspace">
                 <ProjectAssistantPanel
                   applyResult={assistantApplyResult}
+                  bootstrapPending={assistantBootstrapPending}
                   context={assistantContext}
                   contextError={assistantContextError}
                   contextStatus={assistantContextStatus}
                   error={assistantError}
                   onApply={() => void handleProjectAssistantApply()}
+                  onBootstrap={() => void handleProjectAssistantBootstrap()}
                   onInspectContext={(form) => void handleProjectAssistantContext(form)}
                   onDismiss={dismissProjectAssistantProposal}
                   onPropose={(form) => void handleProjectAssistantPropose(form)}


### PR DESCRIPTION
## Summary

- Add a Project Assistant `Bootstrap project` action that refreshes workspace guidance and project skills before requesting a Bootstrap draft.
- Keep the resulting proposal project-scoped and review/apply gated, with no selected work-item attachment.
- Document the UI helper and update Projects UI guidance.

## Validation

- `bun run test -- src/features/projects/ProjectsView.test.tsx`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `just docs-check`
- `git diff --check`