### PR TITLE
refactor(api): extract chat application layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ internal/
   agentadapters/        ACP/process adapters for Codex, Claude Code, Cursor
   eventprotocol/        agent-runtime event protocol v1 envelopes (API-facing shape)
   chat/                 chat transcript persistence (memory / sqlite)
+  chatapp/              chat-session application layer used by API handlers:
+                          create, external-agent prepare, native session cleanup
   projects/             durable project identity store (memory / sqlite)
   projectskills/        project-scoped SKILL.md metadata registry
                           (memory / sqlite; no body injection or execution)

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -146,12 +146,12 @@ External Agent has two live/persistence layers:
 2. `internal/agentadapters` owns the live ACP/process session manager.
 
 Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
-Session create, external-agent prepare, native session metadata persistence, and
-cleanup after prepare/update failure belong there; handlers keep HTTP parsing,
-workspace validation, model/profile resolution, and response rendering. Extend
-that app seam before adding more chat store or adapter-runner orchestration to
-`handler_chat.go`, and keep dependencies narrow to the methods the command
-needs.
+Session create, external-agent prepare, native session metadata persistence,
+native close/delete, and cleanup after prepare/update failure belong there;
+handlers keep HTTP parsing, live-run cancellation, workspace validation,
+model/profile resolution, and response rendering. Extend that app seam before
+adding more chat store or adapter-runner orchestration to `handler_chat.go`, and
+keep dependencies narrow to the methods the command needs.
 
 Task-backed Hecate Chat additionally uses `internal/orchestrator`,
 `internal/taskstate`, and `internal/modelcaps`. Do not add a second lightweight

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -145,6 +145,14 @@ External Agent has two live/persistence layers:
    in memory or sqlite.
 2. `internal/agentadapters` owns the live ACP/process session manager.
 
+Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
+Session create, external-agent prepare, native session metadata persistence, and
+cleanup after prepare/update failure belong there; handlers keep HTTP parsing,
+workspace validation, model/profile resolution, and response rendering. Extend
+that app seam before adding more chat store or adapter-runner orchestration to
+`handler_chat.go`, and keep dependencies narrow to the methods the command
+needs.
+
 Task-backed Hecate Chat additionally uses `internal/orchestrator`,
 `internal/taskstate`, and `internal/modelcaps`. Do not add a second lightweight
 tool-loop runtime; reuse task approvals, run events, artifacts, patch review,

--- a/e2e/chat_session_lifecycle_test.go
+++ b/e2e/chat_session_lifecycle_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestChatSessionApplicationLayerLifecycleE2E(t *testing.T) {
+	baseURL := gatewayServer(t, "HECATE_BACKEND=sqlite")
+
+	created := postJSONDecode[e2eChatSessionResponse](t, baseURL+"/hecate/v1/chat/sessions", `{
+		"agent_id": "hecate",
+		"title": "chat application layer e2e"
+	}`)
+	if created.Object != "chat_session" {
+		t.Fatalf("created object = %q, want chat_session", created.Object)
+	}
+	if created.Data.ID == "" {
+		t.Fatal("created session id is empty")
+	}
+	if created.Data.AgentID != "hecate" || created.Data.Title != "chat application layer e2e" || created.Data.Status != "idle" {
+		t.Fatalf("created session = %+v, want hecate idle session with title", created.Data)
+	}
+
+	got := getJSON[e2eChatSessionResponse](t, baseURL+"/hecate/v1/chat/sessions/"+created.Data.ID)
+	if got.Data.ID != created.Data.ID || got.Data.AgentID != "hecate" {
+		t.Fatalf("fetched session = %+v, want created hecate session", got.Data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, baseURL+"/hecate/v1/chat/sessions/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("NewRequest DELETE chat session: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE chat session: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE chat session status = %d, want 204; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/hecate/v1/chat/sessions/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("NewRequest GET deleted chat session: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET deleted chat session: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET deleted chat session status = %d, want 404; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+}
+
+type e2eChatSessionResponse struct {
+	Object string             `json:"object"`
+	Data   e2eChatSessionItem `json:"data"`
+}
+
+type e2eChatSessionItem struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	AgentID string `json:"agent_id"`
+	Status  string `json:"status"`
+}

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/chatapp"
 	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/requestscope"
@@ -26,6 +27,17 @@ const (
 	agentChatConfigOptionTimeout = 10 * time.Second
 	agentChatMaxOutputBytes      = 4 * 1024 * 1024
 )
+
+func (h *Handler) chatApplication() *chatapp.Application {
+	if h == nil {
+		return chatapp.New(chatapp.Options{})
+	}
+	return chatapp.New(chatapp.Options{
+		Store:          h.agentChat,
+		Runner:         h.agentChatRunner,
+		PrepareTimeout: agentChatPrepareTimeout,
+	})
+}
 
 func (h *Handler) HandleChatSessions(w http.ResponseWriter, r *http.Request) {
 	items, err := h.agentChat.List(r.Context())
@@ -130,41 +142,20 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 		session.DriverKind = agentadapters.DriverKindACP
 		session.ConfigOptions = req.ConfigOptions
 	}
-	session, err = h.agentChat.Create(r.Context(), session)
+	result, err := h.chatApplication().CreateSession(r.Context(), chatapp.CreateSessionCommand{
+		Session:         session,
+		PrepareExternal: isExternalAgent,
+	})
 	if err != nil {
+		var prepareErr chatapp.ExternalPrepareError
+		if errors.As(err, &prepareErr) {
+			writeAgentChatPrepareError(w, externalAdapter.Name, prepareErr.Unwrap())
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if isExternalAgent {
-		prepareCtx, cancel := context.WithTimeout(r.Context(), agentChatPrepareTimeout)
-		result, prepareErr := h.agentChatRunner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
-			SessionID:               session.ID,
-			AdapterID:               session.AgentID,
-			Workspace:               session.Workspace,
-			PreviousNativeSessionID: session.NativeSessionID,
-			ConfigOptions:           session.ConfigOptions,
-		})
-		cancel()
-		if prepareErr != nil {
-			_ = h.agentChat.Delete(context.Background(), session.ID)
-			writeAgentChatPrepareError(w, externalAdapter.Name, prepareErr)
-			return
-		}
-		session, err = h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
-			item.DriverKind = result.DriverKind
-			item.NativeSessionID = result.NativeSessionID
-			item.ConfigOptions = result.ConfigOptions
-		})
-		if err != nil {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), agentChatPrepareTimeout)
-			_ = h.agentChatRunner.CloseSession(cleanupCtx, session.ID)
-			cleanupCancel()
-			_ = h.agentChat.Delete(context.Background(), session.ID)
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-	}
-	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
 }
 
 func normalizeChatAgentID(agentID string) string {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -331,10 +331,10 @@ func (h *Handler) deleteExistingChatSession(ctx context.Context, session chat.Se
 	if !settled {
 		return true, nil
 	}
-	if isExternalChatSession(session) && h.agentChatRunner != nil {
-		_ = h.agentChatRunner.CloseSession(ctx, sessionID)
-	}
-	if err := h.agentChat.Delete(ctx, sessionID); err != nil {
+	if err := h.chatApplication().DeleteSession(ctx, chatapp.DeleteSessionCommand{
+		Session:     session,
+		CloseNative: isExternalChatSession(session),
+	}); err != nil {
 		return false, err
 	}
 	return false, nil
@@ -389,18 +389,14 @@ func (h *Handler) HandleCloseChatSession(w http.ResponseWriter, r *http.Request)
 		writeChatSessionStopping(w)
 		return
 	}
-	if h.agentChatRunner != nil {
-		_ = h.agentChatRunner.CloseSession(r.Context(), session.ID)
-	}
-	updated, err := h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
-		item.DriverKind = ""
-		item.NativeSessionID = ""
+	result, err := h.chatApplication().CloseNativeSession(r.Context(), chatapp.CloseNativeSessionCommand{
+		Session: session,
 	})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
 }
 
 func (h *Handler) HandleSetAgentChatConfigOption(w http.ResponseWriter, r *http.Request) {

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -46,6 +46,19 @@ type CreateSessionResult struct {
 	Session chat.Session
 }
 
+type DeleteSessionCommand struct {
+	Session     chat.Session
+	CloseNative bool
+}
+
+type CloseNativeSessionCommand struct {
+	Session chat.Session
+}
+
+type CloseNativeSessionResult struct {
+	Session chat.Session
+}
+
 type ExternalPrepareError struct {
 	Err error
 }
@@ -113,6 +126,33 @@ func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionComm
 		return &CreateSessionResult{Session: session}, err
 	}
 	return &CreateSessionResult{Session: session}, nil
+}
+
+func (app *Application) DeleteSession(ctx context.Context, cmd DeleteSessionCommand) error {
+	if app == nil || app.store == nil {
+		return ErrStoreNotConfigured
+	}
+	if cmd.CloseNative && app.runner != nil {
+		_ = app.runner.CloseSession(ctx, cmd.Session.ID)
+	}
+	return app.store.Delete(ctx, cmd.Session.ID)
+}
+
+func (app *Application) CloseNativeSession(ctx context.Context, cmd CloseNativeSessionCommand) (*CloseNativeSessionResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	if app.runner != nil {
+		_ = app.runner.CloseSession(ctx, cmd.Session.ID)
+	}
+	session, err := app.store.UpdateSession(ctx, cmd.Session.ID, func(item *chat.Session) {
+		item.DriverKind = ""
+		item.NativeSessionID = ""
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &CloseNativeSessionResult{Session: session}, nil
 }
 
 func (app *Application) cleanupExternalSession(sessionID string) {

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -1,0 +1,127 @@
+package chatapp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/chat"
+)
+
+var (
+	ErrStoreNotConfigured  = errors.New("agent chat store is not configured")
+	ErrRunnerNotConfigured = errors.New("agent chat runner is not configured")
+)
+
+type SessionStore interface {
+	Create(ctx context.Context, session chat.Session) (chat.Session, error)
+	UpdateSession(ctx context.Context, id string, update func(*chat.Session)) (chat.Session, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type AgentRunner interface {
+	PrepareSession(context.Context, agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error)
+	CloseSession(context.Context, string) error
+}
+
+type Application struct {
+	store          SessionStore
+	runner         AgentRunner
+	prepareTimeout time.Duration
+}
+
+type Options struct {
+	Store          SessionStore
+	Runner         AgentRunner
+	PrepareTimeout time.Duration
+}
+
+type CreateSessionCommand struct {
+	Session         chat.Session
+	PrepareExternal bool
+}
+
+type CreateSessionResult struct {
+	Session chat.Session
+}
+
+type ExternalPrepareError struct {
+	Err error
+}
+
+func (e ExternalPrepareError) Error() string {
+	if e.Err == nil {
+		return "external agent prepare failed"
+	}
+	return e.Err.Error()
+}
+
+func (e ExternalPrepareError) Unwrap() error {
+	return e.Err
+}
+
+func New(opts Options) *Application {
+	return &Application{
+		store:          opts.Store,
+		runner:         opts.Runner,
+		prepareTimeout: opts.PrepareTimeout,
+	}
+}
+
+func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionCommand) (*CreateSessionResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	if cmd.PrepareExternal && app.runner == nil {
+		return nil, ErrRunnerNotConfigured
+	}
+	session, err := app.store.Create(ctx, cmd.Session)
+	if err != nil {
+		return nil, err
+	}
+	if !cmd.PrepareExternal {
+		return &CreateSessionResult{Session: session}, nil
+	}
+
+	prepareCtx := ctx
+	cancel := func() {}
+	if app.prepareTimeout > 0 {
+		prepareCtx, cancel = context.WithTimeout(ctx, app.prepareTimeout)
+	}
+	prepared, prepareErr := app.runner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
+		SessionID:               session.ID,
+		AdapterID:               session.AgentID,
+		Workspace:               session.Workspace,
+		PreviousNativeSessionID: session.NativeSessionID,
+		ConfigOptions:           session.ConfigOptions,
+	})
+	cancel()
+	if prepareErr != nil {
+		_ = app.store.Delete(context.Background(), session.ID)
+		return &CreateSessionResult{Session: session}, ExternalPrepareError{Err: prepareErr}
+	}
+
+	sessionID := session.ID
+	session, err = app.store.UpdateSession(ctx, session.ID, func(item *chat.Session) {
+		item.DriverKind = prepared.DriverKind
+		item.NativeSessionID = prepared.NativeSessionID
+		item.ConfigOptions = prepared.ConfigOptions
+	})
+	if err != nil {
+		app.cleanupExternalSession(sessionID)
+		return &CreateSessionResult{Session: session}, err
+	}
+	return &CreateSessionResult{Session: session}, nil
+}
+
+func (app *Application) cleanupExternalSession(sessionID string) {
+	cleanupCtx := context.Background()
+	cancel := func() {}
+	if app.prepareTimeout > 0 {
+		cleanupCtx, cancel = context.WithTimeout(cleanupCtx, app.prepareTimeout)
+	}
+	_ = app.runner.CloseSession(cleanupCtx, sessionID)
+	cancel()
+	_ = app.store.Delete(context.Background(), sessionID)
+}

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -1,0 +1,200 @@
+package chatapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentcontrols"
+	"github.com/hecatehq/hecate/internal/chat"
+)
+
+type recordingAgentRunner struct {
+	prepareCalls   int
+	closeCalls     int
+	prepareErr     error
+	prepareReq     agentadapters.PrepareSessionRequest
+	closedSessions []string
+	configOptions  []agentcontrols.ConfigOption
+}
+
+func (r *recordingAgentRunner) PrepareSession(_ context.Context, req agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error) {
+	r.prepareCalls++
+	r.prepareReq = req
+	if r.prepareErr != nil {
+		return agentadapters.PrepareSessionResult{}, r.prepareErr
+	}
+	return agentadapters.PrepareSessionResult{
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_" + req.SessionID,
+		ConfigOptions:   r.configOptions,
+	}, nil
+}
+
+func (r *recordingAgentRunner) CloseSession(_ context.Context, sessionID string) error {
+	r.closeCalls++
+	r.closedSessions = append(r.closedSessions, sessionID)
+	return nil
+}
+
+func TestApplication_CreateSessionPersistsBuiltInSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	runner := &recordingAgentRunner{}
+	app := New(Options{Store: store, Runner: runner})
+
+	result, err := app.CreateSession(ctx, CreateSessionCommand{
+		Session: chat.Session{
+			ID:      "chat_hecate",
+			Title:   "Hecate Chat",
+			AgentID: chat.DefaultAgentID,
+			Model:   "qwen2.5-coder",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	if result.Session.ID != "chat_hecate" || result.Session.AgentID != chat.DefaultAgentID {
+		t.Fatalf("session = %+v, want persisted built-in session", result.Session)
+	}
+	if runner.prepareCalls != 0 || runner.closeCalls != 0 {
+		t.Fatalf("runner prepare/close = %d/%d, want unused", runner.prepareCalls, runner.closeCalls)
+	}
+	if _, ok, err := store.Get(ctx, "chat_hecate"); err != nil || !ok {
+		t.Fatalf("Get(chat_hecate) ok=%v err=%v, want persisted session", ok, err)
+	}
+}
+
+func TestApplication_CreateSessionPreparesExternalSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	runner := &recordingAgentRunner{
+		configOptions: []agentcontrols.ConfigOption{{
+			ID:           "model",
+			Name:         "Model",
+			CurrentValue: "sonnet",
+		}},
+	}
+	app := New(Options{Store: store, Runner: runner, PrepareTimeout: time.Second})
+
+	result, err := app.CreateSession(ctx, CreateSessionCommand{
+		PrepareExternal: true,
+		Session: chat.Session{
+			ID:              "chat_ext",
+			AgentID:         "codex",
+			Workspace:       "/tmp/hecate",
+			NativeSessionID: "native_previous",
+			ConfigOptions: []agentcontrols.ConfigOption{{
+				ID:           "model",
+				Name:         "Model",
+				CurrentValue: "opus",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(external) error = %v", err)
+	}
+	if runner.prepareCalls != 1 {
+		t.Fatalf("prepareCalls = %d, want 1", runner.prepareCalls)
+	}
+	if runner.prepareReq.SessionID != "chat_ext" || runner.prepareReq.AdapterID != "codex" || runner.prepareReq.PreviousNativeSessionID != "native_previous" {
+		t.Fatalf("prepare request = %+v, want session/adapter/previous native id", runner.prepareReq)
+	}
+	if result.Session.DriverKind != agentadapters.DriverKindACP || result.Session.NativeSessionID != "native_chat_ext" {
+		t.Fatalf("prepared session = %+v, want native metadata", result.Session)
+	}
+	if len(result.Session.ConfigOptions) != 1 || result.Session.ConfigOptions[0].CurrentValue != "sonnet" {
+		t.Fatalf("config options = %+v, want prepared options", result.Session.ConfigOptions)
+	}
+}
+
+func TestApplication_CreateSessionPrepareFailureDeletesSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	runner := &recordingAgentRunner{prepareErr: fmt.Errorf("prepare boom")}
+	app := New(Options{Store: store, Runner: runner})
+
+	_, err := app.CreateSession(ctx, CreateSessionCommand{
+		PrepareExternal: true,
+		Session:         chat.Session{ID: "chat_ext", AgentID: "codex", Workspace: "/tmp/hecate"},
+	})
+	var prepareErr ExternalPrepareError
+	if !errors.As(err, &prepareErr) || !errors.Is(prepareErr.Unwrap(), runner.prepareErr) {
+		t.Fatalf("CreateSession(prepare failure) error = %v, want ExternalPrepareError", err)
+	}
+	if runner.closeCalls != 0 {
+		t.Fatalf("closeCalls = %d, want no close after failed prepare", runner.closeCalls)
+	}
+	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {
+		t.Fatalf("Get(chat_ext) ok=%v err=%v, want deleted session", ok, err)
+	}
+}
+
+type failingUpdateStore struct {
+	SessionStore
+	err        error
+	deletedIDs []string
+}
+
+func (s *failingUpdateStore) UpdateSession(context.Context, string, func(*chat.Session)) (chat.Session, error) {
+	return chat.Session{}, s.err
+}
+
+func (s *failingUpdateStore) Delete(ctx context.Context, id string) error {
+	s.deletedIDs = append(s.deletedIDs, id)
+	return s.SessionStore.Delete(ctx, id)
+}
+
+func TestApplication_CreateSessionUpdateFailureCleansPreparedSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseStore := chat.NewMemoryStore()
+	store := &failingUpdateStore{SessionStore: baseStore, err: fmt.Errorf("update boom")}
+	runner := &recordingAgentRunner{}
+	app := New(Options{Store: store, Runner: runner, PrepareTimeout: time.Second})
+
+	_, err := app.CreateSession(ctx, CreateSessionCommand{
+		PrepareExternal: true,
+		Session:         chat.Session{ID: "chat_ext", AgentID: "codex", Workspace: "/tmp/hecate"},
+	})
+	if err == nil || !errors.Is(err, store.err) {
+		t.Fatalf("CreateSession(update failure) error = %v, want update error", err)
+	}
+	if runner.closeCalls != 1 || len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_ext" {
+		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
+	}
+	if len(store.deletedIDs) != 1 || store.deletedIDs[0] != "chat_ext" {
+		t.Fatalf("deleted ids = %+v, want chat_ext", store.deletedIDs)
+	}
+	if _, ok, err := baseStore.Get(ctx, "chat_ext"); err != nil || ok {
+		t.Fatalf("Get(chat_ext) ok=%v err=%v, want cleaned session", ok, err)
+	}
+}
+
+func TestApplication_CreateSessionNilDependencies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	if _, err := New(Options{}).CreateSession(ctx, CreateSessionCommand{}); !errors.Is(err, ErrStoreNotConfigured) {
+		t.Fatalf("CreateSession(nil store) error = %v, want ErrStoreNotConfigured", err)
+	}
+
+	store := chat.NewMemoryStore()
+	_, err := New(Options{Store: store}).CreateSession(ctx, CreateSessionCommand{
+		PrepareExternal: true,
+		Session:         chat.Session{ID: "chat_ext", AgentID: "codex", Workspace: "/tmp/hecate"},
+	})
+	if !errors.Is(err, ErrRunnerNotConfigured) {
+		t.Fatalf("CreateSession(nil runner) error = %v, want ErrRunnerNotConfigured", err)
+	}
+}

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -198,3 +198,92 @@ func TestApplication_CreateSessionNilDependencies(t *testing.T) {
 		t.Fatalf("CreateSession(nil runner) error = %v, want ErrRunnerNotConfigured", err)
 	}
 }
+
+func TestApplication_DeleteSessionClosesNativeSessionWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	runner := &recordingAgentRunner{}
+	app := New(Options{Store: store, Runner: runner})
+	session, err := store.Create(ctx, chat.Session{
+		ID:              "chat_ext",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_chat_ext",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, CloseNative: true}); err != nil {
+		t.Fatalf("DeleteSession() error = %v", err)
+	}
+	if runner.closeCalls != 1 || runner.closedSessions[0] != "chat_ext" {
+		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
+	}
+	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {
+		t.Fatalf("Get(chat_ext) ok=%v err=%v, want deleted session", ok, err)
+	}
+}
+
+func TestApplication_DeleteSessionWithoutRunnerStillDeletes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	app := New(Options{Store: store})
+	session, err := store.Create(ctx, chat.Session{ID: "chat_ext", AgentID: "codex"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, CloseNative: true}); err != nil {
+		t.Fatalf("DeleteSession(no runner) error = %v", err)
+	}
+	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {
+		t.Fatalf("Get(chat_ext) ok=%v err=%v, want deleted session", ok, err)
+	}
+}
+
+func TestApplication_CloseNativeSessionClearsRuntimeHandles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	runner := &recordingAgentRunner{}
+	app := New(Options{Store: store, Runner: runner})
+	session, err := store.Create(ctx, chat.Session{
+		ID:              "chat_ext",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_chat_ext",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := app.CloseNativeSession(ctx, CloseNativeSessionCommand{Session: session})
+	if err != nil {
+		t.Fatalf("CloseNativeSession() error = %v", err)
+	}
+	if runner.closeCalls != 1 || runner.closedSessions[0] != "chat_ext" {
+		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
+	}
+	if result.Session.DriverKind != "" || result.Session.NativeSessionID != "" {
+		t.Fatalf("session runtime handles = %q/%q, want cleared", result.Session.DriverKind, result.Session.NativeSessionID)
+	}
+}
+
+func TestApplication_DeleteAndCloseNativeSessionNilStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := New(Options{})
+	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: chat.Session{ID: "chat"}}); !errors.Is(err, ErrStoreNotConfigured) {
+		t.Fatalf("DeleteSession(nil store) error = %v, want ErrStoreNotConfigured", err)
+	}
+	if _, err := app.CloseNativeSession(ctx, CloseNativeSessionCommand{Session: chat.Session{ID: "chat"}}); !errors.Is(err, ErrStoreNotConfigured) {
+		t.Fatalf("CloseNativeSession(nil store) error = %v, want ErrStoreNotConfigured", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add internal/chatapp as the app-layer seam for chat session create/prepare/cleanup
- move native close/delete lifecycle orchestration out of HTTP handlers
- add focused chatapp unit tests and a binary e2e chat session lifecycle smoke
- update backend guidance and the codebase map for the new seam

## Tests

- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/chatapp ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestChatSessionApplicationLayerLifecycleE2E ./e2e
- just agent-docs-check
- just docs-format-check
- just check-links
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...
