### PR TITLE
Discover Git worktree project roots

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -28,6 +28,11 @@ project skills registry exposes local `SKILL.md` metadata for roles/profiles
 without granting tools, injecting bodies, or executing skill scripts. The
 operator UI can manage agent profiles and pick registered project skills for
 roles/profiles; those selections remain metadata until launch-time resolution.
+Project roots are concrete checkouts, not project identity: one project can span
+the main checkout and linked Git worktrees, while newly discovered worktree roots
+stay inactive until the operator enables them. Context discovery must not treat
+nested `.worktrees`, `.claude/worktrees`, or other nested Git checkouts as
+inherited guidance for the parent root.
 Profile memory/source policies now control whether assignment context packets
 mark project memory and source metadata active, visible-only, or omitted. Native
 project assignments can include bounded project memory and portable `AGENTS.md`

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -37,16 +37,17 @@ Raw paths are not stable enough to be the durable identity:
 
 ## Terminology
 
-| Term           | Meaning                                                                                                                                                    |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Project        | Durable Hecate object representing a codebase or work area. Identified by `project_id`. Owns defaults, memories, history grouping, and context sources.    |
-| Workspace      | Concrete filesystem root used for execution. A project can have one or more workspaces over time.                                                          |
-| Chat           | Conversation attached to an optional project and, when running, a concrete workspace.                                                                      |
-| Task           | Durable runtime object attached to an optional project and a concrete workspace mode.                                                                      |
-| Run            | One execution attempt under a task. Runs never define project identity by themselves.                                                                      |
-| Agent profile  | Reusable agent configuration for Hecate Chat or an external agent: model/adapter controls, tools, memory sources, system instructions, and safety posture. |
-| Preset         | Template for creating or updating a project default or agent profile. Presets are not used directly at runtime once applied.                               |
-| Context packet | A snapshot of what Hecate assembled for a model/agent call, including project and workspace metadata.                                                      |
+| Term           | Meaning                                                                                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Project        | Durable Hecate object representing a codebase or work area. Identified by `project_id`. Owns defaults, memories, history grouping, and context sources.      |
+| Workspace      | Concrete filesystem root used for execution. A project can have one or more workspaces over time.                                                            |
+| Project root   | A saved checkout/workspace path for a project. Roots can represent the main checkout, a linked Git worktree, an editor-owned workspace, or a temporary root. |
+| Chat           | Conversation attached to an optional project and, when running, a concrete workspace.                                                                        |
+| Task           | Durable runtime object attached to an optional project and a concrete workspace mode.                                                                        |
+| Run            | One execution attempt under a task. Runs never define project identity by themselves.                                                                        |
+| Agent profile  | Reusable agent configuration for Hecate Chat or an external agent: model/adapter controls, tools, memory sources, system instructions, and safety posture.   |
+| Preset         | Template for creating or updating a project default or agent profile. Presets are not used directly at runtime once applied.                                 |
+| Context packet | A snapshot of what Hecate assembled for a model/agent call, including project and workspace metadata.                                                        |
 
 ## Goals
 
@@ -57,6 +58,9 @@ Raw paths are not stable enough to be the durable identity:
   project activity, and reviewed memory/context without replacing Tasks or
   Chats as execution surfaces.
 - Keep workspace modes explicit: in-place, isolated clone, temporary workspace, editor-owned workspace.
+- Treat branches and Git worktrees as concrete root metadata, not project
+  identity. A project can span the main checkout and linked worktrees while
+  preserving one memory/context/work history.
 - Let project defaults feed new chats and tasks: provider, model, agent profile, tools, command-output compaction, approval posture, workspace mode, and system prompt where applicable.
 - Let context assembly use project-level sources: project instructions, selected docs, saved memories, and trusted files.
 - Let Hecate Chat and external-agent chats share project memory when their active agent profile opts into it.
@@ -103,7 +107,7 @@ type Project struct {
 type ProjectRoot struct {
     ID        string
     Path      string
-    Kind      string // local, isolated_clone, editor_owned, temporary
+    Kind      string // local, git, git_worktree, editor_owned, temporary
     GitRemote string
     GitBranch string
     Active    bool
@@ -128,6 +132,10 @@ Rules:
   those files, inject them into prompts, or create memory entries.
 - Operators can rename projects later.
 - Multiple roots can map to one project, but one root should not silently attach to many projects without operator confirmation.
+- Git worktrees are roots, not separate projects by default. Root discovery can
+  register linked worktrees for visibility, but newly discovered worktree roots
+  start inactive so context discovery and assignment launch stay scoped to the
+  operator-selected roots.
 
 ## API Shape
 
@@ -233,6 +241,8 @@ The Projects UI should stay lightweight but operational:
 - Group chat history by selected project, while keeping **No project** valid.
 - Let “New Hecate chat” and External Agent chats attach to the selected project.
 - Show project identity in Task detail once task linkage exists.
+- Show project roots/worktrees with branch and active/default status so the
+  operator knows which checkout an assignment will use.
 - Let future “Use model” and “Use external agent” flows attach to the same project when started from the same workspace.
 - Let agent profiles expose whether project memory is injected, visible only,
   or disabled for that agent.
@@ -292,9 +302,10 @@ The product layers should stay separate:
 | Manager           | Future project run  | Active-state monitoring, blocker detection, sequencing suggestions, follow-up proposals.               |
 | Orchestrator      | Runtime execution   | Approved task/agent coordination, waits, approvals, event emission, and state transitions.             |
 
-Project Assistant can help create a new project or draft a follow-up assignment,
-and the Projects UI can prepare Bootstrap proposals by refreshing workspace
-guidance and project skills before drafting. It does not auto-start work, run
+Project Assistant can help create a new project or draft a follow-up assignment.
+In the Projects UI, Bootstrap is project onboarding: it prepares setup proposals
+by refreshing workspace guidance and project skills, without inheriting nested
+worktree containers as parent-root input. It does not auto-start work, run
 agents, or write durable memory directly.
 Planner and Manager are future proposal/monitoring layers. The orchestrator is
 the runtime coordinator that executes approved work through Tasks, External

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -284,6 +284,9 @@ Implemented registry behavior:
   active project roots and enabled guidance-linked local skill roots.
 - `PATCH /hecate/v1/projects/{id}/skills/{skill_id}` updates operator-owned
   metadata: `enabled`, `title`, `description`, and `trust_label`.
+- Discovery ignores nested worktree containers such as `.worktrees` and
+  `.claude/worktrees`; worktrees should be explicit project roots when the
+  operator wants them represented.
 - Discovery parses bounded metadata only: frontmatter `name`/`title` and
   `description`, then H1/title fallback and directory id.
 - Hecate does not return, store, inject, execute, install, or fetch skill

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -22,8 +22,9 @@ The current composer defaults to deterministic drafting. `Auto` for `Run as`
 resolves to the selected work item's owner role, then the first loaded project
 role. `Auto` for `Via` resolves to the selected role's default driver, then
 `hecate_task`. Operators can also choose model-backed drafting when the project
-has a default model, or deterministic Bootstrap drafting to turn discovered
-guidance metadata and registered project skills into reviewable setup proposals.
+has a default model. Project onboarding uses deterministic Bootstrap drafting to
+turn discovered guidance metadata and registered project skills into reviewable
+setup proposals.
 In model mode the model may author only typed proposal actions from the same
 context packet, and the server still validates those actions before the operator
 can apply them. Bootstrap mode does not call a model and does not start work.
@@ -218,16 +219,18 @@ candidates with source provenance, and uses enabled, available project skills
 from `/hecate/v1/projects/{id}/skills`. The skill registry is refreshed through
 `POST /hecate/v1/projects/{id}/skills/discover`, which reads bounded local
 metadata from `.agents/skills`, `.hecate/skills`, and enabled `AGENTS.md` /
-`CLAUDE.md` context-source references. Bootstrap itself does not perform a
-second filesystem scan. It deduplicates against existing role ids and existing
-memory/candidate source refs. It does not treat host-specific guidance as
-Hecate policy authority, call a model, create durable memory, start tasks, or
-launch agents.
+`CLAUDE.md` context-source references. The refresh ignores nested worktree
+containers such as `.worktrees` and `.claude/worktrees`; linked worktrees should
+be explicit project roots, not inherited onboarding input. Bootstrap itself does
+not perform a second filesystem scan. It deduplicates against existing role ids
+and existing memory/candidate source refs. It does not treat host-specific
+guidance as Hecate policy authority, call a model, create durable memory, start
+tasks, or launch agents.
 
-In the operator UI, **Bootstrap project** is a convenience command around the
-same API contract: it refreshes workspace guidance context sources, refreshes
-the project skills registry, then requests a project-scoped Bootstrap draft.
-The resulting proposal is still review/apply gated and does not attach to the
+In the operator UI, **Bootstrap project** is the project onboarding action, not a
+regular draft mode. It refreshes workspace guidance context sources, refreshes
+the project skills registry, then requests a project-scoped Bootstrap draft. The
+resulting proposal is still review/apply gated and does not attach to the
 currently selected work item.
 
 `draft_mode: "model"` asks the configured gateway model to author the proposal

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1286,6 +1286,55 @@ PATCH /hecate/v1/projects/proj_...
 }
 ```
 
+### `POST /hecate/v1/projects/{id}/roots/discover`
+
+Refreshes Git metadata for active project roots and discovers linked Git
+worktrees for the same repository. This is an explicit operator action. It
+does not create branches, create worktrees, delete roots, change
+`default_root_id`, or start work.
+
+Discovered linked worktrees are appended to `roots` with:
+
+- `kind: "git_worktree"`
+- `git_branch` from `git worktree list --porcelain`
+- `git_remote` from `origin` when configured
+- `active: false` by default
+
+Inactive discovered roots are visible to the operator but are not scanned for
+workspace guidance or used for assignment launch until the operator enables
+them or makes one the default root. Existing roots are matched by path; their
+IDs and active state are preserved while branch/remote metadata is refreshed.
+
+```json
+POST /hecate/v1/projects/proj_.../roots/discover
+→ 200
+{
+  "object": "project",
+  "data": {
+    "id": "proj_...",
+    "roots": [
+      {
+        "id": "root_main",
+        "path": "/Users/alice/src/cynic",
+        "kind": "git",
+        "git_remote": "git@github.com:owner/cynic.git",
+        "git_branch": "main",
+        "active": true
+      },
+      {
+        "id": "root_...",
+        "path": "/Users/alice/src/cynic/.claude/worktrees/fix-array-sort",
+        "kind": "git_worktree",
+        "git_remote": "git@github.com:owner/cynic.git",
+        "git_branch": "fix-array-sort",
+        "active": false
+      }
+    ],
+    "default_root_id": "root_main"
+  }
+}
+```
+
 ### `POST /hecate/v1/projects/{id}/context-sources/discover`
 
 Discovers workspace guidance metadata from active absolute project roots and
@@ -1301,8 +1350,12 @@ are labelled for visibility but remain metadata-only: `CLAUDE.md`,
 
 Discovery skips common vendor/build directories such as `.git`, `node_modules`,
 `vendor`, `dist`, `build`, `.next`, `.turbo`, `.cache`, `target`, and
-`coverage`. Existing sources are matched by `(kind,path)` so operator disabled
-state and source IDs are preserved on rediscovery.
+`coverage`. It also skips nested Git checkouts plus `.worktrees` and
+`.claude/worktrees` under an active root. Linked worktrees should be added as
+explicit project roots through root discovery; their guidance is discovered only
+when that root is active.
+Existing sources are matched by `(kind,path)` plus root metadata so operator
+disabled state and source IDs are preserved on rediscovery.
 
 ```json
 POST /hecate/v1/projects/proj_.../context-sources/discover
@@ -1797,6 +1850,10 @@ Discovery scans:
 - `.hecate/skills/*/SKILL.md`
 - local skill roots explicitly linked from enabled `AGENTS.md` or `CLAUDE.md`
   context sources.
+
+Discovery ignores nested worktree containers such as `.worktrees` and
+`.claude/worktrees` when reading guidance-linked skill roots. Add a linked
+worktree as its own project root when the operator wants it represented.
 
 Only safe metadata is parsed from bounded `SKILL.md` files: frontmatter
 `name`/`title` and `description`, then H1/title fallback and directory id.

--- a/internal/api/handler_project_context_discovery.go
+++ b/internal/api/handler_project_context_discovery.go
@@ -79,7 +79,7 @@ func discoverProjectInstructionSources(project projects.Project) ([]projects.Con
 			}
 			depth := pathDepth(rel)
 			if d.IsDir() {
-				if shouldSkipInstructionDiscoveryDir(d.Name()) || depth > maxProjectInstructionDiscoveryDepth {
+				if shouldSkipInstructionDiscoveryDir(d.Name()) || shouldSkipInstructionDiscoveryPath(rel) || isNestedGitCheckout(path) || depth > maxProjectInstructionDiscoveryDepth {
 					return filepath.SkipDir
 				}
 				return nil
@@ -239,11 +239,22 @@ func instructionScopeForPath(rel string) string {
 
 func shouldSkipInstructionDiscoveryDir(name string) bool {
 	switch name {
-	case ".git", "node_modules", "vendor", "dist", "build", ".next", ".turbo", ".cache", ".gomodcache", "target", "coverage":
+	case ".git", ".worktrees", "node_modules", "vendor", "dist", "build", ".next", ".turbo", ".cache", ".gomodcache", "target", "coverage":
 		return true
 	default:
 		return false
 	}
+}
+
+func shouldSkipInstructionDiscoveryPath(rel string) bool {
+	rel = filepath.ToSlash(strings.TrimSpace(rel))
+	return rel == ".worktrees" || strings.HasPrefix(rel, ".worktrees/") ||
+		rel == ".claude/worktrees" || strings.HasPrefix(rel, ".claude/worktrees/")
+}
+
+func isNestedGitCheckout(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil && (info.IsDir() || info.Mode().IsRegular())
 }
 
 func pathDepth(rel string) int {

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -24,6 +24,10 @@ func TestProjectContextDiscovery_FindsWorkspaceGuidanceMetadata(t *testing.T) {
 	writeDiscoveryFile(t, root, ".github/instructions/go.instructions.md")
 	writeDiscoveryFile(t, root, "vendor/AGENTS.md")
 	writeDiscoveryFile(t, root, "node_modules/pkg/AGENTS.md")
+	writeDiscoveryFile(t, root, ".claude/worktrees/agent/AGENTS.md")
+	writeDiscoveryFile(t, root, ".worktrees/agent/AGENTS.md")
+	writeDiscoveryFile(t, root, "nested-checkout/AGENTS.md")
+	writeDiscoveryFile(t, root, "nested-checkout/.git")
 
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	projectStore := projects.NewMemoryStore()
@@ -84,6 +88,15 @@ func TestProjectContextDiscovery_FindsWorkspaceGuidanceMetadata(t *testing.T) {
 	}
 	if _, ok := sources["node_modules/pkg/AGENTS.md"]; ok {
 		t.Fatalf("node_modules AGENTS.md was discovered: %+v", sources["node_modules/pkg/AGENTS.md"])
+	}
+	if _, ok := sources[".claude/worktrees/agent/AGENTS.md"]; ok {
+		t.Fatalf("nested Claude worktree AGENTS.md was discovered: %+v", sources[".claude/worktrees/agent/AGENTS.md"])
+	}
+	if _, ok := sources[".worktrees/agent/AGENTS.md"]; ok {
+		t.Fatalf("nested worktree AGENTS.md was discovered: %+v", sources[".worktrees/agent/AGENTS.md"])
+	}
+	if _, ok := sources["nested-checkout/AGENTS.md"]; ok {
+		t.Fatalf("nested git checkout AGENTS.md was discovered: %+v", sources["nested-checkout/AGENTS.md"])
 	}
 }
 

--- a/internal/api/handler_project_roots_discovery.go
+++ b/internal/api/handler_project_roots_discovery.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/gitrunner"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+const (
+	projectRootKindGit         = "git"
+	projectRootKindGitWorktree = "git_worktree"
+)
+
+func (h *Handler) HandleDiscoverProjectRoots(w http.ResponseWriter, r *http.Request) {
+	if h.projects == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
+		return
+	}
+	project, ok, err := h.projects.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	discovered, err := discoverProjectGitWorktreeRoots(r.Context(), project, gitrunner.NewLocalRunner())
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	updated, err := h.projects.Update(r.Context(), project.ID, func(item *projects.Project) {
+		item.Roots = mergeDiscoveredProjectRoots(item.Roots, discovered)
+		if item.DefaultRootID == "" && len(item.Roots) > 0 {
+			item.DefaultRootID = item.Roots[0].ID
+		}
+	})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(updated)})
+}
+
+type projectGitRunner interface {
+	IsWorkTree(context.Context, string) bool
+	Worktrees(context.Context, string) ([]gitrunner.Worktree, error)
+	Run(context.Context, string, ...string) (gitrunner.Result, error)
+}
+
+func discoverProjectGitWorktreeRoots(ctx context.Context, project projects.Project, runner projectGitRunner) ([]projects.Root, error) {
+	if runner == nil {
+		runner = gitrunner.NewLocalRunner()
+	}
+	byPath := make(map[string]projects.Root)
+	for _, root := range project.Roots {
+		if !root.Active {
+			continue
+		}
+		rootPath := strings.TrimSpace(root.Path)
+		if rootPath == "" {
+			continue
+		}
+		if !filepath.IsAbs(rootPath) {
+			return nil, fmt.Errorf("project root %q path must be absolute", root.ID)
+		}
+		info, err := os.Stat(rootPath)
+		if err != nil {
+			return nil, fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("project root %q is not a directory", root.ID)
+		}
+		rootCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		if !runner.IsWorkTree(rootCtx, rootPath) {
+			cancel()
+			continue
+		}
+		worktrees, err := runner.Worktrees(rootCtx, rootPath)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("project root %q worktrees could not be discovered: %w", root.ID, err)
+		}
+		for _, worktree := range worktrees {
+			path := strings.TrimSpace(worktree.Path)
+			if path == "" || !filepath.IsAbs(path) || worktree.Bare {
+				continue
+			}
+			path = filepath.Clean(path)
+			branch := projectWorktreeBranchLabel(worktree)
+			item := projects.Root{
+				Path:      path,
+				Kind:      projectRootKindGitWorktree,
+				GitRemote: projectRootGitRemote(ctx, runner, path),
+				GitBranch: branch,
+				Active:    false,
+			}
+			if pathsEqual(path, rootPath) {
+				item.Kind = projectRootKindGit
+				item.Active = root.Active
+			}
+			byPath[cleanProjectRootPath(path)] = item
+		}
+	}
+	out := make([]projects.Root, 0, len(byPath))
+	for _, item := range byPath {
+		out = append(out, item)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Path < out[j].Path
+	})
+	return out, nil
+}
+
+func mergeDiscoveredProjectRoots(existing, discovered []projects.Root) []projects.Root {
+	out := make([]projects.Root, 0, len(existing)+len(discovered))
+	indexByPath := make(map[string]int, len(existing)+len(discovered))
+	for _, root := range existing {
+		path := cleanProjectRootPath(root.Path)
+		out = append(out, root)
+		if path != "" {
+			indexByPath[path] = len(out) - 1
+		}
+	}
+	for _, root := range discovered {
+		path := cleanProjectRootPath(root.Path)
+		if path == "" {
+			continue
+		}
+		if idx, ok := indexByPath[path]; ok {
+			existingRoot := out[idx]
+			if strings.TrimSpace(existingRoot.Kind) == "" {
+				existingRoot.Kind = root.Kind
+			}
+			if strings.TrimSpace(root.GitRemote) != "" {
+				existingRoot.GitRemote = root.GitRemote
+			}
+			if strings.TrimSpace(root.GitBranch) != "" {
+				existingRoot.GitBranch = root.GitBranch
+			}
+			out[idx] = existingRoot
+			continue
+		}
+		root.ID = newOpaqueTaskResourceID("root")
+		root.Active = false
+		out = append(out, root)
+		indexByPath[path] = len(out) - 1
+	}
+	return out
+}
+
+func projectWorktreeBranchLabel(worktree gitrunner.Worktree) string {
+	if branch := strings.TrimSpace(worktree.Branch); branch != "" {
+		return branch
+	}
+	head := strings.TrimSpace(worktree.Head)
+	if head == "" {
+		return ""
+	}
+	if len(head) > 12 {
+		head = head[:12]
+	}
+	return "detached@" + head
+}
+
+func projectRootGitRemote(ctx context.Context, runner projectGitRunner, path string) string {
+	runCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	result, err := runner.Run(runCtx, path, "remote", "get-url", "origin")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(result.Stdout)
+}
+
+func cleanProjectRootPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
+
+func pathsEqual(left, right string) bool {
+	return cleanProjectRootPath(left) == cleanProjectRootPath(right)
+}

--- a/internal/api/handler_project_roots_discovery_test.go
+++ b/internal/api/handler_project_roots_discovery_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+func TestProjectRootsDiscovery_MergesGitWorktrees(t *testing.T) {
+	t.Parallel()
+	repo := initProjectRootDiscoveryRepo(t)
+	worktree := filepath.Join(t.TempDir(), "feature-worktree")
+	if err := exec.Command("git", "-C", repo, "worktree", "add", "-b", "feature/worktrees", worktree).Run(); err != nil {
+		t.Fatalf("git worktree add: %v", err)
+	}
+
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:            "proj_roots",
+		Name:          "Roots",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   repo,
+			Kind:   "git",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots/roots/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discovery response: %v", err)
+	}
+
+	roots := make(map[string]ProjectRootResponseItem)
+	for _, root := range resp.Data.Roots {
+		roots[canonicalProjectRootDiscoveryTestPath(t, root.Path)] = root
+	}
+	main := roots[canonicalProjectRootDiscoveryTestPath(t, repo)]
+	if main.ID != "root_main" || !main.Active || main.Kind != "git" || main.GitBranch != "main" || main.GitRemote != "https://example.com/cynic.git" {
+		t.Fatalf("main root = %+v, want preserved id/active and refreshed git metadata", main)
+	}
+	linked := roots[canonicalProjectRootDiscoveryTestPath(t, worktree)]
+	if linked.ID == "" || linked.ID == "root_main" || linked.Active || linked.Kind != "git_worktree" || linked.GitBranch != "feature/worktrees" || linked.GitRemote != "https://example.com/cynic.git" {
+		t.Fatalf("linked root = %+v, want inactive discovered git worktree", linked)
+	}
+	if resp.Data.DefaultRootID != "root_main" {
+		t.Fatalf("default_root_id = %q, want root_main", resp.Data.DefaultRootID)
+	}
+}
+
+func initProjectRootDiscoveryRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-b", "main").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "origin", "https://example.com/cynic.git").Run(); err != nil {
+		t.Fatalf("git remote add: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "add", ".").Run(); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "initial").Run(); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	return dir
+}
+
+func canonicalProjectRootDiscoveryTestPath(t *testing.T, path string) string {
+	t.Helper()
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -77,6 +77,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/context-sources/discover", handler.HandleDiscoverProjectContextSources)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/skills", handler.HandleProjectSkills)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/skills/discover", handler.HandleDiscoverProjectSkills)

--- a/internal/gitrunner/gitrunner.go
+++ b/internal/gitrunner/gitrunner.go
@@ -20,9 +20,18 @@ type Runner interface {
 	Run(ctx context.Context, workspace string, args ...string) (Result, error)
 	CurrentRef(ctx context.Context, workspace string) string
 	IsWorkTree(ctx context.Context, workspace string) bool
+	Worktrees(ctx context.Context, workspace string) ([]Worktree, error)
 	Diff(ctx context.Context, workspace string, maxBytes int64) (string, string)
 	Restore(ctx context.Context, workspace string, paths []string) (Result, error)
 	Clone(ctx context.Context, sourcePath, workspacePath string) (Result, error)
+}
+
+type Worktree struct {
+	Path     string
+	Head     string
+	Branch   string
+	Detached bool
+	Bare     bool
 }
 
 type LocalRunner struct {
@@ -70,6 +79,66 @@ func (r *LocalRunner) CurrentRef(ctx context.Context, workspace string) string {
 func (r *LocalRunner) IsWorkTree(ctx context.Context, workspace string) bool {
 	result, err := r.Run(ctx, workspace, "rev-parse", "--is-inside-work-tree")
 	return err == nil && strings.TrimSpace(result.Stdout) == "true"
+}
+
+func (r *LocalRunner) Worktrees(ctx context.Context, workspace string) ([]Worktree, error) {
+	result, err := r.Run(ctx, workspace, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return nil, err
+	}
+	return parseWorktreeListPorcelain(result.Stdout), nil
+}
+
+func parseWorktreeListPorcelain(stdout string) []Worktree {
+	var out []Worktree
+	var current Worktree
+	flush := func() {
+		if strings.TrimSpace(current.Path) == "" {
+			current = Worktree{}
+			return
+		}
+		current.Path = strings.TrimSpace(current.Path)
+		current.Head = strings.TrimSpace(current.Head)
+		current.Branch = strings.TrimSpace(current.Branch)
+		out = append(out, current)
+		current = Worktree{}
+	}
+	for _, rawLine := range splitWorktreeListPorcelain(stdout) {
+		line := strings.TrimRight(rawLine, "\r\n")
+		if line == "" {
+			flush()
+			continue
+		}
+		key, value, ok := strings.Cut(line, " ")
+		if !ok {
+			key = line
+			value = ""
+		}
+		switch key {
+		case "worktree":
+			flush()
+			current.Path = strings.TrimSpace(value)
+		case "HEAD":
+			current.Head = strings.TrimSpace(value)
+		case "branch":
+			branch := strings.TrimSpace(value)
+			branch = strings.TrimPrefix(branch, "refs/heads/")
+			current.Branch = branch
+		case "detached":
+			current.Detached = true
+		case "bare":
+			current.Bare = true
+		}
+	}
+	flush()
+	return out
+}
+
+func splitWorktreeListPorcelain(stdout string) []string {
+	if strings.Contains(stdout, "\x00") {
+		return strings.Split(stdout, "\x00")
+	}
+	return strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n")
 }
 
 func (r *LocalRunner) Diff(ctx context.Context, workspace string, maxBytes int64) (string, string) {

--- a/internal/gitrunner/gitrunner_test.go
+++ b/internal/gitrunner/gitrunner_test.go
@@ -46,6 +46,91 @@ func TestLocalRunner_CurrentRef(t *testing.T) {
 	}
 }
 
+func TestLocalRunner_Worktrees(t *testing.T) {
+	dir := initRepo(t)
+	worktree := filepath.Join(t.TempDir(), "feature worktree")
+	if err := exec.Command("git", "-C", dir, "worktree", "add", "-b", "feature/worktrees", worktree).Run(); err != nil {
+		t.Fatalf("git worktree add: %v", err)
+	}
+	runner := NewLocalRunner()
+
+	items, err := runner.Worktrees(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+
+	byPath := make(map[string]Worktree)
+	for _, item := range items {
+		byPath[canonicalTestPath(t, item.Path)] = item
+	}
+	if got := byPath[canonicalTestPath(t, dir)]; got.Branch != "main" {
+		t.Fatalf("main worktree = %+v, want main branch", got)
+	}
+	if got := byPath[canonicalTestPath(t, worktree)]; got.Branch != "feature/worktrees" {
+		t.Fatalf("linked worktree = %+v, want feature/worktrees branch", got)
+	}
+}
+
+func TestLocalRunner_WorktreesUsesPorcelainZ(t *testing.T) {
+	dir := t.TempDir()
+	process := &recordingProcessRunner{}
+	runner := &LocalRunner{Process: process}
+
+	if _, err := runner.Worktrees(context.Background(), dir); err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+	if got := strings.Join(process.request.Args, " "); got != "worktree list --porcelain -z" {
+		t.Fatalf("git args = %q, want porcelain -z worktree list", got)
+	}
+}
+
+func TestParseWorktreeListPorcelain(t *testing.T) {
+	items := parseWorktreeListPorcelain(strings.Join([]string{
+		"worktree /tmp/project main",
+		"HEAD abc123",
+		"branch refs/heads/main",
+		"",
+		"worktree /tmp/project-detached",
+		"HEAD def456",
+		"detached",
+		"",
+	}, "\n"))
+
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want two worktrees", items)
+	}
+	if items[0].Path != "/tmp/project main" || items[0].Branch != "main" || items[0].Head != "abc123" {
+		t.Fatalf("first item = %+v, want path with spaces and main branch", items[0])
+	}
+	if items[1].Path != "/tmp/project-detached" || !items[1].Detached || items[1].Head != "def456" {
+		t.Fatalf("second item = %+v, want detached worktree", items[1])
+	}
+}
+
+func TestParseWorktreeListPorcelainNUL(t *testing.T) {
+	items := parseWorktreeListPorcelain(strings.Join([]string{
+		"worktree /tmp/project",
+		"HEAD abc123",
+		"branch refs/heads/main",
+		"",
+		"worktree /tmp/project\nnewline",
+		"HEAD def456",
+		"detached",
+		"",
+		"",
+	}, "\x00"))
+
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want two worktrees", items)
+	}
+	if items[0].Path != "/tmp/project" || items[0].Branch != "main" || items[0].Head != "abc123" {
+		t.Fatalf("first item = %+v, want main branch", items[0])
+	}
+	if items[1].Path != "/tmp/project\nnewline" || !items[1].Detached || items[1].Head != "def456" {
+		t.Fatalf("second item = %+v, want NUL-delimited detached worktree", items[1])
+	}
+}
+
 func TestLocalRunner_DiffCapturesStatAndPatch(t *testing.T) {
 	dir := initRepo(t)
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\nworld\n"), 0o644); err != nil {
@@ -128,6 +213,15 @@ func TestSanitizedEnvDropsProviderSecrets(t *testing.T) {
 
 type recordingProcessRunner struct {
 	request processrunner.Request
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
 }
 
 func (r *recordingProcessRunner) Run(_ context.Context, req processrunner.Request) (processrunner.Result, error) {

--- a/internal/projectskills/discovery.go
+++ b/internal/projectskills/discovery.go
@@ -96,6 +96,9 @@ func skillBaseDirs(fsys *workspacefs.FS, root projects.Root, sources []projects.
 			continue
 		}
 		for _, dir := range skillBaseDirsFromGuidance(source.Path, body) {
+			if shouldSkipSkillDiscoveryPath(dir) {
+				continue
+			}
 			if idx, ok := seen[dir]; ok {
 				dirs[idx].SourceContextSourceIDs = appendUniqueStrings(dirs[idx].SourceContextSourceIDs, source.ID)
 				continue
@@ -112,6 +115,9 @@ func skillBaseDirs(fsys *workspacefs.FS, root projects.Root, sources []projects.
 
 func guidanceSourceForRoot(source projects.ContextSource, rootID string) bool {
 	if !source.Enabled || strings.TrimSpace(source.Path) == "" {
+		return false
+	}
+	if shouldSkipSkillDiscoveryPath(source.Path) {
 		return false
 	}
 	if source.Metadata != nil {
@@ -146,6 +152,9 @@ func readGuidanceSource(fsys *workspacefs.FS, source projects.ContextSource, war
 }
 
 func discoverInBaseDir(fsys *workspacefs.FS, rootID string, base skillBaseDir, warnings *[]string) []Skill {
+	if shouldSkipSkillDiscoveryPath(base.Path) {
+		return nil
+	}
 	entries, _, err := fsys.ReadDir(base.Path)
 	if err != nil {
 		return nil
@@ -342,4 +351,15 @@ func skillBaseDirsFromToken(sourceDir, token string) []string {
 		}
 	}
 	return nil
+}
+
+func shouldSkipSkillDiscoveryPath(rel string) bool {
+	rel = filepath.ToSlash(strings.TrimSpace(rel))
+	rel = strings.TrimPrefix(rel, "./")
+	if rel == "" {
+		return false
+	}
+	rel = path.Clean(rel)
+	return rel == ".worktrees" || strings.HasPrefix(rel, ".worktrees/") ||
+		rel == ".claude/worktrees" || strings.HasPrefix(rel, ".claude/worktrees/")
 }

--- a/internal/projectskills/discovery_test.go
+++ b/internal/projectskills/discovery_test.go
@@ -18,8 +18,12 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 	writeSkillFile(t, root, ".hecate/skills/qa/SKILL.md", "# QA Review\n")
 	writeSkillFile(t, root, "docs-ai/skills/research/SKILL.md", "# Research\n")
 	writeSkillFile(t, root, "claude-skills/review/SKILL.md", "---\ntitle: Claude Review\ndescription: Host-specific review posture.\n---\n")
+	writeSkillFile(t, root, ".worktrees/refactor/docs-ai/skills/backend/SKILL.md", "# Worktree Backend\n")
+	writeSkillFile(t, root, ".claude/worktrees/refactor/docs-ai/skills/qa/SKILL.md", "# Claude Worktree QA\n")
 	writeFileForDiscoveryTest(t, root, "AGENTS.md", "Use [`docs-ai/skills/research/SKILL.md`](docs-ai/skills/research/SKILL.md).")
 	writeFileForDiscoveryTest(t, root, "CLAUDE.md", "Use [`claude-skills/review/SKILL.md`](claude-skills/review/SKILL.md).")
+	writeFileForDiscoveryTest(t, root, ".worktrees/refactor/AGENTS.md", "Use `.worktrees/refactor/docs-ai/skills/backend/SKILL.md`.")
+	writeFileForDiscoveryTest(t, root, ".claude/worktrees/refactor/AGENTS.md", "Use `.claude/worktrees/refactor/docs-ai/skills/qa/SKILL.md`.")
 	writeSkillFile(t, root, "unreferenced/skills/ignore/SKILL.md", "# Ignore\n")
 
 	skills, warnings := Discover(ctx, projects.Project{
@@ -51,6 +55,26 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 					"root_id": "root_a",
 				},
 			},
+			{
+				ID:      "ctx_worktree",
+				Kind:    "workspace_instruction",
+				Path:    ".worktrees/refactor/AGENTS.md",
+				Enabled: true,
+				Format:  "agents_md",
+				Metadata: map[string]string{
+					"root_id": "root_a",
+				},
+			},
+			{
+				ID:      "ctx_claude_worktree",
+				Kind:    "workspace_instruction",
+				Path:    ".claude/worktrees/refactor/AGENTS.md",
+				Enabled: true,
+				Format:  "agents_md",
+				Metadata: map[string]string{
+					"root_id": "root_a",
+				},
+			},
 		},
 	})
 	if len(warnings) != 0 {
@@ -65,6 +89,56 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 	assertSkillForDiscoveryTest(t, skills, "review", "Claude Review", "Host-specific review posture.", "claude-skills/review/SKILL.md", []string{"ctx_claude"})
 	if findSkillForTest(skills, "ignore") != nil {
 		t.Fatalf("skills = %+v, want unreferenced skill root ignored", skills)
+	}
+}
+
+func TestDiscoverSkipsWorktreeGuidanceAndSkillRoots(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeSkillFile(t, root, ".agents/skills/backend/SKILL.md", "# Backend\n")
+	writeSkillFile(t, root, ".worktrees/branch/docs-ai/skills/backend/SKILL.md", "# Worktree Backend\n")
+	writeSkillFile(t, root, ".claude/worktrees/branch/docs-ai/skills/frontend/SKILL.md", "# Worktree Frontend\n")
+	writeFileForDiscoveryTest(t, root, ".worktrees/branch/AGENTS.md", "Use `.worktrees/branch/docs-ai/skills/backend/SKILL.md`.")
+	writeFileForDiscoveryTest(t, root, "AGENTS.md", "Use `.claude/worktrees/branch/docs-ai/skills/frontend/SKILL.md`.")
+
+	skills, warnings := Discover(context.Background(), projects.Project{
+		ID: "proj_worktree_skills",
+		Roots: []projects.Root{{
+			ID:     "root_a",
+			Path:   root,
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{
+			{
+				ID:      "ctx_stale_worktree",
+				Kind:    "workspace_instruction",
+				Path:    ".worktrees/branch/AGENTS.md",
+				Enabled: true,
+				Format:  "agents_md",
+				Metadata: map[string]string{
+					"root_id": "root_a",
+				},
+			},
+			{
+				ID:      "ctx_agents",
+				Kind:    "workspace_instruction",
+				Path:    "AGENTS.md",
+				Enabled: true,
+				Format:  "agents_md",
+				Metadata: map[string]string{
+					"root_id": "root_a",
+				},
+			},
+		},
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none", warnings)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("skills = %+v, want only non-worktree skill", skills)
+	}
+	if skills[0].ID != "backend" || skills[0].Path != ".agents/skills/backend/SKILL.md" || skills[0].Status != StatusAvailable {
+		t.Fatalf("skill = %+v, want canonical backend skill only", skills[0])
 	}
 }
 

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -94,6 +94,24 @@ export function ProjectAssistantPanel({
           ) : null
         }
       />
+      <div style={assistantOnboardingStyle} aria-label="Project onboarding">
+        <div style={assistantOnboardingCopyStyle}>
+          <div style={sectionLabelStyle}>Project onboarding</div>
+          <div style={{ ...subtleTextStyle, marginTop: 3 }}>
+            {bootstrapPending ? "Preparing setup proposal" : "Setup proposal"}
+          </div>
+        </div>
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={bootstrapBusy || contextBusy}
+          onClick={onBootstrap}
+          style={assistantOnboardingButtonStyle}
+        >
+          <Icon d={Icons.refresh} size={14} />
+          {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
+        </button>
+      </div>
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -142,7 +160,6 @@ export function ProjectAssistantPanel({
                 }
               >
                 <option value="deterministic">Rules</option>
-                <option value="bootstrap">Bootstrap</option>
                 <option value="model" disabled={!modelDraftAvailable}>
                   Assistant{modelDraftAvailable ? "" : " (set model)"}
                 </option>
@@ -199,15 +216,6 @@ export function ProjectAssistantPanel({
             >
               <Icon d={Icons.eye} size={13} />
               {contextBusy ? "Inspecting..." : "Inspect context"}
-            </button>
-            <button
-              className="btn btn-ghost btn-sm"
-              type="button"
-              disabled={bootstrapBusy || contextBusy}
-              onClick={onBootstrap}
-            >
-              <Icon d={Icons.refresh} size={13} />
-              {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
             </button>
           </div>
         </div>
@@ -514,6 +522,28 @@ const assistantComposerStyle: CSSProperties = {
   display: "grid",
   gap: 8,
   minWidth: 0,
+};
+
+const assistantOnboardingStyle: CSSProperties = {
+  alignItems: "center",
+  borderBottom: "1px solid var(--border)",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 10,
+  justifyContent: "space-between",
+  minWidth: 0,
+  padding: "2px 0 10px",
+};
+
+const assistantOnboardingCopyStyle: CSSProperties = {
+  flex: "1 1 240px",
+  minWidth: 0,
+};
+
+const assistantOnboardingButtonStyle: CSSProperties = {
+  flex: "0 0 auto",
+  justifyContent: "center",
+  minWidth: 170,
 };
 
 const assistantPrimaryRowStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -22,6 +22,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   discoverProjectContextSources,
+  discoverProjectRoots,
   discoverProjectSkills,
   getProjectActivity,
   getAgentProfiles,
@@ -266,6 +267,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
     updateProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
     deleteProjectAssignment: vi.fn(async () => undefined),
     updateProject: vi.fn(async () => ({ object: "project", data: null })),
+    discoverProjectRoots: vi.fn(async () => ({ object: "project", data: null })),
     discoverProjectContextSources: vi.fn(async () => ({ object: "project", data: null })),
   };
 });
@@ -938,6 +940,10 @@ function resetProjectWorkMocks() {
       default_workspace_mode: "in_place",
     },
   });
+  vi.mocked(discoverProjectRoots).mockResolvedValue({
+    object: "project",
+    data: project,
+  });
   vi.mocked(discoverProjectContextSources).mockResolvedValue({
     object: "project",
     data: project,
@@ -1011,6 +1017,7 @@ afterEach(() => {
   vi.mocked(updateProjectAssignment).mockReset();
   vi.mocked(deleteProjectAssignment).mockReset();
   vi.mocked(updateProject).mockReset();
+  vi.mocked(discoverProjectRoots).mockReset();
   vi.mocked(discoverProjectContextSources).mockReset();
 });
 
@@ -1333,9 +1340,8 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
-  it("can request bootstrap Project Assistant drafts", async () => {
+  it("surfaces bootstrap as project onboarding instead of a draft mode", async () => {
     resetProjectWorkMocks();
-    const user = userEvent.setup();
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -1345,17 +1351,12 @@ describe("ProjectsView cockpit", () => {
 
     await screen.findByText("Selected work: Build cockpit UI");
     const assistant = await screen.findByRole("region", { name: "Project Assistant" });
-    await user.selectOptions(within(assistant).getByLabelText("Draft"), "bootstrap");
-    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
 
-    await waitFor(() => {
-      expect(draftProjectAssistant).toHaveBeenCalledWith({
-        project_id: project.id,
-        work_item_id: workItem.id,
-        request: "Queue Software developer for Build cockpit UI",
-        draft_mode: "bootstrap",
-      });
-    });
+    expect(within(assistant).getByText("Project onboarding")).toBeInTheDocument();
+    expect(within(assistant).getByRole("button", { name: "Bootstrap project" })).toHaveClass(
+      "btn-primary",
+    );
+    expect(within(assistant).queryByRole("option", { name: "Bootstrap" })).toBeNull();
   });
 
   it("discovers guidance and skills before drafting project bootstrap proposals", async () => {
@@ -4401,6 +4402,16 @@ describe("ProjectsView cockpit", () => {
       default_model: "qwen2.5-coder",
       default_agent_profile: "",
       default_workspace_mode: "ephemeral",
+      default_root_id: "root_1",
+      roots: [
+        {
+          id: "root_1",
+          path: "/Users/alice/dev/hecate",
+          kind: "git",
+          git_branch: "main",
+          active: true,
+        },
+      ],
     });
   });
 
@@ -4463,7 +4474,59 @@ describe("ProjectsView cockpit", () => {
       default_model: "",
       default_agent_profile: "",
       default_workspace_mode: "ephemeral",
+      default_root_id: "root_1",
+      roots: [
+        {
+          id: "root_1",
+          path: "/Users/alice/dev/hecate",
+          kind: "git",
+          git_branch: "main",
+          active: true,
+        },
+      ],
     });
+  });
+
+  it("discovers project worktrees from settings", async () => {
+    resetProjectWorkMocks();
+    const projectWithWorktree: ProjectRecord = {
+      ...project,
+      roots: [
+        ...project.roots,
+        {
+          id: "root_worktree",
+          path: "/Users/alice/dev/hecate/.claude/worktrees/fix-array-sort",
+          kind: "git_worktree",
+          git_branch: "fix-array-sort",
+          active: false,
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T10:00:00Z",
+        },
+      ],
+    };
+    vi.mocked(discoverProjectRoots).mockResolvedValue({
+      object: "project",
+      data: projectWithWorktree,
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Project settings" }));
+    await userEvent.click(screen.getByRole("button", { name: "Discover worktrees" }));
+
+    expect(discoverProjectRoots).toHaveBeenCalledWith(project.id);
+    expect(
+      await screen.findByText("/Users/alice/dev/hecate/.claude/worktrees/fix-array-sort"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Active project root /Users/alice/dev/hecate/.claude/worktrees/fix-array-sort",
+      }),
+    ).not.toBeChecked();
   });
 
   it("starts native Hecate assignments and refreshes detail state", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -18,6 +18,7 @@ import {
   createProjectAssignment,
   createProjectHandoff,
   discoverProjectContextSources,
+  discoverProjectRoots,
   discoverProjectSkills,
   draftProjectAssistant,
   getProjectAssistantContext,
@@ -102,6 +103,8 @@ import type {
   ProjectSkillRecord,
   ProjectAssignmentExecutionRefRecord,
   ProjectRecord,
+  ProjectRootPayload,
+  ProjectRootRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectAssignmentPayload,
@@ -241,6 +244,8 @@ type ProjectDefaultsForm = {
   model: string;
   defaultAgentProfile: string;
   workspaceMode: string;
+  defaultRootID: string;
+  roots: ProjectRootPayload[];
 };
 
 type MemoryForm = {
@@ -391,6 +396,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [rightPanelWidth, setRightPanelWidth] = useState(() => readStoredRightPanelWidth());
   const [defaultsPending, setDefaultsPending] = useState(false);
   const [defaultsError, setDefaultsError] = useState("");
+  const [discoveringRoots, setDiscoveringRoots] = useState(false);
   const [rolesModalOpen, setRolesModalOpen] = useState(false);
   const [rolesPending, setRolesPending] = useState(false);
   const [rolesError, setRolesError] = useState("");
@@ -802,6 +808,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       default_model: form.model.trim(),
       default_agent_profile: form.defaultAgentProfile.trim(),
       default_workspace_mode: form.workspaceMode.trim(),
+      default_root_id: form.defaultRootID.trim(),
+      roots: form.roots,
     };
     try {
       const payload = await updateProject(selectedProject.id, patch);
@@ -811,6 +819,20 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       setDefaultsError(errorMessage(error, "Failed to update project defaults."));
     } finally {
       setDefaultsPending(false);
+    }
+  }
+
+  async function handleDiscoverProjectRoots() {
+    if (!selectedProject) return;
+    setDiscoveringRoots(true);
+    setDefaultsError("");
+    try {
+      const payload = await discoverProjectRoots(selectedProject.id);
+      projects.actions.setProjects((current) => upsertProject(current, payload.data));
+    } catch (error) {
+      setDefaultsError(errorMessage(error, "Failed to discover project roots."));
+    } finally {
+      setDiscoveringRoots(false);
     }
   }
 
@@ -1794,6 +1816,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                 providerOptions={providerOptions}
                 providerPresets={providerPresets}
                 project={selectedProject}
+                rootsPending={discoveringRoots}
+                onDiscoverRoots={handleDiscoverProjectRoots}
                 onSave={handleSaveProjectDefaults}
               />
             </ChatRightPanel>
@@ -3895,6 +3919,8 @@ function ProjectSettingsPanel({
   providerOptions,
   providerPresets,
   project,
+  rootsPending,
+  onDiscoverRoots,
   onSave,
 }: {
   agentProfiles: AgentProfileRecord[];
@@ -3905,14 +3931,16 @@ function ProjectSettingsPanel({
   providerOptions: ProviderOption[];
   providerPresets: ProviderPresetRecord[];
   project: ProjectRecord;
+  rootsPending: boolean;
+  onDiscoverRoots: () => void | Promise<void>;
   onSave: (form: ProjectDefaultsForm) => void | Promise<void>;
 }) {
-  const [form, setForm] = useState<ProjectDefaultsForm>({
-    provider: project.default_provider ?? "",
-    model: project.default_model ?? "",
-    defaultAgentProfile: project.default_agent_profile ?? "",
-    workspaceMode: project.default_workspace_mode || "in_place",
-  });
+  const [form, setForm] = useState<ProjectDefaultsForm>(() =>
+    projectDefaultsFormFromProject(project),
+  );
+  useEffect(() => {
+    setForm(projectDefaultsFormFromProject(project));
+  }, [project]);
   const scopedModels = useMemo(() => {
     if (!form.provider) return models;
     return models.filter((model) => model.metadata?.provider === form.provider);
@@ -3940,9 +3968,24 @@ function ProjectSettingsPanel({
       };
     });
   }
+  function handleDefaultRootChange(rootID: string) {
+    setForm((current) => ({
+      ...current,
+      defaultRootID: rootID,
+      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active: true } : root)),
+    }));
+  }
+  function handleRootActiveChange(rootID: string, active: boolean) {
+    setForm((current) => ({
+      ...current,
+      defaultRootID: !active && current.defaultRootID === rootID ? "" : current.defaultRootID,
+      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active } : root)),
+    }));
+  }
   const submitForm = () => onSave(form);
 
   const workspace = projectDefaultWorkspace(project);
+  const rootCount = form.roots.length;
 
   return (
     <div
@@ -4091,6 +4134,89 @@ function ProjectSettingsPanel({
             </div>
           </ProjectSettingsSection>
           <ProjectSettingsSection title="Project context">
+            <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
+              Project roots are concrete checkouts. Linked worktrees discovered from Git stay
+              inactive until enabled here.
+            </div>
+            <div style={{ display: "grid", gap: 12, marginBottom: 14 }}>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Default root</span>
+                <select
+                  aria-label="Default project root"
+                  className="input"
+                  value={form.defaultRootID}
+                  onChange={(event) => handleDefaultRootChange(event.target.value)}
+                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+                >
+                  <option value="">no default root</option>
+                  {form.roots.map((root) => (
+                    <option key={root.id || root.path} value={root.id ?? ""}>
+                      {projectRootOptionLabel(root)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  className="btn btn-ghost btn-sm"
+                  type="button"
+                  disabled={rootsPending}
+                  onClick={() => void onDiscoverRoots()}
+                >
+                  {rootsPending ? "Discovering…" : "Discover worktrees"}
+                </button>
+                <span style={subtleTextStyle}>
+                  {rootCount === 0
+                    ? "No roots configured."
+                    : `${rootCount} root${rootCount === 1 ? "" : "s"}`}
+                </span>
+              </div>
+              {form.roots.length > 0 && (
+                <div style={{ display: "grid", gap: 8 }}>
+                  {form.roots.map((root) => {
+                    const rootID = root.id ?? root.path;
+                    const isDefault = form.defaultRootID !== "" && root.id === form.defaultRootID;
+                    return (
+                      <label
+                        key={rootID}
+                        style={{
+                          border: "1px solid var(--border)",
+                          borderRadius: 8,
+                          display: "grid",
+                          gap: 5,
+                          padding: "9px 10px",
+                        }}
+                      >
+                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <input
+                            aria-label={`Active project root ${root.path}`}
+                            type="checkbox"
+                            checked={Boolean(root.active)}
+                            onChange={(event) =>
+                              handleRootActiveChange(root.id ?? "", event.target.checked)
+                            }
+                          />
+                          <span
+                            style={{
+                              color: "var(--t1)",
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 11,
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {root.path}
+                          </span>
+                        </span>
+                        <span style={{ ...subtleTextStyle, paddingLeft: 22 }}>
+                          {projectRootSummary(root)}
+                          {isDefault ? " · default" : ""}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
             <div
               style={{
                 display: "grid",
@@ -4120,6 +4246,45 @@ function ProjectSettingsPanel({
       </div>
     </div>
   );
+}
+
+function projectDefaultsFormFromProject(project: ProjectRecord): ProjectDefaultsForm {
+  return {
+    provider: project.default_provider ?? "",
+    model: project.default_model ?? "",
+    defaultAgentProfile: project.default_agent_profile ?? "",
+    workspaceMode: project.default_workspace_mode || "in_place",
+    defaultRootID: project.default_root_id || project.roots[0]?.id || "",
+    roots: project.roots.map(projectRootPayloadFromRecord),
+  };
+}
+
+function projectRootPayloadFromRecord(root: ProjectRootRecord): ProjectRootPayload {
+  const payload: ProjectRootPayload = {
+    id: root.id,
+    path: root.path,
+    kind: root.kind,
+    active: root.active,
+  };
+  if (root.git_remote) payload.git_remote = root.git_remote;
+  if (root.git_branch) payload.git_branch = root.git_branch;
+  return payload;
+}
+
+function projectRootOptionLabel(root: ProjectRootPayload) {
+  const parts = [root.path];
+  if (root.git_branch) parts.push(`git:${root.git_branch}`);
+  if (root.kind) parts.push(root.kind);
+  return parts.join(" · ");
+}
+
+function projectRootSummary(root: ProjectRootPayload) {
+  const parts = [
+    root.active ? "active" : "inactive",
+    root.kind || "root",
+    root.git_branch ? `git:${root.git_branch}` : "",
+  ].filter(Boolean);
+  return parts.join(" · ");
 }
 
 function ProjectSettingsSection({ title, children }: { title: string; children: ReactNode }) {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -18,6 +18,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   discoverLocalProviders,
+  discoverProjectRoots,
   dispatchChatStreamEvent,
   getChatMessageContext,
   getChatMessageFileDiff,
@@ -765,6 +766,20 @@ describe("api client", () => {
           default_model: "ministral-3:latest",
           default_workspace_mode: "in_place",
         }),
+      }),
+    );
+  });
+
+  it("discovers project roots and worktrees", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ object: "project", data: { id: "proj_1" } }));
+
+    await discoverProjectRoots("proj/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj%2F1/roots/discover",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({}),
       }),
     );
   });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -357,6 +357,16 @@ export async function updateProject(
   });
 }
 
+export async function discoverProjectRoots(id: string): Promise<ProjectResponse> {
+  return fetchJSON<ProjectResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(id)}/roots/discover`,
+    {
+      method: "POST",
+      body: {},
+    },
+  );
+}
+
 export async function deleteProject(id: string): Promise<void> {
   return fetchJSON<void>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary

- Add explicit project root discovery for linked Git worktrees through `POST /hecate/v1/projects/{id}/roots/discover`.
- Show discovered roots/worktrees in Project Settings with active/default controls and branch metadata.
- Keep workspace guidance discovery from inheriting nested Git checkouts or `.claude/worktrees` content unless those worktrees are explicit project roots.
- Document roots, worktrees, discovery behavior, and agent guidance.

## Tests

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api ./internal/gitrunner`
- `go vet ./internal/api ./internal/gitrunner`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./...`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/lib/api.test.ts src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run lint`
- `cd ui && bun run test`
- `just agent-docs-check`
- `git diff --check`