### PR TITLE
refactor(api): extract task lifecycle application layer

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -93,6 +93,15 @@ read-only; it may emit projected live frames with the latest persisted sequence,
 but must not append synthetic `snapshot` events. Handler changes should stay
 focused on request setup, polling, and cancellation.
 
+### Change task APIs
+
+Task HTTP handlers should stay thin: parse path/query/body, choose the
+HTTP status/error envelope, and render response DTOs. Task creation,
+task/run loading, active-run conflict checks, approval resolution dispatch,
+resume budget raising, and runner calls live behind `internal/api`
+`taskApplication`. Extend that seam before adding more store/runner
+orchestration directly to handlers.
+
 ### Change chat-session / ACP adapter behavior
 
 Chat sessions separate ownership from turn execution:

--- a/e2e/task_run_lifecycle_test.go
+++ b/e2e/task_run_lifecycle_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -36,6 +38,47 @@ func TestTaskRunQueuedLifecycleE2E(t *testing.T) {
 	events := getJSON[e2eTaskEventsResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/runs/"+started.Data.ID+"/events")
 	assertE2EEventOrder(t, events.Data, []string{"run.created", "run.queued", "run.started", "run.finished"})
 	assertE2EEventData(t, events.Data, "run.finished", "final_status", "completed")
+}
+
+func TestTaskApplicationLayerDirectShellLifecycleE2E(t *testing.T) {
+	workDir := t.TempDir()
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=",
+	)
+
+	body := fmt.Sprintf(`{
+		"title": "application layer shell e2e",
+		"execution_kind": "shell",
+		"shell_command": "printf 'app-layer\n'",
+		"working_directory": %q,
+		"sandbox_allowed_root": %q,
+		"workspace_mode": "in_place",
+		"timeout_ms": 10000
+	}`, workDir, workDir)
+	created := postJSONDecode[e2eTaskResponse](t, baseURL+"/hecate/v1/tasks", body)
+	if created.Data.Status != "queued" {
+		t.Fatalf("created status = %q, want queued", created.Data.Status)
+	}
+
+	started := postJSONDecode[e2eTaskRunResponse](t, baseURL+"/hecate/v1/tasks/"+created.Data.ID+"/start", `{}`)
+	run := waitForE2ETaskRunTerminal(t, baseURL, created.Data.ID, started.Data.ID, 10*time.Second)
+	if run.Status != "completed" {
+		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, baseURL+"/hecate/v1/tasks/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE task: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE task status = %d, want 204; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
 }
 
 func TestTaskRunClaimedStartTransitionPopulatesTraceE2E(t *testing.T) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -99,6 +99,24 @@ type Handler struct {
 	quitFunc func()
 }
 
+func (h *Handler) taskApplication() *taskApplication {
+	if h == nil {
+		return newTaskApplication(taskApplicationOptions{})
+	}
+	var runner taskApplicationRunner
+	if h.taskRunner != nil {
+		runner = h.taskRunner
+	}
+	return newTaskApplication(taskApplicationOptions{
+		Store:         h.taskStore,
+		Runner:        runner,
+		Projects:      h.projects,
+		SecretCipher:  h.secretCipher,
+		MaxMCPServers: h.config.Server.TaskMaxMCPServersPerTask,
+		IDGenerator:   newOpaqueTaskResourceID,
+	})
+}
+
 // approvalConfig bundles everything the coordinator needs apart from
 // the store, so SetAgentApprovalStore can swap stores without
 // re-deriving mode/timeout/hook closures. Also retains the live bus +

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -229,6 +229,10 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if err := h.taskApplication().RequireRunner(); err != nil {
+		writeTaskRuntimePreflightError(w, err)
+		return
+	}
 
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -33,106 +33,14 @@ import (
 // runs the same arbitrary command a task would.
 func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 
 	var req CreateTaskRequest
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	applyExecutionProfileDefaults(&req)
-
-	title := strings.TrimSpace(req.Title)
-	prompt := strings.TrimSpace(req.Prompt)
-	if title == "" {
-		if prompt == "" {
-			title = "New task"
-		} else {
-			title = prompt
-			if len(title) > 80 {
-				title = strings.TrimSpace(title[:80]) + "..."
-			}
-		}
-	}
-	// prompt is required for agent_loop tasks; direct-execution tasks
-	// (shell, git, file) carry their work in the command/file fields and
-	// don't need a natural-language prompt.
-	effectiveKind := strings.TrimSpace(req.ExecutionKind)
-	isAgentLoop := effectiveKind == "" || effectiveKind == "agent_loop"
-	if prompt == "" && isAgentLoop {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "prompt is required")
-		return
-	}
-
-	mcpServers, mcpErr := normalizeMCPServerConfigs(req.MCPServers, h.secretCipher, h.config.Server.TaskMaxMCPServersPerTask)
-	if mcpErr != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, mcpErr.Error())
-		return
-	}
-
-	workspaceMode := strings.TrimSpace(req.WorkspaceMode)
-	if workspaceMode == "" {
-		workspaceMode = "ephemeral"
-	}
-	priority := strings.TrimSpace(req.Priority)
-	if priority == "" {
-		priority = "normal"
-	}
-	projectID := strings.TrimSpace(req.ProjectID)
-	if projectID != "" {
-		if h.projects == nil {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
-			return
-		}
-		if _, ok, err := h.projects.Get(ctx, projectID); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		} else if !ok {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project not found")
-			return
-		}
-	}
-
-	now := time.Now().UTC()
-	task := types.Task{
-		ID:                 newTaskID(),
-		Title:              title,
-		Prompt:             prompt,
-		ProjectID:          projectID,
-		SystemPrompt:       strings.TrimSpace(req.SystemPrompt),
-		ExecutionProfile:   strings.TrimSpace(req.ExecutionProfile),
-		Repo:               strings.TrimSpace(req.Repo),
-		BaseBranch:         strings.TrimSpace(req.BaseBranch),
-		WorkspaceMode:      workspaceMode,
-		ExecutionKind:      strings.TrimSpace(req.ExecutionKind),
-		ShellCommand:       strings.TrimSpace(req.ShellCommand),
-		GitCommand:         strings.TrimSpace(req.GitCommand),
-		WorkingDirectory:   strings.TrimSpace(req.WorkingDirectory),
-		FileOperation:      strings.TrimSpace(req.FileOperation),
-		FilePath:           strings.TrimSpace(req.FilePath),
-		FileContent:        req.FileContent,
-		SandboxAllowedRoot: strings.TrimSpace(req.SandboxAllowedRoot),
-		SandboxReadOnly:    req.SandboxReadOnly,
-		SandboxNetwork:     req.SandboxNetwork,
-		TimeoutMS:          req.TimeoutMS,
-		Status:             "queued",
-		Priority:           priority,
-		RequestedModel:     strings.TrimSpace(req.RequestedModel),
-		RequestedProvider:  strings.TrimSpace(req.RequestedProvider),
-		BudgetMicrosUSD:    req.BudgetMicrosUSD,
-		MCPServers:         mcpServers,
-		CreatedAt:          now,
-		UpdatedAt:          now,
-	}
-	created, err := h.taskStore.CreateTask(ctx, task)
+	created, err := h.taskApplication().CreateTask(ctx, req)
 	if err != nil {
-		telemetry.Error(h.logger, ctx, "gateway.tasks.create.failed",
-			slog.String("event.name", "gateway.tasks.create.failed"),
-			slog.Any("error", err),
-		)
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		h.writeCreateTaskError(w, r, err)
 		return
 	}
 
@@ -140,6 +48,23 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 		Object: "task",
 		Data:   buildTaskItem(ctx, h.taskStore, created),
 	})
+}
+
+func (h *Handler) writeCreateTaskError(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
+	var validation taskValidationError
+	switch {
+	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskProjectStoreNotConfigured):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, errTaskPromptRequired), errors.Is(err, errTaskProjectNotFound), errors.As(err, &validation):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	default:
+		telemetry.Error(h.logger, ctx, "gateway.tasks.create.failed",
+			slog.String("event.name", "gateway.tasks.create.failed"),
+			slog.Any("error", err),
+		)
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	}
 }
 
 func applyExecutionProfileDefaults(req *CreateTaskRequest) {
@@ -188,10 +113,6 @@ Use read_file and list_dir before editing. Prefer file_edit for targeted changes
 
 func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 
 	limit := 50
 	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
@@ -217,8 +138,12 @@ func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 		}
 		filter.ProjectID = &projectID
 	}
-	result, err := h.taskStore.ListTasks(ctx, filter)
+	result, err := h.taskApplication().ListTasks(ctx, filter)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.list.failed",
 			slog.String("event.name", "gateway.tasks.list.failed"),
 			slog.Any("error", err),
@@ -239,10 +164,6 @@ func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 
 	id := strings.TrimSpace(r.PathValue("id"))
 	if id == "" {
@@ -250,17 +171,21 @@ func (h *Handler) HandleTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, found, err := h.taskStore.GetTask(ctx, id)
+	task, err := h.taskApplication().LoadTask(ctx, id)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
+		if errors.Is(err, errTaskNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.get.failed",
 			slog.String("event.name", "gateway.tasks.get.failed"),
 			slog.Any("error", err),
 		)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
 		return
 	}
 	WriteJSON(w, http.StatusOK, TaskResponse{
@@ -271,10 +196,6 @@ func (h *Handler) HandleTask(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 
 	id := strings.TrimSpace(r.PathValue("id"))
 	if id == "" {
@@ -282,24 +203,18 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, found, err := h.taskStore.GetTask(ctx, id)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
-		return
-	}
-	if active, err := taskHasActiveRun(ctx, h.taskStore, task); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "cannot delete a task with an active run; cancel it first")
-		return
-	}
-
-	if err := h.taskStore.DeleteTask(ctx, id); err != nil {
+	if err := h.taskApplication().DeleteTask(ctx, id); err != nil {
+		switch {
+		case errors.Is(err, errTaskStoreNotConfigured):
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		case errors.Is(err, errTaskNotFound):
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
+			return
+		case errors.Is(err, errTaskDeleteActiveRun):
+			WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.delete.failed",
 			slog.String("event.name", "gateway.tasks.delete.failed"),
 			slog.String("task_id", id),
@@ -314,28 +229,21 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
-	if h.taskRunner == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
-		return
-	}
 
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
 	}
-	if active, err := taskHasActiveRun(ctx, h.taskStore, task); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has an active run")
-		return
-	}
-	result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
+	result, err := h.taskApplication().StartTask(ctx, task)
 	if err != nil {
+		switch {
+		case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		case errors.Is(err, errTaskHasActiveRun):
+			WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.start.failed",
 			slog.String("event.name", "gateway.tasks.start.failed"),
 			slog.Any("error", err),
@@ -357,28 +265,6 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 		Object: "task_run",
 		Data:   renderTaskRun(result.Run),
 	})
-}
-
-func taskHasActiveRun(ctx context.Context, store taskstate.Store, task types.Task) (bool, error) {
-	latestRunID := strings.TrimSpace(task.LatestRunID)
-	if latestRunID != "" && store != nil {
-		run, found, err := store.GetRun(ctx, task.ID, latestRunID)
-		if err != nil {
-			return false, err
-		}
-		if found {
-			return !types.IsTerminalTaskRunStatus(run.Status), nil
-		}
-	}
-	return latestRunID != "" && !types.IsTerminalTaskRunStatus(task.Status), nil
-}
-
-func taskHasOtherActiveRun(ctx context.Context, store taskstate.Store, task types.Task, currentRunID string) (bool, error) {
-	latestRunID := strings.TrimSpace(task.LatestRunID)
-	if latestRunID == "" || latestRunID == strings.TrimSpace(currentRunID) {
-		return false, nil
-	}
-	return taskHasActiveRun(ctx, store, task)
 }
 
 func (h *Handler) HandleTaskRuns(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -80,6 +80,10 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if err := h.taskApplication().RequireRunner(); err != nil {
+		writeTaskRuntimePreflightError(w, err)
+		return
+	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
@@ -143,6 +147,10 @@ func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.R
 
 func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if err := h.taskApplication().RequireRunner(); err != nil {
+		writeTaskRuntimePreflightError(w, err)
+		return
+	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
@@ -311,4 +319,13 @@ func (h *Handler) writeTaskLifecycleAppError(w http.ResponseWriter, err error) b
 		return false
 	}
 	return true
+}
+
+func writeTaskRuntimePreflightError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	default:
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	}
 }

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -60,7 +60,7 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return
 		}
-		if errors.Is(err, orchestrator.ErrApprovalNotFound) {
+		if errors.Is(err, errTaskApprovalNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
 			return
 		}

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -9,22 +9,21 @@ import (
 
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/telemetry"
-	"github.com/hecatehq/hecate/pkg/types"
 )
 
 func (h *Handler) HandleTaskApprovals(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
 	}
 
-	approvals, err := h.taskStore.ListApprovals(ctx, task.ID)
+	approvals, err := h.taskApplication().ListTaskApprovals(ctx, task)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.list.failed",
 			slog.String("event.name", "gateway.tasks.approvals.list.failed"),
 			slog.Any("error", err),
@@ -45,10 +44,6 @@ func (h *Handler) HandleTaskApprovals(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
@@ -59,17 +54,21 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	approval, found, err := h.taskStore.GetApproval(ctx, task.ID, approvalID)
+	approval, err := h.taskApplication().GetTaskApproval(ctx, task, approvalID)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
+		if errors.Is(err, orchestrator.ErrApprovalNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
+			return
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.get.failed",
 			slog.String("event.name", "gateway.tasks.approvals.get.failed"),
 			slog.Any("error", err),
 		)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
 		return
 	}
 
@@ -81,14 +80,6 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
-	if h.taskRunner == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
-		return
-	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
@@ -104,14 +95,12 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	result, err := h.taskRunner.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
-		Task:        task,
-		ApprovalID:  approvalID,
-		Decision:    req.Decision,
-		Note:        req.Note,
-		ResolvedBy:  "operator",
-		RequestID:   RequestIDFromContext(ctx),
-		IDGenerator: newOpaqueTaskResourceID,
+	result, err := h.taskApplication().ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
+		Task:       task,
+		ApprovalID: approvalID,
+		Decision:   req.Decision,
+		Note:       req.Note,
+		RequestID:  RequestIDFromContext(ctx),
 	})
 	if err != nil {
 		h.writeResolveTaskApprovalError(w, r, err)
@@ -133,6 +122,8 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.Request, err error) {
 	ctx := r.Context()
 	switch {
+	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 	case errors.Is(err, orchestrator.ErrInvalidApprovalDecision):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "decision must be approve or reject")
 	case errors.Is(err, orchestrator.ErrApprovalNotFound):
@@ -152,14 +143,6 @@ func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.R
 
 func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
-	if h.taskRunner == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
-		return
-	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
 	if !ok {
 		return
@@ -176,8 +159,12 @@ func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&body)
 	}
 
-	run, err := h.taskRunner.CancelRun(ctx, task, run.ID, body.Reason)
+	run, err := h.taskApplication().CancelTaskRun(ctx, task, run, body.Reason)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) || errors.Is(err, errTaskRunnerNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -197,19 +184,11 @@ func (h *Handler) HandleRetryTaskRun(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !types.IsTerminalTaskRunStatus(run.Status) {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "run is not retryable until it reaches a terminal state")
-		return
-	}
-	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
-		return
-	}
-	result, err := h.taskRunner.StartTask(ctx, task, newOpaqueTaskResourceID)
+	result, err := h.taskApplication().RetryTaskRun(ctx, task, run)
 	if err != nil {
+		if h.writeTaskLifecycleAppError(w, err) {
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -230,41 +209,11 @@ func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if run.Status != "failed" && run.Status != "cancelled" {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "run is not resumable")
-		return
-	}
-	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
-		return
-	}
-	// Optional ceiling raise — used by the "Raise ceiling and
-	// resume" UI affordance after a cost_ceiling_exceeded failure.
-	// We persist the new ceiling on the task BEFORE queueing the
-	// resumed run so the agent loop's per-task ceiling check
-	// (priorCost + costSpent vs Task.BudgetMicrosUSD) sees the
-	// raised value on its first turn. The ceiling can only go up
-	// here — a request to lower it is rejected, since the obvious
-	// failure would be to silently strand a run below its
-	// already-spent prior cost.
-	if req.BudgetMicrosUSD > 0 {
-		if req.BudgetMicrosUSD < task.BudgetMicrosUSD {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "budget_micros_usd cannot be lower than the current task ceiling")
-			return
-		}
-		task.BudgetMicrosUSD = req.BudgetMicrosUSD
-		if updated, err := h.taskStore.UpdateTask(ctx, task); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		} else {
-			task = updated
-		}
-	}
-	result, err := h.taskRunner.ResumeTask(ctx, task, run, strings.TrimSpace(req.Reason), newOpaqueTaskResourceID)
+	result, err := h.taskApplication().ResumeTaskRun(ctx, task, run, req)
 	if err != nil {
+		if h.writeTaskLifecycleAppError(w, err) {
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -285,15 +234,11 @@ func (h *Handler) HandleContinueTaskRun(w http.ResponseWriter, r *http.Request) 
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
-		return
-	}
-	result, err := h.taskRunner.ContinueAgentTask(ctx, task, run, req.Prompt, newOpaqueTaskResourceID)
+	result, err := h.taskApplication().ContinueTaskRun(ctx, task, run, req.Prompt)
 	if err != nil {
+		if h.writeTaskLifecycleAppError(w, err) {
+			return
+		}
 		msg := err.Error()
 		if strings.Contains(msg, "not continuable") {
 			WriteError(w, http.StatusConflict, errCodeInvalidRequest, msg)
@@ -333,23 +278,11 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if !types.IsTerminalTaskRunStatus(run.Status) {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "run is not retryable from a turn (must be terminal)")
-		return
-	}
-	if req.Turn < 1 {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "turn must be >= 1")
-		return
-	}
-	if active, err := taskHasOtherActiveRun(ctx, h.taskStore, task, run.ID); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if active {
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, "task already has another active run")
-		return
-	}
-	result, err := h.taskRunner.RetryTaskFromTurn(ctx, task, run, req.Turn, strings.TrimSpace(req.Reason), newOpaqueTaskResourceID)
+	result, err := h.taskApplication().RetryTaskRunFromTurn(ctx, task, run, req)
 	if err != nil {
+		if h.writeTaskLifecycleAppError(w, err) {
+			return
+		}
 		// Validation failures (missing conversation, turn out of
 		// range, malformed artifact) are user errors — return 400 so
 		// the UI can render an actionable message rather than a 500.
@@ -364,4 +297,18 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
+}
+
+func (h *Handler) writeTaskLifecycleAppError(w http.ResponseWriter, err error) bool {
+	switch {
+	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, errTaskHasActiveRun), errors.Is(err, errTaskHasOtherActiveRun), errors.Is(err, errTaskRunNotRetryable), errors.Is(err, errTaskRunNotResumable):
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, errTaskRunNotTurnRetryable), errors.Is(err, errTaskBudgetLower):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -248,17 +249,21 @@ func (h *Handler) loadAuthorizedTask(ctx context.Context, w http.ResponseWriter,
 		return types.Task{}, false
 	}
 
-	task, found, err := h.taskStore.GetTask(ctx, id)
+	task, err := h.taskApplication().LoadTask(ctx, id)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return types.Task{}, false
+		}
+		if errors.Is(err, errTaskNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
+			return types.Task{}, false
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.load.failed",
 			slog.String("event.name", "gateway.tasks.load.failed"),
 			slog.Any("error", err),
 		)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return types.Task{}, false
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
 		return types.Task{}, false
 	}
 	return task, true
@@ -271,17 +276,21 @@ func (h *Handler) loadAuthorizedTaskRun(ctx context.Context, w http.ResponseWrit
 		return types.TaskRun{}, false
 	}
 
-	run, found, err := h.taskStore.GetRun(ctx, task.ID, runID)
+	run, err := h.taskApplication().LoadTaskRun(ctx, task, runID)
 	if err != nil {
+		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return types.TaskRun{}, false
+		}
+		if errors.Is(err, errTaskRunNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
+			return types.TaskRun{}, false
+		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.runs.load.failed",
 			slog.String("event.name", "gateway.tasks.runs.load.failed"),
 			slog.Any("error", err),
 		)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return types.TaskRun{}, false
-	}
-	if !found {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
 		return types.TaskRun{}, false
 	}
 	return run, true

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -5727,6 +5727,45 @@ func TestTaskStartAndDeleteCheckLatestRunWhenTaskSummaryIsStale(t *testing.T) {
 	}
 }
 
+func TestTaskRunnerPreflightBeforeLoadingResources(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	apiHandler.taskRunner = nil
+	handler := NewServer(logger, apiHandler)
+	tasks := newTaskTestClient(t, handler)
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "start missing task",
+			path: "/hecate/v1/tasks/missing/start",
+		},
+		{
+			name: "resolve missing approval",
+			path: "/hecate/v1/tasks/missing/approvals/missing/resolve",
+			body: `{"decision":"approve"}`,
+		},
+		{
+			name: "cancel missing run",
+			path: "/hecate/v1/tasks/missing/runs/missing/cancel",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tasks.mustRequestStatus(http.StatusBadRequest, http.MethodPost, tc.path, tc.body)
+			if !strings.Contains(rec.Body.String(), "task runner is not configured") {
+				t.Fatalf("error body = %s, want task runner preflight error", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestTaskRunRetryReturnsConflictForActiveRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -21,6 +21,7 @@ var (
 	errTaskProjectNotFound           = errors.New("project not found")
 	errTaskNotFound                  = errors.New("task not found")
 	errTaskRunNotFound               = errors.New("task run not found")
+	errTaskApprovalNotFound          = errors.New("task approval not found")
 	errTaskPromptRequired            = errors.New("prompt is required")
 	errTaskHasActiveRun              = errors.New("task already has an active run")
 	errTaskHasOtherActiveRun         = errors.New("task already has another active run")
@@ -385,7 +386,7 @@ func (app *taskApplication) GetTaskApproval(ctx context.Context, task types.Task
 		return types.TaskApproval{}, err
 	}
 	if !found {
-		return types.TaskApproval{}, orchestrator.ErrApprovalNotFound
+		return types.TaskApproval{}, errTaskApprovalNotFound
 	}
 	return approval, nil
 }

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -1,0 +1,426 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/secrets"
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+var (
+	errTaskStoreNotConfigured        = errors.New("task store is not configured")
+	errTaskRunnerNotConfigured       = errors.New("task runner is not configured")
+	errTaskProjectStoreNotConfigured = errors.New("project store is not configured")
+	errTaskProjectNotFound           = errors.New("project not found")
+	errTaskNotFound                  = errors.New("task not found")
+	errTaskRunNotFound               = errors.New("task run not found")
+	errTaskPromptRequired            = errors.New("prompt is required")
+	errTaskHasActiveRun              = errors.New("task already has an active run")
+	errTaskHasOtherActiveRun         = errors.New("task already has another active run")
+	errTaskDeleteActiveRun           = errors.New("cannot delete a task with an active run; cancel it first")
+	errTaskRunNotRetryable           = errors.New("run is not retryable until it reaches a terminal state")
+	errTaskRunNotResumable           = errors.New("run is not resumable")
+	errTaskRunNotTurnRetryable       = errors.New("run is not retryable from a turn (must be terminal)")
+	errTaskBudgetLower               = errors.New("budget_micros_usd cannot be lower than the current task ceiling")
+)
+
+type taskValidationError struct {
+	err error
+}
+
+func (e taskValidationError) Error() string {
+	return e.err.Error()
+}
+
+func (e taskValidationError) Unwrap() error {
+	return e.err
+}
+
+func taskValidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return taskValidationError{err: err}
+}
+
+type taskApplicationRunner interface {
+	StartTask(context.Context, types.Task, func(string) string) (*orchestrator.StartTaskResult, error)
+	ResumeTask(context.Context, types.Task, types.TaskRun, string, func(string) string) (*orchestrator.StartTaskResult, error)
+	ContinueAgentTask(context.Context, types.Task, types.TaskRun, string, func(string) string) (*orchestrator.StartTaskResult, error)
+	RetryTaskFromTurn(context.Context, types.Task, types.TaskRun, int, string, func(string) string) (*orchestrator.StartTaskResult, error)
+	CancelRun(context.Context, types.Task, string, string) (types.TaskRun, error)
+	ResolveTaskApproval(context.Context, orchestrator.ResolveApprovalRequest) (*orchestrator.ResolveApprovalResult, error)
+}
+
+type taskApplication struct {
+	store         taskstate.Store
+	runner        taskApplicationRunner
+	projects      projects.Store
+	secretCipher  secrets.Cipher
+	maxMCPServers int
+	idgen         func(string) string
+	now           func() time.Time
+}
+
+type taskApplicationOptions struct {
+	Store         taskstate.Store
+	Runner        taskApplicationRunner
+	Projects      projects.Store
+	SecretCipher  secrets.Cipher
+	MaxMCPServers int
+	IDGenerator   func(string) string
+	Now           func() time.Time
+}
+
+func newTaskApplication(opts taskApplicationOptions) *taskApplication {
+	app := &taskApplication{
+		store:         opts.Store,
+		runner:        opts.Runner,
+		projects:      opts.Projects,
+		secretCipher:  opts.SecretCipher,
+		maxMCPServers: opts.MaxMCPServers,
+		idgen:         opts.IDGenerator,
+		now:           opts.Now,
+	}
+	if app.idgen == nil {
+		app.idgen = newOpaqueTaskResourceID
+	}
+	if app.now == nil {
+		app.now = func() time.Time { return time.Now().UTC() }
+	}
+	return app
+}
+
+func (app *taskApplication) CreateTask(ctx context.Context, req CreateTaskRequest) (types.Task, error) {
+	if app == nil || app.store == nil {
+		return types.Task{}, errTaskStoreNotConfigured
+	}
+	applyExecutionProfileDefaults(&req)
+
+	title := strings.TrimSpace(req.Title)
+	prompt := strings.TrimSpace(req.Prompt)
+	if title == "" {
+		if prompt == "" {
+			title = "New task"
+		} else {
+			title = prompt
+			if len(title) > 80 {
+				title = strings.TrimSpace(title[:80]) + "..."
+			}
+		}
+	}
+	effectiveKind := strings.TrimSpace(req.ExecutionKind)
+	isAgentLoop := effectiveKind == "" || effectiveKind == "agent_loop"
+	if prompt == "" && isAgentLoop {
+		return types.Task{}, errTaskPromptRequired
+	}
+
+	mcpServers, err := normalizeMCPServerConfigs(req.MCPServers, app.secretCipher, app.maxMCPServers)
+	if err != nil {
+		return types.Task{}, taskValidation(err)
+	}
+
+	workspaceMode := strings.TrimSpace(req.WorkspaceMode)
+	if workspaceMode == "" {
+		workspaceMode = "ephemeral"
+	}
+	priority := strings.TrimSpace(req.Priority)
+	if priority == "" {
+		priority = "normal"
+	}
+	projectID := strings.TrimSpace(req.ProjectID)
+	if projectID != "" {
+		if app.projects == nil {
+			return types.Task{}, errTaskProjectStoreNotConfigured
+		}
+		if _, ok, err := app.projects.Get(ctx, projectID); err != nil {
+			return types.Task{}, err
+		} else if !ok {
+			return types.Task{}, errTaskProjectNotFound
+		}
+	}
+
+	now := app.now().UTC()
+	task := types.Task{
+		ID:                 app.idgen("task"),
+		Title:              title,
+		Prompt:             prompt,
+		ProjectID:          projectID,
+		SystemPrompt:       strings.TrimSpace(req.SystemPrompt),
+		ExecutionProfile:   strings.TrimSpace(req.ExecutionProfile),
+		Repo:               strings.TrimSpace(req.Repo),
+		BaseBranch:         strings.TrimSpace(req.BaseBranch),
+		WorkspaceMode:      workspaceMode,
+		ExecutionKind:      strings.TrimSpace(req.ExecutionKind),
+		ShellCommand:       strings.TrimSpace(req.ShellCommand),
+		GitCommand:         strings.TrimSpace(req.GitCommand),
+		WorkingDirectory:   strings.TrimSpace(req.WorkingDirectory),
+		FileOperation:      strings.TrimSpace(req.FileOperation),
+		FilePath:           strings.TrimSpace(req.FilePath),
+		FileContent:        req.FileContent,
+		SandboxAllowedRoot: strings.TrimSpace(req.SandboxAllowedRoot),
+		SandboxReadOnly:    req.SandboxReadOnly,
+		SandboxNetwork:     req.SandboxNetwork,
+		TimeoutMS:          req.TimeoutMS,
+		Status:             "queued",
+		Priority:           priority,
+		RequestedModel:     strings.TrimSpace(req.RequestedModel),
+		RequestedProvider:  strings.TrimSpace(req.RequestedProvider),
+		BudgetMicrosUSD:    req.BudgetMicrosUSD,
+		MCPServers:         mcpServers,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	return app.store.CreateTask(ctx, task)
+}
+
+func (app *taskApplication) ListTasks(ctx context.Context, filter taskstate.TaskFilter) ([]types.Task, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	return app.store.ListTasks(ctx, filter)
+}
+
+func (app *taskApplication) LoadTask(ctx context.Context, id string) (types.Task, error) {
+	if app == nil || app.store == nil {
+		return types.Task{}, errTaskStoreNotConfigured
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return types.Task{}, fmt.Errorf("task id is required")
+	}
+	task, found, err := app.store.GetTask(ctx, id)
+	if err != nil {
+		return types.Task{}, err
+	}
+	if !found {
+		return types.Task{}, errTaskNotFound
+	}
+	return task, nil
+}
+
+func (app *taskApplication) DeleteTask(ctx context.Context, id string) error {
+	if app == nil || app.store == nil {
+		return errTaskStoreNotConfigured
+	}
+	task, err := app.LoadTask(ctx, id)
+	if err != nil {
+		return err
+	}
+	active, err := taskHasActiveRun(ctx, app.store, task)
+	if err != nil {
+		return err
+	}
+	if active {
+		return errTaskDeleteActiveRun
+	}
+	return app.store.DeleteTask(ctx, strings.TrimSpace(id))
+}
+
+func (app *taskApplication) LoadTaskRun(ctx context.Context, task types.Task, runID string) (types.TaskRun, error) {
+	if app == nil || app.store == nil {
+		return types.TaskRun{}, errTaskStoreNotConfigured
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return types.TaskRun{}, fmt.Errorf("run id is required")
+	}
+	run, found, err := app.store.GetRun(ctx, task.ID, runID)
+	if err != nil {
+		return types.TaskRun{}, err
+	}
+	if !found {
+		return types.TaskRun{}, errTaskRunNotFound
+	}
+	return run, nil
+}
+
+func (app *taskApplication) StartTask(ctx context.Context, task types.Task) (*orchestrator.StartTaskResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	active, err := taskHasActiveRun(ctx, app.store, task)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, errTaskHasActiveRun
+	}
+	return app.runner.StartTask(ctx, task, app.idgen)
+}
+
+func (app *taskApplication) CancelTaskRun(ctx context.Context, task types.Task, run types.TaskRun, reason string) (types.TaskRun, error) {
+	if app == nil || app.store == nil {
+		return types.TaskRun{}, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return types.TaskRun{}, errTaskRunnerNotConfigured
+	}
+	return app.runner.CancelRun(ctx, task, run.ID, reason)
+}
+
+func (app *taskApplication) RetryTaskRun(ctx context.Context, task types.Task, run types.TaskRun) (*orchestrator.StartTaskResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	if !types.IsTerminalTaskRunStatus(run.Status) {
+		return nil, errTaskRunNotRetryable
+	}
+	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, errTaskHasOtherActiveRun
+	}
+	return app.runner.StartTask(ctx, task, app.idgen)
+}
+
+func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, run types.TaskRun, req ResumeTaskRunRequest) (*orchestrator.StartTaskResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	if run.Status != "failed" && run.Status != "cancelled" {
+		return nil, errTaskRunNotResumable
+	}
+	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, errTaskHasOtherActiveRun
+	}
+	if req.BudgetMicrosUSD > 0 {
+		if req.BudgetMicrosUSD < task.BudgetMicrosUSD {
+			return nil, errTaskBudgetLower
+		}
+		// Persist the raised ceiling before queueing; the resumed
+		// agent loop reads the task ceiling on its first turn.
+		task.BudgetMicrosUSD = req.BudgetMicrosUSD
+		updated, err := app.store.UpdateTask(ctx, task)
+		if err != nil {
+			return nil, err
+		}
+		task = updated
+	}
+	return app.runner.ResumeTask(ctx, task, run, strings.TrimSpace(req.Reason), app.idgen)
+}
+
+func (app *taskApplication) ContinueTaskRun(ctx context.Context, task types.Task, run types.TaskRun, prompt string) (*orchestrator.StartTaskResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, errTaskHasOtherActiveRun
+	}
+	return app.runner.ContinueAgentTask(ctx, task, run, prompt, app.idgen)
+}
+
+func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types.Task, run types.TaskRun, req RetryFromTurnRequest) (*orchestrator.StartTaskResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	if !types.IsTerminalTaskRunStatus(run.Status) {
+		return nil, errTaskRunNotTurnRetryable
+	}
+	if req.Turn < 1 {
+		return nil, fmt.Errorf("turn must be >= 1")
+	}
+	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, errTaskHasOtherActiveRun
+	}
+	return app.runner.RetryTaskFromTurn(ctx, task, run, req.Turn, strings.TrimSpace(req.Reason), app.idgen)
+}
+
+func (app *taskApplication) ListTaskApprovals(ctx context.Context, task types.Task) ([]types.TaskApproval, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	return app.store.ListApprovals(ctx, task.ID)
+}
+
+func (app *taskApplication) GetTaskApproval(ctx context.Context, task types.Task, approvalID string) (types.TaskApproval, error) {
+	if app == nil || app.store == nil {
+		return types.TaskApproval{}, errTaskStoreNotConfigured
+	}
+	approvalID = strings.TrimSpace(approvalID)
+	if approvalID == "" {
+		return types.TaskApproval{}, fmt.Errorf("approval id is required")
+	}
+	approval, found, err := app.store.GetApproval(ctx, task.ID, approvalID)
+	if err != nil {
+		return types.TaskApproval{}, err
+	}
+	if !found {
+		return types.TaskApproval{}, orchestrator.ErrApprovalNotFound
+	}
+	return approval, nil
+}
+
+func (app *taskApplication) ResolveTaskApproval(ctx context.Context, req orchestrator.ResolveApprovalRequest) (*orchestrator.ResolveApprovalResult, error) {
+	if app == nil || app.store == nil {
+		return nil, errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
+	if strings.TrimSpace(req.ResolvedBy) == "" {
+		req.ResolvedBy = "operator"
+	}
+	if req.IDGenerator == nil {
+		req.IDGenerator = app.idgen
+	}
+	return app.runner.ResolveTaskApproval(ctx, req)
+}
+
+func taskHasActiveRun(ctx context.Context, store taskstate.Store, task types.Task) (bool, error) {
+	latestRunID := strings.TrimSpace(task.LatestRunID)
+	if latestRunID != "" && store != nil {
+		run, found, err := store.GetRun(ctx, task.ID, latestRunID)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return !types.IsTerminalTaskRunStatus(run.Status), nil
+		}
+	}
+	return latestRunID != "" && !types.IsTerminalTaskRunStatus(task.Status), nil
+}
+
+func taskHasOtherActiveRun(ctx context.Context, store taskstate.Store, task types.Task, currentRunID string) (bool, error) {
+	latestRunID := strings.TrimSpace(task.LatestRunID)
+	if latestRunID == "" || latestRunID == strings.TrimSpace(currentRunID) {
+		return false, nil
+	}
+	return taskHasActiveRun(ctx, store, task)
+}

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -273,9 +273,6 @@ func (app *taskApplication) RetryTaskRun(ctx context.Context, task types.Task, r
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
 	}
-	if app.runner == nil {
-		return nil, errTaskRunnerNotConfigured
-	}
 	if !types.IsTerminalTaskRunStatus(run.Status) {
 		return nil, errTaskRunNotRetryable
 	}
@@ -286,15 +283,15 @@ func (app *taskApplication) RetryTaskRun(ctx context.Context, task types.Task, r
 	if active {
 		return nil, errTaskHasOtherActiveRun
 	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
 	return app.runner.StartTask(ctx, task, app.idgen)
 }
 
 func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, run types.TaskRun, req ResumeTaskRunRequest) (*orchestrator.StartTaskResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
-	}
-	if app.runner == nil {
-		return nil, errTaskRunnerNotConfigured
 	}
 	if run.Status != "failed" && run.Status != "cancelled" {
 		return nil, errTaskRunNotResumable
@@ -310,6 +307,9 @@ func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, 
 		if req.BudgetMicrosUSD < task.BudgetMicrosUSD {
 			return nil, errTaskBudgetLower
 		}
+		if app.runner == nil {
+			return nil, errTaskRunnerNotConfigured
+		}
 		// Persist the raised ceiling before queueing; the resumed
 		// agent loop reads the task ceiling on its first turn.
 		task.BudgetMicrosUSD = req.BudgetMicrosUSD
@@ -319,15 +319,15 @@ func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, 
 		}
 		task = updated
 	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
 	return app.runner.ResumeTask(ctx, task, run, strings.TrimSpace(req.Reason), app.idgen)
 }
 
 func (app *taskApplication) ContinueTaskRun(ctx context.Context, task types.Task, run types.TaskRun, prompt string) (*orchestrator.StartTaskResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
-	}
-	if app.runner == nil {
-		return nil, errTaskRunnerNotConfigured
 	}
 	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
 	if err != nil {
@@ -336,15 +336,15 @@ func (app *taskApplication) ContinueTaskRun(ctx context.Context, task types.Task
 	if active {
 		return nil, errTaskHasOtherActiveRun
 	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
+	}
 	return app.runner.ContinueAgentTask(ctx, task, run, prompt, app.idgen)
 }
 
 func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types.Task, run types.TaskRun, req RetryFromTurnRequest) (*orchestrator.StartTaskResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
-	}
-	if app.runner == nil {
-		return nil, errTaskRunnerNotConfigured
 	}
 	if !types.IsTerminalTaskRunStatus(run.Status) {
 		return nil, errTaskRunNotTurnRetryable
@@ -358,6 +358,9 @@ func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types
 	}
 	if active {
 		return nil, errTaskHasOtherActiveRun
+	}
+	if app.runner == nil {
+		return nil, errTaskRunnerNotConfigured
 	}
 	return app.runner.RetryTaskFromTurn(ctx, task, run, req.Turn, strings.TrimSpace(req.Reason), app.idgen)
 }

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -207,6 +207,16 @@ func (app *taskApplication) LoadTask(ctx context.Context, id string) (types.Task
 	return task, nil
 }
 
+func (app *taskApplication) RequireRunner() error {
+	if app == nil || app.store == nil {
+		return errTaskStoreNotConfigured
+	}
+	if app.runner == nil {
+		return errTaskRunnerNotConfigured
+	}
+	return nil
+}
+
 func (app *taskApplication) DeleteTask(ctx context.Context, id string) error {
 	if app == nil || app.store == nil {
 		return errTaskStoreNotConfigured

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -288,8 +288,8 @@ func TestTaskApplication_LoadNotFoundErrors(t *testing.T) {
 	if _, err := app.LoadTaskRun(ctx, task, "missing"); !errors.Is(err, errTaskRunNotFound) {
 		t.Fatalf("LoadTaskRun(missing) error = %v, want errTaskRunNotFound", err)
 	}
-	if _, err := app.GetTaskApproval(ctx, task, "missing"); !errors.Is(err, orchestrator.ErrApprovalNotFound) {
-		t.Fatalf("GetTaskApproval(missing) error = %v, want ErrApprovalNotFound", err)
+	if _, err := app.GetTaskApproval(ctx, task, "missing"); !errors.Is(err, errTaskApprovalNotFound) {
+		t.Fatalf("GetTaskApproval(missing) error = %v, want errTaskApprovalNotFound", err)
 	}
 }
 

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -407,6 +407,117 @@ func TestTaskApplication_LifecycleRejectsOtherActiveRunBeforeRunner(t *testing.T
 	}
 }
 
+func TestTaskApplication_LifecycleValidationPrecedesRunnerConfiguration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		call func(context.Context, *taskApplication, types.Task, types.TaskRun) error
+		want error
+	}{
+		{
+			name: "retry_nonterminal",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.RetryTaskRun(ctx, task, run)
+				return err
+			},
+			want: errTaskRunNotRetryable,
+		},
+		{
+			name: "resume_nonterminal",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{Reason: "try again"})
+				return err
+			},
+			want: errTaskRunNotResumable,
+		},
+		{
+			name: "turn_retry_nonterminal",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 1})
+				return err
+			},
+			want: errTaskRunNotTurnRetryable,
+		},
+		{
+			name: "resume_other_active_before_lower_budget",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				run.Status = "failed"
+				task.BudgetMicrosUSD = 500
+				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+				return err
+			},
+			want: errTaskHasOtherActiveRun,
+		},
+		{
+			name: "continue_other_active",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.ContinueTaskRun(ctx, task, run, "continue")
+				return err
+			},
+			want: errTaskHasOtherActiveRun,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store := taskstate.NewMemoryStore()
+			app := newTestTaskApplication(store, nil)
+			task := createTaskForAppTest(t, ctx, store, types.Task{
+				ID:          "task_" + tc.name,
+				Status:      "failed",
+				LatestRunID: "run_active",
+			})
+			createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_active", TaskID: task.ID, Status: "running"})
+			run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_source", TaskID: task.ID, Status: "running"})
+
+			err := tc.call(ctx, app, task, run)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("%s error = %v, want %v", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTaskApplication_ResumeLowerBudgetPrecedesRunnerConfiguration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, nil)
+	task := createTaskForAppTest(t, ctx, store, types.Task{
+		ID:              "task_lower_budget_no_runner",
+		Status:          "failed",
+		BudgetMicrosUSD: 500,
+		LatestRunID:     "run_failed",
+	})
+	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "failed"})
+
+	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+	if !errors.Is(err, errTaskBudgetLower) {
+		t.Fatalf("ResumeTaskRun(lower budget, nil runner) error = %v, want errTaskBudgetLower", err)
+	}
+}
+
+func TestTaskApplication_RetryFromTurnValidatesTurnBeforeRunner(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, nil)
+	task := createTaskForAppTest(t, ctx, store, types.Task{ID: "task_turn", Status: "failed"})
+	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_failed", TaskID: task.ID, Status: "failed"})
+
+	_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 0})
+	if err == nil || err.Error() != "turn must be >= 1" {
+		t.Fatalf("RetryTaskRunFromTurn(turn 0) error = %v, want turn must be >= 1", err)
+	}
+}
+
 func TestTaskApplication_ResumeRaisesBudgetBeforeRunner(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -264,8 +264,14 @@ func TestTaskApplication_NilStoreAndRunnerErrors(t *testing.T) {
 	if _, err := app.GetTaskApproval(ctx, types.Task{ID: "task"}, "approval"); !errors.Is(err, errTaskStoreNotConfigured) {
 		t.Fatalf("GetTaskApproval(nil store) error = %v, want errTaskStoreNotConfigured", err)
 	}
+	if err := app.RequireRunner(); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("RequireRunner(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
 
 	app = newTestTaskApplication(taskstate.NewMemoryStore(), nil)
+	if err := app.RequireRunner(); !errors.Is(err, errTaskRunnerNotConfigured) {
+		t.Fatalf("RequireRunner(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
+	}
 	if _, err := app.StartTask(ctx, types.Task{ID: "task"}); !errors.Is(err, errTaskRunnerNotConfigured) {
 		t.Fatalf("StartTask(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
 	}

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -1,0 +1,541 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type recordingTaskApplicationRunner struct {
+	startCalls int
+	startTask  types.Task
+
+	resumeCalls  int
+	resumeTask   types.Task
+	resumeRun    types.TaskRun
+	resumeReason string
+
+	continueCalls  int
+	continuePrompt string
+
+	retryFromTurnCalls int
+	retryFromTurn      int
+
+	cancelCalls  int
+	cancelRunID  string
+	cancelReason string
+
+	resolveCalls int
+	resolveReq   orchestrator.ResolveApprovalRequest
+}
+
+func (r *recordingTaskApplicationRunner) StartTask(_ context.Context, task types.Task, _ func(string) string) (*orchestrator.StartTaskResult, error) {
+	r.startCalls++
+	r.startTask = task
+	run := types.TaskRun{ID: "run_started", TaskID: task.ID, Status: "queued"}
+	return &orchestrator.StartTaskResult{Task: task, Run: run}, nil
+}
+
+func (r *recordingTaskApplicationRunner) ResumeTask(_ context.Context, task types.Task, run types.TaskRun, reason string, _ func(string) string) (*orchestrator.StartTaskResult, error) {
+	r.resumeCalls++
+	r.resumeTask = task
+	r.resumeRun = run
+	r.resumeReason = reason
+	resumed := types.TaskRun{ID: "run_resumed", TaskID: task.ID, Status: "queued"}
+	return &orchestrator.StartTaskResult{Task: task, Run: resumed}, nil
+}
+
+func (r *recordingTaskApplicationRunner) ContinueAgentTask(_ context.Context, task types.Task, run types.TaskRun, prompt string, _ func(string) string) (*orchestrator.StartTaskResult, error) {
+	r.continueCalls++
+	r.continuePrompt = prompt
+	continued := types.TaskRun{ID: "run_continued", TaskID: task.ID, Status: "queued"}
+	return &orchestrator.StartTaskResult{Task: task, Run: continued}, nil
+}
+
+func (r *recordingTaskApplicationRunner) RetryTaskFromTurn(_ context.Context, task types.Task, run types.TaskRun, turn int, _ string, _ func(string) string) (*orchestrator.StartTaskResult, error) {
+	r.retryFromTurnCalls++
+	r.retryFromTurn = turn
+	retried := types.TaskRun{ID: "run_turn_retry", TaskID: task.ID, Status: "queued"}
+	return &orchestrator.StartTaskResult{Task: task, Run: retried}, nil
+}
+
+func (r *recordingTaskApplicationRunner) CancelRun(_ context.Context, task types.Task, runID string, reason string) (types.TaskRun, error) {
+	r.cancelCalls++
+	r.cancelRunID = runID
+	r.cancelReason = reason
+	return types.TaskRun{ID: runID, TaskID: task.ID, Status: "cancelled"}, nil
+}
+
+func (r *recordingTaskApplicationRunner) ResolveTaskApproval(_ context.Context, req orchestrator.ResolveApprovalRequest) (*orchestrator.ResolveApprovalResult, error) {
+	r.resolveCalls++
+	r.resolveReq = req
+	return &orchestrator.ResolveApprovalResult{
+		Approval: types.TaskApproval{
+			ID:     req.ApprovalID,
+			TaskID: req.Task.ID,
+			Status: "approved",
+		},
+	}, nil
+}
+
+func (r *recordingTaskApplicationRunner) totalCalls() int {
+	return r.startCalls + r.resumeCalls + r.continueCalls + r.retryFromTurnCalls + r.cancelCalls + r.resolveCalls
+}
+
+func newTestTaskApplication(store taskstate.Store, runner taskApplicationRunner) *taskApplication {
+	return newTestTaskApplicationWithProjects(store, runner, nil)
+}
+
+func newTestTaskApplicationWithProjects(store taskstate.Store, runner taskApplicationRunner, projectStore projects.Store) *taskApplication {
+	return newTaskApplication(taskApplicationOptions{
+		Store:       store,
+		Runner:      runner,
+		Projects:    projectStore,
+		IDGenerator: func(prefix string) string { return prefix + "_fixed" },
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+		},
+	})
+}
+
+func createTaskForAppTest(t *testing.T, ctx context.Context, store taskstate.Store, task types.Task) types.Task {
+	t.Helper()
+	if task.ID == "" {
+		task.ID = "task_test"
+	}
+	if task.Title == "" {
+		task.Title = task.ID
+	}
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = time.Now().UTC()
+	}
+	if task.UpdatedAt.IsZero() {
+		task.UpdatedAt = task.CreatedAt
+	}
+	created, err := store.CreateTask(ctx, task)
+	if err != nil {
+		t.Fatalf("CreateTask(%s): %v", task.ID, err)
+	}
+	return created
+}
+
+func createRunForAppTest(t *testing.T, ctx context.Context, store taskstate.Store, run types.TaskRun) types.TaskRun {
+	t.Helper()
+	if run.ID == "" {
+		run.ID = "run_test"
+	}
+	if run.StartedAt.IsZero() {
+		run.StartedAt = time.Now().UTC()
+	}
+	created, err := store.CreateRun(ctx, run)
+	if err != nil {
+		t.Fatalf("CreateRun(%s): %v", run.ID, err)
+	}
+	return created
+}
+
+func TestTaskApplication_CreateTaskAppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, &recordingTaskApplicationRunner{})
+
+	task, err := app.CreateTask(ctx, CreateTaskRequest{
+		Prompt:           "  Build the repo  ",
+		ExecutionProfile: "repo_local",
+		Repo:             "/tmp/hecate",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	if task.ID != "task_fixed" {
+		t.Fatalf("id = %q, want task_fixed", task.ID)
+	}
+	if task.Title != "Build the repo" || task.Prompt != "Build the repo" {
+		t.Fatalf("title/prompt = %q/%q, want trimmed prompt title", task.Title, task.Prompt)
+	}
+	if task.ExecutionKind != "agent_loop" {
+		t.Fatalf("execution_kind = %q, want agent_loop", task.ExecutionKind)
+	}
+	if task.WorkspaceMode != "persistent" || task.WorkingDirectory != "." {
+		t.Fatalf("workspace_mode/working_directory = %q/%q, want persistent/.", task.WorkspaceMode, task.WorkingDirectory)
+	}
+	if task.SandboxAllowedRoot != "/tmp/hecate" {
+		t.Fatalf("sandbox_allowed_root = %q, want /tmp/hecate", task.SandboxAllowedRoot)
+	}
+	if task.TimeoutMS != 120000 {
+		t.Fatalf("timeout_ms = %d, want 120000", task.TimeoutMS)
+	}
+	if task.Priority != "normal" || task.Status != "queued" {
+		t.Fatalf("priority/status = %q/%q, want normal/queued", task.Priority, task.Status)
+	}
+	if got := task.CreatedAt; !got.Equal(time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("created_at = %s, want fixed clock", got)
+	}
+}
+
+func TestTaskApplication_CreateTaskValidatesProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, nil)
+
+	_, err := app.CreateTask(ctx, CreateTaskRequest{
+		Prompt:    "Use project context",
+		ProjectID: "proj_missing_store",
+	})
+	if !errors.Is(err, errTaskProjectStoreNotConfigured) {
+		t.Fatalf("CreateTask(project without store) error = %v, want errTaskProjectStoreNotConfigured", err)
+	}
+
+	projectStore := projects.NewMemoryStore()
+	app = newTestTaskApplicationWithProjects(store, nil, projectStore)
+	_, err = app.CreateTask(ctx, CreateTaskRequest{
+		Prompt:    "Use project context",
+		ProjectID: "proj_missing",
+	})
+	if !errors.Is(err, errTaskProjectNotFound) {
+		t.Fatalf("CreateTask(missing project) error = %v, want errTaskProjectNotFound", err)
+	}
+
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Project One"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	task, err := app.CreateTask(ctx, CreateTaskRequest{
+		Prompt:    "Use project context",
+		ProjectID: " proj_1 ",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(existing project) error = %v", err)
+	}
+	if task.ProjectID != "proj_1" {
+		t.Fatalf("task project_id = %q, want proj_1", task.ProjectID)
+	}
+}
+
+func TestTaskApplication_CreateTaskValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := newTestTaskApplication(taskstate.NewMemoryStore(), nil)
+
+	if _, err := app.CreateTask(ctx, CreateTaskRequest{}); !errors.Is(err, errTaskPromptRequired) {
+		t.Fatalf("CreateTask(agent_loop without prompt) error = %v, want errTaskPromptRequired", err)
+	}
+
+	task, err := app.CreateTask(ctx, CreateTaskRequest{
+		ExecutionKind: "shell",
+		ShellCommand:  "printf ok",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask(shell without prompt) error = %v", err)
+	}
+	if task.Prompt != "" || task.Title != "New task" {
+		t.Fatalf("shell task prompt/title = %q/%q, want empty/New task", task.Prompt, task.Title)
+	}
+}
+
+func TestTaskApplication_NilStoreAndRunnerErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := newTaskApplication(taskApplicationOptions{})
+	if _, err := app.CreateTask(ctx, CreateTaskRequest{Prompt: "x"}); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("CreateTask(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
+	if _, err := app.ListTasks(ctx, taskstate.TaskFilter{}); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("ListTasks(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
+	if _, err := app.LoadTask(ctx, "task"); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("LoadTask(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
+	if _, err := app.LoadTaskRun(ctx, types.Task{ID: "task"}, "run"); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("LoadTaskRun(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
+	if _, err := app.GetTaskApproval(ctx, types.Task{ID: "task"}, "approval"); !errors.Is(err, errTaskStoreNotConfigured) {
+		t.Fatalf("GetTaskApproval(nil store) error = %v, want errTaskStoreNotConfigured", err)
+	}
+
+	app = newTestTaskApplication(taskstate.NewMemoryStore(), nil)
+	if _, err := app.StartTask(ctx, types.Task{ID: "task"}); !errors.Is(err, errTaskRunnerNotConfigured) {
+		t.Fatalf("StartTask(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
+	}
+	if _, err := app.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{}); !errors.Is(err, errTaskRunnerNotConfigured) {
+		t.Fatalf("ResolveTaskApproval(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
+	}
+}
+
+func TestTaskApplication_LoadNotFoundErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, nil)
+	task := createTaskForAppTest(t, ctx, store, types.Task{ID: "task_found"})
+
+	if _, err := app.LoadTask(ctx, "missing"); !errors.Is(err, errTaskNotFound) {
+		t.Fatalf("LoadTask(missing) error = %v, want errTaskNotFound", err)
+	}
+	if _, err := app.LoadTaskRun(ctx, task, "missing"); !errors.Is(err, errTaskRunNotFound) {
+		t.Fatalf("LoadTaskRun(missing) error = %v, want errTaskRunNotFound", err)
+	}
+	if _, err := app.GetTaskApproval(ctx, task, "missing"); !errors.Is(err, orchestrator.ErrApprovalNotFound) {
+		t.Fatalf("GetTaskApproval(missing) error = %v, want ErrApprovalNotFound", err)
+	}
+}
+
+func TestTaskApplication_StartTaskRejectsActiveRunBeforeRunner(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(store, runner)
+	task := types.Task{
+		ID:          "task_active",
+		Title:       "active",
+		Status:      "completed",
+		LatestRunID: "run_active",
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	createTaskForAppTest(t, ctx, store, task)
+	createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "awaiting_approval"})
+
+	_, err := app.StartTask(ctx, task)
+	if !errors.Is(err, errTaskHasActiveRun) {
+		t.Fatalf("StartTask() error = %v, want errTaskHasActiveRun", err)
+	}
+	if runner.startCalls != 0 {
+		t.Fatalf("runner start calls = %d, want 0", runner.startCalls)
+	}
+}
+
+func TestTaskApplication_CancelDispatchesRunIDAndReason(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(store, runner)
+	task := types.Task{ID: "task_cancel"}
+	run := types.TaskRun{ID: "run_cancel", TaskID: task.ID, Status: "running"}
+
+	cancelled, err := app.CancelTaskRun(ctx, task, run, "operator stop")
+	if err != nil {
+		t.Fatalf("CancelTaskRun() error = %v", err)
+	}
+	if cancelled.Status != "cancelled" {
+		t.Fatalf("cancelled status = %q, want cancelled", cancelled.Status)
+	}
+	if runner.cancelCalls != 1 || runner.cancelRunID != run.ID || runner.cancelReason != "operator stop" {
+		t.Fatalf("cancel dispatch calls/id/reason = %d/%q/%q, want 1/%q/operator stop", runner.cancelCalls, runner.cancelRunID, runner.cancelReason, run.ID)
+	}
+}
+
+func TestTaskApplication_LifecycleRejectsOtherActiveRunBeforeRunner(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		call func(context.Context, *taskApplication, types.Task, types.TaskRun) error
+	}{
+		{
+			name: "retry",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.RetryTaskRun(ctx, task, run)
+				return err
+			},
+		},
+		{
+			name: "resume",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{Reason: "try again"})
+				return err
+			},
+		},
+		{
+			name: "continue",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.ContinueTaskRun(ctx, task, run, "continue")
+				return err
+			},
+		},
+		{
+			name: "retry_from_turn",
+			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
+				_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 1, Reason: "rewind"})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store := taskstate.NewMemoryStore()
+			runner := &recordingTaskApplicationRunner{}
+			app := newTestTaskApplication(store, runner)
+			task := createTaskForAppTest(t, ctx, store, types.Task{
+				ID:          "task_" + tc.name,
+				Status:      "failed",
+				LatestRunID: "run_active",
+			})
+			createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_active", TaskID: task.ID, Status: "running"})
+			run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_source", TaskID: task.ID, Status: "failed"})
+
+			err := tc.call(ctx, app, task, run)
+			if !errors.Is(err, errTaskHasOtherActiveRun) {
+				t.Fatalf("%s error = %v, want errTaskHasOtherActiveRun", tc.name, err)
+			}
+			if runner.totalCalls() != 0 {
+				t.Fatalf("runner calls = %d, want 0", runner.totalCalls())
+			}
+		})
+	}
+}
+
+func TestTaskApplication_ResumeRaisesBudgetBeforeRunner(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(store, runner)
+	task := types.Task{
+		ID:              "task_budget",
+		Title:           "budget",
+		Status:          "failed",
+		BudgetMicrosUSD: 100,
+		LatestRunID:     "run_failed",
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}
+	run := types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "failed"}
+	createTaskForAppTest(t, ctx, store, task)
+	createRunForAppTest(t, ctx, store, run)
+
+	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{
+		Reason:          "raise ceiling",
+		BudgetMicrosUSD: 250,
+	})
+	if err != nil {
+		t.Fatalf("ResumeTaskRun() error = %v", err)
+	}
+	if runner.resumeCalls != 1 {
+		t.Fatalf("resume calls = %d, want 1", runner.resumeCalls)
+	}
+	if runner.resumeTask.BudgetMicrosUSD != 250 {
+		t.Fatalf("runner task budget = %d, want 250", runner.resumeTask.BudgetMicrosUSD)
+	}
+	if runner.resumeReason != "raise ceiling" {
+		t.Fatalf("resume reason = %q, want raise ceiling", runner.resumeReason)
+	}
+	persisted, found, err := store.GetTask(ctx, task.ID)
+	if err != nil || !found {
+		t.Fatalf("GetTask: found=%t err=%v", found, err)
+	}
+	if persisted.BudgetMicrosUSD != 250 {
+		t.Fatalf("persisted budget = %d, want 250", persisted.BudgetMicrosUSD)
+	}
+}
+
+func TestTaskApplication_ResumeRejectsLowerBudgetBeforeRunner(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(store, runner)
+	task := createTaskForAppTest(t, ctx, store, types.Task{
+		ID:              "task_budget_lower",
+		Status:          "failed",
+		BudgetMicrosUSD: 250,
+		LatestRunID:     "run_failed",
+	})
+	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "failed"})
+
+	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+	if !errors.Is(err, errTaskBudgetLower) {
+		t.Fatalf("ResumeTaskRun(lower budget) error = %v, want errTaskBudgetLower", err)
+	}
+	if runner.resumeCalls != 0 {
+		t.Fatalf("resume calls = %d, want 0", runner.resumeCalls)
+	}
+}
+
+func TestTaskApplication_DeleteRejectsStaleSummaryWhenLatestRunActive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	app := newTestTaskApplication(store, nil)
+	task := types.Task{
+		ID:          "task_stale",
+		Title:       "stale",
+		Status:      "completed",
+		LatestRunID: "run_active",
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	createTaskForAppTest(t, ctx, store, task)
+	createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "running"})
+
+	err := app.DeleteTask(ctx, task.ID)
+	if !errors.Is(err, errTaskDeleteActiveRun) {
+		t.Fatalf("DeleteTask() error = %v, want errTaskDeleteActiveRun", err)
+	}
+	if _, found, err := store.GetTask(ctx, task.ID); err != nil || !found {
+		t.Fatalf("task after delete attempt: found=%t err=%v, want still present", found, err)
+	}
+}
+
+func TestTaskApplication_ResolveApprovalEnrichesRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(taskstate.NewMemoryStore(), runner)
+	task := types.Task{ID: "task_approval"}
+
+	_, err := app.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
+		Task:       task,
+		ApprovalID: "approval_1",
+		Decision:   "approve",
+		Note:       "looks good",
+		RequestID:  "req_1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTaskApproval() error = %v", err)
+	}
+	if runner.resolveCalls != 1 {
+		t.Fatalf("resolve calls = %d, want 1", runner.resolveCalls)
+	}
+	if runner.resolveReq.Task.ID != task.ID || runner.resolveReq.ApprovalID != "approval_1" {
+		t.Fatalf("resolve task/approval = %q/%q, want task_approval/approval_1", runner.resolveReq.Task.ID, runner.resolveReq.ApprovalID)
+	}
+	if runner.resolveReq.ResolvedBy != "operator" {
+		t.Fatalf("resolved_by = %q, want operator", runner.resolveReq.ResolvedBy)
+	}
+	if runner.resolveReq.RequestID != "req_1" {
+		t.Fatalf("request_id = %q, want req_1", runner.resolveReq.RequestID)
+	}
+	if runner.resolveReq.IDGenerator == nil {
+		t.Fatal("IDGenerator is nil, want app default")
+	}
+	if got := runner.resolveReq.IDGenerator("run"); got != "run_fixed" {
+		t.Fatalf("IDGenerator(run) = %q, want run_fixed", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract task lifecycle orchestration from HTTP handlers into an internal `taskApplication` seam.
- Keep task HTTP handlers focused on path/query/body parsing, HTTP error mapping, trace headers, and response rendering.
- Move create/load/delete/start/retry/resume/continue/cancel plus approval lookup/resolve decisions into the app seam.
- Preserve existing HTTP behavior, including lifecycle validation ordering and runner preflight error ordering.
- Update backend guidance so future task API lifecycle work goes through `taskApplication`.

## Reviewer Notes
- Public HTTP routes, response envelopes, status codes, headers, storage schemas, and exported Go APIs are intended to be unchanged.
- The seam stays inside `internal/api` for this PR so API DTOs do not move yet.
- Follow-up commits add app-level error coverage and HTTP regression coverage for validation/preflight ordering.

## Tests
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestTaskApplicationLayerDirectShellLifecycleE2E ./e2e`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go vet ./internal/api`
- GitHub CI: all checks pass on this PR