### PR TITLE
refactor(api): extract model readiness application

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ internal/
   governor/             policy + route gates + append-only usage events
   policy/               approval policy + provider/model allowlists
   catalog/, models/     provider catalog + model registry
+  modelapp/             model listing, refresh, capability resolution, readiness
+                          errors for API/chat callers
   modelcaps/            shared model capability table (streaming, tools, vision, …)
   orchestrator/         task runtime: queue, runner, agent_loop, sandbox boundary
   workspacefs/          shared workspace path resolver for Hecate-mediated

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -230,6 +230,9 @@ When changing this path:
    (`model_not_configured`) if it reaches the server, but UI clients are
    expected to preflight against `/v1/models` plus
    `/hecate/v1/providers/status` and block send with actionable diagnostics.
+   Model listing, refresh selection, capability resolution, and readiness-error
+   wrapping live in `internal/modelapp`; API handlers should render DTOs and
+   map `modelapp.ReadinessError` into the existing error envelope.
 3. Keep `docs/runtime/external-agents.md` aligned for operator-visible
    behavior such as launchers, env sanitisation, persistence, raw diagnostics,
    guardrails, auth/readiness probes, and troubleshooting.

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -364,6 +364,39 @@ func postJSONDecode[T any](t *testing.T, url, body string) T {
 	return out
 }
 
+type e2eModelsResponse struct {
+	Data []e2eModel `json:"data"`
+}
+
+type e2eModel struct {
+	ID       string `json:"id"`
+	Metadata struct {
+		Provider     string `json:"provider"`
+		ProviderKind string `json:"provider_kind"`
+		Capabilities struct {
+			ToolCalling string `json:"tool_calling"`
+			Streaming   bool   `json:"streaming"`
+			Source      string `json:"source"`
+		} `json:"capabilities"`
+		Readiness struct {
+			Ready  bool   `json:"ready"`
+			Status string `json:"status"`
+			Reason string `json:"reason"`
+		} `json:"readiness"`
+	} `json:"metadata"`
+}
+
+func findE2EModel(t *testing.T, models e2eModelsResponse, id string) e2eModel {
+	t.Helper()
+	for _, model := range models.Data {
+		if model.ID == id {
+			return model
+		}
+	}
+	t.Fatalf("model %q not found in %+v", id, models.Data)
+	return e2eModel{}
+}
+
 type e2eAgentAdapterList struct {
 	Data []e2eAgentAdapter `json:"data"`
 }
@@ -734,6 +767,29 @@ func TestGatewayFakeUpstreamKnownModelIsRoutable(t *testing.T) {
 		}
 		defer modelsResp.Body.Close()
 		t.Fatalf("expected known model to route, got %d — body: %s; models: %s", resp.StatusCode, readBody(t, resp), readBody(t, modelsResp))
+	}
+}
+
+func TestGatewayModelsEndpointIncludesReadinessMetadataE2E(t *testing.T) {
+	t.Parallel()
+
+	upstream := fakeOpenAIServer(t, "/v1/chat/completions", `{}`, false)
+	base := gatewayServer(t,
+		"PROVIDER_FAKE_API_KEY=dummy",
+		"PROVIDER_FAKE_BASE_URL="+upstream,
+		"PROVIDER_FAKE_KIND=local",
+	)
+
+	models := getJSON[e2eModelsResponse](t, base+"/v1/models")
+	model := findE2EModel(t, models, "gpt-4o-mini")
+	if model.Metadata.Provider != "fake" || model.Metadata.ProviderKind != "local" {
+		t.Fatalf("model metadata provider = %q/%q, want fake/local", model.Metadata.Provider, model.Metadata.ProviderKind)
+	}
+	if !model.Metadata.Capabilities.Streaming || model.Metadata.Capabilities.ToolCalling != "unknown" || model.Metadata.Capabilities.Source != "provider" {
+		t.Fatalf("capabilities = %+v, want provider-resolved local streaming metadata", model.Metadata.Capabilities)
+	}
+	if !model.Metadata.Readiness.Ready || model.Metadata.Readiness.Status != "ok" || model.Metadata.Readiness.Reason != "model_available" {
+		t.Fatalf("readiness = %+v, want ready model_available", model.Metadata.Readiness)
 	}
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hecatehq/hecate/internal/gateway"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/memory"
-	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projectassistant"
@@ -604,13 +604,7 @@ func (h *Handler) HandleSession(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var result *gateway.ModelsResult
-	var err error
-	if requestRefresh(r) {
-		result, err = h.service.RefreshModels(ctx)
-	} else {
-		result, err = h.service.ListModels(ctx)
-	}
+	models, err := h.modelApplication().ListModels(ctx, modelapp.ListModelsCommand{Refresh: requestRefresh(r)})
 	if err != nil {
 		telemetry.Error(h.logger, ctx, "gateway.models.list.failed",
 			slog.String("event.name", "gateway.models.list.failed"),
@@ -620,9 +614,8 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := make([]OpenAIModelData, 0, len(result.Models))
-	for _, model := range result.Models {
-		caps := modelcaps.ResolveWithProviderCapability(model.Provider, model.Kind, model.ID, model.DiscoverySource, model.Capabilities)
+	data := make([]OpenAIModelData, 0, len(models))
+	for _, model := range models {
 		data = append(data, OpenAIModelData{
 			ID:      model.ID,
 			Object:  "model",
@@ -632,7 +625,7 @@ func (h *Handler) HandleModels(w http.ResponseWriter, r *http.Request) {
 				"provider_kind":    model.Kind,
 				"default":          model.Default,
 				"discovery_source": model.DiscoverySource,
-				"capabilities":     caps,
+				"capabilities":     model.Capabilities,
 				"readiness":        renderModelReadiness(model.Readiness),
 			},
 		})

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -549,6 +549,12 @@ func (h *Handler) HandleCreateChatMessage(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	if !isExternalChatSession(session) {
+		if busy, runStatus := h.hecateAgentSessionBusy(r.Context(), session); busy {
+			writeHecateAgentBusy(w, session, runStatus)
+			return
+		}
+	}
 	hecateToolsUnavailable := false
 	if admission.ToolsEnabled && admission.ExecutionMode == chat.ExecutionModeHecateTask && !isExternalChatSession(session) {
 		// Capability-driven downgrade lets a Hecate turn with tools on fall

--- a/internal/api/handler_chat_errors.go
+++ b/internal/api/handler_chat_errors.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hecatehq/hecate/internal/chat"
-	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/modelapp"
+	"github.com/hecatehq/hecate/pkg/types"
 )
 
 func writeAgentChatWorkspaceRequired(w http.ResponseWriter, mode string) {
@@ -38,9 +39,9 @@ func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
 			UserMessage:    "The selected model is not available from the selected provider.",
 			OperatorAction: "Choose a discovered model, refresh provider status, or open Connections to fix model discovery.",
 		}
-		var readinessErr modelReadinessError
-		if asModelReadinessError(err, &readinessErr) {
-			details = modelReadinessErrorDetails(readinessErr.readiness)
+		var readinessErr modelapp.ReadinessError
+		if errors.As(err, &readinessErr) {
+			details = modelReadinessErrorDetails(readinessErr.Readiness)
 		}
 		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelNotConfigured, message, ErrorDetails{
 			UserMessage:    details.UserMessage,
@@ -52,14 +53,7 @@ func writeAgentChatModelResolutionError(w http.ResponseWriter, err error) {
 	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, message)
 }
 
-func asModelReadinessError(err error, target *modelReadinessError) bool {
-	if err == nil {
-		return false
-	}
-	return errors.As(err, target)
-}
-
-func modelReadinessErrorDetails(readiness gateway.ProviderModelReadiness) ErrorDetails {
+func modelReadinessErrorDetails(readiness types.ModelReadiness) ErrorDetails {
 	details := ErrorDetails{
 		UserMessage:    "The selected model is not ready for this chat.",
 		OperatorAction: readiness.OperatorAction,

--- a/internal/api/model_capabilities.go
+++ b/internal/api/model_capabilities.go
@@ -2,70 +2,18 @@ package api
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/hecatehq/hecate/internal/gateway"
-	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
-type modelReadinessError struct {
-	err       error
-	readiness gateway.ProviderModelReadiness
-}
-
-func (e modelReadinessError) Error() string {
-	if e.err == nil {
-		return ""
+func (h *Handler) modelApplication() *modelapp.Application {
+	if h == nil {
+		return modelapp.New(modelapp.Options{})
 	}
-	return e.err.Error()
-}
-
-func (e modelReadinessError) Unwrap() error {
-	return e.err
+	return modelapp.New(modelapp.Options{Service: h.service})
 }
 
 func (h *Handler) resolveModelCapabilities(ctx context.Context, provider, model string) (types.ModelCapabilities, error) {
-	provider = strings.TrimSpace(provider)
-	if strings.EqualFold(provider, "auto") {
-		provider = ""
-	}
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return types.ModelCapabilities{}, fmt.Errorf("model is required")
-	}
-	if h.service == nil {
-		return modelcaps.Resolve(provider, "", model, ""), nil
-	}
-	result, err := h.service.ListModels(ctx)
-	if err != nil {
-		return types.ModelCapabilities{}, err
-	}
-	for _, item := range result.Models {
-		if provider != "" && !strings.EqualFold(item.Provider, provider) {
-			continue
-		}
-		if !strings.EqualFold(item.ID, model) {
-			continue
-		}
-		return modelcaps.ResolveWithProviderCapability(item.Provider, item.Kind, item.ID, item.DiscoverySource, item.Capabilities), nil
-	}
-	if provider == "" {
-		err := fmt.Errorf("model %q is not available from any configured provider", model)
-		return types.ModelCapabilities{}, h.withModelReadiness(ctx, provider, model, err)
-	}
-	err = fmt.Errorf("model %q is not available from provider %q", model, provider)
-	return types.ModelCapabilities{}, h.withModelReadiness(ctx, provider, model, err)
-}
-
-func (h *Handler) withModelReadiness(ctx context.Context, provider, model string, err error) error {
-	if err == nil || h.service == nil {
-		return err
-	}
-	result, readinessErr := h.service.ProviderModelReadiness(ctx, provider, model)
-	if readinessErr != nil {
-		return err
-	}
-	return modelReadinessError{err: err, readiness: result.Readiness}
+	return h.modelApplication().ResolveCapabilities(ctx, provider, model)
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hecatehq/hecate/internal/governor"
 	"github.com/hecatehq/hecate/internal/mcp"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
+	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/providers"
@@ -2292,12 +2293,13 @@ func TestAgentChatModelResolutionRequiredErrorUsesValidationContract(t *testing.
 
 func TestAgentChatModelResolutionErrorIncludesReadinessFields(t *testing.T) {
 	rec := httptest.NewRecorder()
-	writeAgentChatModelResolutionError(rec, fmt.Errorf("resolve model: %w", modelReadinessError{
-		err: errors.New("model \"gpt-5.4-mini\" is not available from provider \"ollama\""),
-		readiness: gateway.ProviderModelReadiness{
+	writeAgentChatModelResolutionError(rec, fmt.Errorf("resolve model: %w", modelapp.ReadinessError{
+		Cause: errors.New("model \"gpt-5.4-mini\" is not available from provider \"ollama\""),
+		Readiness: types.ModelReadiness{
 			Provider:              "ollama",
 			MatchedProvider:       "ollama",
 			Model:                 "gpt-5.4-mini",
+			Status:                "blocked",
 			Reason:                "model_not_discovered",
 			Message:               "Provider \"ollama\" does not report model \"gpt-5.4-mini\".",
 			OperatorAction:        "Pull or load the model locally.",

--- a/internal/modelapp/application.go
+++ b/internal/modelapp/application.go
@@ -1,0 +1,130 @@
+package modelapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+var ErrServiceNotConfigured = errors.New("model service is not configured")
+
+type Service interface {
+	ListModels(ctx context.Context) (*gateway.ModelsResult, error)
+	RefreshModels(ctx context.Context) (*gateway.ModelsResult, error)
+	ProviderModelReadiness(ctx context.Context, provider, model string) (*gateway.ProviderModelReadinessResult, error)
+}
+
+type Application struct {
+	service Service
+}
+
+type Options struct {
+	Service Service
+}
+
+type ListModelsCommand struct {
+	Refresh bool
+}
+
+type ReadinessError struct {
+	Cause     error
+	Readiness types.ModelReadiness
+}
+
+func (e ReadinessError) Error() string {
+	if e.Cause == nil {
+		return ""
+	}
+	return e.Cause.Error()
+}
+
+func (e ReadinessError) Unwrap() error {
+	return e.Cause
+}
+
+func New(opts Options) *Application {
+	return &Application{service: opts.Service}
+}
+
+func (app *Application) ListModels(ctx context.Context, cmd ListModelsCommand) ([]types.ModelInfo, error) {
+	if app == nil || app.service == nil {
+		return nil, ErrServiceNotConfigured
+	}
+	var (
+		result *gateway.ModelsResult
+		err    error
+	)
+	if cmd.Refresh {
+		result, err = app.service.RefreshModels(ctx)
+	} else {
+		result, err = app.service.ListModels(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]types.ModelInfo, 0, len(result.Models))
+	for _, item := range result.Models {
+		out = append(out, modelWithResolvedCapabilities(item))
+	}
+	return out, nil
+}
+
+func (app *Application) ResolveCapabilities(ctx context.Context, provider, model string) (types.ModelCapabilities, error) {
+	provider = normalizeProvider(provider)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return types.ModelCapabilities{}, fmt.Errorf("model is required")
+	}
+	if app == nil || app.service == nil {
+		return modelcaps.Resolve(provider, "", model, ""), nil
+	}
+	models, err := app.ListModels(ctx, ListModelsCommand{})
+	if err != nil {
+		return types.ModelCapabilities{}, err
+	}
+	for _, item := range models {
+		if provider != "" && !strings.EqualFold(item.Provider, provider) {
+			continue
+		}
+		if !strings.EqualFold(item.ID, model) {
+			continue
+		}
+		return item.Capabilities, nil
+	}
+	if provider == "" {
+		err := fmt.Errorf("model %q is not available from any configured provider", model)
+		return types.ModelCapabilities{}, app.withModelReadiness(ctx, provider, model, err)
+	}
+	err = fmt.Errorf("model %q is not available from provider %q", model, provider)
+	return types.ModelCapabilities{}, app.withModelReadiness(ctx, provider, model, err)
+}
+
+func (app *Application) withModelReadiness(ctx context.Context, provider, model string, err error) error {
+	if err == nil || app == nil || app.service == nil {
+		return err
+	}
+	result, readinessErr := app.service.ProviderModelReadiness(ctx, provider, model)
+	if readinessErr != nil {
+		return err
+	}
+	return ReadinessError{Cause: err, Readiness: result.Readiness.ToModelReadiness()}
+}
+
+func modelWithResolvedCapabilities(item types.ModelInfo) types.ModelInfo {
+	item.Capabilities = modelcaps.ResolveWithProviderCapability(item.Provider, item.Kind, item.ID, item.DiscoverySource, item.Capabilities)
+	item.Readiness.SuggestedModels = append([]string(nil), item.Readiness.SuggestedModels...)
+	return item
+}
+
+func normalizeProvider(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if strings.EqualFold(provider, "auto") {
+		return ""
+	}
+	return provider
+}

--- a/internal/modelapp/application_test.go
+++ b/internal/modelapp/application_test.go
@@ -1,0 +1,181 @@
+package modelapp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestApplication_ListModelsResolvesCapabilities(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeModelService{
+		models: []types.ModelInfo{
+			{
+				ID:              "llama3.1:8b",
+				Provider:        "ollama",
+				Kind:            string(providers.KindLocal),
+				DiscoverySource: "provider",
+				Capabilities: types.ModelCapabilities{
+					ToolCalling: modelcaps.ToolCallingBasic,
+					Streaming:   true,
+				},
+				Readiness: types.ModelReadiness{
+					Ready:           true,
+					Status:          "ok",
+					Reason:          "model_available",
+					SuggestedModels: []string{"other"},
+				},
+			},
+		},
+	}
+
+	models, err := New(Options{Service: service}).ListModels(context.Background(), ListModelsCommand{})
+	if err != nil {
+		t.Fatalf("ListModels returned error: %v", err)
+	}
+	if service.listCalls != 1 || service.refreshCalls != 0 {
+		t.Fatalf("service calls list=%d refresh=%d, want list only", service.listCalls, service.refreshCalls)
+	}
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	caps := models[0].Capabilities
+	if caps.ToolCalling != modelcaps.ToolCallingBasic || !caps.Streaming || caps.Source != modelcaps.SourceProvider {
+		t.Fatalf("capabilities = %+v, want provider-resolved basic streaming", caps)
+	}
+	models[0].Readiness.SuggestedModels[0] = "mutated"
+	if service.models[0].Readiness.SuggestedModels[0] != "other" {
+		t.Fatalf("ListModels returned readiness suggestions aliased to service state")
+	}
+}
+
+func TestApplication_ListModelsRefreshesWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeModelService{}
+	if _, err := New(Options{Service: service}).ListModels(context.Background(), ListModelsCommand{Refresh: true}); err != nil {
+		t.Fatalf("ListModels(refresh) returned error: %v", err)
+	}
+	if service.refreshCalls != 1 || service.listCalls != 0 {
+		t.Fatalf("service calls list=%d refresh=%d, want refresh only", service.listCalls, service.refreshCalls)
+	}
+}
+
+func TestApplication_ResolveCapabilitiesTreatsAutoProviderAsUnpinned(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeModelService{
+		models: []types.ModelInfo{
+			{
+				ID:       "llama3.1:8b",
+				Provider: "ollama",
+				Kind:     string(providers.KindLocal),
+				Capabilities: types.ModelCapabilities{
+					ToolCalling: modelcaps.ToolCallingBasic,
+					Streaming:   true,
+				},
+			},
+		},
+	}
+
+	caps, err := New(Options{Service: service}).ResolveCapabilities(context.Background(), "auto", "llama3.1:8b")
+	if err != nil {
+		t.Fatalf("ResolveCapabilities returned error: %v", err)
+	}
+	if caps.ToolCalling != modelcaps.ToolCallingBasic {
+		t.Fatalf("tool_calling = %q, want basic", caps.ToolCalling)
+	}
+}
+
+func TestApplication_ResolveCapabilitiesWrapsReadinessForUnavailableModel(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeModelService{
+		readiness: gateway.ProviderModelReadiness{
+			Provider:              "ollama",
+			Model:                 "missing-model",
+			Reason:                "model_not_discovered",
+			Message:               "Model is not discovered.",
+			OperatorAction:        "Refresh provider status.",
+			ProviderStatus:        "healthy",
+			ProviderBlockedReason: "",
+			SuggestedModels:       []string{"llama3.1:8b"},
+		},
+	}
+
+	_, err := New(Options{Service: service}).ResolveCapabilities(context.Background(), "ollama", "missing-model")
+	if err == nil {
+		t.Fatal("ResolveCapabilities returned nil error, want readiness error")
+	}
+	var readinessErr ReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("error = %T %v, want ReadinessError", err, err)
+	}
+	if readinessErr.Readiness.Status != "blocked" || readinessErr.Readiness.Reason != "model_not_discovered" || readinessErr.Readiness.SuggestedModels[0] != "llama3.1:8b" {
+		t.Fatalf("readiness = %+v, want blocked model_not_discovered with suggestions", readinessErr.Readiness)
+	}
+	if service.readinessProvider != "ollama" || service.readinessModel != "missing-model" {
+		t.Fatalf("readiness lookup = provider %q model %q, want explicit provider/model", service.readinessProvider, service.readinessModel)
+	}
+}
+
+func TestApplication_ResolveCapabilitiesWithoutServiceFallsBackToStaticRules(t *testing.T) {
+	t.Parallel()
+
+	caps, err := New(Options{}).ResolveCapabilities(context.Background(), "openai", "gpt-4o")
+	if err != nil {
+		t.Fatalf("ResolveCapabilities(no service) returned error: %v", err)
+	}
+	if caps.ToolCalling != modelcaps.ToolCallingParallel {
+		t.Fatalf("tool_calling = %q, want parallel from static rules", caps.ToolCalling)
+	}
+
+	_, err = New(Options{}).ResolveCapabilities(context.Background(), "openai", " ")
+	if err == nil || !strings.Contains(err.Error(), "model is required") {
+		t.Fatalf("missing model error = %v, want model is required", err)
+	}
+}
+
+type fakeModelService struct {
+	models            []types.ModelInfo
+	listErr           error
+	refreshErr        error
+	readiness         gateway.ProviderModelReadiness
+	readinessErr      error
+	listCalls         int
+	refreshCalls      int
+	readinessProvider string
+	readinessModel    string
+}
+
+func (s *fakeModelService) ListModels(context.Context) (*gateway.ModelsResult, error) {
+	s.listCalls++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return &gateway.ModelsResult{Models: append([]types.ModelInfo(nil), s.models...)}, nil
+}
+
+func (s *fakeModelService) RefreshModels(context.Context) (*gateway.ModelsResult, error) {
+	s.refreshCalls++
+	if s.refreshErr != nil {
+		return nil, s.refreshErr
+	}
+	return &gateway.ModelsResult{Models: append([]types.ModelInfo(nil), s.models...)}, nil
+}
+
+func (s *fakeModelService) ProviderModelReadiness(_ context.Context, provider, model string) (*gateway.ProviderModelReadinessResult, error) {
+	s.readinessProvider = provider
+	s.readinessModel = model
+	if s.readinessErr != nil {
+		return nil, s.readinessErr
+	}
+	return &gateway.ProviderModelReadinessResult{Readiness: s.readiness}, nil
+}


### PR DESCRIPTION
Summary
- Add internal/modelapp for model listing, refresh selection, capability resolution, and readiness error wrapping.
- Route /v1/models and chat capability resolution through the new app seam while keeping API DTO/error rendering in internal/api.
- Preserve the busy Hecate Chat 409 contract with a pre-dispatch guard before model fallback/runtime setup.
- Add unit coverage for modelapp and API readiness mapping, plus binary e2e coverage for /v1/models metadata.
- Update AGENTS.md and backend guidance with the new modelapp seam.

Verification
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/modelapp
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestModelsExpose|TestResolveModelCapabilities|TestAgentChatModelResolutionErrorIncludesReadinessFields|TestHecateAgentChatRejectsBusyBackingRun'
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -tags e2e -run TestGatewayModelsEndpointIncludesReadinessMetadataE2E ./e2e
- go vet ./internal/modelapp ./internal/api
- just agent-docs-check
- just docs-format-check
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...