### PR TITLE
refactor(projects): tighten project contract boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ internal/
                           create, external-agent prepare, native session cleanup,
                           session reads/rename, config option writes, Hecate
                           Chat settings, message admission/dispatch planning
-  chatcontext/          pure context-packet lookup/decode helpers shared by API
-                          context endpoints
+  chatcontext/          pure context-packet lookup/decode/normalize helpers and
+                          canonical ref builders shared by API context endpoints
   projects/             durable project identity store (memory / sqlite)
   projectskills/        project-scoped SKILL.md metadata registry
                           (memory / sqlite; no body injection or execution)
@@ -90,7 +90,8 @@ internal/
                           collaboration artifact storage (memory / sqlite)
   projectworkapp/       project work application layer used by API handlers:
                           command shaping, id defaults, driver defaults,
-                          store error boundaries
+                          store error boundaries, execution refs, activity
+                          projection/status signals
   providerapp/          settings provider application layer used by API handlers:
                           settings status, policy rules, provider
                           create/update/delete, API key rotate/clear

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -133,10 +133,13 @@ runner orchestration to `handler_project_work.go`. Keep app-layer dependencies
 narrow: define the minimal store/runner interfaces the command needs instead
 of accepting broad subsystem stores by habit.
 
-Project activity is a read/projection surface: keep its response DTOs,
-linked-chat summaries, artifact/handoff signal grouping, and bucket/status
-summaries in `internal/api/handler_project_activity.go`. Avoid adding activity
-projection helpers back to `handler_project_work.go`.
+Project activity is a read/projection surface with split ownership:
+`internal/projectworkapp` owns assignment execution refs, task/run projection,
+blocking signals, bucket/status summaries, stale/missing detection, and
+canonical linked runtime ids. `internal/api/handler_project_activity.go` owns
+HTTP response DTOs, linked-chat loading/rendering, and artifact/handoff grouping.
+Do not rebuild assignment activity decisions in UI or handlers from raw
+`task_id`/`run_id`/`chat_session_id`; use the `execution_ref` / projection seams.
 
 ### Change chat-session / ACP adapter behavior
 
@@ -186,7 +189,10 @@ Chat context endpoints use `internal/chatcontext` for pure context-packet
 lookup/decode, normalization, cloning, and marshaling helpers. Keep larger
 project/context assembly close to the API until it has a narrow dependency
 shape; move pure packet operations into `chatcontext` instead of duplicating
-JSON decode, reference merging, or transcript scans.
+JSON decode, reference merging, or transcript scans. Compose refs with
+`chatcontext.ChatMessageRefs`, `TaskRunRefs`, `ProjectAssignmentRefs`, and
+`MergeRefs`; do not hand-roll ad hoc `chat.ContextRefs` structs in new
+call sites unless you are constructing the packet body itself.
 
 ### Change provider settings APIs
 

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -186,6 +186,14 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
 - External Agent file changes are already applied to the selected workspace when
   Hecate captures them. UI copy should say "inspect" / "revert" / "keep", not
   "apply", unless the backend grows a true staged-artifact flow.
+- Project assignment UI reads canonical backend contracts. `turn_kind` is the
+  chat turn discriminator, and project assignment runtime links come from
+  `execution_ref` / activity linked ids. Do not infer task-backed, direct-model,
+  or external-agent state from legacy `execution_mode`, `tools_enabled`, raw
+  `task_id`, raw `run_id`, or `chat_session_id` fields. Project rows, activity,
+  health, and timeline surfaces should use
+  `ui/src/features/projects/projectAssignmentViewModels.ts` instead of
+  reconstructing status/link logic in components.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -89,9 +89,9 @@ permission model.
   install skills, run scripts, grant tools, or change approval policy. Disabled,
   missing, invalid, or conflicting skills are skipped with warnings.
 - Assignment proposals create unstarted queued assignments. They cannot attach
-  execution evidence or links such as `task_id`, `run_id`, `chat_session_id`,
-  `message_id`, or `context_snapshot_id`; linking existing execution later
-  needs a separate explicit same-project action.
+  execution evidence or links such as `execution_ref`, `task_id`, `run_id`,
+  `chat_session_id`, `message_id`, or `context_snapshot_id`; linking existing
+  execution later needs a separate explicit same-project action.
 - Assistant code does not perform raw filesystem, shell, or Git access.
   Workspace-bound behavior must use WorkspaceFS, ProcessRunner, GitRunner, or
   existing task-runtime paths.
@@ -484,12 +484,13 @@ Drafting a proposal does not create a chat session, task, run, or assignment.
 Applying a proposal may create durable project records such as work items or
 queued assignments, but a queued assignment still does not start execution.
 Task/chat execution starts only through the assignment start flow, which may
-then attach `task_id`, `run_id`, or `chat_session_id` links to the assignment.
+then attach `execution_ref.task_id`, `execution_ref.run_id`, or
+`execution_ref.chat_session_id` links to the assignment.
 For `external_agent` assignments, "start" means "prepare the linked chat":
 Hecate creates and prepares the External Agent session, stores the assignment
-context packet, and links `chat_session_id`, but it does not append a visible
-chat message or send the first prompt. The operator sends that first prompt
-from Chats after reviewing the prepared session.
+context packet, and links `execution_ref.chat_session_id`, but it does not
+append a visible chat message or send the first prompt. The operator sends that
+first prompt from Chats after reviewing the prepared session.
 
 Project-launched Hecate chat drafts reuse an existing matching 0-message idle
 chat instead of creating another empty chat row. Once the operator sends a

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1540,10 +1540,12 @@ Supported structured handoff statuses are `pending`, `accepted`, `superseded`,
 and `dismissed`.
 
 Assignment responses are projected from linked canonical task/run state when
-`task_id` and `run_id` point at a Hecate task run. If `task_id` is present and
-`run_id` is empty, Hecate uses that task's `latest_run_id` when available. The
-stored assignment row is coordination metadata; reads do not mutate the task,
-run, or assignment rows. Run statuses map directly into assignment statuses:
+`execution_ref.kind="task_run"` and `execution_ref.task_id` /
+`execution_ref.run_id` point at a Hecate task run. If
+`execution_ref.task_id` is present and `execution_ref.run_id` is empty, Hecate
+uses that task's `latest_run_id` when available. The stored assignment row is
+coordination metadata; reads do not mutate the task, run, or assignment rows.
+Run statuses map directly into assignment statuses:
 
 | Task/run status     | Project assignment status |
 | ------------------- | ------------------------- |
@@ -1562,12 +1564,11 @@ runtime state. The `execution` summary may include `task_status`, `run_status`,
 projected `status`, pending approval count, step/approval/artifact counts,
 model/provider, last error, run timestamps, and trace ID.
 
-Assignments also include `execution_ref`, a compact canonical link projection
-for UI clients. It prefers projected execution data when available and falls
-back to stored links, with `kind` set to `task_run`, `chat_session`, or
-`context_snapshot`. Legacy raw link fields (`task_id`, `run_id`,
-`chat_session_id`, `message_id`, `context_snapshot_id`) and the richer
-`execution` summary remain for compatibility and detail views.
+Assignments include `execution_ref`, the canonical compact execution link for
+UI clients and API callers. It prefers projected execution data when available
+and falls back to stored links, with `kind` set to `task_run`, `chat_session`,
+or `context_snapshot`. The richer `execution` summary remains for detail views;
+raw top-level assignment link fields are not part of the alpha contract.
 
 Work-item list and detail responses apply the same conservative rollup over
 projected assignment statuses: any active linked assignment (`queued`,
@@ -1958,17 +1959,19 @@ Lists assignment metadata for a work item.
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 
 Creates an assignment metadata record. `role_id` is required. `driver_kind`
-defaults to `hecate_task`. Optional link fields (`task_id`, `run_id`,
-`chat_session_id`, `message_id`, `context_snapshot_id`) are stored as
-references only.
+defaults to `hecate_task`. Optional execution links are stored under
+`execution_ref` only.
 
 ```json
 {
   "role_id": "software_developer",
   "driver_kind": "hecate_task",
-  "task_id": "task_...",
-  "run_id": "run_...",
-  "context_snapshot_id": "ctx_..."
+  "execution_ref": {
+    "kind": "task_run",
+    "task_id": "task_...",
+    "run_id": "run_...",
+    "context_snapshot_id": "ctx_..."
+  }
 }
 ```
 
@@ -1984,9 +1987,6 @@ Returns:
     "role_id": "software_developer",
     "driver_kind": "hecate_task",
     "status": "queued",
-    "task_id": "task_...",
-    "run_id": "run_...",
-    "context_snapshot_id": "ctx_...",
     "execution_ref": {
       "kind": "task_run",
       "task_id": "task_...",
@@ -2022,8 +2022,8 @@ or external-agent execution.
 Returns the best available context packet for the assignment. Hecate resolves
 linked Task/Run packets first, then falls back to the assignment-stored packet
 created by an External Agent start, then to a linked Chat `chat_session_id` +
-`message_id` packet when present. Unstarted assignments, legacy rows without a
-stored packet or execution link, or older runs that predate snapshots return
+`message_id` from `execution_ref` when present. Unstarted assignments, rows
+without a stored packet or execution link, or older runs that predate snapshots return
 `404 not_found`. The Projects cockpit uses this endpoint for the assignment
 `Inspect context` action so operators can inspect the resolved profile, launch
 instructions, memory, project sources, work context, runtime refs, and skipped
@@ -2061,9 +2061,9 @@ or defaultless roots return `400 invalid_request`. A missing model returns
 The endpoint then starts the task through the canonical task runner, so normal
 task approvals, queueing, run events, artifacts, and SSE inspection apply. On
 success it also persists a structured context packet on the created run, updates
-`context_snapshot_id` to that packet id, then updates the assignment with
-`task_id`, latest `run_id`, status, and timestamps before returning the updated
-assignment:
+`execution_ref.context_snapshot_id` to that packet id, then updates the
+assignment with `execution_ref.task_id`, latest `execution_ref.run_id`, status,
+and timestamps before returning the updated assignment:
 
 The persisted context packet records the resolved profile and applies its
 project memory/context-source policies. `include` / `include_enabled` make the
@@ -2088,9 +2088,13 @@ model request.
     "role_id": "software_developer",
     "driver_kind": "hecate_task",
     "status": "queued",
-    "task_id": "task_...",
-    "run_id": "run_...",
-    "context_snapshot_id": "ctx_...",
+    "execution_ref": {
+      "kind": "task_run",
+      "task_id": "task_...",
+      "run_id": "run_...",
+      "context_snapshot_id": "ctx_...",
+      "status": "queued"
+    },
     "execution": {
       "task_id": "task_...",
       "run_id": "run_...",
@@ -2112,8 +2116,9 @@ Profile must name an `external_agent_kind` such as `codex`, `claude_code`,
 Hecate-owned launch controls for that adapter. Hecate validates the project
 workspace root, creates and prepares the chat session through the External Agent
 supervisor, stores a project assignment context packet on the assignment, and
-links `chat_session_id` plus `context_snapshot_id`. `task_id`, `run_id`, and
-`message_id` remain empty until the operator sends a turn in the linked chat.
+links `execution_ref.chat_session_id` plus
+`execution_ref.context_snapshot_id`. Task-run fields and `message_id` remain
+empty until the operator sends a turn in the linked chat.
 
 ```json
 {
@@ -2125,8 +2130,12 @@ links `chat_session_id` plus `context_snapshot_id`. `task_id`, `run_id`, and
     "role_id": "software_developer",
     "driver_kind": "external_agent",
     "status": "running",
-    "chat_session_id": "chat_...",
-    "context_snapshot_id": "ctx_...",
+    "execution_ref": {
+      "kind": "chat_session",
+      "chat_session_id": "chat_...",
+      "context_snapshot_id": "ctx_...",
+      "status": "running"
+    },
     "created_at": "2026-06-03T12:00:00Z",
     "updated_at": "2026-06-03T12:00:01Z",
     "started_at": "2026-06-03T12:00:01Z"
@@ -2138,8 +2147,9 @@ Repeated starts for an assignment that already has an active execution return
 `409` with the current assignment envelope and do not create another task/run.
 Assignments in terminal states (`completed`, `failed`, `cancelled`) also return
 `409`. If task creation succeeds but task start fails, Hecate keeps the
-assignment's `task_id`, marks the assignment `failed`, and returns an error so
-the operator can inspect the linked task instead of losing the partial state.
+assignment's `execution_ref.task_id`, marks the assignment `failed`, and returns
+an error so the operator can inspect the linked task instead of losing the
+partial state.
 
 #### `GET /hecate/v1/projects/{id}/handoffs`
 

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -607,12 +607,10 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 	}))
 	contextPacket := h.externalAgentContextPacket(r.Context(), session, adapter.Name)
 	contextPacket.ID = newChatID("ctx")
-	contextPacket = chatcontext.Normalize(contextPacket, chat.ContextRefs{
-		SessionID: session.ID,
-		MessageID: assistantID,
-		RunID:     runID,
-		ProjectID: session.ProjectID,
-	})
+	contextPacket = chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+		chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+		chatcontext.TaskRunRefs("", runID, session.ProjectID),
+	))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeExternalAgent,
@@ -794,12 +792,10 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		if result.DiffStat != "" {
 			message.Activities = append(message.Activities, newChatActivity("files_changed", "completed", "Files changed", result.DiffStat))
 		}
-		message.Context = chatcontext.Normalize(message.Context, chat.ContextRefs{
-			SessionID: session.ID,
-			MessageID: assistantID,
-			RunID:     runID,
-			ProjectID: session.ProjectID,
-		})
+		message.Context = chatcontext.Normalize(message.Context, chatcontext.MergeRefs(
+			chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+			chatcontext.TaskRunRefs("", runID, session.ProjectID),
+		))
 		message.Activities = append(message.Activities, newChatActivity(status, status, finalChatActivityTitle(status), errorText))
 	})
 	if err != nil {
@@ -927,12 +923,10 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 	history := agentChatModelHistory(session, strings.TrimSpace(req.SystemPrompt), content)
 	contextPacket := h.directModelContextPacket(r.Context(), session, provider, model, strings.TrimSpace(req.SystemPrompt))
 	contextPacket.ID = newChatID("ctx")
-	contextPacket = chatcontext.Normalize(contextPacket, chat.ContextRefs{
-		SessionID: session.ID,
-		MessageID: assistantID,
-		RunID:     runID,
-		ProjectID: session.ProjectID,
-	})
+	contextPacket = chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+		chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+		chatcontext.TaskRunRefs("", runID, session.ProjectID),
+	))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: chat.ExecutionModeHecateTask,
@@ -992,12 +986,10 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 				ContextUsed: result.Metadata.TotalTokens,
 			}
 		}
-		message.Context = chatcontext.Normalize(message.Context, chat.ContextRefs{
-			SessionID: session.ID,
-			MessageID: assistantID,
-			RunID:     message.RunID,
-			ProjectID: session.ProjectID,
-		})
+		message.Context = chatcontext.Normalize(message.Context, chatcontext.MergeRefs(
+			chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+			chatcontext.TaskRunRefs("", message.RunID, session.ProjectID),
+		))
 		message.Activities = append(message.Activities, newChatActivity(status, status, finalChatActivityTitle(status), errorText))
 	})
 	if err != nil {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -62,11 +62,7 @@ func (h *Handler) HandleChatMessageContext(w http.ResponseWriter, r *http.Reques
 		if message.ID != messageID {
 			continue
 		}
-		writeChatContextPacket(w, chatcontext.Normalize(message.Context, chat.ContextRefs{
-			SessionID: sessionID,
-			MessageID: messageID,
-			ProjectID: session.ProjectID,
-		}))
+		writeChatContextPacket(w, chatcontext.Normalize(message.Context, chatcontext.ChatMessageRefs(sessionID, messageID, session.ProjectID)))
 		return
 	}
 	WriteError(w, http.StatusNotFound, errCodeNotFound, "agent chat message not found")
@@ -95,10 +91,7 @@ func (h *Handler) HandleTaskRunContext(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "task run context packet not found; the run may predate context snapshots or have no linked run/chat packet")
 		return
 	}
-	writeChatContextPacket(w, chatcontext.Normalize(packet, chat.ContextRefs{
-		TaskID: task.ID,
-		RunID:  run.ID,
-	}))
+	writeChatContextPacket(w, chatcontext.Normalize(packet, chatcontext.TaskRunRefs(task.ID, run.ID, task.ProjectID)))
 }
 
 func writeChatContextPacket(w http.ResponseWriter, packet chat.ContextPacket) {
@@ -140,16 +133,11 @@ func (h *Handler) HandleProjectWorkAssignmentContext(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project assignment context packet not found")
 		return
 	}
-	writeChatContextPacket(w, chatcontext.Normalize(packet, chat.ContextRefs{
-		ProjectID:    projectID,
-		WorkItemID:   workItemID,
-		AssignmentID: assignmentID,
-		RoleID:       assignment.RoleID,
-		TaskID:       assignment.TaskID,
-		RunID:        assignment.RunID,
-		SessionID:    assignment.ChatSessionID,
-		MessageID:    assignment.MessageID,
-	}))
+	writeChatContextPacket(w, chatcontext.Normalize(packet, chatcontext.MergeRefs(
+		chatcontext.ProjectAssignmentRefs(projectID, workItemID, assignmentID, assignment.RoleID),
+		chatcontext.TaskRunRefs(assignment.TaskID, assignment.RunID, projectID),
+		chatcontext.ChatMessageRefs(assignment.ChatSessionID, assignment.MessageID, projectID),
+	)))
 }
 
 func (h *Handler) contextPacketForTaskRun(ctx context.Context, task types.Task, run types.TaskRun) (chat.ContextPacket, bool, error) {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -135,8 +135,8 @@ func (h *Handler) HandleProjectWorkAssignmentContext(w http.ResponseWriter, r *h
 	}
 	writeChatContextPacket(w, chatcontext.Normalize(packet, chatcontext.MergeRefs(
 		chatcontext.ProjectAssignmentRefs(projectID, workItemID, assignmentID, assignment.RoleID),
-		chatcontext.TaskRunRefs(assignment.TaskID, assignment.RunID, projectID),
-		chatcontext.ChatMessageRefs(assignment.ChatSessionID, assignment.MessageID, projectID),
+		chatcontext.TaskRunRefs(assignment.ExecutionRef.TaskID, assignment.ExecutionRef.RunID, projectID),
+		chatcontext.ChatMessageRefs(assignment.ExecutionRef.ChatSessionID, assignment.ExecutionRef.MessageID, projectID),
 	)))
 }
 
@@ -175,13 +175,14 @@ func (h *Handler) contextPacketForTaskRun(ctx context.Context, task types.Task, 
 }
 
 func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignment projectwork.Assignment) (chat.ContextPacket, bool, error) {
-	if h != nil && h.taskStore != nil && strings.TrimSpace(assignment.TaskID) != "" && strings.TrimSpace(assignment.RunID) != "" {
-		task, ok, err := h.taskStore.GetTask(ctx, assignment.TaskID)
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	if h != nil && h.taskStore != nil && strings.TrimSpace(ref.TaskID) != "" && strings.TrimSpace(ref.RunID) != "" {
+		task, ok, err := h.taskStore.GetTask(ctx, ref.TaskID)
 		if err != nil {
 			return chat.ContextPacket{}, false, err
 		}
 		if ok {
-			run, ok, err := h.taskStore.GetRun(ctx, assignment.TaskID, assignment.RunID)
+			run, ok, err := h.taskStore.GetRun(ctx, ref.TaskID, ref.RunID)
 			if err != nil {
 				return chat.ContextPacket{}, false, err
 			}
@@ -196,15 +197,15 @@ func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignm
 	if packet, ok, err := chatcontext.FromProjectAssignmentPayload(assignment.ContextPacket); err != nil || ok {
 		return packet, ok, err
 	}
-	if h == nil || h.agentChat == nil || strings.TrimSpace(assignment.ChatSessionID) == "" || strings.TrimSpace(assignment.MessageID) == "" {
+	if h == nil || h.agentChat == nil || strings.TrimSpace(ref.ChatSessionID) == "" || strings.TrimSpace(ref.MessageID) == "" {
 		return chat.ContextPacket{}, false, nil
 	}
-	session, ok, err := h.agentChat.Get(ctx, assignment.ChatSessionID)
+	session, ok, err := h.agentChat.Get(ctx, ref.ChatSessionID)
 	if err != nil || !ok {
 		return chat.ContextPacket{}, false, err
 	}
 	for _, message := range session.Messages {
-		if message.ID != strings.TrimSpace(assignment.MessageID) {
+		if message.ID != strings.TrimSpace(ref.MessageID) {
 			continue
 		}
 		packet, found := chatcontext.FromSessionMessage(session, message.ID)
@@ -374,9 +375,10 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 	packet.ID = newChatID("ctx")
 	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
 	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role, profile, promptContext)) != ""
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
 	packet.Refs = &chat.ContextRefs{
-		TaskID:       strings.TrimSpace(assignment.TaskID),
-		RunID:        strings.TrimSpace(assignment.RunID),
+		TaskID:       strings.TrimSpace(ref.TaskID),
+		RunID:        strings.TrimSpace(ref.RunID),
 		ProjectID:    strings.TrimSpace(project.ID),
 		WorkItemID:   strings.TrimSpace(workItem.ID),
 		AssignmentID: strings.TrimSpace(assignment.ID),

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -138,12 +138,10 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 
 	contextPacket := h.hecateTaskContextPacket(r.Context(), session, messageSnapshot.Provider, messageSnapshot.Model, strings.TrimSpace(req.SystemPrompt), forceNewTask)
 	contextPacket.ID = newChatID("ctx")
-	contextPacket = chatcontext.Normalize(contextPacket, chat.ContextRefs{
-		SessionID: session.ID,
-		MessageID: assistantID,
-		TaskID:    messageSnapshot.TaskID,
-		ProjectID: session.ProjectID,
-	})
+	contextPacket = chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+		chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+		chatcontext.TaskRunRefs(messageSnapshot.TaskID, "", session.ProjectID),
+	))
 	updated, err = h.agentChat.AppendMessage(r.Context(), session.ID, chat.Message{
 		ID:            assistantID,
 		ExecutionMode: messageSnapshot.ExecutionMode,
@@ -231,13 +229,10 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		message.Provider = messageSnapshot.Provider
 		message.Model = messageSnapshot.Model
 		message.Capabilities = messageSnapshot.Capabilities
-		message.Context = chatcontext.Normalize(message.Context, chat.ContextRefs{
-			SessionID: session.ID,
-			MessageID: assistantID,
-			TaskID:    task.ID,
-			RunID:     run.ID,
-			ProjectID: session.ProjectID,
-		})
+		message.Context = chatcontext.Normalize(message.Context, chatcontext.MergeRefs(
+			chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),
+			chatcontext.TaskRunRefs(task.ID, run.ID, session.ProjectID),
+		))
 		message.Activities = mergeChatActivity(message.Activities, newHecateAgentRunActivity(task.ID, run.ID, run.Status))
 	})
 	if err == nil {
@@ -395,7 +390,7 @@ func shouldStartNewHecateAgentSegment(session chat.Session, provider, model stri
 		if strings.TrimSpace(message.Content) == "" && message.Role == "assistant" {
 			continue
 		}
-		if chatMessageTurnKind(session, message) != chatTurnKindHecateTask {
+		if chat.MessageTurnKind(session, message) != chat.TurnKindHecateTask {
 			return true
 		}
 		if provider != "" && strings.TrimSpace(message.Provider) != "" && strings.TrimSpace(message.Provider) != provider {
@@ -445,12 +440,10 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 				message.RequestID = firstNonEmpty(run.RequestID, message.RequestID)
 				message.TraceID = firstNonEmpty(run.TraceID, message.TraceID)
 				message.SpanID = firstNonEmpty(run.RootSpanID, message.SpanID)
-				message.Context = chatcontext.Normalize(message.Context, chat.ContextRefs{
-					SessionID: sessionID,
-					MessageID: messageID,
-					TaskID:    taskID,
-					RunID:     run.ID,
-				})
+				message.Context = chatcontext.Normalize(message.Context, chatcontext.MergeRefs(
+					chatcontext.ChatMessageRefs(sessionID, messageID, ""),
+					chatcontext.TaskRunRefs(taskID, run.ID, ""),
+				))
 				message.Status = agentChatStatusFromTaskRun(run.Status)
 				if liveContent != "" {
 					message.Content = liveContent

--- a/internal/api/handler_chat_hecate_task.go
+++ b/internal/api/handler_chat_hecate_task.go
@@ -102,12 +102,10 @@ func (o hecateAgentTaskOrchestrator) startNewTask(ctx context.Context, cmd hecat
 		return types.Task{}, types.TaskRun{}, err
 	}
 	result, err := o.runner.StartTaskWithRunInitializer(ctx, task, o.resourceID, func(run *types.TaskRun) {
-		run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(cmd.ContextPacket, chat.ContextRefs{
-			SessionID: cmd.Session.ID,
-			TaskID:    task.ID,
-			RunID:     run.ID,
-			ProjectID: cmd.Session.ProjectID,
-		}))
+		run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(cmd.ContextPacket, chatcontext.MergeRefs(
+			chatcontext.ChatMessageRefs(cmd.Session.ID, "", cmd.Session.ProjectID),
+			chatcontext.TaskRunRefs(task.ID, run.ID, cmd.Session.ProjectID),
+		)))
 	})
 	if err != nil {
 		return types.Task{}, types.TaskRun{}, err
@@ -131,12 +129,10 @@ func (o hecateAgentTaskOrchestrator) continueTask(ctx context.Context, cmd hecat
 		return types.Task{}, types.TaskRun{}, fmt.Errorf("latest task run %q not found", cmd.Session.LatestRunID)
 	}
 	result, err := o.runner.ContinueAgentTaskWithRunInitializer(ctx, task, run, cmd.Prompt, o.resourceID, func(nextRun *types.TaskRun) {
-		nextRun.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(cmd.ContextPacket, chat.ContextRefs{
-			SessionID: cmd.Session.ID,
-			TaskID:    task.ID,
-			RunID:     nextRun.ID,
-			ProjectID: cmd.Session.ProjectID,
-		}))
+		nextRun.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(cmd.ContextPacket, chatcontext.MergeRefs(
+			chatcontext.ChatMessageRefs(cmd.Session.ID, "", cmd.Session.ProjectID),
+			chatcontext.TaskRunRefs(task.ID, nextRun.ID, cmd.Session.ProjectID),
+		)))
 	})
 	if err != nil {
 		return types.Task{}, types.TaskRun{}, err

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -443,8 +443,8 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if modelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || modelAssistant.TaskID != "" || modelAssistant.Model != "gpt-4o-mini" {
 		t.Fatalf("model assistant snapshot = execution_mode %q task %q model %q", modelAssistant.ExecutionMode, modelAssistant.TaskID, modelAssistant.Model)
 	}
-	if modelAssistant.TurnKind != chatTurnKindDirectModel {
-		t.Fatalf("model assistant turn_kind = %q, want %q", modelAssistant.TurnKind, chatTurnKindDirectModel)
+	if modelAssistant.TurnKind != chat.TurnKindDirectModel {
+		t.Fatalf("model assistant turn_kind = %q, want %q", modelAssistant.TurnKind, chat.TurnKindDirectModel)
 	}
 	if modelAssistant.ToolsEnabled {
 		t.Errorf("model assistant tools_enabled = true, want false (hecate_task dispatch records tools-off)")
@@ -463,8 +463,8 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if toolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || toolsAssistant.TaskID != firstTaskID || toolsAssistant.SegmentID != "task:"+firstTaskID {
 		t.Fatalf("tools assistant snapshot = execution_mode %q task %q segment %q", toolsAssistant.ExecutionMode, toolsAssistant.TaskID, toolsAssistant.SegmentID)
 	}
-	if toolsAssistant.TurnKind != chatTurnKindHecateTask {
-		t.Fatalf("tools assistant turn_kind = %q, want %q", toolsAssistant.TurnKind, chatTurnKindHecateTask)
+	if toolsAssistant.TurnKind != chat.TurnKindHecateTask {
+		t.Fatalf("tools assistant turn_kind = %q, want %q", toolsAssistant.TurnKind, chat.TurnKindHecateTask)
 	}
 	if !toolsAssistant.ToolsEnabled {
 		t.Errorf("tools assistant tools_enabled = false, want true (hecate_task dispatch records tools-on)")
@@ -479,8 +479,8 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if secondModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondModelAssistant.TaskID != "" {
 		t.Fatalf("second model assistant snapshot = execution_mode %q task %q", secondModelAssistant.ExecutionMode, secondModelAssistant.TaskID)
 	}
-	if secondModelAssistant.TurnKind != chatTurnKindDirectModel {
-		t.Fatalf("second model assistant turn_kind = %q, want %q", secondModelAssistant.TurnKind, chatTurnKindDirectModel)
+	if secondModelAssistant.TurnKind != chat.TurnKindDirectModel {
+		t.Fatalf("second model assistant turn_kind = %q, want %q", secondModelAssistant.TurnKind, chat.TurnKindDirectModel)
 	}
 	if secondModelAssistant.ToolsEnabled {
 		t.Fatalf("second model assistant tools_enabled = true, want false (direct-model turn)")
@@ -495,8 +495,8 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if secondToolsAssistant.ExecutionMode != chat.ExecutionModeHecateTask || secondToolsAssistant.TaskID != secondTools.Data.TaskID || secondToolsAssistant.SegmentID != "task:"+secondTools.Data.TaskID {
 		t.Fatalf("second tools assistant snapshot = execution_mode %q task %q segment %q", secondToolsAssistant.ExecutionMode, secondToolsAssistant.TaskID, secondToolsAssistant.SegmentID)
 	}
-	if secondToolsAssistant.TurnKind != chatTurnKindHecateTask {
-		t.Fatalf("second tools assistant turn_kind = %q, want %q", secondToolsAssistant.TurnKind, chatTurnKindHecateTask)
+	if secondToolsAssistant.TurnKind != chat.TurnKindHecateTask {
+		t.Fatalf("second tools assistant turn_kind = %q, want %q", secondToolsAssistant.TurnKind, chat.TurnKindHecateTask)
 	}
 
 	changedModelTools := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
@@ -508,8 +508,8 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 	if changedModelAssistant.ExecutionMode != chat.ExecutionModeHecateTask || changedModelAssistant.TaskID != changedModelTools.Data.TaskID || changedModelAssistant.Model != "gpt-4o-mini-2024-07-18" {
 		t.Fatalf("model-change assistant snapshot = execution_mode %q task %q model %q", changedModelAssistant.ExecutionMode, changedModelAssistant.TaskID, changedModelAssistant.Model)
 	}
-	if changedModelAssistant.TurnKind != chatTurnKindHecateTask {
-		t.Fatalf("model-change assistant turn_kind = %q, want %q", changedModelAssistant.TurnKind, chatTurnKindHecateTask)
+	if changedModelAssistant.TurnKind != chat.TurnKindHecateTask {
+		t.Fatalf("model-change assistant turn_kind = %q, want %q", changedModelAssistant.TurnKind, chat.TurnKindHecateTask)
 	}
 	changedTask := mustRequestJSON[TaskResponse](client, http.MethodGet, "/hecate/v1/tasks/"+changedModelTools.Data.TaskID, "")
 	if changedTask.Data.RequestedModel != "gpt-4o-mini-2024-07-18" {
@@ -527,7 +527,7 @@ func TestHecateChatCanSwitchBetweenModelAndToolsSegments(t *testing.T) {
 		if segment.ExecutionMode != chat.ExecutionModeHecateTask {
 			t.Fatalf("segment %d execution_mode = %q, want hecate_task: %+v", i, segment.ExecutionMode, segments)
 		}
-		wantKind := []string{chatTurnKindDirectModel, chatTurnKindHecateTask, chatTurnKindDirectModel, chatTurnKindHecateTask, chatTurnKindHecateTask}[i]
+		wantKind := []string{chat.TurnKindDirectModel, chat.TurnKindHecateTask, chat.TurnKindDirectModel, chat.TurnKindHecateTask, chat.TurnKindHecateTask}[i]
 		if segment.TurnKind != wantKind {
 			t.Fatalf("segment %d turn_kind = %q, want %q: %+v", i, segment.TurnKind, wantKind, segments)
 		}

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -58,7 +58,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 	for _, message := range session.Messages {
 		messages = append(messages, ChatMessageItem{
 			ID:              message.ID,
-			TurnKind:        chatMessageTurnKind(session, message),
+			TurnKind:        chat.MessageTurnKind(session, message),
 			ExecutionMode:   message.ExecutionMode,
 			ToolsEnabled:    message.ToolsEnabled,
 			SegmentID:       message.SegmentID,
@@ -203,7 +203,7 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 			builders = append(builders, agentChatSegmentBuilder{
 				item: ChatSegmentItem{
 					ID:            segmentID,
-					TurnKind:      chatMessageTurnKind(session, message),
+					TurnKind:      chat.MessageTurnKind(session, message),
 					ExecutionMode: firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session)),
 					ToolsEnabled:  message.ToolsEnabled,
 					Provider:      firstNonEmpty(message.Provider, session.Provider),
@@ -219,7 +219,7 @@ func renderChatSegments(session chat.Session) []ChatSegmentItem {
 			builder.item.ExecutionMode = firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
 		}
 		if builder.item.TurnKind == "" {
-			builder.item.TurnKind = chatMessageTurnKind(session, message)
+			builder.item.TurnKind = chat.MessageTurnKind(session, message)
 		}
 		if message.ToolsEnabled {
 			builder.item.ToolsEnabled = true
@@ -306,33 +306,6 @@ func defaultMessageExecutionModeForRender(session chat.Session) string {
 	// recorded on the per-message ToolsEnabled field, not on the
 	// execution_mode string.
 	return chat.ExecutionModeHecateTask
-}
-
-const (
-	chatTurnKindDirectModel   = "direct_model"
-	chatTurnKindHecateTask    = "hecate_task"
-	chatTurnKindExternalAgent = "external_agent"
-)
-
-func chatMessageTurnKind(session chat.Session, message chat.Message) string {
-	executionMode := firstNonEmpty(message.ExecutionMode, defaultMessageExecutionModeForRender(session))
-	switch executionMode {
-	case chat.ExecutionModeExternalAgent:
-		return chatTurnKindExternalAgent
-	case chat.ExecutionModeHecateTask:
-		if !message.ToolsEnabled {
-			return chatTurnKindDirectModel
-		}
-		return chatTurnKindHecateTask
-	default:
-		if message.AgentID != "" && message.AgentID != chat.DefaultAgentID {
-			return chatTurnKindExternalAgent
-		}
-		if message.TaskID != "" {
-			return chatTurnKindHecateTask
-		}
-		return ""
-	}
 }
 
 func agentChatUsageFromResult(usage agentadapters.Usage) chat.Usage {

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 type ProjectActivityEnvelope struct {
@@ -255,30 +255,94 @@ func latestProjectActivityChatMessage(messages []chat.Message) *chat.Message {
 func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, role projectwork.AgentRoleProfile, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, linkedChat *ProjectActivityLinkedChatResponse) ProjectActivityItemResponse {
 	artifactSummary, recentArtifacts := renderProjectActivityArtifactSignals(artifacts)
 	handoffSummary, recentHandoffs := renderProjectActivityHandoffSignals(handoffs)
-	status := strings.TrimSpace(projectActivityProjectedStatus(assignment, linkedChat))
-	if status == "" {
-		status = "unknown"
-	}
-	signal := projectActivityBlockingSignal(assignment, linkedChat)
+	state := projectworkapp.ProjectActivityAssignmentState(projectActivityAssignmentInput(assignment, linkedChat, artifactSummary.Count))
 	return ProjectActivityItemResponse{
 		ID:              assignment.ID,
 		ProjectID:       assignment.ProjectID,
 		WorkItem:        renderProjectActivityWorkItem(workItem),
 		Assignment:      assignment,
 		Role:            renderProjectWorkRole(role),
-		Status:          status,
-		BlockingSignal:  signal,
-		StatusSummary:   projectActivityStatusSummary(assignment, linkedChat, signal, artifactSummary.Count),
-		LinkedTaskID:    firstNonEmpty(projectActivityExecutionTaskID(assignment), assignment.TaskID),
-		LinkedRunID:     firstNonEmpty(projectActivityExecutionRunID(assignment), assignment.RunID),
-		LinkedChatID:    firstNonEmpty(projectActivityExecutionChatID(assignment), assignment.ChatSessionID),
+		Status:          state.Status,
+		BlockingSignal:  state.BlockingSignal,
+		StatusSummary:   state.StatusSummary,
+		LinkedTaskID:    state.LinkedTaskID,
+		LinkedRunID:     state.LinkedRunID,
+		LinkedChatID:    state.LinkedChatID,
 		LinkedChat:      linkedChat,
-		LinkedMessageID: assignment.MessageID,
+		LinkedMessageID: projectActivityExecutionMessageID(assignment),
 		RecentArtifacts: recentArtifacts,
 		ArtifactSummary: artifactSummary,
 		RecentHandoffs:  recentHandoffs,
 		HandoffSummary:  handoffSummary,
 		UpdatedAt:       projectActivityUpdatedAt(workItem, assignment, linkedChat, artifactSummary, handoffSummary),
+	}
+}
+
+func projectActivityAssignmentInput(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, artifactCount int) projectworkapp.ActivityAssignmentInput {
+	return projectworkapp.ActivityAssignmentInput{
+		Status:        assignment.Status,
+		TaskID:        assignment.TaskID,
+		RunID:         assignment.RunID,
+		ChatSessionID: assignment.ChatSessionID,
+		Execution:     projectActivityExecutionSummaryForApp(assignment.Execution),
+		ExecutionRef:  projectActivityExecutionRefForApp(assignment.ExecutionRef),
+		LinkedChat:    projectActivityLinkedChatForApp(linkedChat),
+		ArtifactCount: artifactCount,
+	}
+}
+
+func projectActivityExecutionSummaryForApp(execution *ProjectWorkAssignmentExecutionResponse) *projectworkapp.AssignmentExecutionSummary {
+	if execution == nil {
+		return nil
+	}
+	return &projectworkapp.AssignmentExecutionSummary{
+		TaskID:               execution.TaskID,
+		RunID:                execution.RunID,
+		TaskStatus:           execution.TaskStatus,
+		RunStatus:            execution.RunStatus,
+		Status:               execution.Status,
+		PendingApprovalCount: execution.PendingApprovalCount,
+		StepCount:            execution.StepCount,
+		ApprovalCount:        execution.ApprovalCount,
+		ArtifactCount:        execution.ArtifactCount,
+		Model:                execution.Model,
+		Provider:             execution.Provider,
+		LastError:            execution.LastError,
+		TraceID:              execution.TraceID,
+		Missing:              execution.Missing,
+	}
+}
+
+func projectActivityExecutionRefForApp(ref *ProjectWorkAssignmentExecutionRefResponse) *projectworkapp.AssignmentExecutionRef {
+	if ref == nil {
+		return nil
+	}
+	return &projectworkapp.AssignmentExecutionRef{
+		Kind:                 ref.Kind,
+		TaskID:               ref.TaskID,
+		RunID:                ref.RunID,
+		ChatSessionID:        ref.ChatSessionID,
+		MessageID:            ref.MessageID,
+		ContextSnapshotID:    ref.ContextSnapshotID,
+		Status:               ref.Status,
+		PendingApprovalCount: ref.PendingApprovalCount,
+		TraceID:              ref.TraceID,
+		Missing:              ref.Missing,
+	}
+}
+
+func projectActivityLinkedChatForApp(linkedChat *ProjectActivityLinkedChatResponse) *projectworkapp.ActivityLinkedChat {
+	if linkedChat == nil {
+		return nil
+	}
+	return &projectworkapp.ActivityLinkedChat{
+		ID:           linkedChat.ID,
+		Status:       linkedChat.Status,
+		LatestRole:   linkedChat.LatestRole,
+		LatestStatus: linkedChat.LatestStatus,
+		LatestError:  linkedChat.LatestError,
+		MessageCount: linkedChat.MessageCount,
+		Missing:      linkedChat.Missing,
 	}
 }
 
@@ -311,7 +375,7 @@ func renderProjectActivityArtifactSignals(artifacts []projectwork.CollaborationA
 		Count:        len(items),
 		LatestKind:   latest.Kind,
 		LatestTitle:  firstNonEmpty(latest.Title, latest.ID),
-		LatestAt:     formatOptionalTime(firstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
+		LatestAt:     formatOptionalTime(projectworkapp.FirstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
 		AssignmentID: latest.AssignmentID,
 	}
 	limit := len(items)
@@ -358,7 +422,7 @@ func renderProjectActivityHandoffSignals(handoffs []projectwork.Handoff) (Projec
 		Count:          len(items),
 		LatestStatus:   latest.Status,
 		LatestTitle:    firstNonEmpty(latest.Title, latest.ID),
-		LatestAt:       formatOptionalTime(firstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
+		LatestAt:       formatOptionalTime(projectworkapp.FirstNonZeroTime(latest.UpdatedAt, latest.CreatedAt)),
 		AssignmentID:   latest.SourceAssignmentID,
 		TargetRoleID:   latest.TargetRoleID,
 		TargetWorkItem: latest.TargetWorkItemID,
@@ -423,168 +487,14 @@ func boundedProjectActivityItems(items []ProjectActivityItemResponse, limit int)
 }
 
 func projectActivityBucket(item ProjectActivityItemResponse) string {
-	switch item.BlockingSignal {
-	case "awaiting_approval", "failed", "cancelled", "not_started", "stale_unknown":
-		return "blocked"
-	case "completed":
-		return "completed"
-	case "running":
-		return "active"
-	default:
-		return "active"
-	}
+	return projectworkapp.ProjectActivityBucket(item.BlockingSignal)
 }
 
-func projectActivityBlockingSignal(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse) string {
-	if linkedChat != nil && linkedChat.Missing {
-		return "stale_unknown"
-	}
-	status := strings.TrimSpace(projectActivityProjectedStatus(assignment, linkedChat))
-	switch status {
-	case projectwork.AssignmentStatusAwaitingApproval:
-		return "awaiting_approval"
-	case projectwork.AssignmentStatusFailed:
-		return "failed"
-	case projectwork.AssignmentStatusCancelled, "closed":
-		return "cancelled"
-	case projectwork.AssignmentStatusCompleted:
-		return "completed"
-	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusQueued:
-		if assignment.Execution == nil && assignment.TaskID == "" && assignment.RunID != "" {
-			return "stale_unknown"
-		}
-		if assignment.Execution != nil && assignment.Execution.Missing {
-			return "stale_unknown"
-		}
-		if status == projectwork.AssignmentStatusQueued && assignment.TaskID == "" && assignment.RunID == "" && assignment.ChatSessionID == "" {
-			return "not_started"
-		}
-		return "running"
-	default:
-		if assignment.Execution != nil && assignment.Execution.Missing {
-			return "stale_unknown"
-		}
-		return "stale_unknown"
-	}
-}
-
-func projectActivityStatusSummary(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, signal string, artifactCount int) string {
-	switch signal {
-	case "awaiting_approval":
-		count := 0
-		if assignment.Execution != nil {
-			count = assignment.Execution.PendingApprovalCount
-		}
-		if count > 0 {
-			return fmt.Sprintf("%d approval pending", count)
-		}
-		return "awaiting approval"
-	case "failed":
-		if linkedChat != nil && linkedChat.LatestError != "" {
-			return linkedChat.LatestError
-		}
-		if assignment.Execution != nil && assignment.Execution.LastError != "" {
-			return assignment.Execution.LastError
-		}
-		if linkedChat != nil {
-			return "linked chat failed"
-		}
-		return "failed run"
-	case "cancelled":
-		if linkedChat != nil {
-			return "linked chat cancelled"
-		}
-		return "cancelled"
-	case "not_started":
-		return "not started"
-	case "running":
-		if linkedChat != nil {
-			return projectActivityLinkedChatSummary(linkedChat)
-		}
-		return "running"
-	case "completed":
-		if artifactCount > 0 {
-			return fmt.Sprintf("completed with %d artifact%s", artifactCount, pluralSuffix(artifactCount))
-		}
-		return "completed"
-	default:
-		if linkedChat != nil && linkedChat.Missing {
-			return "linked chat missing"
-		}
-		return "stale or unknown"
-	}
-}
-
-func projectActivityProjectedStatus(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse) string {
-	if linkedChat != nil {
-		if linkedChat.Missing {
-			return "stale_unknown"
-		}
-		if status := strings.TrimSpace(linkedChat.Status); status != "" && status != "idle" {
-			return status
-		}
-		if status := strings.TrimSpace(linkedChat.LatestStatus); status != "" {
-			return status
-		}
-		if strings.TrimSpace(linkedChat.Status) == "idle" {
-			return firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status, projectwork.AssignmentStatusRunning)
-		}
-	}
-	return firstNonEmpty(projectActivityExecutionStatus(assignment), assignment.Status)
-}
-
-func projectActivityLinkedChatSummary(linkedChat *ProjectActivityLinkedChatResponse) string {
-	if linkedChat == nil {
-		return ""
-	}
-	parts := []string{"linked chat"}
-	if linkedChat.Status != "" {
-		parts = append(parts, linkedChat.Status)
-	}
-	if linkedChat.LatestRole != "" && linkedChat.LatestStatus != "" {
-		parts = append(parts, linkedChat.LatestRole+" "+linkedChat.LatestStatus)
-	}
-	if linkedChat.MessageCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d message%s", linkedChat.MessageCount, pluralSuffix(linkedChat.MessageCount)))
-	}
-	return strings.Join(parts, " · ")
-}
-
-func projectActivityExecutionStatus(assignment ProjectWorkAssignmentResponse) string {
-	if assignment.ExecutionRef != nil {
-		return assignment.ExecutionRef.Status
-	}
-	if assignment.Execution == nil {
-		return ""
-	}
-	return assignment.Execution.Status
-}
-
-func projectActivityExecutionTaskID(assignment ProjectWorkAssignmentResponse) string {
-	if assignment.ExecutionRef != nil {
-		return assignment.ExecutionRef.TaskID
-	}
-	if assignment.Execution == nil {
-		return ""
-	}
-	return assignment.Execution.TaskID
-}
-
-func projectActivityExecutionRunID(assignment ProjectWorkAssignmentResponse) string {
-	if assignment.ExecutionRef != nil {
-		return assignment.ExecutionRef.RunID
-	}
-	if assignment.Execution == nil {
-		return ""
-	}
-	return assignment.Execution.RunID
-}
-
-func projectActivityExecutionChatID(assignment ProjectWorkAssignmentResponse) string {
+func projectActivityExecutionMessageID(assignment ProjectWorkAssignmentResponse) string {
 	if assignment.ExecutionRef == nil {
 		return ""
 	}
-	return assignment.ExecutionRef.ChatSessionID
+	return assignment.ExecutionRef.MessageID
 }
 
 func projectActivityUpdatedAt(workItem ProjectWorkItemResponse, assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, artifacts ProjectActivityArtifactSummaryResponse, handoffs ProjectActivityHandoffSummaryResponse) string {

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -193,7 +193,7 @@ func (h *Handler) projectActivityLinkedChats(ctx context.Context, projectID stri
 		return linked
 	}
 	for _, assignment := range assignments {
-		chatID := strings.TrimSpace(assignment.ChatSessionID)
+		chatID := strings.TrimSpace(assignment.ExecutionRef.ChatSessionID)
 		if chatID == "" {
 			continue
 		}
@@ -281,9 +281,6 @@ func renderProjectActivityItem(workItem ProjectWorkItemResponse, assignment Proj
 func projectActivityAssignmentInput(assignment ProjectWorkAssignmentResponse, linkedChat *ProjectActivityLinkedChatResponse, artifactCount int) projectworkapp.ActivityAssignmentInput {
 	return projectworkapp.ActivityAssignmentInput{
 		Status:        assignment.Status,
-		TaskID:        assignment.TaskID,
-		RunID:         assignment.RunID,
-		ChatSessionID: assignment.ChatSessionID,
 		Execution:     projectActivityExecutionSummaryForApp(assignment.Execution),
 		ExecutionRef:  projectActivityExecutionRefForApp(assignment.ExecutionRef),
 		LinkedChat:    projectActivityLinkedChatForApp(linkedChat),

--- a/internal/api/handler_project_activity_test.go
+++ b/internal/api/handler_project_activity_test.go
@@ -95,6 +95,13 @@ func TestProjectActivityProjection_ItemStatusSummaryAndBucket(t *testing.T) {
 			Status:               projectwork.AssignmentStatusAwaitingApproval,
 			PendingApprovalCount: 2,
 		},
+		ExecutionRef: &ProjectWorkAssignmentExecutionRefResponse{
+			Kind:                 "task_run",
+			TaskID:               "task-projected",
+			RunID:                "run-projected",
+			Status:               projectwork.AssignmentStatusAwaitingApproval,
+			PendingApprovalCount: 2,
+		},
 		UpdatedAt: formatOptionalTime(base.Add(time.Minute)),
 	}
 	artifacts := []projectwork.CollaborationArtifact{

--- a/internal/api/handler_project_activity_test.go
+++ b/internal/api/handler_project_activity_test.go
@@ -87,8 +87,6 @@ func TestProjectActivityProjection_ItemStatusSummaryAndBucket(t *testing.T) {
 		WorkItemID: "work-1",
 		RoleID:     "role-1",
 		Status:     projectwork.AssignmentStatusAwaitingApproval,
-		TaskID:     "task-stored",
-		RunID:      "run-stored",
 		Execution: &ProjectWorkAssignmentExecutionResponse{
 			TaskID:               "task-projected",
 			RunID:                "run-projected",
@@ -140,12 +138,15 @@ func TestProjectActivityProjection_ItemStatusSummaryAndBucket(t *testing.T) {
 	}
 
 	missingChat := renderProjectActivityItem(workItem, ProjectWorkAssignmentResponse{
-		ID:            "asgn-chat",
-		ProjectID:     "proj",
-		WorkItemID:    "work-1",
-		RoleID:        "role-1",
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat-missing",
+		ID:         "asgn-chat",
+		ProjectID:  "proj",
+		WorkItemID: "work-1",
+		RoleID:     "role-1",
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: &ProjectWorkAssignmentExecutionRefResponse{
+			Kind:          "chat_session",
+			ChatSessionID: "chat-missing",
+		},
 	}, role, nil, nil, missingProjectActivityLinkedChat("chat-missing"))
 	if missingChat.BlockingSignal != "stale_unknown" || missingChat.StatusSummary != "linked chat missing" || projectActivityBucket(missingChat) != "blocked" {
 		t.Fatalf("missing chat item = %+v, want stale linked-chat signal", missingChat)

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -794,14 +794,10 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		},
 		InitializeRun: func(task types.Task, run *types.TaskRun) {
 			contextPacket.Refs.RunID = run.ID
-			run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(contextPacket, chat.ContextRefs{
-				TaskID:       task.ID,
-				RunID:        run.ID,
-				ProjectID:    project.ID,
-				WorkItemID:   workItem.ID,
-				AssignmentID: assignment.ID,
-				RoleID:       role.ID,
-			}))
+			run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+				chatcontext.TaskRunRefs(task.ID, run.ID, project.ID),
+				chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID),
+			)))
 		},
 	})
 	if err != nil {
@@ -915,13 +911,10 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		ConfigOptions:   configOptions,
 	}
 	contextPacket.Refs.SessionID = session.ID
-	contextPacket = chatcontext.Normalize(contextPacket, chat.ContextRefs{
-		SessionID:    session.ID,
-		ProjectID:    project.ID,
-		WorkItemID:   workItem.ID,
-		AssignmentID: assignment.ID,
-		RoleID:       role.ID,
-	})
+	contextPacket = chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+		chatcontext.ChatMessageRefs(session.ID, "", project.ID),
+		chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID),
+	))
 	packetBytes := chatcontext.Marshal(contextPacket)
 	result, err := h.projectWorkApplication().StartExternalAgentAssignment(ctx, projectworkapp.StartExternalAgentAssignmentCommand{
 		ProjectID:         project.ID,
@@ -2006,56 +1999,25 @@ func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignm
 		StartedAt:         formatOptionalTime(item.StartedAt),
 		CompletedAt:       formatOptionalTime(item.CompletedAt),
 	}
-	response.ExecutionRef = projectWorkAssignmentExecutionRef(response)
+	response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefFor(item, nil, response.Status))
 	return response
 }
 
-func projectWorkAssignmentExecutionRef(response ProjectWorkAssignmentResponse) *ProjectWorkAssignmentExecutionRefResponse {
-	taskID := strings.TrimSpace(response.TaskID)
-	runID := strings.TrimSpace(response.RunID)
-	status := strings.TrimSpace(response.Status)
-	pendingApprovalCount := 0
-	traceID := ""
-	missing := false
-	if response.Execution != nil {
-		taskID = firstNonEmpty(response.Execution.TaskID, taskID)
-		runID = firstNonEmpty(response.Execution.RunID, runID)
-		status = firstNonEmpty(response.Execution.Status, status)
-		pendingApprovalCount = response.Execution.PendingApprovalCount
-		traceID = response.Execution.TraceID
-		missing = response.Execution.Missing
-	}
-	chatSessionID := strings.TrimSpace(response.ChatSessionID)
-	messageID := strings.TrimSpace(response.MessageID)
-	contextSnapshotID := strings.TrimSpace(response.ContextSnapshotID)
-	kind := projectWorkAssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID)
-	if kind == "" {
+func renderProjectWorkAssignmentExecutionRef(ref *projectworkapp.AssignmentExecutionRef) *ProjectWorkAssignmentExecutionRefResponse {
+	if ref == nil {
 		return nil
 	}
 	return &ProjectWorkAssignmentExecutionRefResponse{
-		Kind:                 kind,
-		TaskID:               taskID,
-		RunID:                runID,
-		ChatSessionID:        chatSessionID,
-		MessageID:            messageID,
-		ContextSnapshotID:    contextSnapshotID,
-		Status:               status,
-		PendingApprovalCount: pendingApprovalCount,
-		TraceID:              traceID,
-		Missing:              missing,
-	}
-}
-
-func projectWorkAssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID string) string {
-	switch {
-	case taskID != "" || runID != "":
-		return "task_run"
-	case chatSessionID != "" || messageID != "":
-		return "chat_session"
-	case contextSnapshotID != "":
-		return "context_snapshot"
-	default:
-		return ""
+		Kind:                 ref.Kind,
+		TaskID:               ref.TaskID,
+		RunID:                ref.RunID,
+		ChatSessionID:        ref.ChatSessionID,
+		MessageID:            ref.MessageID,
+		ContextSnapshotID:    ref.ContextSnapshotID,
+		Status:               ref.Status,
+		PendingApprovalCount: ref.PendingApprovalCount,
+		TraceID:              ref.TraceID,
+		Missing:              ref.Missing,
 	}
 }
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -71,30 +71,22 @@ type updateProjectWorkItemRequest struct {
 }
 
 type createProjectWorkAssignmentRequest struct {
-	ID                string `json:"id,omitempty"`
-	RoleID            string `json:"role_id"`
-	DriverKind        string `json:"driver_kind,omitempty"`
-	Status            string `json:"status,omitempty"`
-	TaskID            string `json:"task_id,omitempty"`
-	RunID             string `json:"run_id,omitempty"`
-	ChatSessionID     string `json:"chat_session_id,omitempty"`
-	MessageID         string `json:"message_id,omitempty"`
-	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
-	StartedAt         string `json:"started_at,omitempty"`
-	CompletedAt       string `json:"completed_at,omitempty"`
+	ID           string                                     `json:"id,omitempty"`
+	RoleID       string                                     `json:"role_id"`
+	DriverKind   string                                     `json:"driver_kind,omitempty"`
+	Status       string                                     `json:"status,omitempty"`
+	ExecutionRef *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
+	StartedAt    string                                     `json:"started_at,omitempty"`
+	CompletedAt  string                                     `json:"completed_at,omitempty"`
 }
 
 type updateProjectWorkAssignmentRequest struct {
-	RoleID            *string `json:"role_id,omitempty"`
-	DriverKind        *string `json:"driver_kind,omitempty"`
-	Status            *string `json:"status,omitempty"`
-	TaskID            *string `json:"task_id,omitempty"`
-	RunID             *string `json:"run_id,omitempty"`
-	ChatSessionID     *string `json:"chat_session_id,omitempty"`
-	MessageID         *string `json:"message_id,omitempty"`
-	ContextSnapshotID *string `json:"context_snapshot_id,omitempty"`
-	StartedAt         *string `json:"started_at,omitempty"`
-	CompletedAt       *string `json:"completed_at,omitempty"`
+	RoleID       *string                                    `json:"role_id,omitempty"`
+	DriverKind   *string                                    `json:"driver_kind,omitempty"`
+	Status       *string                                    `json:"status,omitempty"`
+	ExecutionRef *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
+	StartedAt    *string                                    `json:"started_at,omitempty"`
+	CompletedAt  *string                                    `json:"completed_at,omitempty"`
 }
 
 type startProjectWorkAssignmentRequest struct {
@@ -248,23 +240,18 @@ type ProjectWorkAssignmentEnvelope struct {
 }
 
 type ProjectWorkAssignmentResponse struct {
-	ID                string                                     `json:"id"`
-	ProjectID         string                                     `json:"project_id"`
-	WorkItemID        string                                     `json:"work_item_id"`
-	RoleID            string                                     `json:"role_id"`
-	DriverKind        string                                     `json:"driver_kind"`
-	Status            string                                     `json:"status"`
-	TaskID            string                                     `json:"task_id,omitempty"`
-	RunID             string                                     `json:"run_id,omitempty"`
-	ChatSessionID     string                                     `json:"chat_session_id,omitempty"`
-	MessageID         string                                     `json:"message_id,omitempty"`
-	ContextSnapshotID string                                     `json:"context_snapshot_id,omitempty"`
-	CreatedAt         string                                     `json:"created_at"`
-	UpdatedAt         string                                     `json:"updated_at"`
-	StartedAt         string                                     `json:"started_at,omitempty"`
-	CompletedAt       string                                     `json:"completed_at,omitempty"`
-	ExecutionRef      *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
-	Execution         *ProjectWorkAssignmentExecutionResponse    `json:"execution,omitempty"`
+	ID           string                                     `json:"id"`
+	ProjectID    string                                     `json:"project_id"`
+	WorkItemID   string                                     `json:"work_item_id"`
+	RoleID       string                                     `json:"role_id"`
+	DriverKind   string                                     `json:"driver_kind"`
+	Status       string                                     `json:"status"`
+	CreatedAt    string                                     `json:"created_at"`
+	UpdatedAt    string                                     `json:"updated_at"`
+	StartedAt    string                                     `json:"started_at,omitempty"`
+	CompletedAt  string                                     `json:"completed_at,omitempty"`
+	ExecutionRef *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
+	Execution    *ProjectWorkAssignmentExecutionResponse    `json:"execution,omitempty"`
 }
 
 type ProjectWorkArtifactsResponse struct {
@@ -574,17 +561,13 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 		return
 	}
 	item, err := h.projectWorkApplication().CreateAssignment(r.Context(), projectID, workItemID, projectworkapp.CreateAssignmentCommand{
-		ID:                req.ID,
-		RoleID:            req.RoleID,
-		DriverKind:        req.DriverKind,
-		Status:            req.Status,
-		TaskID:            req.TaskID,
-		RunID:             req.RunID,
-		ChatSessionID:     req.ChatSessionID,
-		MessageID:         req.MessageID,
-		ContextSnapshotID: req.ContextSnapshotID,
-		StartedAt:         startedAt,
-		CompletedAt:       completedAt,
+		ID:           req.ID,
+		RoleID:       req.RoleID,
+		DriverKind:   req.DriverKind,
+		Status:       req.Status,
+		ExecutionRef: projectWorkAssignmentExecutionRefFromRequest(req.ExecutionRef),
+		StartedAt:    startedAt,
+		CompletedAt:  completedAt,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -621,16 +604,12 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 		completedAtPtr = &completedAt
 	}
 	item, err := h.projectWorkApplication().UpdateAssignment(r.Context(), projectID, assignmentID, projectworkapp.UpdateAssignmentCommand{
-		RoleID:            req.RoleID,
-		DriverKind:        req.DriverKind,
-		Status:            req.Status,
-		TaskID:            req.TaskID,
-		RunID:             req.RunID,
-		ChatSessionID:     req.ChatSessionID,
-		MessageID:         req.MessageID,
-		ContextSnapshotID: req.ContextSnapshotID,
-		StartedAt:         startedAtPtr,
-		CompletedAt:       completedAtPtr,
+		RoleID:       req.RoleID,
+		DriverKind:   req.DriverKind,
+		Status:       req.Status,
+		ExecutionRef: projectWorkAssignmentExecutionRefPtrFromRequest(req.ExecutionRef),
+		StartedAt:    startedAtPtr,
+		CompletedAt:  completedAtPtr,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -849,7 +828,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, "agent chat runner is not configured")
 		return
 	}
-	if strings.TrimSpace(assignment.ChatSessionID) != "" {
+	if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" {
 		projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, assignment)
 		if projectErr != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
@@ -1983,24 +1962,45 @@ func renderProjectWorkItem(item projectwork.WorkItem) ProjectWorkItemResponse {
 
 func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignmentResponse {
 	response := ProjectWorkAssignmentResponse{
-		ID:                item.ID,
-		ProjectID:         item.ProjectID,
-		WorkItemID:        item.WorkItemID,
-		RoleID:            item.RoleID,
-		DriverKind:        item.DriverKind,
-		Status:            item.Status,
-		TaskID:            item.TaskID,
-		RunID:             item.RunID,
-		ChatSessionID:     item.ChatSessionID,
-		MessageID:         item.MessageID,
-		ContextSnapshotID: item.ContextSnapshotID,
-		CreatedAt:         formatOptionalTime(item.CreatedAt),
-		UpdatedAt:         formatOptionalTime(item.UpdatedAt),
-		StartedAt:         formatOptionalTime(item.StartedAt),
-		CompletedAt:       formatOptionalTime(item.CompletedAt),
+		ID:          item.ID,
+		ProjectID:   item.ProjectID,
+		WorkItemID:  item.WorkItemID,
+		RoleID:      item.RoleID,
+		DriverKind:  item.DriverKind,
+		Status:      item.Status,
+		CreatedAt:   formatOptionalTime(item.CreatedAt),
+		UpdatedAt:   formatOptionalTime(item.UpdatedAt),
+		StartedAt:   formatOptionalTime(item.StartedAt),
+		CompletedAt: formatOptionalTime(item.CompletedAt),
 	}
 	response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefFor(item, nil, response.Status))
 	return response
+}
+
+func projectWorkAssignmentExecutionRefFromRequest(ref *ProjectWorkAssignmentExecutionRefResponse) projectwork.AssignmentExecutionRef {
+	if ref == nil {
+		return projectwork.AssignmentExecutionRef{}
+	}
+	return projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
+		Kind:                 ref.Kind,
+		TaskID:               ref.TaskID,
+		RunID:                ref.RunID,
+		ChatSessionID:        ref.ChatSessionID,
+		MessageID:            ref.MessageID,
+		ContextSnapshotID:    ref.ContextSnapshotID,
+		Status:               ref.Status,
+		PendingApprovalCount: ref.PendingApprovalCount,
+		TraceID:              ref.TraceID,
+		Missing:              ref.Missing,
+	})
+}
+
+func projectWorkAssignmentExecutionRefPtrFromRequest(ref *ProjectWorkAssignmentExecutionRefResponse) *projectwork.AssignmentExecutionRef {
+	if ref == nil {
+		return nil
+	}
+	converted := projectWorkAssignmentExecutionRefFromRequest(ref)
+	return &converted
 }
 
 func renderProjectWorkAssignmentExecutionRef(ref *projectworkapp.AssignmentExecutionRef) *ProjectWorkAssignmentExecutionRefResponse {

--- a/internal/api/handler_project_work_projection.go
+++ b/internal/api/handler_project_work_projection.go
@@ -2,11 +2,9 @@ package api
 
 import (
 	"context"
-	"strings"
-	"time"
 
 	"github.com/hecatehq/hecate/internal/projectwork"
-	"github.com/hecatehq/hecate/pkg/types"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 func (h *Handler) renderProjectedProjectWorkItem(ctx context.Context, item projectwork.WorkItem) (ProjectWorkItemResponse, error) {
@@ -43,14 +41,14 @@ func (h *Handler) renderProjectedProjectWorkItemWithAssignments(ctx context.Cont
 
 func (h *Handler) renderProjectedProjectWorkAssignment(ctx context.Context, item projectwork.Assignment) (ProjectWorkAssignmentResponse, error) {
 	response := renderProjectWorkAssignment(item)
-	projection, err := h.projectWorkAssignmentExecution(ctx, item)
+	projection, err := projectworkapp.ProjectAssignmentExecution(ctx, h.taskStore, item)
 	if err != nil {
 		return ProjectWorkAssignmentResponse{}, err
 	}
 	if projection == nil {
 		return response, nil
 	}
-	response.Execution = &projection.Execution
+	response.Execution = renderProjectWorkAssignmentExecution(projection.Execution)
 	if projection.Status != "" {
 		response.Status = projection.Status
 	}
@@ -60,104 +58,29 @@ func (h *Handler) renderProjectedProjectWorkAssignment(ctx context.Context, item
 	if response.CompletedAt == "" && !projection.CompletedAt.IsZero() {
 		response.CompletedAt = formatOptionalTime(projection.CompletedAt)
 	}
-	response.ExecutionRef = projectWorkAssignmentExecutionRef(response)
+	response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefFor(item, &projection.Execution, response.Status))
 	return response, nil
 }
 
-type projectWorkAssignmentExecutionProjection struct {
-	Execution   ProjectWorkAssignmentExecutionResponse
-	Status      string
-	StartedAt   time.Time
-	CompletedAt time.Time
-}
-
-func (h *Handler) projectWorkAssignmentExecution(ctx context.Context, assignment projectwork.Assignment) (*projectWorkAssignmentExecutionProjection, error) {
-	taskID := strings.TrimSpace(assignment.TaskID)
-	runID := strings.TrimSpace(assignment.RunID)
-	if taskID == "" {
-		return nil, nil
+func renderProjectWorkAssignmentExecution(execution projectworkapp.AssignmentExecutionSummary) *ProjectWorkAssignmentExecutionResponse {
+	return &ProjectWorkAssignmentExecutionResponse{
+		TaskID:               execution.TaskID,
+		RunID:                execution.RunID,
+		TaskStatus:           execution.TaskStatus,
+		RunStatus:            execution.RunStatus,
+		Status:               execution.Status,
+		PendingApprovalCount: execution.PendingApprovalCount,
+		StepCount:            execution.StepCount,
+		ApprovalCount:        execution.ApprovalCount,
+		ArtifactCount:        execution.ArtifactCount,
+		Model:                execution.Model,
+		Provider:             execution.Provider,
+		LastError:            execution.LastError,
+		StartedAt:            formatOptionalTime(execution.StartedAt),
+		FinishedAt:           formatOptionalTime(execution.FinishedAt),
+		TraceID:              execution.TraceID,
+		Missing:              execution.Missing,
 	}
-	projection := &projectWorkAssignmentExecutionProjection{
-		Status:    assignment.Status,
-		StartedAt: assignment.StartedAt,
-		Execution: ProjectWorkAssignmentExecutionResponse{
-			TaskID: taskID,
-			RunID:  runID,
-		},
-	}
-	if h == nil || h.taskStore == nil {
-		projection.Execution.Missing = true
-		return projection, nil
-	}
-
-	var task types.Task
-	if taskID != "" {
-		foundTask, found, err := h.taskStore.GetTask(ctx, taskID)
-		if err != nil {
-			return nil, err
-		}
-		if !found {
-			projection.Execution.Missing = true
-			return projection, nil
-		}
-		task = foundTask
-		projection.Execution.TaskStatus = task.Status
-		if runID == "" {
-			runID = strings.TrimSpace(task.LatestRunID)
-			projection.Execution.RunID = runID
-		}
-	}
-
-	if runID == "" {
-		status := projectWorkAssignmentStatusFromRun(task.Status)
-		projection.Execution.Status = status
-		projection.Status = projectWorkProjectedAssignmentStatus(assignment, status, task.UpdatedAt)
-		return projection, nil
-	}
-
-	run, found, err := h.taskStore.GetRun(ctx, taskID, runID)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		projection.Execution.Missing = true
-		return projection, nil
-	}
-
-	status := projectWorkAssignmentStatusFromRun(run.Status)
-	pendingApprovalCount := 0
-	if status == projectwork.AssignmentStatusAwaitingApproval {
-		pendingCount, err := projectWorkPendingApprovalCount(ctx, h.taskStore, taskID, runID)
-		if err != nil {
-			return nil, err
-		}
-		pendingApprovalCount = pendingCount
-	}
-	projection.Status = projectWorkProjectedAssignmentStatus(assignment, status, projectWorkRunProjectionTime(run))
-	projection.StartedAt = firstNonZeroTime(assignment.StartedAt, run.StartedAt)
-	if types.IsTerminalTaskRunStatus(run.Status) {
-		projection.CompletedAt = firstNonZeroTime(assignment.CompletedAt, run.FinishedAt)
-	} else {
-		projection.CompletedAt = assignment.CompletedAt
-	}
-	projection.Execution = ProjectWorkAssignmentExecutionResponse{
-		TaskID:               taskID,
-		RunID:                runID,
-		TaskStatus:           task.Status,
-		RunStatus:            run.Status,
-		Status:               status,
-		PendingApprovalCount: pendingApprovalCount,
-		StepCount:            run.StepCount,
-		ApprovalCount:        run.ApprovalCount,
-		ArtifactCount:        run.ArtifactCount,
-		Model:                run.Model,
-		Provider:             run.Provider,
-		LastError:            run.LastError,
-		StartedAt:            formatOptionalTime(run.StartedAt),
-		FinishedAt:           formatOptionalTime(run.FinishedAt),
-		TraceID:              run.TraceID,
-	}
-	return projection, nil
 }
 
 func groupProjectWorkAssignmentsByWorkItem(assignments []projectwork.Assignment) map[string][]projectwork.Assignment {
@@ -169,54 +92,4 @@ func groupProjectWorkAssignmentsByWorkItem(assignments []projectwork.Assignment)
 		grouped[assignment.WorkItemID] = append(grouped[assignment.WorkItemID], assignment)
 	}
 	return grouped
-}
-
-func projectWorkProjectedAssignmentStatus(assignment projectwork.Assignment, projectedStatus string, projectedAt time.Time) string {
-	projectedStatus = strings.TrimSpace(projectedStatus)
-	if projectedStatus == "" {
-		return assignment.Status
-	}
-	if projectWorkAssignmentIsTerminal(assignment.Status) && assignment.Status != projectedStatus {
-		if projectedAt.IsZero() || !projectedAt.After(assignment.UpdatedAt) {
-			return assignment.Status
-		}
-	}
-	return projectedStatus
-}
-
-func projectWorkRunProjectionTime(run types.TaskRun) time.Time {
-	if !run.FinishedAt.IsZero() {
-		return run.FinishedAt
-	}
-	return run.StartedAt
-}
-
-func firstNonZeroTime(values ...time.Time) time.Time {
-	for _, value := range values {
-		if !value.IsZero() {
-			return value
-		}
-	}
-	return time.Time{}
-}
-
-func projectWorkPendingApprovalCount(ctx context.Context, store taskRunApprovalStore, taskID, runID string) (int, error) {
-	if store == nil {
-		return 0, nil
-	}
-	approvals, err := store.ListApprovals(ctx, taskID)
-	if err != nil {
-		return 0, err
-	}
-	count := 0
-	for _, approval := range approvals {
-		if approval.RunID == runID && approval.Status == "pending" {
-			count++
-		}
-	}
-	return count, nil
-}
-
-type taskRunApprovalStore interface {
-	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
 }

--- a/internal/api/handler_project_work_projection_test.go
+++ b/internal/api/handler_project_work_projection_test.go
@@ -39,25 +39,30 @@ func TestProjectWorkProjection_AssignmentExecutionHydratesAwaitingRun(t *testing
 	handler := &Handler{taskStore: store}
 	startedAt := time.Date(2026, 6, 4, 13, 0, 0, 0, time.UTC)
 	assignment := projectwork.Assignment{
-		ID:        "asgn_awaiting",
-		Status:    projectwork.AssignmentStatusQueued,
-		TaskID:    "task_awaiting",
-		RunID:     "run_awaiting",
+		ID:     "asgn_awaiting",
+		Status: projectwork.AssignmentStatusQueued,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionKindTaskRun,
+			TaskID: "task_awaiting",
+			RunID:  "run_awaiting",
+		},
 		UpdatedAt: startedAt.Add(-time.Minute),
 	}
+	taskID := assignment.ExecutionRef.TaskID
+	runID := assignment.ExecutionRef.RunID
 
 	if _, err := store.CreateTask(ctx, types.Task{
-		ID:          assignment.TaskID,
+		ID:          taskID,
 		Status:      "awaiting_approval",
-		LatestRunID: assignment.RunID,
+		LatestRunID: runID,
 		CreatedAt:   startedAt,
 		UpdatedAt:   startedAt,
 	}); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	if _, err := store.CreateRun(ctx, types.TaskRun{
-		ID:            assignment.RunID,
-		TaskID:        assignment.TaskID,
+		ID:            runID,
+		TaskID:        taskID,
 		Number:        1,
 		Status:        "awaiting_approval",
 		Model:         "qwen2.5-coder",
@@ -71,9 +76,9 @@ func TestProjectWorkProjection_AssignmentExecutionHydratesAwaitingRun(t *testing
 		t.Fatalf("CreateRun: %v", err)
 	}
 	for _, approval := range []types.TaskApproval{
-		{ID: "ap_pending", TaskID: assignment.TaskID, RunID: assignment.RunID, Status: "pending", CreatedAt: startedAt},
-		{ID: "ap_approved", TaskID: assignment.TaskID, RunID: assignment.RunID, Status: "approved", CreatedAt: startedAt},
-		{ID: "ap_other_run", TaskID: assignment.TaskID, RunID: "run_other", Status: "pending", CreatedAt: startedAt},
+		{ID: "ap_pending", TaskID: taskID, RunID: runID, Status: "pending", CreatedAt: startedAt},
+		{ID: "ap_approved", TaskID: taskID, RunID: runID, Status: "approved", CreatedAt: startedAt},
+		{ID: "ap_other_run", TaskID: taskID, RunID: "run_other", Status: "pending", CreatedAt: startedAt},
 	} {
 		if _, err := store.CreateApproval(ctx, approval); err != nil {
 			t.Fatalf("CreateApproval(%s): %v", approval.ID, err)
@@ -94,7 +99,7 @@ func TestProjectWorkProjection_AssignmentExecutionHydratesAwaitingRun(t *testing
 		t.Fatalf("response execution is nil, want hydrated execution")
 	}
 	execution := response.Execution
-	if execution.TaskID != assignment.TaskID || execution.RunID != assignment.RunID {
+	if execution.TaskID != taskID || execution.RunID != runID {
 		t.Fatalf("execution ids = %q/%q, want linked task/run", execution.TaskID, execution.RunID)
 	}
 	if execution.TaskStatus != "awaiting_approval" || execution.RunStatus != "awaiting_approval" || execution.Status != projectwork.AssignmentStatusAwaitingApproval {

--- a/internal/api/handler_project_work_projection_test.go
+++ b/internal/api/handler_project_work_projection_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -19,13 +20,13 @@ func TestProjectWorkProjection_StatusPrefersStoredTerminalUntilRunIsNewer(t *tes
 		UpdatedAt: storedAt,
 	}
 
-	if got := projectWorkProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt); got != projectwork.AssignmentStatusFailed {
+	if got := projectworkapp.ProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt); got != projectwork.AssignmentStatusFailed {
 		t.Fatalf("status with same projection timestamp = %q, want stored failed", got)
 	}
-	if got := projectWorkProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt.Add(-time.Second)); got != projectwork.AssignmentStatusFailed {
+	if got := projectworkapp.ProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt.Add(-time.Second)); got != projectwork.AssignmentStatusFailed {
 		t.Fatalf("status with older projection timestamp = %q, want stored failed", got)
 	}
-	if got := projectWorkProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt.Add(time.Second)); got != projectwork.AssignmentStatusCompleted {
+	if got := projectworkapp.ProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, storedAt.Add(time.Second)); got != projectwork.AssignmentStatusCompleted {
 		t.Fatalf("status with newer projection timestamp = %q, want projected completed", got)
 	}
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -174,9 +174,12 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments", bytes.NewReader([]byte(`{
 		"id":"asgn_backend",
 		"role_id":"software_developer",
-		"task_id":"task_123",
-		"run_id":"run_123",
-		"context_snapshot_id":"ctx_123"
+		"execution_ref":{
+			"kind":"task_run",
+			"task_id":"task_123",
+			"run_id":"run_123",
+			"context_snapshot_id":"ctx_123"
+		}
 	}`))))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
@@ -185,7 +188,7 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	if assignment.Data.Status != projectwork.AssignmentStatusQueued || assignment.Data.TaskID != "task_123" {
+	if assignment.Data.Status != projectwork.AssignmentStatusQueued || assignmentExecutionRefForTest(t, assignment.Data).TaskID != "task_123" {
 		t.Fatalf("assignment = %+v, want queued linked task", assignment.Data)
 	}
 
@@ -203,14 +206,21 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", bytes.NewReader([]byte(`{"status":"completed","chat_session_id":"chat_123","message_id":"msg_123"}`))))
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/assignments/asgn_backend", bytes.NewReader([]byte(`{
+		"status":"completed",
+		"execution_ref":{
+			"kind":"chat_session",
+			"chat_session_id":"chat_123",
+			"message_id":"msg_123"
+		}
+	}`))))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("patch assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode patched assignment: %v", err)
 	}
-	if assignment.Data.Status != projectwork.AssignmentStatusCompleted || assignment.Data.ChatSessionID != "chat_123" {
+	if assignment.Data.Status != projectwork.AssignmentStatusCompleted || assignmentExecutionRefForTest(t, assignment.Data).ChatSessionID != "chat_123" {
 		t.Fatalf("patched assignment = %+v, want completed linked chat", assignment.Data)
 	}
 
@@ -515,19 +525,20 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	if assignment.Data.TaskID == "" || assignment.Data.RunID == "" {
-		t.Fatalf("assignment links = task %q run %q, want both set", assignment.Data.TaskID, assignment.Data.RunID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.TaskID == "" || ref.RunID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want task and run links", ref)
 	}
 	if assignment.Data.DriverKind != projectwork.AssignmentDriverHecateTask {
 		t.Fatalf("driver_kind = %q, want hecate_task", assignment.Data.DriverKind)
 	}
-	if assignment.Data.Execution == nil || assignment.Data.Execution.TaskID != assignment.Data.TaskID || assignment.Data.Execution.RunID != assignment.Data.RunID {
+	if assignment.Data.Execution == nil || assignment.Data.Execution.TaskID != ref.TaskID || assignment.Data.Execution.RunID != ref.RunID {
 		t.Fatalf("assignment execution = %+v, want linked task/run summary", assignment.Data.Execution)
 	}
 
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if task.ExecutionKind != "agent_loop" || task.OriginKind != "project_work_item" || task.OriginID != "work_start" {
 		t.Fatalf("task execution/origin = %q %q/%q, want agent_loop project_work_item/work_start", task.ExecutionKind, task.OriginKind, task.OriginID)
@@ -565,8 +576,8 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	if !strings.Contains(task.SystemPrompt, "Role instructions:\nFollow backend invariants.") || !strings.Contains(task.SystemPrompt, "Project system prompt:\nProject default system prompt.") {
 		t.Fatalf("task system_prompt = %q, want role and project prompts", task.SystemPrompt)
 	}
-	if _, found, err := handler.taskStore.GetRun(t.Context(), task.ID, assignment.Data.RunID); err != nil || !found {
-		t.Fatalf("GetRun(%q) found=%v err=%v, want run", assignment.Data.RunID, found, err)
+	if _, found, err := handler.taskStore.GetRun(t.Context(), task.ID, ref.RunID); err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v, want run", ref.RunID, found, err)
 	}
 }
 
@@ -645,13 +656,14 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	if assignment.Data.ContextSnapshotID == "" {
-		t.Fatalf("context_snapshot_id = %q, want persisted packet id", assignment.Data.ContextSnapshotID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.ContextSnapshotID == "" {
+		t.Fatalf("execution_ref = %+v, want persisted packet id", ref)
 	}
 
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
-	if packetResp.Data.ID != assignment.Data.ContextSnapshotID {
-		t.Fatalf("task run context id = %q, want %q", packetResp.Data.ID, assignment.Data.ContextSnapshotID)
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+	if packetResp.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("task run context id = %q, want %q", packetResp.Data.ID, ref.ContextSnapshotID)
 	}
 	if packetResp.Data.ExecutionProfile != "implementation" {
 		t.Fatalf("execution_profile = %q, want implementation", packetResp.Data.ExecutionProfile)
@@ -676,8 +688,8 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	}
 
 	assignmentPacket := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
-	if assignmentPacket.Data.ID != assignment.Data.ContextSnapshotID {
-		t.Fatalf("assignment context id = %q, want %q", assignmentPacket.Data.ID, assignment.Data.ContextSnapshotID)
+	if assignmentPacket.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want %q", assignmentPacket.Data.ID, ref.ContextSnapshotID)
 	}
 }
 
@@ -785,7 +797,8 @@ func TestProjectWorkAPI_StartAssignmentAppliesProfileContextPolicies(t *testing.
 			if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 				t.Fatalf("decode assignment: %v", err)
 			}
-			packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+			ref := assignmentExecutionRefForTest(t, assignment.Data)
+			packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 
 			memoryItem := findRenderedContextItemByOrigin(packetResp.Data, "mem_runtime")
 			if tc.wantMemoryItem {
@@ -882,9 +895,10 @@ func TestProjectWorkAPI_StartAssignmentIncludesExplicitPromptContext(t *testing.
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	for _, want := range []string{
 		"Project memory: Runtime preference",
@@ -900,7 +914,7 @@ func TestProjectWorkAPI_StartAssignmentIncludesExplicitPromptContext(t *testing.
 		t.Fatalf("task system_prompt = %q, want host-specific source body omitted", task.SystemPrompt)
 	}
 
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 	promptItem := findRenderedContextItemByKind(packetResp.Data, "prompt_context")
 	if promptItem == nil || !promptItem.Included || promptItem.Section != contextSectionInstructions {
 		t.Fatalf("prompt context item = %+v, want included instructions item", promptItem)
@@ -974,9 +988,10 @@ func TestProjectWorkAPI_StartAssignmentKeepsVisibleOnlyPromptContextOutOfSystemP
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	for _, notWant := range []string{
 		"Do not include this visible-only memory body.",
@@ -986,7 +1001,7 @@ func TestProjectWorkAPI_StartAssignmentKeepsVisibleOnlyPromptContextOutOfSystemP
 			t.Fatalf("task system_prompt = %q, want visible-only body %q omitted", task.SystemPrompt, notWant)
 		}
 	}
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 	if item := findRenderedContextItemByKind(packetResp.Data, "prompt_context"); item != nil {
 		t.Fatalf("prompt context item = %+v, want omitted when no prompt context was loaded", item)
 	}
@@ -1032,14 +1047,15 @@ func TestProjectWorkAPI_StartAssignmentTruncatesPromptContext(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if !strings.Contains(task.SystemPrompt, "[truncated]") {
 		t.Fatalf("task system_prompt = %q, want truncated prompt context marker", task.SystemPrompt)
 	}
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 	promptItem := findRenderedContextItemByKind(packetResp.Data, "prompt_context")
 	if promptItem == nil || !strings.Contains(promptItem.Body, "Truncated prompt context items: 1") || !strings.Contains(promptItem.Body, "mem_long was truncated") {
 		t.Fatalf("prompt context item = %+v, want truncation summary", promptItem)
@@ -1131,9 +1147,10 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "role_profile" {
 		t.Fatalf("task provider/model/profile = %q/%q/%q, want role profile hints", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
@@ -1142,7 +1159,7 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 		t.Fatalf("task system prompt = %q, want profile instructions", task.SystemPrompt)
 	}
 
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 	if packetResp.Data.ExecutionProfile != "role_profile" {
 		t.Fatalf("packet execution_profile = %q, want role_profile", packetResp.Data.ExecutionProfile)
 	}
@@ -1218,11 +1235,12 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	if assignment.Data.ChatSessionID == "" || assignment.Data.ContextSnapshotID == "" {
-		t.Fatalf("assignment links = chat %q context %q, want linked session and context", assignment.Data.ChatSessionID, assignment.Data.ContextSnapshotID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.ChatSessionID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want linked session and context", ref)
 	}
-	if assignment.Data.TaskID != "" || assignment.Data.RunID != "" || assignment.Data.MessageID != "" {
-		t.Fatalf("assignment task/run/message links = %q/%q/%q, want no task run or dispatched message", assignment.Data.TaskID, assignment.Data.RunID, assignment.Data.MessageID)
+	if ref.TaskID != "" || ref.RunID != "" || ref.MessageID != "" {
+		t.Fatalf("assignment execution_ref = %+v, want no task run or dispatched message", ref)
 	}
 	if assignment.Data.Status != projectwork.AssignmentStatusRunning {
 		t.Fatalf("assignment status = %q, want running", assignment.Data.Status)
@@ -1238,10 +1256,10 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	if err != nil {
 		t.Fatalf("ValidateWorkspace: %v", err)
 	}
-	if prepare.AdapterID != "codex" || prepare.SessionID != assignment.Data.ChatSessionID || prepare.Workspace != resolvedWorkspace {
+	if prepare.AdapterID != "codex" || prepare.SessionID != ref.ChatSessionID || prepare.Workspace != resolvedWorkspace {
 		t.Fatalf("prepare request = %+v, want codex session in workspace", prepare)
 	}
-	session, ok, err := handler.agentChat.Get(t.Context(), assignment.Data.ChatSessionID)
+	session, ok, err := handler.agentChat.Get(t.Context(), ref.ChatSessionID)
 	if err != nil || !ok {
 		t.Fatalf("Get chat session found=%v err=%v, want linked session", ok, err)
 	}
@@ -1250,10 +1268,10 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	}
 
 	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
-	if packetResp.Data.ID != assignment.Data.ContextSnapshotID {
-		t.Fatalf("assignment context id = %q, want %q", packetResp.Data.ID, assignment.Data.ContextSnapshotID)
+	if packetResp.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want %q", packetResp.Data.ID, ref.ContextSnapshotID)
 	}
-	if packetResp.Data.ExecutionMode != chat.ExecutionModeExternalAgent || packetResp.Data.Refs == nil || packetResp.Data.Refs.SessionID != assignment.Data.ChatSessionID {
+	if packetResp.Data.ExecutionMode != chat.ExecutionModeExternalAgent || packetResp.Data.Refs == nil || packetResp.Data.Refs.SessionID != ref.ChatSessionID {
 		t.Fatalf("packet execution/refs = %q/%+v, want external agent session refs", packetResp.Data.ExecutionMode, packetResp.Data.Refs)
 	}
 	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_external")
@@ -1334,7 +1352,7 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentConcurrentRequestsCreateOneC
 	if err != nil {
 		t.Fatalf("ListAssignments: %v", err)
 	}
-	if len(assignments) != 1 || assignments[0].ChatSessionID != sessions[0].ID {
+	if len(assignments) != 1 || assignments[0].ExecutionRef.ChatSessionID != sessions[0].ID {
 		t.Fatalf("assignment/chat link = %+v / %+v, want one linked surviving chat", assignments, sessions)
 	}
 	if got := runner.prepareCount(); got != 2 {
@@ -1405,7 +1423,8 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+assignment.Data.TaskID+"/runs/"+assignment.Data.RunID+"/context", "")
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
 	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_missing")
 	if profileItem == nil || profileItem.Included || profileItem.Section != contextSectionProfile {
 		t.Fatalf("profile item = %+v, want excluded missing profile item", profileItem)
@@ -1476,9 +1495,10 @@ func TestProjectWorkAPI_StartAssignmentKeepsExplicitModelEqualToRouterDefault(t 
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if task.RequestedModel != "qwen2.5-coder" {
 		t.Fatalf("task requested model = %q, want explicit project default", task.RequestedModel)
@@ -1524,9 +1544,10 @@ func TestProjectWorkAPI_StartAssignmentKeepsExplicitRoleModelEqualToRouterDefaul
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if task.RequestedModel != "qwen2.5-coder" {
 		t.Fatalf("task requested model = %q, want explicit role default", task.RequestedModel)
@@ -1569,8 +1590,11 @@ func TestProjectWorkAPI_AssignmentContextFallsBackToLinkedChatPacket(t *testing.
 		t.Fatalf("Append linked message: %v", err)
 	}
 	if _, err := handler.projectWork.UpdateAssignment(t.Context(), "proj_start", "asgn_start", func(item *projectwork.Assignment) {
-		item.ChatSessionID = "chat_linked"
-		item.MessageID = "msg_linked"
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_linked",
+			MessageID:     "msg_linked",
+		}
 	}); err != nil {
 		t.Fatalf("Update assignment links: %v", err)
 	}
@@ -1601,9 +1625,10 @@ func TestProjectWorkAPI_StartAssignmentFallsBackToProjectDefaults(t *testing.T) 
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), assignment.Data.TaskID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", assignment.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
 	}
 	if task.RequestedProvider != "ollama" || task.RequestedModel != "qwen2.5-coder" || task.ExecutionProfile != "project_review" {
 		t.Fatalf("task provider/model/profile = %q/%q/%q, want project defaults", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
@@ -1781,8 +1806,10 @@ func TestProjectWorkAPI_StartAssignmentRepeatedReturnsCurrentAssignment(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &second); err != nil {
 		t.Fatalf("decode second assignment: %v", err)
 	}
-	if second.Data.TaskID != first.Data.TaskID || second.Data.RunID != first.Data.RunID {
-		t.Fatalf("second assignment links = %q/%q, want existing %q/%q", second.Data.TaskID, second.Data.RunID, first.Data.TaskID, first.Data.RunID)
+	firstRef := assignmentExecutionRefForTest(t, first.Data)
+	secondRef := assignmentExecutionRefForTest(t, second.Data)
+	if secondRef.TaskID != firstRef.TaskID || secondRef.RunID != firstRef.RunID {
+		t.Fatalf("second assignment execution_ref = %+v, want existing %+v", secondRef, firstRef)
 	}
 	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
 	if err != nil {
@@ -1810,8 +1837,9 @@ func TestProjectWorkAPI_StartAssignmentActiveConflictBeatsModelValidation(t *tes
 	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
 		t.Fatalf("decode first assignment: %v", err)
 	}
-	if first.Data.TaskID == "" || first.Data.RunID == "" {
-		t.Fatalf("first assignment links = %q/%q, want task and run", first.Data.TaskID, first.Data.RunID)
+	firstRef := assignmentExecutionRefForTest(t, first.Data)
+	if firstRef.TaskID == "" || firstRef.RunID == "" {
+		t.Fatalf("first assignment execution_ref = %+v, want task and run", firstRef)
 	}
 
 	handler.config.Router.DefaultModel = ""
@@ -1837,8 +1865,9 @@ func TestProjectWorkAPI_StartAssignmentActiveConflictBeatsModelValidation(t *tes
 	if err := json.Unmarshal(rec.Body.Bytes(), &second); err != nil {
 		t.Fatalf("decode second assignment: %v", err)
 	}
-	if second.Data.TaskID != first.Data.TaskID || second.Data.RunID != first.Data.RunID {
-		t.Fatalf("second assignment links = %q/%q, want existing %q/%q", second.Data.TaskID, second.Data.RunID, first.Data.TaskID, first.Data.RunID)
+	secondRef := assignmentExecutionRefForTest(t, second.Data)
+	if secondRef.TaskID != firstRef.TaskID || secondRef.RunID != firstRef.RunID {
+		t.Fatalf("second assignment execution_ref = %+v, want existing %+v", secondRef, firstRef)
 	}
 }
 
@@ -1929,8 +1958,9 @@ func TestProjectWorkAPI_StartAssignmentTerminalReturnsCurrentAssignment(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
 		t.Fatalf("decode assignment: %v", err)
 	}
-	if assignment.Data.TaskID != "task_existing" || assignment.Data.RunID != "run_existing" {
-		t.Fatalf("terminal assignment links = %q/%q, want existing links", assignment.Data.TaskID, assignment.Data.RunID)
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.TaskID != "task_existing" || ref.RunID != "run_existing" {
+		t.Fatalf("terminal assignment execution_ref = %+v, want existing links", ref)
 	}
 	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
 	if err != nil {
@@ -1965,8 +1995,8 @@ func TestProjectWorkAPI_StartAssignmentPreservesTaskLinkWhenStartFails(t *testin
 		t.Fatalf("assignments = %+v, want one assignment", assignments)
 	}
 	assignment := assignments[0]
-	if assignment.TaskID == "" {
-		t.Fatalf("assignment task_id is empty, want preserved task link")
+	if assignment.ExecutionRef.TaskID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want preserved task link", assignment.ExecutionRef)
 	}
 	if assignment.Status != projectwork.AssignmentStatusFailed {
 		t.Fatalf("assignment status = %q, want failed", assignment.Status)
@@ -1974,8 +2004,8 @@ func TestProjectWorkAPI_StartAssignmentPreservesTaskLinkWhenStartFails(t *testin
 	if assignment.CompletedAt.IsZero() {
 		t.Fatalf("assignment completed_at is zero, want failure timestamp")
 	}
-	if _, found, err := handler.taskStore.GetTask(t.Context(), assignment.TaskID); err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want preserved task", assignment.TaskID, found, err)
+	if _, found, err := handler.taskStore.GetTask(t.Context(), assignment.ExecutionRef.TaskID); err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want preserved task", assignment.ExecutionRef.TaskID, found, err)
 	}
 }
 
@@ -2001,8 +2031,8 @@ func TestProjectWorkAPI_StartAssignmentClearsClaimWhenTaskCreateFails(t *testing
 		t.Fatalf("assignments = %+v, want one assignment", assignments)
 	}
 	assignment := assignments[0]
-	if assignment.TaskID != "" || assignment.RunID != "" {
-		t.Fatalf("assignment links = %q/%q, want cleared task/run links", assignment.TaskID, assignment.RunID)
+	if assignment.ExecutionRef.TaskID != "" || assignment.ExecutionRef.RunID != "" {
+		t.Fatalf("assignment execution_ref = %+v, want cleared task/run links", assignment.ExecutionRef)
 	}
 	if assignment.Status != projectwork.AssignmentStatusQueued {
 		t.Fatalf("assignment status = %q, want queued for retry", assignment.Status)
@@ -2072,10 +2102,11 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 			assertProjectWorkStatusForTest(t, server, "work_missing", projectwork.WorkItemStatusReady)
 
 			runOnly := getProjectWorkAssignmentForTest(t, server, "work_run_only", "asgn_run_only")
-			if runOnly.Status != projectwork.AssignmentStatusQueued || runOnly.RunID == "" || runOnly.Execution != nil {
+			runOnlyRef := assignmentExecutionRefForTest(t, runOnly)
+			if runOnly.Status != projectwork.AssignmentStatusQueued || runOnlyRef.RunID == "" || runOnly.Execution != nil {
 				t.Fatalf("run-only assignment = %+v, want stored queued status without execution projection", runOnly)
 			}
-			if runOnly.ExecutionRef == nil || runOnly.ExecutionRef.Kind != "task_run" || runOnly.ExecutionRef.RunID != runOnly.RunID {
+			if runOnlyRef.Kind != "task_run" {
 				t.Fatalf("run-only execution_ref = %+v, want raw run ref", runOnly.ExecutionRef)
 			}
 			assertProjectWorkStatusForTest(t, server, "work_run_only", projectwork.WorkItemStatusReady)
@@ -2319,8 +2350,11 @@ func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed pro
 		RoleID:     "role_backend",
 		DriverKind: seed.Driver,
 		Status:     seed.Status,
-		TaskID:     seed.TaskID,
-		RunID:      seed.RunID,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionRefKind(seed.TaskID, seed.RunID, "", "", ""),
+			TaskID: seed.TaskID,
+			RunID:  seed.RunID,
+		},
 	}); err != nil {
 		t.Fatalf("CreateAssignment: %v", err)
 	}
@@ -2419,80 +2453,98 @@ func seedProjectWorkExternalChatProjectionCase(t *testing.T, handler *Handler) {
 		t.Fatalf("CreateWorkItem(work_external_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_external_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_projection",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_external_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_projection",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_external_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_missing_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_missing",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_missing_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_missing",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_missing_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_failed_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_failed",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_failed_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_failed",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_failed_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_prepared_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_prepared",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_prepared_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_prepared",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_prepared_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_cross_project_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_other_project",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_cross_project_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_other_project",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_cross_project_chat): %v", err)
 	}
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
-		ID:            "asgn_error_chat",
-		ProjectID:     "proj_projection",
-		WorkItemID:    "work_external_chat",
-		RoleID:        "role_projection",
-		DriverKind:    projectwork.AssignmentDriverExternalAgent,
-		Status:        projectwork.AssignmentStatusRunning,
-		ChatSessionID: "chat_external_error",
-		CreatedAt:     createdAt,
-		UpdatedAt:     createdAt,
+		ID:         "asgn_error_chat",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_external_chat",
+		RoleID:     "role_projection",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_external_error",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_error_chat): %v", err)
 	}
@@ -2580,7 +2632,10 @@ func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
 		RoleID:     "role_projection",
 		DriverKind: projectwork.AssignmentDriverHecateTask,
 		Status:     projectwork.AssignmentStatusQueued,
-		RunID:      "run_without_task",
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:  projectwork.AssignmentExecutionKindTaskRun,
+			RunID: "run_without_task",
+		},
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_run_only): %v", err)
 	}
@@ -2657,10 +2712,13 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 		RoleID:     "role_projection",
 		DriverKind: projectwork.AssignmentDriverHecateTask,
 		Status:     assignmentStatus,
-		TaskID:     taskID,
-		RunID:      runID,
-		CreatedAt:  assignmentUpdated,
-		UpdatedAt:  assignmentUpdated,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionRefKind(taskID, runID, "", "", ""),
+			TaskID: taskID,
+			RunID:  runID,
+		},
+		CreatedAt: assignmentUpdated,
+		UpdatedAt: assignmentUpdated,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(%s): %v", assignmentID, err)
 	}
@@ -2756,6 +2814,14 @@ func getProjectWorkAssignmentForTest(t *testing.T, server http.Handler, workID, 
 	}
 	t.Fatalf("assignment %s not found in %+v", assignmentID, response.Data)
 	return ProjectWorkAssignmentResponse{}
+}
+
+func assignmentExecutionRefForTest(t *testing.T, assignment ProjectWorkAssignmentResponse) ProjectWorkAssignmentExecutionRefResponse {
+	t.Helper()
+	if assignment.ExecutionRef == nil {
+		t.Fatalf("assignment %q execution_ref is nil", assignment.ID)
+	}
+	return *assignment.ExecutionRef
 }
 
 func assertProjectWorkStatusForTest(t *testing.T, server http.Handler, workID, want string) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -2672,7 +2673,7 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 		Status:      runStatus,
 		LatestRunID: runID,
 		CreatedAt:   assignmentUpdated,
-		UpdatedAt:   firstNonZeroTime(runFinishedAt, runStartedAt, assignmentUpdated),
+		UpdatedAt:   projectworkapp.FirstNonZeroTime(runFinishedAt, runStartedAt, assignmentUpdated),
 	}); err != nil {
 		t.Fatalf("CreateTask(%s): %v", taskID, err)
 	}

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -100,12 +100,13 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 	}
 
 	started := mustRequestJSON[ProjectWorkAssignmentEnvelope](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_backend/assignments/asgn_backend/start", `{}`)
-	if started.Data.TaskID == "" || started.Data.RunID == "" || started.Data.ContextSnapshotID == "" {
-		t.Fatalf("started assignment = %+v, want task/run/context links", started.Data)
+	startedRef := assignmentExecutionRefForTest(t, started.Data)
+	if startedRef.TaskID == "" || startedRef.RunID == "" || startedRef.ContextSnapshotID == "" {
+		t.Fatalf("started assignment execution_ref = %+v, want task/run/context links", startedRef)
 	}
-	task, found, err := handler.taskStore.GetTask(t.Context(), started.Data.TaskID)
+	task, found, err := handler.taskStore.GetTask(t.Context(), startedRef.TaskID)
 	if err != nil || !found {
-		t.Fatalf("GetTask(%q) found=%v err=%v, want task", started.Data.TaskID, found, err)
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", startedRef.TaskID, found, err)
 	}
 	if task.ProjectID != projectID || task.WorkspaceSystemPromptPolicy != types.WorkspaceSystemPromptExclude {
 		t.Fatalf("task project/prompt policy = %q/%q, want project id and excluded workspace prompt layer", task.ProjectID, task.WorkspaceSystemPromptPolicy)
@@ -132,12 +133,12 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 	handoff := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_backend/handoffs", projectJourneyJSON(t, map[string]any{
 		"id":                      "handoff_review",
 		"source_assignment_id":    "asgn_backend",
-		"source_run_id":           started.Data.RunID,
+		"source_run_id":           startedRef.RunID,
 		"target_role_id":          "reviewer_qa",
 		"title":                   "Review handoff",
 		"summary":                 "Backend journey implementation is ready for review.",
 		"recommended_next_action": "Create a review assignment and inspect the context packet.",
-		"context_refs":            []string{started.Data.ContextSnapshotID},
+		"context_refs":            []string{startedRef.ContextSnapshotID},
 		"created_by_role_id":      "role_backend",
 		"provenance_kind":         "agent_draft",
 		"trust_label":             "operator_reviewed",
@@ -152,7 +153,7 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 		"role_id":     "reviewer_qa",
 		"driver_kind": "hecate_task",
 	}))
-	if reviewAssignment.Data.ID != "asgn_review" || reviewAssignment.Data.TaskID != "" {
+	if reviewAssignment.Data.ID != "asgn_review" || reviewAssignment.Data.ExecutionRef != nil {
 		t.Fatalf("review assignment = %+v, want queued unstarted follow-up", reviewAssignment.Data)
 	}
 	patchedHandoff := mustRequestJSON[ProjectHandoffEnvelope](client, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_backend/handoffs/handoff_review", projectJourneyJSON(t, map[string]any{

--- a/internal/chat/turn_kind.go
+++ b/internal/chat/turn_kind.go
@@ -1,0 +1,38 @@
+package chat
+
+const (
+	TurnKindDirectModel   = "direct_model"
+	TurnKindHecateTask    = "hecate_task"
+	TurnKindExternalAgent = "external_agent"
+)
+
+func MessageTurnKind(session Session, message Message) string {
+	executionMode := firstNonEmpty(message.ExecutionMode, defaultExecutionMode(session))
+	switch executionMode {
+	case ExecutionModeExternalAgent:
+		return TurnKindExternalAgent
+	case ExecutionModeHecateTask:
+		if !message.ToolsEnabled {
+			return TurnKindDirectModel
+		}
+		return TurnKindHecateTask
+	default:
+		return ""
+	}
+}
+
+func defaultExecutionMode(session Session) string {
+	if session.AgentID != "" && session.AgentID != DefaultAgentID {
+		return ExecutionModeExternalAgent
+	}
+	return ExecutionModeHecateTask
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/chat/turn_kind_test.go
+++ b/internal/chat/turn_kind_test.go
@@ -1,0 +1,49 @@
+package chat
+
+import "testing"
+
+func TestMessageTurnKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		session Session
+		message Message
+		want    string
+	}{
+		{
+			name:    "hecate tools off is direct model",
+			session: Session{AgentID: DefaultAgentID},
+			message: Message{ExecutionMode: ExecutionModeHecateTask, ToolsEnabled: false},
+			want:    TurnKindDirectModel,
+		},
+		{
+			name:    "hecate tools on is task",
+			session: Session{AgentID: DefaultAgentID},
+			message: Message{ExecutionMode: ExecutionModeHecateTask, ToolsEnabled: true},
+			want:    TurnKindHecateTask,
+		},
+		{
+			name:    "external execution mode",
+			session: Session{AgentID: "codex"},
+			message: Message{ExecutionMode: ExecutionModeExternalAgent},
+			want:    TurnKindExternalAgent,
+		},
+		{
+			name:    "external session default",
+			session: Session{AgentID: "codex"},
+			message: Message{},
+			want:    TurnKindExternalAgent,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := MessageTurnKind(tt.session, tt.message); got != tt.want {
+				t.Fatalf("MessageTurnKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/chatcontext/packets.go
+++ b/internal/chatcontext/packets.go
@@ -66,8 +66,63 @@ func FromProjectAssignmentPayload(raw json.RawMessage) (chat.ContextPacket, bool
 	return packet, true, nil
 }
 
+func Refs(refs chat.ContextRefs) chat.ContextRefs {
+	return chat.ContextRefs{
+		SessionID:    strings.TrimSpace(refs.SessionID),
+		MessageID:    strings.TrimSpace(refs.MessageID),
+		TaskID:       strings.TrimSpace(refs.TaskID),
+		RunID:        strings.TrimSpace(refs.RunID),
+		ProjectID:    strings.TrimSpace(refs.ProjectID),
+		WorkItemID:   strings.TrimSpace(refs.WorkItemID),
+		AssignmentID: strings.TrimSpace(refs.AssignmentID),
+		RoleID:       strings.TrimSpace(refs.RoleID),
+	}
+}
+
+func MergeRefs(values ...chat.ContextRefs) chat.ContextRefs {
+	merged := chat.ContextRefs{}
+	for _, value := range values {
+		value = Refs(value)
+		merged.SessionID = firstNonEmpty(merged.SessionID, value.SessionID)
+		merged.MessageID = firstNonEmpty(merged.MessageID, value.MessageID)
+		merged.TaskID = firstNonEmpty(merged.TaskID, value.TaskID)
+		merged.RunID = firstNonEmpty(merged.RunID, value.RunID)
+		merged.ProjectID = firstNonEmpty(merged.ProjectID, value.ProjectID)
+		merged.WorkItemID = firstNonEmpty(merged.WorkItemID, value.WorkItemID)
+		merged.AssignmentID = firstNonEmpty(merged.AssignmentID, value.AssignmentID)
+		merged.RoleID = firstNonEmpty(merged.RoleID, value.RoleID)
+	}
+	return merged
+}
+
+func ChatMessageRefs(sessionID, messageID, projectID string) chat.ContextRefs {
+	return Refs(chat.ContextRefs{
+		SessionID: sessionID,
+		MessageID: messageID,
+		ProjectID: projectID,
+	})
+}
+
+func TaskRunRefs(taskID, runID, projectID string) chat.ContextRefs {
+	return Refs(chat.ContextRefs{
+		TaskID:    taskID,
+		RunID:     runID,
+		ProjectID: projectID,
+	})
+}
+
+func ProjectAssignmentRefs(projectID, workItemID, assignmentID, roleID string) chat.ContextRefs {
+	return Refs(chat.ContextRefs{
+		ProjectID:    projectID,
+		WorkItemID:   workItemID,
+		AssignmentID: assignmentID,
+		RoleID:       roleID,
+	})
+}
+
 func Normalize(packet chat.ContextPacket, refs chat.ContextRefs) chat.ContextPacket {
 	packet = Clone(packet)
+	refs = Refs(refs)
 	if packet.Refs == nil && !refsEmpty(refs) {
 		packet.Refs = &chat.ContextRefs{}
 	}

--- a/internal/chatcontext/packets_test.go
+++ b/internal/chatcontext/packets_test.go
@@ -98,6 +98,22 @@ func TestNormalizeMergesRefsAndDefaultSections(t *testing.T) {
 	}
 }
 
+func TestRefsMergeCanonicalContextRefs(t *testing.T) {
+	t.Parallel()
+
+	refs := MergeRefs(
+		ChatMessageRefs(" session_1 ", " msg_1 ", " proj_1 "),
+		TaskRunRefs(" task_1 ", " run_1 ", "ignored_project"),
+		ProjectAssignmentRefs("proj_1", " work_1 ", " asgn_1 ", " role_1 "),
+	)
+	if refs.SessionID != "session_1" || refs.MessageID != "msg_1" || refs.TaskID != "task_1" || refs.RunID != "run_1" {
+		t.Fatalf("runtime refs = %+v, want trimmed chat/task refs", refs)
+	}
+	if refs.ProjectID != "proj_1" || refs.WorkItemID != "work_1" || refs.AssignmentID != "asgn_1" || refs.RoleID != "role_1" {
+		t.Fatalf("project refs = %+v, want project assignment refs", refs)
+	}
+}
+
 func TestMarshalEmptyAndNonEmptyPackets(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -129,20 +129,16 @@ type ProjectSkillContext struct {
 }
 
 type AssignmentContext struct {
-	ID                string     `json:"id"`
-	WorkItemID        string     `json:"work_item_id"`
-	RoleID            string     `json:"role_id"`
-	DriverKind        string     `json:"driver_kind"`
-	Status            string     `json:"status"`
-	TaskID            string     `json:"task_id,omitempty"`
-	RunID             string     `json:"run_id,omitempty"`
-	ChatSessionID     string     `json:"chat_session_id,omitempty"`
-	MessageID         string     `json:"message_id,omitempty"`
-	ContextSnapshotID string     `json:"context_snapshot_id,omitempty"`
-	CreatedAt         time.Time  `json:"created_at"`
-	UpdatedAt         time.Time  `json:"updated_at"`
-	StartedAt         *time.Time `json:"started_at,omitempty"`
-	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+	ID           string                             `json:"id"`
+	WorkItemID   string                             `json:"work_item_id"`
+	RoleID       string                             `json:"role_id"`
+	DriverKind   string                             `json:"driver_kind"`
+	Status       string                             `json:"status"`
+	ExecutionRef projectwork.AssignmentExecutionRef `json:"execution_ref,omitempty"`
+	CreatedAt    time.Time                          `json:"created_at"`
+	UpdatedAt    time.Time                          `json:"updated_at"`
+	StartedAt    *time.Time                         `json:"started_at,omitempty"`
+	CompletedAt  *time.Time                         `json:"completed_at,omitempty"`
 }
 
 type MemoryContext struct {
@@ -547,20 +543,16 @@ func projectSkillContext(item projectskills.Skill) ProjectSkillContext {
 
 func assignmentContext(item projectwork.Assignment) AssignmentContext {
 	return AssignmentContext{
-		ID:                item.ID,
-		WorkItemID:        item.WorkItemID,
-		RoleID:            item.RoleID,
-		DriverKind:        item.DriverKind,
-		Status:            item.Status,
-		TaskID:            item.TaskID,
-		RunID:             item.RunID,
-		ChatSessionID:     item.ChatSessionID,
-		MessageID:         item.MessageID,
-		ContextSnapshotID: item.ContextSnapshotID,
-		CreatedAt:         item.CreatedAt,
-		UpdatedAt:         item.UpdatedAt,
-		StartedAt:         timePtrIfSet(item.StartedAt),
-		CompletedAt:       timePtrIfSet(item.CompletedAt),
+		ID:           item.ID,
+		WorkItemID:   item.WorkItemID,
+		RoleID:       item.RoleID,
+		DriverKind:   item.DriverKind,
+		Status:       item.Status,
+		ExecutionRef: projectwork.NormalizeAssignmentExecutionRef(item.ExecutionRef),
+		CreatedAt:    item.CreatedAt,
+		UpdatedAt:    item.UpdatedAt,
+		StartedAt:    timePtrIfSet(item.StartedAt),
+		CompletedAt:  timePtrIfSet(item.CompletedAt),
 	}
 }
 

--- a/internal/projectassistant/model_draft.go
+++ b/internal/projectassistant/model_draft.go
@@ -237,6 +237,13 @@ func validateModelDraftAction(draftContext DraftContext, index int, action Actio
 		if selectedWorkID == "" {
 			return fmt.Errorf("%w: model draft action %d cannot create assignment without selected_work", ErrInvalid, index+1)
 		}
+		hasRuntimeLinks, err := assignmentPatchHasRuntimeLinks(action.Patch)
+		if err != nil {
+			return err
+		}
+		if hasRuntimeLinks {
+			return fmt.Errorf("%w: model draft action %d assignment cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid, index+1)
+		}
 		var patch assignmentPatch
 		if err := decodePatch(action, &patch); err != nil {
 			return err
@@ -255,9 +262,6 @@ func validateModelDraftAction(draftContext DraftContext, index int, action Actio
 		}
 		if patch.Status != "" && patch.Status != projectwork.AssignmentStatusQueued {
 			return fmt.Errorf("%w: model draft action %d assignment status must be queued", ErrInvalid, index+1)
-		}
-		if patch.TaskID != "" || patch.RunID != "" || patch.ChatSessionID != "" || patch.MessageID != "" || patch.ContextSnapshotID != "" {
-			return fmt.Errorf("%w: model draft action %d assignment cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid, index+1)
 		}
 	case ActionCreateHandoff:
 		if selectedWorkID == "" {

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -393,6 +393,13 @@ func validateActionShape(action Action) error {
 			return fmt.Errorf("%w: action %q patch is required", ErrInvalid, kind)
 		}
 		if kind == ActionCreateAssignment {
+			hasRuntimeLinks, err := assignmentPatchHasRuntimeLinks(action.Patch)
+			if err != nil {
+				return err
+			}
+			if hasRuntimeLinks {
+				return fmt.Errorf("%w: create_assignment proposals cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid)
+			}
 			var patch assignmentPatch
 			if err := decodePatch(action, &patch); err != nil {
 				return err
@@ -408,13 +415,29 @@ func validateActionShape(action Action) error {
 }
 
 func validateAssignmentProposalBoundary(patch assignmentPatch) error {
-	if patch.TaskID != "" || patch.RunID != "" || patch.ChatSessionID != "" || patch.MessageID != "" || patch.ContextSnapshotID != "" || len(patch.ExecutionRef) > 0 {
+	if len(patch.ExecutionRef) > 0 {
 		return fmt.Errorf("%w: create_assignment proposals cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid)
 	}
 	if patch.Status != "" && patch.Status != projectwork.AssignmentStatusQueued {
 		return fmt.Errorf("%w: create_assignment proposals must create queued assignments", ErrInvalid)
 	}
 	return nil
+}
+
+func assignmentPatchHasRuntimeLinks(raw json.RawMessage) (bool, error) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return false, fmt.Errorf("%w: decode assignment patch keys: %v", ErrInvalid, err)
+	}
+	for _, key := range []string{"task_id", "run_id", "chat_session_id", "message_id", "context_snapshot_id", "execution_ref"} {
+		if _, ok := fields[key]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Service) applyCreateProject(ctx context.Context, action Action) (ActionResult, error) {
@@ -964,18 +987,13 @@ type updateWorkItemPatch struct {
 }
 
 type assignmentPatch struct {
-	ID                string          `json:"id,omitempty"`
-	ProjectID         string          `json:"project_id,omitempty"`
-	WorkItemID        string          `json:"work_item_id,omitempty"`
-	RoleID            string          `json:"role_id,omitempty"`
-	DriverKind        string          `json:"driver_kind,omitempty"`
-	Status            string          `json:"status,omitempty"`
-	TaskID            string          `json:"task_id,omitempty"`
-	RunID             string          `json:"run_id,omitempty"`
-	ChatSessionID     string          `json:"chat_session_id,omitempty"`
-	MessageID         string          `json:"message_id,omitempty"`
-	ContextSnapshotID string          `json:"context_snapshot_id,omitempty"`
-	ExecutionRef      json.RawMessage `json:"execution_ref,omitempty"`
+	ID           string          `json:"id,omitempty"`
+	ProjectID    string          `json:"project_id,omitempty"`
+	WorkItemID   string          `json:"work_item_id,omitempty"`
+	RoleID       string          `json:"role_id,omitempty"`
+	DriverKind   string          `json:"driver_kind,omitempty"`
+	Status       string          `json:"status,omitempty"`
+	ExecutionRef json.RawMessage `json:"execution_ref,omitempty"`
 }
 
 type handoffPatch struct {

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -408,7 +408,7 @@ func validateActionShape(action Action) error {
 }
 
 func validateAssignmentProposalBoundary(patch assignmentPatch) error {
-	if patch.TaskID != "" || patch.RunID != "" || patch.ChatSessionID != "" || patch.MessageID != "" || patch.ContextSnapshotID != "" {
+	if patch.TaskID != "" || patch.RunID != "" || patch.ChatSessionID != "" || patch.MessageID != "" || patch.ContextSnapshotID != "" || len(patch.ExecutionRef) > 0 {
 		return fmt.Errorf("%w: create_assignment proposals cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid)
 	}
 	if patch.Status != "" && patch.Status != projectwork.AssignmentStatusQueued {
@@ -750,17 +750,12 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 		id = s.idgen("asgn")
 	}
 	assignment, err := s.work.CreateAssignment(ctx, projectwork.Assignment{
-		ID:                id,
-		ProjectID:         projectID,
-		WorkItemID:        patch.WorkItemID,
-		RoleID:            patch.RoleID,
-		DriverKind:        patch.DriverKind,
-		Status:            patch.Status,
-		TaskID:            patch.TaskID,
-		RunID:             patch.RunID,
-		ChatSessionID:     patch.ChatSessionID,
-		MessageID:         patch.MessageID,
-		ContextSnapshotID: patch.ContextSnapshotID,
+		ID:         id,
+		ProjectID:  projectID,
+		WorkItemID: patch.WorkItemID,
+		RoleID:     patch.RoleID,
+		DriverKind: patch.DriverKind,
+		Status:     patch.Status,
 	})
 	if err != nil {
 		return ActionResult{}, mapProjectWorkErr(err)
@@ -969,17 +964,18 @@ type updateWorkItemPatch struct {
 }
 
 type assignmentPatch struct {
-	ID                string `json:"id,omitempty"`
-	ProjectID         string `json:"project_id,omitempty"`
-	WorkItemID        string `json:"work_item_id,omitempty"`
-	RoleID            string `json:"role_id,omitempty"`
-	DriverKind        string `json:"driver_kind,omitempty"`
-	Status            string `json:"status,omitempty"`
-	TaskID            string `json:"task_id,omitempty"`
-	RunID             string `json:"run_id,omitempty"`
-	ChatSessionID     string `json:"chat_session_id,omitempty"`
-	MessageID         string `json:"message_id,omitempty"`
-	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
+	ID                string          `json:"id,omitempty"`
+	ProjectID         string          `json:"project_id,omitempty"`
+	WorkItemID        string          `json:"work_item_id,omitempty"`
+	RoleID            string          `json:"role_id,omitempty"`
+	DriverKind        string          `json:"driver_kind,omitempty"`
+	Status            string          `json:"status,omitempty"`
+	TaskID            string          `json:"task_id,omitempty"`
+	RunID             string          `json:"run_id,omitempty"`
+	ChatSessionID     string          `json:"chat_session_id,omitempty"`
+	MessageID         string          `json:"message_id,omitempty"`
+	ContextSnapshotID string          `json:"context_snapshot_id,omitempty"`
+	ExecutionRef      json.RawMessage `json:"execution_ref,omitempty"`
 }
 
 type handoffPatch struct {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1444,6 +1444,17 @@ func TestService_ApplyRejectsNonQueuedAssignmentProposal(t *testing.T) {
 			errContains: "cannot bind chats, tasks, runs",
 		},
 		{
+			name: "execution ref",
+			patch: map[string]any{
+				"status": projectwork.AssignmentStatusQueued,
+				"execution_ref": map[string]any{
+					"kind":    "task_run",
+					"task_id": "task_existing",
+				},
+			},
+			errContains: "cannot bind chats, tasks, runs",
+		},
+		{
 			name: "running status",
 			patch: map[string]any{
 				"status": projectwork.AssignmentStatusRunning,

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -98,11 +98,7 @@ CREATE TABLE IF NOT EXISTS %s (
 	role_id TEXT NOT NULL,
 	driver_kind TEXT NOT NULL DEFAULT 'hecate_task',
 	status TEXT NOT NULL,
-	task_id TEXT NOT NULL DEFAULT '',
-	run_id TEXT NOT NULL DEFAULT '',
-	chat_session_id TEXT NOT NULL DEFAULT '',
-	message_id TEXT NOT NULL DEFAULT '',
-	context_snapshot_id TEXT NOT NULL DEFAULT '',
+	execution_ref TEXT NOT NULL DEFAULT '{}',
 	context_packet TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
@@ -163,6 +159,12 @@ CREATE TABLE IF NOT EXISTS %s (
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "context_packet", `TEXT NOT NULL DEFAULT ''`); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, s.assignmentsTbl, "execution_ref", `TEXT NOT NULL DEFAULT '{}'`); err != nil {
+		return err
+	}
+	if err := s.migrateAssignmentExecutionRefs(ctx); err != nil {
+		return err
+	}
 	for _, column := range []string{"default_driver_kind", "default_provider", "default_model", "default_agent_profile"} {
 		if err := s.ensureColumn(ctx, s.rolesTbl, column, `TEXT NOT NULL DEFAULT ''`); err != nil {
 			return err
@@ -186,6 +188,68 @@ CREATE TABLE IF NOT EXISTS %s (
 		name := strings.Trim(stmt.table, `"`) + "_" + stmt.name
 		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (%s)`, name, stmt.table, stmt.cols)); err != nil {
 			return fmt.Errorf("create %s index: %w", stmt.name, err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) migrateAssignmentExecutionRefs(ctx context.Context) error {
+	for _, column := range []string{"task_id", "run_id", "chat_session_id", "message_id", "context_snapshot_id"} {
+		exists, err := s.columnExists(ctx, s.assignmentsTbl, column)
+		if err != nil {
+			return fmt.Errorf("inspect sqlite project work legacy assignment columns: %w", err)
+		}
+		if !exists {
+			return nil
+		}
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, execution_ref, task_id, run_id, chat_session_id, message_id, context_snapshot_id
+FROM %s`, s.assignmentsTbl))
+	if err != nil {
+		return fmt.Errorf("read legacy project assignment execution refs: %w", err)
+	}
+	defer rows.Close()
+
+	type migratedRef struct {
+		id        string
+		projectID string
+		encoded   string
+	}
+	var updates []migratedRef
+	for rows.Next() {
+		var (
+			id, projectID, existing string
+			ref                     AssignmentExecutionRef
+		)
+		if err := rows.Scan(&id, &projectID, &existing, &ref.TaskID, &ref.RunID, &ref.ChatSessionID, &ref.MessageID, &ref.ContextSnapshotID); err != nil {
+			return fmt.Errorf("scan legacy project assignment execution ref: %w", err)
+		}
+		if !emptyAssignmentExecutionRefJSON(existing) {
+			continue
+		}
+		ref = NormalizeAssignmentExecutionRef(ref)
+		if ref.Kind == "" {
+			continue
+		}
+		encoded, err := encodeAssignmentExecutionRef(ref)
+		if err != nil {
+			return err
+		}
+		updates = append(updates, migratedRef{id: id, projectID: projectID, encoded: encoded})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := s.db.ExecContext(
+			ctx,
+			fmt.Sprintf(`UPDATE %s SET execution_ref = ? WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
+			update.encoded,
+			update.projectID,
+			update.id,
+		); err != nil {
+			return fmt.Errorf("migrate project assignment execution ref: %w", err)
 		}
 	}
 	return nil
@@ -496,7 +560,7 @@ func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilt
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ?`, s.assignmentsTbl)
 	args := []any{filter.ProjectID}
@@ -533,14 +597,18 @@ func (s *SQLiteStore) CreateAssignment(ctx context.Context, assignment Assignmen
 	} else if !ok {
 		return Assignment{}, fmt.Errorf("%w: work item not found", ErrNotFound)
 	}
-	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+	executionRef, err := encodeAssignmentExecutionRef(assignment.ExecutionRef)
+	if err != nil {
+		return Assignment{}, err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id,
-	message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
+	id, project_id, work_item_id, role_id, driver_kind, status, execution_ref,
+	context_packet, created_at, updated_at, started_at, completed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
 		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID, assignment.DriverKind,
-		assignment.Status, assignment.TaskID, assignment.RunID, assignment.ChatSessionID,
-		assignment.MessageID, assignment.ContextSnapshotID, string(assignment.ContextPacket), formatTime(assignment.CreatedAt),
+		assignment.Status, executionRef,
+		string(assignment.ContextPacket), formatTime(assignment.CreatedAt),
 		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
 	)
 	if err != nil {
@@ -582,13 +650,16 @@ func (s *SQLiteStore) UpdateAssignment(ctx context.Context, projectID, id string
 	if err := validateAssignment(item); err != nil {
 		return Assignment{}, err
 	}
+	executionRef, err := encodeAssignmentExecutionRef(item.ExecutionRef)
+	if err != nil {
+		return Assignment{}, err
+	}
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
-SET role_id = ?, driver_kind = ?, status = ?, task_id = ?, run_id = ?, chat_session_id = ?, message_id = ?,
-	context_snapshot_id = ?, context_packet = ?, updated_at = ?, started_at = ?, completed_at = ?
+SET role_id = ?, driver_kind = ?, status = ?, execution_ref = ?, context_packet = ?, updated_at = ?, started_at = ?, completed_at = ?
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
-		item.RoleID, item.DriverKind, item.Status, item.TaskID, item.RunID, item.ChatSessionID,
-		item.MessageID, item.ContextSnapshotID, string(item.ContextPacket), formatTime(item.UpdatedAt),
+		item.RoleID, item.DriverKind, item.Status, executionRef,
+		string(item.ContextPacket), formatTime(item.UpdatedAt),
 		formatTime(item.StartedAt), formatTime(item.CompletedAt), projectID, id,
 	)
 	if err != nil {
@@ -1026,7 +1097,7 @@ WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID),
 
 func (s *SQLiteStore) getRequiredAssignment(ctx context.Context, projectID, id string) (Assignment, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, task_id, run_id, chat_session_id, message_id, context_snapshot_id, context_packet, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanAssignment(row)
@@ -1144,14 +1215,17 @@ func scanWorkItem(row scanner) (WorkItem, error) {
 func scanAssignment(row scanner) (Assignment, error) {
 	var item Assignment
 	var createdAt, updatedAt, startedAt, completedAt string
+	var executionRef string
 	if err := row.Scan(
 		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.DriverKind, &item.Status,
-		&item.TaskID, &item.RunID, &item.ChatSessionID, &item.MessageID,
-		&item.ContextSnapshotID, &item.ContextPacket, &createdAt, &updatedAt, &startedAt, &completedAt,
+		&executionRef, &item.ContextPacket, &createdAt, &updatedAt, &startedAt, &completedAt,
 	); err != nil {
 		return Assignment{}, err
 	}
 	var err error
+	if item.ExecutionRef, err = decodeAssignmentExecutionRef(executionRef); err != nil {
+		return Assignment{}, err
+	}
 	if item.CreatedAt, err = parseTime(createdAt); err != nil {
 		return Assignment{}, err
 	}
@@ -1257,6 +1331,32 @@ func decodeStringList(value string) ([]string, error) {
 		return nil, err
 	}
 	return normalizeStringList(values), nil
+}
+
+func encodeAssignmentExecutionRef(ref AssignmentExecutionRef) (string, error) {
+	ref = NormalizeAssignmentExecutionRef(ref)
+	data, err := json.Marshal(ref)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func decodeAssignmentExecutionRef(value string) (AssignmentExecutionRef, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return AssignmentExecutionRef{}, nil
+	}
+	var ref AssignmentExecutionRef
+	if err := json.Unmarshal([]byte(value), &ref); err != nil {
+		return AssignmentExecutionRef{}, err
+	}
+	return NormalizeAssignmentExecutionRef(ref), nil
+}
+
+func emptyAssignmentExecutionRefJSON(value string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || value == "{}" || value == "null"
 }
 
 func formatTime(value time.Time) string {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -14,6 +14,10 @@ const (
 	AssignmentDriverHecateTask    = "hecate_task"
 	AssignmentDriverExternalAgent = "external_agent"
 
+	AssignmentExecutionKindTaskRun         = "task_run"
+	AssignmentExecutionKindChatSession     = "chat_session"
+	AssignmentExecutionKindContextSnapshot = "context_snapshot"
+
 	WorkItemStatusBacklog   = "backlog"
 	WorkItemStatusReady     = "ready"
 	WorkItemStatusRunning   = "running"
@@ -78,22 +82,31 @@ type WorkItem struct {
 }
 
 type Assignment struct {
-	ID                string
-	ProjectID         string
-	WorkItemID        string
-	RoleID            string
-	DriverKind        string
-	Status            string
-	TaskID            string
-	RunID             string
-	ChatSessionID     string
-	MessageID         string
-	ContextSnapshotID string
-	ContextPacket     []byte
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	StartedAt         time.Time
-	CompletedAt       time.Time
+	ID            string
+	ProjectID     string
+	WorkItemID    string
+	RoleID        string
+	DriverKind    string
+	Status        string
+	ExecutionRef  AssignmentExecutionRef
+	ContextPacket []byte
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	StartedAt     time.Time
+	CompletedAt   time.Time
+}
+
+type AssignmentExecutionRef struct {
+	Kind                 string `json:"kind,omitempty"`
+	TaskID               string `json:"task_id,omitempty"`
+	RunID                string `json:"run_id,omitempty"`
+	ChatSessionID        string `json:"chat_session_id,omitempty"`
+	MessageID            string `json:"message_id,omitempty"`
+	ContextSnapshotID    string `json:"context_snapshot_id,omitempty"`
+	Status               string `json:"status,omitempty"`
+	PendingApprovalCount int    `json:"pending_approval_count,omitempty"`
+	TraceID              string `json:"trace_id,omitempty"`
+	Missing              bool   `json:"missing,omitempty"`
 }
 
 type CollaborationArtifact struct {
@@ -780,11 +793,7 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 	item.RoleID = strings.TrimSpace(item.RoleID)
 	item.DriverKind = strings.TrimSpace(item.DriverKind)
 	item.Status = strings.TrimSpace(item.Status)
-	item.TaskID = strings.TrimSpace(item.TaskID)
-	item.RunID = strings.TrimSpace(item.RunID)
-	item.ChatSessionID = strings.TrimSpace(item.ChatSessionID)
-	item.MessageID = strings.TrimSpace(item.MessageID)
-	item.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
+	item.ExecutionRef = NormalizeAssignmentExecutionRef(item.ExecutionRef)
 	item.ContextPacket = append([]byte(nil), item.ContextPacket...)
 	if item.Status == "" {
 		item.Status = AssignmentStatusQueued
@@ -802,6 +811,37 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 		item.UpdatedAt = item.CreatedAt
 	}
 	return item
+}
+
+func NormalizeAssignmentExecutionRef(ref AssignmentExecutionRef) AssignmentExecutionRef {
+	ref.Kind = strings.TrimSpace(ref.Kind)
+	ref.TaskID = strings.TrimSpace(ref.TaskID)
+	ref.RunID = strings.TrimSpace(ref.RunID)
+	ref.ChatSessionID = strings.TrimSpace(ref.ChatSessionID)
+	ref.MessageID = strings.TrimSpace(ref.MessageID)
+	ref.ContextSnapshotID = strings.TrimSpace(ref.ContextSnapshotID)
+	ref.Status = strings.TrimSpace(ref.Status)
+	ref.TraceID = strings.TrimSpace(ref.TraceID)
+	if ref.Kind == "" {
+		ref.Kind = AssignmentExecutionRefKind(ref.TaskID, ref.RunID, ref.ChatSessionID, ref.MessageID, ref.ContextSnapshotID)
+	}
+	if ref.PendingApprovalCount < 0 {
+		ref.PendingApprovalCount = 0
+	}
+	return ref
+}
+
+func AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID string) string {
+	switch {
+	case strings.TrimSpace(taskID) != "" || strings.TrimSpace(runID) != "":
+		return AssignmentExecutionKindTaskRun
+	case strings.TrimSpace(chatSessionID) != "" || strings.TrimSpace(messageID) != "":
+		return AssignmentExecutionKindChatSession
+	case strings.TrimSpace(contextSnapshotID) != "":
+		return AssignmentExecutionKindContextSnapshot
+	default:
+		return ""
+	}
 }
 
 func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationArtifact {

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -125,14 +125,17 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			}
 
 			assignment, err := store.CreateAssignment(ctx, Assignment{
-				ID:                "asgn_impl",
-				ProjectID:         "proj_alpha",
-				WorkItemID:        "work_api",
-				RoleID:            "software_developer",
-				TaskID:            "task_123",
-				RunID:             "run_123",
-				ContextSnapshotID: "ctx_123",
-				ContextPacket:     []byte(`{"id":"ctx_123","version":"chat.context.v1"}`),
+				ID:         "asgn_impl",
+				ProjectID:  "proj_alpha",
+				WorkItemID: "work_api",
+				RoleID:     "software_developer",
+				ExecutionRef: AssignmentExecutionRef{
+					Kind:              AssignmentExecutionKindTaskRun,
+					TaskID:            "task_123",
+					RunID:             "run_123",
+					ContextSnapshotID: "ctx_123",
+				},
+				ContextPacket: []byte(`{"id":"ctx_123","version":"chat.context.v1"}`),
 			})
 			if err != nil {
 				t.Fatalf("CreateAssignment: %v", err)
@@ -145,6 +148,9 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			}
 			if string(assignment.ContextPacket) != `{"id":"ctx_123","version":"chat.context.v1"}` {
 				t.Fatalf("assignment context packet = %s, want stored packet", string(assignment.ContextPacket))
+			}
+			if assignment.ExecutionRef.TaskID != "task_123" || assignment.ExecutionRef.RunID != "run_123" || assignment.ExecutionRef.ContextSnapshotID != "ctx_123" {
+				t.Fatalf("assignment execution_ref = %+v, want stored canonical links", assignment.ExecutionRef)
 			}
 
 			startedAt := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
@@ -416,9 +422,9 @@ CREATE TABLE `+assignmentsTbl+` (
 	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
 	if _, err := client.DB().ExecContext(ctx, `
 INSERT INTO `+assignmentsTbl+` (
-	id, project_id, work_item_id, role_id, status, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		"asgn_legacy", "proj_alpha", "work_alpha", "software_developer", AssignmentStatusQueued, now, now,
+	id, project_id, work_item_id, role_id, status, task_id, run_id, context_snapshot_id, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"asgn_legacy", "proj_alpha", "work_alpha", "software_developer", AssignmentStatusQueued, "task_legacy", "run_legacy", "ctx_legacy", now, now,
 	); err != nil {
 		t.Fatalf("insert legacy assignment: %v", err)
 	}
@@ -433,6 +439,9 @@ INSERT INTO `+assignmentsTbl+` (
 	}
 	if len(assignments) != 1 || assignments[0].DriverKind != AssignmentDriverHecateTask {
 		t.Fatalf("assignments = %+v, want legacy assignment backfilled to hecate_task", assignments)
+	}
+	if assignments[0].ExecutionRef.TaskID != "task_legacy" || assignments[0].ExecutionRef.RunID != "run_legacy" || assignments[0].ExecutionRef.ContextSnapshotID != "ctx_legacy" {
+		t.Fatalf("assignment execution_ref = %+v, want legacy columns folded into canonical ref", assignments[0].ExecutionRef)
 	}
 }
 

--- a/internal/projectworkapp/activity.go
+++ b/internal/projectworkapp/activity.go
@@ -19,9 +19,6 @@ type ActivityLinkedChat struct {
 
 type ActivityAssignmentInput struct {
 	Status        string
-	TaskID        string
-	RunID         string
-	ChatSessionID string
 	Execution     *AssignmentExecutionSummary
 	ExecutionRef  *AssignmentExecutionRef
 	LinkedChat    *ActivityLinkedChat
@@ -83,16 +80,16 @@ func ProjectActivityBlockingSignal(input ActivityAssignmentInput) string {
 	case projectwork.AssignmentStatusCompleted:
 		return "completed"
 	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusQueued:
-		if input.Execution == nil && strings.TrimSpace(input.TaskID) == "" && strings.TrimSpace(input.RunID) != "" {
+		if input.Execution == nil && activityExecutionTaskID(input) == "" && activityExecutionRunID(input) != "" {
 			return "stale_unknown"
 		}
 		if input.Execution != nil && input.Execution.Missing {
 			return "stale_unknown"
 		}
 		if status == projectwork.AssignmentStatusQueued &&
-			strings.TrimSpace(input.TaskID) == "" &&
-			strings.TrimSpace(input.RunID) == "" &&
-			strings.TrimSpace(input.ChatSessionID) == "" {
+			activityExecutionTaskID(input) == "" &&
+			activityExecutionRunID(input) == "" &&
+			activityExecutionChatID(input) == "" {
 			return "not_started"
 		}
 		return "running"

--- a/internal/projectworkapp/activity.go
+++ b/internal/projectworkapp/activity.go
@@ -1,0 +1,228 @@
+package projectworkapp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type ActivityLinkedChat struct {
+	ID           string
+	Status       string
+	LatestRole   string
+	LatestStatus string
+	LatestError  string
+	MessageCount int
+	Missing      bool
+}
+
+type ActivityAssignmentInput struct {
+	Status        string
+	TaskID        string
+	RunID         string
+	ChatSessionID string
+	Execution     *AssignmentExecutionSummary
+	ExecutionRef  *AssignmentExecutionRef
+	LinkedChat    *ActivityLinkedChat
+	ArtifactCount int
+}
+
+type ActivityAssignmentState struct {
+	Status         string
+	BlockingSignal string
+	StatusSummary  string
+	LinkedTaskID   string
+	LinkedRunID    string
+	LinkedChatID   string
+	Bucket         string
+}
+
+func ProjectActivityAssignmentState(input ActivityAssignmentInput) ActivityAssignmentState {
+	status := strings.TrimSpace(ProjectActivityProjectedStatus(input))
+	if status == "" {
+		status = "unknown"
+	}
+	signal := ProjectActivityBlockingSignal(input)
+	return ActivityAssignmentState{
+		Status:         status,
+		BlockingSignal: signal,
+		StatusSummary:  ProjectActivityStatusSummary(input, signal),
+		LinkedTaskID:   activityExecutionTaskID(input),
+		LinkedRunID:    activityExecutionRunID(input),
+		LinkedChatID:   activityExecutionChatID(input),
+		Bucket:         ProjectActivityBucket(signal),
+	}
+}
+
+func ProjectActivityBucket(signal string) string {
+	switch strings.TrimSpace(signal) {
+	case "awaiting_approval", "failed", "cancelled", "not_started", "stale_unknown":
+		return "blocked"
+	case "completed":
+		return "completed"
+	case "running":
+		return "active"
+	default:
+		return "active"
+	}
+}
+
+func ProjectActivityBlockingSignal(input ActivityAssignmentInput) string {
+	if input.LinkedChat != nil && input.LinkedChat.Missing {
+		return "stale_unknown"
+	}
+	status := strings.TrimSpace(ProjectActivityProjectedStatus(input))
+	switch status {
+	case projectwork.AssignmentStatusAwaitingApproval:
+		return "awaiting_approval"
+	case projectwork.AssignmentStatusFailed:
+		return "failed"
+	case projectwork.AssignmentStatusCancelled, "closed":
+		return "cancelled"
+	case projectwork.AssignmentStatusCompleted:
+		return "completed"
+	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusQueued:
+		if input.Execution == nil && strings.TrimSpace(input.TaskID) == "" && strings.TrimSpace(input.RunID) != "" {
+			return "stale_unknown"
+		}
+		if input.Execution != nil && input.Execution.Missing {
+			return "stale_unknown"
+		}
+		if status == projectwork.AssignmentStatusQueued &&
+			strings.TrimSpace(input.TaskID) == "" &&
+			strings.TrimSpace(input.RunID) == "" &&
+			strings.TrimSpace(input.ChatSessionID) == "" {
+			return "not_started"
+		}
+		return "running"
+	default:
+		if input.Execution != nil && input.Execution.Missing {
+			return "stale_unknown"
+		}
+		return "stale_unknown"
+	}
+}
+
+func ProjectActivityStatusSummary(input ActivityAssignmentInput, signal string) string {
+	switch strings.TrimSpace(signal) {
+	case "awaiting_approval":
+		count := 0
+		if input.Execution != nil {
+			count = input.Execution.PendingApprovalCount
+		}
+		if input.ExecutionRef != nil && input.ExecutionRef.PendingApprovalCount > count {
+			count = input.ExecutionRef.PendingApprovalCount
+		}
+		if count > 0 {
+			return fmt.Sprintf("%d approval pending", count)
+		}
+		return "awaiting approval"
+	case "failed":
+		if input.LinkedChat != nil && input.LinkedChat.LatestError != "" {
+			return input.LinkedChat.LatestError
+		}
+		if input.Execution != nil && input.Execution.LastError != "" {
+			return input.Execution.LastError
+		}
+		if input.LinkedChat != nil {
+			return "linked chat failed"
+		}
+		return "failed run"
+	case "cancelled":
+		if input.LinkedChat != nil {
+			return "linked chat cancelled"
+		}
+		return "cancelled"
+	case "not_started":
+		return "not started"
+	case "running":
+		if input.LinkedChat != nil {
+			return ProjectActivityLinkedChatSummary(input.LinkedChat)
+		}
+		return "running"
+	case "completed":
+		if input.ArtifactCount > 0 {
+			return fmt.Sprintf("completed with %d artifact%s", input.ArtifactCount, pluralSuffix(input.ArtifactCount))
+		}
+		return "completed"
+	default:
+		if input.LinkedChat != nil && input.LinkedChat.Missing {
+			return "linked chat missing"
+		}
+		return "stale or unknown"
+	}
+}
+
+func ProjectActivityProjectedStatus(input ActivityAssignmentInput) string {
+	if input.LinkedChat != nil {
+		if input.LinkedChat.Missing {
+			return "stale_unknown"
+		}
+		if status := strings.TrimSpace(input.LinkedChat.Status); status != "" && status != "idle" {
+			return status
+		}
+		if status := strings.TrimSpace(input.LinkedChat.LatestStatus); status != "" {
+			return status
+		}
+		if strings.TrimSpace(input.LinkedChat.Status) == "idle" {
+			return firstNonEmpty(activityExecutionStatus(input), input.Status, projectwork.AssignmentStatusRunning)
+		}
+	}
+	return firstNonEmpty(activityExecutionStatus(input), input.Status)
+}
+
+func ProjectActivityLinkedChatSummary(linkedChat *ActivityLinkedChat) string {
+	if linkedChat == nil {
+		return ""
+	}
+	parts := []string{"linked chat"}
+	if linkedChat.Status != "" {
+		parts = append(parts, linkedChat.Status)
+	}
+	if linkedChat.LatestRole != "" && linkedChat.LatestStatus != "" {
+		parts = append(parts, linkedChat.LatestRole+" "+linkedChat.LatestStatus)
+	}
+	if linkedChat.MessageCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d message%s", linkedChat.MessageCount, pluralSuffix(linkedChat.MessageCount)))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func activityExecutionStatus(input ActivityAssignmentInput) string {
+	if input.ExecutionRef != nil {
+		return input.ExecutionRef.Status
+	}
+	if input.Execution == nil {
+		return ""
+	}
+	return input.Execution.Status
+}
+
+func activityExecutionTaskID(input ActivityAssignmentInput) string {
+	if input.ExecutionRef == nil {
+		return ""
+	}
+	return input.ExecutionRef.TaskID
+}
+
+func activityExecutionRunID(input ActivityAssignmentInput) string {
+	if input.ExecutionRef == nil {
+		return ""
+	}
+	return input.ExecutionRef.RunID
+}
+
+func activityExecutionChatID(input ActivityAssignmentInput) string {
+	if input.ExecutionRef == nil {
+		return ""
+	}
+	return input.ExecutionRef.ChatSessionID
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/projectworkapp/activity_test.go
+++ b/internal/projectworkapp/activity_test.go
@@ -1,0 +1,99 @@
+package projectworkapp
+
+import (
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestProjectActivityAssignmentState_AwaitingApprovalUsesCanonicalRef(t *testing.T) {
+	t.Parallel()
+
+	state := ProjectActivityAssignmentState(ActivityAssignmentInput{
+		Status: projectwork.AssignmentStatusQueued,
+		Execution: &AssignmentExecutionSummary{
+			Status:               projectwork.AssignmentStatusAwaitingApproval,
+			PendingApprovalCount: 1,
+		},
+		ExecutionRef: &AssignmentExecutionRef{
+			Kind:                 AssignmentExecutionKindTaskRun,
+			TaskID:               "task_1",
+			RunID:                "run_1",
+			Status:               projectwork.AssignmentStatusAwaitingApproval,
+			PendingApprovalCount: 2,
+		},
+	})
+	if state.Status != projectwork.AssignmentStatusAwaitingApproval || state.BlockingSignal != "awaiting_approval" || state.Bucket != "blocked" {
+		t.Fatalf("state = %+v, want awaiting approval blocked state", state)
+	}
+	if state.StatusSummary != "2 approval pending" || state.LinkedTaskID != "task_1" || state.LinkedRunID != "run_1" {
+		t.Fatalf("state = %+v, want ref-backed links and approval summary", state)
+	}
+}
+
+func TestProjectActivityAssignmentState_MissingRuntimeAndMissingChatAreStale(t *testing.T) {
+	t.Parallel()
+
+	missingRun := ProjectActivityAssignmentState(ActivityAssignmentInput{
+		Status: projectwork.AssignmentStatusRunning,
+		Execution: &AssignmentExecutionSummary{
+			Missing: true,
+		},
+		ExecutionRef: &AssignmentExecutionRef{
+			Kind:    AssignmentExecutionKindTaskRun,
+			TaskID:  "task_missing",
+			RunID:   "run_missing",
+			Missing: true,
+		},
+	})
+	if missingRun.BlockingSignal != "stale_unknown" || missingRun.Bucket != "blocked" || missingRun.LinkedTaskID != "task_missing" {
+		t.Fatalf("missing run state = %+v, want stale blocked state with canonical task link", missingRun)
+	}
+
+	missingChat := ProjectActivityAssignmentState(ActivityAssignmentInput{
+		Status: projectwork.AssignmentStatusRunning,
+		ExecutionRef: &AssignmentExecutionRef{
+			Kind:          AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_missing",
+		},
+		LinkedChat: &ActivityLinkedChat{ID: "chat_missing", Missing: true},
+	})
+	if missingChat.BlockingSignal != "stale_unknown" || missingChat.StatusSummary != "linked chat missing" || missingChat.LinkedChatID != "chat_missing" {
+		t.Fatalf("missing chat state = %+v, want stale linked-chat state", missingChat)
+	}
+}
+
+func TestProjectActivityAssignmentState_LinkedChatAndCompletedSummaries(t *testing.T) {
+	t.Parallel()
+
+	chatState := ProjectActivityAssignmentState(ActivityAssignmentInput{
+		Status: projectwork.AssignmentStatusRunning,
+		ExecutionRef: &AssignmentExecutionRef{
+			Kind:          AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_1",
+			Status:        projectwork.AssignmentStatusRunning,
+		},
+		LinkedChat: &ActivityLinkedChat{
+			ID:           "chat_1",
+			Status:       "running",
+			LatestRole:   "assistant",
+			LatestStatus: "completed",
+			MessageCount: 2,
+		},
+	})
+	if chatState.BlockingSignal != "running" || chatState.StatusSummary != "linked chat · running · assistant completed · 2 messages" || chatState.Bucket != "active" {
+		t.Fatalf("chat state = %+v, want active linked-chat summary", chatState)
+	}
+
+	completed := ProjectActivityAssignmentState(ActivityAssignmentInput{
+		Status:        projectwork.AssignmentStatusCompleted,
+		ArtifactCount: 2,
+		ExecutionRef: &AssignmentExecutionRef{
+			Kind:   AssignmentExecutionKindTaskRun,
+			Status: projectwork.AssignmentStatusCompleted,
+		},
+	})
+	if completed.BlockingSignal != "completed" || completed.StatusSummary != "completed with 2 artifacts" || completed.Bucket != "completed" {
+		t.Fatalf("completed state = %+v, want completed artifact summary", completed)
+	}
+}

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -111,30 +111,22 @@ type UpdateWorkItemCommand struct {
 }
 
 type CreateAssignmentCommand struct {
-	ID                string
-	RoleID            string
-	DriverKind        string
-	Status            string
-	TaskID            string
-	RunID             string
-	ChatSessionID     string
-	MessageID         string
-	ContextSnapshotID string
-	StartedAt         time.Time
-	CompletedAt       time.Time
+	ID           string
+	RoleID       string
+	DriverKind   string
+	Status       string
+	ExecutionRef projectwork.AssignmentExecutionRef
+	StartedAt    time.Time
+	CompletedAt  time.Time
 }
 
 type UpdateAssignmentCommand struct {
-	RoleID            *string
-	DriverKind        *string
-	Status            *string
-	TaskID            *string
-	RunID             *string
-	ChatSessionID     *string
-	MessageID         *string
-	ContextSnapshotID *string
-	StartedAt         *time.Time
-	CompletedAt       *time.Time
+	RoleID       *string
+	DriverKind   *string
+	Status       *string
+	ExecutionRef *projectwork.AssignmentExecutionRef
+	StartedAt    *time.Time
+	CompletedAt  *time.Time
 }
 
 type StartTaskAssignmentCommand struct {
@@ -334,19 +326,15 @@ func (app *Application) CreateAssignment(ctx context.Context, projectID, workIte
 		}
 	}
 	return app.store.CreateAssignment(ctx, projectwork.Assignment{
-		ID:                id,
-		ProjectID:         projectID,
-		WorkItemID:        workItemID,
-		RoleID:            cmd.RoleID,
-		DriverKind:        driverKind,
-		Status:            cmd.Status,
-		TaskID:            cmd.TaskID,
-		RunID:             cmd.RunID,
-		ChatSessionID:     cmd.ChatSessionID,
-		MessageID:         cmd.MessageID,
-		ContextSnapshotID: cmd.ContextSnapshotID,
-		StartedAt:         cmd.StartedAt,
-		CompletedAt:       cmd.CompletedAt,
+		ID:           id,
+		ProjectID:    projectID,
+		WorkItemID:   workItemID,
+		RoleID:       cmd.RoleID,
+		DriverKind:   driverKind,
+		Status:       cmd.Status,
+		ExecutionRef: cmd.ExecutionRef,
+		StartedAt:    cmd.StartedAt,
+		CompletedAt:  cmd.CompletedAt,
 	})
 }
 
@@ -364,20 +352,8 @@ func (app *Application) UpdateAssignment(ctx context.Context, projectID, assignm
 		if cmd.Status != nil {
 			item.Status = *cmd.Status
 		}
-		if cmd.TaskID != nil {
-			item.TaskID = *cmd.TaskID
-		}
-		if cmd.RunID != nil {
-			item.RunID = *cmd.RunID
-		}
-		if cmd.ChatSessionID != nil {
-			item.ChatSessionID = *cmd.ChatSessionID
-		}
-		if cmd.MessageID != nil {
-			item.MessageID = *cmd.MessageID
-		}
-		if cmd.ContextSnapshotID != nil {
-			item.ContextSnapshotID = *cmd.ContextSnapshotID
+		if cmd.ExecutionRef != nil {
+			item.ExecutionRef = *cmd.ExecutionRef
 		}
 		if cmd.StartedAt != nil {
 			item.StartedAt = *cmd.StartedAt
@@ -419,11 +395,16 @@ func (app *Application) StartTaskAssignment(ctx context.Context, cmd StartTaskAs
 	taskID := app.idgen("task")
 	claimRejected := false
 	assignment, err := app.store.UpdateAssignment(ctx, cmd.ProjectID, cmd.Assignment.ID, func(item *projectwork.Assignment) {
-		if item.TaskID != "" || item.RunID != "" || AssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverHecateTask {
+		ref := projectwork.NormalizeAssignmentExecutionRef(item.ExecutionRef)
+		if ref.TaskID != "" || ref.RunID != "" || AssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverHecateTask {
 			claimRejected = true
 			return
 		}
-		item.TaskID = taskID
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionKindTaskRun,
+			TaskID: taskID,
+			Status: projectwork.AssignmentStatusQueued,
+		}
 		item.Status = projectwork.AssignmentStatusQueued
 		if item.StartedAt.IsZero() {
 			item.StartedAt = app.now().UTC()
@@ -463,7 +444,11 @@ func (app *Application) StartTaskAssignment(ctx context.Context, cmd StartTaskAs
 	})
 	if err != nil {
 		assignment, updateErr := app.store.UpdateAssignment(ctx, cmd.ProjectID, cmd.Assignment.ID, func(item *projectwork.Assignment) {
-			item.TaskID = task.ID
+			item.ExecutionRef = projectwork.AssignmentExecutionRef{
+				Kind:   projectwork.AssignmentExecutionKindTaskRun,
+				TaskID: task.ID,
+				Status: projectwork.AssignmentStatusFailed,
+			}
 			item.Status = projectwork.AssignmentStatusFailed
 			item.CompletedAt = app.now().UTC()
 		})
@@ -474,10 +459,16 @@ func (app *Application) StartTaskAssignment(ctx context.Context, cmd StartTaskAs
 	}
 
 	assignment, err = app.store.UpdateAssignment(ctx, cmd.ProjectID, cmd.Assignment.ID, func(item *projectwork.Assignment) {
-		item.TaskID = result.Task.ID
-		item.RunID = result.Run.ID
-		item.ContextSnapshotID = cmd.ContextSnapshotID
-		item.Status = AssignmentStatusFromRun(result.Run.Status)
+		status := AssignmentStatusFromRun(result.Run.Status)
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{
+			Kind:              projectwork.AssignmentExecutionKindTaskRun,
+			TaskID:            result.Task.ID,
+			RunID:             result.Run.ID,
+			ContextSnapshotID: cmd.ContextSnapshotID,
+			Status:            status,
+			TraceID:           result.Run.TraceID,
+		}
+		item.Status = status
 		if item.StartedAt.IsZero() {
 			item.StartedAt = app.now().UTC()
 		}
@@ -504,7 +495,7 @@ func (app *Application) StartExternalAgentAssignment(ctx context.Context, cmd St
 	if app.agentRunner == nil {
 		return nil, ErrAgentRunnerNotConfigured
 	}
-	if strings.TrimSpace(cmd.Assignment.ChatSessionID) != "" ||
+	if strings.TrimSpace(cmd.Assignment.ExecutionRef.ChatSessionID) != "" ||
 		AssignmentIsTerminal(cmd.Assignment.Status) ||
 		cmd.Assignment.DriverKind != projectwork.AssignmentDriverExternalAgent {
 		return &StartExternalAgentAssignmentResult{Assignment: cmd.Assignment}, ErrAssignmentStartConflict
@@ -542,11 +533,16 @@ func (app *Application) StartExternalAgentAssignment(ctx context.Context, cmd St
 	}
 
 	assignment, err := app.store.UpdateAssignment(ctx, cmd.ProjectID, cmd.Assignment.ID, func(item *projectwork.Assignment) {
-		if item.ChatSessionID != "" || AssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverExternalAgent {
+		ref := projectwork.NormalizeAssignmentExecutionRef(item.ExecutionRef)
+		if ref.ChatSessionID != "" || AssignmentIsTerminal(item.Status) || item.DriverKind != projectwork.AssignmentDriverExternalAgent {
 			return
 		}
-		item.ChatSessionID = session.ID
-		item.ContextSnapshotID = cmd.ContextSnapshotID
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{
+			Kind:              projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID:     session.ID,
+			ContextSnapshotID: cmd.ContextSnapshotID,
+			Status:            projectwork.AssignmentStatusRunning,
+		}
 		item.ContextPacket = append([]byte(nil), cmd.ContextPacket...)
 		item.Status = projectwork.AssignmentStatusRunning
 		if item.StartedAt.IsZero() {
@@ -557,7 +553,7 @@ func (app *Application) StartExternalAgentAssignment(ctx context.Context, cmd St
 		app.cleanupExternalSession(session.ID)
 		return &StartExternalAgentAssignmentResult{Session: session}, err
 	}
-	if assignment.ChatSessionID != session.ID {
+	if assignment.ExecutionRef.ChatSessionID != session.ID {
 		app.cleanupExternalSession(session.ID)
 		return &StartExternalAgentAssignmentResult{Assignment: assignment, Session: session}, ErrAssignmentStartConflict
 	}
@@ -580,8 +576,9 @@ func (app *Application) loadRole(ctx context.Context, projectID, roleID string) 
 
 func (app *Application) clearTaskClaim(ctx context.Context, projectID, assignmentID, taskID string) (projectwork.Assignment, error) {
 	return app.store.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
-		if item.TaskID == taskID && item.RunID == "" {
-			item.TaskID = ""
+		ref := projectwork.NormalizeAssignmentExecutionRef(item.ExecutionRef)
+		if ref.TaskID == taskID && ref.RunID == "" {
+			item.ExecutionRef = projectwork.AssignmentExecutionRef{}
 			item.Status = projectwork.AssignmentStatusQueued
 			item.StartedAt = time.Time{}
 			item.CompletedAt = time.Time{}
@@ -627,11 +624,12 @@ func AssignmentStatusFromRun(status string) string {
 }
 
 func AssignmentHasActiveExecution(ctx context.Context, store TaskRunLookupStore, assignment projectwork.Assignment) (bool, error) {
-	if strings.TrimSpace(assignment.RunID) != "" && strings.TrimSpace(assignment.TaskID) != "" && store == nil {
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	if strings.TrimSpace(ref.RunID) != "" && strings.TrimSpace(ref.TaskID) != "" && store == nil {
 		return false, ErrTaskStoreNotConfigured
 	}
-	if strings.TrimSpace(assignment.RunID) != "" && strings.TrimSpace(assignment.TaskID) != "" {
-		run, ok, err := store.GetRun(ctx, assignment.TaskID, assignment.RunID)
+	if strings.TrimSpace(ref.RunID) != "" && strings.TrimSpace(ref.TaskID) != "" {
+		run, ok, err := store.GetRun(ctx, ref.TaskID, ref.RunID)
 		if err != nil {
 			return false, err
 		}
@@ -643,7 +641,7 @@ func AssignmentHasActiveExecution(ctx context.Context, store TaskRunLookupStore,
 	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
 		return true, nil
 	case projectwork.AssignmentStatusQueued:
-		return strings.TrimSpace(assignment.TaskID) != "" || strings.TrimSpace(assignment.RunID) != "", nil
+		return strings.TrimSpace(ref.TaskID) != "" || strings.TrimSpace(ref.RunID) != "", nil
 	default:
 		return false, nil
 	}

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -93,17 +93,17 @@ func TestApplication_UpdateAssignmentAppliesOptionalFields(t *testing.T) {
 	}
 
 	status := projectwork.AssignmentStatusRunning
-	runID := "run_1"
+	ref := projectwork.AssignmentExecutionRef{Kind: projectwork.AssignmentExecutionKindTaskRun, RunID: "run_1", Status: status}
 	startedAt := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
 	updated, err := app.UpdateAssignment(ctx, "proj_1", assignment.ID, UpdateAssignmentCommand{
-		Status:    &status,
-		RunID:     &runID,
-		StartedAt: &startedAt,
+		Status:       &status,
+		ExecutionRef: &ref,
+		StartedAt:    &startedAt,
 	})
 	if err != nil {
 		t.Fatalf("UpdateAssignment() error = %v", err)
 	}
-	if updated.Status != status || updated.RunID != runID || !updated.StartedAt.Equal(startedAt) {
+	if updated.Status != status || updated.ExecutionRef.RunID != ref.RunID || !updated.StartedAt.Equal(startedAt) {
 		t.Fatalf("updated assignment = %+v, want optional fields applied", updated)
 	}
 }
@@ -201,7 +201,7 @@ func TestApplication_StartTaskAssignmentCreatesTaskAndLinksRun(t *testing.T) {
 	if result.Task.ID != "task_fixed" || result.Run.ID != "run_started" || result.TraceID != "trace-start" {
 		t.Fatalf("result = %+v, want task/run/trace from runner", result)
 	}
-	if result.Assignment.TaskID != result.Task.ID || result.Assignment.RunID != result.Run.ID || result.Assignment.ContextSnapshotID != "ctx_1" {
+	if result.Assignment.ExecutionRef.TaskID != result.Task.ID || result.Assignment.ExecutionRef.RunID != result.Run.ID || result.Assignment.ExecutionRef.ContextSnapshotID != "ctx_1" {
 		t.Fatalf("linked assignment = %+v, want task/run/context links", result.Assignment)
 	}
 	if _, ok, err := taskStore.GetTask(ctx, result.Task.ID); err != nil || !ok {
@@ -219,7 +219,7 @@ func TestApplication_StartTaskAssignmentRejectsActiveAssignmentBeforeRunner(t *t
 	app := newStartTestApplication(workStore, taskStore, runner)
 	assignment := seedStartTestAssignment(t, ctx, app)
 	assignment, err := workStore.UpdateAssignment(ctx, "proj_1", assignment.ID, func(item *projectwork.Assignment) {
-		item.TaskID = "task_existing"
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{Kind: projectwork.AssignmentExecutionKindTaskRun, TaskID: "task_existing"}
 		item.Status = projectwork.AssignmentStatusQueued
 	})
 	if err != nil {
@@ -268,7 +268,7 @@ func TestApplication_StartTaskAssignmentBuildFailureClearsClaim(t *testing.T) {
 		t.Fatalf("ListAssignments() error = %v", err)
 	}
 	got := items[0]
-	if got.TaskID != "" || got.RunID != "" || got.Status != projectwork.AssignmentStatusQueued || !got.StartedAt.IsZero() {
+	if got.ExecutionRef.TaskID != "" || got.ExecutionRef.RunID != "" || got.Status != projectwork.AssignmentStatusQueued || !got.StartedAt.IsZero() {
 		t.Fatalf("assignment after build failure = %+v, want cleared queued claim", got)
 	}
 	if runner.calls != 0 {
@@ -300,7 +300,7 @@ func TestApplication_StartTaskAssignmentRunnerFailureMarksFailed(t *testing.T) {
 	if result == nil || result.Task.ID != "task_fixed" {
 		t.Fatalf("result = %+v, want created task on runner failure", result)
 	}
-	if result.Assignment.Status != projectwork.AssignmentStatusFailed || result.Assignment.TaskID != "task_fixed" || result.Assignment.CompletedAt.IsZero() {
+	if result.Assignment.Status != projectwork.AssignmentStatusFailed || result.Assignment.ExecutionRef.TaskID != "task_fixed" || result.Assignment.CompletedAt.IsZero() {
 		t.Fatalf("assignment after runner failure = %+v, want failed linked task", result.Assignment)
 	}
 }
@@ -385,7 +385,7 @@ func TestApplication_StartExternalAgentAssignmentPreparesAndLinksSession(t *test
 	if runner.prepareCalls != 1 || runner.closeCalls != 0 {
 		t.Fatalf("runner prepare/close = %d/%d, want 1/0", runner.prepareCalls, runner.closeCalls)
 	}
-	if result.Assignment.ChatSessionID != "chat_ext" || result.Assignment.ContextSnapshotID != "ctx_ext" || result.Assignment.Status != projectwork.AssignmentStatusRunning {
+	if result.Assignment.ExecutionRef.ChatSessionID != "chat_ext" || result.Assignment.ExecutionRef.ContextSnapshotID != "ctx_ext" || result.Assignment.Status != projectwork.AssignmentStatusRunning {
 		t.Fatalf("assignment = %+v, want linked running session", result.Assignment)
 	}
 	session, ok, err := chatStore.Get(ctx, "chat_ext")
@@ -428,7 +428,7 @@ func TestApplication_StartExternalAgentAssignmentPrepareFailureDeletesSession(t 
 	if err != nil {
 		t.Fatalf("ListAssignments() error = %v", err)
 	}
-	if items[0].ChatSessionID != "" || items[0].Status != projectwork.AssignmentStatusQueued {
+	if items[0].ExecutionRef.ChatSessionID != "" || items[0].Status != projectwork.AssignmentStatusQueued {
 		t.Fatalf("assignment after prepare failure = %+v, want unlinked queued", items[0])
 	}
 }
@@ -470,7 +470,7 @@ func (s *racingAssignmentStore) UpdateAssignment(ctx context.Context, projectID,
 	if !s.raced && assignmentID == "asgn_ext" {
 		s.raced = true
 		if _, err := s.Store.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
-			item.ChatSessionID = "chat_winner"
+			item.ExecutionRef = projectwork.AssignmentExecutionRef{Kind: projectwork.AssignmentExecutionKindChatSession, ChatSessionID: "chat_winner"}
 			item.Status = projectwork.AssignmentStatusRunning
 		}); err != nil {
 			return projectwork.Assignment{}, err
@@ -498,7 +498,7 @@ func TestApplication_StartExternalAgentAssignmentCleansPreparedSessionWhenClaimL
 	if !errors.Is(err, ErrAssignmentStartConflict) {
 		t.Fatalf("StartExternalAgentAssignment(raced claim) error = %v, want ErrAssignmentStartConflict", err)
 	}
-	if result == nil || result.Assignment.ChatSessionID != "chat_winner" {
+	if result == nil || result.Assignment.ExecutionRef.ChatSessionID != "chat_winner" {
 		t.Fatalf("result = %+v, want winning assignment", result)
 	}
 	if runner.prepareCalls != 1 || runner.closeCalls != 1 {
@@ -519,7 +519,7 @@ func TestApplication_StartExternalAgentAssignmentRejectsExistingChatBeforePrepar
 	app := newExternalStartTestApplication(workStore, chatStore, runner)
 	assignment := seedExternalStartTestAssignment(t, ctx, app)
 	assignment, err := workStore.UpdateAssignment(ctx, "proj_1", assignment.ID, func(item *projectwork.Assignment) {
-		item.ChatSessionID = "chat_existing"
+		item.ExecutionRef = projectwork.AssignmentExecutionRef{Kind: projectwork.AssignmentExecutionKindChatSession, ChatSessionID: "chat_existing"}
 	})
 	if err != nil {
 		t.Fatalf("UpdateAssignment() error = %v", err)

--- a/internal/projectworkapp/projection.go
+++ b/internal/projectworkapp/projection.go
@@ -1,0 +1,250 @@
+package projectworkapp
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	AssignmentExecutionKindTaskRun         = "task_run"
+	AssignmentExecutionKindChatSession     = "chat_session"
+	AssignmentExecutionKindContextSnapshot = "context_snapshot"
+)
+
+type AssignmentProjectionStore interface {
+	TaskRunLookupStore
+	GetTask(ctx context.Context, taskID string) (types.Task, bool, error)
+	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
+}
+
+type AssignmentExecutionSummary struct {
+	TaskID               string
+	RunID                string
+	TaskStatus           string
+	RunStatus            string
+	Status               string
+	PendingApprovalCount int
+	StepCount            int
+	ApprovalCount        int
+	ArtifactCount        int
+	Model                string
+	Provider             string
+	LastError            string
+	StartedAt            time.Time
+	FinishedAt           time.Time
+	TraceID              string
+	Missing              bool
+}
+
+type AssignmentExecutionRef struct {
+	Kind                 string
+	TaskID               string
+	RunID                string
+	ChatSessionID        string
+	MessageID            string
+	ContextSnapshotID    string
+	Status               string
+	PendingApprovalCount int
+	TraceID              string
+	Missing              bool
+}
+
+type AssignmentExecutionProjection struct {
+	Execution   AssignmentExecutionSummary
+	Status      string
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+func ProjectAssignmentExecution(ctx context.Context, store AssignmentProjectionStore, assignment projectwork.Assignment) (*AssignmentExecutionProjection, error) {
+	taskID := strings.TrimSpace(assignment.TaskID)
+	runID := strings.TrimSpace(assignment.RunID)
+	if taskID == "" {
+		return nil, nil
+	}
+	projection := &AssignmentExecutionProjection{
+		Status:    assignment.Status,
+		StartedAt: assignment.StartedAt,
+		Execution: AssignmentExecutionSummary{
+			TaskID: taskID,
+			RunID:  runID,
+		},
+	}
+	if store == nil {
+		projection.Execution.Missing = true
+		return projection, nil
+	}
+
+	foundTask, found, err := store.GetTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		projection.Execution.Missing = true
+		return projection, nil
+	}
+	task := foundTask
+	projection.Execution.TaskStatus = task.Status
+	if runID == "" {
+		runID = strings.TrimSpace(task.LatestRunID)
+		projection.Execution.RunID = runID
+	}
+
+	if runID == "" {
+		status := AssignmentStatusFromRun(task.Status)
+		projection.Execution.Status = status
+		projection.Status = ProjectedAssignmentStatus(assignment, status, task.UpdatedAt)
+		return projection, nil
+	}
+
+	run, found, err := store.GetRun(ctx, taskID, runID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		projection.Execution.Missing = true
+		return projection, nil
+	}
+
+	status := AssignmentStatusFromRun(run.Status)
+	pendingApprovalCount := 0
+	if status == projectwork.AssignmentStatusAwaitingApproval {
+		pendingCount, err := PendingApprovalCount(ctx, store, taskID, runID)
+		if err != nil {
+			return nil, err
+		}
+		pendingApprovalCount = pendingCount
+	}
+	projection.Status = ProjectedAssignmentStatus(assignment, status, RunProjectionTime(run))
+	projection.StartedAt = FirstNonZeroTime(assignment.StartedAt, run.StartedAt)
+	if types.IsTerminalTaskRunStatus(run.Status) {
+		projection.CompletedAt = FirstNonZeroTime(assignment.CompletedAt, run.FinishedAt)
+	} else {
+		projection.CompletedAt = assignment.CompletedAt
+	}
+	projection.Execution = AssignmentExecutionSummary{
+		TaskID:               taskID,
+		RunID:                runID,
+		TaskStatus:           task.Status,
+		RunStatus:            run.Status,
+		Status:               status,
+		PendingApprovalCount: pendingApprovalCount,
+		StepCount:            run.StepCount,
+		ApprovalCount:        run.ApprovalCount,
+		ArtifactCount:        run.ArtifactCount,
+		Model:                run.Model,
+		Provider:             run.Provider,
+		LastError:            run.LastError,
+		StartedAt:            run.StartedAt,
+		FinishedAt:           run.FinishedAt,
+		TraceID:              run.TraceID,
+	}
+	return projection, nil
+}
+
+func AssignmentExecutionRefFor(assignment projectwork.Assignment, execution *AssignmentExecutionSummary, status string) *AssignmentExecutionRef {
+	taskID := strings.TrimSpace(assignment.TaskID)
+	runID := strings.TrimSpace(assignment.RunID)
+	pendingApprovalCount := 0
+	traceID := ""
+	missing := false
+	if execution != nil {
+		taskID = firstNonEmpty(execution.TaskID, taskID)
+		runID = firstNonEmpty(execution.RunID, runID)
+		status = firstNonEmpty(execution.Status, status)
+		pendingApprovalCount = execution.PendingApprovalCount
+		traceID = execution.TraceID
+		missing = execution.Missing
+	}
+	chatSessionID := strings.TrimSpace(assignment.ChatSessionID)
+	messageID := strings.TrimSpace(assignment.MessageID)
+	contextSnapshotID := strings.TrimSpace(assignment.ContextSnapshotID)
+	kind := AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID)
+	if kind == "" {
+		return nil
+	}
+	return &AssignmentExecutionRef{
+		Kind:                 kind,
+		TaskID:               taskID,
+		RunID:                runID,
+		ChatSessionID:        chatSessionID,
+		MessageID:            messageID,
+		ContextSnapshotID:    contextSnapshotID,
+		Status:               strings.TrimSpace(status),
+		PendingApprovalCount: pendingApprovalCount,
+		TraceID:              traceID,
+		Missing:              missing,
+	}
+}
+
+func AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID string) string {
+	switch {
+	case strings.TrimSpace(taskID) != "" || strings.TrimSpace(runID) != "":
+		return AssignmentExecutionKindTaskRun
+	case strings.TrimSpace(chatSessionID) != "" || strings.TrimSpace(messageID) != "":
+		return AssignmentExecutionKindChatSession
+	case strings.TrimSpace(contextSnapshotID) != "":
+		return AssignmentExecutionKindContextSnapshot
+	default:
+		return ""
+	}
+}
+
+func ProjectedAssignmentStatus(assignment projectwork.Assignment, projectedStatus string, projectedAt time.Time) string {
+	projectedStatus = strings.TrimSpace(projectedStatus)
+	if projectedStatus == "" {
+		return assignment.Status
+	}
+	if AssignmentIsTerminal(assignment.Status) && assignment.Status != projectedStatus {
+		if projectedAt.IsZero() || !projectedAt.After(assignment.UpdatedAt) {
+			return assignment.Status
+		}
+	}
+	return projectedStatus
+}
+
+func RunProjectionTime(run types.TaskRun) time.Time {
+	if !run.FinishedAt.IsZero() {
+		return run.FinishedAt
+	}
+	return run.StartedAt
+}
+
+func FirstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func PendingApprovalCount(ctx context.Context, store AssignmentProjectionStore, taskID, runID string) (int, error) {
+	if store == nil {
+		return 0, nil
+	}
+	approvals, err := store.ListApprovals(ctx, taskID)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, approval := range approvals {
+		if approval.RunID == runID && approval.Status == "pending" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/projectworkapp/projection.go
+++ b/internal/projectworkapp/projection.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	AssignmentExecutionKindTaskRun         = "task_run"
-	AssignmentExecutionKindChatSession     = "chat_session"
-	AssignmentExecutionKindContextSnapshot = "context_snapshot"
+	AssignmentExecutionKindTaskRun         = projectwork.AssignmentExecutionKindTaskRun
+	AssignmentExecutionKindChatSession     = projectwork.AssignmentExecutionKindChatSession
+	AssignmentExecutionKindContextSnapshot = projectwork.AssignmentExecutionKindContextSnapshot
 )
 
 type AssignmentProjectionStore interface {
@@ -40,18 +40,7 @@ type AssignmentExecutionSummary struct {
 	Missing              bool
 }
 
-type AssignmentExecutionRef struct {
-	Kind                 string
-	TaskID               string
-	RunID                string
-	ChatSessionID        string
-	MessageID            string
-	ContextSnapshotID    string
-	Status               string
-	PendingApprovalCount int
-	TraceID              string
-	Missing              bool
-}
+type AssignmentExecutionRef = projectwork.AssignmentExecutionRef
 
 type AssignmentExecutionProjection struct {
 	Execution   AssignmentExecutionSummary
@@ -61,8 +50,9 @@ type AssignmentExecutionProjection struct {
 }
 
 func ProjectAssignmentExecution(ctx context.Context, store AssignmentProjectionStore, assignment projectwork.Assignment) (*AssignmentExecutionProjection, error) {
-	taskID := strings.TrimSpace(assignment.TaskID)
-	runID := strings.TrimSpace(assignment.RunID)
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	taskID := strings.TrimSpace(ref.TaskID)
+	runID := strings.TrimSpace(ref.RunID)
 	if taskID == "" {
 		return nil, nil
 	}
@@ -147,11 +137,13 @@ func ProjectAssignmentExecution(ctx context.Context, store AssignmentProjectionS
 }
 
 func AssignmentExecutionRefFor(assignment projectwork.Assignment, execution *AssignmentExecutionSummary, status string) *AssignmentExecutionRef {
-	taskID := strings.TrimSpace(assignment.TaskID)
-	runID := strings.TrimSpace(assignment.RunID)
-	pendingApprovalCount := 0
-	traceID := ""
-	missing := false
+	base := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	taskID := strings.TrimSpace(base.TaskID)
+	runID := strings.TrimSpace(base.RunID)
+	status = firstNonEmpty(status, base.Status)
+	pendingApprovalCount := base.PendingApprovalCount
+	traceID := base.TraceID
+	missing := base.Missing
 	if execution != nil {
 		taskID = firstNonEmpty(execution.TaskID, taskID)
 		runID = firstNonEmpty(execution.RunID, runID)
@@ -160,10 +152,10 @@ func AssignmentExecutionRefFor(assignment projectwork.Assignment, execution *Ass
 		traceID = execution.TraceID
 		missing = execution.Missing
 	}
-	chatSessionID := strings.TrimSpace(assignment.ChatSessionID)
-	messageID := strings.TrimSpace(assignment.MessageID)
-	contextSnapshotID := strings.TrimSpace(assignment.ContextSnapshotID)
-	kind := AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID)
+	chatSessionID := strings.TrimSpace(base.ChatSessionID)
+	messageID := strings.TrimSpace(base.MessageID)
+	contextSnapshotID := strings.TrimSpace(base.ContextSnapshotID)
+	kind := firstNonEmpty(base.Kind, AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID))
 	if kind == "" {
 		return nil
 	}
@@ -182,16 +174,7 @@ func AssignmentExecutionRefFor(assignment projectwork.Assignment, execution *Ass
 }
 
 func AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID string) string {
-	switch {
-	case strings.TrimSpace(taskID) != "" || strings.TrimSpace(runID) != "":
-		return AssignmentExecutionKindTaskRun
-	case strings.TrimSpace(chatSessionID) != "" || strings.TrimSpace(messageID) != "":
-		return AssignmentExecutionKindChatSession
-	case strings.TrimSpace(contextSnapshotID) != "":
-		return AssignmentExecutionKindContextSnapshot
-	default:
-		return ""
-	}
+	return projectwork.AssignmentExecutionRefKind(taskID, runID, chatSessionID, messageID, contextSnapshotID)
 }
 
 func ProjectedAssignmentStatus(assignment projectwork.Assignment, projectedStatus string, projectedAt time.Time) string {

--- a/internal/projectworkapp/projection_test.go
+++ b/internal/projectworkapp/projection_test.go
@@ -38,9 +38,12 @@ func TestProjectAssignmentExecution_ProjectsRunAndCanonicalRef(t *testing.T) {
 	}
 
 	assignment := projectwork.Assignment{
-		ID:        "asgn_1",
-		TaskID:    "task_1",
-		RunID:     "run_1",
+		ID: "asgn_1",
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionKindTaskRun,
+			TaskID: "task_1",
+			RunID:  "run_1",
+		},
 		Status:    projectwork.AssignmentStatusQueued,
 		UpdatedAt: startedAt.Add(-time.Minute),
 	}
@@ -67,9 +70,9 @@ func TestProjectAssignmentExecution_MissingTaskMarksExecutionMissing(t *testing.
 	t.Parallel()
 
 	projection, err := ProjectAssignmentExecution(context.Background(), taskstate.NewMemoryStore(), projectwork.Assignment{
-		ID:     "asgn_1",
-		TaskID: "task_missing",
-		Status: projectwork.AssignmentStatusQueued,
+		ID:           "asgn_1",
+		ExecutionRef: projectwork.AssignmentExecutionRef{Kind: projectwork.AssignmentExecutionKindTaskRun, TaskID: "task_missing"},
+		Status:       projectwork.AssignmentStatusQueued,
 	})
 	if err != nil {
 		t.Fatalf("ProjectAssignmentExecution() error = %v", err)
@@ -77,7 +80,7 @@ func TestProjectAssignmentExecution_MissingTaskMarksExecutionMissing(t *testing.
 	if projection == nil || !projection.Execution.Missing || projection.Execution.TaskID != "task_missing" {
 		t.Fatalf("projection = %+v, want missing execution summary", projection)
 	}
-	ref := AssignmentExecutionRefFor(projectwork.Assignment{TaskID: "task_missing"}, &projection.Execution, projection.Status)
+	ref := AssignmentExecutionRefFor(projectwork.Assignment{ExecutionRef: projectwork.AssignmentExecutionRef{TaskID: "task_missing"}}, &projection.Execution, projection.Status)
 	if ref == nil || !ref.Missing || ref.Kind != AssignmentExecutionKindTaskRun {
 		t.Fatalf("execution ref = %+v, want missing task-run ref", ref)
 	}
@@ -87,16 +90,22 @@ func TestAssignmentExecutionRefFor_RawChatAndContextLinks(t *testing.T) {
 	t.Parallel()
 
 	chatRef := AssignmentExecutionRefFor(projectwork.Assignment{
-		ChatSessionID: "chat_1",
-		MessageID:     "msg_1",
-		Status:        projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_1",
+			MessageID:     "msg_1",
+		},
+		Status: projectwork.AssignmentStatusRunning,
 	}, nil, projectwork.AssignmentStatusRunning)
 	if chatRef == nil || chatRef.Kind != AssignmentExecutionKindChatSession || chatRef.ChatSessionID != "chat_1" || chatRef.MessageID != "msg_1" {
 		t.Fatalf("chat ref = %+v, want chat-session ref", chatRef)
 	}
 	contextRef := AssignmentExecutionRefFor(projectwork.Assignment{
-		ContextSnapshotID: "ctx_1",
-		Status:            projectwork.AssignmentStatusQueued,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:              projectwork.AssignmentExecutionKindContextSnapshot,
+			ContextSnapshotID: "ctx_1",
+		},
+		Status: projectwork.AssignmentStatusQueued,
 	}, nil, projectwork.AssignmentStatusQueued)
 	if contextRef == nil || contextRef.Kind != AssignmentExecutionKindContextSnapshot || contextRef.ContextSnapshotID != "ctx_1" {
 		t.Fatalf("context ref = %+v, want context-snapshot ref", contextRef)

--- a/internal/projectworkapp/projection_test.go
+++ b/internal/projectworkapp/projection_test.go
@@ -1,0 +1,119 @@
+package projectworkapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestProjectAssignmentExecution_ProjectsRunAndCanonicalRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	startedAt := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	if _, err := store.CreateTask(ctx, types.Task{ID: "task_1", Status: "running", LatestRunID: "run_1"}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := store.CreateRun(ctx, types.TaskRun{
+		ID:            "run_1",
+		TaskID:        "task_1",
+		Status:        "awaiting_approval",
+		Model:         "gpt-4o-mini",
+		Provider:      "openai",
+		StepCount:     3,
+		ApprovalCount: 1,
+		ArtifactCount: 2,
+		StartedAt:     startedAt,
+		TraceID:       "trace_1",
+	}); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	if _, err := store.CreateApproval(ctx, types.TaskApproval{ID: "approval_1", TaskID: "task_1", RunID: "run_1", Status: "pending"}); err != nil {
+		t.Fatalf("CreateApproval() error = %v", err)
+	}
+
+	assignment := projectwork.Assignment{
+		ID:        "asgn_1",
+		TaskID:    "task_1",
+		RunID:     "run_1",
+		Status:    projectwork.AssignmentStatusQueued,
+		UpdatedAt: startedAt.Add(-time.Minute),
+	}
+	projection, err := ProjectAssignmentExecution(ctx, store, assignment)
+	if err != nil {
+		t.Fatalf("ProjectAssignmentExecution() error = %v", err)
+	}
+	if projection == nil {
+		t.Fatal("ProjectAssignmentExecution() = nil, want projection")
+	}
+	if projection.Status != projectwork.AssignmentStatusAwaitingApproval || projection.Execution.PendingApprovalCount != 1 {
+		t.Fatalf("projection = %+v, want awaiting approval with pending count", projection)
+	}
+	if projection.Execution.StepCount != 3 || projection.Execution.ArtifactCount != 2 || projection.Execution.TraceID != "trace_1" {
+		t.Fatalf("execution summary = %+v, want run metadata copied", projection.Execution)
+	}
+	ref := AssignmentExecutionRefFor(assignment, &projection.Execution, projection.Status)
+	if ref == nil || ref.Kind != AssignmentExecutionKindTaskRun || ref.TaskID != "task_1" || ref.RunID != "run_1" || ref.Status != projectwork.AssignmentStatusAwaitingApproval || ref.PendingApprovalCount != 1 || ref.TraceID != "trace_1" {
+		t.Fatalf("execution ref = %+v, want canonical task-run ref", ref)
+	}
+}
+
+func TestProjectAssignmentExecution_MissingTaskMarksExecutionMissing(t *testing.T) {
+	t.Parallel()
+
+	projection, err := ProjectAssignmentExecution(context.Background(), taskstate.NewMemoryStore(), projectwork.Assignment{
+		ID:     "asgn_1",
+		TaskID: "task_missing",
+		Status: projectwork.AssignmentStatusQueued,
+	})
+	if err != nil {
+		t.Fatalf("ProjectAssignmentExecution() error = %v", err)
+	}
+	if projection == nil || !projection.Execution.Missing || projection.Execution.TaskID != "task_missing" {
+		t.Fatalf("projection = %+v, want missing execution summary", projection)
+	}
+	ref := AssignmentExecutionRefFor(projectwork.Assignment{TaskID: "task_missing"}, &projection.Execution, projection.Status)
+	if ref == nil || !ref.Missing || ref.Kind != AssignmentExecutionKindTaskRun {
+		t.Fatalf("execution ref = %+v, want missing task-run ref", ref)
+	}
+}
+
+func TestAssignmentExecutionRefFor_RawChatAndContextLinks(t *testing.T) {
+	t.Parallel()
+
+	chatRef := AssignmentExecutionRefFor(projectwork.Assignment{
+		ChatSessionID: "chat_1",
+		MessageID:     "msg_1",
+		Status:        projectwork.AssignmentStatusRunning,
+	}, nil, projectwork.AssignmentStatusRunning)
+	if chatRef == nil || chatRef.Kind != AssignmentExecutionKindChatSession || chatRef.ChatSessionID != "chat_1" || chatRef.MessageID != "msg_1" {
+		t.Fatalf("chat ref = %+v, want chat-session ref", chatRef)
+	}
+	contextRef := AssignmentExecutionRefFor(projectwork.Assignment{
+		ContextSnapshotID: "ctx_1",
+		Status:            projectwork.AssignmentStatusQueued,
+	}, nil, projectwork.AssignmentStatusQueued)
+	if contextRef == nil || contextRef.Kind != AssignmentExecutionKindContextSnapshot || contextRef.ContextSnapshotID != "ctx_1" {
+		t.Fatalf("context ref = %+v, want context-snapshot ref", contextRef)
+	}
+}
+
+func TestProjectedAssignmentStatus_ManualTerminalWinsUntilRunIsNewer(t *testing.T) {
+	t.Parallel()
+
+	assignment := projectwork.Assignment{
+		Status:    projectwork.AssignmentStatusFailed,
+		UpdatedAt: time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC),
+	}
+	if got := ProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, assignment.UpdatedAt.Add(-time.Minute)); got != projectwork.AssignmentStatusFailed {
+		t.Fatalf("ProjectedAssignmentStatus(stale run) = %q, want manual failed", got)
+	}
+	if got := ProjectedAssignmentStatus(assignment, projectwork.AssignmentStatusCompleted, assignment.UpdatedAt.Add(time.Minute)); got != projectwork.AssignmentStatusCompleted {
+		t.Fatalf("ProjectedAssignmentStatus(new run) = %q, want completed", got)
+	}
+}

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -963,12 +963,14 @@ test("agent chat previews failed tool stdout and stderr in Advanced details", as
       {
         id: "m-user",
         role: "user",
+        turn_kind: "hecate_task",
         content: "why did git fail?",
         created_at: "2026-04-21T10:00:00Z",
       },
       {
         id: "m-agent",
         role: "assistant",
+        turn_kind: "hecate_task",
         execution_mode: "hecate_task",
         content: "The command failed while inspecting git state.",
         provider: "ollama",
@@ -1758,10 +1760,12 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       : isHecateAgent
         ? `Tools answer ${taskID.endsWith("-1") ? "one" : "two"} from ${body.model}`
         : `Direct model answer from ${body.model}`;
+    const turnKind = isHecateAgent ? "hecate_task" : "direct_model";
 
     messages.push(
       {
         id: `msg-user-${turn}`,
+        turn_kind: turnKind,
         execution_mode: executionMode,
         tools_enabled: isHecateAgent,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,
@@ -1774,6 +1778,7 @@ test("Hecate Chat can move tools on, tools off, then tools on again in one trans
       },
       {
         id: `msg-assistant-${turn}`,
+        turn_kind: turnKind,
         execution_mode: executionMode,
         tools_enabled: isHecateAgent,
         segment_id: isHecateAgent ? `task:${taskID}` : `model:${turn}`,

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -681,6 +681,12 @@ describe("ConsoleShell navigation", () => {
       status: "running",
       chat_session_id: "chat_external_1",
       context_snapshot_id: "ctx_external_1",
+      execution_ref: {
+        kind: "chat_session",
+        chat_session_id: "chat_external_1",
+        context_snapshot_id: "ctx_external_1",
+        status: "running",
+      },
       created_at: "2026-06-02T10:00:00Z",
       updated_at: "2026-06-02T11:00:00Z",
     };

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -679,8 +679,6 @@ describe("ConsoleShell navigation", () => {
       role_id: "software_developer",
       driver_kind: "external_agent",
       status: "running",
-      chat_session_id: "chat_external_1",
-      context_snapshot_id: "ctx_external_1",
       execution_ref: {
         kind: "chat_session",
         chat_session_id: "chat_external_1",

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2251,6 +2251,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             provider: "ollama",
@@ -2260,6 +2261,7 @@ describe("ChatView input", () => {
           },
           {
             id: "task:task_hecate_123456",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             provider: "ollama",
             model: "qwen2.5-coder",
@@ -2484,6 +2486,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             segment_id: "task:task_hecate_123456",
             task_id: "task_hecate_123456",
@@ -2493,6 +2496,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             segment_id: "task:task_hecate_123456",
             task_id: "task_hecate_123456",
@@ -2581,6 +2585,7 @@ describe("ChatView input", () => {
         segments: [
           {
             id: "model:first",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             provider: "ollama",
@@ -2590,6 +2595,7 @@ describe("ChatView input", () => {
           },
           {
             id: "task:task_first",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             provider: "ollama",
             model: "qwen2.5-coder",
@@ -2600,6 +2606,7 @@ describe("ChatView input", () => {
           },
           {
             id: "model:second",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             provider: "ollama",
@@ -2611,6 +2618,7 @@ describe("ChatView input", () => {
         messages: [
           {
             id: "m1",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             segment_id: "model:first",
@@ -2620,6 +2628,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m2",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             segment_id: "model:first",
@@ -2631,6 +2640,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m3",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             segment_id: "task:task_first",
             task_id: "task_first",
@@ -2640,6 +2650,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m4",
+            turn_kind: "hecate_task",
             execution_mode: "hecate_task",
             segment_id: "task:task_first",
             task_id: "task_first",
@@ -2652,6 +2663,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m5",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             segment_id: "model:second",
@@ -2661,6 +2673,7 @@ describe("ChatView input", () => {
           },
           {
             id: "m6",
+            turn_kind: "direct_model",
             execution_mode: "hecate_task",
             tools_enabled: false,
             segment_id: "model:second",
@@ -4763,6 +4776,7 @@ describe("ChatView external-agent target", () => {
           segments: [
             {
               id: "seg_1",
+              turn_kind: "external_agent",
               execution_mode: "external_agent",
               workspace: "/tmp/hecate",
               status: "running",

--- a/ui/src/features/chats/chatTurnViewModels.test.ts
+++ b/ui/src/features/chats/chatTurnViewModels.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./chatTurnViewModels";
 
 describe("chatTurnViewModels", () => {
-  it("prefers explicit turn_kind over legacy execution fields", () => {
+  it("uses explicit turn_kind without reconstructing legacy execution fields", () => {
     expect(
       chatTurnKindFromWire({
         turn_kind: "direct_model",
@@ -18,7 +18,7 @@ describe("chatTurnViewModels", () => {
     ).toBe("direct_model");
   });
 
-  it("maps legacy Hecate tools-off turns to direct model turns", () => {
+  it("treats missing turn_kind as unknown instead of inferring from legacy fields", () => {
     const turn = toChatMessageViewModel({
       id: "msg_1",
       role: "assistant",
@@ -28,15 +28,16 @@ describe("chatTurnViewModels", () => {
       task_id: "task_legacy_should_not_link",
     });
 
-    expect(turn.turnKind).toBe("direct_model");
-    expect(turn.isDirectModel).toBe(true);
+    expect(turn.turnKind).toBe("unknown");
+    expect(turn.isDirectModel).toBe(false);
     expect(turn.isTaskBacked).toBe(false);
     expect(turn.taskID).toBe("");
   });
 
-  it("maps legacy Hecate tools-on segments to task-backed turns", () => {
+  it("maps explicit Hecate task-backed segments", () => {
     const turn = toChatSegmentViewModel({
       id: "seg_1",
+      turn_kind: "hecate_task",
       execution_mode: "hecate_task",
       tools_enabled: true,
       task_id: "task_1",
@@ -53,9 +54,10 @@ describe("chatTurnViewModels", () => {
     expect(turn.messageCount).toBe(2);
   });
 
-  it("maps external-agent segments independently of tools_enabled", () => {
+  it("maps explicit external-agent segments independently of tools_enabled", () => {
     const turn = toChatSegmentViewModel({
       id: "seg_1",
+      turn_kind: "external_agent",
       execution_mode: "external_agent",
       tools_enabled: false,
       status: "running",

--- a/ui/src/features/chats/chatTurnViewModels.ts
+++ b/ui/src/features/chats/chatTurnViewModels.ts
@@ -45,15 +45,6 @@ export type ChatSegmentViewModel = ChatTurnViewModel & {
 export function chatTurnKindFromWire(input: ChatTurnWire): ChatTurnKind {
   const explicit = normalizeChatTurnKind(input.turn_kind);
   if (explicit) return explicit;
-  if (input.execution_mode === "external_agent") return "external_agent";
-  // Legacy snapshots can carry stale Hecate execution_mode values; a foreign
-  // agent_id is the stronger owner signal when turn_kind is absent.
-  if (input.agent_id && input.agent_id !== "hecate") return "external_agent";
-  if (input.execution_mode === "hecate_task") {
-    return input.tools_enabled === false ? "direct_model" : "hecate_task";
-  }
-  if (input.task_id) return "hecate_task";
-  if (input.native_session_id || input.driver_kind) return "external_agent";
   return "unknown";
 }
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -318,8 +318,6 @@ const hecateAssignment: ProjectAssignmentRecord = {
   role_id: "software_developer",
   driver_kind: "hecate_task",
   status: "queued",
-  task_id: "task_1",
-  run_id: "run_1",
   execution_ref: {
     kind: "task_run",
     task_id: "task_1",
@@ -2168,8 +2166,6 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       driver_kind: "external_agent",
       status: "queued",
-      task_id: "",
-      run_id: "",
       execution_ref: undefined,
       execution: undefined,
     };
@@ -2215,8 +2211,6 @@ describe("ProjectsView cockpit", () => {
       data: {
         ...externalAssignment,
         status: "running",
-        chat_session_id: "chat_external_1",
-        context_snapshot_id: "ctx_external_1",
         execution_ref: {
           kind: "chat_session",
           chat_session_id: "chat_external_1",
@@ -2237,10 +2231,6 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       driver_kind: "external_agent",
       status: "running",
-      task_id: "",
-      run_id: "",
-      chat_session_id: "chat_external_1",
-      context_snapshot_id: "ctx_external_1",
       execution_ref: {
         kind: "chat_session",
         chat_session_id: "chat_external_1",
@@ -2287,11 +2277,6 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       driver_kind: "external_agent",
       status: "running",
-      task_id: "",
-      run_id: "",
-      chat_session_id: "chat_external_1",
-      message_id: "",
-      context_snapshot_id: "ctx_external_1",
       execution_ref: {
         kind: "chat_session",
         chat_session_id: "chat_external_1",
@@ -3411,8 +3396,6 @@ describe("ProjectsView cockpit", () => {
     const notStartedAssignment: ProjectAssignmentRecord = {
       ...hecateAssignment,
       id: "asgn_not_started",
-      task_id: "",
-      run_id: "",
       status: "queued",
       execution_ref: undefined,
       execution: undefined,
@@ -3588,8 +3571,6 @@ describe("ProjectsView cockpit", () => {
     resetProjectWorkMocks();
     const unstartedAssignment: ProjectAssignmentRecord = {
       ...hecateAssignment,
-      task_id: "",
-      run_id: "",
       execution_ref: undefined,
       execution: undefined,
       status: "queued",
@@ -4126,11 +4107,11 @@ describe("ProjectsView cockpit", () => {
         role_id: "software_developer",
         driver_kind: "external_agent",
         status: "running",
-        task_id: "task_1",
-        run_id: "run_1",
-        chat_session_id: "",
-        message_id: "",
-        context_snapshot_id: "",
+        execution_ref: {
+          kind: "task_run",
+          task_id: "task_1",
+          run_id: "run_1",
+        },
       },
     );
 
@@ -4361,8 +4342,6 @@ describe("ProjectsView cockpit", () => {
       id: "asgn_external",
       driver_kind: "external_agent",
       status: "queued",
-      task_id: "",
-      run_id: "",
       execution_ref: undefined,
       execution: undefined,
     };

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -320,6 +320,13 @@ const hecateAssignment: ProjectAssignmentRecord = {
   status: "queued",
   task_id: "task_1",
   run_id: "run_1",
+  execution_ref: {
+    kind: "task_run",
+    task_id: "task_1",
+    run_id: "run_1",
+    status: "awaiting_approval",
+    pending_approval_count: 2,
+  },
   execution: {
     task_id: "task_1",
     run_id: "run_1",
@@ -2163,6 +2170,7 @@ describe("ProjectsView cockpit", () => {
       status: "queued",
       task_id: "",
       run_id: "",
+      execution_ref: undefined,
       execution: undefined,
     };
     vi.mocked(getProjectWorkItems).mockResolvedValue({
@@ -2209,6 +2217,12 @@ describe("ProjectsView cockpit", () => {
         status: "running",
         chat_session_id: "chat_external_1",
         context_snapshot_id: "ctx_external_1",
+        execution_ref: {
+          kind: "chat_session",
+          chat_session_id: "chat_external_1",
+          context_snapshot_id: "ctx_external_1",
+          status: "running",
+        },
       },
     });
     await waitFor(() => {
@@ -2227,6 +2241,12 @@ describe("ProjectsView cockpit", () => {
       run_id: "",
       chat_session_id: "chat_external_1",
       context_snapshot_id: "ctx_external_1",
+      execution_ref: {
+        kind: "chat_session",
+        chat_session_id: "chat_external_1",
+        context_snapshot_id: "ctx_external_1",
+        status: "running",
+      },
       execution: undefined,
     };
     vi.mocked(getProjectWorkItems).mockResolvedValue({
@@ -2272,6 +2292,12 @@ describe("ProjectsView cockpit", () => {
       chat_session_id: "chat_external_1",
       message_id: "",
       context_snapshot_id: "ctx_external_1",
+      execution_ref: {
+        kind: "chat_session",
+        chat_session_id: "chat_external_1",
+        context_snapshot_id: "ctx_external_1",
+        status: "running",
+      },
       execution: undefined,
     };
     vi.mocked(getProjectActivity).mockResolvedValue({
@@ -2733,8 +2759,15 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       id: "asgn_failed",
       status: "failed",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_failed",
+        status: "failed",
+      },
       execution: {
         ...hecateAssignment.execution,
+        run_id: "run_failed",
         status: "failed",
         pending_approval_count: 0,
       },
@@ -2744,8 +2777,16 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       id: "asgn_stale_health",
       status: "running",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_missing",
+        status: "running",
+        missing: true,
+      },
       execution: {
         ...hecateAssignment.execution,
+        run_id: "run_missing",
         status: "running",
         pending_approval_count: 0,
         missing: true,
@@ -3183,8 +3224,16 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       id: "asgn_stale",
       status: "running",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_missing",
+        status: "running",
+        missing: true,
+      },
       execution: {
         ...hecateAssignment.execution,
+        run_id: "run_missing",
         status: "running",
         pending_approval_count: 0,
         missing: true,
@@ -3277,6 +3326,12 @@ describe("ProjectsView cockpit", () => {
     const completedAssignment: ProjectAssignmentRecord = {
       ...hecateAssignment,
       status: "completed",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        status: "completed",
+      },
       execution: {
         ...hecateAssignment.execution,
         status: "completed",
@@ -3359,6 +3414,7 @@ describe("ProjectsView cockpit", () => {
       task_id: "",
       run_id: "",
       status: "queued",
+      execution_ref: undefined,
       execution: undefined,
       started_at: undefined,
     };
@@ -3534,6 +3590,7 @@ describe("ProjectsView cockpit", () => {
       ...hecateAssignment,
       task_id: "",
       run_id: "",
+      execution_ref: undefined,
       execution: undefined,
       status: "queued",
       started_at: undefined,
@@ -4235,6 +4292,12 @@ describe("ProjectsView cockpit", () => {
     const queuedAssignment = {
       ...hecateAssignment,
       status: "running",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        status: "queued",
+      },
       execution: { ...hecateAssignment.execution, status: "queued" },
     };
     vi.mocked(getProjectAssignments).mockResolvedValue({
@@ -4293,17 +4356,27 @@ describe("ProjectsView cockpit", () => {
   it("exposes chat preparation for queued external-agent assignments", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);
+    const externalAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_external",
+      driver_kind: "external_agent",
+      status: "queued",
+      task_id: "",
+      run_id: "",
+      execution_ref: undefined,
+      execution: undefined,
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [externalAssignment] }],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: { ...workItem, assignments: [externalAssignment] },
+    });
     vi.mocked(getProjectAssignments).mockResolvedValue({
       object: "project_assignments",
-      data: [
-        {
-          ...hecateAssignment,
-          id: "asgn_external",
-          driver_kind: "external_agent",
-          status: "queued",
-          execution: undefined,
-        },
-      ],
+      data: [externalAssignment],
     });
     const state = createRuntimeConsoleFixture({
       projects: [project],

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -98,6 +98,7 @@ import type {
   ProjectHandoffRecord,
   ProjectMemoryRecord,
   ProjectSkillRecord,
+  ProjectAssignmentExecutionRefRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
@@ -182,6 +183,32 @@ type EditAssignmentForm = NewAssignmentForm & {
   messageID: string;
   contextSnapshotID: string;
 };
+
+function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
+  if (form.taskID.trim() || form.runID.trim()) return "task_run";
+  if (form.chatSessionID.trim() || form.messageID.trim()) return "chat_session";
+  if (form.contextSnapshotID.trim()) return "context_snapshot";
+  return "none";
+}
+
+function projectAssignmentExecutionRefFromForm(
+  form: EditAssignmentForm,
+): ProjectAssignmentExecutionRefRecord {
+  const ref: ProjectAssignmentExecutionRefRecord = {
+    kind: projectAssignmentExecutionKindFromForm(form),
+  };
+  const taskID = form.taskID.trim();
+  const runID = form.runID.trim();
+  const chatSessionID = form.chatSessionID.trim();
+  const messageID = form.messageID.trim();
+  const contextSnapshotID = form.contextSnapshotID.trim();
+  if (taskID) ref.task_id = taskID;
+  if (runID) ref.run_id = runID;
+  if (chatSessionID) ref.chat_session_id = chatSessionID;
+  if (messageID) ref.message_id = messageID;
+  if (contextSnapshotID) ref.context_snapshot_id = contextSnapshotID;
+  return ref;
+}
 
 type HandoffForm = {
   id: string;
@@ -1124,11 +1151,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       role_id: roleID,
       driver_kind: form.driverKind || "hecate_task",
       status: form.status || "queued",
-      task_id: form.taskID.trim(),
-      run_id: form.runID.trim(),
-      chat_session_id: form.chatSessionID.trim(),
-      message_id: form.messageID.trim(),
-      context_snapshot_id: form.contextSnapshotID.trim(),
+      execution_ref: projectAssignmentExecutionRefFromForm(form),
     };
     try {
       const payload = await updateProjectAssignment(
@@ -5182,11 +5205,11 @@ function EditAssignmentModal({
     roleID: assignment.role_id,
     driverKind: assignment.driver_kind || "hecate_task",
     status: assignment.status || "queued",
-    taskID: assignment.task_id ?? "",
-    runID: assignment.run_id ?? "",
-    chatSessionID: assignment.chat_session_id ?? "",
-    messageID: assignment.message_id ?? "",
-    contextSnapshotID: assignment.context_snapshot_id ?? "",
+    taskID: assignment.execution_ref?.task_id ?? "",
+    runID: assignment.execution_ref?.run_id ?? "",
+    chatSessionID: assignment.execution_ref?.chat_session_id ?? "",
+    messageID: assignment.execution_ref?.message_id ?? "",
+    contextSnapshotID: assignment.execution_ref?.context_snapshot_id ?? "",
   });
   const valid = form.roleID.trim().length > 0;
   return (

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -72,7 +72,10 @@ import {
   type ProjectHealthAttention,
   type ProjectTimelineItem,
 } from "./projectInsights";
-import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
+import {
+  toProjectActivityItemViewModel,
+  toProjectAssignmentExecutionViewModel,
+} from "./projectAssignmentViewModels";
 import {
   PROJECT_ASSISTANT_AUTO,
   ProjectAssistantPanel,
@@ -5579,20 +5582,24 @@ function AssignmentRow({
   starting: boolean;
 }) {
   const execution = assignment.execution;
-  const executionRef = toProjectAssignmentExecutionViewModel(assignment);
+  const assignmentExecution = toProjectAssignmentExecutionViewModel(assignment);
+  const activityView = activityItem ? toProjectActivityItemViewModel(activityItem) : null;
+  const executionRef = assignmentExecution.hasAnyLink
+    ? assignmentExecution
+    : (activityView?.execution ?? assignmentExecution);
   const taskID = executionRef.taskID;
   const runID = executionRef.runID;
   const chatSessionID = executionRef.chatSessionID;
   const linkedChat = activityItem?.linked_chat;
-  const projectedStatus = executionRef.status;
+  const projectedStatus = assignmentExecution.status;
   const startable =
     (assignment.driver_kind === "hecate_task" || assignment.driver_kind === "external_agent") &&
     projectedStatus === "queued";
   const external = assignment.driver_kind === "external_agent";
   const startActionLabel = external ? "Prepare chat" : "Start";
   const startingLabel = external ? "Preparing…" : "Starting…";
-  const startedAt = execution?.started_at || assignment.started_at;
-  const finishedAt = execution?.finished_at || assignment.completed_at;
+  const startedAt = activityView?.startedAt || execution?.started_at || assignment.started_at;
+  const finishedAt = activityView?.finishedAt || execution?.finished_at || assignment.completed_at;
   return (
     <div style={assignmentStyle}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -5727,10 +5734,10 @@ function AssignmentRow({
           </button>
         )}
       </div>
-      {activityItem?.status_summary &&
-        activityItem.status_summary !== projectedStatus &&
-        activityItem.status_summary !== "linked run missing" && (
-          <div style={{ ...subtleTextStyle, marginTop: 8 }}>{activityItem.status_summary}</div>
+      {activityView?.statusSummary &&
+        activityView.statusSummary !== projectedStatus &&
+        activityView.statusSummary !== "linked run missing" && (
+          <div style={{ ...subtleTextStyle, marginTop: 8 }}>{activityView.statusSummary}</div>
         )}
       {(startedAt || finishedAt) && (
         <div style={{ ...metaLineStyle, marginTop: 8 }}>

--- a/ui/src/features/projects/projectAssignmentViewModels.test.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.test.ts
@@ -8,7 +8,7 @@ import {
 import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
 
 describe("projectAssignmentViewModels", () => {
-  it("prefers canonical execution_ref over legacy assignment fields", () => {
+  it("uses canonical execution_ref for task-run links", () => {
     const execution = toProjectAssignmentExecutionViewModel({
       id: "assign_1",
       project_id: "proj_1",
@@ -16,8 +16,6 @@ describe("projectAssignmentViewModels", () => {
       role_id: "developer",
       driver_kind: "hecate_task",
       status: "queued",
-      task_id: "task_legacy",
-      run_id: "run_legacy",
       execution_ref: {
         kind: "task_run",
         task_id: "task_ref",
@@ -39,7 +37,7 @@ describe("projectAssignmentViewModels", () => {
     expect(execution.hasTaskRun).toBe(true);
   });
 
-  it("does not reconstruct runtime links from legacy execution or raw fields", () => {
+  it("does not reconstruct runtime links from execution summaries", () => {
     const execution = toProjectAssignmentExecutionViewModel({
       id: "assign_1",
       project_id: "proj_1",
@@ -47,8 +45,6 @@ describe("projectAssignmentViewModels", () => {
       role_id: "developer",
       driver_kind: "hecate_task",
       status: "queued",
-      task_id: "task_raw",
-      run_id: "run_raw",
       execution: {
         task_id: "task_projected",
         run_id: "run_projected",
@@ -75,8 +71,6 @@ describe("projectAssignmentViewModels", () => {
       role_id: "developer",
       driver_kind: "external_agent",
       status: "running",
-      chat_session_id: "chat_assignment",
-      message_id: "msg_assignment",
       execution_ref: {
         kind: "chat_session",
         chat_session_id: "chat_assignment",
@@ -127,7 +121,6 @@ describe("projectAssignmentViewModels", () => {
       role_id: "reviewer",
       driver_kind: "hecate_task",
       status: "queued",
-      context_snapshot_id: "ctx_1",
       execution_ref: {
         kind: "context_snapshot",
         context_snapshot_id: "ctx_1",

--- a/ui/src/features/projects/projectAssignmentViewModels.test.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   toProjectActivityAssignmentExecutionViewModel,
+  toProjectActivityItemViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
@@ -38,7 +39,7 @@ describe("projectAssignmentViewModels", () => {
     expect(execution.hasTaskRun).toBe(true);
   });
 
-  it("falls back to projected execution before raw links", () => {
+  it("does not reconstruct runtime links from legacy execution or raw fields", () => {
     const execution = toProjectAssignmentExecutionViewModel({
       id: "assign_1",
       project_id: "proj_1",
@@ -58,11 +59,12 @@ describe("projectAssignmentViewModels", () => {
       updated_at: "2026-01-01T00:00:00Z",
     });
 
-    expect(execution.kind).toBe("task_run");
-    expect(execution.taskID).toBe("task_projected");
-    expect(execution.runID).toBe("run_projected");
-    expect(execution.status).toBe("completed");
-    expect(execution.missing).toBe(true);
+    expect(execution.kind).toBe("none");
+    expect(execution.taskID).toBe("");
+    expect(execution.runID).toBe("");
+    expect(execution.status).toBe("queued");
+    expect(execution.missing).toBe(false);
+    expect(execution.hasAnyLink).toBe(false);
   });
 
   it("uses activity linked refs ahead of assignment refs", () => {
@@ -75,6 +77,12 @@ describe("projectAssignmentViewModels", () => {
       status: "running",
       chat_session_id: "chat_assignment",
       message_id: "msg_assignment",
+      execution_ref: {
+        kind: "chat_session",
+        chat_session_id: "chat_assignment",
+        message_id: "msg_assignment",
+        status: "running",
+      },
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
@@ -111,7 +119,7 @@ describe("projectAssignmentViewModels", () => {
     expect(execution.hasChatSession).toBe(true);
   });
 
-  it("infers context-only assignments", () => {
+  it("uses explicit context-only execution refs", () => {
     const execution = toProjectAssignmentExecutionViewModel({
       id: "assign_1",
       project_id: "proj_1",
@@ -120,6 +128,11 @@ describe("projectAssignmentViewModels", () => {
       driver_kind: "hecate_task",
       status: "queued",
       context_snapshot_id: "ctx_1",
+      execution_ref: {
+        kind: "context_snapshot",
+        context_snapshot_id: "ctx_1",
+        status: "queued",
+      },
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     });
@@ -128,5 +141,63 @@ describe("projectAssignmentViewModels", () => {
     expect(execution.contextSnapshotID).toBe("ctx_1");
     expect(execution.hasContextSnapshot).toBe(true);
     expect(execution.hasAnyLink).toBe(true);
+  });
+
+  it("builds activity item view models from canonical execution refs", () => {
+    const item = {
+      id: "activity_1",
+      project_id: "proj_1",
+      work_item: {
+        id: "work_1",
+        title: "Build",
+        status: "running",
+        priority: "normal",
+      },
+      assignment: {
+        id: "assign_1",
+        project_id: "proj_1",
+        work_item_id: "work_1",
+        role_id: "developer",
+        driver_kind: "hecate_task",
+        status: "queued",
+        execution_ref: {
+          kind: "task_run",
+          task_id: "task_1",
+          run_id: "run_1",
+          status: "awaiting_approval",
+          pending_approval_count: 2,
+        },
+        execution: {
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:03:00Z",
+        },
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:01:00Z",
+      },
+      role: {
+        id: "developer",
+        project_id: "proj_1",
+        name: "Developer",
+        built_in: true,
+      },
+      status: "awaiting_approval",
+      blocking_signal: "awaiting_approval",
+      status_summary: "2 approval pending",
+      linked_task_id: "task_1",
+      linked_run_id: "run_1",
+      artifact_summary: { count: 0 },
+      handoff_summary: { count: 0 },
+      updated_at: "2026-01-01T00:01:00Z",
+    } satisfies ProjectActivityItemRecord;
+
+    const view = toProjectActivityItemViewModel(item);
+
+    expect(view.execution.taskID).toBe("task_1");
+    expect(view.execution.pendingApprovalCount).toBe(2);
+    expect(view.status).toBe("awaiting_approval");
+    expect(view.blockingSignal).toBe("awaiting_approval");
+    expect(view.bucket).toBe("blocked");
+    expect(view.startedAt).toBe("2026-01-01T00:00:00Z");
+    expect(view.finishedAt).toBe("2026-01-01T00:03:00Z");
   });
 });

--- a/ui/src/features/projects/projectAssignmentViewModels.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.ts
@@ -24,6 +24,16 @@ export type ProjectAssignmentExecutionViewModel = {
   hasAnyLink: boolean;
 };
 
+export type ProjectActivityItemViewModel = {
+  execution: ProjectAssignmentExecutionViewModel;
+  status: string;
+  blockingSignal: string;
+  statusSummary: string;
+  bucket: "active" | "blocked" | "completed";
+  startedAt: string;
+  finishedAt: string;
+};
+
 type LinkedExecutionOverrides = {
   taskID?: string;
   runID?: string;
@@ -35,21 +45,15 @@ export function toProjectAssignmentExecutionViewModel(
   assignment: ProjectAssignmentRecord,
   linked: LinkedExecutionOverrides = {},
 ): ProjectAssignmentExecutionViewModel {
-  const execution = assignment.execution;
   const ref = assignment.execution_ref;
-  const taskID = firstNonEmpty(linked.taskID, ref?.task_id, execution?.task_id, assignment.task_id);
-  const runID = firstNonEmpty(linked.runID, ref?.run_id, execution?.run_id, assignment.run_id);
-  const chatSessionID = firstNonEmpty(
-    linked.chatSessionID,
-    ref?.chat_session_id,
-    assignment.chat_session_id,
-  );
-  const messageID = firstNonEmpty(linked.messageID, ref?.message_id, assignment.message_id);
-  const contextSnapshotID = firstNonEmpty(ref?.context_snapshot_id, assignment.context_snapshot_id);
-  const kind = ref?.kind || inferExecutionKind({ taskID, runID, chatSessionID, contextSnapshotID });
-  const pendingApprovalCount =
-    ref?.pending_approval_count ?? execution?.pending_approval_count ?? 0;
-  const missing = ref?.missing ?? execution?.missing ?? false;
+  const taskID = firstNonEmpty(linked.taskID, ref?.task_id);
+  const runID = firstNonEmpty(linked.runID, ref?.run_id);
+  const chatSessionID = firstNonEmpty(linked.chatSessionID, ref?.chat_session_id);
+  const messageID = firstNonEmpty(linked.messageID, ref?.message_id);
+  const contextSnapshotID = firstNonEmpty(ref?.context_snapshot_id);
+  const kind = ref?.kind || "none";
+  const pendingApprovalCount = ref?.pending_approval_count ?? 0;
+  const missing = ref?.missing ?? false;
   return {
     kind,
     taskID,
@@ -57,9 +61,9 @@ export function toProjectAssignmentExecutionViewModel(
     chatSessionID,
     messageID,
     contextSnapshotID,
-    status: firstNonEmpty(ref?.status, execution?.status, assignment.status),
+    status: firstNonEmpty(ref?.status, assignment.status),
     pendingApprovalCount,
-    traceID: firstNonEmpty(ref?.trace_id, execution?.trace_id),
+    traceID: firstNonEmpty(ref?.trace_id),
     missing,
     hasTaskRun: Boolean(taskID || runID),
     hasChatSession: Boolean(chatSessionID || messageID),
@@ -79,21 +83,35 @@ export function toProjectActivityAssignmentExecutionViewModel(
   });
 }
 
-function inferExecutionKind({
-  chatSessionID,
-  contextSnapshotID,
-  runID,
-  taskID,
-}: {
-  chatSessionID: string;
-  contextSnapshotID: string;
-  runID: string;
-  taskID: string;
-}): ProjectAssignmentExecutionKind {
-  if (taskID || runID) return "task_run";
-  if (chatSessionID) return "chat_session";
-  if (contextSnapshotID) return "context_snapshot";
-  return "none";
+export function toProjectActivityItemViewModel(
+  item: ProjectActivityItemRecord,
+): ProjectActivityItemViewModel {
+  const execution = toProjectActivityAssignmentExecutionViewModel(item);
+  const blockingSignal = firstNonEmpty(item.blocking_signal, "running");
+  return {
+    execution,
+    status: firstNonEmpty(item.status, execution.status, item.assignment.status, "unknown"),
+    blockingSignal,
+    statusSummary: firstNonEmpty(item.status_summary),
+    bucket: activityBucket(blockingSignal),
+    startedAt: firstNonEmpty(item.assignment.execution?.started_at, item.assignment.started_at),
+    finishedAt: firstNonEmpty(item.assignment.execution?.finished_at, item.assignment.completed_at),
+  };
+}
+
+function activityBucket(signal: string): ProjectActivityItemViewModel["bucket"] {
+  switch (signal) {
+    case "awaiting_approval":
+    case "failed":
+    case "cancelled":
+    case "not_started":
+    case "stale_unknown":
+      return "blocked";
+    case "completed":
+      return "completed";
+    default:
+      return "active";
+  }
 }
 
 function firstNonEmpty(...values: Array<string | undefined | null>): string {

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -175,7 +175,7 @@ describe("projectInsights", () => {
     } satisfies ProjectRecord;
     const item = activityItem(project.id, []);
     item.assignment.driver_kind = "external_agent";
-    item.assignment.chat_session_id = "chat_failed";
+    item.assignment.execution_ref = { kind: "chat_session", chat_session_id: "chat_failed" };
     item.blocking_signal = "failed";
     item.linked_chat_id = "chat_failed";
     const activity = {

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../types/project";
 import {
   toProjectActivityAssignmentExecutionViewModel,
+  toProjectActivityItemViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 
@@ -127,25 +128,25 @@ export function buildProjectTimelineItems({
   const roleByID = new Map(roles.map((role) => [role.id, role]));
   const workByID = new Map(workItems.map((item) => [item.id, item]));
   for (const activityItem of projectActivityItems(activity)) {
+    const activityView = toProjectActivityItemViewModel(activityItem);
     const workItem =
       workByID.get(activityItem.work_item.id) ??
       projectActivityWorkItemToWorkItem(project.id, activityItem.work_item);
     const role = roleByID.get(activityItem.assignment.role_id) ?? activityItem.role;
-    if (activityItem.blocking_signal !== "not_started") {
-      const execution = toProjectActivityAssignmentExecutionViewModel(activityItem);
+    if (activityView.blockingSignal !== "not_started") {
       setTimelineItem(items, {
         id: `assignment:${activityItem.assignment.id}`,
         kind: "assignment",
         title: workItem.title,
-        summary: activityItem.status_summary,
+        summary: activityView.statusSummary,
         actor: `role ${role?.name || activityItem.assignment.role_id}`,
         source: activityItem.assignment.driver_kind,
         timestamp: activityItem.updated_at || activityItem.assignment.updated_at,
-        status: activityItem.blocking_signal,
+        status: activityView.blockingSignal,
         workItemID: workItem.id,
-        taskID: execution.taskID,
-        runID: execution.runID,
-        chatID: execution.chatSessionID,
+        taskID: activityView.execution.taskID,
+        runID: activityView.execution.runID,
+        chatID: activityView.execution.chatSessionID,
         assignment: activityItem.assignment,
       });
     }
@@ -209,8 +210,10 @@ export function buildProjectHealthSummary(
     })),
   );
   const staleItems = [
-    ...activityItems.filter((item) => item.blocking_signal === "stale_unknown"),
-    ...activityItems.filter((item) => toProjectActivityAssignmentExecutionViewModel(item).missing),
+    ...activityItems.filter(
+      (item) => toProjectActivityItemViewModel(item).blockingSignal === "stale_unknown",
+    ),
+    ...activityItems.filter((item) => toProjectActivityItemViewModel(item).execution.missing),
     ...projectedAssignments
       .filter((item) => isStaleAssignment(item.assignment, item.status))
       .map((item) => projectAssignmentToActivityAttention(project, item.workItem, item.assignment)),
@@ -295,7 +298,8 @@ export function buildProjectHealthSummary(
   const firstFailedExternal = activityItems.find(
     (item) =>
       item.assignment.driver_kind === "external_agent" &&
-      (item.blocking_signal === "failed" || item.blocking_signal === "cancelled"),
+      (toProjectActivityItemViewModel(item).blockingSignal === "failed" ||
+        toProjectActivityItemViewModel(item).blockingSignal === "cancelled"),
   );
   if (firstFailedExternal) {
     attention.push(

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -2997,6 +2997,7 @@ describe("useRuntimeConsole", () => {
                 segments: [
                   {
                     id: "model:first",
+                    turn_kind: "direct_model",
                     execution_mode: "hecate_task",
                     tools_enabled: false,
                     provider: "ollama",
@@ -3006,6 +3007,7 @@ describe("useRuntimeConsole", () => {
                   },
                   {
                     id: "task:task_tools",
+                    turn_kind: "hecate_task",
                     execution_mode: "hecate_task",
                     provider: "ollama",
                     model: "qwen2.5-coder",

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -183,11 +183,7 @@ export type ProjectAssistantContextAssignment = {
   role_id: string;
   driver_kind: string;
   status: string;
-  task_id?: string;
-  run_id?: string;
-  chat_session_id?: string;
-  message_id?: string;
-  context_snapshot_id?: string;
+  execution_ref?: ProjectAssignmentExecutionRefRecord;
   created_at: string;
   updated_at: string;
   started_at?: string;
@@ -564,11 +560,6 @@ export type ProjectAssignmentRecord = {
   role_id: string;
   driver_kind: ProjectAssignmentDriverKind | string;
   status: ProjectAssignmentStatus | string;
-  task_id?: string;
-  run_id?: string;
-  chat_session_id?: string;
-  message_id?: string;
-  context_snapshot_id?: string;
   created_at: string;
   updated_at: string;
   started_at?: string;
@@ -582,11 +573,7 @@ export type CreateProjectAssignmentPayload = {
   role_id: string;
   driver_kind?: ProjectAssignmentDriverKind | string;
   status?: ProjectAssignmentStatus | string;
-  task_id?: string;
-  run_id?: string;
-  chat_session_id?: string;
-  message_id?: string;
-  context_snapshot_id?: string;
+  execution_ref?: ProjectAssignmentExecutionRefRecord;
   started_at?: string;
   completed_at?: string;
 };


### PR DESCRIPTION
## Summary
- move chat turn_kind and context refs into domain helpers, and stop the UI from inferring legacy chat turn kinds
- move project assignment execution/activity projection into projectworkapp and make the UI trust canonical execution_ref
- keep Project Assistant assignment proposals project-domain only by rejecting runtime execution refs
- update agent docs for the new project contract boundaries

## Tests
- go test ./internal/chat ./internal/chatcontext ./internal/projectworkapp ./internal/projectassistant ./internal/api
- go vet ./internal/chat ./internal/chatcontext ./internal/projectworkapp ./internal/projectassistant ./internal/api
- go test -race -timeout 10m ./...
- go test -tags e2e -run 'Test(ProjectActivityProjectionE2E|ChatSessionApplicationLayerLifecycleE2E)' ./e2e
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/projects/projectAssignmentViewModels.test.ts src/features/projects/projectInsights.test.ts src/features/chats/chatTurnViewModels.test.ts src/features/projects/ProjectsView.test.tsx
- cd ui && bun run lint
- cd ui && bun run format:check
- just agent-docs-check
- just docs-format-check
- just check-links