### PR TITLE
refactor(api): extend app seam extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ internal/
   chat/                 chat transcript persistence (memory / sqlite)
   chatapp/              chat-session application layer used by API handlers:
                           create, external-agent prepare, native session cleanup,
-                          config option writes, Hecate Chat settings
+                          session reads/rename, config option writes, Hecate
+                          Chat settings, message admission/dispatch planning
   chatcontext/          pure context-packet lookup/decode helpers shared by API
                           context endpoints
   projects/             durable project identity store (memory / sqlite)
@@ -89,7 +90,8 @@ internal/
                           command shaping, id defaults, driver defaults,
                           store error boundaries
   providerapp/          settings provider application layer used by API handlers:
-                          provider create/update/delete, API key rotate/clear
+                          settings status, policy rules, provider
+                          create/update/delete, API key rotate/clear
   storage/              sqlite client wrappers
   retention/            retention worker (subsystems: traces, usage_events, audit, provider_history, turn_events, agent_chat_approvals)
   mcp/                  stdio MCP server (read tools + write tools)

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -109,8 +109,9 @@ Application packages should use shared app-layer wrappers from
 `internal/apperrors` for validation/conflict classes, while preserving any
 package-local helper aliases (`taskapp.Validation`, `providerapp.Conflict`,
 etc.) that keep call sites readable. HTTP status-code decisions remain in
-`internal/api` mapping helpers; do not import API response types into app
-packages.
+`internal/api` mapping helpers; use shared app-error mapping helpers for
+validation/conflict/fallback cases before adding package-specific switches. Do
+not import API response types into app packages.
 
 ### Change project work APIs
 
@@ -155,11 +156,14 @@ External Agent has two live/persistence layers:
 Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
 Session create, external-agent prepare, native session metadata persistence,
 native close/delete, adapter config option writes, Hecate Chat settings, and
-cleanup after prepare/update failure belong there; handlers keep HTTP parsing,
-live-run cancellation, workspace validation, model/profile resolution, live
-publish, and response rendering. Extend that app seam before adding more chat
-store, task-store, or adapter-runner orchestration to `handler_chat.go`, and
-keep dependencies narrow to the methods the command needs.
+cleanup after prepare/update failure belong there. Session reads/rename and
+message admission / dispatch planning also belong in `chatapp` so handlers do
+not re-own transcript validation or execution-mode branching. Handlers keep
+HTTP parsing, live-run cancellation, workspace validation, model/profile
+resolution, live publish, and response rendering. Extend that app seam before
+adding more chat store, task-store, or adapter-runner orchestration to
+`handler_chat.go`, and keep dependencies narrow to the methods the command
+needs.
 
 Chat context endpoints use `internal/chatcontext` for pure context-packet
 lookup/decode helpers. Keep larger project/context assembly close to the API
@@ -169,11 +173,12 @@ until it has a narrow dependency shape; move pure packet operations into
 ### Change provider settings APIs
 
 Provider settings HTTP handlers follow the app-layer rule too. Provider
-create/update/delete, duplicate/base-URL guards, provider id derivation, API key
-rotate/clear, and dynamic provider-runtime dispatch live behind
-`internal/providerapp.Application`. Handlers parse request DTOs, attach the
-settings actor to context, render `SettingsProviderRecord`, and map known
-provider-app validation/conflict errors through `writeAppError`.
+settings status aggregation, policy-rule commands, provider create/update/delete,
+duplicate/base-URL guards, provider id derivation, API key rotate/clear, and
+dynamic provider-runtime dispatch live behind `internal/providerapp.Application`.
+Handlers parse request DTOs, attach the settings actor to context, render
+`SettingsProviderRecord`, and map known provider-app validation/conflict errors
+through `writeAppError`.
 
 Keep providerapp dependencies narrow: it needs a control-plane snapshot reader
 and the small provider runtime interface for `Upsert`, `RotateSecret`,

--- a/internal/api/app_error.go
+++ b/internal/api/app_error.go
@@ -1,6 +1,10 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/hecatehq/hecate/internal/apperrors"
+)
 
 type appErrorMapping struct {
 	Match  func(error) bool
@@ -17,4 +21,27 @@ func writeAppError(w http.ResponseWriter, err error, mappings []appErrorMapping)
 		return true
 	}
 	return false
+}
+
+func writeAppErrorWithFallback(w http.ResponseWriter, err error, mappings []appErrorMapping, status int, code string) {
+	if writeAppError(w, err, mappings) {
+		return
+	}
+	WriteError(w, status, code, err.Error())
+}
+
+func validationAppErrorMapping(status int, code string) appErrorMapping {
+	return appErrorMapping{
+		Match:  apperrors.IsValidationError,
+		Status: status,
+		Code:   code,
+	}
+}
+
+func conflictAppErrorMapping(status int, code string) appErrorMapping {
+	return appErrorMapping{
+		Match:  apperrors.IsConflictError,
+		Status: status,
+		Code:   code,
+	}
 }

--- a/internal/api/app_error_test.go
+++ b/internal/api/app_error_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/apperrors"
+)
+
+func TestValidationAppErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	ok := writeAppError(rec, apperrors.Validation(errors.New("bad input")), []appErrorMapping{
+		validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
+	})
+
+	if !ok {
+		t.Fatal("writeAppError(validation) = false, want true")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := decodeAppErrorType(t, rec.Body.Bytes()); got != errCodeInvalidRequest {
+		t.Fatalf("error type = %q, want %q", got, errCodeInvalidRequest)
+	}
+}
+
+func TestConflictAppErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	ok := writeAppError(rec, apperrors.Conflict(errors.New("already exists")), []appErrorMapping{
+		conflictAppErrorMapping(http.StatusConflict, errCodeConflict),
+	})
+
+	if !ok {
+		t.Fatal("writeAppError(conflict) = false, want true")
+	}
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if got := decodeAppErrorType(t, rec.Body.Bytes()); got != errCodeConflict {
+		t.Fatalf("error type = %q, want %q", got, errCodeConflict)
+	}
+}
+
+func TestWriteAppErrorWithFallback(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	writeAppErrorWithFallback(rec, errors.New("boom"), nil, http.StatusInternalServerError, errCodeGatewayError)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got := decodeAppErrorType(t, rec.Body.Bytes()); got != errCodeGatewayError {
+		t.Fatalf("error type = %q, want %q", got, errCodeGatewayError)
+	}
+}
+
+func decodeAppErrorType(t *testing.T, body []byte) string {
+	t.Helper()
+	var payload struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	return payload.Error.Type
+}

--- a/internal/api/chat_application_http.go
+++ b/internal/api/chat_application_http.go
@@ -8,10 +8,10 @@ import (
 )
 
 var chatAppErrorMappings = []appErrorMapping{
+	validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
 	{
 		Match: func(err error) bool {
-			return errors.Is(err, chatapp.ErrNoSettingsProvided) ||
-				chatapp.IsValidationError(err)
+			return errors.Is(err, chatapp.ErrNoSettingsProvided)
 		},
 		Status: http.StatusBadRequest,
 		Code:   errCodeInvalidRequest,

--- a/internal/api/chat_application_http.go
+++ b/internal/api/chat_application_http.go
@@ -11,6 +11,13 @@ var chatAppErrorMappings = []appErrorMapping{
 	validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
 	{
 		Match: func(err error) bool {
+			return errors.Is(err, chatapp.ErrSessionNotFound)
+		},
+		Status: http.StatusNotFound,
+		Code:   errCodeNotFound,
+	},
+	{
+		Match: func(err error) bool {
 			return errors.Is(err, chatapp.ErrNoSettingsProvided)
 		},
 		Status: http.StatusBadRequest,

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -41,13 +41,13 @@ func (h *Handler) chatApplication() *chatapp.Application {
 }
 
 func (h *Handler) HandleChatSessions(w http.ResponseWriter, r *http.Request) {
-	items, err := h.agentChat.List(r.Context())
+	result, err := h.chatApplication().ListSessions(r.Context())
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	data := make([]ChatSessionSummaryItem, 0, len(items))
-	for _, item := range items {
+	data := make([]ChatSessionSummaryItem, 0, len(result.Sessions))
+	for _, item := range result.Sessions {
 		data = append(data, renderChatSessionSummary(item))
 	}
 	WriteJSON(w, http.StatusOK, ChatSessionsResponse{Object: "chat_sessions", Data: data})
@@ -175,53 +175,35 @@ func (h *Handler) isValidChatAgentID(agentID string) bool {
 }
 
 func (h *Handler) HandleChatSession(w http.ResponseWriter, r *http.Request) {
-	session, ok, err := h.agentChat.Get(r.Context(), r.PathValue("id"))
+	result, err := h.chatApplication().GetSession(r.Context(), r.PathValue("id"))
 	if err != nil {
+		if writeChatAppError(w, err) {
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
-		return
-	}
-	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
 }
 
 func (h *Handler) HandleUpdateChatSession(w http.ResponseWriter, r *http.Request) {
-	sessionID := strings.TrimSpace(r.PathValue("id"))
-	if sessionID == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "session id is required")
-		return
-	}
 	var req UpdateChatSessionRequest
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if req.Title == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request must include title")
-		return
-	}
-	title := strings.TrimSpace(*req.Title)
-	if title == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "title cannot be set to an empty string")
-		return
-	}
-	if _, ok, err := h.agentChat.Get(r.Context(), sessionID); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat session not found")
-		return
-	}
-	updated, err := h.agentChat.UpdateSession(r.Context(), sessionID, func(item *chat.Session) {
-		item.Title = title
+	result, err := h.chatApplication().RenameSession(r.Context(), chatapp.RenameSessionCommand{
+		ID:    r.PathValue("id"),
+		Title: req.Title,
 	})
 	if err != nil {
+		if writeChatAppError(w, err) {
+			return
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	h.agentChatLive.publishSession(updated)
-	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
+	h.agentChatLive.publishSession(result.Session)
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
 }
 
 func (h *Handler) HandleChatSessionStream(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -567,29 +567,30 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	content := admission.Content
-	executionMode := admission.ExecutionMode
-	toolsEnabled := admission.ToolsEnabled
-	// Capability-driven downgrade lets a Hecate turn with tools on fall
-	// back to the direct model path without changing its runtime owner.
-	if toolsEnabled && !isExternalChatSession(session) && h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req) {
-		toolsEnabled = false
+	hecateToolsUnavailable := false
+	if admission.ToolsEnabled && admission.ExecutionMode == chat.ExecutionModeHecateTask && !isExternalChatSession(session) {
+		// Capability-driven downgrade lets a Hecate turn with tools on fall
+		// back to the direct model path without changing its runtime owner.
+		hecateToolsUnavailable = h.hecateTaskShouldFallbackToDirectModel(r.Context(), session, req)
 	}
-	switch executionMode {
-	case chat.ExecutionModeHecateTask:
+	plan := chatapp.ResolveMessageDispatch(session, *admission, hecateToolsUnavailable)
+	switch plan.Route {
+	case chatapp.MessageDispatchHecateTask, chatapp.MessageDispatchDirectModel:
 		// One unified entry point for every Hecate-side turn,
 		// regardless of tools_enabled. handleCreateHecateChatMessage
 		// branches at the top: tools-off delegates to
 		// `handleDirectModelTurn`; tools-on runs the existing
 		// agent_loop task-creation path.
-		h.handleCreateHecateChatMessage(w, r, session, req, toolsEnabled)
+		h.handleCreateHecateChatMessage(w, r, session, req, plan.ToolsEnabled)
 		return
-	case chat.ExecutionModeExternalAgent:
-	default:
-		writeChatExecutionModeInvalid(w)
+	case chatapp.MessageDispatchExternalAgent:
+		h.handleCreateExternalAgentChatMessage(w, r, session, req, plan)
 		return
 	}
+	writeChatExecutionModeInvalid(w)
+}
 
+func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r *http.Request, session chat.Session, req CreateChatMessageRequest, plan chatapp.MessageDispatchPlan) {
 	adapter, ok := agentadapters.BuiltInByID(session.AgentID)
 	if !ok {
 		writeAgentChatAdapterNotFound(w, session.AgentID)
@@ -616,7 +617,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		ID:            newChatID("msg"),
 		ExecutionMode: chat.ExecutionModeExternalAgent,
 		Role:          "user",
-		Content:       content,
+		Content:       plan.Content,
 		CreatedAt:     time.Now().UTC(),
 	})
 	if err != nil {
@@ -720,7 +721,7 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		Workspace:               session.Workspace,
 		PreviousNativeSessionID: session.NativeSessionID,
 		ConfigOptions:           session.ConfigOptions,
-		Prompt:                  content,
+		Prompt:                  plan.Content,
 		Timeout:                 agentChatTimeout,
 		MaxOutputBytes:          agentChatMaxOutputBytes,
 		OnOutput: func(display string) {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1929,10 +1929,7 @@ func writeProjectWorkError(w http.ResponseWriter, err error) bool {
 	if err == nil {
 		return true
 	}
-	if writeAppError(w, err, projectWorkErrorMappings) {
-		return false
-	}
-	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	writeAppErrorWithFallback(w, err, projectWorkErrorMappings, http.StatusInternalServerError, errCodeGatewayError)
 	return false
 }
 

--- a/internal/api/handler_settings.go
+++ b/internal/api/handler_settings.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -17,39 +16,32 @@ func (h *Handler) providerApplication() *providerapp.Application {
 	return providerapp.New(providerapp.Options{
 		ControlPlane: h.controlPlane,
 		Runtime:      h.providerRuntime,
+		Config:       h.config,
 	})
 }
 
 func (h *Handler) HandleSettingsStatus(w http.ResponseWriter, r *http.Request) {
+	result, err := h.providerApplication().Status(r.Context())
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	payload := SettingsResponse{
 		Object: "settings",
 		Data: SettingsResponseItem{
-			Backend:     "env",
+			Backend:     result.Backend,
 			Providers:   []SettingsProviderRecord{},
 			PolicyRules: []SettingsPolicyRuleRecord{},
 			Events:      []SettingsAuditEventRecord{},
 		},
 	}
-
-	if h.controlPlane == nil {
-		WriteJSON(w, http.StatusOK, payload)
-		return
+	for _, record := range result.Providers {
+		payload.Data.Providers = append(payload.Data.Providers, renderProviderAppRecord(record))
 	}
-
-	state, err := h.controlPlane.Snapshot(r.Context())
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-
-	payload.Data.Backend = h.controlPlane.Backend()
-	for _, record := range buildSettingsProviderList(h.config, state) {
-		payload.Data.Providers = append(payload.Data.Providers, record)
-	}
-	for _, rule := range state.PolicyRules {
+	for _, rule := range result.PolicyRules {
 		payload.Data.PolicyRules = append(payload.Data.PolicyRules, renderSettingsPolicyRule(rule))
 	}
-	for _, event := range state.Events {
+	for _, event := range result.Events {
 		payload.Data.Events = append(payload.Data.Events, renderSettingsAuditEvent(event))
 	}
 
@@ -203,7 +195,7 @@ func (h *Handler) HandleSettingsUpsertPolicyRule(w http.ResponseWriter, r *http.
 		return
 	}
 
-	rule, err := h.controlPlane.UpsertPolicyRule(controlplane.WithActor(r.Context(), settingsActor(r)), config.PolicyRuleConfig{
+	rule, err := h.providerApplication().UpsertPolicyRule(controlplane.WithActor(r.Context(), settingsActor(r)), providerapp.PolicyRuleCommand{
 		ID:                     req.ID,
 		Action:                 req.Action,
 		Reason:                 req.Reason,
@@ -216,7 +208,7 @@ func (h *Handler) HandleSettingsUpsertPolicyRule(w http.ResponseWriter, r *http.
 		RewriteModelTo:         req.RewriteModelTo,
 	})
 	if err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		writeProviderAppError(w, err)
 		return
 	}
 
@@ -231,13 +223,9 @@ func (h *Handler) HandleSettingsDeletePolicyRule(w http.ResponseWriter, r *http.
 		return
 	}
 
-	id := strings.TrimSpace(r.PathValue("id"))
-	if id == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "policy rule id is required")
-		return
-	}
-	if err := h.controlPlane.DeletePolicyRule(controlplane.WithActor(r.Context(), settingsActor(r)), id); err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	id, err := h.providerApplication().DeletePolicyRule(controlplane.WithActor(r.Context(), settingsActor(r)), r.PathValue("id"))
+	if err != nil {
+		writeProviderAppError(w, err)
 		return
 	}
 
@@ -278,73 +266,22 @@ func renderSettingsAuditEvent(event controlplane.AuditEvent) SettingsAuditEventR
 	return record
 }
 
-// buildSettingsProviderList returns one record per provider in the
-// settings store. Providers are explicit: the operator adds them via
-// POST /hecate/v1/settings/providers, picking from the preset catalog or
-// supplying a custom OpenAI-compatible endpoint. The list starts empty and
-// stays empty until the operator adds at least one. The preset catalog is
-// served separately at GET /hecate/v1/providers/presets.
-func buildSettingsProviderList(cfg config.Config, state controlplane.State) []SettingsProviderRecord {
-	envKeyByID := make(map[string]bool)
-	for _, pc := range cfg.Providers.OpenAICompatible {
-		if pc.APIKey != "" {
-			envKeyByID[pc.Name] = true
-		}
+func renderProviderAppRecord(record providerapp.ProviderRecord) SettingsProviderRecord {
+	return SettingsProviderRecord{
+		ID:                   record.ID,
+		Name:                 record.Name,
+		PresetID:             record.PresetID,
+		CustomName:           record.CustomName,
+		Kind:                 record.Kind,
+		Protocol:             record.Protocol,
+		BaseURL:              record.BaseURL,
+		APIVersion:           record.APIVersion,
+		DefaultModel:         record.DefaultModel,
+		ExplicitFields:       append([]string(nil), record.ExplicitFields...),
+		InheritedFields:      append([]string(nil), record.InheritedFields...),
+		CredentialConfigured: record.CredentialConfigured,
+		CredentialSource:     record.CredentialSource,
 	}
-
-	presetByID := make(map[string]config.BuiltInProvider)
-	for _, b := range config.BuiltInProviders() {
-		presetByID[b.ID] = b
-	}
-
-	records := make([]SettingsProviderRecord, 0, len(state.Providers))
-	for _, cp := range state.Providers {
-		preset, hasPreset := presetByID[cp.ID]
-		record := SettingsProviderRecord{
-			ID:           cp.ID,
-			Name:         cp.Name,
-			CustomName:   cp.CustomName,
-			Kind:         cp.Kind,
-			Protocol:     cp.Protocol,
-			BaseURL:      cp.BaseURL,
-			DefaultModel: cp.DefaultModel,
-		}
-		if record.Name == "" {
-			record.Name = cp.ID
-		}
-		if hasPreset {
-			record.PresetID = preset.ID
-			if record.Kind == "" {
-				record.Kind = preset.Kind
-			}
-			if record.Protocol == "" {
-				record.Protocol = preset.Protocol
-			}
-			if record.BaseURL == "" {
-				record.BaseURL = preset.BaseURL
-			}
-			if record.APIVersion == "" {
-				record.APIVersion = preset.APIVersion
-			}
-			if record.DefaultModel == "" {
-				record.DefaultModel = preset.DefaultModel
-			}
-		}
-		for _, secret := range state.ProviderSecrets {
-			if secret.ProviderID == cp.ID {
-				record.CredentialConfigured = secret.APIKeyEncrypted != ""
-				record.CredentialSource = "vault"
-				break
-			}
-		}
-		if !record.CredentialConfigured && envKeyByID[cp.ID] {
-			record.CredentialConfigured = true
-			record.CredentialSource = "env"
-		}
-		records = append(records, record)
-	}
-
-	return records
 }
 
 func renderSettingsProvider(provider controlplane.Provider, secrets []controlplane.ProviderSecret) SettingsProviderRecord {

--- a/internal/api/provider_application_http.go
+++ b/internal/api/provider_application_http.go
@@ -8,19 +8,13 @@ import (
 )
 
 var providerAppErrorMappings = []appErrorMapping{
+	validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
+	conflictAppErrorMapping(http.StatusConflict, errCodeInvalidRequest),
 	{
 		Match: func(err error) bool {
-			return errors.Is(err, providerapp.ErrRuntimeNotConfigured) ||
-				providerapp.IsValidationError(err)
+			return errors.Is(err, providerapp.ErrRuntimeNotConfigured)
 		},
 		Status: http.StatusBadRequest,
-		Code:   errCodeInvalidRequest,
-	},
-	{
-		Match: func(err error) bool {
-			return providerapp.IsConflictError(err)
-		},
-		Status: http.StatusConflict,
 		Code:   errCodeInvalidRequest,
 	},
 }
@@ -30,8 +24,5 @@ func writeProviderAppError(w http.ResponseWriter, err error) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if writeAppError(w, err, providerAppErrorMappings) {
-		return
-	}
-	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	writeAppErrorWithFallback(w, err, providerAppErrorMappings, http.StatusInternalServerError, errCodeGatewayError)
 }

--- a/internal/api/task_application_http.go
+++ b/internal/api/task_application_http.go
@@ -8,6 +8,7 @@ import (
 )
 
 var taskAppErrorMappings = []appErrorMapping{
+	validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
 	{
 		Match: func(err error) bool {
 			return errors.Is(err, taskapp.ErrStoreNotConfigured) ||
@@ -16,8 +17,7 @@ var taskAppErrorMappings = []appErrorMapping{
 				errors.Is(err, taskapp.ErrProjectNotFound) ||
 				errors.Is(err, taskapp.ErrPromptRequired) ||
 				errors.Is(err, taskapp.ErrRunNotTurnRetryable) ||
-				errors.Is(err, taskapp.ErrBudgetLower) ||
-				taskapp.IsValidationError(err)
+				errors.Is(err, taskapp.ErrBudgetLower)
 		},
 		Status: http.StatusBadRequest,
 		Code:   errCodeInvalidRequest,

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -131,6 +131,21 @@ type AdmitMessageResult struct {
 	ToolsEnabled  bool
 }
 
+type MessageDispatchRoute string
+
+const (
+	MessageDispatchHecateTask    MessageDispatchRoute = "hecate_task"
+	MessageDispatchDirectModel   MessageDispatchRoute = "direct_model"
+	MessageDispatchExternalAgent MessageDispatchRoute = "external_agent"
+)
+
+type MessageDispatchPlan struct {
+	Content       string
+	ExecutionMode string
+	ToolsEnabled  bool
+	Route         MessageDispatchRoute
+}
+
 type MessageLimitError struct {
 	Code      string
 	Message   string
@@ -391,6 +406,28 @@ func (app *Application) AdmitMessage(cmd AdmitMessageCommand) (*AdmitMessageResu
 		ExecutionMode: executionMode,
 		ToolsEnabled:  toolsEnabled,
 	}, nil
+}
+
+func ResolveMessageDispatch(session chat.Session, admission AdmitMessageResult, hecateToolsUnavailable bool) MessageDispatchPlan {
+	toolsEnabled := admission.ToolsEnabled
+	route := MessageDispatchHecateTask
+	switch admission.ExecutionMode {
+	case chat.ExecutionModeExternalAgent:
+		route = MessageDispatchExternalAgent
+	case chat.ExecutionModeHecateTask:
+		if toolsEnabled && !isExternalSession(session) && hecateToolsUnavailable {
+			toolsEnabled = false
+		}
+		if !toolsEnabled {
+			route = MessageDispatchDirectModel
+		}
+	}
+	return MessageDispatchPlan{
+		Content:       admission.Content,
+		ExecutionMode: admission.ExecutionMode,
+		ToolsEnabled:  toolsEnabled,
+		Route:         route,
+	}
 }
 
 func (app *Application) cleanupExternalSession(sessionID string) {

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -24,6 +24,10 @@ var (
 	ErrExecutionModeInvalid    = errors.New("execution_mode must be hecate_task or external_agent")
 	ErrExternalCannotRunHecate = errors.New("external agent sessions cannot run Hecate Chat turns")
 	ErrHecateCannotRunExternal = errors.New("Hecate Chat sessions cannot run external-agent turns")
+	ErrSessionNotFound         = errors.New("agent chat session not found")
+	ErrSessionIDRequired       = errors.New("session id is required")
+	ErrTitleRequired           = errors.New("request must include title")
+	ErrTitleEmpty              = errors.New("title cannot be set to an empty string")
 )
 
 type ValidationError = apperrors.ValidationError
@@ -38,6 +42,8 @@ func IsValidationError(err error) bool {
 
 type SessionStore interface {
 	Create(ctx context.Context, session chat.Session) (chat.Session, error)
+	Get(ctx context.Context, id string) (chat.Session, bool, error)
+	List(ctx context.Context) ([]chat.Session, error)
 	UpdateSession(ctx context.Context, id string, update func(*chat.Session)) (chat.Session, error)
 	Delete(ctx context.Context, id string) error
 }
@@ -108,6 +114,19 @@ type SetHecateSettingsCommand struct {
 
 type SetHecateSettingsResult struct {
 	Session chat.Session
+}
+
+type RenameSessionCommand struct {
+	ID    string
+	Title *string
+}
+
+type SessionResult struct {
+	Session chat.Session
+}
+
+type ListSessionsResult struct {
+	Sessions []chat.Session
 }
 
 type MessageLimits struct {
@@ -183,6 +202,64 @@ func New(opts Options) *Application {
 		prepareTimeout:      opts.PrepareTimeout,
 		configOptionTimeout: opts.ConfigOptionTimeout,
 	}
+}
+
+func (app *Application) ListSessions(ctx context.Context) (*ListSessionsResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	sessions, err := app.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &ListSessionsResult{Sessions: sessions}, nil
+}
+
+func (app *Application) GetSession(ctx context.Context, id string) (*SessionResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, Validation(ErrSessionIDRequired)
+	}
+	session, ok, err := app.store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return &SessionResult{Session: session}, nil
+}
+
+func (app *Application) RenameSession(ctx context.Context, cmd RenameSessionCommand) (*SessionResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	id := strings.TrimSpace(cmd.ID)
+	if id == "" {
+		return nil, Validation(ErrSessionIDRequired)
+	}
+	if cmd.Title == nil {
+		return nil, Validation(ErrTitleRequired)
+	}
+	title := strings.TrimSpace(*cmd.Title)
+	if title == "" {
+		return nil, Validation(ErrTitleEmpty)
+	}
+	if _, ok, err := app.store.Get(ctx, id); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrSessionNotFound
+	}
+	updated, err := app.store.UpdateSession(ctx, id, func(item *chat.Session) {
+		item.Title = title
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &SessionResult{Session: updated}, nil
 }
 
 func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionCommand) (*CreateSessionResult, error) {

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -83,6 +83,90 @@ func TestApplication_CreateSessionPersistsBuiltInSession(t *testing.T) {
 	}
 }
 
+func TestApplication_ListAndGetSessions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	if _, err := store.Create(ctx, chat.Session{ID: "chat_1", Title: "One"}); err != nil {
+		t.Fatalf("Create chat_1: %v", err)
+	}
+	app := New(Options{Store: store})
+
+	list, err := app.ListSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(list.Sessions) != 1 || list.Sessions[0].ID != "chat_1" {
+		t.Fatalf("sessions = %+v, want chat_1", list.Sessions)
+	}
+	got, err := app.GetSession(ctx, " chat_1 ")
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if got.Session.Title != "One" {
+		t.Fatalf("session = %+v, want title One", got.Session)
+	}
+}
+
+func TestApplication_GetSessionValidationAndNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	app := New(Options{Store: chat.NewMemoryStore()})
+	if _, err := app.GetSession(ctx, " "); !errors.Is(err, ErrSessionIDRequired) || !IsValidationError(err) {
+		t.Fatalf("GetSession(empty) error = %v, want session id validation", err)
+	}
+	if _, err := app.GetSession(ctx, "missing"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("GetSession(missing) error = %v, want ErrSessionNotFound", err)
+	}
+	if _, err := New(Options{}).GetSession(ctx, "chat_1"); !errors.Is(err, ErrStoreNotConfigured) {
+		t.Fatalf("GetSession(no store) error = %v, want ErrStoreNotConfigured", err)
+	}
+}
+
+func TestApplication_RenameSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	if _, err := store.Create(ctx, chat.Session{ID: "chat_1", Title: "Old"}); err != nil {
+		t.Fatalf("Create chat_1: %v", err)
+	}
+	app := New(Options{Store: store})
+	title := " New title "
+
+	result, err := app.RenameSession(ctx, RenameSessionCommand{ID: " chat_1 ", Title: &title})
+	if err != nil {
+		t.Fatalf("RenameSession() error = %v", err)
+	}
+	if result.Session.Title != "New title" {
+		t.Fatalf("title = %q, want trimmed New title", result.Session.Title)
+	}
+}
+
+func TestApplication_RenameSessionValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	app := New(Options{Store: store})
+	if _, err := app.RenameSession(ctx, RenameSessionCommand{ID: " "}); !errors.Is(err, ErrSessionIDRequired) || !IsValidationError(err) {
+		t.Fatalf("RenameSession(empty id) error = %v, want id validation", err)
+	}
+	if _, err := app.RenameSession(ctx, RenameSessionCommand{ID: "chat_1"}); !errors.Is(err, ErrTitleRequired) || !IsValidationError(err) {
+		t.Fatalf("RenameSession(no title) error = %v, want title required", err)
+	}
+	blank := " "
+	if _, err := app.RenameSession(ctx, RenameSessionCommand{ID: "chat_1", Title: &blank}); !errors.Is(err, ErrTitleEmpty) || !IsValidationError(err) {
+		t.Fatalf("RenameSession(blank title) error = %v, want title empty", err)
+	}
+	title := "New"
+	if _, err := app.RenameSession(ctx, RenameSessionCommand{ID: "missing", Title: &title}); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("RenameSession(missing) error = %v, want ErrSessionNotFound", err)
+	}
+}
+
 func TestApplication_CreateSessionPreparesExternalSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -526,6 +526,71 @@ func TestApplication_AdmitMessageExternalDefault(t *testing.T) {
 	}
 }
 
+func TestResolveMessageDispatchRoutesHecateToolsToTask(t *testing.T) {
+	t.Parallel()
+
+	plan := ResolveMessageDispatch(chat.Session{AgentID: chat.DefaultAgentID}, AdmitMessageResult{
+		Content:       "run tests",
+		ExecutionMode: chat.ExecutionModeHecateTask,
+		ToolsEnabled:  true,
+	}, false)
+
+	if plan.Route != MessageDispatchHecateTask || !plan.ToolsEnabled {
+		t.Fatalf("plan = %+v, want tools-on hecate task", plan)
+	}
+}
+
+func TestResolveMessageDispatchDowngradesHecateWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name             string
+		admission        AdmitMessageResult
+		toolsUnavailable bool
+	}{
+		{
+			name: "explicit tools off",
+			admission: AdmitMessageResult{
+				Content:       "hello",
+				ExecutionMode: chat.ExecutionModeHecateTask,
+				ToolsEnabled:  false,
+			},
+		},
+		{
+			name: "capability fallback",
+			admission: AdmitMessageResult{
+				Content:       "hello",
+				ExecutionMode: chat.ExecutionModeHecateTask,
+				ToolsEnabled:  true,
+			},
+			toolsUnavailable: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := ResolveMessageDispatch(chat.Session{AgentID: chat.DefaultAgentID}, tc.admission, tc.toolsUnavailable)
+			if plan.Route != MessageDispatchDirectModel || plan.ToolsEnabled {
+				t.Fatalf("plan = %+v, want direct model with tools disabled", plan)
+			}
+		})
+	}
+}
+
+func TestResolveMessageDispatchRoutesExternalAgent(t *testing.T) {
+	t.Parallel()
+
+	plan := ResolveMessageDispatch(chat.Session{AgentID: "codex"}, AdmitMessageResult{
+		Content:       "work",
+		ExecutionMode: chat.ExecutionModeExternalAgent,
+		ToolsEnabled:  true,
+	}, true)
+
+	if plan.Route != MessageDispatchExternalAgent || !plan.ToolsEnabled {
+		t.Fatalf("plan = %+v, want external-agent route preserving tools flag", plan)
+	}
+}
+
 func TestApplication_AdmitMessageValidationAndRuntimeMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providerapp/application.go
+++ b/internal/providerapp/application.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hecatehq/hecate/internal/apperrors"
+	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
 )
 
@@ -37,7 +38,10 @@ func IsConflictError(err error) bool {
 }
 
 type ControlPlane interface {
+	Backend() string
 	Snapshot(ctx context.Context) (controlplane.State, error)
+	UpsertPolicyRule(ctx context.Context, rule config.PolicyRuleConfig) (config.PolicyRuleConfig, error)
+	DeletePolicyRule(ctx context.Context, id string) error
 }
 
 type Runtime interface {
@@ -50,11 +54,13 @@ type Runtime interface {
 type Application struct {
 	controlPlane ControlPlane
 	runtime      Runtime
+	config       config.Config
 }
 
 type Options struct {
 	ControlPlane ControlPlane
 	Runtime      Runtime
+	Config       config.Config
 }
 
 type UpdateProviderCommand struct {
@@ -79,9 +85,45 @@ type SetAPIKeyCommand struct {
 	Key string
 }
 
+type PolicyRuleCommand struct {
+	ID                     string
+	Action                 string
+	Reason                 string
+	Providers              []string
+	ProviderKinds          []string
+	Models                 []string
+	RouteReasons           []string
+	MinPromptTokens        int
+	MinEstimatedCostMicros int64
+	RewriteModelTo         string
+}
+
 type ProviderResult struct {
 	Provider controlplane.Provider
 	State    controlplane.State
+}
+
+type StatusResult struct {
+	Backend     string
+	Providers   []ProviderRecord
+	PolicyRules []config.PolicyRuleConfig
+	Events      []controlplane.AuditEvent
+}
+
+type ProviderRecord struct {
+	ID                   string
+	Name                 string
+	PresetID             string
+	CustomName           string
+	Kind                 string
+	Protocol             string
+	BaseURL              string
+	APIVersion           string
+	DefaultModel         string
+	ExplicitFields       []string
+	InheritedFields      []string
+	CredentialConfigured bool
+	CredentialSource     string
 }
 
 type ClearAPIKeyResult struct {
@@ -90,7 +132,23 @@ type ClearAPIKeyResult struct {
 }
 
 func New(opts Options) *Application {
-	return &Application{controlPlane: opts.ControlPlane, runtime: opts.Runtime}
+	return &Application{controlPlane: opts.ControlPlane, runtime: opts.Runtime, config: opts.Config}
+}
+
+func (app *Application) Status(ctx context.Context) (*StatusResult, error) {
+	if app == nil || app.controlPlane == nil {
+		return &StatusResult{Backend: "env"}, nil
+	}
+	state, err := app.controlPlane.Snapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &StatusResult{
+		Backend:     app.controlPlane.Backend(),
+		Providers:   buildProviderRecords(app.config, state),
+		PolicyRules: append([]config.PolicyRuleConfig(nil), state.PolicyRules...),
+		Events:      append([]controlplane.AuditEvent(nil), state.Events...),
+	}, nil
 }
 
 func (app *Application) UpdateProvider(ctx context.Context, cmd UpdateProviderCommand) (*ProviderResult, error) {
@@ -237,6 +295,42 @@ func (app *Application) DeleteProvider(ctx context.Context, id string) error {
 	return nil
 }
 
+func (app *Application) UpsertPolicyRule(ctx context.Context, cmd PolicyRuleCommand) (config.PolicyRuleConfig, error) {
+	if app == nil || app.controlPlane == nil {
+		return config.PolicyRuleConfig{}, ErrControlPlaneNotConfigured
+	}
+	rule, err := app.controlPlane.UpsertPolicyRule(ctx, config.PolicyRuleConfig{
+		ID:                     cmd.ID,
+		Action:                 cmd.Action,
+		Reason:                 cmd.Reason,
+		Providers:              append([]string(nil), cmd.Providers...),
+		ProviderKinds:          append([]string(nil), cmd.ProviderKinds...),
+		Models:                 append([]string(nil), cmd.Models...),
+		RouteReasons:           append([]string(nil), cmd.RouteReasons...),
+		MinPromptTokens:        cmd.MinPromptTokens,
+		MinEstimatedCostMicros: cmd.MinEstimatedCostMicros,
+		RewriteModelTo:         cmd.RewriteModelTo,
+	})
+	if err != nil {
+		return config.PolicyRuleConfig{}, Validation(err)
+	}
+	return rule, nil
+}
+
+func (app *Application) DeletePolicyRule(ctx context.Context, id string) (string, error) {
+	if app == nil || app.controlPlane == nil {
+		return "", ErrControlPlaneNotConfigured
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", Validation(errors.New("policy rule id is required"))
+	}
+	if err := app.controlPlane.DeletePolicyRule(ctx, id); err != nil {
+		return "", Validation(err)
+	}
+	return id, nil
+}
+
 func findProvider(state controlplane.State, id string) *controlplane.Provider {
 	id = strings.TrimSpace(id)
 	for i := range state.Providers {
@@ -245,6 +339,70 @@ func findProvider(state controlplane.State, id string) *controlplane.Provider {
 		}
 	}
 	return nil
+}
+
+func buildProviderRecords(cfg config.Config, state controlplane.State) []ProviderRecord {
+	envKeyByID := make(map[string]bool)
+	for _, pc := range cfg.Providers.OpenAICompatible {
+		if pc.APIKey != "" {
+			envKeyByID[pc.Name] = true
+		}
+	}
+
+	presetByID := make(map[string]config.BuiltInProvider)
+	for _, b := range config.BuiltInProviders() {
+		presetByID[b.ID] = b
+	}
+
+	records := make([]ProviderRecord, 0, len(state.Providers))
+	for _, cp := range state.Providers {
+		preset, hasPreset := presetByID[cp.ID]
+		record := ProviderRecord{
+			ID:             cp.ID,
+			Name:           cp.Name,
+			CustomName:     cp.CustomName,
+			Kind:           cp.Kind,
+			Protocol:       cp.Protocol,
+			BaseURL:        cp.BaseURL,
+			DefaultModel:   cp.DefaultModel,
+			ExplicitFields: append([]string(nil), cp.ExplicitFields...),
+		}
+		if record.Name == "" {
+			record.Name = cp.ID
+		}
+		if hasPreset {
+			record.PresetID = preset.ID
+			if record.Kind == "" {
+				record.Kind = preset.Kind
+			}
+			if record.Protocol == "" {
+				record.Protocol = preset.Protocol
+			}
+			if record.BaseURL == "" {
+				record.BaseURL = preset.BaseURL
+			}
+			if record.APIVersion == "" {
+				record.APIVersion = preset.APIVersion
+			}
+			if record.DefaultModel == "" {
+				record.DefaultModel = preset.DefaultModel
+			}
+		}
+		for _, secret := range state.ProviderSecrets {
+			if secret.ProviderID == cp.ID {
+				record.CredentialConfigured = secret.APIKeyEncrypted != ""
+				record.CredentialSource = "vault"
+				break
+			}
+		}
+		if !record.CredentialConfigured && envKeyByID[cp.ID] {
+			record.CredentialConfigured = true
+			record.CredentialSource = "env"
+		}
+		records = append(records, record)
+	}
+
+	return records
 }
 
 func slugify(name string) string {

--- a/internal/providerapp/application_test.go
+++ b/internal/providerapp/application_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
 )
 
@@ -86,6 +87,65 @@ func TestApplication_CreateProviderBuildsRuntimeProvider(t *testing.T) {
 	}
 }
 
+func TestApplication_StatusBuildsProviderRecordsAndPolicyRules(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := controlplane.NewMemoryStore()
+	if _, err := store.UpsertProvider(ctx, controlplane.Provider{
+		ID:       "anthropic",
+		Name:     "Anthropic",
+		PresetID: "anthropic",
+		Kind:     "cloud",
+		Protocol: "openai",
+		BaseURL:  "https://api.anthropic.com",
+		Enabled:  true,
+	}, &controlplane.ProviderSecret{ProviderID: "anthropic", APIKeyEncrypted: "cipher"}); err != nil {
+		t.Fatalf("UpsertProvider: %v", err)
+	}
+	if _, err := store.UpsertPolicyRule(ctx, config.PolicyRuleConfig{
+		ID:     "deny-cloud",
+		Action: "deny",
+		Reason: "local only",
+	}); err != nil {
+		t.Fatalf("UpsertPolicyRule: %v", err)
+	}
+	app := New(Options{ControlPlane: store})
+
+	result, err := app.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if result.Backend == "" {
+		t.Fatal("backend is empty, want control-plane backend")
+	}
+	if len(result.Providers) != 1 {
+		t.Fatalf("providers = %+v, want one provider", result.Providers)
+	}
+	provider := result.Providers[0]
+	if provider.ID != "anthropic" || provider.PresetID != "anthropic" || provider.BaseURL == "" {
+		t.Fatalf("provider record = %+v, want preset metadata joined", provider)
+	}
+	if !provider.CredentialConfigured || provider.CredentialSource != "vault" {
+		t.Fatalf("credential fields = %v/%q, want vault credential", provider.CredentialConfigured, provider.CredentialSource)
+	}
+	if len(result.PolicyRules) != 1 || result.PolicyRules[0].ID != "deny-cloud" {
+		t.Fatalf("policy rules = %+v, want deny-cloud", result.PolicyRules)
+	}
+}
+
+func TestApplication_StatusWithoutControlPlaneReturnsEnvDefaults(t *testing.T) {
+	t.Parallel()
+
+	result, err := New(Options{}).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status(no control plane) error = %v", err)
+	}
+	if result.Backend != "env" || len(result.Providers) != 0 || len(result.PolicyRules) != 0 || len(result.Events) != 0 {
+		t.Fatalf("result = %+v, want env empty status", result)
+	}
+}
+
 func TestApplication_CreateProviderRejectsDuplicates(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +166,56 @@ func TestApplication_CreateProviderRejectsDuplicates(t *testing.T) {
 	}
 	if _, err := app.CreateProvider(ctx, CreateProviderCommand{Name: "Other", BaseURL: "https://api.anthropic.com"}); !IsConflictError(err) {
 		t.Fatalf("CreateProvider(duplicate base url) error = %v, want conflict", err)
+	}
+}
+
+func TestApplication_UpsertAndDeletePolicyRule(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := controlplane.NewMemoryStore()
+	app := New(Options{ControlPlane: store})
+
+	rule, err := app.UpsertPolicyRule(ctx, PolicyRuleCommand{
+		ID:        "deny-cloud",
+		Action:    "deny",
+		Providers: []string{"anthropic"},
+	})
+	if err != nil {
+		t.Fatalf("UpsertPolicyRule() error = %v", err)
+	}
+	if rule.ID != "deny-cloud" || rule.Action != "deny" {
+		t.Fatalf("rule = %+v, want deny-cloud deny", rule)
+	}
+	deleted, err := app.DeletePolicyRule(ctx, " deny-cloud ")
+	if err != nil {
+		t.Fatalf("DeletePolicyRule() error = %v", err)
+	}
+	if deleted != "deny-cloud" {
+		t.Fatalf("deleted id = %q, want deny-cloud", deleted)
+	}
+	result, err := app.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(result.PolicyRules) != 0 {
+		t.Fatalf("policy rules = %+v, want deleted", result.PolicyRules)
+	}
+}
+
+func TestApplication_PolicyRuleValidationAndDependencies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	if _, err := New(Options{}).UpsertPolicyRule(ctx, PolicyRuleCommand{ID: "x", Action: "deny"}); !errors.Is(err, ErrControlPlaneNotConfigured) {
+		t.Fatalf("UpsertPolicyRule(no control plane) error = %v, want ErrControlPlaneNotConfigured", err)
+	}
+	app := New(Options{ControlPlane: controlplane.NewMemoryStore()})
+	if _, err := app.UpsertPolicyRule(ctx, PolicyRuleCommand{ID: "x", Action: ""}); !IsValidationError(err) {
+		t.Fatalf("UpsertPolicyRule(invalid) error = %v, want validation", err)
+	}
+	if _, err := app.DeletePolicyRule(ctx, " "); !IsValidationError(err) {
+		t.Fatalf("DeletePolicyRule(empty) error = %v, want validation", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- move settings status and policy-rule commands into providerapp
- add chatapp message dispatch planning and keep external-agent dispatch behind a helper
- share app-error HTTP mapping helpers across task/chat/provider/project-work handlers
- move chat session list/get/rename read paths into chatapp
- update backend agent guidance for the expanded app seams

## Commit structure

1. refactor(api): move settings commands into provider app
2. refactor(api): extract chat message dispatch plan
3. refactor(api): share app error mapping helpers
4. refactor(api): move chat session reads into chat app
5. docs(agent): update app seam guidance

## Verification

- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/apperrors ./internal/chatapp ./internal/chatcontext ./internal/providerapp ./internal/taskapp ./internal/projectworkapp ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestChatSessionApplicationLayerLifecycleE2E ./e2e
- go vet ./internal/apperrors ./internal/chatapp ./internal/chatcontext ./internal/providerapp ./internal/taskapp ./internal/projectworkapp ./internal/api
- just agent-docs-check
- just docs-format-check
- just check-links
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...