### PR TITLE
refactor(projects): share assignment launch planning

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -159,7 +159,9 @@ API-local context-packet assembly. Do not add launch planning, workspace
 resolution, profile/skill resolution, adapter-option validation, or start
 orchestration back to the broad `handler_project_work.go`; either extend the
 dedicated launch helper or move the narrow behavior into `projectworkapp` when
-the dependency shape is ready.
+the dependency shape is ready. Preflight and start must share the same launch
+plan helpers; do not resolve provider/model/profile/workspace or External Agent
+adapter/options separately for preview and dispatch.
 
 Project activity is a read/projection surface with split ownership:
 `internal/projectworkapp` owns assignment execution refs, task/run projection,

--- a/e2e/project_assignment_launch_test.go
+++ b/e2e/project_assignment_launch_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestProjectAssignmentPreflightStartLaunchPlanE2E(t *testing.T) {
+	workDir := t.TempDir()
+	canonicalWorkDir, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		t.Fatalf("canonicalize temp dir: %v", err)
+	}
+	upstream, _ := fakeAgentLoopToolCallingUpstream(t)
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_TASK_APPROVAL_POLICIES=",
+		"PROVIDER_FAKE_API_KEY=dummy",
+		"PROVIDER_FAKE_BASE_URL="+upstream,
+		"PROVIDER_FAKE_KIND=local",
+		"PROVIDER_FAKE_MODELS="+agentLoopE2EModel,
+	)
+
+	project := postJSONDecodeStatus[e2eProjectResponse](t, baseURL+"/hecate/v1/projects", e2eProjectLaunchJSON(t, map[string]any{
+		"name":                   "Project launch plan e2e",
+		"workspace_path":         canonicalWorkDir,
+		"workspace_kind":         "git",
+		"default_provider":       "fake",
+		"default_model":          agentLoopE2EModel,
+		"default_workspace_mode": "in_place",
+	}), http.StatusCreated)
+	projectID := project.Data.ID
+	if projectID == "" {
+		t.Fatal("created project id is empty")
+	}
+	postJSONDecodeStatus[e2eProjectWorkRoleResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/roles", `{
+		"id": "role_launch",
+		"name": "Launch engineer",
+		"default_driver_kind": "hecate_task"
+	}`, http.StatusCreated)
+	postJSONDecodeStatus[e2eProjectWorkItemResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items", `{
+		"id": "work_launch",
+		"title": "Exercise launch plan",
+		"brief": "Start a project assignment through the real API."
+	}`, http.StatusCreated)
+	postJSONDecodeStatus[e2eProjectWorkAssignmentResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items/work_launch/assignments", `{
+		"id": "asgn_launch",
+		"role_id": "role_launch",
+		"driver_kind": "hecate_task"
+	}`, http.StatusCreated)
+
+	preflight := getJSON[e2eProjectLaunchContextResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items/work_launch/assignments/asgn_launch/preflight")
+	if preflight.Data.ExecutionMode != "hecate_task" {
+		t.Fatalf("preflight execution_mode = %q, want hecate_task", preflight.Data.ExecutionMode)
+	}
+
+	started := postJSONDecode[e2eProjectWorkAssignmentLaunchResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items/work_launch/assignments/asgn_launch/start", `{}`)
+	ref := started.Data.ExecutionRef
+	if ref.Kind != "task_run" || ref.TaskID == "" || ref.RunID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("execution_ref = %+v, want task/run/context links", ref)
+	}
+
+	run := waitForE2ETaskRunTerminal(t, baseURL, ref.TaskID, ref.RunID, 10*time.Second)
+	if run.Status != "completed" {
+		t.Fatalf("run status = %q last_error=%q, want completed", run.Status, run.LastError)
+	}
+	if run.Provider != "fake" || run.ProviderKind != "local" || run.Model != agentLoopE2EModel {
+		t.Fatalf("run route = provider %q kind %q model %q, want fake/local/%s", run.Provider, run.ProviderKind, run.Model, agentLoopE2EModel)
+	}
+
+	context := getJSON[e2eProjectLaunchContextResponse](t, baseURL+"/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context")
+	if context.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("context id = %q, want execution_ref context %q", context.Data.ID, ref.ContextSnapshotID)
+	}
+	assertProjectLaunchContextMatches(t, preflight.Data, context.Data)
+	if context.Data.Refs == nil || context.Data.Refs.ProjectID != projectID || context.Data.Refs.WorkItemID != "work_launch" || context.Data.Refs.AssignmentID != "asgn_launch" || context.Data.Refs.TaskID != ref.TaskID || context.Data.Refs.RunID != ref.RunID {
+		t.Fatalf("context refs = %+v, want project/work/assignment/task/run refs", context.Data.Refs)
+	}
+
+	assignmentContext := getJSON[e2eProjectLaunchContextResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items/work_launch/assignments/asgn_launch/context")
+	if assignmentContext.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want %q", assignmentContext.Data.ID, ref.ContextSnapshotID)
+	}
+}
+
+func e2eProjectLaunchJSON(t *testing.T, payload any) string {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(raw)
+}
+
+func assertProjectLaunchContextMatches(t *testing.T, preflight, started e2eProjectLaunchContext) {
+	t.Helper()
+	if preflight.ExecutionMode != started.ExecutionMode ||
+		preflight.Provider != started.Provider ||
+		preflight.Model != started.Model ||
+		preflight.ExecutionProfile != started.ExecutionProfile ||
+		preflight.Workspace != started.Workspace {
+		t.Fatalf("preflight launch shape = mode/provider/model/profile/workspace %q/%q/%q/%q/%q, started = %q/%q/%q/%q/%q",
+			preflight.ExecutionMode, preflight.Provider, preflight.Model, preflight.ExecutionProfile, preflight.Workspace,
+			started.ExecutionMode, started.Provider, started.Model, started.ExecutionProfile, started.Workspace)
+	}
+}
+
+type e2eProjectWorkAssignmentLaunchResponse struct {
+	Data struct {
+		ID           string                        `json:"id"`
+		Status       string                        `json:"status"`
+		ExecutionRef e2eProjectAssignmentExecution `json:"execution_ref"`
+	} `json:"data"`
+}
+
+type e2eProjectAssignmentExecution struct {
+	Kind              string `json:"kind"`
+	TaskID            string `json:"task_id,omitempty"`
+	RunID             string `json:"run_id,omitempty"`
+	ContextSnapshotID string `json:"context_snapshot_id,omitempty"`
+	Status            string `json:"status,omitempty"`
+}
+
+type e2eProjectLaunchContextResponse struct {
+	Object string                  `json:"object"`
+	Data   e2eProjectLaunchContext `json:"data"`
+}
+
+type e2eProjectLaunchContext struct {
+	ID               string                       `json:"id"`
+	ExecutionMode    string                       `json:"execution_mode"`
+	Provider         string                       `json:"provider,omitempty"`
+	Model            string                       `json:"model,omitempty"`
+	ExecutionProfile string                       `json:"execution_profile,omitempty"`
+	Workspace        string                       `json:"workspace,omitempty"`
+	Refs             *e2eProjectLaunchContextRefs `json:"refs,omitempty"`
+}
+
+type e2eProjectLaunchContextRefs struct {
+	ProjectID    string `json:"project_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	TaskID       string `json:"task_id,omitempty"`
+	RunID        string `json:"run_id,omitempty"`
+	SessionID    string `json:"session_id,omitempty"`
+}

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -167,45 +167,22 @@ func (h *Handler) projectExternalAgentAssignmentPreflightContext(ctx context.Con
 	if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" {
 		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusConflict, errCodeConflict, "external-agent assignment already has a prepared chat session")
 	}
-	workingDirectory, _, err := resolveProjectAssignmentWorkspace(project)
+	plan, err := h.resolveProjectExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
 	if err != nil {
-		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
-	if err != nil {
+		var adapterErr projectAssignmentAdapterNotFoundError
+		if errors.As(err, &adapterErr) {
+			return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, err.Error())
+		}
 		return chat.ContextPacket{}, err
 	}
-	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
-	if adapterID == "" {
-		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusUnprocessableEntity, errCodeInvalidRequest, "external-agent assignment requires an agent profile with external_agent_kind")
-	}
-	adapter, ok := agentadapters.BuiltInByID(adapterID)
-	if !ok {
-		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "external-agent adapter not found: "+adapterID)
-	}
-	configOptions, err := projectExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
-	if err != nil {
-		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
-	if err != nil {
-		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	resolvedSkills := h.resolveProjectAssignmentSkills(ctx, project.ID, role, profile)
-	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workspace, "", "", firstNonEmptyString(profile.ExecutionProfile, "external_agent_assignment"), profile, resolvedSkills, projectAssignmentPromptContext{})
-	packet.ExecutionMode = chat.ExecutionModeExternalAgent
-	packet.Provider = ""
-	packet.Model = ""
-	packet.Workspace = workspace
-	packet.Refs.TaskID = ""
-	packet.Refs.RunID = ""
+	packet := h.projectExternalAgentAssignmentContextPacket(ctx, project, workItem, assignment, role, plan, "")
 	appendProjectAssignmentLaunchPreflight(&packet, projectwork.AssignmentDriverExternalAgent, []string{
-		"External agent: " + firstNonEmptyString(adapter.Name, adapterID),
-		"Adapter ID: " + adapterID,
+		"External agent: " + firstNonEmptyString(plan.Adapter.Name, plan.AdapterID),
+		"Adapter ID: " + plan.AdapterID,
 		"Chat session: created when the assignment is prepared",
-		"Session title: " + projectExternalAgentAssignmentTitle(workItem, role, adapter),
-		"Workspace: " + workspace,
-		"Config options: " + formatProjectExternalAgentConfigOptions(configOptions),
+		"Session title: " + plan.SessionTitle,
+		"Workspace: " + plan.Workspace,
+		"Config options: " + formatProjectExternalAgentConfigOptions(plan.ConfigOptions),
 	})
 	return chatcontext.Normalize(packet, chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID)), nil
 }
@@ -417,6 +394,78 @@ func (h *Handler) resolveProjectAssignmentLaunchPlan(ctx context.Context, projec
 	}, nil
 }
 
+type projectExternalAgentAssignmentLaunchPlan struct {
+	Workspace        string
+	AdapterID        string
+	Adapter          agentadapters.Adapter
+	ConfigOptions    []agentcontrols.ConfigOption
+	SessionTitle     string
+	ExecutionProfile string
+	Profile          resolvedAgentProfile
+	ResolvedSkills   resolvedProjectSkills
+}
+
+type projectAssignmentAdapterNotFoundError struct {
+	adapterID string
+}
+
+func (err projectAssignmentAdapterNotFoundError) Error() string {
+	return "external-agent adapter not found: " + err.adapterID
+}
+
+func (err projectAssignmentAdapterNotFoundError) AdapterID() string {
+	return err.adapterID
+}
+
+func (h *Handler) resolveProjectExternalAgentAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) (projectExternalAgentAssignmentLaunchPlan, error) {
+	workingDirectory, _, err := resolveProjectAssignmentWorkspace(project)
+	if err != nil {
+		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	}
+	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
+	if err != nil {
+		return projectExternalAgentAssignmentLaunchPlan{}, err
+	}
+	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
+	if adapterID == "" {
+		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusUnprocessableEntity, errCodeInvalidRequest, "external-agent assignment requires an agent profile with external_agent_kind")
+	}
+	adapter, ok := agentadapters.BuiltInByID(adapterID)
+	if !ok {
+		return projectExternalAgentAssignmentLaunchPlan{}, projectAssignmentAdapterNotFoundError{adapterID: adapterID}
+	}
+	configOptions, err := projectExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
+	if err != nil {
+		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	}
+	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
+	if err != nil {
+		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	}
+	return projectExternalAgentAssignmentLaunchPlan{
+		Workspace:        workspace,
+		AdapterID:        adapterID,
+		Adapter:          adapter,
+		ConfigOptions:    configOptions,
+		SessionTitle:     projectExternalAgentAssignmentTitle(workItem, role, adapter),
+		ExecutionProfile: firstNonEmptyString(profile.ExecutionProfile, "external_agent_assignment"),
+		Profile:          profile,
+		ResolvedSkills:   h.resolveProjectAssignmentSkills(ctx, project.ID, role, profile),
+	}, nil
+}
+
+func (h *Handler) projectExternalAgentAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectExternalAgentAssignmentLaunchPlan, sessionID string) chat.ContextPacket {
+	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Workspace, "", "", plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, projectAssignmentPromptContext{})
+	packet.ExecutionMode = chat.ExecutionModeExternalAgent
+	packet.Provider = ""
+	packet.Model = ""
+	packet.Workspace = plan.Workspace
+	packet.Refs.SessionID = strings.TrimSpace(sessionID)
+	packet.Refs.TaskID = ""
+	packet.Refs.RunID = ""
+	return packet
+}
+
 func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *http.Request, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) {
 	ctx := r.Context()
 	if h.agentChat == nil {
@@ -436,57 +485,29 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
-	workingDirectory, _, err := resolveProjectAssignmentWorkspace(project)
+	plan, err := h.resolveProjectExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
 	if err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-		return
-	}
-	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
-	if adapterID == "" {
-		WriteError(w, http.StatusUnprocessableEntity, errCodeInvalidRequest, "external-agent assignment requires an agent profile with external_agent_kind")
-		return
-	}
-	adapter, ok := agentadapters.BuiltInByID(adapterID)
-	if !ok {
-		writeAgentChatAdapterNotFound(w, adapterID)
-		return
-	}
-	configOptions, err := projectExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
-	if err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-		return
-	}
-	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
-	if err != nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		var adapterErr projectAssignmentAdapterNotFoundError
+		if errors.As(err, &adapterErr) {
+			writeAgentChatAdapterNotFound(w, adapterErr.AdapterID())
+			return
+		}
+		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
 		return
 	}
 	sessionID := newChatID("chat")
-	resolvedSkills := h.resolveProjectAssignmentSkills(ctx, project.ID, role, profile)
-	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, workspace, "", "", firstNonEmptyString(profile.ExecutionProfile, "external_agent_assignment"), profile, resolvedSkills, projectAssignmentPromptContext{})
+	contextPacket := h.projectExternalAgentAssignmentContextPacket(ctx, project, workItem, assignment, role, plan, sessionID)
 	contextPacket.ID = firstNonEmptyString(contextPacket.ID, newChatID("ctx"))
-	contextPacket.ExecutionMode = chat.ExecutionModeExternalAgent
-	contextPacket.Provider = ""
-	contextPacket.Model = ""
-	contextPacket.Workspace = workspace
-	contextPacket.Refs.SessionID = sessionID
-	contextPacket.Refs.TaskID = ""
-	contextPacket.Refs.RunID = ""
 
 	session := chat.Session{
 		ID:              sessionID,
-		Title:           projectExternalAgentAssignmentTitle(workItem, role, adapter),
+		Title:           plan.SessionTitle,
 		ProjectID:       project.ID,
-		AgentID:         adapterID,
+		AgentID:         plan.AdapterID,
 		DriverKind:      agentadapters.DriverKindACP,
-		Workspace:       workspace,
-		WorkspaceBranch: workspaceGitBranch(workspace),
-		ConfigOptions:   configOptions,
+		Workspace:       plan.Workspace,
+		WorkspaceBranch: workspaceGitBranch(plan.Workspace),
+		ConfigOptions:   plan.ConfigOptions,
 	}
 	contextPacket.Refs.SessionID = session.ID
 	contextPacket = chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
@@ -504,7 +525,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 	if err != nil {
 		var prepareErr projectworkapp.ExternalAgentPrepareError
 		if errors.As(err, &prepareErr) {
-			writeAgentChatPrepareError(w, adapter.Name, prepareErr.Unwrap())
+			writeAgentChatPrepareError(w, plan.Adapter.Name, prepareErr.Unwrap())
 			return
 		}
 		resultAssignment := assignment

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -626,6 +626,50 @@ func TestProjectWorkAPI_PreflightAssignmentReturnsLaunchContextWithoutSideEffect
 	}
 }
 
+func TestProjectWorkAPI_PreflightAndStartShareNativeLaunchPlan(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	client := newAPITestClient(t, server)
+	preflight := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
+	}
+	started := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+
+	if preflight.Data.ExecutionMode != started.Data.ExecutionMode ||
+		preflight.Data.Provider != started.Data.Provider ||
+		preflight.Data.Model != started.Data.Model ||
+		preflight.Data.ExecutionProfile != started.Data.ExecutionProfile ||
+		preflight.Data.Workspace != started.Data.Workspace {
+		t.Fatalf("preflight launch shape = mode/provider/model/profile/workspace %q/%q/%q/%q/%q, started = %q/%q/%q/%q/%q",
+			preflight.Data.ExecutionMode, preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace,
+			started.Data.ExecutionMode, started.Data.Provider, started.Data.Model, started.Data.ExecutionProfile, started.Data.Workspace)
+	}
+	if task.RequestedProvider != preflight.Data.Provider || task.RequestedModel != preflight.Data.Model || task.ExecutionProfile != preflight.Data.ExecutionProfile || task.WorkingDirectory != preflight.Data.Workspace {
+		t.Fatalf("task launch shape = provider/model/profile/workspace %q/%q/%q/%q, want preflight %q/%q/%q/%q",
+			task.RequestedProvider, task.RequestedModel, task.ExecutionProfile, task.WorkingDirectory,
+			preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace)
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -1380,6 +1424,76 @@ func TestProjectWorkAPI_PreflightExternalAgentAssignmentShowsSessionTargetWithou
 	}
 	if len(sessions) != 0 {
 		t.Fatalf("sessions = %+v, want no chat session created by preflight", sessions)
+	}
+}
+
+func TestProjectWorkAPI_PreflightAndStartShareExternalAgentLaunchPlan(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	runner := &fakeAgentChatRunner{nativeSessionID: "native_project_external"}
+	handler.SetAgentChatRunner(runner)
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                "prof_external",
+		Name:              "External implementer",
+		Surface:           agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:  "external_implementation",
+		ExternalAgentKind: "codex",
+		SkillIDs:          []string{"project-handoff"},
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	client := newAPITestClient(t, server)
+	preflight := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	started := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/context", "")
+
+	if preflight.Data.ExecutionMode != started.Data.ExecutionMode ||
+		preflight.Data.Provider != started.Data.Provider ||
+		preflight.Data.Model != started.Data.Model ||
+		preflight.Data.ExecutionProfile != started.Data.ExecutionProfile ||
+		preflight.Data.Workspace != started.Data.Workspace {
+		t.Fatalf("preflight external shape = mode/provider/model/profile/workspace %q/%q/%q/%q/%q, started = %q/%q/%q/%q/%q",
+			preflight.Data.ExecutionMode, preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace,
+			started.Data.ExecutionMode, started.Data.Provider, started.Data.Model, started.Data.ExecutionProfile, started.Data.Workspace)
+	}
+	if started.Data.Refs == nil || started.Data.Refs.SessionID != ref.ChatSessionID || started.Data.Refs.TaskID != "" || started.Data.Refs.RunID != "" {
+		t.Fatalf("started refs = %+v, want external chat session only", started.Data.Refs)
+	}
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
+	}
+	prepare := runner.prepareRequests[0]
+	if prepare.AdapterID != "codex" || prepare.SessionID != ref.ChatSessionID || prepare.Workspace != preflight.Data.Workspace {
+		t.Fatalf("prepare request = %+v, want codex session %q in preflight workspace %q", prepare, ref.ChatSessionID, preflight.Data.Workspace)
+	}
+	session, ok, err := handler.agentChat.Get(t.Context(), ref.ChatSessionID)
+	if err != nil || !ok {
+		t.Fatalf("Get chat session found=%v err=%v, want linked session", ok, err)
+	}
+	if session.Title != "Native assignment start - Backend engineer - Codex" || session.Workspace != preflight.Data.Workspace || session.AgentID != "codex" {
+		t.Fatalf("session = %+v, want preflight launch target", session)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Share External Agent assignment launch planning between preflight and start.
- Keep adapter lookup, config-option validation, workspace validation, session title, profile, and skill resolution on one path.
- Add native and External Agent API parity tests plus a binary e2e smoke for project assignment preflight/start context parity.
- Update backend guidance so future assignment preview/dispatch work does not split launch-plan resolution again.

## Tests

- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(PreflightAndStartShare|PreflightAssignment|PreflightExternal|StartAssignment|StartExternalAgentAssignment)'`
- `GOCACHE="$PWD/.gocache" go test ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -tags e2e -run TestProjectAssignmentPreflightStartLaunchPlanE2E ./e2e`
- `just agent-docs-check`
- `git diff --check`
- `git ls-files -z '*.md' '*.mdc' | xargs -0 /Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check`
