### PR TITLE
Fix project identity duplicates and onboarding

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -230,7 +230,9 @@ tasks, or launch agents.
 In the operator UI, **Bootstrap project** is the project onboarding action, not a
 regular draft mode. It refreshes workspace guidance context sources, refreshes
 the project skills registry, then requests a project-scoped Bootstrap draft. The
-resulting proposal is still review/apply gated and does not attach to the
+Projects with a workspace root but no work items use Bootstrap as their primary
+onboarding action before showing the full work cockpit.
+The resulting proposal is still review/apply gated and does not attach to the
 currently selected work item.
 
 `draft_mode: "model"` asks the configured gateway model to author the proposal

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1214,6 +1214,9 @@ empty and at least one root is supplied, the first root becomes the default.
 When supplied, `default_root_id` must match one of the supplied roots.
 Context source `id` values are optional; Hecate generates `ctxsrc_...` IDs for
 sources that omit them. Context sources are metadata only in this release.
+Project names are unique across the local project catalog, and root/workspace
+paths are unique across all projects. Duplicate project names or root paths
+return `409 conflict`.
 
 Projects may be created without a workspace by omitting both `workspace_path`
 and `roots`. For the common one-workspace case, send `workspace_path` and
@@ -1275,7 +1278,9 @@ until narrower root endpoints exist.
 When `context_sources` is present, it replaces the full source-metadata list;
 use this for add/remove/reorder until narrower context-source endpoints exist.
 When `default_root_id` is supplied, it must match the replacement root list or,
-if `roots` is omitted, one of the existing roots.
+if `roots` is omitted, one of the existing roots. Renames and root replacements
+preserve the same catalog uniqueness rules as creation: duplicate project names
+or root paths return `409 conflict`.
 
 ```json
 PATCH /hecate/v1/projects/proj_...

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -286,6 +286,26 @@ func TestDirectHecateChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	}
 }
 
+func TestProjectChatPromptHelpersBoundUTF8Text(t *testing.T) {
+	remaining := 64
+	section, truncated := boundedPromptContextSection("Header", strings.Repeat("é", 80), 48, &remaining)
+	if !truncated {
+		t.Fatalf("truncated = false, want true")
+	}
+	if section == "" || !strings.HasSuffix(section, "\n[truncated]") {
+		t.Fatalf("section = %q, want truncated section", section)
+	}
+	if !utf8.ValidString(section) {
+		t.Fatalf("section is not valid UTF-8: %q", section)
+	}
+	if len(section) > 48 {
+		t.Fatalf("section length = %d, want <= 48", len(section))
+	}
+	if remaining != 64-len(section) {
+		t.Fatalf("remaining = %d, want %d", remaining, 64-len(section))
+	}
+}
+
 func TestChatSessionsProjectID(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	provider := &fakeProvider{name: "openai"}

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
@@ -142,4 +143,48 @@ func projectChatMemorySection(entry memory.Entry, remaining *int) (string, bool)
 		return "", false
 	}
 	return section, true
+}
+
+func boundedPromptContextSection(header, body string, itemMaxBytes int, remaining *int) (string, bool) {
+	if remaining == nil || *remaining <= 0 {
+		return "", false
+	}
+	header = strings.TrimSpace(header)
+	body = strings.TrimSpace(body)
+	if header == "" || body == "" {
+		return "", false
+	}
+	limit := itemMaxBytes
+	if *remaining < limit {
+		limit = *remaining
+	}
+	text := header + "\n" + body
+	text, truncated := truncatePromptContextText(text, limit)
+	if text == "" {
+		return "", truncated
+	}
+	*remaining -= len(text)
+	return text, truncated
+}
+
+func truncatePromptContextText(text string, maxBytes int) (string, bool) {
+	text = strings.TrimSpace(text)
+	if maxBytes <= 0 {
+		return "", text != ""
+	}
+	if len(text) <= maxBytes {
+		return text, false
+	}
+	if maxBytes <= len("\n[truncated]") {
+		return "", true
+	}
+	cut := maxBytes - len("\n[truncated]")
+	raw := []byte(text)
+	for cut > 0 && !utf8.Valid(raw[:cut]) {
+		cut--
+	}
+	if cut <= 0 {
+		return "", true
+	}
+	return strings.TrimSpace(string(raw[:cut])) + "\n[truncated]", true
 }

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -112,6 +112,10 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	if errors.Is(err, projects.ErrAlreadyExists) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return
+	}
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -255,6 +259,10 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if errors.Is(err, projects.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if errors.Is(err, projects.ErrAlreadyExists) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
 		return
 	}
 	if err != nil {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -166,6 +166,69 @@ func TestProjectsAPI_CreateWithWorkspacePathDefaultsRoot(t *testing.T) {
 	}
 }
 
+func TestProjectsAPI_RejectsDuplicateProjectIdentity(t *testing.T) {
+	t.Parallel()
+	server := newProjectsTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Hecate",
+		"workspace_path":"/tmp/hecate",
+		"workspace_kind":"git"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":" hecate ",
+		"workspace_path":"/tmp/other",
+		"workspace_kind":"git"
+	}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate name status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project name") {
+		t.Fatalf("duplicate name body = %s, want project name conflict", rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Runtime",
+		"workspace_path":"/tmp/hecate/",
+		"workspace_kind":"git"
+	}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate root status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project root path") {
+		t.Fatalf("duplicate root body = %s, want root path conflict", rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Other"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create other status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var other ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &other); err != nil {
+		t.Fatalf("decode other response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+other.Data.ID, bytes.NewReader([]byte(`{"name":"HECATE"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate rename status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+other.Data.ID, bytes.NewReader([]byte(`{"roots":[{"path":"/tmp/hecate/"}]}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate root patch status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectsAPI_CreateWithoutWorkspace(t *testing.T) {
 	t.Parallel()
 	server := newProjectsTestServer()

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -1234,6 +1234,8 @@ func mapProjectErr(err error) error {
 		return fmt.Errorf("%w: %v", ErrNotFound, err)
 	case errors.Is(err, projects.ErrInvalid):
 		return fmt.Errorf("%w: %v", ErrInvalid, err)
+	case errors.Is(err, projects.ErrAlreadyExists):
+		return fmt.Errorf("%w: %v", ErrConflict, err)
 	default:
 		return err
 	}

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1188,6 +1188,65 @@ func TestService_ApplyCreateProjectWorkspacePathAcrossStores(t *testing.T) {
 	}
 }
 
+func TestService_ApplyCreateProjectRejectsDuplicateIdentityAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			workspacePath := filepath.Join(t.TempDir(), "workspace")
+			if _, err := fixture.projects.Create(ctx, projects.Project{
+				ID:   "proj_existing",
+				Name: "Existing",
+				Roots: []projects.Root{{
+					ID:     "root_existing",
+					Path:   workspacePath,
+					Active: true,
+				}},
+			}); err != nil {
+				t.Fatalf("Create existing project: %v", err)
+			}
+
+			for _, tc := range []struct {
+				name  string
+				patch map[string]any
+			}{
+				{
+					name: "duplicate name",
+					patch: map[string]any{
+						"id":   "proj_duplicate_name",
+						"name": " existing ",
+					},
+				},
+				{
+					name: "duplicate workspace path",
+					patch: map[string]any{
+						"id":             "proj_duplicate_workspace",
+						"name":           "Duplicate workspace",
+						"workspace_path": workspacePath + string(filepath.Separator),
+						"workspace_kind": "git",
+					},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					_, err := fixture.service.Apply(ctx, Proposal{
+						ID:                   "pa_" + strings.ReplaceAll(tc.name, " ", "_"),
+						RequiresConfirmation: true,
+						Actions: []Action{{
+							Kind:  ActionCreateProject,
+							Patch: rawPatch(t, tc.patch),
+						}},
+					}, true)
+					if !errors.Is(err, ErrConflict) {
+						t.Fatalf("Apply err = %v, want ErrConflict", err)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestService_ApplyCreateProjectWithoutWorkspaceAcrossStores(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {

--- a/internal/projects/sqlite.go
+++ b/internal/projects/sqlite.go
@@ -159,6 +159,17 @@ func (s *SQLiteStore) Create(ctx context.Context, project Project) (Project, err
 	if err != nil {
 		return Project{}, err
 	}
+	if _, err := s.loadProjectWith(ctx, tx, project.ID); err == nil {
+		_ = tx.Rollback()
+		return Project{}, fmt.Errorf("%w: project id %q already exists", ErrAlreadyExists, project.ID)
+	} else if !errors.Is(err, ErrNotFound) {
+		_ = tx.Rollback()
+		return Project{}, err
+	}
+	if err := s.ensureProjectUniqueWith(ctx, tx, project, project.ID); err != nil {
+		_ = tx.Rollback()
+		return Project{}, err
+	}
 	if err := s.upsertProject(ctx, tx, project); err != nil {
 		_ = tx.Rollback()
 		return Project{}, err
@@ -283,6 +294,10 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Projec
 		_ = tx.Rollback()
 		return Project{}, err
 	}
+	if err := s.ensureProjectUniqueWith(ctx, tx, project, originalID); err != nil {
+		_ = tx.Rollback()
+		return Project{}, err
+	}
 	if err := s.upsertProject(ctx, tx, project); err != nil {
 		_ = tx.Rollback()
 		return Project{}, err
@@ -324,6 +339,62 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 		return ErrNotFound
 	}
 	return tx.Commit()
+}
+
+func (s *SQLiteStore) ensureProjectUniqueWith(ctx context.Context, q sqliteQuerier, project Project, currentID string) error {
+	currentID = strings.TrimSpace(currentID)
+	nameKey := projectNameKey(project.Name)
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(`SELECT id, name FROM %s`, s.projectsTbl))
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var id, name string
+		if err := rows.Scan(&id, &name); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if strings.TrimSpace(id) == currentID {
+			continue
+		}
+		if projectNameKey(name) == nameKey {
+			_ = rows.Close()
+			return fmt.Errorf("%w: project name %q already exists", ErrAlreadyExists, project.Name)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	rootPathKeys := projectRootPathKeys(project.Roots)
+	if len(rootPathKeys) == 0 {
+		return nil
+	}
+	rows, err = q.QueryContext(ctx, fmt.Sprintf(`SELECT project_id, path FROM %s`, s.rootsTbl))
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var projectID, path string
+		if err := rows.Scan(&projectID, &path); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if strings.TrimSpace(projectID) == currentID {
+			continue
+		}
+		if conflictPath, ok := rootPathKeys[projectRootPathKey(path)]; ok {
+			_ = rows.Close()
+			return fmt.Errorf("%w: project root path %q already belongs to project %q", ErrAlreadyExists, conflictPath, projectID)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	return rows.Err()
 }
 
 func (s *SQLiteStore) upsertProject(ctx context.Context, tx *sql.Tx, project Project) error {

--- a/internal/projects/sqlite_test.go
+++ b/internal/projects/sqlite_test.go
@@ -206,6 +206,74 @@ func TestSQLiteStore_UpdateRejectsProjectIDChange(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_RejectsDuplicateProjectIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteTestStore(t)
+	root := t.TempDir()
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		Roots: []Root{{
+			ID:     "root_alpha",
+			Path:   root,
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create alpha: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		project Project
+	}{
+		{
+			name:    "same id",
+			project: Project{ID: "proj_alpha", Name: "Beta"},
+		},
+		{
+			name:    "same name",
+			project: Project{ID: "proj_beta", Name: " alpha "},
+		},
+		{
+			name: "same root path",
+			project: Project{
+				ID:   "proj_beta",
+				Name: "Beta",
+				Roots: []Root{{
+					ID:     "root_beta",
+					Path:   root + string(filepath.Separator),
+					Active: true,
+				}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.Create(ctx, tc.project)
+			if !errors.Is(err, ErrAlreadyExists) {
+				t.Fatalf("Create duplicate error = %v, want ErrAlreadyExists", err)
+			}
+		})
+	}
+
+	if _, err := store.Create(ctx, Project{ID: "proj_gamma", Name: "Gamma"}); err != nil {
+		t.Fatalf("Create gamma: %v", err)
+	}
+	_, err := store.Update(ctx, "proj_gamma", func(item *Project) {
+		item.Name = "ALPHA"
+	})
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("Update duplicate name error = %v, want ErrAlreadyExists", err)
+	}
+	_, err = store.Update(ctx, "proj_gamma", func(item *Project) {
+		item.Roots = []Root{{ID: "root_gamma", Path: root + string(filepath.Separator), Active: true}}
+	})
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("Update duplicate root path error = %v, want ErrAlreadyExists", err)
+	}
+}
+
 func TestSQLiteStore_UpdatePreservesCreatedAt(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -347,6 +415,19 @@ func TestSQLiteStore_RejectsInvalidProject(t *testing.T) {
 	})
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Create invalid project error = %v, want ErrInvalid", err)
+	}
+
+	root := t.TempDir()
+	_, err = store.Create(ctx, Project{
+		ID:   "proj_duplicate_path",
+		Name: "Duplicate path",
+		Roots: []Root{
+			{ID: "root_one", Path: root, Active: true},
+			{ID: "root_two", Path: root + string(filepath.Separator), Active: true},
+		},
+	})
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create duplicate root path error = %v, want ErrInvalid", err)
 	}
 }
 

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -12,8 +14,9 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("project not found")
-	ErrInvalid  = errors.New("invalid project")
+	ErrNotFound      = errors.New("project not found")
+	ErrInvalid       = errors.New("invalid project")
+	ErrAlreadyExists = errors.New("project already exists")
 )
 
 type Project struct {
@@ -90,6 +93,12 @@ func (s *MemoryStore) Create(_ context.Context, project Project) (Project, error
 	if err := validateProject(project); err != nil {
 		return Project{}, err
 	}
+	if _, exists := s.projects[project.ID]; exists {
+		return Project{}, fmt.Errorf("%w: project id %q already exists", ErrAlreadyExists, project.ID)
+	}
+	if err := s.ensureProjectUnique(project, project.ID); err != nil {
+		return Project{}, err
+	}
 	s.projects[project.ID] = cloneProject(project)
 	return cloneProject(project), nil
 }
@@ -144,8 +153,29 @@ func (s *MemoryStore) Update(_ context.Context, id string, update func(*Project)
 	if err := validateProject(project); err != nil {
 		return Project{}, err
 	}
+	if err := s.ensureProjectUnique(project, originalID); err != nil {
+		return Project{}, err
+	}
 	s.projects[id] = cloneProject(project)
 	return cloneProject(project), nil
+}
+
+func (s *MemoryStore) ensureProjectUnique(project Project, currentID string) error {
+	currentID = strings.TrimSpace(currentID)
+	nameKey := projectNameKey(project.Name)
+	rootPathKeys := projectRootPathKeys(project.Roots)
+	for _, existing := range s.projects {
+		if strings.TrimSpace(existing.ID) == currentID {
+			continue
+		}
+		if projectNameKey(existing.Name) == nameKey {
+			return fmt.Errorf("%w: project name %q already exists", ErrAlreadyExists, project.Name)
+		}
+		if conflictPath, ok := firstConflictingRootPath(rootPathKeys, existing.Roots); ok {
+			return fmt.Errorf("%w: project root path %q already belongs to project %q", ErrAlreadyExists, conflictPath, existing.ID)
+		}
+	}
+	return nil
 }
 
 func (s *MemoryStore) Delete(_ context.Context, id string) error {
@@ -361,6 +391,7 @@ func validateProject(project Project) error {
 		return fmt.Errorf("%w: project name is required", ErrInvalid)
 	}
 	rootIDs := make(map[string]struct{}, len(project.Roots))
+	rootPaths := make(map[string]string, len(project.Roots))
 	for _, root := range project.Roots {
 		if root.ID == "" {
 			return fmt.Errorf("%w: project root id is required", ErrInvalid)
@@ -372,6 +403,11 @@ func validateProject(project Project) error {
 			return fmt.Errorf("%w: duplicate project root id %q", ErrInvalid, root.ID)
 		}
 		rootIDs[root.ID] = struct{}{}
+		pathKey := projectRootPathKey(root.Path)
+		if previous, exists := rootPaths[pathKey]; exists {
+			return fmt.Errorf("%w: duplicate project root path %q", ErrInvalid, previous)
+		}
+		rootPaths[pathKey] = root.Path
 	}
 	sourceIDs := make(map[string]struct{}, len(project.ContextSources))
 	for _, source := range project.ContextSources {
@@ -392,6 +428,56 @@ func validateProject(project Project) error {
 		}
 	}
 	return nil
+}
+
+func projectNameKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func projectRootPathKeys(roots []Root) map[string]string {
+	if len(roots) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(roots))
+	for _, root := range roots {
+		key := projectRootPathKey(root.Path)
+		if key == "" {
+			continue
+		}
+		if _, exists := out[key]; !exists {
+			out[key] = strings.TrimSpace(root.Path)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func firstConflictingRootPath(rootPathKeys map[string]string, roots []Root) (string, bool) {
+	if len(rootPathKeys) == 0 || len(roots) == 0 {
+		return "", false
+	}
+	for _, root := range roots {
+		if path, ok := rootPathKeys[projectRootPathKey(root.Path)]; ok {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func projectRootPathKey(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	// Keep project-root identity lexical so not-yet-created paths stay valid;
+	// this deliberately does not resolve symlinks or other mount aliases.
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		path = strings.ToLower(path)
+	}
+	return path
 }
 
 func hasRootID(roots []Root, id string) bool {

--- a/internal/projects/store_test.go
+++ b/internal/projects/store_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -166,6 +167,74 @@ func TestMemoryStore_UpdateRejectsProjectIDChange(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_RejectsDuplicateProjectIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	root := t.TempDir()
+	if _, err := store.Create(ctx, Project{
+		ID:   "proj_alpha",
+		Name: "Alpha",
+		Roots: []Root{{
+			ID:     "root_alpha",
+			Path:   root,
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create alpha: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		project Project
+	}{
+		{
+			name:    "same id",
+			project: Project{ID: "proj_alpha", Name: "Beta"},
+		},
+		{
+			name:    "same name",
+			project: Project{ID: "proj_beta", Name: " alpha "},
+		},
+		{
+			name: "same root path",
+			project: Project{
+				ID:   "proj_beta",
+				Name: "Beta",
+				Roots: []Root{{
+					ID:     "root_beta",
+					Path:   root + string(filepath.Separator),
+					Active: true,
+				}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.Create(ctx, tc.project)
+			if !errors.Is(err, ErrAlreadyExists) {
+				t.Fatalf("Create duplicate error = %v, want ErrAlreadyExists", err)
+			}
+		})
+	}
+
+	if _, err := store.Create(ctx, Project{ID: "proj_gamma", Name: "Gamma"}); err != nil {
+		t.Fatalf("Create gamma: %v", err)
+	}
+	_, err := store.Update(ctx, "proj_gamma", func(item *Project) {
+		item.Name = "ALPHA"
+	})
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("Update duplicate name error = %v, want ErrAlreadyExists", err)
+	}
+	_, err = store.Update(ctx, "proj_gamma", func(item *Project) {
+		item.Roots = []Root{{ID: "root_gamma", Path: root + string(filepath.Separator), Active: true}}
+	})
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("Update duplicate root path error = %v, want ErrAlreadyExists", err)
+	}
+}
+
 func TestMemoryStore_UpdatePreservesCreatedAt(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -324,6 +393,19 @@ func TestMemoryStore_RejectsInvalidProject(t *testing.T) {
 	})
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Create duplicate context source error = %v, want ErrInvalid", err)
+	}
+
+	root := t.TempDir()
+	_, err = store.Create(ctx, Project{
+		ID:   "proj_gamma",
+		Name: "Gamma",
+		Roots: []Root{
+			{ID: "root_one", Path: root, Active: true},
+			{ID: "root_two", Path: root + string(filepath.Separator), Active: true},
+		},
+	})
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Create duplicate root path error = %v, want ErrInvalid", err)
 	}
 }
 

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1043,8 +1043,9 @@ describe("ProjectsView index", () => {
     expect((await screen.findAllByText("Build cockpit UI")).length).toBeGreaterThan(0);
   });
 
-  it("keeps work coordination in the cockpit when the selected project has no work", async () => {
+  it("shows project onboarding before the selected project has work", async () => {
     resetProjectWorkMocks();
+    const user = userEvent.setup();
     vi.mocked(getProjectActivity).mockResolvedValue({
       object: "project_activity",
       data: emptyActivityData(),
@@ -1060,17 +1061,27 @@ describe("ProjectsView index", () => {
       wrapper: directWrapper({ projects: [project] }),
     });
 
-    expect(await screen.findByText("Work Queue")).toBeTruthy();
+    expect(await screen.findByRole("region", { name: "Project onboarding" })).toBeTruthy();
+    expect(screen.getByText("Set up Hecate")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Bootstrap project" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Projects" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open project Hecate" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Collapse projects panel" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Expand projects panel" })).toBeNull();
     expect(screen.queryByRole("region", { name: "Collapsed projects panel" })).toBeNull();
     expect(screen.queryByRole("region", { name: "Project work items" })).toBeNull();
-    const workPanel = screen.getByRole("region", { name: "Work coordination" });
-    expect(workPanel).toBeTruthy();
-    expect(screen.getByText("No work items for this project.")).toBeTruthy();
-    expect(within(workPanel).getByRole("button", { name: "Work" })).toBeTruthy();
+    expect(screen.queryByRole("tablist", { name: "Project workspace views" })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Work coordination" })).toBeNull();
+    expect(screen.queryByText("No work items for this project.")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Bootstrap project" }));
+    await waitFor(() => {
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        request: "Bootstrap project guidance",
+        draft_mode: "bootstrap",
+      });
+    });
   });
 
   it("keeps cockpit controls and work coordination in stable regions when work items exist", async () => {
@@ -1204,6 +1215,10 @@ describe("ProjectsView index", () => {
       wrapper: directWrapper({ projects: [] }),
     });
     expect(screen.getByText("No projects yet")).toBeTruthy();
+    expect(screen.getByText("Add a project to begin")).toBeTruthy();
+    expect(screen.queryByRole("tablist", { name: "Project workspace views" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Project settings" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Work" })).toBeNull();
     empty.unmount();
 
     render(<ProjectsView />, {
@@ -1546,10 +1561,14 @@ describe("ProjectsView cockpit", () => {
     expect(within(assistant).queryByLabelText("Project Assistant context")).toBeNull();
   });
 
-  it("drafts Project Assistant work proposals without an owner role when none exists", async () => {
+  it("routes empty projects through onboarding bootstrap before drafting work", async () => {
     resetProjectWorkMocks();
     vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_work_roles", data: [] });
     vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: emptyActivityData(),
+    });
     const user = userEvent.setup();
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
@@ -1558,18 +1577,17 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
-    await screen.findByText("No work items for this project.");
-    expect(within(assistant).getByText("Project queue")).toBeTruthy();
-    fireEvent.change(within(assistant).getByLabelText("Request"), {
-      target: { value: "Write project brief\nCapture the next operator task." },
-    });
-    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+    const onboarding = await screen.findByRole("region", { name: "Project onboarding" });
+    expect(within(onboarding).getByText("Set up Hecate")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Project Assistant" })).toBeNull();
+    expect(screen.queryByText("No work items for this project.")).toBeNull();
+    await user.click(within(onboarding).getByRole("button", { name: "Bootstrap project" }));
 
     await waitFor(() => {
       expect(draftProjectAssistant).toHaveBeenCalledWith({
         project_id: project.id,
-        request: "Write project brief\nCapture the next operator task.",
+        request: "Bootstrap project guidance",
+        draft_mode: "bootstrap",
       });
     });
   });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1498,6 +1498,18 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
 
   const hasWorkItemDetail =
     Boolean(selectedWorkItemID) || detailLoadState === "loading" || Boolean(detailError);
+  const projectNeedsOnboarding =
+    Boolean(selectedProject) &&
+    workLoadState === "loaded" &&
+    workItems.length === 0 &&
+    !assistantProposal &&
+    !assistantApplyResult;
+  const projectEmptyTitle =
+    projects.state.projects.length === 0 ? "Add a project to begin" : "Select a project";
+  const projectEmptyDetail =
+    projects.state.projects.length === 0
+      ? "Choose a workspace folder from the project list to create the first durable project record."
+      : "Choose a project from the list to view its work, memory, skills, and settings.";
 
   return (
     <div style={shellStyle}>
@@ -1601,203 +1613,234 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
         <div style={projectMainBodyStyle}>
           <section style={detailStyle} aria-label="Selected work item">
             <div className="project-cockpit-workspace" style={cockpitWorkspaceStyle}>
-              <section style={domainSectionStyle} aria-label="Project workspace">
-                <ProjectAssistantPanel
-                  applyResult={assistantApplyResult}
-                  bootstrapPending={assistantBootstrapPending}
-                  context={assistantContext}
-                  contextError={assistantContextError}
-                  contextStatus={assistantContextStatus}
-                  error={assistantError}
-                  onApply={() => void handleProjectAssistantApply()}
-                  onBootstrap={() => void handleProjectAssistantBootstrap()}
-                  onInspectContext={(form) => void handleProjectAssistantContext(form)}
-                  onDismiss={dismissProjectAssistantProposal}
-                  onPropose={(form) => void handleProjectAssistantPropose(form)}
-                  project={selectedProject}
-                  proposal={assistantProposal}
-                  roles={roles}
-                  status={assistantStatus}
-                  workItem={selectedWorkItem}
-                />
-                <ProjectWorkspaceTabs
-                  activeTab={workspaceTab}
-                  memoryCandidateCount={memoryCandidates.length}
-                  memoryEntryCount={memoryEntries.length}
-                  onChange={setWorkspaceTab}
-                  projectSkillCount={projectSkills.length}
-                  workItemCount={workItems.length}
-                />
-                {workspaceTab === "work" && (
-                  <section style={projectTabPanelStyle} aria-label="Work coordination">
-                    <section aria-label="Work activity" style={workActivityPanelStyle}>
-                      <SectionHeader
-                        title="Work Queue"
-                        detail={
-                          workLoadState === "loading" && workItems.length === 0
-                            ? "Loading project work..."
-                            : undefined
-                        }
-                        actions={
-                          <button
-                            className="btn btn-primary btn-sm"
-                            type="button"
-                            onClick={() => {
-                              setNewWorkError("");
-                              setNewWorkModalOpen(true);
-                            }}
-                            disabled={!selectedProject}
-                          >
-                            <Icon d={Icons.plus} size={13} />
-                            Work
-                          </button>
-                        }
+              {selectedProject ? (
+                <section style={domainSectionStyle} aria-label="Project workspace">
+                  {projectNeedsOnboarding ? (
+                    <ProjectOnboardingPanel
+                      bootstrapPending={assistantBootstrapPending}
+                      contextSourceCount={
+                        (selectedProject.context_sources ?? []).filter((source) => source.enabled)
+                          .length
+                      }
+                      onBootstrap={() => void handleProjectAssistantBootstrap()}
+                      onCreateWork={() => {
+                        setNewWorkError("");
+                        setNewWorkModalOpen(true);
+                      }}
+                      onOpenSettings={() => {
+                        setDefaultsError("");
+                        setSettingsPanelOpen(true);
+                      }}
+                      project={selectedProject}
+                      roleCount={roles.length}
+                      skillCount={projectSkills.length}
+                    />
+                  ) : (
+                    <>
+                      <ProjectAssistantPanel
+                        applyResult={assistantApplyResult}
+                        bootstrapPending={assistantBootstrapPending}
+                        context={assistantContext}
+                        contextError={assistantContextError}
+                        contextStatus={assistantContextStatus}
+                        error={assistantError}
+                        onApply={() => void handleProjectAssistantApply()}
+                        onBootstrap={() => void handleProjectAssistantBootstrap()}
+                        onInspectContext={(form) => void handleProjectAssistantContext(form)}
+                        onDismiss={dismissProjectAssistantProposal}
+                        onPropose={(form) => void handleProjectAssistantPropose(form)}
+                        project={selectedProject}
+                        proposal={assistantProposal}
+                        roles={roles}
+                        status={assistantStatus}
+                        workItem={selectedWorkItem}
                       />
-                      <ProjectActivityBucketTabs
-                        activity={activity}
-                        bucket={activityBucket}
-                        onBucketChange={setActivityBucket}
+                      <ProjectWorkspaceTabs
+                        activeTab={workspaceTab}
+                        memoryCandidateCount={memoryCandidates.length}
+                        memoryEntryCount={memoryEntries.length}
+                        onChange={setWorkspaceTab}
+                        projectSkillCount={projectSkills.length}
                         workItemCount={workItems.length}
                       />
-                    </section>
-                    {workError && <InlineError message={workError} />}
-                    <div
-                      className="project-work-coordination-grid"
-                      style={workCoordinationGridStyle}
-                    >
-                      <ProjectActivityInbox
-                        activity={activity}
-                        bucket={activityBucket}
-                        loading={workLoadState === "loading"}
-                        onSelectWorkItem={setSelectedWorkItemID}
-                        project={selectedProject}
-                        roleByID={roleByID}
-                        selectedWorkItemID={selectedWorkItemID}
-                        workItemSummaries={workItemSummaries}
-                        workItems={workItems}
-                      />
-                      <div style={workDetailColumnStyle}>
-                        {hasWorkItemDetail ? (
-                          <WorkItemDetail
-                            assignments={assignments}
-                            artifacts={artifacts}
-                            handoffActionID={handoffActionID}
-                            handoffError={handoffError}
-                            handoffs={handoffs}
-                            assignmentErrors={assignmentErrors}
-                            detailError={detailError}
-                            loading={detailLoadState === "loading"}
-                            onOpenTask={onOpenTask}
-                            onRefresh={refreshSelectedWorkItem}
-                            onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
-                            activityByAssignmentID={activityByAssignmentID}
-                            onDeleteHandoff={(handoff) => void handleDeleteHandoff(handoff)}
-                            onDeleteWorkItem={(item) => setDeleteWorkItem(item)}
-                            onEditHandoff={(handoff) => {
-                              setHandoffError("");
-                              setNewHandoffDraft(null);
-                              setEditingHandoff(handoff);
-                            }}
-                            onEditAssignment={(assignment) => {
-                              setEditAssignmentError("");
-                              setEditingAssignment(assignment);
-                            }}
-                            onEditWorkItem={(item) => {
-                              setEditWorkError("");
-                              setEditingWorkItem(item);
-                            }}
-                            onDeleteAssignment={(assignment) => setDeleteAssignment(assignment)}
-                            onOpenChat={onOpenChat}
-                            onStartAssignment={handleStartAssignment}
-                            onStartHandoff={(handoff) => void handleStartHandoff(handoff)}
-                            onSetHandoffStatus={(handoff, status) =>
-                              void handleSetHandoffStatus(handoff, status)
-                            }
-                            project={selectedProject}
-                            roleByID={roleByID}
-                            startingAssignmentID={startingAssignmentID}
-                            workItem={selectedWorkItem}
-                            onAddAssignment={() => {
-                              setNewAssignmentError("");
-                              setNewAssignmentModalOpen(true);
-                            }}
-                            onAddHandoff={() => {
-                              setHandoffError("");
-                              setNewHandoffDraft(null);
-                              setEditingHandoff("new");
-                            }}
-                            onAddHandoffFromAssignment={(assignment, activityItem) => {
-                              setHandoffError("");
-                              setNewHandoffDraft(
-                                handoffFormFromAssignment(
-                                  assignment,
-                                  roleByID.get(assignment.role_id) ?? null,
-                                  activityItem,
-                                ),
-                              );
-                              setEditingHandoff("new");
-                            }}
-                          />
-                        ) : (
-                          <EmptyBlock
-                            title={
-                              workLoadState === "loading" ? "Loading detail..." : "No work selected"
-                            }
-                            detail="Create or select a work item to manage assignments and collaboration artifacts."
-                          />
-                        )}
+                    </>
+                  )}
+                  {!projectNeedsOnboarding && workspaceTab === "work" && (
+                    <section style={projectTabPanelStyle} aria-label="Work coordination">
+                      <section aria-label="Work activity" style={workActivityPanelStyle}>
+                        <SectionHeader
+                          title="Work Queue"
+                          detail={
+                            workLoadState === "loading" && workItems.length === 0
+                              ? "Loading project work..."
+                              : undefined
+                          }
+                          actions={
+                            <button
+                              className="btn btn-primary btn-sm"
+                              type="button"
+                              onClick={() => {
+                                setNewWorkError("");
+                                setNewWorkModalOpen(true);
+                              }}
+                            >
+                              <Icon d={Icons.plus} size={13} />
+                              Work
+                            </button>
+                          }
+                        />
+                        <ProjectActivityBucketTabs
+                          activity={activity}
+                          bucket={activityBucket}
+                          onBucketChange={setActivityBucket}
+                          workItemCount={workItems.length}
+                        />
+                      </section>
+                      {workError && <InlineError message={workError} />}
+                      <div
+                        className="project-work-coordination-grid"
+                        style={workCoordinationGridStyle}
+                      >
+                        <ProjectActivityInbox
+                          activity={activity}
+                          bucket={activityBucket}
+                          loading={workLoadState === "loading"}
+                          onSelectWorkItem={setSelectedWorkItemID}
+                          project={selectedProject}
+                          roleByID={roleByID}
+                          selectedWorkItemID={selectedWorkItemID}
+                          workItemSummaries={workItemSummaries}
+                          workItems={workItems}
+                        />
+                        <div style={workDetailColumnStyle}>
+                          {hasWorkItemDetail ? (
+                            <WorkItemDetail
+                              assignments={assignments}
+                              artifacts={artifacts}
+                              handoffActionID={handoffActionID}
+                              handoffError={handoffError}
+                              handoffs={handoffs}
+                              assignmentErrors={assignmentErrors}
+                              detailError={detailError}
+                              loading={detailLoadState === "loading"}
+                              onOpenTask={onOpenTask}
+                              onRefresh={refreshSelectedWorkItem}
+                              onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
+                              activityByAssignmentID={activityByAssignmentID}
+                              onDeleteHandoff={(handoff) => void handleDeleteHandoff(handoff)}
+                              onDeleteWorkItem={(item) => setDeleteWorkItem(item)}
+                              onEditHandoff={(handoff) => {
+                                setHandoffError("");
+                                setNewHandoffDraft(null);
+                                setEditingHandoff(handoff);
+                              }}
+                              onEditAssignment={(assignment) => {
+                                setEditAssignmentError("");
+                                setEditingAssignment(assignment);
+                              }}
+                              onEditWorkItem={(item) => {
+                                setEditWorkError("");
+                                setEditingWorkItem(item);
+                              }}
+                              onDeleteAssignment={(assignment) => setDeleteAssignment(assignment)}
+                              onOpenChat={onOpenChat}
+                              onStartAssignment={handleStartAssignment}
+                              onStartHandoff={(handoff) => void handleStartHandoff(handoff)}
+                              onSetHandoffStatus={(handoff, status) =>
+                                void handleSetHandoffStatus(handoff, status)
+                              }
+                              project={selectedProject}
+                              roleByID={roleByID}
+                              startingAssignmentID={startingAssignmentID}
+                              workItem={selectedWorkItem}
+                              onAddAssignment={() => {
+                                setNewAssignmentError("");
+                                setNewAssignmentModalOpen(true);
+                              }}
+                              onAddHandoff={() => {
+                                setHandoffError("");
+                                setNewHandoffDraft(null);
+                                setEditingHandoff("new");
+                              }}
+                              onAddHandoffFromAssignment={(assignment, activityItem) => {
+                                setHandoffError("");
+                                setNewHandoffDraft(
+                                  handoffFormFromAssignment(
+                                    assignment,
+                                    roleByID.get(assignment.role_id) ?? null,
+                                    activityItem,
+                                  ),
+                                );
+                                setEditingHandoff("new");
+                              }}
+                            />
+                          ) : (
+                            <EmptyBlock
+                              title={
+                                workLoadState === "loading"
+                                  ? "Loading detail..."
+                                  : "No work selected"
+                              }
+                              detail="Create or select a work item to manage assignments and collaboration artifacts."
+                            />
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  </section>
-                )}
-                {workspaceTab === "timeline" && (
-                  <ProjectTimelinePanel
-                    activity={activity}
-                    artifacts={artifacts}
-                    handoffs={handoffs}
-                    memoryCandidates={memoryCandidates}
-                    memoryEntries={memoryEntries}
-                    onEditMemory={setEditingMemory}
-                    onOpenChat={onOpenChat}
-                    onOpenTask={onOpenTask}
-                    onSelectWorkItem={setSelectedWorkItemID}
-                    project={selectedProject}
-                    roles={roles}
-                    workItems={workItems}
-                  />
-                )}
-                {workspaceTab === "memory" && (
-                  <ProjectMemoryPanel
-                    candidates={memoryCandidates}
-                    discoveringContext={discoveringContext}
-                    entries={memoryEntries}
-                    error={memoryError}
-                    loading={memoryLoadState === "loading"}
-                    onDiscoverContextSources={handleDiscoverContextSources}
-                    onPromoteCandidate={setPromotingCandidate}
-                    onRejectCandidate={handleRejectCandidate}
-                    onDelete={setDeleteMemory}
-                    onEdit={setEditingMemory}
-                    onNew={() => setEditingMemory("new")}
-                    onRefresh={() => void loadProjectMemory(selectedProjectID)}
-                    project={selectedProject}
-                    rejectingCandidateID={rejectingCandidateID}
-                  />
-                )}
-                {workspaceTab === "skills" && (
-                  <ProjectSkillsPanel
-                    discovering={discoveringSkills}
-                    error={skillsError}
-                    loading={skillsLoadState === "loading"}
-                    onDiscover={handleDiscoverProjectSkills}
-                    onRefresh={() => void loadProjectSkills(selectedProjectID)}
-                    onUpdate={(skill, patch) => void handleUpdateProjectSkill(skill, patch)}
-                    project={selectedProject}
-                    skills={projectSkills}
-                    updatingSkillID={updatingSkillID}
-                  />
-                )}
-              </section>
+                    </section>
+                  )}
+                  {!projectNeedsOnboarding && workspaceTab === "timeline" && (
+                    <ProjectTimelinePanel
+                      activity={activity}
+                      artifacts={artifacts}
+                      handoffs={handoffs}
+                      memoryCandidates={memoryCandidates}
+                      memoryEntries={memoryEntries}
+                      onEditMemory={setEditingMemory}
+                      onOpenChat={onOpenChat}
+                      onOpenTask={onOpenTask}
+                      onSelectWorkItem={setSelectedWorkItemID}
+                      project={selectedProject}
+                      roles={roles}
+                      workItems={workItems}
+                    />
+                  )}
+                  {!projectNeedsOnboarding && workspaceTab === "memory" && (
+                    <ProjectMemoryPanel
+                      candidates={memoryCandidates}
+                      discoveringContext={discoveringContext}
+                      entries={memoryEntries}
+                      error={memoryError}
+                      loading={memoryLoadState === "loading"}
+                      onDiscoverContextSources={handleDiscoverContextSources}
+                      onPromoteCandidate={setPromotingCandidate}
+                      onRejectCandidate={handleRejectCandidate}
+                      onDelete={setDeleteMemory}
+                      onEdit={setEditingMemory}
+                      onNew={() => setEditingMemory("new")}
+                      onRefresh={() => void loadProjectMemory(selectedProjectID)}
+                      project={selectedProject}
+                      rejectingCandidateID={rejectingCandidateID}
+                    />
+                  )}
+                  {!projectNeedsOnboarding && workspaceTab === "skills" && (
+                    <ProjectSkillsPanel
+                      discovering={discoveringSkills}
+                      error={skillsError}
+                      loading={skillsLoadState === "loading"}
+                      onDiscover={handleDiscoverProjectSkills}
+                      onRefresh={() => void loadProjectSkills(selectedProjectID)}
+                      onUpdate={(skill, patch) => void handleUpdateProjectSkill(skill, patch)}
+                      project={selectedProject}
+                      skills={projectSkills}
+                      updatingSkillID={updatingSkillID}
+                    />
+                  )}
+                </section>
+              ) : (
+                <section aria-label="Project empty state" style={projectEmptyStateStyle}>
+                  <EmptyBlock title={projectEmptyTitle} detail={projectEmptyDetail} />
+                </section>
+              )}
             </div>
           </section>
 
@@ -2247,121 +2290,125 @@ function ProjectHeader({
           </div>
         )}
       </div>
-      <div aria-label="Project header actions" style={projectHeaderActionsStyle}>
-        <div ref={attentionMenu.wrapRef} style={projectAttentionMenuStyle}>
+      {project && (
+        <div aria-label="Project header actions" style={projectHeaderActionsStyle}>
+          <div ref={attentionMenu.wrapRef} style={projectAttentionMenuStyle}>
+            <button
+              ref={attentionMenu.triggerRef}
+              className="btn btn-ghost btn-sm"
+              type="button"
+              aria-expanded={attentionMenu.open}
+              aria-label={`Project attention${attentionCount > 0 ? `: ${attentionCount}` : ""}`}
+              title="Project attention"
+              onClick={attentionMenu.toggle}
+              disabled={!project}
+              style={{
+                ...projectHeaderActionButtonStyle,
+                color: attentionCount > 0 ? "var(--amber)" : "var(--t2)",
+              }}
+            >
+              <Icon d={Icons.warning} size={13} />
+              {attentionCount > 0 && (
+                <span style={projectAttentionCountStyle}>{attentionCount}</span>
+              )}
+            </button>
+            {attentionMenu.open && project && (
+              <div
+                ref={attentionMenu.menuRef}
+                role="menu"
+                aria-label="Project attention"
+                style={projectAttentionPopoverStyle}
+              >
+                <div style={projectAttentionPopoverHeaderStyle}>
+                  <div style={sectionLabelStyle}>Needs Attention</div>
+                  <span className="badge badge-muted">{attentionCount}</span>
+                </div>
+                {attentionItems.length === 0 ? (
+                  <div style={subtleTextStyle}>No project attention items detected.</div>
+                ) : (
+                  <div style={{ display: "grid", gap: 8 }}>
+                    {attentionItems.map((item) => (
+                      <ProjectHealthAttentionRow
+                        key={item.id}
+                        item={item}
+                        onActivate={() => handleAttentionAction(item)}
+                        onBucketChange={(bucket) => {
+                          onAttentionBucket(bucket);
+                          attentionMenu.close();
+                        }}
+                        onOpenTask={(taskID, runID) => {
+                          onAttentionTask?.(taskID, runID);
+                          attentionMenu.close();
+                        }}
+                        onReviewCandidate={(candidate) => {
+                          onAttentionReviewCandidate(candidate);
+                          attentionMenu.close();
+                        }}
+                        onSelectWorkItem={(workItemID) => {
+                          onAttentionWorkItem(workItemID);
+                          attentionMenu.close();
+                        }}
+                        reviewCandidate={memoryCandidates.find(
+                          (candidate) => candidate.id === item.candidateID,
+                        )}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
           <button
-            ref={attentionMenu.triggerRef}
             className="btn btn-ghost btn-sm"
             type="button"
-            aria-expanded={attentionMenu.open}
-            aria-label={`Project attention${attentionCount > 0 ? `: ${attentionCount}` : ""}`}
-            title="Project attention"
-            onClick={attentionMenu.toggle}
+            aria-label="Roles"
+            title="Project roles"
+            onClick={onManageRoles}
+            disabled={!project}
+            style={projectHeaderActionButtonStyle}
+          >
+            <Icon d={Icons.user} size={13} />
+          </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-label="Agent profiles"
+            title="Agent profiles"
+            onClick={onManageProfiles}
+            disabled={!project}
+            style={projectHeaderActionButtonStyle}
+          >
+            <Icon d={Icons.model} size={13} />
+          </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-expanded={settingsOpen}
+            aria-label="Project settings"
+            title="Project settings"
+            onClick={onEditDefaults}
             disabled={!project}
             style={{
               ...projectHeaderActionButtonStyle,
-              color: attentionCount > 0 ? "var(--amber)" : "var(--t2)",
+              background: settingsOpen ? "var(--teal-bg)" : "transparent",
+              color: settingsOpen ? "var(--teal)" : "var(--t2)",
             }}
           >
-            <Icon d={Icons.warning} size={13} />
-            {attentionCount > 0 && <span style={projectAttentionCountStyle}>{attentionCount}</span>}
+            <Icon d={Icons.settings} size={13} />
           </button>
-          {attentionMenu.open && project && (
-            <div
-              ref={attentionMenu.menuRef}
-              role="menu"
-              aria-label="Project attention"
-              style={projectAttentionPopoverStyle}
-            >
-              <div style={projectAttentionPopoverHeaderStyle}>
-                <div style={sectionLabelStyle}>Needs Attention</div>
-                <span className="badge badge-muted">{attentionCount}</span>
-              </div>
-              {attentionItems.length === 0 ? (
-                <div style={subtleTextStyle}>No project attention items detected.</div>
-              ) : (
-                <div style={{ display: "grid", gap: 8 }}>
-                  {attentionItems.map((item) => (
-                    <ProjectHealthAttentionRow
-                      key={item.id}
-                      item={item}
-                      onActivate={() => handleAttentionAction(item)}
-                      onBucketChange={(bucket) => {
-                        onAttentionBucket(bucket);
-                        attentionMenu.close();
-                      }}
-                      onOpenTask={(taskID, runID) => {
-                        onAttentionTask?.(taskID, runID);
-                        attentionMenu.close();
-                      }}
-                      onReviewCandidate={(candidate) => {
-                        onAttentionReviewCandidate(candidate);
-                        attentionMenu.close();
-                      }}
-                      onSelectWorkItem={(workItemID) => {
-                        onAttentionWorkItem(workItemID);
-                        attentionMenu.close();
-                      }}
-                      reviewCandidate={memoryCandidates.find(
-                        (candidate) => candidate.id === item.candidateID,
-                      )}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            aria-label="Refresh project work"
+            title="Refresh"
+            onClick={onRefresh}
+            disabled={!project}
+            style={projectHeaderActionButtonStyle}
+          >
+            <Icon d={Icons.refresh} size={13} />
+          </button>
         </div>
-        <button
-          className="btn btn-ghost btn-sm"
-          type="button"
-          aria-label="Roles"
-          title="Project roles"
-          onClick={onManageRoles}
-          disabled={!project}
-          style={projectHeaderActionButtonStyle}
-        >
-          <Icon d={Icons.user} size={13} />
-        </button>
-        <button
-          className="btn btn-ghost btn-sm"
-          type="button"
-          aria-label="Agent profiles"
-          title="Agent profiles"
-          onClick={onManageProfiles}
-          disabled={!project}
-          style={projectHeaderActionButtonStyle}
-        >
-          <Icon d={Icons.model} size={13} />
-        </button>
-        <button
-          className="btn btn-ghost btn-sm"
-          type="button"
-          aria-expanded={settingsOpen}
-          aria-label="Project settings"
-          title="Project settings"
-          onClick={onEditDefaults}
-          disabled={!project}
-          style={{
-            ...projectHeaderActionButtonStyle,
-            background: settingsOpen ? "var(--teal-bg)" : "transparent",
-            color: settingsOpen ? "var(--teal)" : "var(--t2)",
-          }}
-        >
-          <Icon d={Icons.settings} size={13} />
-        </button>
-        <button
-          className="btn btn-ghost btn-sm"
-          type="button"
-          aria-label="Refresh project work"
-          title="Refresh"
-          onClick={onRefresh}
-          disabled={!project}
-          style={projectHeaderActionButtonStyle}
-        >
-          <Icon d={Icons.refresh} size={13} />
-        </button>
-      </div>
+      )}
     </div>
   );
 }
@@ -2436,6 +2483,101 @@ function SectionHeader({
       </div>
       {actions && <div style={domainHeaderActionsStyle}>{actions}</div>}
     </div>
+  );
+}
+
+function ProjectOnboardingPanel({
+  bootstrapPending,
+  contextSourceCount,
+  onBootstrap,
+  onCreateWork,
+  onOpenSettings,
+  project,
+  roleCount,
+  skillCount,
+}: {
+  bootstrapPending: boolean;
+  contextSourceCount: number;
+  onBootstrap: () => void;
+  onCreateWork: () => void;
+  onOpenSettings: () => void;
+  project: ProjectRecord;
+  roleCount: number;
+  skillCount: number;
+}) {
+  const hasRoot = project.roots.some((root) => root.active !== false && root.path);
+  const hasDefaults = Boolean(project.default_provider && project.default_model);
+  const hasGuidance = contextSourceCount > 0 || skillCount > 0;
+  const checks = [
+    {
+      label: "Workspace root",
+      detail: hasRoot ? projectDefaultWorkspace(project) || "Ready" : "Missing",
+      done: hasRoot,
+    },
+    {
+      label: "Provider and model",
+      detail: hasDefaults ? `${project.default_provider} / ${project.default_model}` : "Not set",
+      done: hasDefaults,
+    },
+    {
+      label: "Guidance and skills",
+      detail: `${contextSourceCount} sources · ${skillCount} skills`,
+      done: hasGuidance,
+    },
+    {
+      label: "Roles and first work",
+      detail: `${roleCount} roles · no work items`,
+      done: false,
+    },
+  ];
+  return (
+    <section aria-label="Project onboarding" style={projectOnboardingStyle}>
+      <div style={projectOnboardingCopyStyle}>
+        <div>
+          <div style={sectionLabelStyle}>Project Onboarding</div>
+          <div style={projectOnboardingTitleStyle}>Set up {project.name}</div>
+        </div>
+        <div style={projectOnboardingDetailStyle}>
+          Create reviewable setup actions from this workspace: roles, guidance, skills, and first
+          work.
+        </div>
+        <div style={projectOnboardingActionsStyle}>
+          <button
+            className="btn btn-primary btn-sm"
+            type="button"
+            disabled={bootstrapPending}
+            onClick={onBootstrap}
+          >
+            <Icon d={Icons.refresh} size={13} />
+            {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
+          </button>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onCreateWork}>
+            <Icon d={Icons.plus} size={13} />
+            Create work
+          </button>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenSettings}>
+            <Icon d={Icons.settings} size={13} />
+            Project settings
+          </button>
+        </div>
+      </div>
+      <div style={projectOnboardingChecklistStyle}>
+        {checks.map((check) => (
+          <div key={check.label} style={projectOnboardingCheckStyle}>
+            <span
+              className={check.done ? "badge badge-green" : "badge badge-muted"}
+              style={projectOnboardingCheckBadgeStyle}
+            >
+              {check.done ? "ready" : "todo"}
+            </span>
+            <div style={{ minWidth: 0 }}>
+              <div style={titleStyle}>{check.label}</div>
+              <div style={subtleTextStyle}>{check.detail}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -7344,6 +7486,75 @@ const cockpitWorkspaceStyle: CSSProperties = {
   alignItems: "start",
   minWidth: 0,
   padding: 14,
+};
+
+const projectEmptyStateStyle: CSSProperties = {
+  alignItems: "center",
+  display: "grid",
+  minHeight: "min(520px, calc(100vh - 160px))",
+  placeItems: "center",
+};
+
+const projectOnboardingStyle: CSSProperties = {
+  ...panelStyle,
+  alignItems: "start",
+  display: "grid",
+  gap: 18,
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+  minHeight: "min(420px, calc(100vh - 180px))",
+  padding: 20,
+};
+
+const projectOnboardingCopyStyle: CSSProperties = {
+  alignContent: "center",
+  display: "grid",
+  gap: 16,
+  minHeight: 260,
+  minWidth: 0,
+};
+
+const projectOnboardingTitleStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: 20,
+  fontWeight: 650,
+  lineHeight: 1.2,
+  marginTop: 8,
+};
+
+const projectOnboardingDetailStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 13,
+  lineHeight: 1.45,
+  maxWidth: 520,
+};
+
+const projectOnboardingActionsStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+};
+
+const projectOnboardingChecklistStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  minWidth: 0,
+};
+
+const projectOnboardingCheckStyle: CSSProperties = {
+  alignItems: "center",
+  background: "var(--bg0)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 10,
+  gridTemplateColumns: "auto minmax(0, 1fr)",
+  minWidth: 0,
+  padding: 10,
+};
+
+const projectOnboardingCheckBadgeStyle: CSSProperties = {
+  justifySelf: "start",
+  textTransform: "uppercase",
 };
 
 const projectWorkspaceTabsStyle: CSSProperties = {


### PR DESCRIPTION
## Summary

- Reject duplicate project identities across memory and sqlite stores by checking project IDs, case-insensitive project names, and normalized root/workspace paths.
- Return `409 conflict` for duplicate project create/update calls and propagate duplicate Project Assistant create-project actions as conflicts.
- Improve Projects UI empty states: hide project workspace/settings controls before a project exists, and show a Bootstrap-first onboarding panel for a selected project with no work.
- Add the missing API prompt-bounding helpers after rebasing onto the latest chat guidance changes, with UTF-8-safe truncation coverage.

## Validation

- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/projects ./internal/api ./internal/projectassistant`
- `go vet ./internal/projects ./internal/api ./internal/projectassistant`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `just agent-docs-check`
- `oxfmt --check ui/src/features/projects/ProjectsView.tsx ui/src/features/projects/ProjectsView.test.tsx docs/runtime/project-assistant.md docs/runtime/runtime-api.md`
- `git diff --check`
