### PR TITLE
feat(projects): show assignment execution evidence

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -193,7 +193,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   `task_id`, raw `run_id`, or `chat_session_id` fields. Project rows, activity,
   health, and timeline surfaces should use
   `ui/src/features/projects/projectAssignmentViewModels.ts` instead of
-  reconstructing status/link logic in components.
+  reconstructing status/link logic in components. Keep compact assignment row
+  evidence separate from the full Context Inspector: the row summarizes
+  canonical refs and warnings, while the inspector renders the persisted packet
+  sections the agent actually saw.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -260,6 +260,15 @@ The Projects UI should stay lightweight but operational:
 - Treat the selected work item as one card. The work title, brief,
   assignments, collaboration artifacts, and handoffs are one work coordination
   object with internal sections, not separate dashboard panels.
+- Show assignment execution evidence close to the assignment row using
+  canonical `execution_ref` and activity linked ids: task, run, chat, message,
+  context snapshot, trace, provider/model, counts, and missing/stale warnings.
+  Keep this as compact provenance; the full Context Inspector remains the
+  place to inspect the persisted packet sections the agent actually saw.
+- Show handoff source evidence separately from target assignment evidence.
+  Source assignment/run/chat/message/context refs explain provenance; target
+  assignment refs explain the follow-up work. Accepting or linking a handoff
+  still records operator intent only and must not auto-dispatch work.
 - Open Project Settings as the same right-side inspector pattern used by Chat
   settings, with the same right-panel width behavior. The project header stays
   above the workspace/settings split so the inspector starts below the header,
@@ -325,8 +334,11 @@ defaults, handoff summaries, memory candidates, and memory/context metadata so
 operators can separate live assignment buckets from actionable setup gaps,
 waiting approvals, blocked or stale assignments, pending handoffs, memory review
 work, missing provider/model defaults, and context readiness without adding a
-separate persisted health model. Broader task `project_id` scoping, profiles,
-and presets are not linked to `project_id` yet.
+separate persisted health model. Assignment rows now render compact execution
+evidence from canonical assignment/activity refs, while the Context Inspector
+renders the full persisted launch packet with Profile, Instructions, Skills,
+Memory, Project sources, Work context, and Runtime evidence groups. Broader task
+`project_id` scoping, profiles, and presets are not linked to `project_id` yet.
 
 Persist `project_id` on:
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -322,6 +322,7 @@ const hecateAssignment: ProjectAssignmentRecord = {
     kind: "task_run",
     task_id: "task_1",
     run_id: "run_1",
+    context_snapshot_id: "ctx_assignment_1",
     status: "awaiting_approval",
     pending_approval_count: 2,
   },
@@ -2089,7 +2090,7 @@ describe("ProjectsView cockpit", () => {
     expect(within(detail).getAllByText("approval").length).toBeGreaterThan(0);
     expect(within(detail).getAllByText("2 approval pending").length).toBeGreaterThan(0);
     expect(within(detail).getByText("4 steps")).toBeTruthy();
-    expect(within(detail).getByText("ollama / qwen2.5-coder")).toBeTruthy();
+    expect(within(detail).getAllByText("ollama / qwen2.5-coder").length).toBeGreaterThan(0);
   });
 
   it("renders project activity inbox states and actions", async () => {
@@ -2119,6 +2120,15 @@ describe("ProjectsView cockpit", () => {
 
     const detail = screen.getByRole("region", { name: "Selected work item" });
     expect(within(detail).getAllByText("2 approval pending").length).toBeGreaterThan(0);
+    const evidence = within(detail).getByRole("group", { name: "Execution evidence" });
+    expect(within(evidence).getByText("Task")).toBeTruthy();
+    expect(within(evidence).getByText("task_1")).toBeTruthy();
+    expect(within(evidence).getByText("Run")).toBeTruthy();
+    expect(within(evidence).getByText("run_1")).toBeTruthy();
+    expect(within(evidence).getByText("Context snapshot")).toBeTruthy();
+    expect(within(evidence).getByText("ctx_assignment_1")).toBeTruthy();
+    expect(within(evidence).getByText("Provider / model")).toBeTruthy();
+    expect(within(evidence).getByText("ollama / qwen2.5-coder")).toBeTruthy();
 
     await userEvent.click(within(detail).getByRole("button", { name: "Open task" }));
     expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
@@ -3771,9 +3781,10 @@ describe("ProjectsView cockpit", () => {
     await waitFor(() => {
       expect(within(detail).getAllByText("QA handoff").length).toBeGreaterThan(0);
     });
-    expect(within(detail).getByText(/Source refs: assignment asgn_1/)).toBeTruthy();
-    expect(within(detail).getByText(/chat chat_1/)).toBeTruthy();
-    expect(within(detail).getByText(/context ctx_1/)).toBeTruthy();
+    const sourceEvidence = within(detail).getByRole("group", { name: "Source evidence" });
+    expect(within(sourceEvidence).getByText("assignment asgn_1")).toBeTruthy();
+    expect(within(sourceEvidence).getByText("chat chat_1")).toBeTruthy();
+    expect(within(sourceEvidence).getByText("context ctx_1")).toBeTruthy();
     await userEvent.click(
       within(detail).getByRole("button", { name: "Create follow-up assignment" }),
     );
@@ -4111,6 +4122,7 @@ describe("ProjectsView cockpit", () => {
           kind: "task_run",
           task_id: "task_1",
           run_id: "run_1",
+          context_snapshot_id: "ctx_assignment_1",
         },
       },
     );

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -74,6 +74,7 @@ import {
 } from "./projectInsights";
 import {
   toProjectActivityItemViewModel,
+  toProjectAssignmentEvidenceViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 import {
@@ -5607,6 +5608,7 @@ function AssignmentRow({
   const execution = assignment.execution;
   const assignmentExecution = toProjectAssignmentExecutionViewModel(assignment);
   const activityView = activityItem ? toProjectActivityItemViewModel(activityItem) : null;
+  const evidence = toProjectAssignmentEvidenceViewModel(assignment, activityItem);
   const executionRef = assignmentExecution.hasAnyLink
     ? assignmentExecution
     : (activityView?.execution ?? assignmentExecution);
@@ -5757,6 +5759,7 @@ function AssignmentRow({
           </button>
         )}
       </div>
+      {evidence.hasEvidence && <ProjectAssignmentEvidence evidence={evidence} />}
       {activityView?.statusSummary &&
         activityView.statusSummary !== projectedStatus &&
         activityView.statusSummary !== "linked run missing" && (
@@ -5806,6 +5809,7 @@ function ProjectHandoffRow({
   starting: boolean;
 }) {
   const executionRef = assignment ? toProjectAssignmentExecutionViewModel(assignment) : null;
+  const targetEvidence = assignment ? toProjectAssignmentEvidenceViewModel(assignment) : null;
   const startable =
     (assignment?.driver_kind === "hecate_task" || assignment?.driver_kind === "external_agent") &&
     executionRef?.status === "queued";
@@ -5846,10 +5850,9 @@ function ProjectHandoffRow({
         <span>{handoff.trust_label}</span>
         {handoff.updated_at && <span>Updated {formatAbsoluteTime(handoff.updated_at)}</span>}
       </div>
-      {sourceRefs.length > 0 && (
-        <div style={{ ...subtleTextStyle, marginTop: 7 }}>
-          Source refs: {sourceRefs.join(" · ")}
-        </div>
+      {sourceRefs.length > 0 && <HandoffSourceEvidence refs={sourceRefs} />}
+      {targetEvidence?.hasEvidence && (
+        <ProjectAssignmentEvidence evidence={targetEvidence} title="Target evidence" compact />
       )}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 9 }}>
         {handoff.status === "pending" && (
@@ -5906,6 +5909,64 @@ function ProjectHandoffRow({
             {starting ? "Starting…" : "Start from handoff"}
           </button>
         )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectAssignmentEvidence({
+  compact = false,
+  evidence,
+  title = "Execution evidence",
+}: {
+  compact?: boolean;
+  evidence: ReturnType<typeof toProjectAssignmentEvidenceViewModel>;
+  title?: string;
+}) {
+  if (!evidence.hasEvidence) return null;
+  return (
+    <div
+      aria-label={title}
+      role="group"
+      style={{
+        ...assignmentEvidenceStyle,
+        padding: compact ? "8px 9px" : assignmentEvidenceStyle.padding,
+      }}
+    >
+      <div className="kicker">{title}</div>
+      {evidence.items.length > 0 && (
+        <div style={assignmentEvidenceGridStyle}>
+          {evidence.items.map((item) => (
+            <div key={item.key} style={assignmentEvidenceCellStyle}>
+              <div style={assignmentEvidenceLabelStyle}>{item.label}</div>
+              <div style={assignmentEvidenceValueStyle}>{item.value}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      {evidence.warnings.length > 0 && (
+        <div style={assignmentEvidenceWarningsStyle}>
+          {evidence.warnings.map((warning) => (
+            <span key={warning} className="badge badge-amber">
+              {warning}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HandoffSourceEvidence({ refs }: { refs: string[] }) {
+  return (
+    <div aria-label="Source evidence" role="group" style={assignmentEvidenceStyle}>
+      <div className="kicker">Source evidence</div>
+      <div style={assignmentEvidenceWarningsStyle}>
+        {refs.map((ref) => (
+          <span key={ref} className="badge badge-muted">
+            {ref}
+          </span>
+        ))}
       </div>
     </div>
   );
@@ -7089,6 +7150,51 @@ const assignmentStyle: CSSProperties = {
   background: "var(--bg2)",
   borderRadius: "var(--radius-sm)",
   padding: 10,
+};
+
+const assignmentEvidenceStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 8,
+  marginTop: 9,
+  minWidth: 0,
+  padding: "9px 10px",
+};
+
+const assignmentEvidenceGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "8px 12px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+  minWidth: 0,
+};
+
+const assignmentEvidenceCellStyle: CSSProperties = {
+  minWidth: 0,
+};
+
+const assignmentEvidenceLabelStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  lineHeight: 1.4,
+  textTransform: "uppercase",
+};
+
+const assignmentEvidenceValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  lineHeight: 1.45,
+  overflowWrap: "anywhere",
+};
+
+const assignmentEvidenceWarningsStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  minWidth: 0,
 };
 
 const timelineGridStyle: CSSProperties = {

--- a/ui/src/features/projects/projectAssignmentViewModels.test.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   toProjectActivityAssignmentExecutionViewModel,
   toProjectActivityItemViewModel,
+  toProjectAssignmentEvidenceViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
@@ -192,5 +193,101 @@ describe("projectAssignmentViewModels", () => {
     expect(view.bucket).toBe("blocked");
     expect(view.startedAt).toBe("2026-01-01T00:00:00Z");
     expect(view.finishedAt).toBe("2026-01-01T00:03:00Z");
+  });
+
+  it("builds evidence from canonical execution refs and activity link state", () => {
+    const assignment: ProjectAssignmentRecord = {
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "external_agent",
+      status: "running",
+      execution_ref: {
+        kind: "chat_session",
+        chat_session_id: "chat_1",
+        message_id: "msg_1",
+        context_snapshot_id: "ctx_1",
+        status: "running",
+        pending_approval_count: 1,
+        trace_id: "trace_1",
+      },
+      execution: {
+        status: "running",
+        provider: "anthropic",
+        model: "claude-sonnet",
+        step_count: 3,
+        artifact_count: 2,
+      },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:01:00Z",
+    };
+    const activityItem = {
+      id: "activity_1",
+      project_id: "proj_1",
+      work_item: {
+        id: "work_1",
+        title: "Build",
+        status: "running",
+        priority: "normal",
+      },
+      assignment,
+      role: {
+        id: "developer",
+        project_id: "proj_1",
+        name: "Developer",
+        built_in: true,
+      },
+      status: "running",
+      blocking_signal: "running",
+      status_summary: "running",
+      linked_chat_id: "chat_1",
+      linked_chat: {
+        id: "chat_1",
+        missing: true,
+        latest_error: "adapter exited",
+      },
+      linked_message_id: "msg_1",
+      artifact_summary: { count: 0 },
+      handoff_summary: { count: 0 },
+      updated_at: "2026-01-01T00:01:00Z",
+    } satisfies ProjectActivityItemRecord;
+
+    const evidence = toProjectAssignmentEvidenceViewModel(assignment, activityItem);
+
+    expect(evidence.hasEvidence).toBe(true);
+    expect(evidence.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Kind", value: "chat_session" }),
+        expect.objectContaining({ label: "Chat", value: "chat_1" }),
+        expect.objectContaining({ label: "Message", value: "msg_1" }),
+        expect.objectContaining({ label: "Context snapshot", value: "ctx_1" }),
+        expect.objectContaining({ label: "Provider / model", value: "anthropic / claude-sonnet" }),
+        expect.objectContaining({ label: "Steps", value: "3" }),
+        expect.objectContaining({ label: "Artifacts", value: "2" }),
+      ]),
+    );
+    expect(evidence.warnings).toEqual([
+      "1 approval pending",
+      "Linked runtime record is missing or unavailable.",
+      "adapter exited",
+    ]);
+  });
+
+  it("does not render evidence for status-only queued assignments", () => {
+    const evidence = toProjectAssignmentEvidenceViewModel({
+      id: "assign_1",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "hecate_task",
+      status: "queued",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    expect(evidence.hasEvidence).toBe(false);
+    expect(evidence.items).toEqual([]);
+    expect(evidence.warnings).toEqual([]);
   });
 });

--- a/ui/src/features/projects/projectAssignmentViewModels.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.ts
@@ -34,6 +34,18 @@ export type ProjectActivityItemViewModel = {
   finishedAt: string;
 };
 
+export type ProjectAssignmentEvidenceItem = {
+  key: string;
+  label: string;
+  value: string;
+};
+
+export type ProjectAssignmentEvidenceViewModel = {
+  items: ProjectAssignmentEvidenceItem[];
+  warnings: string[];
+  hasEvidence: boolean;
+};
+
 type LinkedExecutionOverrides = {
   taskID?: string;
   runID?: string;
@@ -99,6 +111,69 @@ export function toProjectActivityItemViewModel(
   };
 }
 
+export function toProjectAssignmentEvidenceViewModel(
+  assignment: ProjectAssignmentRecord,
+  activityItem?: ProjectActivityItemRecord,
+): ProjectAssignmentEvidenceViewModel {
+  const assignmentExecution = toProjectAssignmentExecutionViewModel(assignment);
+  const activityView = activityItem ? toProjectActivityItemViewModel(activityItem) : null;
+  const execution =
+    assignmentExecution.hasAnyLink || !activityView ? assignmentExecution : activityView.execution;
+  const summary = assignment.execution;
+  const items: ProjectAssignmentEvidenceItem[] = [];
+
+  pushEvidenceItem(items, "kind", "Kind", execution.kind === "none" ? "" : execution.kind);
+  pushEvidenceItem(items, "status", "Status", firstNonEmpty(execution.status, assignment.status));
+  pushEvidenceItem(items, "task", "Task", execution.taskID);
+  pushEvidenceItem(items, "run", "Run", execution.runID);
+  pushEvidenceItem(items, "chat", "Chat", execution.chatSessionID);
+  pushEvidenceItem(items, "message", "Message", execution.messageID);
+  pushEvidenceItem(items, "context", "Context snapshot", execution.contextSnapshotID);
+  pushEvidenceItem(items, "trace", "Trace", execution.traceID);
+  pushEvidenceItem(
+    items,
+    "provider_model",
+    "Provider / model",
+    [summary?.provider, summary?.model].filter(Boolean).join(" / "),
+  );
+  pushEvidenceItem(
+    items,
+    "steps",
+    "Steps",
+    typeof summary?.step_count === "number" ? String(summary.step_count) : "",
+  );
+  pushEvidenceItem(
+    items,
+    "artifacts",
+    "Artifacts",
+    typeof summary?.artifact_count === "number" ? String(summary.artifact_count) : "",
+  );
+  const warnings: string[] = [];
+  if (execution.pendingApprovalCount > 0) {
+    addEvidenceWarning(warnings, `${execution.pendingApprovalCount} approval pending`);
+  }
+  if (execution.missing || summary?.missing || activityItem?.linked_chat?.missing) {
+    addEvidenceWarning(warnings, "Linked runtime record is missing or unavailable.");
+  }
+  if (activityItem?.linked_chat?.latest_error) {
+    addEvidenceWarning(warnings, activityItem.linked_chat.latest_error);
+  }
+  if (!execution.hasAnyLink && assignment.status !== "queued") {
+    addEvidenceWarning(warnings, "No canonical execution refs are stored for this assignment.");
+  }
+  if (summary?.last_error) {
+    addEvidenceWarning(warnings, summary.last_error);
+  }
+
+  const hasEvidence = items.some((item) => item.key !== "status") || warnings.length > 0;
+
+  return {
+    items: hasEvidence ? items : [],
+    warnings,
+    hasEvidence,
+  };
+}
+
 function activityBucket(signal: string): ProjectActivityItemViewModel["bucket"] {
   switch (signal) {
     case "awaiting_approval":
@@ -112,6 +187,23 @@ function activityBucket(signal: string): ProjectActivityItemViewModel["bucket"] 
     default:
       return "active";
   }
+}
+
+function pushEvidenceItem(
+  items: ProjectAssignmentEvidenceItem[],
+  key: string,
+  label: string,
+  value: string,
+) {
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  items.push({ key, label, value: trimmed });
+}
+
+function addEvidenceWarning(warnings: string[], value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || warnings.includes(trimmed)) return;
+  warnings.push(trimmed);
 }
 
 function firstNonEmpty(...values: Array<string | undefined | null>): string {


### PR DESCRIPTION
## Summary

- Add a Projects assignment evidence view model that summarizes canonical execution refs and activity-linked runtime state.
- Render compact execution evidence on assignment rows, plus separate source/target evidence for handoff follow-up flows.
- Update Projects and UI guidance docs to keep compact row evidence distinct from the full Context Inspector packet view.

## Validation

- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/features/projects/projectAssignmentViewModels.test.ts src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test`
- `just agent-docs-check`
- `git diff --check`

No backend files changed; Go/race checks were not run.