### PR TITLE
refactor(api): normalize task app commands and errors

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -99,8 +99,11 @@ Task HTTP handlers should stay thin: parse path/query/body, choose the
 HTTP status/error envelope, and render response DTOs. Task creation,
 task/run loading, active-run conflict checks, approval resolution dispatch,
 resume budget raising, and runner calls live behind `internal/api`
-`taskApplication`. Extend that seam before adding more store/runner
-orchestration directly to handlers.
+`taskApplication`. Keep that seam on internal command structs rather than
+HTTP request DTOs, and route known app sentinels / validation wrappers through
+the shared task app HTTP error mapper before adding handler-local switch
+blocks. Extend the seam before adding more store/runner orchestration directly
+to handlers.
 
 ### Change chat-session / ACP adapter behavior
 

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -51,18 +51,14 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) writeCreateTaskError(w http.ResponseWriter, r *http.Request, err error) {
 	ctx := r.Context()
-	switch {
-	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskProjectStoreNotConfigured):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	case errors.Is(err, errTaskPromptRequired), errors.Is(err, errTaskProjectNotFound), isTaskValidationError(err):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	default:
-		telemetry.Error(h.logger, ctx, "gateway.tasks.create.failed",
-			slog.String("event.name", "gateway.tasks.create.failed"),
-			slog.Any("error", err),
-		)
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	if writeTaskAppError(w, err) {
+		return
 	}
+	telemetry.Error(h.logger, ctx, "gateway.tasks.create.failed",
+		slog.String("event.name", "gateway.tasks.create.failed"),
+		slog.Any("error", err),
+	)
+	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 }
 
 const codingAgentProfileSystemPrompt = `You are running inside Hecate's coding-agent runtime.
@@ -146,8 +142,7 @@ func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.taskApplication().ListTasks(ctx, filter)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.list.failed",
@@ -179,16 +174,7 @@ func (h *Handler) HandleTask(w http.ResponseWriter, r *http.Request) {
 
 	task, err := h.taskApplication().LoadTask(ctx, id)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		}
-		if isTaskValidationError(err) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		}
-		if errors.Is(err, errTaskNotFound) {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.get.failed",
@@ -214,15 +200,7 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.taskApplication().DeleteTask(ctx, id); err != nil {
-		switch {
-		case errors.Is(err, errTaskStoreNotConfigured), isTaskValidationError(err):
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		case errors.Is(err, errTaskNotFound):
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
-			return
-		case errors.Is(err, errTaskDeleteActiveRun):
-			WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.delete.failed",
@@ -240,7 +218,7 @@ func (h *Handler) HandleDeleteTask(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if err := h.taskApplication().RequireRunner(); err != nil {
-		writeTaskRuntimePreflightError(w, err)
+		writeTaskAppError(w, err)
 		return
 	}
 
@@ -250,12 +228,7 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.taskApplication().StartTask(ctx, task)
 	if err != nil {
-		switch {
-		case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		case errors.Is(err, errTaskHasActiveRun):
-			WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.start.failed",

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,7 +37,7 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	created, err := h.taskApplication().CreateTask(ctx, req)
+	created, err := h.taskApplication().CreateTask(ctx, taskCreateCommandFromRequest(req))
 	if err != nil {
 		h.writeCreateTaskError(w, r, err)
 		return
@@ -66,49 +65,57 @@ func (h *Handler) writeCreateTaskError(w http.ResponseWriter, r *http.Request, e
 	}
 }
 
-func applyExecutionProfileDefaults(req *CreateTaskRequest) {
-	if req == nil {
-		return
-	}
-	profile := strings.TrimSpace(req.ExecutionProfile)
-	if profile != "repo_local" && profile != "coding_agent" {
-		return
-	}
-	if strings.TrimSpace(req.ExecutionKind) == "" {
-		req.ExecutionKind = "agent_loop"
-	}
-	if strings.TrimSpace(req.WorkspaceMode) == "" {
-		req.WorkspaceMode = "persistent"
-	}
-	if strings.TrimSpace(req.WorkingDirectory) == "" {
-		req.WorkingDirectory = "."
-	}
-	if strings.TrimSpace(req.SandboxAllowedRoot) == "" {
-		workingDir := strings.TrimSpace(req.WorkingDirectory)
-		repo := strings.TrimSpace(req.Repo)
-		switch {
-		case filepath.IsAbs(workingDir):
-			req.SandboxAllowedRoot = workingDir
-		case filepath.IsAbs(repo):
-			req.SandboxAllowedRoot = repo
-		}
-	}
-	if req.TimeoutMS <= 0 {
-		req.TimeoutMS = 120000
-	}
-	if profile == "coding_agent" {
-		if req.TimeoutMS <= 120000 {
-			req.TimeoutMS = 300000
-		}
-		if strings.TrimSpace(req.SystemPrompt) == "" {
-			req.SystemPrompt = codingAgentProfileSystemPrompt
-		}
-	}
-}
-
 const codingAgentProfileSystemPrompt = `You are running inside Hecate's coding-agent runtime.
 
 Use read_file and list_dir before editing. Prefer file_edit for targeted changes and file_write only for new files or full rewrites. Keep changes scoped to the user's request. Explain important tradeoffs in the final answer, and mention files changed when useful.`
+
+func taskCreateCommandFromRequest(req CreateTaskRequest) taskCreateCommand {
+	return taskCreateCommand{
+		Title:              req.Title,
+		Prompt:             req.Prompt,
+		ProjectID:          req.ProjectID,
+		SystemPrompt:       req.SystemPrompt,
+		ExecutionProfile:   req.ExecutionProfile,
+		Repo:               req.Repo,
+		BaseBranch:         req.BaseBranch,
+		WorkspaceMode:      req.WorkspaceMode,
+		ExecutionKind:      req.ExecutionKind,
+		ShellCommand:       req.ShellCommand,
+		GitCommand:         req.GitCommand,
+		WorkingDirectory:   req.WorkingDirectory,
+		FileOperation:      req.FileOperation,
+		FilePath:           req.FilePath,
+		FileContent:        req.FileContent,
+		SandboxAllowedRoot: req.SandboxAllowedRoot,
+		SandboxReadOnly:    req.SandboxReadOnly,
+		SandboxNetwork:     req.SandboxNetwork,
+		TimeoutMS:          req.TimeoutMS,
+		Priority:           req.Priority,
+		RequestedModel:     req.RequestedModel,
+		RequestedProvider:  req.RequestedProvider,
+		BudgetMicrosUSD:    req.BudgetMicrosUSD,
+		MCPServers:         taskMCPServerCommandsFromRequest(req.MCPServers),
+	}
+}
+
+func taskMCPServerCommandsFromRequest(items []MCPServerConfigItem) []taskMCPServerCommand {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]taskMCPServerCommand, 0, len(items))
+	for _, item := range items {
+		out = append(out, taskMCPServerCommand{
+			Name:           item.Name,
+			Command:        item.Command,
+			Args:           append([]string(nil), item.Args...),
+			Env:            cloneStringMap(item.Env),
+			URL:            item.URL,
+			Headers:        cloneStringMap(item.Headers),
+			ApprovalPolicy: item.ApprovalPolicy,
+		})
+	}
+	return out
+}
 
 func (h *Handler) HandleTasks(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -690,7 +697,7 @@ func renderTaskItem(task types.Task) TaskItem {
 //
 // Returns nil for an empty input (the agent loop skips MCP-host
 // startup when MCPServers is nil/empty).
-func normalizeMCPServerConfigs(items []MCPServerConfigItem, cipher secrets.Cipher, maxEntries int) ([]types.MCPServerConfig, error) {
+func normalizeMCPServerConfigs(items []taskMCPServerCommand, cipher secrets.Cipher, maxEntries int) ([]types.MCPServerConfig, error) {
 	if len(items) == 0 {
 		return nil, nil
 	}

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -20,8 +20,7 @@ func (h *Handler) HandleTaskApprovals(w http.ResponseWriter, r *http.Request) {
 
 	approvals, err := h.taskApplication().ListTaskApprovals(ctx, task)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.list.failed",
@@ -56,16 +55,7 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 
 	approval, err := h.taskApplication().GetTaskApproval(ctx, task, approvalID)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		}
-		if isTaskValidationError(err) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return
-		}
-		if errors.Is(err, errTaskApprovalNotFound) {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "task approval not found")
+		if writeTaskAppError(w, err) {
 			return
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.approvals.get.failed",
@@ -85,7 +75,7 @@ func (h *Handler) HandleTaskApproval(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if err := h.taskApplication().RequireRunner(); err != nil {
-		writeTaskRuntimePreflightError(w, err)
+		writeTaskAppError(w, err)
 		return
 	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
@@ -130,8 +120,7 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.Request, err error) {
 	ctx := r.Context()
 	switch {
-	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case writeTaskAppError(w, err):
 	case errors.Is(err, orchestrator.ErrInvalidApprovalDecision):
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "decision must be approve or reject")
 	case errors.Is(err, orchestrator.ErrApprovalNotFound):
@@ -152,7 +141,7 @@ func (h *Handler) writeResolveTaskApprovalError(w http.ResponseWriter, r *http.R
 func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if err := h.taskApplication().RequireRunner(); err != nil {
-		writeTaskRuntimePreflightError(w, err)
+		writeTaskAppError(w, err)
 		return
 	}
 	task, ok := h.loadAuthorizedTask(ctx, w, r)
@@ -173,8 +162,7 @@ func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 
 	run, err := h.taskApplication().CancelTaskRun(ctx, task, run, body.Reason)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) || errors.Is(err, errTaskRunnerNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		if writeTaskAppError(w, err) {
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -198,7 +186,7 @@ func (h *Handler) HandleRetryTaskRun(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.taskApplication().RetryTaskRun(ctx, task, run)
 	if err != nil {
-		if h.writeTaskLifecycleAppError(w, err) {
+		if writeTaskAppError(w, err) {
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -226,7 +214,7 @@ func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
 		BudgetMicrosUSD: req.BudgetMicrosUSD,
 	})
 	if err != nil {
-		if h.writeTaskLifecycleAppError(w, err) {
+		if writeTaskAppError(w, err) {
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -251,7 +239,7 @@ func (h *Handler) HandleContinueTaskRun(w http.ResponseWriter, r *http.Request) 
 	}
 	result, err := h.taskApplication().ContinueTaskRun(ctx, task, run, req.Prompt)
 	if err != nil {
-		if h.writeTaskLifecycleAppError(w, err) {
+		if writeTaskAppError(w, err) {
 			return
 		}
 		msg := err.Error()
@@ -298,7 +286,7 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 		Reason: req.Reason,
 	})
 	if err != nil {
-		if h.writeTaskLifecycleAppError(w, err) {
+		if writeTaskAppError(w, err) {
 			return
 		}
 		// Validation failures (missing conversation, turn out of
@@ -315,29 +303,4 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
-}
-
-func (h *Handler) writeTaskLifecycleAppError(w http.ResponseWriter, err error) bool {
-	switch {
-	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	case isTaskValidationError(err):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	case errors.Is(err, errTaskHasActiveRun), errors.Is(err, errTaskHasOtherActiveRun), errors.Is(err, errTaskRunNotRetryable), errors.Is(err, errTaskRunNotResumable):
-		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
-	case errors.Is(err, errTaskRunNotTurnRetryable), errors.Is(err, errTaskBudgetLower):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	default:
-		return false
-	}
-	return true
-}
-
-func writeTaskRuntimePreflightError(w http.ResponseWriter, err error) {
-	switch {
-	case errors.Is(err, errTaskStoreNotConfigured), errors.Is(err, errTaskRunnerNotConfigured):
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	default:
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-	}
 }

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -103,7 +103,7 @@ func (h *Handler) HandleResolveTaskApproval(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	result, err := h.taskApplication().ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
+	result, err := h.taskApplication().ResolveTaskApproval(ctx, taskResolveApprovalCommand{
 		Task:       task,
 		ApprovalID: approvalID,
 		Decision:   req.Decision,
@@ -221,7 +221,10 @@ func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	result, err := h.taskApplication().ResumeTaskRun(ctx, task, run, req)
+	result, err := h.taskApplication().ResumeTaskRun(ctx, task, run, taskResumeCommand{
+		Reason:          req.Reason,
+		BudgetMicrosUSD: req.BudgetMicrosUSD,
+	})
 	if err != nil {
 		if h.writeTaskLifecycleAppError(w, err) {
 			return
@@ -290,7 +293,10 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	result, err := h.taskApplication().RetryTaskRunFromTurn(ctx, task, run, req)
+	result, err := h.taskApplication().RetryTaskRunFromTurn(ctx, task, run, taskRetryFromTurnCommand{
+		Turn:   req.Turn,
+		Reason: req.Reason,
+	})
 	if err != nil {
 		if h.writeTaskLifecycleAppError(w, err) {
 			return

--- a/internal/api/handler_tasks_mcp_test.go
+++ b/internal/api/handler_tasks_mcp_test.go
@@ -44,22 +44,22 @@ func TestNormalizeMCPServerConfigs_Validation(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		desc    string
-		items   []MCPServerConfigItem
+		items   []taskMCPServerCommand
 		wantErr string
 	}{
 		{
 			desc:    "empty name",
-			items:   []MCPServerConfigItem{{Name: "", Command: "npx"}},
+			items:   []taskMCPServerCommand{{Name: "", Command: "npx"}},
 			wantErr: "name is required",
 		},
 		{
 			desc:    "empty command and url",
-			items:   []MCPServerConfigItem{{Name: "fs", Command: ""}},
+			items:   []taskMCPServerCommand{{Name: "fs", Command: ""}},
 			wantErr: "either command or url is required",
 		},
 		{
 			desc: "duplicate name",
-			items: []MCPServerConfigItem{
+			items: []taskMCPServerCommand{
 				{Name: "fs", Command: "npx"},
 				{Name: "fs", Command: "uvx"},
 			},
@@ -67,7 +67,7 @@ func TestNormalizeMCPServerConfigs_Validation(t *testing.T) {
 		},
 		{
 			desc: "invalid approval_policy value",
-			items: []MCPServerConfigItem{
+			items: []taskMCPServerCommand{
 				{Name: "gh", Command: "npx", ApprovalPolicy: "yolo"},
 			},
 			wantErr: "approval_policy",
@@ -91,7 +91,7 @@ func TestNormalizeMCPServerConfigs_Validation(t *testing.T) {
 func TestNormalizeMCPServerConfigs_RefPassesThrough(t *testing.T) {
 	t.Parallel()
 	for _, cipher := range []secrets.Cipher{nil, newTestCipherForAPI(t)} {
-		items := []MCPServerConfigItem{
+		items := []taskMCPServerCommand{
 			{Name: "gh", Command: "npx", Env: map[string]string{"TOKEN": "$GITHUB_TOKEN"}},
 		}
 		out, err := normalizeMCPServerConfigs(items, cipher, 0)
@@ -109,7 +109,7 @@ func TestNormalizeMCPServerConfigs_RefPassesThrough(t *testing.T) {
 // haven't configured a key continue to work.
 func TestNormalizeMCPServerConfigs_NoCipherLiteralStoredAsIs(t *testing.T) {
 	t.Parallel()
-	items := []MCPServerConfigItem{
+	items := []taskMCPServerCommand{
 		{Name: "gh", Command: "npx", Env: map[string]string{"TOKEN": "plaintext-secret"}},
 	}
 	out, err := normalizeMCPServerConfigs(items, nil, 0)
@@ -127,7 +127,7 @@ func TestNormalizeMCPServerConfigs_NoCipherLiteralStoredAsIs(t *testing.T) {
 func TestNormalizeMCPServerConfigs_CipherEncryptsLiteral(t *testing.T) {
 	t.Parallel()
 	cipher := newTestCipherForAPI(t)
-	items := []MCPServerConfigItem{
+	items := []taskMCPServerCommand{
 		{Name: "gh", Command: "npx", Env: map[string]string{"TOKEN": "my-plaintext-token"}},
 	}
 	out, err := normalizeMCPServerConfigs(items, cipher, 0)
@@ -156,7 +156,7 @@ func TestNormalizeMCPServerConfigs_AlreadyEncryptedPassesThrough(t *testing.T) {
 	ct, _ := cipher.Encrypt("secret")
 	already := types.MCPEnvEncPrefix + ct
 
-	items := []MCPServerConfigItem{
+	items := []taskMCPServerCommand{
 		{Name: "gh", Command: "npx", Env: map[string]string{"TOKEN": already}},
 	}
 	out, err := normalizeMCPServerConfigs(items, cipher, 0)
@@ -225,7 +225,7 @@ func TestNormalizeMCPServerConfigs_ApprovalPolicyAccepted(t *testing.T) {
 	cases := []string{"", types.MCPApprovalAuto, types.MCPApprovalRequireApproval, types.MCPApprovalBlock}
 	for _, policy := range cases {
 		t.Run("policy="+policy, func(t *testing.T) {
-			items := []MCPServerConfigItem{
+			items := []taskMCPServerCommand{
 				{Name: "gh", Command: "npx", ApprovalPolicy: policy},
 			}
 			out, err := normalizeMCPServerConfigs(items, nil, 0)
@@ -257,10 +257,10 @@ func TestRenderMCPServerConfigs_ApprovalPolicyShownVerbatim(t *testing.T) {
 // stdio server per index. Handy for the cap tests: the validation
 // only counts entries, the per-row content doesn't matter beyond
 // passing the structural checks (non-empty name, command set).
-func makeMCPItems(n int) []MCPServerConfigItem {
-	out := make([]MCPServerConfigItem, n)
+func makeMCPItems(n int) []taskMCPServerCommand {
+	out := make([]taskMCPServerCommand, n)
 	for i := range out {
-		out[i] = MCPServerConfigItem{
+		out[i] = taskMCPServerCommand{
 			Name:    fmt.Sprintf("srv-%d", i),
 			Command: "npx",
 		}

--- a/internal/api/handler_tasks_stream.go
+++ b/internal/api/handler_tasks_stream.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -251,16 +250,7 @@ func (h *Handler) loadAuthorizedTask(ctx context.Context, w http.ResponseWriter,
 
 	task, err := h.taskApplication().LoadTask(ctx, id)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return types.Task{}, false
-		}
-		if isTaskValidationError(err) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return types.Task{}, false
-		}
-		if errors.Is(err, errTaskNotFound) {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "task not found")
+		if writeTaskAppError(w, err) {
 			return types.Task{}, false
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.load.failed",
@@ -282,16 +272,7 @@ func (h *Handler) loadAuthorizedTaskRun(ctx context.Context, w http.ResponseWrit
 
 	run, err := h.taskApplication().LoadTaskRun(ctx, task, runID)
 	if err != nil {
-		if errors.Is(err, errTaskStoreNotConfigured) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return types.TaskRun{}, false
-		}
-		if isTaskValidationError(err) {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-			return types.TaskRun{}, false
-		}
-		if errors.Is(err, errTaskRunNotFound) {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "task run not found")
+		if writeTaskAppError(w, err) {
 			return types.TaskRun{}, false
 		}
 		telemetry.Error(h.logger, ctx, "gateway.tasks.runs.load.failed",

--- a/internal/api/task_application.go
+++ b/internal/api/task_application.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -88,6 +89,62 @@ type taskApplicationOptions struct {
 	Now           func() time.Time
 }
 
+type taskCreateCommand struct {
+	Title              string
+	Prompt             string
+	ProjectID          string
+	SystemPrompt       string
+	ExecutionProfile   string
+	Repo               string
+	BaseBranch         string
+	WorkspaceMode      string
+	ExecutionKind      string
+	ShellCommand       string
+	GitCommand         string
+	WorkingDirectory   string
+	FileOperation      string
+	FilePath           string
+	FileContent        string
+	SandboxAllowedRoot string
+	SandboxReadOnly    bool
+	SandboxNetwork     bool
+	TimeoutMS          int
+	Priority           string
+	RequestedModel     string
+	RequestedProvider  string
+	BudgetMicrosUSD    int64
+	MCPServers         []taskMCPServerCommand
+}
+
+type taskMCPServerCommand struct {
+	Name           string
+	Command        string
+	Args           []string
+	Env            map[string]string
+	URL            string
+	Headers        map[string]string
+	ApprovalPolicy string
+}
+
+type taskResumeCommand struct {
+	Reason          string
+	BudgetMicrosUSD int64
+}
+
+type taskRetryFromTurnCommand struct {
+	Turn   int
+	Reason string
+}
+
+type taskResolveApprovalCommand struct {
+	Task       types.Task
+	ApprovalID string
+	Decision   string
+	Note       string
+	ResolvedBy string
+	RequestID  string
+}
+
 func newTaskApplication(opts taskApplicationOptions) *taskApplication {
 	app := &taskApplication{
 		store:         opts.Store,
@@ -107,14 +164,14 @@ func newTaskApplication(opts taskApplicationOptions) *taskApplication {
 	return app
 }
 
-func (app *taskApplication) CreateTask(ctx context.Context, req CreateTaskRequest) (types.Task, error) {
+func (app *taskApplication) CreateTask(ctx context.Context, cmd taskCreateCommand) (types.Task, error) {
 	if app == nil || app.store == nil {
 		return types.Task{}, errTaskStoreNotConfigured
 	}
-	applyExecutionProfileDefaults(&req)
+	applyExecutionProfileDefaults(&cmd)
 
-	title := strings.TrimSpace(req.Title)
-	prompt := strings.TrimSpace(req.Prompt)
+	title := strings.TrimSpace(cmd.Title)
+	prompt := strings.TrimSpace(cmd.Prompt)
 	if title == "" {
 		if prompt == "" {
 			title = "New task"
@@ -125,26 +182,26 @@ func (app *taskApplication) CreateTask(ctx context.Context, req CreateTaskReques
 			}
 		}
 	}
-	effectiveKind := strings.TrimSpace(req.ExecutionKind)
+	effectiveKind := strings.TrimSpace(cmd.ExecutionKind)
 	isAgentLoop := effectiveKind == "" || effectiveKind == "agent_loop"
 	if prompt == "" && isAgentLoop {
 		return types.Task{}, errTaskPromptRequired
 	}
 
-	mcpServers, err := normalizeMCPServerConfigs(req.MCPServers, app.secretCipher, app.maxMCPServers)
+	mcpServers, err := normalizeMCPServerConfigs(cmd.MCPServers, app.secretCipher, app.maxMCPServers)
 	if err != nil {
 		return types.Task{}, taskValidation(err)
 	}
 
-	workspaceMode := strings.TrimSpace(req.WorkspaceMode)
+	workspaceMode := strings.TrimSpace(cmd.WorkspaceMode)
 	if workspaceMode == "" {
 		workspaceMode = "ephemeral"
 	}
-	priority := strings.TrimSpace(req.Priority)
+	priority := strings.TrimSpace(cmd.Priority)
 	if priority == "" {
 		priority = "normal"
 	}
-	projectID := strings.TrimSpace(req.ProjectID)
+	projectID := strings.TrimSpace(cmd.ProjectID)
 	if projectID != "" {
 		if app.projects == nil {
 			return types.Task{}, errTaskProjectStoreNotConfigured
@@ -162,32 +219,72 @@ func (app *taskApplication) CreateTask(ctx context.Context, req CreateTaskReques
 		Title:              title,
 		Prompt:             prompt,
 		ProjectID:          projectID,
-		SystemPrompt:       strings.TrimSpace(req.SystemPrompt),
-		ExecutionProfile:   strings.TrimSpace(req.ExecutionProfile),
-		Repo:               strings.TrimSpace(req.Repo),
-		BaseBranch:         strings.TrimSpace(req.BaseBranch),
+		SystemPrompt:       strings.TrimSpace(cmd.SystemPrompt),
+		ExecutionProfile:   strings.TrimSpace(cmd.ExecutionProfile),
+		Repo:               strings.TrimSpace(cmd.Repo),
+		BaseBranch:         strings.TrimSpace(cmd.BaseBranch),
 		WorkspaceMode:      workspaceMode,
-		ExecutionKind:      strings.TrimSpace(req.ExecutionKind),
-		ShellCommand:       strings.TrimSpace(req.ShellCommand),
-		GitCommand:         strings.TrimSpace(req.GitCommand),
-		WorkingDirectory:   strings.TrimSpace(req.WorkingDirectory),
-		FileOperation:      strings.TrimSpace(req.FileOperation),
-		FilePath:           strings.TrimSpace(req.FilePath),
-		FileContent:        req.FileContent,
-		SandboxAllowedRoot: strings.TrimSpace(req.SandboxAllowedRoot),
-		SandboxReadOnly:    req.SandboxReadOnly,
-		SandboxNetwork:     req.SandboxNetwork,
-		TimeoutMS:          req.TimeoutMS,
+		ExecutionKind:      strings.TrimSpace(cmd.ExecutionKind),
+		ShellCommand:       strings.TrimSpace(cmd.ShellCommand),
+		GitCommand:         strings.TrimSpace(cmd.GitCommand),
+		WorkingDirectory:   strings.TrimSpace(cmd.WorkingDirectory),
+		FileOperation:      strings.TrimSpace(cmd.FileOperation),
+		FilePath:           strings.TrimSpace(cmd.FilePath),
+		FileContent:        cmd.FileContent,
+		SandboxAllowedRoot: strings.TrimSpace(cmd.SandboxAllowedRoot),
+		SandboxReadOnly:    cmd.SandboxReadOnly,
+		SandboxNetwork:     cmd.SandboxNetwork,
+		TimeoutMS:          cmd.TimeoutMS,
 		Status:             "queued",
 		Priority:           priority,
-		RequestedModel:     strings.TrimSpace(req.RequestedModel),
-		RequestedProvider:  strings.TrimSpace(req.RequestedProvider),
-		BudgetMicrosUSD:    req.BudgetMicrosUSD,
+		RequestedModel:     strings.TrimSpace(cmd.RequestedModel),
+		RequestedProvider:  strings.TrimSpace(cmd.RequestedProvider),
+		BudgetMicrosUSD:    cmd.BudgetMicrosUSD,
 		MCPServers:         mcpServers,
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}
 	return app.store.CreateTask(ctx, task)
+}
+
+func applyExecutionProfileDefaults(cmd *taskCreateCommand) {
+	if cmd == nil {
+		return
+	}
+	profile := strings.TrimSpace(cmd.ExecutionProfile)
+	if profile != "repo_local" && profile != "coding_agent" {
+		return
+	}
+	if strings.TrimSpace(cmd.ExecutionKind) == "" {
+		cmd.ExecutionKind = "agent_loop"
+	}
+	if strings.TrimSpace(cmd.WorkspaceMode) == "" {
+		cmd.WorkspaceMode = "persistent"
+	}
+	if strings.TrimSpace(cmd.WorkingDirectory) == "" {
+		cmd.WorkingDirectory = "."
+	}
+	if strings.TrimSpace(cmd.SandboxAllowedRoot) == "" {
+		workingDir := strings.TrimSpace(cmd.WorkingDirectory)
+		repo := strings.TrimSpace(cmd.Repo)
+		switch {
+		case filepath.IsAbs(workingDir):
+			cmd.SandboxAllowedRoot = workingDir
+		case filepath.IsAbs(repo):
+			cmd.SandboxAllowedRoot = repo
+		}
+	}
+	if cmd.TimeoutMS <= 0 {
+		cmd.TimeoutMS = 120000
+	}
+	if profile == "coding_agent" {
+		if cmd.TimeoutMS <= 120000 {
+			cmd.TimeoutMS = 300000
+		}
+		if strings.TrimSpace(cmd.SystemPrompt) == "" {
+			cmd.SystemPrompt = codingAgentProfileSystemPrompt
+		}
+	}
 }
 
 func (app *taskApplication) ListTasks(ctx context.Context, filter taskstate.TaskFilter) ([]types.Task, error) {
@@ -308,7 +405,7 @@ func (app *taskApplication) RetryTaskRun(ctx context.Context, task types.Task, r
 	return app.runner.StartTask(ctx, task, app.idgen)
 }
 
-func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, run types.TaskRun, req ResumeTaskRunRequest) (*orchestrator.StartTaskResult, error) {
+func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, run types.TaskRun, cmd taskResumeCommand) (*orchestrator.StartTaskResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
 	}
@@ -322,8 +419,8 @@ func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, 
 	if active {
 		return nil, errTaskHasOtherActiveRun
 	}
-	if req.BudgetMicrosUSD > 0 {
-		if req.BudgetMicrosUSD < task.BudgetMicrosUSD {
+	if cmd.BudgetMicrosUSD > 0 {
+		if cmd.BudgetMicrosUSD < task.BudgetMicrosUSD {
 			return nil, errTaskBudgetLower
 		}
 		if app.runner == nil {
@@ -331,7 +428,7 @@ func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, 
 		}
 		// Persist the raised ceiling before queueing; the resumed
 		// agent loop reads the task ceiling on its first turn.
-		task.BudgetMicrosUSD = req.BudgetMicrosUSD
+		task.BudgetMicrosUSD = cmd.BudgetMicrosUSD
 		updated, err := app.store.UpdateTask(ctx, task)
 		if err != nil {
 			return nil, err
@@ -341,7 +438,7 @@ func (app *taskApplication) ResumeTaskRun(ctx context.Context, task types.Task, 
 	if app.runner == nil {
 		return nil, errTaskRunnerNotConfigured
 	}
-	return app.runner.ResumeTask(ctx, task, run, strings.TrimSpace(req.Reason), app.idgen)
+	return app.runner.ResumeTask(ctx, task, run, strings.TrimSpace(cmd.Reason), app.idgen)
 }
 
 func (app *taskApplication) ContinueTaskRun(ctx context.Context, task types.Task, run types.TaskRun, prompt string) (*orchestrator.StartTaskResult, error) {
@@ -361,14 +458,14 @@ func (app *taskApplication) ContinueTaskRun(ctx context.Context, task types.Task
 	return app.runner.ContinueAgentTask(ctx, task, run, prompt, app.idgen)
 }
 
-func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types.Task, run types.TaskRun, req RetryFromTurnRequest) (*orchestrator.StartTaskResult, error) {
+func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types.Task, run types.TaskRun, cmd taskRetryFromTurnCommand) (*orchestrator.StartTaskResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
 	}
 	if !types.IsTerminalTaskRunStatus(run.Status) {
 		return nil, errTaskRunNotTurnRetryable
 	}
-	if req.Turn < 1 {
+	if cmd.Turn < 1 {
 		return nil, taskValidation(errTaskTurnRequired)
 	}
 	active, err := taskHasOtherActiveRun(ctx, app.store, task, run.ID)
@@ -381,7 +478,7 @@ func (app *taskApplication) RetryTaskRunFromTurn(ctx context.Context, task types
 	if app.runner == nil {
 		return nil, errTaskRunnerNotConfigured
 	}
-	return app.runner.RetryTaskFromTurn(ctx, task, run, req.Turn, strings.TrimSpace(req.Reason), app.idgen)
+	return app.runner.RetryTaskFromTurn(ctx, task, run, cmd.Turn, strings.TrimSpace(cmd.Reason), app.idgen)
 }
 
 func (app *taskApplication) ListTaskApprovals(ctx context.Context, task types.Task) ([]types.TaskApproval, error) {
@@ -409,19 +506,25 @@ func (app *taskApplication) GetTaskApproval(ctx context.Context, task types.Task
 	return approval, nil
 }
 
-func (app *taskApplication) ResolveTaskApproval(ctx context.Context, req orchestrator.ResolveApprovalRequest) (*orchestrator.ResolveApprovalResult, error) {
+func (app *taskApplication) ResolveTaskApproval(ctx context.Context, cmd taskResolveApprovalCommand) (*orchestrator.ResolveApprovalResult, error) {
 	if app == nil || app.store == nil {
 		return nil, errTaskStoreNotConfigured
 	}
 	if app.runner == nil {
 		return nil, errTaskRunnerNotConfigured
 	}
-	if strings.TrimSpace(req.ResolvedBy) == "" {
+	req := orchestrator.ResolveApprovalRequest{
+		Task:       cmd.Task,
+		ApprovalID: strings.TrimSpace(cmd.ApprovalID),
+		Decision:   cmd.Decision,
+		Note:       cmd.Note,
+		ResolvedBy: strings.TrimSpace(cmd.ResolvedBy),
+		RequestID:  cmd.RequestID,
+	}
+	if req.ResolvedBy == "" {
 		req.ResolvedBy = "operator"
 	}
-	if req.IDGenerator == nil {
-		req.IDGenerator = app.idgen
-	}
+	req.IDGenerator = app.idgen
 	return app.runner.ResolveTaskApproval(ctx, req)
 }
 

--- a/internal/api/task_application_http.go
+++ b/internal/api/task_application_http.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+)
+
+func writeTaskAppError(w http.ResponseWriter, err error) bool {
+	switch {
+	case errors.Is(err, errTaskStoreNotConfigured),
+		errors.Is(err, errTaskRunnerNotConfigured),
+		errors.Is(err, errTaskProjectStoreNotConfigured),
+		errors.Is(err, errTaskProjectNotFound),
+		errors.Is(err, errTaskPromptRequired),
+		errors.Is(err, errTaskRunNotTurnRetryable),
+		errors.Is(err, errTaskBudgetLower),
+		isTaskValidationError(err):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, errTaskNotFound),
+		errors.Is(err, errTaskRunNotFound),
+		errors.Is(err, errTaskApprovalNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
+	case errors.Is(err, errTaskHasActiveRun),
+		errors.Is(err, errTaskHasOtherActiveRun),
+		errors.Is(err, errTaskDeleteActiveRun),
+		errors.Is(err, errTaskRunNotRetryable),
+		errors.Is(err, errTaskRunNotResumable):
+		WriteError(w, http.StatusConflict, errCodeInvalidRequest, err.Error())
+	default:
+		return false
+	}
+	return true
+}

--- a/internal/api/task_application_http_test.go
+++ b/internal/api/task_application_http_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteTaskAppError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		err     error
+		status  int
+		code    string
+		message string
+	}{
+		{
+			name:    "store_not_configured",
+			err:     errTaskStoreNotConfigured,
+			status:  http.StatusBadRequest,
+			code:    errCodeInvalidRequest,
+			message: "task store is not configured",
+		},
+		{
+			name:    "validation",
+			err:     taskValidation(errTaskIDRequired),
+			status:  http.StatusBadRequest,
+			code:    errCodeInvalidRequest,
+			message: "task id is required",
+		},
+		{
+			name:    "not_found",
+			err:     errTaskRunNotFound,
+			status:  http.StatusNotFound,
+			code:    errCodeNotFound,
+			message: "task run not found",
+		},
+		{
+			name:    "conflict",
+			err:     errTaskHasOtherActiveRun,
+			status:  http.StatusConflict,
+			code:    errCodeInvalidRequest,
+			message: "task already has another active run",
+		},
+		{
+			name:    "turn_retry_nonterminal",
+			err:     errTaskRunNotTurnRetryable,
+			status:  http.StatusBadRequest,
+			code:    errCodeInvalidRequest,
+			message: "run is not retryable from a turn (must be terminal)",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			if !writeTaskAppError(rec, tc.err) {
+				t.Fatalf("writeTaskAppError(%v) = false, want true", tc.err)
+			}
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, tc.status, rec.Body.String())
+			}
+			payload := decodeRecorder[struct {
+				Error struct {
+					Type    string `json:"type"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}](t, rec)
+			if payload.Error.Type != tc.code || payload.Error.Message != tc.message {
+				t.Fatalf("error = %#v, want type=%q message=%q", payload.Error, tc.code, tc.message)
+			}
+		})
+	}
+}
+
+func TestWriteTaskAppErrorUnknown(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	if writeTaskAppError(rec, errors.New("boom")) {
+		t.Fatal("writeTaskAppError(unknown) = true, want false")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("body = %q, want empty for unmapped error", rec.Body.String())
+	}
+}

--- a/internal/api/task_application_test.go
+++ b/internal/api/task_application_test.go
@@ -147,7 +147,7 @@ func TestTaskApplication_CreateTaskAppliesDefaults(t *testing.T) {
 	store := taskstate.NewMemoryStore()
 	app := newTestTaskApplication(store, &recordingTaskApplicationRunner{})
 
-	task, err := app.CreateTask(ctx, CreateTaskRequest{
+	task, err := app.CreateTask(ctx, taskCreateCommand{
 		Prompt:           "  Build the repo  ",
 		ExecutionProfile: "repo_local",
 		Repo:             "/tmp/hecate",
@@ -189,7 +189,7 @@ func TestTaskApplication_CreateTaskValidatesProject(t *testing.T) {
 	store := taskstate.NewMemoryStore()
 	app := newTestTaskApplication(store, nil)
 
-	_, err := app.CreateTask(ctx, CreateTaskRequest{
+	_, err := app.CreateTask(ctx, taskCreateCommand{
 		Prompt:    "Use project context",
 		ProjectID: "proj_missing_store",
 	})
@@ -199,7 +199,7 @@ func TestTaskApplication_CreateTaskValidatesProject(t *testing.T) {
 
 	projectStore := projects.NewMemoryStore()
 	app = newTestTaskApplicationWithProjects(store, nil, projectStore)
-	_, err = app.CreateTask(ctx, CreateTaskRequest{
+	_, err = app.CreateTask(ctx, taskCreateCommand{
 		Prompt:    "Use project context",
 		ProjectID: "proj_missing",
 	})
@@ -210,7 +210,7 @@ func TestTaskApplication_CreateTaskValidatesProject(t *testing.T) {
 	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Project One"}); err != nil {
 		t.Fatalf("Create project: %v", err)
 	}
-	task, err := app.CreateTask(ctx, CreateTaskRequest{
+	task, err := app.CreateTask(ctx, taskCreateCommand{
 		Prompt:    "Use project context",
 		ProjectID: " proj_1 ",
 	})
@@ -228,11 +228,11 @@ func TestTaskApplication_CreateTaskValidation(t *testing.T) {
 	ctx := context.Background()
 	app := newTestTaskApplication(taskstate.NewMemoryStore(), nil)
 
-	if _, err := app.CreateTask(ctx, CreateTaskRequest{}); !errors.Is(err, errTaskPromptRequired) {
+	if _, err := app.CreateTask(ctx, taskCreateCommand{}); !errors.Is(err, errTaskPromptRequired) {
 		t.Fatalf("CreateTask(agent_loop without prompt) error = %v, want errTaskPromptRequired", err)
 	}
 
-	task, err := app.CreateTask(ctx, CreateTaskRequest{
+	task, err := app.CreateTask(ctx, taskCreateCommand{
 		ExecutionKind: "shell",
 		ShellCommand:  "printf ok",
 	})
@@ -249,7 +249,7 @@ func TestTaskApplication_NilStoreAndRunnerErrors(t *testing.T) {
 
 	ctx := context.Background()
 	app := newTaskApplication(taskApplicationOptions{})
-	if _, err := app.CreateTask(ctx, CreateTaskRequest{Prompt: "x"}); !errors.Is(err, errTaskStoreNotConfigured) {
+	if _, err := app.CreateTask(ctx, taskCreateCommand{Prompt: "x"}); !errors.Is(err, errTaskStoreNotConfigured) {
 		t.Fatalf("CreateTask(nil store) error = %v, want errTaskStoreNotConfigured", err)
 	}
 	if _, err := app.ListTasks(ctx, taskstate.TaskFilter{}); !errors.Is(err, errTaskStoreNotConfigured) {
@@ -275,7 +275,7 @@ func TestTaskApplication_NilStoreAndRunnerErrors(t *testing.T) {
 	if _, err := app.StartTask(ctx, types.Task{ID: "task"}); !errors.Is(err, errTaskRunnerNotConfigured) {
 		t.Fatalf("StartTask(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
 	}
-	if _, err := app.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{}); !errors.Is(err, errTaskRunnerNotConfigured) {
+	if _, err := app.ResolveTaskApproval(ctx, taskResolveApprovalCommand{}); !errors.Is(err, errTaskRunnerNotConfigured) {
 		t.Fatalf("ResolveTaskApproval(nil runner) error = %v, want errTaskRunnerNotConfigured", err)
 	}
 }
@@ -374,7 +374,7 @@ func TestTaskApplication_LifecycleRejectsOtherActiveRunBeforeRunner(t *testing.T
 		{
 			name: "resume",
 			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
-				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{Reason: "try again"})
+				_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{Reason: "try again"})
 				return err
 			},
 		},
@@ -388,7 +388,7 @@ func TestTaskApplication_LifecycleRejectsOtherActiveRunBeforeRunner(t *testing.T
 		{
 			name: "retry_from_turn",
 			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
-				_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 1, Reason: "rewind"})
+				_, err := app.RetryTaskRunFromTurn(ctx, task, run, taskRetryFromTurnCommand{Turn: 1, Reason: "rewind"})
 				return err
 			},
 		},
@@ -441,7 +441,7 @@ func TestTaskApplication_LifecycleValidationPrecedesRunnerConfiguration(t *testi
 		{
 			name: "resume_nonterminal",
 			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
-				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{Reason: "try again"})
+				_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{Reason: "try again"})
 				return err
 			},
 			want: errTaskRunNotResumable,
@@ -449,7 +449,7 @@ func TestTaskApplication_LifecycleValidationPrecedesRunnerConfiguration(t *testi
 		{
 			name: "turn_retry_nonterminal",
 			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
-				_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 1})
+				_, err := app.RetryTaskRunFromTurn(ctx, task, run, taskRetryFromTurnCommand{Turn: 1})
 				return err
 			},
 			want: errTaskRunNotTurnRetryable,
@@ -459,7 +459,7 @@ func TestTaskApplication_LifecycleValidationPrecedesRunnerConfiguration(t *testi
 			call: func(ctx context.Context, app *taskApplication, task types.Task, run types.TaskRun) error {
 				run.Status = "failed"
 				task.BudgetMicrosUSD = 500
-				_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+				_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{BudgetMicrosUSD: 100})
 				return err
 			},
 			want: errTaskHasOtherActiveRun,
@@ -512,7 +512,7 @@ func TestTaskApplication_ResumeLowerBudgetPrecedesRunnerConfiguration(t *testing
 	})
 	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "failed"})
 
-	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+	_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{BudgetMicrosUSD: 100})
 	if !errors.Is(err, errTaskBudgetLower) {
 		t.Fatalf("ResumeTaskRun(lower budget, nil runner) error = %v, want errTaskBudgetLower", err)
 	}
@@ -527,7 +527,7 @@ func TestTaskApplication_RetryFromTurnValidatesTurnBeforeRunner(t *testing.T) {
 	task := createTaskForAppTest(t, ctx, store, types.Task{ID: "task_turn", Status: "failed"})
 	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: "run_failed", TaskID: task.ID, Status: "failed"})
 
-	_, err := app.RetryTaskRunFromTurn(ctx, task, run, RetryFromTurnRequest{Turn: 0})
+	_, err := app.RetryTaskRunFromTurn(ctx, task, run, taskRetryFromTurnCommand{Turn: 0})
 	if !errors.Is(err, errTaskTurnRequired) || !isTaskValidationError(err) {
 		t.Fatalf("RetryTaskRunFromTurn(turn 0) error = %v, want task validation errTaskTurnRequired", err)
 	}
@@ -553,7 +553,7 @@ func TestTaskApplication_ResumeRaisesBudgetBeforeRunner(t *testing.T) {
 	createTaskForAppTest(t, ctx, store, task)
 	createRunForAppTest(t, ctx, store, run)
 
-	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{
+	_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{
 		Reason:          "raise ceiling",
 		BudgetMicrosUSD: 250,
 	})
@@ -593,7 +593,7 @@ func TestTaskApplication_ResumeRejectsLowerBudgetBeforeRunner(t *testing.T) {
 	})
 	run := createRunForAppTest(t, ctx, store, types.TaskRun{ID: task.LatestRunID, TaskID: task.ID, Status: "failed"})
 
-	_, err := app.ResumeTaskRun(ctx, task, run, ResumeTaskRunRequest{BudgetMicrosUSD: 100})
+	_, err := app.ResumeTaskRun(ctx, task, run, taskResumeCommand{BudgetMicrosUSD: 100})
 	if !errors.Is(err, errTaskBudgetLower) {
 		t.Fatalf("ResumeTaskRun(lower budget) error = %v, want errTaskBudgetLower", err)
 	}
@@ -636,7 +636,7 @@ func TestTaskApplication_ResolveApprovalEnrichesRequest(t *testing.T) {
 	app := newTestTaskApplication(taskstate.NewMemoryStore(), runner)
 	task := types.Task{ID: "task_approval"}
 
-	_, err := app.ResolveTaskApproval(ctx, orchestrator.ResolveApprovalRequest{
+	_, err := app.ResolveTaskApproval(ctx, taskResolveApprovalCommand{
 		Task:       task,
 		ApprovalID: "approval_1",
 		Decision:   "approve",


### PR DESCRIPTION
## Summary
- Replace task app HTTP request DTO inputs with internal command structs for create, resume, retry-from-turn, and approval resolution.
- Keep HTTP request decoding in handlers and move execution-profile defaults onto the app command path.
- Centralize task app sentinel / validation HTTP error mapping with focused unit coverage.
- Update backend guidance to keep future task API work on the app seam, command structs, and shared error mapper.

## Behavior
- Intended to be behavior-preserving: public routes, response envelopes, status codes, headers, storage schemas, and exported Go APIs stay unchanged.
- Context-specific orchestrator/runner errors still stay near their handlers; only known task app sentinels and validation wrappers moved into the shared mapper.

## Tests
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go vet ./internal/api`
- `just agent-docs-check`
- `just docs-format-check`
- `just check-links`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestTaskApplicationLayerDirectShellLifecycleE2E ./e2e`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`