### PR TITLE
refactor(ui): add turn and assignment view models

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -152,6 +152,12 @@ instead of split across two execution-mode values:
   artifact history.
   When the backing provider supports streaming, the running assistant message
   updates from the task conversation artifact before the task run completes.
+
+  API responses include derived `turn_kind` on messages and transcript
+  segments. Clients should prefer `turn_kind` (`direct_model`, `hecate_task`,
+  or `external_agent`) for UI routing and keep `execution_mode` /
+  `tools_enabled` as durable compatibility fields.
+
 - **External Agent** sessions map one chat session to one supervised ACP
   session such as Codex, Claude Code, Cursor Agent, or Grok Build. Composer
   controls may be ACP-owned session options or Hecate-managed launch options;

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1562,6 +1562,13 @@ runtime state. The `execution` summary may include `task_status`, `run_status`,
 projected `status`, pending approval count, step/approval/artifact counts,
 model/provider, last error, run timestamps, and trace ID.
 
+Assignments also include `execution_ref`, a compact canonical link projection
+for UI clients. It prefers projected execution data when available and falls
+back to stored links, with `kind` set to `task_run`, `chat_session`, or
+`context_snapshot`. Legacy raw link fields (`task_id`, `run_id`,
+`chat_session_id`, `message_id`, `context_snapshot_id`) and the richer
+`execution` summary remain for compatibility and detail views.
+
 Work-item list and detail responses apply the same conservative rollup over
 projected assignment statuses: any active linked assignment (`queued`,
 `running`, or `awaiting_approval`) makes the work item `running`; all
@@ -1980,6 +1987,12 @@ Returns:
     "task_id": "task_...",
     "run_id": "run_...",
     "context_snapshot_id": "ctx_...",
+    "execution_ref": {
+      "kind": "task_run",
+      "task_id": "task_...",
+      "run_id": "run_...",
+      "status": "queued"
+    },
     "execution": {
       "task_id": "task_...",
       "run_id": "run_...",
@@ -2538,19 +2551,21 @@ messages produced by the backing runtime. Hecate-owned sessions include
 `provider`, `model`, and the current capability snapshot; once a tools-on turn
 creates a backing task, they also include `task_id` and `latest_run_id`.
 Individual chat messages carry the durable runtime snapshot:
-`execution_mode`, `segment_id`, optional `task_id`, optional `run_id`,
-provider/model, and capabilities. Frontends should prefer those message-level
-fields when rendering historical turns because the session header can change as
-the operator switches tools on/off. If tools are re-enabled after a direct
-model segment, Hecate creates a new task-backed segment in the same transcript;
-older messages keep their original runtime/model/task snapshots.
+`execution_mode`, derived `turn_kind`, `segment_id`, optional `task_id`,
+optional `run_id`, provider/model, and capabilities. Frontends should prefer
+message-level `turn_kind` (`direct_model`, `hecate_task`, or `external_agent`)
+for UI routing and keep `execution_mode` / `tools_enabled` as compatibility
+fields. If tools are re-enabled after a direct model segment, Hecate creates a
+new task-backed segment in the same transcript; older messages keep their
+original runtime/model/task snapshots.
 
 The response also includes a derived `segments` array. Messages remain the
 durable source of truth; segments are a render helper that groups contiguous
 turns with the same `segment_id` so clients can show transcript boundaries such
 as "tools off with smollm2" → "tools on with qwen2.5-coder". Each segment
-contains its `execution_mode`, provider/model snapshot, optional `task_id`,
-latest run id, status, message count, and first/last timestamps.
+contains its derived `turn_kind`, `execution_mode`, provider/model snapshot,
+optional `task_id`, latest run id, status, message count, and first/last
+timestamps.
 
 External Agent sessions may also include `config_options`, a normalized
 projection of ACP session configuration options reported by the agent during

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -395,12 +395,7 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		if strings.TrimSpace(message.Content) == "" && message.Role == "assistant" {
 			continue
 		}
-		// Post-unification: every Hecate-side message persists as
-		// `hecate_task`; the tools-on/off discriminant lives on the
-		// per-message ToolsEnabled boolean. A tools-off turn breaks
-		// the running tool-task segment, so the next tools-on turn gets
-		// its own backing task.
-		if !isHecateTaskToolsOnMessage(message) {
+		if chatMessageTurnKind(session, message) != chatTurnKindHecateTask {
 			return true
 		}
 		if provider != "" && strings.TrimSpace(message.Provider) != "" && strings.TrimSpace(message.Provider) != provider {
@@ -412,17 +407,6 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		return false
 	}
 	return false
-}
-
-// isHecateTaskToolsOnMessage reports whether the persisted message
-// is a tools-on Hecate-task turn — i.e., a turn that ran through the
-// agent_loop runtime with tools. Used by segment continuation logic
-// to detect when a turn breaks a running tool-task segment.
-func isHecateTaskToolsOnMessage(message chat.Message) bool {
-	if message.ExecutionMode != chat.ExecutionModeHecateTask {
-		return false
-	}
-	return message.ToolsEnabled
 }
 
 func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sessionID, messageID string) (types.TaskRun, error) {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -443,6 +443,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if modelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
 		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
+	if modelAssistant.TurnKind != chatTurnKindDirectModel {
+		t.Fatalf("model assistant turn_kind = %q, want %q", modelAssistant.TurnKind, chatTurnKindDirectModel)
+	}
 	if modelAssistant.ToolsEnabled {
 		t.Errorf("model assistant tools_enabled = true, want false (hecate_task dispatch records tools-off)")
 	}
@@ -460,6 +463,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if toolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || toolsAssistant.TaskID != firstTaskID || toolsAssistant.SegmentID != "task:"+firstTaskID {
 		t.Fatalf("tools assistant snapshot = execution_mode %q task %q segment %q", toolsAssistant.ExecutionMode, toolsAssistant.TaskID, toolsAssistant.SegmentID)
 	}
+	if toolsAssistant.TurnKind != chatTurnKindHecateTask {
+		t.Fatalf("tools assistant turn_kind = %q, want %q", toolsAssistant.TurnKind, chatTurnKindHecateTask)
+	}
 	if !toolsAssistant.ToolsEnabled {
 		t.Errorf("tools assistant tools_enabled = false, want true (hecate_task dispatch records tools-on)")
 	}
@@ -472,6 +478,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	secondModelAssistant := secondModel.Data.Messages[len(secondModel.Data.Messages)-1]
 	if secondModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondModelAssistant.TaskID != "" {
 		t.Fatalf("second model assistant snapshot = execution_mode %q task %q", secondModelAssistant.ExecutionMode, secondModelAssistant.TaskID)
+	}
+	if secondModelAssistant.TurnKind != chatTurnKindDirectModel {
+		t.Fatalf("second model assistant turn_kind = %q, want %q", secondModelAssistant.TurnKind, chatTurnKindDirectModel)
 	}
 	if secondModelAssistant.ToolsEnabled {
 		t.Fatalf("second model assistant tools_enabled = true, want false (direct-model turn)")
@@ -486,6 +495,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if secondToolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondToolsAssistant.TaskID != secondTools.Data.TaskID || secondToolsAssistant.SegmentID != "task:"+secondTools.Data.TaskID {
 		t.Fatalf("second tools assistant snapshot = execution_mode %q task %q segment %q", secondToolsAssistant.ExecutionMode, secondToolsAssistant.TaskID, secondToolsAssistant.SegmentID)
 	}
+	if secondToolsAssistant.TurnKind != chatTurnKindHecateTask {
+		t.Fatalf("second tools assistant turn_kind = %q, want %q", secondToolsAssistant.TurnKind, chatTurnKindHecateTask)
+	}
 
 	changedModelTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
 		fmt.Sprintf(`{"execution_mode":"hecate_task","provider":"openai","model":"gpt-4o-mini-2024-07-18","workspace":%q,"content":"use a different model with tools"}`, workspace))
@@ -495,6 +507,9 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	changedModelAssistant := changedModelTools.Data.Messages[len(changedModelTools.Data.Messages)-1]
 	if changedModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || changedModelAssistant.TaskID != changedModelTools.Data.TaskID || changedModelAssistant.Model != "gpt-4o-mini-2024-07-18" {
 		t.Fatalf("model-change assistant snapshot = execution_mode %q task %q model %q", changedModelAssistant.ExecutionMode, changedModelAssistant.TaskID, changedModelAssistant.Model)
+	}
+	if changedModelAssistant.TurnKind != chatTurnKindHecateTask {
+		t.Fatalf("model-change assistant turn_kind = %q, want %q", changedModelAssistant.TurnKind, chatTurnKindHecateTask)
 	}
 	changedTask := mustRequestJSON[TaskResponse](client, http.MethodGet, "/hecate/v1/tasks/"+changedModelTools.Data.TaskID, "")
 	if changedTask.Data.RequestedModel != "gpt-4o-mini-2024-07-18" {
@@ -511,6 +526,10 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	for i, segment := range segments {
 		if segment.ExecutionMode != chat.ExecutionModeHecateTask {
 			t.Fatalf("segment %d execution_mode = %q, want hecate_task: %+v", i, segment.ExecutionMode, segments)
+		}
+		wantKind := []string{chatTurnKindDirectModel, chatTurnKindHecateTask, chatTurnKindDirectModel, chatTurnKindHecateTask, chatTurnKindHecateTask}[i]
+		if segment.TurnKind != wantKind {
+			t.Fatalf("segment %d turn_kind = %q, want %q: %+v", i, segment.TurnKind, wantKind, segments)
 		}
 		if segment.MessageCount != 2 {
 			t.Fatalf("segment %d message_count = %d, want 2: %+v", i, segment.MessageCount, segments)

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -58,6 +58,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 	for _, message := range session.Messages {
 		messages = append(messages, ChatMessageItem{
 			ID:              message.ID,
+			TurnKind:        chatMessageTurnKind(session, message),
 			ExecutionMode:   message.ExecutionMode,
 			ToolsEnabled:    message.ToolsEnabled,
 			SegmentID:       message.SegmentID,
@@ -202,6 +203,7 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 			builders = append(builders, agentChatSegmentBuilder{
 				item: ChatSegmentItem{
 					ID:            segmentID,
+					TurnKind:      chatMessageTurnKind(session, message),
 					ExecutionMode: firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session)),
 					ToolsEnabled:  message.ToolsEnabled,
 					Provider:      firstNonEmpty(message.Provider, session.Provider),
@@ -215,6 +217,9 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 		builder.item.MessageCount++
 		if builder.item.ExecutionMode == "" {
 			builder.item.ExecutionMode = firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
+		}
+		if builder.item.TurnKind == "" {
+			builder.item.TurnKind = chatMessageTurnKind(session, message)
 		}
 		if message.ToolsEnabled {
 			builder.item.ToolsEnabled = true
@@ -301,6 +306,33 @@ func defaultMessageExecutionModeForRender(session chat.Session) string {
 	// recorded on the per-message ToolsEnabled field, not on the
 	// execution_mode string.
 	return chat.ExecutionModeHecateTask
+}
+
+const (
+	chatTurnKindDirectModel   = "direct_model"
+	chatTurnKindHecateTask    = "hecate_task"
+	chatTurnKindExternalAgent = "external_agent"
+)
+
+func chatMessageTurnKind(session chat.Session, message chat.Message) string {
+	executionMode := firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
+	switch executionMode {
+	case chat.ExecutionModeExternalAgent:
+		return chatTurnKindExternalAgent
+	case chat.ExecutionModeHecateTask:
+		if !message.ToolsEnabled {
+			return chatTurnKindDirectModel
+		}
+		return chatTurnKindHecateTask
+	default:
+		if message.AgentID != "" && message.AgentID != chat.DefaultAgentID {
+			return chatTurnKindExternalAgent
+		}
+		if message.TaskID != "" {
+			return chatTurnKindHecateTask
+		}
+		return ""
+	}
 }
 
 func agentChatUsageFromResult(usage agentadapters.Usage) chat.Usage {

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -271,7 +271,7 @@ func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment Proj
 		StatusSummary:   projectActivityStatusSummary(assignment, linkedChat, signal, artifactSummary.Count),
 		LinkedTaskID:    firstNonEmpty(projectActivityExecutionTaskID(assignment), assignment.TaskID),
 		LinkedRunID:     firstNonEmpty(projectActivityExecutionRunID(assignment), assignment.RunID),
-		LinkedChatID:    assignment.ChatSessionID,
+		LinkedChatID:    firstNonEmpty(projectActivityExecutionChatID(assignment), assignment.ChatSessionID),
 		LinkedChat:      linkedChat,
 		LinkedMessageID: assignment.MessageID,
 		RecentArtifacts: recentArtifacts,
@@ -551,6 +551,9 @@ func projectActivityLinkedChatSummary(linkedChat *ProjectActivityLinkedChatRespo
 }
 
 func projectActivityExecutionStatus(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.ExecutionRef != nil {
+		return assignment.ExecutionRef.Status
+	}
 	if assignment.Execution == nil {
 		return ""
 	}
@@ -558,6 +561,9 @@ func projectActivityExecutionStatus(assignment ProjectWorkAssignmentResponse) st
 }
 
 func projectActivityExecutionTaskID(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.ExecutionRef != nil {
+		return assignment.ExecutionRef.TaskID
+	}
 	if assignment.Execution == nil {
 		return ""
 	}
@@ -565,10 +571,20 @@ func projectActivityExecutionTaskID(assignment ProjectWorkAssignmentResponse) st
 }
 
 func projectActivityExecutionRunID(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.ExecutionRef != nil {
+		return assignment.ExecutionRef.RunID
+	}
 	if assignment.Execution == nil {
 		return ""
 	}
 	return assignment.Execution.RunID
+}
+
+func projectActivityExecutionChatID(assignment ProjectWorkAssignmentResponse) string {
+	if assignment.ExecutionRef == nil {
+		return ""
+	}
+	return assignment.ExecutionRef.ChatSessionID
 }
 
 func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, artifacts ProjectActivityArtifactSummaryResponse, handoffs ProjectActivityHandoffSummaryResponse) string {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -224,6 +224,19 @@ type ProjectWorkAssignmentExecutionResponse struct {
 	Missing              bool   `json:"missing,omitempty"`
 }
 
+type ProjectWorkAssignmentExecutionRefResponse struct {
+	Kind                 string `json:"kind"`
+	TaskID               string `json:"task_id,omitempty"`
+	RunID                string `json:"run_id,omitempty"`
+	ChatSessionID        string `json:"chat_session_id,omitempty"`
+	MessageID            string `json:"message_id,omitempty"`
+	ContextSnapshotID    string `json:"context_snapshot_id,omitempty"`
+	Status               string `json:"status,omitempty"`
+	PendingApprovalCount int    `json:"pending_approval_count,omitempty"`
+	TraceID              string `json:"trace_id,omitempty"`
+	Missing              bool   `json:"missing,omitempty"`
+}
+
 type ProjectWorkAssignmentsResponse struct {
 	Object string                          `json:"object"`
 	Data   []ProjectWorkAssignmentResponse `json:"data"`
@@ -235,22 +248,23 @@ type ProjectWorkAssignmentEnvelope struct {
 }
 
 type ProjectWorkAssignmentResponse struct {
-	ID                string                                  `json:"id"`
-	ProjectID         string                                  `json:"project_id"`
-	WorkItemID        string                                  `json:"work_item_id"`
-	RoleID            string                                  `json:"role_id"`
-	DriverKind        string                                  `json:"driver_kind"`
-	Status            string                                  `json:"status"`
-	TaskID            string                                  `json:"task_id,omitempty"`
-	RunID             string                                  `json:"run_id,omitempty"`
-	ChatSessionID     string                                  `json:"chat_session_id,omitempty"`
-	MessageID         string                                  `json:"message_id,omitempty"`
-	ContextSnapshotID string                                  `json:"context_snapshot_id,omitempty"`
-	CreatedAt         string                                  `json:"created_at"`
-	UpdatedAt         string                                  `json:"updated_at"`
-	StartedAt         string                                  `json:"started_at,omitempty"`
-	CompletedAt       string                                  `json:"completed_at,omitempty"`
-	Execution         *ProjectWorkAssignmentExecutionResponse `json:"execution,omitempty"`
+	ID                string                                     `json:"id"`
+	ProjectID         string                                     `json:"project_id"`
+	WorkItemID        string                                     `json:"work_item_id"`
+	RoleID            string                                     `json:"role_id"`
+	DriverKind        string                                     `json:"driver_kind"`
+	Status            string                                     `json:"status"`
+	TaskID            string                                     `json:"task_id,omitempty"`
+	RunID             string                                     `json:"run_id,omitempty"`
+	ChatSessionID     string                                     `json:"chat_session_id,omitempty"`
+	MessageID         string                                     `json:"message_id,omitempty"`
+	ContextSnapshotID string                                     `json:"context_snapshot_id,omitempty"`
+	CreatedAt         string                                     `json:"created_at"`
+	UpdatedAt         string                                     `json:"updated_at"`
+	StartedAt         string                                     `json:"started_at,omitempty"`
+	CompletedAt       string                                     `json:"completed_at,omitempty"`
+	ExecutionRef      *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
+	Execution         *ProjectWorkAssignmentExecutionResponse    `json:"execution,omitempty"`
 }
 
 type ProjectWorkArtifactsResponse struct {
@@ -1975,7 +1989,7 @@ func renderProjectWorkItem(item projectwork.WorkItem) ProjectWorkItemResponse {
 }
 
 func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignmentResponse {
-	return ProjectWorkAssignmentResponse{
+	response := ProjectWorkAssignmentResponse{
 		ID:                item.ID,
 		ProjectID:         item.ProjectID,
 		WorkItemID:        item.WorkItemID,
@@ -1991,6 +2005,57 @@ func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignm
 		UpdatedAt:         formatOptionalTime(item.UpdatedAt),
 		StartedAt:         formatOptionalTime(item.StartedAt),
 		CompletedAt:       formatOptionalTime(item.CompletedAt),
+	}
+	response.ExecutionRef = projectWorkAssignmentExecutionRef(response)
+	return response
+}
+
+func projectWorkAssignmentExecutionRef(response ProjectWorkAssignmentResponse) *ProjectWorkAssignmentExecutionRefResponse {
+	taskID := strings.TrimSpace(response.TaskID)
+	runID := strings.TrimSpace(response.RunID)
+	status := strings.TrimSpace(response.Status)
+	pendingApprovalCount := 0
+	traceID := ""
+	missing := false
+	if response.Execution != nil {
+		taskID = firstNonEmpty(response.Execution.TaskID, taskID)
+		runID = firstNonEmpty(response.Execution.RunID, runID)
+		status = firstNonEmpty(response.Execution.Status, status)
+		pendingApprovalCount = response.Execution.PendingApprovalCount
+		traceID = response.Execution.TraceID
+		missing = response.Execution.Missing
+	}
+	chatSessionID := strings.TrimSpace(response.ChatSessionID)
+	messageID := strings.TrimSpace(response.MessageID)
+	contextSnapshotID := strings.TrimSpace(response.ContextSnapshotID)
+	kind := projectWorkAssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID)
+	if kind == "" {
+		return nil
+	}
+	return &ProjectWorkAssignmentExecutionRefResponse{
+		Kind:                 kind,
+		TaskID:               taskID,
+		RunID:                runID,
+		ChatSessionID:        chatSessionID,
+		MessageID:            messageID,
+		ContextSnapshotID:    contextSnapshotID,
+		Status:               status,
+		PendingApprovalCount: pendingApprovalCount,
+		TraceID:              traceID,
+		Missing:              missing,
+	}
+}
+
+func projectWorkAssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID string) string {
+	switch {
+	case taskID != "" || runID != "":
+		return "task_run"
+	case chatSessionID != "" || messageID != "":
+		return "chat_session"
+	case contextSnapshotID != "":
+		return "context_snapshot"
+	default:
+		return ""
 	}
 }
 

--- a/internal/api/handler_project_work_projection.go
+++ b/internal/api/handler_project_work_projection.go
@@ -60,6 +60,7 @@ func (h *Handler) renderProjectedProjectWorkAssignment(ctx context.Context, item
 	if response.CompletedAt == "" && !projection.CompletedAt.IsZero() {
 		response.CompletedAt = formatOptionalTime(projection.CompletedAt)
 	}
+	response.ExecutionRef = projectWorkAssignmentExecutionRef(response)
 	return response, nil
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2024,6 +2024,9 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 			if running.Status != projectwork.AssignmentStatusRunning || running.Execution == nil || running.Execution.RunStatus != "running" {
 				t.Fatalf("running assignment = %+v, want projected running execution", running)
 			}
+			if running.ExecutionRef == nil || running.ExecutionRef.Kind != "task_run" || running.ExecutionRef.TaskID != running.Execution.TaskID || running.ExecutionRef.RunID != running.Execution.RunID || running.ExecutionRef.Status != running.Status {
+				t.Fatalf("running execution_ref = %+v, want projected task/run ref for %+v", running.ExecutionRef, running.Execution)
+			}
 			if running.StartedAt == "" {
 				t.Fatalf("running assignment started_at is empty, want projected run timestamp")
 			}
@@ -2038,6 +2041,9 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 			awaiting := getProjectWorkAssignmentForTest(t, server, "work_awaiting", "asgn_awaiting")
 			if awaiting.Status != projectwork.AssignmentStatusAwaitingApproval || awaiting.Execution == nil || awaiting.Execution.PendingApprovalCount != 1 {
 				t.Fatalf("awaiting assignment = %+v, want awaiting approval with one pending approval", awaiting)
+			}
+			if awaiting.ExecutionRef == nil || awaiting.ExecutionRef.PendingApprovalCount != 1 || awaiting.ExecutionRef.Status != projectwork.AssignmentStatusAwaitingApproval {
+				t.Fatalf("awaiting execution_ref = %+v, want awaiting ref with pending approval count", awaiting.ExecutionRef)
 			}
 
 			completed := getProjectWorkAssignmentForTest(t, server, "work_completed", "asgn_completed")
@@ -2067,6 +2073,9 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 			runOnly := getProjectWorkAssignmentForTest(t, server, "work_run_only", "asgn_run_only")
 			if runOnly.Status != projectwork.AssignmentStatusQueued || runOnly.RunID == "" || runOnly.Execution != nil {
 				t.Fatalf("run-only assignment = %+v, want stored queued status without execution projection", runOnly)
+			}
+			if runOnly.ExecutionRef == nil || runOnly.ExecutionRef.Kind != "task_run" || runOnly.ExecutionRef.RunID != runOnly.RunID {
+				t.Fatalf("run-only execution_ref = %+v, want raw run ref", runOnly.ExecutionRef)
 			}
 			assertProjectWorkStatusForTest(t, server, "work_run_only", projectwork.WorkItemStatusReady)
 
@@ -2111,6 +2120,9 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			awaiting := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_awaiting")
 			if awaiting.BlockingSignal != "awaiting_approval" || awaiting.Assignment.Execution == nil || awaiting.Assignment.Execution.PendingApprovalCount != 1 {
 				t.Fatalf("awaiting activity = %+v, want approval blocking signal", awaiting)
+			}
+			if awaiting.Assignment.ExecutionRef == nil || awaiting.Assignment.ExecutionRef.PendingApprovalCount != 1 || awaiting.LinkedTaskID != awaiting.Assignment.ExecutionRef.TaskID || awaiting.LinkedRunID != awaiting.Assignment.ExecutionRef.RunID {
+				t.Fatalf("awaiting activity execution_ref = %+v linked=%q/%q, want ref-backed links", awaiting.Assignment.ExecutionRef, awaiting.LinkedTaskID, awaiting.LinkedRunID)
 			}
 			if awaiting.WorkItem.Status != projectwork.WorkItemStatusRunning || awaiting.Role.Name != "Projection engineer" {
 				t.Fatalf("awaiting context = %+v, want projected work item and role", awaiting)
@@ -2160,6 +2172,9 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			external := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_external_chat")
 			if external.LinkedChat == nil || external.LinkedChat.ID != "chat_external_projection" || external.LinkedChat.LatestMessageID != "msg_external_done" {
 				t.Fatalf("external linked chat = %+v, want chat summary with latest message", external.LinkedChat)
+			}
+			if external.Assignment.ExecutionRef == nil || external.Assignment.ExecutionRef.Kind != "chat_session" || external.LinkedChatID != external.Assignment.ExecutionRef.ChatSessionID {
+				t.Fatalf("external execution_ref = %+v linked_chat=%q, want chat-session ref", external.Assignment.ExecutionRef, external.LinkedChatID)
 			}
 			if external.BlockingSignal != "running" || external.StatusSummary != "linked chat · running · assistant completed · 2 messages" {
 				t.Fatalf("external activity = %+v, want linked chat running summary", external)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -836,6 +836,7 @@ type ChatSessionItem struct {
 
 type ChatSegmentItem struct {
 	ID            string `json:"id"`
+	TurnKind      string `json:"turn_kind,omitempty"`
 	ExecutionMode string `json:"execution_mode"`
 	ToolsEnabled  bool   `json:"tools_enabled"`
 	Provider      string `json:"provider,omitempty"`
@@ -851,6 +852,7 @@ type ChatSegmentItem struct {
 
 type ChatMessageItem struct {
 	ID            string `json:"id"`
+	TurnKind      string `json:"turn_kind,omitempty"`
 	ExecutionMode string `json:"execution_mode,omitempty"`
 	// ToolsEnabled is the per-turn tools-on/off signal the gateway
 	// recorded when this message was appended. Always present on the

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -52,6 +52,10 @@ import {
 import { modelSelectionHasNoToolCalling } from "../../../lib/chat-setup-readiness";
 import { projectByID, projectDefaultWorkspace } from "../../../lib/project-workspace";
 import {
+  toChatMessageViewModel,
+  toChatSegmentViewModel,
+} from "../../../features/chats/chatTurnViewModels";
+import {
   type ChatExecutionMode,
   type ChatTarget,
   type QueuedChatMessage,
@@ -135,12 +139,12 @@ function deriveHecateChatSelectionFromSession(session: ChatSessionRecord | null)
     return { provider: "", model: "" };
   }
   const segments = [...(session.segments ?? [])].reverse();
-  const segment = segments.find((item) => item.execution_mode === "hecate_task");
+  const segment = segments.find((item) => toChatSegmentViewModel(item).isHecateOwned);
   if (segment?.provider || segment?.model) {
     return { provider: segment.provider ?? "", model: segment.model ?? "" };
   }
   const messages = [...(session.messages ?? [])].reverse();
-  const message = messages.find((item) => item.execution_mode === "hecate_task");
+  const message = messages.find((item) => toChatMessageViewModel(item).isHecateOwned);
   if (message?.provider || message?.model) {
     return { provider: message.provider ?? "", model: message.model ?? "" };
   }

--- a/ui/src/app/state/derived.ts
+++ b/ui/src/app/state/derived.ts
@@ -9,6 +9,7 @@ import { useContext, useMemo } from "react";
 
 import { buildLocalProviderIssue, type LocalProviderIssue } from "../../lib/provider-issues";
 import { filterModelsByKind, filterModelsByProvider } from "../../lib/runtime-utils";
+import { toChatSegmentViewModel } from "../../features/chats/chatTurnViewModels";
 import { useChat } from "./chat";
 import { CoordinatorOverridesContext } from "./coordinators/overrides";
 import { useProvidersAndModels } from "./providersAndModels";
@@ -30,12 +31,10 @@ function hecateTaskStatusIsActive(status?: string): boolean {
 function sessionHasActiveHecateTaskSegment(session: ChatSessionRecord | null): boolean {
   if (!session) return false;
   if (session.task_id && hecateTaskStatusIsActive(session.status)) return true;
-  return (session.segments ?? []).some(
-    (segment) =>
-      segment.execution_mode === "hecate_task" &&
-      Boolean(segment.task_id) &&
-      hecateTaskStatusIsActive(segment.status),
-  );
+  return (session.segments ?? []).some((segment) => {
+    const turn = toChatSegmentViewModel(segment);
+    return turn.isTaskBacked && hecateTaskStatusIsActive(turn.status);
+  });
 }
 
 // chatTarget gates several views' route/copy decisions. The active

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -21,9 +21,11 @@ import {
   compactWorkspaceChangeLabel,
   workspaceChangeSummaryLabel,
 } from "./ChatWorkspaceChangesPanel";
+import { toChatMessageViewModel, toChatSegmentViewModel } from "./chatTurnViewModels";
 
 export type VisibleChatMessage = {
   id: string;
+  turn_kind?: string;
   execution_mode?: string;
   tools_enabled?: boolean;
   segment_id?: string;
@@ -395,7 +397,8 @@ const ChatTranscriptRow = memo(function ChatTranscriptRow({
     role === "assistant"
       ? formatAgentRuntimeMetaTitle(m.run_id, m.duration_ms, m.native_session_id)
       : "";
-  const taskID = m.execution_mode === "hecate_task" ? m.task_id : "";
+  const turn = toChatMessageViewModel(m);
+  const taskID = turn.isTaskBacked ? turn.taskID : "";
   const taskRunID = taskID ? m.run_id : "";
   const traceRequestID = m.request_id;
   const traceID = m.trace_id;
@@ -522,6 +525,7 @@ export function projectVisibleMessage(
 function buildVisibleMessage(m: ChatMessageRecord, id: string): VisibleChatMessage {
   return {
     id,
+    turn_kind: m.turn_kind,
     execution_mode: m.execution_mode,
     tools_enabled: m.tools_enabled,
     segment_id: m.segment_id,
@@ -560,6 +564,7 @@ function fallbackSegmentID(message: VisibleChatMessage): string {
 function segmentFromMessage(message: VisibleChatMessage, segmentID: string): ChatSegmentRecord {
   return {
     id: segmentID,
+    turn_kind: message.turn_kind,
     execution_mode: message.execution_mode || "hecate_task",
     tools_enabled: message.tools_enabled,
     provider: message.provider,
@@ -667,23 +672,20 @@ function describeChatSegment(segment: ChatSegmentRecord): {
 } {
   const model = segment.model || "selected model";
   const provider = segment.provider && segment.provider !== "auto" ? segment.provider : "";
-  switch (segment.execution_mode) {
+  const turn = toChatSegmentViewModel(segment);
+  switch (turn.turnKind) {
+    case "direct_model": {
+      const meta = [provider, "direct model chat"].filter(Boolean).join(" · ");
+      return {
+        kicker: "Tools off",
+        title: model,
+        meta,
+        label: `Tools off segment using ${model}`,
+        tone: "off",
+      };
+    }
     case "hecate_task": {
-      if (segment.tools_enabled === false) {
-        const meta = [provider, "direct model chat"].filter(Boolean).join(" · ");
-        return {
-          kicker: "Tools off",
-          title: model,
-          meta,
-          label: `Tools off segment using ${model}`,
-          tone: "off",
-        };
-      }
-      const meta = [
-        provider,
-        segment.task_id ? formatTaskLinkLabel(segment.task_id) : "",
-        segment.status,
-      ]
+      const meta = [provider, turn.taskID ? formatTaskLinkLabel(turn.taskID) : "", turn.status]
         .filter(Boolean)
         .join(" · ");
       return {
@@ -695,9 +697,7 @@ function describeChatSegment(segment: ChatSegmentRecord): {
       };
     }
     case "external_agent": {
-      const meta = [segment.status, segment.workspace ? "workspace" : ""]
-        .filter(Boolean)
-        .join(" · ");
+      const meta = [turn.status, turn.workspace ? "workspace" : ""].filter(Boolean).join(" · ");
       return {
         kicker: "External",
         title: model === "selected model" ? "External Agent" : model,

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -51,6 +51,7 @@ import {
 import { ChatWorkspaceChangesPanel } from "./ChatWorkspaceChangesPanel";
 import { externalAgentRequiresModelSelection, mergeAgentConfigOptions } from "./agentConfigOptions";
 import { chatAgentOption } from "./ChatAgentControls";
+import { toChatSegmentViewModel } from "./chatTurnViewModels";
 import {
   HecateTaskApprovalsBanner,
   activeTaskBackedHecateSegment,
@@ -1199,9 +1200,10 @@ function externalAgentSessionIsBusy(session: ChatSessionRecord | null): boolean 
   if (!session?.agent_id || session.agent_id === "hecate") return false;
   if (busy(session.status)) return true;
   if (
-    (session.segments ?? []).some(
-      (segment) => segment.execution_mode === "external_agent" && busy(segment.status),
-    )
+    (session.segments ?? []).some((segment) => {
+      const turn = toChatSegmentViewModel(segment);
+      return turn.isExternalAgent && busy(turn.status);
+    })
   ) {
     return true;
   }

--- a/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
+++ b/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
@@ -1,6 +1,7 @@
 import { formatLocaleTime } from "../../lib/format";
 import type { ChatActivityRecord, ChatSegmentRecord, ChatSessionRecord } from "../../types/chat";
 import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeRow } from "./ChatNotice";
+import { toChatSegmentViewModel } from "./chatTurnViewModels";
 
 export type HecateTaskApproval = {
   approvalID: string;
@@ -74,12 +75,10 @@ export function activeTaskBackedHecateSegment(
   session: ChatSessionRecord | null,
 ): ChatSegmentRecord | null {
   const segments = [...(session?.segments ?? [])].reverse();
-  const activeSegment = segments.find(
-    (segment) =>
-      segment.execution_mode === "hecate_task" &&
-      Boolean(segment.task_id) &&
-      hecateAgentSessionIsActive(segment.status),
-  );
+  const activeSegment = segments.find((segment) => {
+    const turn = toChatSegmentViewModel(segment);
+    return turn.isTaskBacked && hecateAgentSessionIsActive(turn.status);
+  });
   if (activeSegment) {
     return activeSegment;
   }

--- a/ui/src/features/chats/chatTurnViewModels.test.ts
+++ b/ui/src/features/chats/chatTurnViewModels.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chatTurnKindFromWire,
+  toChatMessageViewModel,
+  toChatSegmentViewModel,
+} from "./chatTurnViewModels";
+
+describe("chatTurnViewModels", () => {
+  it("prefers explicit turn_kind over legacy execution fields", () => {
+    expect(
+      chatTurnKindFromWire({
+        turn_kind: "direct_model",
+        execution_mode: "hecate_task",
+        tools_enabled: true,
+        task_id: "task_1",
+      }),
+    ).toBe("direct_model");
+  });
+
+  it("maps legacy Hecate tools-off turns to direct model turns", () => {
+    const turn = toChatMessageViewModel({
+      id: "msg_1",
+      role: "assistant",
+      content: "hello",
+      execution_mode: "hecate_task",
+      tools_enabled: false,
+      task_id: "task_legacy_should_not_link",
+    });
+
+    expect(turn.turnKind).toBe("direct_model");
+    expect(turn.isDirectModel).toBe(true);
+    expect(turn.isTaskBacked).toBe(false);
+    expect(turn.taskID).toBe("");
+  });
+
+  it("maps legacy Hecate tools-on segments to task-backed turns", () => {
+    const turn = toChatSegmentViewModel({
+      id: "seg_1",
+      execution_mode: "hecate_task",
+      tools_enabled: true,
+      task_id: "task_1",
+      latest_run_id: "run_1",
+      status: "awaiting_approval",
+      message_count: 2,
+    });
+
+    expect(turn.turnKind).toBe("hecate_task");
+    expect(turn.isTaskBacked).toBe(true);
+    expect(turn.taskID).toBe("task_1");
+    expect(turn.latestRunID).toBe("run_1");
+    expect(turn.isBusy).toBe(true);
+    expect(turn.messageCount).toBe(2);
+  });
+
+  it("maps external-agent segments independently of tools_enabled", () => {
+    const turn = toChatSegmentViewModel({
+      id: "seg_1",
+      execution_mode: "external_agent",
+      tools_enabled: false,
+      status: "running",
+      message_count: 1,
+    });
+
+    expect(turn.turnKind).toBe("external_agent");
+    expect(turn.isExternalAgent).toBe(true);
+    expect(turn.isBusy).toBe(true);
+  });
+});

--- a/ui/src/features/chats/chatTurnViewModels.ts
+++ b/ui/src/features/chats/chatTurnViewModels.ts
@@ -1,0 +1,116 @@
+import type { ChatMessageRecord, ChatSegmentRecord } from "../../types/chat";
+
+export type ChatTurnKind = "direct_model" | "hecate_task" | "external_agent" | "unknown";
+
+type ChatTurnWire = {
+  turn_kind?: string;
+  execution_mode?: string;
+  tools_enabled?: boolean;
+  segment_id?: string;
+  task_id?: string;
+  run_id?: string;
+  latest_run_id?: string;
+  native_session_id?: string;
+  agent_id?: string;
+  driver_kind?: string;
+  provider?: string;
+  model?: string;
+  workspace?: string;
+  status?: string;
+};
+
+export type ChatTurnViewModel = {
+  turnKind: ChatTurnKind;
+  executionMode: string;
+  toolsEnabled: boolean | undefined;
+  segmentID: string;
+  taskID: string;
+  runID: string;
+  latestRunID: string;
+  provider: string;
+  model: string;
+  workspace: string;
+  status: string;
+  isDirectModel: boolean;
+  isTaskBacked: boolean;
+  isExternalAgent: boolean;
+  isHecateOwned: boolean;
+  isBusy: boolean;
+};
+
+export type ChatSegmentViewModel = ChatTurnViewModel & {
+  messageCount: number;
+};
+
+export function chatTurnKindFromWire(input: ChatTurnWire): ChatTurnKind {
+  const explicit = normalizeChatTurnKind(input.turn_kind);
+  if (explicit) return explicit;
+  if (input.execution_mode === "external_agent") return "external_agent";
+  if (input.agent_id && input.agent_id !== "hecate") return "external_agent";
+  if (input.execution_mode === "hecate_task") {
+    return input.tools_enabled === false ? "direct_model" : "hecate_task";
+  }
+  if (input.task_id) return "hecate_task";
+  if (input.native_session_id || input.driver_kind) return "external_agent";
+  return "unknown";
+}
+
+export function toChatMessageViewModel(
+  message: ChatMessageRecord | ChatTurnWire,
+): ChatTurnViewModel {
+  return toChatTurnViewModel(message);
+}
+
+export function toChatSegmentViewModel(segment: ChatSegmentRecord): ChatSegmentViewModel {
+  const base = toChatTurnViewModel(segment);
+  return {
+    ...base,
+    messageCount: segment.message_count ?? 0,
+  };
+}
+
+function toChatTurnViewModel(input: ChatTurnWire): ChatTurnViewModel {
+  const turnKind = chatTurnKindFromWire(input);
+  const taskID = turnKind === "hecate_task" ? (input.task_id ?? "") : "";
+  const runID = turnKind === "hecate_task" ? (input.run_id ?? "") : "";
+  const latestRunID = turnKind === "hecate_task" ? (input.latest_run_id ?? "") : "";
+  return {
+    turnKind,
+    executionMode: input.execution_mode ?? "",
+    toolsEnabled: input.tools_enabled,
+    segmentID: input.segment_id ?? "",
+    taskID,
+    runID,
+    latestRunID,
+    provider: input.provider ?? "",
+    model: input.model ?? "",
+    workspace: input.workspace ?? "",
+    status: input.status ?? "",
+    isDirectModel: turnKind === "direct_model",
+    isTaskBacked: turnKind === "hecate_task" && Boolean(taskID),
+    isExternalAgent: turnKind === "external_agent",
+    isHecateOwned: turnKind === "direct_model" || turnKind === "hecate_task",
+    isBusy: chatTurnStatusIsBusy(input.status),
+  };
+}
+
+function normalizeChatTurnKind(value?: string): ChatTurnKind | "" {
+  switch (value) {
+    case "direct_model":
+    case "hecate_task":
+    case "external_agent":
+      return value;
+    default:
+      return "";
+  }
+}
+
+function chatTurnStatusIsBusy(status?: string): boolean {
+  return (
+    status === "queued" ||
+    status === "running" ||
+    status === "in_progress" ||
+    status === "awaiting_approval" ||
+    status === "pending"
+  );
+}

--- a/ui/src/features/chats/chatTurnViewModels.ts
+++ b/ui/src/features/chats/chatTurnViewModels.ts
@@ -46,6 +46,8 @@ export function chatTurnKindFromWire(input: ChatTurnWire): ChatTurnKind {
   const explicit = normalizeChatTurnKind(input.turn_kind);
   if (explicit) return explicit;
   if (input.execution_mode === "external_agent") return "external_agent";
+  // Legacy snapshots can carry stale Hecate execution_mode values; a foreign
+  // agent_id is the stronger owner signal when turn_kind is absent.
   if (input.agent_id && input.agent_id !== "hecate") return "external_agent";
   if (input.execution_mode === "hecate_task") {
     return input.tools_enabled === false ? "direct_model" : "hecate_task";

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -72,6 +72,7 @@ import {
   type ProjectHealthAttention,
   type ProjectTimelineItem,
 } from "./projectInsights";
+import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
 import {
   PROJECT_ASSISTANT_AUTO,
   ProjectAssistantPanel,
@@ -3713,12 +3714,13 @@ function WorkItemDetail({
                   onEdit={() => onEditAssignment(assignment)}
                   onOpenChat={
                     project
-                      ? () =>
+                      ? () => {
+                          const executionRef = toProjectAssignmentExecutionViewModel(assignment);
                           onOpenChat?.(
-                            assignment.chat_session_id
+                            executionRef.chatSessionID
                               ? {
                                   projectID: project.id,
-                                  chatSessionID: assignment.chat_session_id,
+                                  chatSessionID: executionRef.chatSessionID,
                                 }
                               : buildProjectAssignmentChatLaunchRequest({
                                   project,
@@ -3726,7 +3728,8 @@ function WorkItemDetail({
                                   assignment,
                                   role: roleByID.get(assignment.role_id) ?? null,
                                 }),
-                          )
+                          );
+                        }
                       : undefined
                   }
                   onOpenTask={onOpenTask}
@@ -5576,11 +5579,12 @@ function AssignmentRow({
   starting: boolean;
 }) {
   const execution = assignment.execution;
-  const taskID = execution?.task_id || assignment.task_id || "";
-  const runID = execution?.run_id || assignment.run_id || "";
-  const chatSessionID = assignment.chat_session_id || "";
+  const executionRef = toProjectAssignmentExecutionViewModel(assignment);
+  const taskID = executionRef.taskID;
+  const runID = executionRef.runID;
+  const chatSessionID = executionRef.chatSessionID;
   const linkedChat = activityItem?.linked_chat;
-  const projectedStatus = execution?.status || assignment.status;
+  const projectedStatus = executionRef.status;
   const startable =
     (assignment.driver_kind === "hecate_task" || assignment.driver_kind === "external_agent") &&
     projectedStatus === "queued";
@@ -5632,7 +5636,7 @@ function AssignmentRow({
             {starting ? startingLabel : startActionLabel}
           </button>
         )}
-        {external && !startable && !assignment.chat_session_id && (
+        {external && !startable && !executionRef.chatSessionID && (
           <span
             style={subtleTextStyle}
             title="Prepare this assignment to create a supervised External Agent chat session."
@@ -5694,9 +5698,9 @@ function AssignmentRow({
               : `chat ${linkedChat.latest_status || linkedChat.status || "active"}`}
           </span>
         )}
-        {execution?.pending_approval_count ? (
+        {executionRef.pendingApprovalCount ? (
           <span className="badge badge-amber">
-            {execution.pending_approval_count} approval pending
+            {executionRef.pendingApprovalCount} approval pending
           </span>
         ) : null}
         {typeof execution?.step_count === "number" && (
@@ -5710,8 +5714,8 @@ function AssignmentRow({
             {[execution.provider, execution.model].filter(Boolean).join(" / ")}
           </span>
         ) : null}
-        {execution?.missing && <span className="badge badge-amber">linked run missing</span>}
-        {(taskID || runID || chatSessionID || assignment.context_snapshot_id) && (
+        {executionRef.missing && <span className="badge badge-amber">linked run missing</span>}
+        {executionRef.hasAnyLink && (
           <button
             aria-label={`Create handoff from assignment ${assignment.id}`}
             className="btn btn-ghost btn-sm"
@@ -5771,9 +5775,10 @@ function ProjectHandoffRow({
   role?: ProjectWorkRoleRecord;
   starting: boolean;
 }) {
+  const executionRef = assignment ? toProjectAssignmentExecutionViewModel(assignment) : null;
   const startable =
     (assignment?.driver_kind === "hecate_task" || assignment?.driver_kind === "external_agent") &&
-    (assignment.execution?.status || assignment.status) === "queued";
+    executionRef?.status === "queued";
   const canCreateAssignment = !assignment && handoff.status !== "dismissed";
   const sourceRefs = handoffSourceRefs(handoff);
   return (
@@ -5892,7 +5897,7 @@ function EmptyBlock({ title, detail }: { title: string; detail: string }) {
 function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemSummary {
   return assignments.reduce<WorkItemSummary>(
     (summary, assignment) => {
-      const status = assignment.execution?.status || assignment.status;
+      const status = toProjectAssignmentExecutionViewModel(assignment).status;
       summary.assignmentCount += 1;
       if (status === "running" || status === "queued" || status === "awaiting_approval") {
         summary.activeCount += 1;
@@ -6160,16 +6165,17 @@ function handoffFormFromAssignment(
   role: ProjectWorkRoleRecord | null,
   activityItem?: ProjectActivityItemRecord,
 ): HandoffForm {
-  const sourceChatSessionID = assignment.chat_session_id ?? "";
-  const sourceRunID = assignment.execution?.run_id || assignment.run_id || "";
+  const execution = toProjectAssignmentExecutionViewModel(assignment);
+  const sourceChatSessionID = execution.chatSessionID;
+  const sourceRunID = execution.runID;
   const sourceMessageID =
-    assignment.message_id ||
+    execution.messageID ||
     activityItem?.linked_message_id ||
     activityItem?.linked_chat?.latest_message_id ||
     "";
   const contextRefs = [
-    assignment.context_snapshot_id,
-    assignment.execution?.task_id || assignment.task_id,
+    execution.contextSnapshotID,
+    execution.taskID,
     sourceRunID,
     sourceChatSessionID,
     sourceMessageID,
@@ -6325,6 +6331,7 @@ function projectAssignmentLaunchDraft({
   provider: string;
   model: string;
 }): string {
+  const execution = toProjectAssignmentExecutionViewModel(assignment);
   const resolvedDriver = firstNonEmpty(
     assignment.driver_kind,
     role?.default_driver_kind,
@@ -6344,7 +6351,7 @@ function projectAssignmentLaunchDraft({
     "",
     "Assignment:",
     `- ID: ${assignment.id}`,
-    `- Status: ${firstNonEmpty(assignment.execution?.status, assignment.status, "queued")}`,
+    `- Status: ${firstNonEmpty(execution.status, "queued")}`,
     `- Driver: ${resolvedDriver}`,
     "",
     "Role:",
@@ -6377,11 +6384,11 @@ function projectAssignmentLaunchDraft({
     ])}`,
   ];
   const linkedIDs = formatHintList([
-    ["task", assignment.execution?.task_id || assignment.task_id],
-    ["run", assignment.execution?.run_id || assignment.run_id],
-    ["chat", assignment.chat_session_id],
-    ["message", assignment.message_id],
-    ["context", assignment.context_snapshot_id],
+    ["task", execution.taskID],
+    ["run", execution.runID],
+    ["chat", execution.chatSessionID],
+    ["message", execution.messageID],
+    ["context", execution.contextSnapshotID],
   ]);
   if (linkedIDs !== "none") {
     lines.push("", "Linked runtime ids:", `- ${linkedIDs}`);

--- a/ui/src/features/projects/projectAssignmentViewModels.test.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  toProjectActivityAssignmentExecutionViewModel,
+  toProjectAssignmentExecutionViewModel,
+} from "./projectAssignmentViewModels";
+import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
+
+describe("projectAssignmentViewModels", () => {
+  it("prefers canonical execution_ref over legacy assignment fields", () => {
+    const execution = toProjectAssignmentExecutionViewModel({
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "hecate_task",
+      status: "queued",
+      task_id: "task_legacy",
+      run_id: "run_legacy",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_ref",
+        run_id: "run_ref",
+        status: "running",
+        pending_approval_count: 2,
+        trace_id: "trace_ref",
+      },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    expect(execution.kind).toBe("task_run");
+    expect(execution.taskID).toBe("task_ref");
+    expect(execution.runID).toBe("run_ref");
+    expect(execution.status).toBe("running");
+    expect(execution.pendingApprovalCount).toBe(2);
+    expect(execution.traceID).toBe("trace_ref");
+    expect(execution.hasTaskRun).toBe(true);
+  });
+
+  it("falls back to projected execution before raw links", () => {
+    const execution = toProjectAssignmentExecutionViewModel({
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "hecate_task",
+      status: "queued",
+      task_id: "task_raw",
+      run_id: "run_raw",
+      execution: {
+        task_id: "task_projected",
+        run_id: "run_projected",
+        status: "completed",
+        missing: true,
+      },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    expect(execution.kind).toBe("task_run");
+    expect(execution.taskID).toBe("task_projected");
+    expect(execution.runID).toBe("run_projected");
+    expect(execution.status).toBe("completed");
+    expect(execution.missing).toBe(true);
+  });
+
+  it("uses activity linked refs ahead of assignment refs", () => {
+    const assignment: ProjectAssignmentRecord = {
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "external_agent",
+      status: "running",
+      chat_session_id: "chat_assignment",
+      message_id: "msg_assignment",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const item = {
+      id: "activity_1",
+      project_id: "proj_1",
+      work_item: {
+        id: "work_1",
+        title: "Build",
+        status: "active",
+        priority: "normal",
+      },
+      assignment,
+      role: {
+        id: "developer",
+        project_id: "proj_1",
+        name: "Developer",
+        built_in: false,
+      },
+      status: "running",
+      blocking_signal: "running",
+      status_summary: "running",
+      linked_chat_id: "chat_activity",
+      linked_message_id: "msg_activity",
+      artifact_summary: { count: 0 },
+      updated_at: "2026-01-01T00:00:00Z",
+    } satisfies ProjectActivityItemRecord;
+
+    const execution = toProjectActivityAssignmentExecutionViewModel(item);
+
+    expect(execution.kind).toBe("chat_session");
+    expect(execution.chatSessionID).toBe("chat_activity");
+    expect(execution.messageID).toBe("msg_activity");
+    expect(execution.hasChatSession).toBe(true);
+  });
+
+  it("infers context-only assignments", () => {
+    const execution = toProjectAssignmentExecutionViewModel({
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "reviewer",
+      driver_kind: "hecate_task",
+      status: "queued",
+      context_snapshot_id: "ctx_1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    expect(execution.kind).toBe("context_snapshot");
+    expect(execution.contextSnapshotID).toBe("ctx_1");
+    expect(execution.hasContextSnapshot).toBe(true);
+    expect(execution.hasAnyLink).toBe(true);
+  });
+});

--- a/ui/src/features/projects/projectAssignmentViewModels.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.ts
@@ -1,0 +1,105 @@
+import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
+
+export type ProjectAssignmentExecutionKind =
+  | "task_run"
+  | "chat_session"
+  | "context_snapshot"
+  | "none"
+  | string;
+
+export type ProjectAssignmentExecutionViewModel = {
+  kind: ProjectAssignmentExecutionKind;
+  taskID: string;
+  runID: string;
+  chatSessionID: string;
+  messageID: string;
+  contextSnapshotID: string;
+  status: string;
+  pendingApprovalCount: number;
+  traceID: string;
+  missing: boolean;
+  hasTaskRun: boolean;
+  hasChatSession: boolean;
+  hasContextSnapshot: boolean;
+  hasAnyLink: boolean;
+};
+
+type LinkedExecutionOverrides = {
+  taskID?: string;
+  runID?: string;
+  chatSessionID?: string;
+  messageID?: string;
+};
+
+export function toProjectAssignmentExecutionViewModel(
+  assignment: ProjectAssignmentRecord,
+  linked: LinkedExecutionOverrides = {},
+): ProjectAssignmentExecutionViewModel {
+  const execution = assignment.execution;
+  const ref = assignment.execution_ref;
+  const taskID = firstNonEmpty(linked.taskID, ref?.task_id, execution?.task_id, assignment.task_id);
+  const runID = firstNonEmpty(linked.runID, ref?.run_id, execution?.run_id, assignment.run_id);
+  const chatSessionID = firstNonEmpty(
+    linked.chatSessionID,
+    ref?.chat_session_id,
+    assignment.chat_session_id,
+  );
+  const messageID = firstNonEmpty(linked.messageID, ref?.message_id, assignment.message_id);
+  const contextSnapshotID = firstNonEmpty(ref?.context_snapshot_id, assignment.context_snapshot_id);
+  const kind = ref?.kind || inferExecutionKind({ taskID, runID, chatSessionID, contextSnapshotID });
+  const pendingApprovalCount =
+    ref?.pending_approval_count ?? execution?.pending_approval_count ?? 0;
+  const missing = ref?.missing ?? execution?.missing ?? false;
+  return {
+    kind,
+    taskID,
+    runID,
+    chatSessionID,
+    messageID,
+    contextSnapshotID,
+    status: firstNonEmpty(ref?.status, execution?.status, assignment.status),
+    pendingApprovalCount,
+    traceID: firstNonEmpty(ref?.trace_id, execution?.trace_id),
+    missing,
+    hasTaskRun: Boolean(taskID || runID),
+    hasChatSession: Boolean(chatSessionID || messageID),
+    hasContextSnapshot: Boolean(contextSnapshotID),
+    hasAnyLink: Boolean(taskID || runID || chatSessionID || messageID || contextSnapshotID),
+  };
+}
+
+export function toProjectActivityAssignmentExecutionViewModel(
+  item: ProjectActivityItemRecord,
+): ProjectAssignmentExecutionViewModel {
+  return toProjectAssignmentExecutionViewModel(item.assignment, {
+    taskID: item.linked_task_id,
+    runID: item.linked_run_id,
+    chatSessionID: item.linked_chat_id,
+    messageID: item.linked_message_id,
+  });
+}
+
+function inferExecutionKind({
+  chatSessionID,
+  contextSnapshotID,
+  runID,
+  taskID,
+}: {
+  chatSessionID: string;
+  contextSnapshotID: string;
+  runID: string;
+  taskID: string;
+}): ProjectAssignmentExecutionKind {
+  if (taskID || runID) return "task_run";
+  if (chatSessionID) return "chat_session";
+  if (contextSnapshotID) return "context_snapshot";
+  return "none";
+}
+
+function firstNonEmpty(...values: Array<string | undefined | null>): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return "";
+}

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -13,6 +13,10 @@ import type {
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
+import {
+  toProjectActivityAssignmentExecutionViewModel,
+  toProjectAssignmentExecutionViewModel,
+} from "./projectAssignmentViewModels";
 
 export type ProjectActivityBucketKey = "all" | "active" | "blocked" | "completed" | "recent";
 
@@ -128,8 +132,7 @@ export function buildProjectTimelineItems({
       projectActivityWorkItemToWorkItem(project.id, activityItem.work_item);
     const role = roleByID.get(activityItem.assignment.role_id) ?? activityItem.role;
     if (activityItem.blocking_signal !== "not_started") {
-      const taskID = activityItem.linked_task_id || activityItem.assignment.task_id || "";
-      const runID = activityItem.linked_run_id || activityItem.assignment.run_id || "";
+      const execution = toProjectActivityAssignmentExecutionViewModel(activityItem);
       setTimelineItem(items, {
         id: `assignment:${activityItem.assignment.id}`,
         kind: "assignment",
@@ -140,9 +143,9 @@ export function buildProjectTimelineItems({
         timestamp: activityItem.updated_at || activityItem.assignment.updated_at,
         status: activityItem.blocking_signal,
         workItemID: workItem.id,
-        taskID,
-        runID,
-        chatID: activityItem.linked_chat_id || activityItem.assignment.chat_session_id,
+        taskID: execution.taskID,
+        runID: execution.runID,
+        chatID: execution.chatSessionID,
         assignment: activityItem.assignment,
       });
     }
@@ -202,12 +205,12 @@ export function buildProjectHealthSummary(
     (item.assignments ?? []).map((assignment) => ({
       assignment,
       workItem: item,
-      status: assignment.execution?.status || assignment.status,
+      status: toProjectAssignmentExecutionViewModel(assignment).status,
     })),
   );
   const staleItems = [
     ...activityItems.filter((item) => item.blocking_signal === "stale_unknown"),
-    ...activityItems.filter((item) => item.assignment.execution?.missing),
+    ...activityItems.filter((item) => toProjectActivityAssignmentExecutionViewModel(item).missing),
     ...projectedAssignments
       .filter((item) => isStaleAssignment(item.assignment, item.status))
       .map((item) => projectAssignmentToActivityAttention(project, item.workItem, item.assignment)),
@@ -694,6 +697,7 @@ function projectAssignmentToActivityAttention(
   assignment: ProjectAssignmentRecord,
 ): ProjectActivityItemRecord | null {
   if (!project) return null;
+  const execution = toProjectAssignmentExecutionViewModel(assignment);
   return {
     id: assignment.id,
     project_id: project.id,
@@ -710,12 +714,12 @@ function projectAssignmentToActivityAttention(
       name: assignment.role_id,
       built_in: false,
     },
-    status: assignment.execution?.status || assignment.status,
+    status: execution.status,
     blocking_signal: "stale_unknown",
     status_summary: "active assignment has not changed recently",
-    linked_task_id: assignment.execution?.task_id || assignment.task_id,
-    linked_run_id: assignment.execution?.run_id || assignment.run_id,
-    linked_chat_id: assignment.chat_session_id,
+    linked_task_id: execution.taskID,
+    linked_run_id: execution.runID,
+    linked_chat_id: execution.chatSessionID,
     artifact_summary: { count: assignment.execution?.artifact_count ?? 0 },
     updated_at: assignment.updated_at,
   };
@@ -727,10 +731,7 @@ function activityAttention(
   actionLabel: string,
   bucket: ProjectActivityBucketKey,
 ): ProjectHealthAttention {
-  const taskID =
-    item.linked_task_id || item.assignment.execution?.task_id || item.assignment.task_id;
-  const runID = item.linked_run_id || item.assignment.execution?.run_id || item.assignment.run_id;
-  const chatID = item.linked_chat_id || item.assignment.chat_session_id;
+  const execution = toProjectActivityAssignmentExecutionViewModel(item);
   return {
     id: item.id,
     title: `${title}: ${item.work_item.title}`,
@@ -744,9 +745,9 @@ function activityAttention(
     status: item.blocking_signal || item.status,
     bucket,
     workItemID: item.work_item.id,
-    taskID,
-    runID,
-    chatID,
+    taskID: execution.taskID,
+    runID: execution.runID,
+    chatID: execution.chatSessionID,
     actionLabel,
   };
 }

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -47,6 +47,7 @@ export type ChatSessionSummaryRecord = {
 
 export type ChatMessageRecord = {
   id: string;
+  turn_kind?: "direct_model" | "hecate_task" | "external_agent" | string;
   execution_mode?: "external_agent" | "hecate_task" | string;
   // tools_enabled is the per-turn tools-on/off signal the gateway
   // recorded when this message was appended.
@@ -91,6 +92,7 @@ export type ChatContextItemRecord = ContextPacketItemRecord;
 
 export type ChatSegmentRecord = {
   id: string;
+  turn_kind?: "direct_model" | "hecate_task" | "external_agent" | string;
   execution_mode: "external_agent" | "hecate_task" | string;
   tools_enabled?: boolean;
   provider?: string;

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -544,6 +544,19 @@ export type ProjectAssignmentExecutionSummary = {
   missing?: boolean;
 };
 
+export type ProjectAssignmentExecutionRefRecord = {
+  kind: "task_run" | "chat_session" | "context_snapshot" | "none" | string;
+  task_id?: string;
+  run_id?: string;
+  chat_session_id?: string;
+  message_id?: string;
+  context_snapshot_id?: string;
+  status?: ProjectAssignmentStatus | string;
+  pending_approval_count?: number;
+  trace_id?: string;
+  missing?: boolean;
+};
+
 export type ProjectAssignmentRecord = {
   id: string;
   project_id: string;
@@ -560,6 +573,7 @@ export type ProjectAssignmentRecord = {
   updated_at: string;
   started_at?: string;
   completed_at?: string;
+  execution_ref?: ProjectAssignmentExecutionRefRecord;
   execution?: ProjectAssignmentExecutionSummary;
 };
 


### PR DESCRIPTION
## Summary

- add chat turn view models so UI routing prefers `turn_kind` and falls back to legacy `execution_mode` / `tools_enabled`
- add project assignment execution view models so assignment links prefer `execution_ref` and keep legacy fallbacks in one place
- expose canonical API response fields: chat message/segment `turn_kind` and assignment `execution_ref`
- update runtime docs for the new response fields

## Commits

- `refactor(ui): add chat turn view models`
- `refactor(ui): add project assignment execution view models`
- `refactor(api): expose canonical chat and assignment refs`

## Verification

- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `go test ./internal/api`
- `go vet ./internal/api`
- `go test -tags e2e -run 'Test(ChatSessionApplicationLayerLifecycleE2E|ProjectActivityProjectionE2E)' ./e2e`
- `just docs-format-check`
- `just check-links`
- `go test -race -timeout 10m ./...`
