### PR TITLE
Compact Project Assistant surface

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -457,9 +457,12 @@ The first visible UI should stay small and inspectable:
 - place the composer at the top of the project workspace because the assistant
   is project-scoped, above workspace tabs and tab panels even when it uses the
   selected work item as context;
+- keep the request and primary draft action in the first row; route controls,
+  bootstrap, and context inspection stay secondary so the assistant reads as a
+  project command band rather than a work-detail editor;
 - keep route controls contextual, with an automatic choice for the common path;
-- show proposal cards with exact actions before apply, either inline or behind
-  an inspect affordance;
+- show context details only after explicit inspection, and proposal cards with
+  exact actions only after drafting;
 - show `Apply` and `Dismiss`;
 - require explicit confirmation for durable/destructive proposals;
 - show stale-state failures as "State changed, refresh proposal";
@@ -471,8 +474,9 @@ V0 uses a composer-style request box that drafts typed proposals from the
 selected project/work item. The `Rules` draft option uses deterministic server
 logic; `Bootstrap` proposes project setup records from guidance and skill
 registry metadata; the `Assistant` draft option asks the project default model
-to author the same typed proposal shape. Later Hecate Chat can call the same proposal API,
-but durable mutations should still stop at the same explicit review/apply card.
+to author the same typed proposal shape. Later Hecate Chat can call the same
+proposal API, but durable mutations should still stop at the same explicit
+review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
 project list, project work, selected work-item detail, and project memory.

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -102,18 +102,31 @@ export function ProjectAssistantPanel({
         }}
         style={assistantComposerStyle}
       >
-        <label style={requestFieldStyle}>
-          <span style={fieldLabelStyle}>Request</span>
-          <textarea
-            className="input"
-            rows={workItem ? 2 : 3}
-            value={form.request}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, request: event.target.value }))
-            }
-            style={assistantRequestInputStyle}
-          />
-        </label>
+        <div style={assistantPrimaryRowStyle}>
+          <label style={requestFieldStyle}>
+            <span style={fieldLabelStyle}>Request</span>
+            <textarea
+              className="input"
+              rows={workItem ? 1 : 2}
+              value={form.request}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, request: event.target.value }))
+              }
+              style={assistantRequestInputStyle}
+            />
+          </label>
+          <div style={assistantPrimaryActionsStyle}>
+            <button
+              className="btn btn-primary btn-sm"
+              type="submit"
+              disabled={!valid || busy}
+              style={assistantSubmitStyle}
+            >
+              <Icon d={Icons.send} size={13} />
+              {status === "proposing" ? "Drafting..." : "Draft proposal"}
+            </button>
+          </div>
+        </div>
         <div style={assistantRouteBarStyle}>
           <div style={assistantRouteFieldsStyle}>
             <label style={routeFieldStyle}>
@@ -177,33 +190,26 @@ export function ProjectAssistantPanel({
               </select>
             </label>
           </div>
-          <button
-            className="btn btn-ghost btn-sm"
-            type="button"
-            disabled={!valid || busy || contextBusy}
-            onClick={() => onInspectContext(form)}
-          >
-            <Icon d={Icons.eye} size={13} />
-            {contextBusy ? "Inspecting..." : "Inspect context"}
-          </button>
-          <button
-            className="btn btn-ghost btn-sm"
-            type="button"
-            disabled={bootstrapBusy || contextBusy}
-            onClick={onBootstrap}
-          >
-            <Icon d={Icons.refresh} size={13} />
-            {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
-          </button>
-          <button
-            className="btn btn-primary btn-sm"
-            type="submit"
-            disabled={!valid || busy}
-            style={assistantSubmitStyle}
-          >
-            <Icon d={Icons.send} size={13} />
-            {status === "proposing" ? "Drafting..." : "Draft proposal"}
-          </button>
+          <div style={assistantSecondaryActionsStyle}>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              disabled={!valid || busy || contextBusy}
+              onClick={() => onInspectContext(form)}
+            >
+              <Icon d={Icons.eye} size={13} />
+              {contextBusy ? "Inspecting..." : "Inspect context"}
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              type="button"
+              disabled={bootstrapBusy || contextBusy}
+              onClick={onBootstrap}
+            >
+              <Icon d={Icons.refresh} size={13} />
+              {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
+            </button>
+          </div>
         </div>
       </form>
       {contextError && (
@@ -493,48 +499,63 @@ function formatAssistantValue(value: unknown): string {
 }
 
 const assistantPanelStyle: CSSProperties = {
-  background: "var(--bg1)",
+  background: "var(--bg0)",
   border: "1px solid var(--border)",
   borderRadius: "var(--radius-sm)",
   boxSizing: "border-box",
   display: "grid",
-  gap: 10,
+  gap: 8,
   maxWidth: "100%",
   minWidth: 0,
-  padding: 12,
+  padding: "10px 12px",
 };
 
 const assistantComposerStyle: CSSProperties = {
   display: "grid",
-  gap: 10,
+  gap: 8,
+  minWidth: 0,
+};
+
+const assistantPrimaryRowStyle: CSSProperties = {
+  alignItems: "end",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
   minWidth: 0,
 };
 
 const requestFieldStyle: CSSProperties = {
   display: "grid",
+  flex: "1 1 360px",
   gap: 6,
+  minWidth: 220,
 };
 
 const assistantRequestInputStyle: CSSProperties = {
   lineHeight: 1.45,
-  minHeight: 78,
+  minHeight: 40,
   resize: "vertical",
+};
+
+const assistantPrimaryActionsStyle: CSSProperties = {
+  display: "flex",
+  flex: "0 0 auto",
+  justifyContent: "flex-end",
+  minWidth: 0,
 };
 
 const assistantRouteBarStyle: CSSProperties = {
   alignItems: "end",
-  borderTop: "1px solid var(--border)",
   display: "flex",
   flexWrap: "wrap",
   gap: 8,
   justifyContent: "space-between",
   minWidth: 0,
-  paddingTop: 10,
 };
 
 const assistantRouteFieldsStyle: CSSProperties = {
   display: "flex",
-  flex: "1 1 320px",
+  flex: "1 1 420px",
   flexWrap: "wrap",
   gap: 8,
   minWidth: 0,
@@ -542,16 +563,25 @@ const assistantRouteFieldsStyle: CSSProperties = {
 
 const routeFieldStyle: CSSProperties = {
   display: "grid",
-  flex: "1 1 150px",
+  flex: "0 1 190px",
   gap: 5,
-  maxWidth: 260,
-  minWidth: 140,
+  maxWidth: 220,
+  minWidth: 128,
+};
+
+const assistantSecondaryActionsStyle: CSSProperties = {
+  display: "flex",
+  flex: "0 1 auto",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "flex-end",
+  minWidth: 0,
 };
 
 const assistantSubmitStyle: CSSProperties = {
   flex: "0 0 auto",
   justifyContent: "center",
-  minWidth: 150,
+  minWidth: 140,
 };
 
 const assistantProposalStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1126,6 +1126,7 @@ describe("ProjectsView index", () => {
     const assistant = within(workspace).getByRole("region", { name: "Project Assistant" });
     const tabs = within(workspace).getByRole("tablist", { name: "Project workspace views" });
     expect(assistant.compareDocumentPosition(tabs) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(assistant).getByLabelText("Request")).toHaveAttribute("rows", "1");
     expect(screen.getByRole("region", { name: "Work queue" })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Project attention/ })).toBeTruthy();
     expect(screen.queryByRole("region", { name: "Needs attention" })).toBeNull();
@@ -1139,6 +1140,7 @@ describe("ProjectsView index", () => {
     expect(within(tabs).getByRole("tab", { name: /Skills/ })).toBeTruthy();
     const workPanel = within(workspace).getByRole("region", { name: "Work coordination" });
     expect(workPanel).toBeTruthy();
+    expect(within(workPanel).queryByRole("region", { name: "Project Assistant" })).toBeNull();
     expect(workPanel.querySelector(".project-work-coordination-grid")).toBeTruthy();
     expect(within(workspace).getByRole("heading", { name: "Build cockpit UI" })).toBeTruthy();
     expect(within(workspace).queryByLabelText("Project timeline")).toBeNull();


### PR DESCRIPTION
## Summary
- Compact the Project Assistant into a project-level command band with the request and primary draft action together.
- Move route, context inspection, and bootstrap controls into the secondary row so the assistant no longer reads like a work-detail editor.
- Update the Project Assistant runtime docs and add UI regression coverage for placement outside Work Coordination plus the compact selected-work request box.

## Tests
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `cd ui && bun run build`
- Browser check: loaded Vite at `http://127.0.0.1:5173/`; local runtime had no projects, so the populated Project Assistant state was verified by the DOM/unit regression test rather than live local records.
