### PR TITLE
refactor(projects): move assignment launch planning to projectworkapp

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -153,15 +153,15 @@ runner orchestration to `handler_project_work.go`. Keep app-layer dependencies
 narrow: define the minimal store/runner interfaces the command needs instead
 of accepting broad subsystem stores by habit.
 
-Project assignment launch/preflight wiring belongs in
-`internal/api/handler_project_assignment_launch.go` while it still needs
-API-local context-packet assembly. Do not add launch planning, workspace
-resolution, profile/skill resolution, adapter-option validation, or start
-orchestration back to the broad `handler_project_work.go`; either extend the
-dedicated launch helper or move the narrow behavior into `projectworkapp` when
-the dependency shape is ready. Preflight and start must share the same launch
-plan helpers; do not resolve provider/model/profile/workspace or External Agent
-adapter/options separately for preview and dispatch.
+Project assignment launch planning belongs in `internal/projectworkapp`.
+Workspace resolution, profile/skill resolution, provider/model defaults,
+External Agent adapter/option validation, assignment task construction, and
+preflight/start launch-plan parity should stay behind that app seam.
+`internal/api/handler_project_assignment_launch.go` owns HTTP parsing, error
+mapping, response projection, and API-local context-packet assembly. Do not add
+launch planning or start orchestration back to the broad
+`handler_project_work.go`, and do not resolve provider/model/profile/workspace
+or External Agent adapter/options separately for preview and dispatch.
 
 Project activity is a read/projection surface with split ownership:
 `internal/projectworkapp` owns assignment execution refs, task/run projection,

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -55,13 +55,17 @@ func (h *Handler) projectWorkApplication() *projectworkapp.Application {
 		return projectworkapp.New(projectworkapp.Options{})
 	}
 	return projectworkapp.New(projectworkapp.Options{
-		Store:          h.projectWork,
-		TaskStore:      h.taskStore,
-		Runner:         h.taskRunner,
-		ChatStore:      h.agentChat,
-		AgentRunner:    h.agentChatRunner,
-		PrepareTimeout: agentChatPrepareTimeout,
-		IDGenerator:    newOpaqueTaskResourceID,
+		Store:               h.projectWork,
+		TaskStore:           h.taskStore,
+		Runner:              h.taskRunner,
+		ChatStore:           h.agentChat,
+		AgentRunner:         h.agentChatRunner,
+		ProfileStore:        h.agentProfiles,
+		MemoryStore:         h.memory,
+		SkillStore:          h.projectSkills,
+		PrepareTimeout:      agentChatPrepareTimeout,
+		RuntimeDefaultModel: h.config.Router.DefaultModel,
+		IDGenerator:         newOpaqueTaskResourceID,
 	})
 }
 

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -365,7 +366,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	return packet
 }
 
-func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string, profile resolvedAgentProfile, skills resolvedProjectSkills, promptContext projectAssignmentPromptContext) chat.ContextPacket {
+func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string, profile projectworkapp.ResolvedAgentProfile, skills projectworkapp.ResolvedProjectSkills, promptContext projectworkapp.AssignmentPromptContext) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
 	driverKind := firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
 	includedReason := "Included in the native project assignment launch context"
@@ -374,7 +375,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 	}
 	packet.ID = newChatID("ctx")
 	packet.ExecutionProfile = strings.TrimSpace(executionProfile)
-	packet.SystemPromptIncluded = strings.TrimSpace(projectAssignmentSystemPrompt(project, role, profile, promptContext)) != ""
+	packet.SystemPromptIncluded = strings.TrimSpace(projectworkapp.AssignmentSystemPrompt(project, role, profile, promptContext)) != ""
 	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
 	packet.Refs = &chat.ContextRefs{
 		TaskID:       strings.TrimSpace(ref.TaskID),
@@ -614,7 +615,7 @@ func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
 	appendProjectMemoryWithInclusion(packet, entries, true, "Enabled project memory entry")
 }
 
-func appendProjectMemoryForProfilePolicy(packet *chat.ContextPacket, entries []memory.Entry, profile resolvedAgentProfile) {
+func appendProjectMemoryForProfilePolicy(packet *chat.ContextPacket, entries []memory.Entry, profile projectworkapp.ResolvedAgentProfile) {
 	policy := effectiveProjectMemoryPolicy(profile.ProjectMemoryPolicy)
 	switch policy {
 	case agentprofiles.MemoryExclude:
@@ -657,7 +658,7 @@ func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.Cont
 	appendProjectContextSourcesWithInclusion(packet, sources, true, "Enabled project context source metadata")
 }
 
-func appendProjectContextSourcesForProfilePolicy(packet *chat.ContextPacket, sources []chat.ContextSource, profile resolvedAgentProfile) {
+func appendProjectContextSourcesForProfilePolicy(packet *chat.ContextPacket, sources []chat.ContextSource, profile projectworkapp.ResolvedAgentProfile) {
 	policy := effectiveContextSourcePolicy(profile.ContextSourcePolicy)
 	switch policy {
 	case agentprofiles.ContextExclude:
@@ -710,7 +711,7 @@ func effectiveContextSourcePolicy(policy string) string {
 	}
 }
 
-func appendResolvedAgentProfile(packet *chat.ContextPacket, profile resolvedAgentProfile) {
+func appendResolvedAgentProfile(packet *chat.ContextPacket, profile projectworkapp.ResolvedAgentProfile) {
 	if strings.TrimSpace(profile.ID) == "" {
 		return
 	}
@@ -773,61 +774,7 @@ func appendResolvedAgentProfile(packet *chat.ContextPacket, profile resolvedAgen
 	}
 }
 
-type resolvedProjectSkills struct {
-	Requested []string
-	Resolved  []projectskills.Skill
-	Skipped   []resolvedProjectSkillSkip
-	Warnings  []string
-}
-
-type resolvedProjectSkillSkip struct {
-	ID     string
-	Reason string
-	Status string
-}
-
-func (h *Handler) resolveProjectAssignmentSkills(ctx context.Context, projectID string, role projectwork.AgentRoleProfile, profile resolvedAgentProfile) resolvedProjectSkills {
-	requested := normalizeContextStringList(append(append([]string(nil), role.SkillIDs...), profile.SkillIDs...))
-	result := resolvedProjectSkills{Requested: requested}
-	if len(requested) == 0 {
-		return result
-	}
-	if h == nil || h.projectSkills == nil {
-		result.Warnings = []string{"Project skills store is not configured; skill references were not resolved."}
-		for _, id := range requested {
-			result.Skipped = append(result.Skipped, resolvedProjectSkillSkip{ID: id, Reason: "store_unavailable"})
-		}
-		return result
-	}
-	items, err := h.projectSkills.List(ctx, projectID)
-	if err != nil {
-		result.Warnings = []string{"Project skills could not be loaded; skill references were not resolved."}
-		for _, id := range requested {
-			result.Skipped = append(result.Skipped, resolvedProjectSkillSkip{ID: id, Reason: "store_error"})
-		}
-		return result
-	}
-	byID := make(map[string]projectskills.Skill, len(items))
-	for _, item := range items {
-		byID[item.ID] = item
-	}
-	for _, id := range requested {
-		item, ok := byID[id]
-		switch {
-		case !ok:
-			result.Skipped = append(result.Skipped, resolvedProjectSkillSkip{ID: id, Reason: "missing", Status: projectskills.StatusMissing})
-		case !item.Enabled:
-			result.Skipped = append(result.Skipped, resolvedProjectSkillSkip{ID: id, Reason: "disabled", Status: item.Status})
-		case item.Status != projectskills.StatusAvailable:
-			result.Skipped = append(result.Skipped, resolvedProjectSkillSkip{ID: id, Reason: item.Status, Status: item.Status})
-		default:
-			result.Resolved = append(result.Resolved, item)
-		}
-	}
-	return result
-}
-
-func appendResolvedProjectSkills(packet *chat.ContextPacket, skills resolvedProjectSkills) {
+func appendResolvedProjectSkills(packet *chat.ContextPacket, skills projectworkapp.ResolvedProjectSkills) {
 	if len(skills.Requested) == 0 {
 		return
 	}
@@ -869,7 +816,7 @@ func appendResolvedProjectSkills(packet *chat.ContextPacket, skills resolvedProj
 	})
 }
 
-func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptContext projectAssignmentPromptContext) {
+func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptContext projectworkapp.AssignmentPromptContext) {
 	if len(promptContext.Sections) == 0 && len(promptContext.Warnings) == 0 {
 		return
 	}
@@ -902,23 +849,6 @@ func boolLabel(v bool) string {
 		return "true"
 	}
 	return "false"
-}
-
-func normalizeContextStringList(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	seen := make(map[string]bool, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" || seen[value] {
-			continue
-		}
-		seen[value] = true
-		out = append(out, value)
-	}
-	return out
 }
 
 func appendProjectAssignmentHandoffs(packet *chat.ContextPacket, items []projectwork.Handoff, included bool, reason string) {

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -7,24 +7,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
-	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/chatcontext"
-	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
-	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -105,6 +99,19 @@ func projectAssignmentPreflightHTTPStatus(err error) int {
 	if errors.As(err, &preflightErr) && preflightErr.status != 0 {
 		return preflightErr.status
 	}
+	var launchErr projectworkapp.LaunchPlanError
+	if errors.As(err, &launchErr) {
+		switch launchErr.Kind {
+		case projectworkapp.LaunchPlanInvalidRequest:
+			return http.StatusBadRequest
+		case projectworkapp.LaunchPlanUnprocessable:
+			return http.StatusUnprocessableEntity
+		case projectworkapp.LaunchPlanModelNotConfigured:
+			return http.StatusUnprocessableEntity
+		case projectworkapp.LaunchPlanAdapterNotFound:
+			return http.StatusNotFound
+		}
+	}
 	return http.StatusInternalServerError
 }
 
@@ -112,6 +119,19 @@ func projectAssignmentPreflightErrorCode(err error) string {
 	var preflightErr projectAssignmentPreflightError
 	if errors.As(err, &preflightErr) && preflightErr.code != "" {
 		return preflightErr.code
+	}
+	var launchErr projectworkapp.LaunchPlanError
+	if errors.As(err, &launchErr) {
+		switch launchErr.Kind {
+		case projectworkapp.LaunchPlanInvalidRequest:
+			return errCodeInvalidRequest
+		case projectworkapp.LaunchPlanUnprocessable:
+			return errCodeInvalidRequest
+		case projectworkapp.LaunchPlanModelNotConfigured:
+			return errCodeModelNotConfigured
+		case projectworkapp.LaunchPlanAdapterNotFound:
+			return errCodeNotFound
+		}
 	}
 	return errCodeGatewayError
 }
@@ -144,7 +164,7 @@ func (h *Handler) projectHecateTaskAssignmentPreflightContext(ctx context.Contex
 	if active {
 		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusConflict, errCodeConflict, "assignment already has active execution")
 	}
-	plan, err := h.resolveProjectAssignmentLaunchPlan(ctx, project, role)
+	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, role)
 	if err != nil {
 		return chat.ContextPacket{}, err
 	}
@@ -167,10 +187,10 @@ func (h *Handler) projectExternalAgentAssignmentPreflightContext(ctx context.Con
 	if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" {
 		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusConflict, errCodeConflict, "external-agent assignment already has a prepared chat session")
 	}
-	plan, err := h.resolveProjectExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
 	if err != nil {
-		var adapterErr projectAssignmentAdapterNotFoundError
-		if errors.As(err, &adapterErr) {
+		var launchErr projectworkapp.LaunchPlanError
+		if errors.As(err, &launchErr) && launchErr.Kind == projectworkapp.LaunchPlanAdapterNotFound {
 			return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, err.Error())
 		}
 		return chat.ContextPacket{}, err
@@ -281,7 +301,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	plan, err := h.resolveProjectAssignmentLaunchPlan(ctx, project, role)
+	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, role)
 	if err != nil {
 		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
 		return
@@ -297,7 +317,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		Assignment:        assignment,
 		ContextSnapshotID: contextPacket.ID,
 		BuildTask: func(taskID string) (types.Task, error) {
-			return h.buildProjectAssignmentTask(taskID, project, workItem, assignment, role, plan.Profile, plan.WorkingDirectory, plan.WorkspaceMode, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.PromptContext), nil
+			return projectworkapp.NewAssignmentTask(taskID, project, workItem, assignment, role, plan, time.Now().UTC()), nil
 		},
 		OnTaskCreated: func(task types.Task) {
 			contextPacket.Refs.TaskID = task.ID
@@ -349,113 +369,8 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
 
-type projectAssignmentLaunchPlan struct {
-	WorkingDirectory  string
-	WorkspaceMode     string
-	RequestedProvider string
-	RequestedModel    string
-	ExecutionProfile  string
-	Profile           resolvedAgentProfile
-	ResolvedSkills    resolvedProjectSkills
-	PromptContext     projectAssignmentPromptContext
-}
-
-func (h *Handler) resolveProjectAssignmentLaunchPlan(ctx context.Context, project projects.Project, role projectwork.AgentRoleProfile) (projectAssignmentLaunchPlan, error) {
-	workingDirectory, workspaceMode, err := resolveProjectAssignmentWorkspace(project)
-	if err != nil {
-		return projectAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
-	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel))
-	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
-	if err != nil {
-		return projectAssignmentLaunchPlan{}, err
-	}
-	executionProfile := strings.TrimSpace(firstNonEmpty(profile.ExecutionProfile, role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
-	if profile.ProviderHint != "" && requestedProvider == "" {
-		requestedProvider = profile.ProviderHint
-	}
-	if profile.ModelHint != "" && requestedModel == "" {
-		requestedModel = profile.ModelHint
-	}
-	requestedModel = strings.TrimSpace(firstNonEmpty(requestedModel, h.config.Router.DefaultModel))
-	if requestedModel == "" {
-		return projectAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusUnprocessableEntity, errCodeModelNotConfigured, "project assignment start requires a default model")
-	}
-	return projectAssignmentLaunchPlan{
-		WorkingDirectory:  workingDirectory,
-		WorkspaceMode:     workspaceMode,
-		RequestedProvider: requestedProvider,
-		RequestedModel:    requestedModel,
-		ExecutionProfile:  executionProfile,
-		Profile:           profile,
-		ResolvedSkills:    h.resolveProjectAssignmentSkills(ctx, project.ID, role, profile),
-		PromptContext:     h.projectAssignmentPromptContext(ctx, project, profile, workingDirectory),
-	}, nil
-}
-
-type projectExternalAgentAssignmentLaunchPlan struct {
-	Workspace        string
-	AdapterID        string
-	Adapter          agentadapters.Adapter
-	ConfigOptions    []agentcontrols.ConfigOption
-	SessionTitle     string
-	ExecutionProfile string
-	Profile          resolvedAgentProfile
-	ResolvedSkills   resolvedProjectSkills
-}
-
-type projectAssignmentAdapterNotFoundError struct {
-	adapterID string
-}
-
-func (err projectAssignmentAdapterNotFoundError) Error() string {
-	return "external-agent adapter not found: " + err.adapterID
-}
-
-func (err projectAssignmentAdapterNotFoundError) AdapterID() string {
-	return err.adapterID
-}
-
-func (h *Handler) resolveProjectExternalAgentAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) (projectExternalAgentAssignmentLaunchPlan, error) {
-	workingDirectory, _, err := resolveProjectAssignmentWorkspace(project)
-	if err != nil {
-		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	profile, err := h.resolveProjectAssignmentProfile(ctx, role, project)
-	if err != nil {
-		return projectExternalAgentAssignmentLaunchPlan{}, err
-	}
-	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
-	if adapterID == "" {
-		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusUnprocessableEntity, errCodeInvalidRequest, "external-agent assignment requires an agent profile with external_agent_kind")
-	}
-	adapter, ok := agentadapters.BuiltInByID(adapterID)
-	if !ok {
-		return projectExternalAgentAssignmentLaunchPlan{}, projectAssignmentAdapterNotFoundError{adapterID: adapterID}
-	}
-	configOptions, err := projectExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
-	if err != nil {
-		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
-	if err != nil {
-		return projectExternalAgentAssignmentLaunchPlan{}, newProjectAssignmentPreflightError(http.StatusBadRequest, errCodeInvalidRequest, err.Error())
-	}
-	return projectExternalAgentAssignmentLaunchPlan{
-		Workspace:        workspace,
-		AdapterID:        adapterID,
-		Adapter:          adapter,
-		ConfigOptions:    configOptions,
-		SessionTitle:     projectExternalAgentAssignmentTitle(workItem, role, adapter),
-		ExecutionProfile: firstNonEmptyString(profile.ExecutionProfile, "external_agent_assignment"),
-		Profile:          profile,
-		ResolvedSkills:   h.resolveProjectAssignmentSkills(ctx, project.ID, role, profile),
-	}, nil
-}
-
-func (h *Handler) projectExternalAgentAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectExternalAgentAssignmentLaunchPlan, sessionID string) chat.ContextPacket {
-	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Workspace, "", "", plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, projectAssignmentPromptContext{})
+func (h *Handler) projectExternalAgentAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectworkapp.ExternalAgentAssignmentLaunchPlan, sessionID string) chat.ContextPacket {
+	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Workspace, "", "", plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, projectworkapp.AssignmentPromptContext{})
 	packet.ExecutionMode = chat.ExecutionModeExternalAgent
 	packet.Provider = ""
 	packet.Model = ""
@@ -485,11 +400,11 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
-	plan, err := h.resolveProjectExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
 	if err != nil {
-		var adapterErr projectAssignmentAdapterNotFoundError
-		if errors.As(err, &adapterErr) {
-			writeAgentChatAdapterNotFound(w, adapterErr.AdapterID())
+		var launchErr projectworkapp.LaunchPlanError
+		if errors.As(err, &launchErr) && launchErr.Kind == projectworkapp.LaunchPlanAdapterNotFound {
+			writeAgentChatAdapterNotFound(w, launchErr.AdapterID)
 			return
 		}
 		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
@@ -590,485 +505,9 @@ type taskRunLookupStore interface {
 	GetRun(ctx context.Context, taskID, runID string) (types.TaskRun, bool, error)
 }
 
-func resolveProjectAssignmentWorkspace(project projects.Project) (string, string, error) {
-	root, ok := selectProjectAssignmentRoot(project)
-	if !ok {
-		return "", "", fmt.Errorf("project has no workspace root; add a project root before starting an assignment")
-	}
-	path := strings.TrimSpace(root.Path)
-	if path == "" {
-		return "", "", fmt.Errorf("project root %q has no path", root.ID)
-	}
-	if !filepath.IsAbs(path) {
-		return "", "", fmt.Errorf("project root %q path must be absolute", root.ID)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return "", "", fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
-	}
-	if !info.IsDir() {
-		return "", "", fmt.Errorf("project root %q is not a directory", root.ID)
-	}
-	workspaceMode := strings.TrimSpace(project.DefaultWorkspaceMode)
-	if workspaceMode == "" {
-		workspaceMode = "ephemeral"
-	}
-	return path, workspaceMode, nil
-}
-
-func selectProjectAssignmentRoot(project projects.Project) (projects.Root, bool) {
-	defaultRootID := strings.TrimSpace(project.DefaultRootID)
-	if defaultRootID != "" {
-		for _, root := range project.Roots {
-			if root.ID == defaultRootID {
-				return root, true
-			}
-		}
-	}
-	for _, root := range project.Roots {
-		if root.Active {
-			return root, true
-		}
-	}
-	if len(project.Roots) > 0 {
-		return project.Roots[0], true
-	}
-	return projects.Root{}, false
-}
-
-func (h *Handler) buildProjectAssignmentTask(taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, profile resolvedAgentProfile, workingDirectory, workspaceMode, requestedProvider, requestedModel, executionProfile string, promptContext projectAssignmentPromptContext) types.Task {
-	now := time.Now().UTC()
-	return types.Task{
-		ID:                          taskID,
-		Title:                       projectAssignmentTaskTitle(workItem, role),
-		Prompt:                      projectAssignmentPrompt(project, workItem, assignment, role),
-		ProjectID:                   project.ID,
-		SystemPrompt:                projectAssignmentSystemPrompt(project, role, profile, promptContext),
-		WorkspaceSystemPromptPolicy: types.WorkspaceSystemPromptExclude,
-		ExecutionKind:               "agent_loop",
-		ExecutionProfile:            executionProfile,
-		OriginKind:                  "project_work_item",
-		OriginID:                    workItem.ID,
-		WorkspaceMode:               workspaceMode,
-		WorkingDirectory:            workingDirectory,
-		SandboxAllowedRoot:          workingDirectory,
-		Status:                      "queued",
-		Priority:                    firstNonEmpty(workItem.Priority, "normal"),
-		RequestedProvider:           requestedProvider,
-		RequestedModel:              requestedModel,
-		CreatedAt:                   now,
-		UpdatedAt:                   now,
-	}
-}
-
-func projectAssignmentTaskTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) string {
-	title := strings.TrimSpace(workItem.Title)
-	roleName := strings.TrimSpace(role.Name)
-	switch {
-	case title != "" && roleName != "":
-		return title + " - " + roleName
-	case title != "":
-		return title
-	case roleName != "":
-		return roleName + " assignment"
-	default:
-		return "Project work assignment"
-	}
-}
-
-func projectAssignmentPrompt(project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) string {
-	provider := firstNonEmpty(role.DefaultProvider, project.DefaultProvider, "auto")
-	model := firstNonEmpty(role.DefaultModel, project.DefaultModel, "project/runtime default")
-	profile := firstNonEmpty(role.DefaultAgentProfile, project.DefaultAgentProfile, "none")
-	driver := firstNonEmpty(assignment.DriverKind, role.DefaultDriverKind, projectwork.AssignmentDriverHecateTask)
-	sections := []string{
-		"Launch context",
-		"Project: " + labelWithID(project.Name, project.ID),
-		strings.Join([]string{
-			"Work item:",
-			"- Title: " + firstNonEmpty(workItem.Title, workItem.ID),
-			launchContextBullet("Brief", firstNonEmpty(workItem.Brief, "No brief recorded.")),
-			"- Status: " + firstNonEmpty(workItem.Status, "unknown"),
-			"- Priority: " + firstNonEmpty(workItem.Priority, "normal"),
-		}, "\n"),
-		strings.Join([]string{
-			"Assignment:",
-			"- ID: " + assignment.ID,
-			"- Status: " + firstNonEmpty(assignment.Status, projectwork.AssignmentStatusQueued),
-			"- Driver: " + driver,
-		}, "\n"),
-		strings.Join([]string{
-			"Role:",
-			"- Name: " + firstNonEmpty(role.Name, assignment.RoleID),
-			launchContextBullet("Description", firstNonEmpty(role.Description, "No description recorded.")),
-			launchContextBullet("Instructions", firstNonEmpty(role.Instructions, "No role instructions recorded.")),
-		}, "\n"),
-		strings.Join([]string{
-			"Execution hints:",
-			"- Driver: " + driver,
-			"- Provider: " + provider,
-			"- Model: " + model,
-			"- Profile: " + profile,
-			"- Role defaults: " + formatAssignmentHints([]assignmentHint{
-				{"driver", role.DefaultDriverKind},
-				{"provider", role.DefaultProvider},
-				{"model", role.DefaultModel},
-				{"profile", role.DefaultAgentProfile},
-			}),
-			"- Project defaults: " + formatAssignmentHints([]assignmentHint{
-				{"provider", project.DefaultProvider},
-				{"model", project.DefaultModel},
-				{"profile", project.DefaultAgentProfile},
-				{"workspace_mode", project.DefaultWorkspaceMode},
-			}),
-		}, "\n"),
-		"Request:\nExecute this assignment as a native agent_loop task. Keep outputs and artifacts linked to this work item.",
-	}
-	return strings.Join(sections, "\n\n")
-}
-
-func projectAssignmentSystemPrompt(project projects.Project, role projectwork.AgentRoleProfile, profile resolvedAgentProfile, promptContext projectAssignmentPromptContext) string {
-	var parts []string
-	if prompt := strings.TrimSpace(project.DefaultSystemPrompt); prompt != "" {
-		parts = append(parts, "Project system prompt:\n"+prompt)
-	}
-	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" && !profile.Missing {
-		parts = append(parts, "Agent profile instructions:\n"+instructions)
-	}
-	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
-		parts = append(parts, "Role instructions:\n"+instructions)
-	} else if role.Name != "" {
-		parts = append(parts, "Act as the "+strings.TrimSpace(role.Name)+" for this project work assignment.")
-	}
-	if contextText := promptContext.SystemPrompt(); contextText != "" {
-		parts = append(parts, contextText)
-	}
-	return strings.Join(parts, "\n\n")
-}
-
-const (
-	projectAssignmentPromptContextMaxBytes       = 12 * 1024
-	projectAssignmentPromptContextMemoryMaxBytes = 2 * 1024
-	projectAssignmentPromptContextSourceMaxBytes = 8 * 1024
-	projectAssignmentPromptContextMaxWarnings    = 8
-)
-
-type projectAssignmentPromptContext struct {
-	Sections        []string
-	IncludedMemory  int
-	IncludedSources int
-	Truncated       int
-	Warnings        []string
-}
-
-func (ctx projectAssignmentPromptContext) SystemPrompt() string {
-	if len(ctx.Sections) == 0 {
-		return ""
-	}
-	return strings.Join(ctx.Sections, "\n\n")
-}
-
-func (h *Handler) projectAssignmentPromptContext(ctx context.Context, project projects.Project, profile resolvedAgentProfile, workingDirectory string) projectAssignmentPromptContext {
-	builder := projectPromptContextBuilder{Remaining: projectAssignmentPromptContextMaxBytes}
-	if effectiveProjectMemoryPolicy(profile.ProjectMemoryPolicy) == agentprofiles.MemoryInclude {
-		builder.AppendMemory(h.enabledProjectMemoryEntries(ctx, project.ID))
-	}
-	if effectiveContextSourcePolicy(profile.ContextSourcePolicy) == agentprofiles.ContextIncludeEnabled {
-		builder.AppendSources(project, workingDirectory)
-	}
-	return builder.Result()
-}
-
-type projectPromptContextBuilder struct {
-	Remaining int
-	ResultCtx projectAssignmentPromptContext
-}
-
-func (builder *projectPromptContextBuilder) AppendMemory(entries []memory.Entry) {
-	for _, entry := range entries {
-		if builder.Remaining <= 0 {
-			builder.Warn("project memory prompt context budget exhausted; remaining memory entries were skipped")
-			return
-		}
-		title := firstNonEmptyString(strings.TrimSpace(entry.Title), strings.TrimSpace(entry.ID))
-		body := strings.TrimSpace(entry.Body)
-		if body == "" {
-			continue
-		}
-		header := fmt.Sprintf("Project memory: %s\nID: %s\nTrust: %s", title, strings.TrimSpace(entry.ID), firstNonEmptyString(strings.TrimSpace(entry.TrustLabel), contextTrustOperatorMemory))
-		section, truncated := boundedPromptContextSection(header, body, projectAssignmentPromptContextMemoryMaxBytes, &builder.Remaining)
-		if section == "" {
-			builder.Warn("project memory prompt context budget exhausted before " + strings.TrimSpace(entry.ID))
-			return
-		}
-		if truncated {
-			builder.ResultCtx.Truncated++
-			builder.Warn("project memory " + strings.TrimSpace(entry.ID) + " was truncated for prompt context")
-		}
-		builder.ResultCtx.IncludedMemory++
-		builder.ResultCtx.Sections = append(builder.ResultCtx.Sections, section)
-	}
-}
-
-func (builder *projectPromptContextBuilder) AppendSources(project projects.Project, workingDirectory string) {
-	for _, source := range project.ContextSources {
-		if !source.Enabled {
-			continue
-		}
-		if builder.Remaining <= 0 {
-			builder.Warn("project source prompt context budget exhausted; remaining sources were skipped")
-			return
-		}
-		if !projectContextSourcePromptEligible(source) {
-			if strings.TrimSpace(source.Path) != "" {
-				builder.Warn("project source " + strings.TrimSpace(source.Path) + " is metadata-only for Hecate prompt context")
-			}
-			continue
-		}
-		rootPath := projectContextSourceRootPath(project, source, workingDirectory)
-		if strings.TrimSpace(rootPath) == "" {
-			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not resolve an active root")
-			continue
-		}
-		fsys, err := workspacefs.New(rootPath)
-		if err != nil {
-			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not open its workspace root")
-			continue
-		}
-		raw, _, err := fsys.ReadFile(source.Path)
-		if err != nil {
-			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not be read for prompt context")
-			continue
-		}
-		body := strings.TrimSpace(string(raw))
-		if body == "" {
-			continue
-		}
-		title := firstNonEmptyString(strings.TrimSpace(source.Title), strings.TrimSpace(source.Path))
-		header := fmt.Sprintf("Workspace instruction: %s\nPath: %s\nTrust: %s", title, strings.TrimSpace(source.Path), firstNonEmptyString(strings.TrimSpace(source.TrustLabel), contextTrustWorkspaceGuidance))
-		section, truncated := boundedPromptContextSection(header, body, projectAssignmentPromptContextSourceMaxBytes, &builder.Remaining)
-		if section == "" {
-			builder.Warn("project source prompt context budget exhausted before " + strings.TrimSpace(source.Path))
-			return
-		}
-		if truncated {
-			builder.ResultCtx.Truncated++
-			builder.Warn("project source " + strings.TrimSpace(source.Path) + " was truncated for prompt context")
-		}
-		builder.ResultCtx.IncludedSources++
-		builder.ResultCtx.Sections = append(builder.ResultCtx.Sections, section)
-	}
-}
-
-func (builder *projectPromptContextBuilder) Warn(warning string) {
-	warning = strings.TrimSpace(warning)
-	if warning == "" || len(builder.ResultCtx.Warnings) >= projectAssignmentPromptContextMaxWarnings {
-		return
-	}
-	builder.ResultCtx.Warnings = append(builder.ResultCtx.Warnings, warning)
-}
-
-func (builder projectPromptContextBuilder) Result() projectAssignmentPromptContext {
-	return builder.ResultCtx
-}
-
-func projectContextSourcePromptEligible(source projects.ContextSource) bool {
-	return strings.TrimSpace(source.Kind) == "workspace_instruction" && strings.TrimSpace(source.Format) == "agents_md"
-}
-
-func projectContextSourceRootPath(project projects.Project, source projects.ContextSource, fallback string) string {
-	rootID := ""
-	if source.Metadata != nil {
-		rootID = strings.TrimSpace(source.Metadata["root_id"])
-	}
-	if rootID != "" {
-		for _, root := range project.Roots {
-			if root.Active && strings.TrimSpace(root.ID) == rootID {
-				return strings.TrimSpace(root.Path)
-			}
-		}
-		return ""
-	}
-	return strings.TrimSpace(fallback)
-}
-
-func boundedPromptContextSection(header, body string, itemMaxBytes int, remaining *int) (string, bool) {
-	if remaining == nil || *remaining <= 0 {
-		return "", false
-	}
-	header = strings.TrimSpace(header)
-	body = strings.TrimSpace(body)
-	if header == "" || body == "" {
-		return "", false
-	}
-	limit := itemMaxBytes
-	if *remaining < limit {
-		limit = *remaining
-	}
-	text := header + "\n" + body
-	text, truncated := truncatePromptContextText(text, limit)
-	if text == "" {
-		return "", truncated
-	}
-	*remaining -= len(text)
-	return text, truncated
-}
-
-func truncatePromptContextText(text string, maxBytes int) (string, bool) {
-	text = strings.TrimSpace(text)
-	if maxBytes <= 0 {
-		return "", text != ""
-	}
-	if len(text) <= maxBytes {
-		return text, false
-	}
-	if maxBytes <= len("\n[truncated]") {
-		return "", true
-	}
-	cut := maxBytes - len("\n[truncated]")
-	raw := []byte(text)
-	for cut > 0 && !utf8.Valid(raw[:cut]) {
-		cut--
-	}
-	if cut <= 0 {
-		return "", true
-	}
-	return strings.TrimSpace(string(raw[:cut])) + "\n[truncated]", true
-}
-
 type assignmentHint struct {
 	label string
 	value string
-}
-
-type resolvedAgentProfile struct {
-	ID                   string
-	Name                 string
-	Source               string
-	Instructions         string
-	Missing              bool
-	Surface              string
-	ProviderHint         string
-	ModelHint            string
-	ExecutionProfile     string
-	ToolsEnabled         bool
-	WritesAllowed        bool
-	NetworkAllowed       bool
-	ApprovalPolicy       string
-	ProjectMemoryPolicy  string
-	ContextSourcePolicy  string
-	SkillIDs             []string
-	ExternalAgentKind    string
-	ExternalAgentOptions map[string]string
-	Warnings             []string
-}
-
-func (h *Handler) resolveProjectAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) (resolvedAgentProfile, error) {
-	for _, candidate := range []struct {
-		id     string
-		source string
-	}{
-		{strings.TrimSpace(role.DefaultAgentProfile), "role_default"},
-		{strings.TrimSpace(project.DefaultAgentProfile), "project_default"},
-	} {
-		if candidate.id == "" {
-			continue
-		}
-		if h != nil && h.agentProfiles != nil {
-			profile, ok, err := h.agentProfiles.Get(ctx, candidate.id)
-			if err != nil {
-				return resolvedAgentProfile{}, err
-			}
-			if ok {
-				return resolvedProfileFromStore(profile, candidate.source), nil
-			}
-		}
-		return resolvedAgentProfile{
-			ID:                  candidate.id,
-			Name:                candidate.id,
-			Source:              candidate.source,
-			Missing:             true,
-			ExecutionProfile:    candidate.id,
-			ApprovalPolicy:      agentprofiles.ApprovalInherit,
-			ProjectMemoryPolicy: agentprofiles.MemoryInherit,
-			ContextSourcePolicy: agentprofiles.ContextInherit,
-			Warnings:            []string{fmt.Sprintf("Referenced agent profile %q was not found; using stored profile id as execution_profile hint.", candidate.id)},
-		}, nil
-	}
-	return resolvedAgentProfile{
-		ID:                  "project_assignment",
-		Name:                "Project Assignment",
-		Source:              "built_in_fallback",
-		Surface:             agentprofiles.SurfaceHecateTask,
-		ExecutionProfile:    "project_assignment",
-		ToolsEnabled:        true,
-		WritesAllowed:       true,
-		ApprovalPolicy:      agentprofiles.ApprovalInherit,
-		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
-		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
-	}, nil
-}
-
-func resolvedProfileFromStore(profile agentprofiles.Profile, source string) resolvedAgentProfile {
-	return resolvedAgentProfile{
-		ID:                   profile.ID,
-		Name:                 profile.Name,
-		Source:               source,
-		Instructions:         profile.Instructions,
-		Surface:              profile.Surface,
-		ProviderHint:         profile.ProviderHint,
-		ModelHint:            profile.ModelHint,
-		ExecutionProfile:     firstNonEmptyString(profile.ExecutionProfile, profile.ID),
-		ToolsEnabled:         profile.ToolsEnabled,
-		WritesAllowed:        profile.WritesAllowed,
-		NetworkAllowed:       profile.NetworkAllowed,
-		ApprovalPolicy:       profile.ApprovalPolicy,
-		ProjectMemoryPolicy:  profile.ProjectMemoryPolicy,
-		ContextSourcePolicy:  profile.ContextSourcePolicy,
-		SkillIDs:             append([]string(nil), profile.SkillIDs...),
-		ExternalAgentKind:    profile.ExternalAgentKind,
-		ExternalAgentOptions: cloneStringMap(profile.ExternalAgentOptions),
-	}
-}
-
-func projectExternalAgentConfigOptions(adapterID string, options map[string]string) ([]agentcontrols.ConfigOption, error) {
-	if len(options) == 0 {
-		return nil, nil
-	}
-	out := make([]agentcontrols.ConfigOption, 0, len(options))
-	for key, value := range options {
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		if key == "" || value == "" {
-			continue
-		}
-		option, ok := agentadapters.LaunchConfigOptionForSet(adapterID, key, value)
-		if !ok {
-			return nil, fmt.Errorf("external_agent_options.%s is not a launch option for %s", key, adapterID)
-		}
-		out = append(out, option)
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].ID < out[j].ID
-	})
-	return out, nil
-}
-
-func projectExternalAgentAssignmentTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile, adapter agentadapters.Adapter) string {
-	parts := []string{}
-	if title := strings.TrimSpace(workItem.Title); title != "" {
-		parts = append(parts, title)
-	}
-	if roleName := strings.TrimSpace(role.Name); roleName != "" {
-		parts = append(parts, roleName)
-	}
-	if adapter.Name != "" {
-		parts = append(parts, adapter.Name)
-	}
-	if len(parts) == 0 {
-		return "External Agent assignment"
-	}
-	return strings.Join(parts, " - ")
 }
 
 func appendProjectAssignmentLaunchPreflight(packet *chat.ContextPacket, driverKind string, details []string) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1865,7 +1865,7 @@ func TestProjectWorkAPI_StartAssignmentFallsBackToProjectDefaults(t *testing.T) 
 
 func TestProjectWorkAPI_AssignmentPromptIndentsMultilineLaunchContextValues(t *testing.T) {
 	t.Parallel()
-	prompt := projectAssignmentPrompt(
+	prompt := projectworkapp.AssignmentPrompt(
 		projects.Project{
 			ID:              "proj_multiline",
 			Name:            "Hecate",

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -47,25 +47,33 @@ type ChatSessionStore interface {
 }
 
 type Application struct {
-	store          projectwork.Store
-	taskStore      TaskStore
-	runner         TaskRunner
-	chatStore      ChatSessionStore
-	agentRunner    AgentRunner
-	prepareTimeout time.Duration
-	idgen          func(string) string
-	now            func() time.Time
+	store               projectwork.Store
+	taskStore           TaskStore
+	runner              TaskRunner
+	chatStore           ChatSessionStore
+	agentRunner         AgentRunner
+	profileStore        AgentProfileStore
+	memoryStore         ProjectMemoryStore
+	skillStore          ProjectSkillStore
+	prepareTimeout      time.Duration
+	runtimeDefaultModel string
+	idgen               func(string) string
+	now                 func() time.Time
 }
 
 type Options struct {
-	Store          projectwork.Store
-	TaskStore      TaskStore
-	Runner         TaskRunner
-	ChatStore      ChatSessionStore
-	AgentRunner    AgentRunner
-	PrepareTimeout time.Duration
-	IDGenerator    func(string) string
-	Now            func() time.Time
+	Store               projectwork.Store
+	TaskStore           TaskStore
+	Runner              TaskRunner
+	ChatStore           ChatSessionStore
+	AgentRunner         AgentRunner
+	ProfileStore        AgentProfileStore
+	MemoryStore         ProjectMemoryStore
+	SkillStore          ProjectSkillStore
+	PrepareTimeout      time.Duration
+	RuntimeDefaultModel string
+	IDGenerator         func(string) string
+	Now                 func() time.Time
 }
 
 type CreateRoleCommand struct {
@@ -177,14 +185,18 @@ func (e ExternalAgentPrepareError) Unwrap() error {
 
 func New(opts Options) *Application {
 	app := &Application{
-		store:          opts.Store,
-		taskStore:      opts.TaskStore,
-		runner:         opts.Runner,
-		chatStore:      opts.ChatStore,
-		agentRunner:    opts.AgentRunner,
-		prepareTimeout: opts.PrepareTimeout,
-		idgen:          opts.IDGenerator,
-		now:            opts.Now,
+		store:               opts.Store,
+		taskStore:           opts.TaskStore,
+		runner:              opts.Runner,
+		chatStore:           opts.ChatStore,
+		agentRunner:         opts.AgentRunner,
+		profileStore:        opts.ProfileStore,
+		memoryStore:         opts.MemoryStore,
+		skillStore:          opts.SkillStore,
+		prepareTimeout:      opts.PrepareTimeout,
+		runtimeDefaultModel: strings.TrimSpace(opts.RuntimeDefaultModel),
+		idgen:               opts.IDGenerator,
+		now:                 opts.Now,
 	}
 	if app.idgen == nil {
 		app.idgen = func(prefix string) string { return strings.TrimSpace(prefix) }

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -1,0 +1,793 @@
+package projectworkapp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentcontrols"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/workspacefs"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	LaunchPlanInvalidRequest     = "invalid_request"
+	LaunchPlanUnprocessable      = "unprocessable"
+	LaunchPlanModelNotConfigured = "model_not_configured"
+	LaunchPlanAdapterNotFound    = "adapter_not_found"
+)
+
+type LaunchPlanError struct {
+	Kind      string
+	Message   string
+	AdapterID string
+}
+
+func (err LaunchPlanError) Error() string {
+	return err.Message
+}
+
+func launchPlanError(kind, message string) error {
+	return LaunchPlanError{Kind: kind, Message: message}
+}
+
+func launchPlanAdapterNotFound(adapterID string) error {
+	return LaunchPlanError{
+		Kind:      LaunchPlanAdapterNotFound,
+		Message:   "external-agent adapter not found: " + strings.TrimSpace(adapterID),
+		AdapterID: strings.TrimSpace(adapterID),
+	}
+}
+
+type AgentProfileStore interface {
+	Get(ctx context.Context, id string) (agentprofiles.Profile, bool, error)
+}
+
+type ProjectMemoryStore interface {
+	List(ctx context.Context, filter memory.Filter) ([]memory.Entry, error)
+}
+
+type ProjectSkillStore interface {
+	List(ctx context.Context, projectID string) ([]projectskills.Skill, error)
+}
+
+type TaskAssignmentLaunchPlan struct {
+	WorkingDirectory  string
+	WorkspaceMode     string
+	RequestedProvider string
+	RequestedModel    string
+	ExecutionProfile  string
+	Profile           ResolvedAgentProfile
+	ResolvedSkills    ResolvedProjectSkills
+	PromptContext     AssignmentPromptContext
+}
+
+type ExternalAgentAssignmentLaunchPlan struct {
+	Workspace        string
+	AdapterID        string
+	Adapter          agentadapters.Adapter
+	ConfigOptions    []agentcontrols.ConfigOption
+	SessionTitle     string
+	ExecutionProfile string
+	Profile          ResolvedAgentProfile
+	ResolvedSkills   ResolvedProjectSkills
+}
+
+type ResolvedAgentProfile struct {
+	ID                   string
+	Name                 string
+	Source               string
+	Instructions         string
+	Missing              bool
+	Surface              string
+	ProviderHint         string
+	ModelHint            string
+	ExecutionProfile     string
+	ToolsEnabled         bool
+	WritesAllowed        bool
+	NetworkAllowed       bool
+	ApprovalPolicy       string
+	ProjectMemoryPolicy  string
+	ContextSourcePolicy  string
+	SkillIDs             []string
+	ExternalAgentKind    string
+	ExternalAgentOptions map[string]string
+	Warnings             []string
+}
+
+type ResolvedProjectSkills struct {
+	Requested []string
+	Resolved  []projectskills.Skill
+	Skipped   []ResolvedProjectSkillSkip
+	Warnings  []string
+}
+
+type ResolvedProjectSkillSkip struct {
+	ID     string
+	Reason string
+	Status string
+}
+
+const (
+	assignmentPromptContextMaxBytes       = 12 * 1024
+	assignmentPromptContextMemoryMaxBytes = 2 * 1024
+	assignmentPromptContextSourceMaxBytes = 8 * 1024
+	assignmentPromptContextMaxWarnings    = 8
+)
+
+type AssignmentPromptContext struct {
+	Sections        []string
+	IncludedMemory  int
+	IncludedSources int
+	Truncated       int
+	Warnings        []string
+}
+
+func (ctx AssignmentPromptContext) SystemPrompt() string {
+	if len(ctx.Sections) == 0 {
+		return ""
+	}
+	return strings.Join(ctx.Sections, "\n\n")
+}
+
+func (app *Application) ResolveTaskAssignmentLaunchPlan(ctx context.Context, project projects.Project, role projectwork.AgentRoleProfile) (TaskAssignmentLaunchPlan, error) {
+	workingDirectory, workspaceMode, err := ResolveAssignmentWorkspace(project)
+	if err != nil {
+		return TaskAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
+	}
+	requestedProvider := strings.TrimSpace(firstNonEmpty(role.DefaultProvider, project.DefaultProvider))
+	requestedModel := strings.TrimSpace(firstNonEmpty(role.DefaultModel, project.DefaultModel))
+	profile, err := app.ResolveAssignmentProfile(ctx, role, project)
+	if err != nil {
+		return TaskAssignmentLaunchPlan{}, err
+	}
+	executionProfile := strings.TrimSpace(firstNonEmpty(profile.ExecutionProfile, role.DefaultAgentProfile, project.DefaultAgentProfile, "project_assignment"))
+	if profile.ProviderHint != "" && requestedProvider == "" {
+		requestedProvider = profile.ProviderHint
+	}
+	if profile.ModelHint != "" && requestedModel == "" {
+		requestedModel = profile.ModelHint
+	}
+	requestedModel = strings.TrimSpace(firstNonEmpty(requestedModel, app.runtimeDefaultModel))
+	if requestedModel == "" {
+		return TaskAssignmentLaunchPlan{}, launchPlanError(LaunchPlanModelNotConfigured, "project assignment start requires a default model")
+	}
+	return TaskAssignmentLaunchPlan{
+		WorkingDirectory:  workingDirectory,
+		WorkspaceMode:     workspaceMode,
+		RequestedProvider: requestedProvider,
+		RequestedModel:    requestedModel,
+		ExecutionProfile:  executionProfile,
+		Profile:           profile,
+		ResolvedSkills:    app.ResolveAssignmentSkills(ctx, project.ID, role, profile),
+		PromptContext:     app.AssignmentPromptContext(ctx, project, profile, workingDirectory),
+	}, nil
+}
+
+func (app *Application) ResolveExternalAgentAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) (ExternalAgentAssignmentLaunchPlan, error) {
+	workingDirectory, _, err := ResolveAssignmentWorkspace(project)
+	if err != nil {
+		return ExternalAgentAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
+	}
+	profile, err := app.ResolveAssignmentProfile(ctx, role, project)
+	if err != nil {
+		return ExternalAgentAssignmentLaunchPlan{}, err
+	}
+	adapterID := strings.TrimSpace(profile.ExternalAgentKind)
+	if adapterID == "" {
+		return ExternalAgentAssignmentLaunchPlan{}, launchPlanError(LaunchPlanUnprocessable, "external-agent assignment requires an agent profile with external_agent_kind")
+	}
+	adapter, ok := agentadapters.BuiltInByID(adapterID)
+	if !ok {
+		return ExternalAgentAssignmentLaunchPlan{}, launchPlanAdapterNotFound(adapterID)
+	}
+	configOptions, err := ExternalAgentConfigOptions(adapterID, profile.ExternalAgentOptions)
+	if err != nil {
+		return ExternalAgentAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
+	}
+	workspace, err := agentadapters.ValidateWorkspace(workingDirectory)
+	if err != nil {
+		return ExternalAgentAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
+	}
+	return ExternalAgentAssignmentLaunchPlan{
+		Workspace:        workspace,
+		AdapterID:        adapterID,
+		Adapter:          adapter,
+		ConfigOptions:    configOptions,
+		SessionTitle:     ExternalAgentAssignmentTitle(workItem, role, adapter),
+		ExecutionProfile: firstNonEmpty(profile.ExecutionProfile, "external_agent_assignment"),
+		Profile:          profile,
+		ResolvedSkills:   app.ResolveAssignmentSkills(ctx, project.ID, role, profile),
+	}, nil
+}
+
+func ResolveAssignmentWorkspace(project projects.Project) (string, string, error) {
+	root, ok := SelectAssignmentRoot(project)
+	if !ok {
+		return "", "", fmt.Errorf("project has no workspace root; add a project root before starting an assignment")
+	}
+	path := strings.TrimSpace(root.Path)
+	if path == "" {
+		return "", "", fmt.Errorf("project root %q has no path", root.ID)
+	}
+	if !filepath.IsAbs(path) {
+		return "", "", fmt.Errorf("project root %q path must be absolute", root.ID)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", "", fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("project root %q is not a directory", root.ID)
+	}
+	workspaceMode := strings.TrimSpace(project.DefaultWorkspaceMode)
+	if workspaceMode == "" {
+		workspaceMode = "ephemeral"
+	}
+	return path, workspaceMode, nil
+}
+
+func SelectAssignmentRoot(project projects.Project) (projects.Root, bool) {
+	defaultRootID := strings.TrimSpace(project.DefaultRootID)
+	if defaultRootID != "" {
+		for _, root := range project.Roots {
+			if root.ID == defaultRootID {
+				return root, true
+			}
+		}
+	}
+	for _, root := range project.Roots {
+		if root.Active {
+			return root, true
+		}
+	}
+	if len(project.Roots) > 0 {
+		return project.Roots[0], true
+	}
+	return projects.Root{}, false
+}
+
+func (app *Application) ResolveAssignmentProfile(ctx context.Context, role projectwork.AgentRoleProfile, project projects.Project) (ResolvedAgentProfile, error) {
+	for _, candidate := range []struct {
+		id     string
+		source string
+	}{
+		{strings.TrimSpace(role.DefaultAgentProfile), "role_default"},
+		{strings.TrimSpace(project.DefaultAgentProfile), "project_default"},
+	} {
+		if candidate.id == "" {
+			continue
+		}
+		if app != nil && app.profileStore != nil {
+			profile, ok, err := app.profileStore.Get(ctx, candidate.id)
+			if err != nil {
+				return ResolvedAgentProfile{}, err
+			}
+			if ok {
+				return resolvedProfileFromStore(profile, candidate.source), nil
+			}
+		}
+		return ResolvedAgentProfile{
+			ID:                  candidate.id,
+			Name:                candidate.id,
+			Source:              candidate.source,
+			Missing:             true,
+			ExecutionProfile:    candidate.id,
+			ApprovalPolicy:      agentprofiles.ApprovalInherit,
+			ProjectMemoryPolicy: agentprofiles.MemoryInherit,
+			ContextSourcePolicy: agentprofiles.ContextInherit,
+			Warnings:            []string{fmt.Sprintf("Referenced agent profile %q was not found; using stored profile id as execution_profile hint.", candidate.id)},
+		}, nil
+	}
+	return ResolvedAgentProfile{
+		ID:                  "project_assignment",
+		Name:                "Project Assignment",
+		Source:              "built_in_fallback",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ExecutionProfile:    "project_assignment",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		ApprovalPolicy:      agentprofiles.ApprovalInherit,
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}, nil
+}
+
+func resolvedProfileFromStore(profile agentprofiles.Profile, source string) ResolvedAgentProfile {
+	return ResolvedAgentProfile{
+		ID:                   profile.ID,
+		Name:                 profile.Name,
+		Source:               source,
+		Instructions:         profile.Instructions,
+		Surface:              profile.Surface,
+		ProviderHint:         profile.ProviderHint,
+		ModelHint:            profile.ModelHint,
+		ExecutionProfile:     firstNonEmpty(profile.ExecutionProfile, profile.ID),
+		ToolsEnabled:         profile.ToolsEnabled,
+		WritesAllowed:        profile.WritesAllowed,
+		NetworkAllowed:       profile.NetworkAllowed,
+		ApprovalPolicy:       profile.ApprovalPolicy,
+		ProjectMemoryPolicy:  profile.ProjectMemoryPolicy,
+		ContextSourcePolicy:  profile.ContextSourcePolicy,
+		SkillIDs:             append([]string(nil), profile.SkillIDs...),
+		ExternalAgentKind:    profile.ExternalAgentKind,
+		ExternalAgentOptions: cloneStringMap(profile.ExternalAgentOptions),
+	}
+}
+
+func (app *Application) ResolveAssignmentSkills(ctx context.Context, projectID string, role projectwork.AgentRoleProfile, profile ResolvedAgentProfile) ResolvedProjectSkills {
+	requested := normalizeStringList(append(append([]string(nil), role.SkillIDs...), profile.SkillIDs...))
+	result := ResolvedProjectSkills{Requested: requested}
+	if len(requested) == 0 {
+		return result
+	}
+	if app == nil || app.skillStore == nil {
+		result.Warnings = []string{"Project skills store is not configured; skill references were not resolved."}
+		for _, id := range requested {
+			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: "store_unavailable"})
+		}
+		return result
+	}
+	items, err := app.skillStore.List(ctx, projectID)
+	if err != nil {
+		result.Warnings = []string{"Project skills could not be loaded; skill references were not resolved."}
+		for _, id := range requested {
+			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: "store_error"})
+		}
+		return result
+	}
+	byID := make(map[string]projectskills.Skill, len(items))
+	for _, item := range items {
+		byID[item.ID] = item
+	}
+	for _, id := range requested {
+		item, ok := byID[id]
+		switch {
+		case !ok:
+			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: "missing", Status: projectskills.StatusMissing})
+		case !item.Enabled:
+			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: "disabled", Status: item.Status})
+		case item.Status != projectskills.StatusAvailable:
+			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: item.Status, Status: item.Status})
+		default:
+			result.Resolved = append(result.Resolved, item)
+		}
+	}
+	return result
+}
+
+func (app *Application) AssignmentPromptContext(ctx context.Context, project projects.Project, profile ResolvedAgentProfile, workingDirectory string) AssignmentPromptContext {
+	builder := promptContextBuilder{Remaining: assignmentPromptContextMaxBytes}
+	if effectiveProjectMemoryPolicy(profile.ProjectMemoryPolicy) == agentprofiles.MemoryInclude {
+		builder.AppendMemory(app.enabledProjectMemoryEntries(ctx, project.ID))
+	}
+	if effectiveContextSourcePolicy(profile.ContextSourcePolicy) == agentprofiles.ContextIncludeEnabled {
+		builder.AppendSources(project, workingDirectory)
+	}
+	return builder.Result()
+}
+
+func (app *Application) enabledProjectMemoryEntries(ctx context.Context, projectID string) []memory.Entry {
+	if app == nil || app.memoryStore == nil || strings.TrimSpace(projectID) == "" {
+		return nil
+	}
+	items, err := app.memoryStore.List(ctx, memory.Filter{ProjectID: projectID})
+	if err != nil {
+		return nil
+	}
+	return items
+}
+
+func NewAssignmentTask(taskID string, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan TaskAssignmentLaunchPlan, now time.Time) types.Task {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return types.Task{
+		ID:                          taskID,
+		Title:                       AssignmentTaskTitle(workItem, role),
+		Prompt:                      AssignmentPrompt(project, workItem, assignment, role),
+		ProjectID:                   project.ID,
+		SystemPrompt:                AssignmentSystemPrompt(project, role, plan.Profile, plan.PromptContext),
+		WorkspaceSystemPromptPolicy: types.WorkspaceSystemPromptExclude,
+		ExecutionKind:               "agent_loop",
+		ExecutionProfile:            plan.ExecutionProfile,
+		OriginKind:                  "project_work_item",
+		OriginID:                    workItem.ID,
+		WorkspaceMode:               plan.WorkspaceMode,
+		WorkingDirectory:            plan.WorkingDirectory,
+		SandboxAllowedRoot:          plan.WorkingDirectory,
+		Status:                      "queued",
+		Priority:                    firstNonEmpty(workItem.Priority, "normal"),
+		RequestedProvider:           plan.RequestedProvider,
+		RequestedModel:              plan.RequestedModel,
+		CreatedAt:                   now,
+		UpdatedAt:                   now,
+	}
+}
+
+func AssignmentTaskTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) string {
+	title := strings.TrimSpace(workItem.Title)
+	roleName := strings.TrimSpace(role.Name)
+	switch {
+	case title != "" && roleName != "":
+		return title + " - " + roleName
+	case title != "":
+		return title
+	case roleName != "":
+		return roleName + " assignment"
+	default:
+		return "Project work assignment"
+	}
+}
+
+func AssignmentPrompt(project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) string {
+	provider := firstNonEmpty(role.DefaultProvider, project.DefaultProvider, "auto")
+	model := firstNonEmpty(role.DefaultModel, project.DefaultModel, "project/runtime default")
+	profile := firstNonEmpty(role.DefaultAgentProfile, project.DefaultAgentProfile, "none")
+	driver := firstNonEmpty(assignment.DriverKind, role.DefaultDriverKind, projectwork.AssignmentDriverHecateTask)
+	sections := []string{
+		"Launch context",
+		"Project: " + labelWithID(project.Name, project.ID),
+		strings.Join([]string{
+			"Work item:",
+			"- Title: " + firstNonEmpty(workItem.Title, workItem.ID),
+			launchContextBullet("Brief", firstNonEmpty(workItem.Brief, "No brief recorded.")),
+			"- Status: " + firstNonEmpty(workItem.Status, "unknown"),
+			"- Priority: " + firstNonEmpty(workItem.Priority, "normal"),
+		}, "\n"),
+		strings.Join([]string{
+			"Assignment:",
+			"- ID: " + assignment.ID,
+			"- Status: " + firstNonEmpty(assignment.Status, projectwork.AssignmentStatusQueued),
+			"- Driver: " + driver,
+		}, "\n"),
+		strings.Join([]string{
+			"Role:",
+			"- Name: " + firstNonEmpty(role.Name, assignment.RoleID),
+			launchContextBullet("Description", firstNonEmpty(role.Description, "No description recorded.")),
+			launchContextBullet("Instructions", firstNonEmpty(role.Instructions, "No role instructions recorded.")),
+		}, "\n"),
+		strings.Join([]string{
+			"Execution hints:",
+			"- Driver: " + driver,
+			"- Provider: " + provider,
+			"- Model: " + model,
+			"- Profile: " + profile,
+			"- Role defaults: " + formatAssignmentHints([]assignmentHint{
+				{"driver", role.DefaultDriverKind},
+				{"provider", role.DefaultProvider},
+				{"model", role.DefaultModel},
+				{"profile", role.DefaultAgentProfile},
+			}),
+			"- Project defaults: " + formatAssignmentHints([]assignmentHint{
+				{"provider", project.DefaultProvider},
+				{"model", project.DefaultModel},
+				{"profile", project.DefaultAgentProfile},
+				{"workspace_mode", project.DefaultWorkspaceMode},
+			}),
+		}, "\n"),
+		"Request:\nExecute this assignment as a native agent_loop task. Keep outputs and artifacts linked to this work item.",
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func AssignmentSystemPrompt(project projects.Project, role projectwork.AgentRoleProfile, profile ResolvedAgentProfile, promptContext AssignmentPromptContext) string {
+	var parts []string
+	if prompt := strings.TrimSpace(project.DefaultSystemPrompt); prompt != "" {
+		parts = append(parts, "Project system prompt:\n"+prompt)
+	}
+	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" && !profile.Missing {
+		parts = append(parts, "Agent profile instructions:\n"+instructions)
+	}
+	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
+		parts = append(parts, "Role instructions:\n"+instructions)
+	} else if role.Name != "" {
+		parts = append(parts, "Act as the "+strings.TrimSpace(role.Name)+" for this project work assignment.")
+	}
+	if contextText := promptContext.SystemPrompt(); contextText != "" {
+		parts = append(parts, contextText)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func ExternalAgentConfigOptions(adapterID string, options map[string]string) ([]agentcontrols.ConfigOption, error) {
+	if len(options) == 0 {
+		return nil, nil
+	}
+	out := make([]agentcontrols.ConfigOption, 0, len(options))
+	for key, value := range options {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		option, ok := agentadapters.LaunchConfigOptionForSet(adapterID, key, value)
+		if !ok {
+			return nil, fmt.Errorf("external_agent_options.%s is not a launch option for %s", key, adapterID)
+		}
+		out = append(out, option)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+func ExternalAgentAssignmentTitle(workItem projectwork.WorkItem, role projectwork.AgentRoleProfile, adapter agentadapters.Adapter) string {
+	parts := []string{}
+	if title := strings.TrimSpace(workItem.Title); title != "" {
+		parts = append(parts, title)
+	}
+	if roleName := strings.TrimSpace(role.Name); roleName != "" {
+		parts = append(parts, roleName)
+	}
+	if adapter.Name != "" {
+		parts = append(parts, adapter.Name)
+	}
+	if len(parts) == 0 {
+		return "External Agent assignment"
+	}
+	return strings.Join(parts, " - ")
+}
+
+type promptContextBuilder struct {
+	Remaining int
+	ResultCtx AssignmentPromptContext
+}
+
+func (builder *promptContextBuilder) AppendMemory(entries []memory.Entry) {
+	for _, entry := range entries {
+		if builder.Remaining <= 0 {
+			builder.Warn("project memory prompt context budget exhausted; remaining memory entries were skipped")
+			return
+		}
+		title := firstNonEmpty(strings.TrimSpace(entry.Title), strings.TrimSpace(entry.ID))
+		body := strings.TrimSpace(entry.Body)
+		if body == "" {
+			continue
+		}
+		header := fmt.Sprintf("Project memory: %s\nID: %s\nTrust: %s", title, strings.TrimSpace(entry.ID), firstNonEmpty(strings.TrimSpace(entry.TrustLabel), "operator_memory"))
+		section, truncated := boundedPromptContextSection(header, body, assignmentPromptContextMemoryMaxBytes, &builder.Remaining)
+		if section == "" {
+			builder.Warn("project memory prompt context budget exhausted before " + strings.TrimSpace(entry.ID))
+			return
+		}
+		if truncated {
+			builder.ResultCtx.Truncated++
+			builder.Warn("project memory " + strings.TrimSpace(entry.ID) + " was truncated for prompt context")
+		}
+		builder.ResultCtx.IncludedMemory++
+		builder.ResultCtx.Sections = append(builder.ResultCtx.Sections, section)
+	}
+}
+
+func (builder *promptContextBuilder) AppendSources(project projects.Project, workingDirectory string) {
+	for _, source := range project.ContextSources {
+		if !source.Enabled {
+			continue
+		}
+		if builder.Remaining <= 0 {
+			builder.Warn("project source prompt context budget exhausted; remaining sources were skipped")
+			return
+		}
+		if !projectContextSourcePromptEligible(source) {
+			if strings.TrimSpace(source.Path) != "" {
+				builder.Warn("project source " + strings.TrimSpace(source.Path) + " is metadata-only for Hecate prompt context")
+			}
+			continue
+		}
+		rootPath := projectContextSourceRootPath(project, source, workingDirectory)
+		if strings.TrimSpace(rootPath) == "" {
+			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not resolve an active root")
+			continue
+		}
+		fsys, err := workspacefs.New(rootPath)
+		if err != nil {
+			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not open its workspace root")
+			continue
+		}
+		raw, _, err := fsys.ReadFile(source.Path)
+		if err != nil {
+			builder.Warn("project source " + strings.TrimSpace(source.Path) + " could not be read for prompt context")
+			continue
+		}
+		body := strings.TrimSpace(string(raw))
+		if body == "" {
+			continue
+		}
+		title := firstNonEmpty(strings.TrimSpace(source.Title), strings.TrimSpace(source.Path))
+		header := fmt.Sprintf("Workspace instruction: %s\nPath: %s\nTrust: %s", title, strings.TrimSpace(source.Path), firstNonEmpty(strings.TrimSpace(source.TrustLabel), "workspace_guidance"))
+		section, truncated := boundedPromptContextSection(header, body, assignmentPromptContextSourceMaxBytes, &builder.Remaining)
+		if section == "" {
+			builder.Warn("project source prompt context budget exhausted before " + strings.TrimSpace(source.Path))
+			return
+		}
+		if truncated {
+			builder.ResultCtx.Truncated++
+			builder.Warn("project source " + strings.TrimSpace(source.Path) + " was truncated for prompt context")
+		}
+		builder.ResultCtx.IncludedSources++
+		builder.ResultCtx.Sections = append(builder.ResultCtx.Sections, section)
+	}
+}
+
+func (builder *promptContextBuilder) Warn(warning string) {
+	warning = strings.TrimSpace(warning)
+	if warning == "" || len(builder.ResultCtx.Warnings) >= assignmentPromptContextMaxWarnings {
+		return
+	}
+	builder.ResultCtx.Warnings = append(builder.ResultCtx.Warnings, warning)
+}
+
+func (builder promptContextBuilder) Result() AssignmentPromptContext {
+	return builder.ResultCtx
+}
+
+func projectContextSourcePromptEligible(source projects.ContextSource) bool {
+	return strings.TrimSpace(source.Kind) == "workspace_instruction" && strings.TrimSpace(source.Format) == "agents_md"
+}
+
+func projectContextSourceRootPath(project projects.Project, source projects.ContextSource, fallback string) string {
+	rootID := ""
+	if source.Metadata != nil {
+		rootID = strings.TrimSpace(source.Metadata["root_id"])
+	}
+	if rootID != "" {
+		for _, root := range project.Roots {
+			if root.Active && strings.TrimSpace(root.ID) == rootID {
+				return strings.TrimSpace(root.Path)
+			}
+		}
+		return ""
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func boundedPromptContextSection(header, body string, itemMaxBytes int, remaining *int) (string, bool) {
+	if remaining == nil || *remaining <= 0 {
+		return "", false
+	}
+	header = strings.TrimSpace(header)
+	body = strings.TrimSpace(body)
+	if header == "" || body == "" {
+		return "", false
+	}
+	limit := itemMaxBytes
+	if *remaining < limit {
+		limit = *remaining
+	}
+	text := header + "\n" + body
+	text, truncated := truncatePromptContextText(text, limit)
+	if text == "" {
+		return "", truncated
+	}
+	*remaining -= len(text)
+	return text, truncated
+}
+
+func truncatePromptContextText(text string, maxBytes int) (string, bool) {
+	text = strings.TrimSpace(text)
+	if maxBytes <= 0 {
+		return "", text != ""
+	}
+	if len(text) <= maxBytes {
+		return text, false
+	}
+	if maxBytes <= len("\n[truncated]") {
+		return "", true
+	}
+	cut := maxBytes - len("\n[truncated]")
+	raw := []byte(text)
+	for cut > 0 && !utf8.Valid(raw[:cut]) {
+		cut--
+	}
+	if cut <= 0 {
+		return "", true
+	}
+	return strings.TrimSpace(string(raw[:cut])) + "\n[truncated]", true
+}
+
+type assignmentHint struct {
+	label string
+	value string
+}
+
+func formatAssignmentHints(items []assignmentHint) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		value := strings.TrimSpace(item.value)
+		if value == "" {
+			continue
+		}
+		parts = append(parts, item.label+"="+value)
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func labelWithID(label, id string) string {
+	label = strings.TrimSpace(label)
+	id = strings.TrimSpace(id)
+	if label != "" && id != "" {
+		return label + " (" + id + ")"
+	}
+	return firstNonEmpty(label, id)
+}
+
+func launchContextBullet(label, value string) string {
+	lines := strings.Split(strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"), "\n")
+	if len(lines) == 0 {
+		return "- " + label + ": "
+	}
+	if len(lines) == 1 {
+		return "- " + label + ": " + lines[0]
+	}
+	return "- " + label + ": " + lines[0] + "\n  " + strings.Join(lines[1:], "\n  ")
+}
+
+func effectiveProjectMemoryPolicy(policy string) string {
+	switch strings.TrimSpace(policy) {
+	case agentprofiles.MemoryInclude:
+		return agentprofiles.MemoryInclude
+	case agentprofiles.MemoryExclude:
+		return agentprofiles.MemoryExclude
+	case agentprofiles.MemoryVisibleOnly:
+		return agentprofiles.MemoryVisibleOnly
+	default:
+		return agentprofiles.MemoryVisibleOnly
+	}
+}
+
+func effectiveContextSourcePolicy(policy string) string {
+	switch strings.TrimSpace(policy) {
+	case agentprofiles.ContextIncludeEnabled:
+		return agentprofiles.ContextIncludeEnabled
+	case agentprofiles.ContextExclude:
+		return agentprofiles.ContextExclude
+	case agentprofiles.ContextVisibleOnly:
+		return agentprofiles.ContextVisibleOnly
+	default:
+		return agentprofiles.ContextVisibleOnly
+	}
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/projectworkapp/launch_plan_test.go
+++ b/internal/projectworkapp/launch_plan_test.go
@@ -1,0 +1,305 @@
+package projectworkapp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestApplication_ResolveTaskAssignmentLaunchPlanAppliesProfileHintsAndPromptContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "AGENTS.md"), []byte("Use focused launch tests."), 0o600); err != nil {
+		t.Fatalf("write workspace instruction: %v", err)
+	}
+
+	profiles := agentprofiles.NewMemoryStore()
+	if _, err := profiles.Create(ctx, agentprofiles.Profile{
+		ID:                  "prof_backend",
+		Name:                "Backend",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		Instructions:        "Prefer small backend slices.",
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-4o-mini",
+		ExecutionProfile:    "implementation",
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		SkillIDs:            []string{"backend"},
+	}); err != nil {
+		t.Fatalf("Create(profile) error = %v", err)
+	}
+	memories := memory.NewMemoryStore()
+	if _, err := memories.Create(ctx, memory.Entry{
+		ID:         "mem_1",
+		Scope:      memory.ScopeProject,
+		ProjectID:  "proj_1",
+		Title:      "Testing",
+		Body:       "Prefer focused tests.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create(memory) error = %v", err)
+	}
+	skills := projectskills.NewMemoryStore()
+	if _, err := skills.UpsertDiscovered(ctx, "proj_1", []projectskills.Skill{{
+		ID:         "backend",
+		Title:      "Backend",
+		Path:       ".hecate/skills/backend/SKILL.md",
+		Format:     projectskills.FormatSkillMD,
+		Enabled:    true,
+		Status:     projectskills.StatusAvailable,
+		TrustLabel: projectskills.TrustWorkspaceSkill,
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered() error = %v", err)
+	}
+	app := New(Options{
+		ProfileStore: profiles,
+		MemoryStore:  memories,
+		SkillStore:   skills,
+	})
+	project := launchPlanTestProject(workspace)
+	role := projectwork.AgentRoleProfile{
+		ID:                  "role_backend",
+		Name:                "Backend engineer",
+		Instructions:        "Keep the change reviewable.",
+		DefaultAgentProfile: "prof_backend",
+		SkillIDs:            []string{"missing_skill"},
+	}
+
+	plan, err := app.ResolveTaskAssignmentLaunchPlan(ctx, project, role)
+	if err != nil {
+		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v", err)
+	}
+	if plan.WorkingDirectory != workspace || plan.WorkspaceMode != "in_place" {
+		t.Fatalf("workspace = (%q, %q), want (%q, in_place)", plan.WorkingDirectory, plan.WorkspaceMode, workspace)
+	}
+	if plan.RequestedProvider != "openai" || plan.RequestedModel != "gpt-4o-mini" || plan.ExecutionProfile != "implementation" {
+		t.Fatalf("launch hints = provider %q model %q profile %q", plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile)
+	}
+	if plan.Profile.ID != "prof_backend" || plan.Profile.Source != "role_default" {
+		t.Fatalf("profile = %+v, want resolved role default", plan.Profile)
+	}
+	if plan.PromptContext.IncludedMemory != 1 || plan.PromptContext.IncludedSources != 1 {
+		t.Fatalf("prompt context = %+v, want one memory and one source", plan.PromptContext)
+	}
+	systemContext := plan.PromptContext.SystemPrompt()
+	if !strings.Contains(systemContext, "Prefer focused tests.") || !strings.Contains(systemContext, "Use focused launch tests.") {
+		t.Fatalf("system context = %q, want memory and workspace instruction", systemContext)
+	}
+	if got, want := plan.ResolvedSkills.Requested, []string{"missing_skill", "backend"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("requested skills = %#v, want %#v", got, want)
+	}
+	if len(plan.ResolvedSkills.Resolved) != 1 || plan.ResolvedSkills.Resolved[0].ID != "backend" {
+		t.Fatalf("resolved skills = %+v, want backend", plan.ResolvedSkills.Resolved)
+	}
+	if len(plan.ResolvedSkills.Skipped) != 1 || plan.ResolvedSkills.Skipped[0].ID != "missing_skill" {
+		t.Fatalf("skipped skills = %+v, want missing_skill", plan.ResolvedSkills.Skipped)
+	}
+
+	task := NewAssignmentTask("task_1", project, launchPlanTestWorkItem(), launchPlanTestAssignment(), role, plan, time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC))
+	if task.RequestedProvider != "openai" || task.RequestedModel != "gpt-4o-mini" || task.ExecutionProfile != "implementation" {
+		t.Fatalf("task launch hints = provider %q model %q profile %q", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
+	}
+	if task.WorkingDirectory != workspace || task.SandboxAllowedRoot != workspace || task.WorkspaceMode != "in_place" {
+		t.Fatalf("task workspace = %+v, want planned workspace", task)
+	}
+	if !strings.Contains(task.SystemPrompt, "Prefer focused tests.") || !strings.Contains(task.SystemPrompt, "Use focused launch tests.") {
+		t.Fatalf("task system prompt = %q, want prompt context", task.SystemPrompt)
+	}
+}
+
+func TestApplication_ResolveTaskAssignmentLaunchPlanRejectsMissingModel(t *testing.T) {
+	t.Parallel()
+
+	app := New(Options{})
+	_, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), projectwork.AgentRoleProfile{Name: "Builder"})
+	var launchErr LaunchPlanError
+	if !errors.As(err, &launchErr) || launchErr.Kind != LaunchPlanModelNotConfigured {
+		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v, want LaunchPlanModelNotConfigured", err)
+	}
+}
+
+func TestApplication_ResolveTaskAssignmentLaunchPlanUsesRuntimeDefaultModel(t *testing.T) {
+	t.Parallel()
+
+	app := New(Options{RuntimeDefaultModel: "runtime-default"})
+	plan, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), projectwork.AgentRoleProfile{Name: "Builder"})
+	if err != nil {
+		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v", err)
+	}
+	if plan.RequestedModel != "runtime-default" {
+		t.Fatalf("requested model = %q, want runtime-default", plan.RequestedModel)
+	}
+}
+
+func TestApplication_ResolveExternalAgentAssignmentLaunchPlanResolvesAdapter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	profiles := agentprofiles.NewMemoryStore()
+	if _, err := profiles.Create(ctx, agentprofiles.Profile{
+		ID:                  "prof_codex",
+		Name:                "Codex",
+		Surface:             agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:    "external_implementation",
+		ExternalAgentKind:   "codex",
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}); err != nil {
+		t.Fatalf("Create(profile) error = %v", err)
+	}
+	app := New(Options{ProfileStore: profiles})
+	role := projectwork.AgentRoleProfile{
+		ID:                  "role_ext",
+		Name:                "External implementer",
+		DefaultAgentProfile: "prof_codex",
+	}
+
+	plan, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, launchPlanTestProject(t.TempDir()), launchPlanTestWorkItem(), role)
+	if err != nil {
+		t.Fatalf("ResolveExternalAgentAssignmentLaunchPlan() error = %v", err)
+	}
+	adapter, _ := agentadapters.BuiltInByID("codex")
+	if plan.AdapterID != "codex" || plan.Adapter.ID != adapter.ID || plan.Adapter.Name != adapter.Name {
+		t.Fatalf("adapter = %+v, want codex", plan.Adapter)
+	}
+	if plan.ExecutionProfile != "external_implementation" {
+		t.Fatalf("execution profile = %q, want external_implementation", plan.ExecutionProfile)
+	}
+	for _, part := range []string{"Build feature", "External implementer", "Codex"} {
+		if !strings.Contains(plan.SessionTitle, part) {
+			t.Fatalf("session title = %q, missing %q", plan.SessionTitle, part)
+		}
+	}
+}
+
+func TestApplication_ResolveExternalAgentAssignmentLaunchPlanErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	workspace := t.TempDir()
+	project := launchPlanTestProject(workspace)
+	workItem := launchPlanTestWorkItem()
+
+	for _, tc := range []struct {
+		name    string
+		profile agentprofiles.Profile
+		want    string
+		adapter string
+	}{
+		{
+			name: "missing external kind",
+			profile: agentprofiles.Profile{
+				ID:      "prof_missing_kind",
+				Name:    "Missing kind",
+				Surface: agentprofiles.SurfaceExternalAgent,
+			},
+			want: LaunchPlanUnprocessable,
+		},
+		{
+			name: "unknown adapter",
+			profile: agentprofiles.Profile{
+				ID:                "prof_unknown_adapter",
+				Name:              "Unknown adapter",
+				Surface:           agentprofiles.SurfaceExternalAgent,
+				ExternalAgentKind: "does_not_exist",
+			},
+			want:    LaunchPlanAdapterNotFound,
+			adapter: "does_not_exist",
+		},
+		{
+			name: "unknown launch option",
+			profile: agentprofiles.Profile{
+				ID:                   "prof_bad_option",
+				Name:                 "Bad option",
+				Surface:              agentprofiles.SurfaceExternalAgent,
+				ExternalAgentKind:    "codex",
+				ExternalAgentOptions: map[string]string{"definitely_unknown": "x"},
+			},
+			want: LaunchPlanInvalidRequest,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			profiles := agentprofiles.NewMemoryStore()
+			if _, err := profiles.Create(ctx, tc.profile); err != nil {
+				t.Fatalf("Create(profile) error = %v", err)
+			}
+			app := New(Options{ProfileStore: profiles})
+			role := projectwork.AgentRoleProfile{
+				ID:                  "role_ext",
+				Name:                "External implementer",
+				DefaultAgentProfile: tc.profile.ID,
+			}
+			_, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+			var launchErr LaunchPlanError
+			if !errors.As(err, &launchErr) || launchErr.Kind != tc.want {
+				t.Fatalf("ResolveExternalAgentAssignmentLaunchPlan() error = %v, want %s", err, tc.want)
+			}
+			if launchErr.AdapterID != tc.adapter {
+				t.Fatalf("adapter id = %q, want %q", launchErr.AdapterID, tc.adapter)
+			}
+		})
+	}
+}
+
+func launchPlanTestProject(workspace string) projects.Project {
+	return projects.Project{
+		ID:                   "proj_1",
+		Name:                 "Hecate",
+		DefaultRootID:        "root_1",
+		DefaultWorkspaceMode: "in_place",
+		DefaultSystemPrompt:  "Follow project conventions.",
+		Roots: []projects.Root{{
+			ID:     "root_1",
+			Path:   workspace,
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:         "ctx_agents",
+			Kind:       "workspace_instruction",
+			Title:      "Agents",
+			Path:       "AGENTS.md",
+			Enabled:    true,
+			Format:     "agents_md",
+			TrustLabel: "workspace_guidance",
+		}},
+	}
+}
+
+func launchPlanTestWorkItem() projectwork.WorkItem {
+	return projectwork.WorkItem{
+		ID:       "work_1",
+		Title:    "Build feature",
+		Brief:    "Ship the feature.",
+		Status:   "ready",
+		Priority: "high",
+	}
+}
+
+func launchPlanTestAssignment() projectwork.Assignment {
+	return projectwork.Assignment{
+		ID:         "asgn_1",
+		WorkItemID: "work_1",
+		RoleID:     "role_backend",
+		Status:     projectwork.AssignmentStatusQueued,
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+	}
+}


### PR DESCRIPTION
## Summary

- move project assignment launch planning into internal/projectworkapp
- keep API handlers focused on HTTP parsing, error mapping, context packet projection, and response rendering
- add focused launch-plan tests for native task planning, runtime model fallback, prompt context, skill resolution, and External Agent adapter errors
- update backend agent guidance so future agents keep launch planning behind the projectworkapp seam

## Verification

- GOCACHE="$PWD/.gocache" go test ./internal/projectworkapp
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(PreflightAndStartShare|PreflightAssignment|PreflightExternal|StartAssignment|StartExternalAgentAssignment|AssignmentPromptIndents)'
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go test -tags e2e -run TestProjectAssignmentPreflightStartLaunchPlanE2E ./e2e
- just agent-docs-check
- just check-links
- git diff --check
- /Users/chicoxyzzy/dev/hecate/ui/node_modules/.bin/oxfmt --check on tracked markdown files
- GOCACHE="$PWD/.gocache" go vet ./internal/projectworkapp ./internal/api ./e2e/...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...

Note: just docs-format-check could not run directly in the fresh worktree because ui/node_modules is absent there; the equivalent markdown formatter check was run with the main checkout formatter.