### PR TITLE
refactor(api): extract chat turn outcomes

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -165,6 +165,11 @@ adding more chat store, task-store, or adapter-runner orchestration to
 `handler_chat.go`, and keep dependencies narrow to the methods the command
 needs.
 
+Chat turn terminal status/output classification lives in
+`internal/api/handler_chat_turn_execution.go`. Extend that helper and its
+focused tests before reintroducing inline direct-model or External Agent
+success/failure/cancel classification in the handlers.
+
 Chat context endpoints use `internal/chatcontext` for pure context-packet
 lookup/decode helpers. Keep larger project/context assembly close to the API
 until it has a narrow dependency shape; move pure packet operations into

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -714,53 +714,21 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		},
 	})
 	streamCoalescer.close()
-	status := "completed"
-	if runErr != nil {
-		status = "failed"
-	}
-	if errors.Is(runCtx.Err(), context.Canceled) {
-		status = "cancelled"
-	}
-	output := strings.TrimSpace(result.Output)
-	displayErr := ""
-	if runErr != nil {
-		displayErr = agentadapters.NormalizeError(adapter.Name, runErr)
-	}
-	if status != "cancelled" && runErr != nil {
-		if output == "" {
-			output = displayErr
-		} else {
-			output = output + "\n\n" + displayErr
-		}
-	}
-	if status != "cancelled" && output == "" {
-		output = "(agent completed without output)"
-	}
-	completedAt := time.Now().UTC()
-	if !result.StartedAt.IsZero() {
-		startedAt = result.StartedAt
-	}
-	if !result.CompletedAt.IsZero() {
-		completedAt = result.CompletedAt
-	}
-	errorText := ""
-	if runErr != nil && status != "cancelled" {
-		errorText = displayErr
-	}
+	outcome := newExternalAgentTurnOutcome(adapter.Name, result, runErr, runCtx.Err(), startedAt, time.Now().UTC())
+	status := outcome.Status
+	output := outcome.Output
+	errorText := outcome.ErrorText
+	startedAt = outcome.StartedAt
+	completedAt := outcome.CompletedAt
 	if result.DiffStat != "" {
 		trace.Record(telemetry.EventAgentChatFilesChanged, agentChatTraceAttrs(session, adapter, runID, assistantID, map[string]any{
 			telemetry.AttrHecateRunStatus:         status,
 			telemetry.AttrHecateAgentDiffCaptured: true,
 		}))
 	}
-	durationMS := completedAt.Sub(startedAt).Milliseconds()
-	resultLabel := telemetry.ResultSuccess
-	if runErr != nil || status == "cancelled" {
-		resultLabel = telemetry.ResultError
-	}
 	terminalAttrs := agentChatTraceAttrs(session, adapter, runID, assistantID, map[string]any{
 		telemetry.AttrHecateRunStatus:            status,
-		telemetry.AttrHecateRunDurationMS:        durationMS,
+		telemetry.AttrHecateRunDurationMS:        outcome.DurationMS,
 		telemetry.AttrHecateAgentOutputBytes:     int64(len(output)),
 		telemetry.AttrHecateAgentRawOutputBytes:  int64(len(result.RawOutput)),
 		telemetry.AttrHecateAgentDiffCaptured:    result.Diff != "",
@@ -772,7 +740,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		terminalAttrs[telemetry.AttrHecateResult] = telemetry.ResultError
 		terminalAttrs[telemetry.AttrHecateErrorKind] = telemetry.ErrorKindOther
 		terminalAttrs[telemetry.AttrErrorType] = "agent_adapter_failed"
-		terminalAttrs[telemetry.AttrErrorMessage] = displayErr
+		terminalAttrs[telemetry.AttrErrorMessage] = outcome.DisplayErr
 	}
 	trace.Record(agentChatTerminalEvent(status), terminalAttrs)
 	driverKind := result.DriverKind
@@ -783,8 +751,8 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		AdapterID:  adapter.ID,
 		DriverKind: driverKind,
 		Status:     status,
-		Result:     resultLabel,
-		DurationMS: durationMS,
+		Result:     outcome.ResultLabel,
+		DurationMS: outcome.DurationMS,
 	})
 	if status == "cancelled" {
 		// Reason classification: cancelRun / cancelRunAndWait stamp
@@ -1007,27 +975,10 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 	}
 	result, runErr := h.service.HandleChat(runCtx, chatReq)
 	completedAt := time.Now().UTC()
-	status := "completed"
-	output := ""
-	errorText := ""
-	if runErr != nil {
-		status = "failed"
-		errorText = runErr.Error()
-		output = errorText
-	}
-	if errors.Is(runCtx.Err(), context.Canceled) {
-		status = "cancelled"
-		errorText = "cancelled"
-		output = "model request cancelled"
-	}
-	if result != nil && result.Response != nil {
-		if len(result.Response.Choices) > 0 {
-			output = strings.TrimSpace(result.Response.Choices[0].Message.Content)
-		}
-		if output == "" {
-			output = "(model completed without output)"
-		}
-	}
+	outcome := newDirectModelTurnOutcome(result, runErr, runCtx.Err())
+	status := outcome.Status
+	output := outcome.Output
+	errorText := outcome.ErrorText
 	updated, err = h.agentChat.UpdateMessage(r.Context(), session.ID, assistantID, func(message *chat.Message) {
 		message.Status = status
 		message.Content = output

--- a/internal/api/handler_chat_turn_execution.go
+++ b/internal/api/handler_chat_turn_execution.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/telemetry"
+)
+
+type externalAgentTurnOutcome struct {
+	Status      string
+	Output      string
+	DisplayErr  string
+	ErrorText   string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	DurationMS  int64
+	ResultLabel string
+}
+
+func newExternalAgentTurnOutcome(adapterName string, result agentadapters.RunResult, runErr, ctxErr error, startedAt, completedAt time.Time) externalAgentTurnOutcome {
+	status := "completed"
+	if runErr != nil {
+		status = "failed"
+	}
+	if errors.Is(ctxErr, context.Canceled) {
+		status = "cancelled"
+	}
+
+	output := strings.TrimSpace(result.Output)
+	displayErr := ""
+	if runErr != nil {
+		displayErr = agentadapters.NormalizeError(adapterName, runErr)
+	}
+	if status != "cancelled" && runErr != nil {
+		if output == "" {
+			output = displayErr
+		} else {
+			output = output + "\n\n" + displayErr
+		}
+	}
+	if status != "cancelled" && output == "" {
+		output = "(agent completed without output)"
+	}
+
+	if !result.StartedAt.IsZero() {
+		startedAt = result.StartedAt
+	}
+	if !result.CompletedAt.IsZero() {
+		completedAt = result.CompletedAt
+	}
+	errorText := ""
+	if runErr != nil && status != "cancelled" {
+		errorText = displayErr
+	}
+	resultLabel := telemetry.ResultSuccess
+	if runErr != nil || status == "cancelled" {
+		resultLabel = telemetry.ResultError
+	}
+
+	return externalAgentTurnOutcome{
+		Status:      status,
+		Output:      output,
+		DisplayErr:  displayErr,
+		ErrorText:   errorText,
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+		DurationMS:  completedAt.Sub(startedAt).Milliseconds(),
+		ResultLabel: resultLabel,
+	}
+}
+
+type directModelTurnOutcome struct {
+	Status    string
+	Output    string
+	ErrorText string
+}
+
+func newDirectModelTurnOutcome(result *gateway.ChatResult, runErr, ctxErr error) directModelTurnOutcome {
+	status := "completed"
+	output := ""
+	errorText := ""
+	if runErr != nil {
+		status = "failed"
+		errorText = runErr.Error()
+		output = errorText
+	}
+	if errors.Is(ctxErr, context.Canceled) {
+		status = "cancelled"
+		errorText = "cancelled"
+		output = "model request cancelled"
+	}
+	if result != nil && result.Response != nil {
+		if len(result.Response.Choices) > 0 {
+			output = strings.TrimSpace(result.Response.Choices[0].Message.Content)
+		}
+		if output == "" {
+			output = "(model completed without output)"
+		}
+	}
+	return directModelTurnOutcome{Status: status, Output: output, ErrorText: errorText}
+}

--- a/internal/api/handler_chat_turn_execution_test.go
+++ b/internal/api/handler_chat_turn_execution_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestExternalAgentTurnOutcomeCompletedUsesAdapterTimesAndPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	completed := started.Add(2 * time.Second)
+
+	outcome := newExternalAgentTurnOutcome("Codex", agentadapters.RunResult{
+		StartedAt:   started,
+		CompletedAt: completed,
+	}, nil, nil, time.Time{}, time.Time{})
+
+	if outcome.Status != "completed" {
+		t.Fatalf("status = %q, want completed", outcome.Status)
+	}
+	if outcome.Output != "(agent completed without output)" {
+		t.Fatalf("output = %q, want empty-output placeholder", outcome.Output)
+	}
+	if outcome.ResultLabel != telemetry.ResultSuccess || outcome.DurationMS != 2000 {
+		t.Fatalf("result/duration = %q/%d, want success/2000", outcome.ResultLabel, outcome.DurationMS)
+	}
+}
+
+func TestExternalAgentTurnOutcomeFailureAppendsNormalizedError(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New(`{"message":"Internal error: tool failed","data":{"errorKind":"tool"}}`)
+	outcome := newExternalAgentTurnOutcome("Codex", agentadapters.RunResult{
+		Output: "partial output",
+	}, err, nil, time.Unix(10, 0).UTC(), time.Unix(11, 0).UTC())
+
+	wantErr := "Codex error (tool): tool failed"
+	if outcome.Status != "failed" || outcome.ErrorText != wantErr || outcome.DisplayErr != wantErr {
+		t.Fatalf("outcome = %+v, want failed with normalized error %q", outcome, wantErr)
+	}
+	if outcome.Output != "partial output\n\n"+wantErr {
+		t.Fatalf("output = %q, want partial output plus normalized error", outcome.Output)
+	}
+	if outcome.ResultLabel != telemetry.ResultError {
+		t.Fatalf("result label = %q, want error", outcome.ResultLabel)
+	}
+}
+
+func TestExternalAgentTurnOutcomeCancelledDoesNotInventOutput(t *testing.T) {
+	t.Parallel()
+
+	outcome := newExternalAgentTurnOutcome("Codex", agentadapters.RunResult{}, errors.New("boom"), context.Canceled, time.Unix(10, 0).UTC(), time.Unix(11, 0).UTC())
+
+	if outcome.Status != "cancelled" {
+		t.Fatalf("status = %q, want cancelled", outcome.Status)
+	}
+	if outcome.Output != "" || outcome.ErrorText != "" {
+		t.Fatalf("output/error = %q/%q, want empty output/error on cancellation", outcome.Output, outcome.ErrorText)
+	}
+	if outcome.ResultLabel != telemetry.ResultError {
+		t.Fatalf("result label = %q, want error", outcome.ResultLabel)
+	}
+}
+
+func TestDirectModelTurnOutcomeCompletedUsesChoiceOrPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	outcome := newDirectModelTurnOutcome(&gateway.ChatResult{
+		Response: &types.ChatResponse{Choices: []types.ChatChoice{{Message: types.Message{Content: "  hello  "}}}},
+	}, nil, nil)
+	if outcome.Status != "completed" || outcome.Output != "hello" || outcome.ErrorText != "" {
+		t.Fatalf("outcome = %+v, want completed hello", outcome)
+	}
+
+	outcome = newDirectModelTurnOutcome(&gateway.ChatResult{Response: &types.ChatResponse{}}, nil, nil)
+	if outcome.Output != "(model completed without output)" {
+		t.Fatalf("empty output = %q, want model placeholder", outcome.Output)
+	}
+}
+
+func TestDirectModelTurnOutcomeFailureAndCancellation(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("provider failed")
+	outcome := newDirectModelTurnOutcome(nil, err, nil)
+	if outcome.Status != "failed" || outcome.Output != "provider failed" || outcome.ErrorText != "provider failed" {
+		t.Fatalf("failure outcome = %+v, want failed provider error", outcome)
+	}
+
+	outcome = newDirectModelTurnOutcome(nil, err, context.Canceled)
+	if outcome.Status != "cancelled" || outcome.Output != "model request cancelled" || outcome.ErrorText != "cancelled" {
+		t.Fatalf("cancel outcome = %+v, want cancellation result", outcome)
+	}
+}


### PR DESCRIPTION
## Summary

- extract direct-model and External Agent chat turn terminal outcome classification into handler_chat_turn_execution.go
- keep HTTP/live/persistence behavior in handlers, but remove inline success/failure/cancel output branching
- add focused unit tests for completed, failed, empty-output, and cancelled outcomes
- update backend agent guidance for the new chat turn execution seam

## Verification

- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestChatSessionApplicationLayerLifecycleE2E ./e2e
- go vet ./internal/api
- just agent-docs-check
- just docs-format-check
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...