### PR TITLE
fix(api): wrap task app validation errors

### DIFF
--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -52,11 +52,10 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) writeCreateTaskError(w http.ResponseWriter, r *http.Request, err error) {
 	ctx := r.Context()
-	var validation taskValidationError
 	switch {
 	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskProjectStoreNotConfigured):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	case errors.Is(err, errTaskPromptRequired), errors.Is(err, errTaskProjectNotFound), errors.As(err, &validation):
+	case errors.Is(err, errTaskPromptRequired), errors.Is(err, errTaskProjectNotFound), isTaskValidationError(err):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 	default:
 		telemetry.Error(h.logger, ctx, "gateway.tasks.create.failed",
@@ -177,6 +176,10 @@ func (h *Handler) HandleTask(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return
 		}
+		if isTaskValidationError(err) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
 		if errors.Is(err, errTaskNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
 			return
@@ -205,7 +208,7 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.taskApplication().DeleteTask(ctx, id); err != nil {
 		switch {
-		case errors.Is(err, errTaskStoreNotConfigured):
+		case errors.Is(err, errTaskStoreNotConfigured), isTaskValidationError(err):
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return
 		case errors.Is(err, errTaskNotFound):

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -60,6 +60,10 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return
 		}
+		if isTaskValidationError(err) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
 		if errors.Is(err, errTaskApprovalNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
 			return
@@ -310,6 +314,8 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 func (h *Handler) writeTaskLifecycleAppError(w http.ResponseWriter, err error) bool {
 	switch {
 	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case isTaskValidationError(err):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 	case errors.Is(err, errTaskHasActiveRun), errors.Is(err, errTaskHasOtherActiveRun), errors.Is(err, errTaskRunNotRetryable), errors.Is(err, errTaskRunNotResumable):
 		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -255,6 +255,10 @@ func (h *Handler) loadAuthorizedTask(ctx context.Context, w http.ResponseWriter,
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return types.Task{}, false
 		}
+		if isTaskValidationError(err) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return types.Task{}, false
+		}
 		if errors.Is(err, errTaskNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
 			return types.Task{}, false
@@ -279,6 +283,10 @@ func (h *Handler) loadAuthorizedTaskRun(ctx context.Context, w http.ResponseWrit
 	run, err := h.taskApplication().LoadTaskRun(ctx, task, runID)
 	if err != nil {
 		if errors.Is(err, errTaskStoreNotConfigured) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return types.TaskRun{}, false
+		}
+		if isTaskValidationError(err) {
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return types.TaskRun{}, false
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -5891,6 +5891,55 @@ func TestTaskRunMutationsReturnConflictWhenAnotherLatestRunActive(t *testing.T) 
 	}
 }
 
+func TestTaskRunRetryFromTurnInvalidTurnReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, nil, config.Config{}, nil)
+	apiHandler.taskRunner = nil
+	handler := NewServer(logger, apiHandler)
+	tasks := newTaskTestClient(t, handler)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	task := types.Task{
+		ID:          "task-invalid-turn",
+		Title:       "invalid turn",
+		Prompt:      "retry should validate turn before runner dispatch",
+		Status:      "failed",
+		LatestRunID: "run-invalid-turn",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if _, err := apiHandler.taskStore.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{
+		ID:         task.LatestRunID,
+		TaskID:     task.ID,
+		Number:     1,
+		Status:     "failed",
+		StartedAt:  now.Add(-time.Minute),
+		FinishedAt: now,
+	}
+	if _, err := apiHandler.taskStore.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	rec := tasks.mustRequestStatus(http.StatusBadRequest, http.MethodPost,
+		"/hecate/v1/tasks/"+task.ID+"/runs/"+run.ID+"/retry-from-turn",
+		`{"turn":0}`)
+	payload := decodeRecorder[struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}](t, rec)
+	if payload.Error.Type != errCodeInvalidRequest || payload.Error.Message != "turn must be >= 1" {
+		t.Fatalf("error = %#v, want invalid_request turn validation", payload.Error)
+	}
+}
+
 func TestTaskRunResumeFromCancelledRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -22,6 +21,10 @@ var (
 	errTaskNotFound                  = errors.New("task not found")
 	errTaskRunNotFound               = errors.New("task run not found")
 	errTaskApprovalNotFound          = errors.New("task approval not found")
+	errTaskIDRequired                = errors.New("task id is required")
+	errTaskRunIDRequired             = errors.New("run id is required")
+	errTaskApprovalIDRequired        = errors.New("approval id is required")
+	errTaskTurnRequired              = errors.New("turn must be >= 1")
 	errTaskPromptRequired            = errors.New("prompt is required")
 	errTaskHasActiveRun              = errors.New("task already has an active run")
 	errTaskHasOtherActiveRun         = errors.New("task already has another active run")
@@ -49,6 +52,11 @@ func taskValidation(err error) error {
 		return nil
 	}
 	return taskValidationError{err: err}
+}
+
+func isTaskValidationError(err error) bool {
+	var validation taskValidationError
+	return errors.As(err, &validation)
 }
 
 type taskApplicationRunner interface {
@@ -195,7 +203,7 @@ func (app *taskApplication) LoadTask(ctx context.Context, id string) (types.Task
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return types.Task{}, fmt.Errorf("task id is required")
+		return types.Task{}, taskValidation(errTaskIDRequired)
 	}
 	task, found, err := app.store.GetTask(ctx, id)
 	if err != nil {
@@ -241,7 +249,7 @@ func (app *taskApplication) LoadTaskRun(ctx context.Context, task types.Task, ru
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		return types.TaskRun{}, fmt.Errorf("run id is required")
+		return types.TaskRun{}, taskValidation(errTaskRunIDRequired)
 	}
 	run, found, err := app.store.GetRun(ctx, task.ID, runID)
 	if err != nil {
@@ -361,7 +369,7 @@ func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types
 		return nil, errTaskRunNotTurnRetryable
 	}
 	if req.Turn < 1 {
-		return nil, fmt.Errorf("turn must be >= 1")
+		return nil, taskValidation(errTaskTurnRequired)
 	}
 	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
 	if err != nil {
@@ -389,7 +397,7 @@ func (app *taskApplication) GetTaskApproval(ctx context.Context, task types.Task
 	}
 	approvalID = strings.TrimSpace(approvalID)
 	if approvalID == "" {
-		return types.TaskApproval{}, fmt.Errorf("approval id is required")
+		return types.TaskApproval{}, taskValidation(errTaskApprovalIDRequired)
 	}
 	approval, found, err := app.store.GetApproval(ctx, task.ID, approvalID)
 	if err != nil {

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -291,11 +291,20 @@ func TestTaskApplication_LoadNotFoundErrors(t *testing.T) {
 	if _, err := app.LoadTask(ctx, "missing"); !errors.Is(err, errTaskNotFound) {
 		t.Fatalf("LoadTask(missing) error = %v, want errTaskNotFound", err)
 	}
+	if _, err := app.LoadTask(ctx, " "); !errors.Is(err, errTaskIDRequired) || !isTaskValidationError(err) {
+		t.Fatalf("LoadTask(empty) error = %v, want task validation errTaskIDRequired", err)
+	}
 	if _, err := app.LoadTaskRun(ctx, task, "missing"); !errors.Is(err, errTaskRunNotFound) {
 		t.Fatalf("LoadTaskRun(missing) error = %v, want errTaskRunNotFound", err)
 	}
+	if _, err := app.LoadTaskRun(ctx, task, " "); !errors.Is(err, errTaskRunIDRequired) || !isTaskValidationError(err) {
+		t.Fatalf("LoadTaskRun(empty) error = %v, want task validation errTaskRunIDRequired", err)
+	}
 	if _, err := app.GetTaskApproval(ctx, task, "missing"); !errors.Is(err, errTaskApprovalNotFound) {
 		t.Fatalf("GetTaskApproval(missing) error = %v, want errTaskApprovalNotFound", err)
+	}
+	if _, err := app.GetTaskApproval(ctx, task, " "); !errors.Is(err, errTaskApprovalIDRequired) || !isTaskValidationError(err) {
+		t.Fatalf("GetTaskApproval(empty) error = %v, want task validation errTaskApprovalIDRequired", err)
 	}
 }
 
@@ -519,8 +528,8 @@ func TestTaskApplication_RetryFromTurnValidatesTurnBeforeRunner(t *testing.T) {
 	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_failed", TaskID: task.ID, Status: "failed"})
 
 	_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 0})
-	if err == nil || err.Error() != "turn must be >= 1" {
-		t.Fatalf("RetryTaskRunFromTurn(turn 0) error = %v, want turn must be >= 1", err)
+	if !errors.Is(err, errTaskTurnRequired) || !isTaskValidationError(err) {
+		t.Fatalf("RetryTaskRunFromTurn(turn 0) error = %v, want task validation errTaskTurnRequired", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wrap defensive task app validation failures in `taskValidationError` for uniform HTTP mapping.
- Map task app validation errors to `400 invalid_request` across task load/lifecycle handlers.
- Add unit coverage for task/run/approval id validation wrappers and an HTTP regression for `retry-from-turn` with `turn: 0`.

## Context
Follow-up to #350 after review noted that bare app-layer validation errors could drift into default `500` handling in future call paths.

## Tests
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestTaskApplicationLayerDirectShellLifecycleE2E ./e2e`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go vet ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`