### PR TITLE
Add project-aware context hints to Hecate Chat

### DIFF
--- a/docs/runtime/agent-runtime.md
+++ b/docs/runtime/agent-runtime.md
@@ -20,12 +20,13 @@ Providers without streaming fall back to the normal non-streaming chat call.
 
 When a Hecate Chat session is linked to a project, Hecate keeps the Chat UI
 simple and injects project workflow guidance into the effective system prompt
-for project-linked turns. The prompt uses the same project, role, and memory
-vocabulary as project assignment launch context, and tells the model to treat
-planning/assignment/handoff/memory requests as proposal-only Project Assistant
-intent. It does not grant Chat or the agent loop direct authority to
-create/start project records, tasks, runs, chats, external-agent sessions, or
-promoted memory.
+for project-linked turns. The prompt uses the same project, role, skill,
+current-work, and accepted-memory vocabulary as project assignment launch
+context, and tells the model to treat planning/assignment/handoff/memory
+requests as proposal-only Project Assistant intent. Skill entries are metadata
+only; `SKILL.md` bodies are not injected by the simple chat path. The guidance
+does not grant Chat or the agent loop direct authority to create/start project
+records, tasks, runs, chats, external-agent sessions, or promoted memory.
 
 **Invariant: one chat, many segments, one active task-backed loop.** A single
 Hecate Chat session can carry an arbitrary history of segments — alternating

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -86,16 +86,17 @@ visible transcript message count for that turn, the legacy high-level
 `sources`, and itemized `items` with `kind`, `trust_level`, `origin`, `title`,
 optional `body` / `body_ref`, `included`, and `inclusion_reason`. Current items
 cover visible metadata only: system prompt presence, transcript count, enabled
-project context-source metadata, workspace path metadata, Hecate task-runtime
-state, and external-agent session metadata. It deliberately does not persist
-full system prompts, raw transcript text, file contents, or agent-private prompt
-packing. External Agent packets explicitly note that Hecate can show adapter
-metadata and transcript rows it receives but cannot inspect the agent's private
-prompt or packed model context. The message count is an operator-facing
-transcript count, not a provider token count or a guarantee that every counted
-message was packed into the provider or agent prompt. Context packets are
-snapshots on assistant messages; changing project context sources later does
-not rewrite old message packets.
+project context-source metadata, enabled project skill metadata, current
+project work metadata, accepted project memory, workspace path metadata, Hecate
+task-runtime state, and external-agent session metadata. It deliberately does
+not persist full system prompts, raw transcript text, file contents, `SKILL.md`
+bodies, or agent-private prompt packing. External Agent packets explicitly note
+that Hecate can show adapter metadata and transcript rows it receives but cannot
+inspect the agent's private prompt or packed model context. The message count is
+an operator-facing transcript count, not a provider token count or a guarantee
+that every counted message was packed into the provider or agent prompt. Context
+packets are snapshots on assistant messages; changing project context sources,
+skills, or work records later does not rewrite old message packets.
 
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -486,16 +486,17 @@ to author the same typed proposal shape.
 Hecate Chat stays visually simple. Project-linked Hecate Chat turns receive
 hidden project workflow guidance and bounded project context so the model can
 infer when an operator is asking for planning, assignment, handoff, or memory
-work. That guidance uses the same project, role, and accepted-memory vocabulary
-as project assignment launch context, so Chat and project agents share one
-mental model without adding controls to the conversation view. It tells the
-model to treat durable project changes as Project Assistant proposal intent,
-not as permission to mutate project stores through generic tools or direct API
-calls. If the selected chat model routes to a cloud provider, that bounded
-project prompt context follows the normal model gateway route. A future
-chat-side proposal tool or slash-command shortcut can call the same Project
-Assistant APIs, but durable mutations must still stop at the explicit
-review/apply card.
+work. That guidance uses the same project, role, enabled skill metadata,
+current work-state, and accepted-memory vocabulary as project assignment launch
+context, so Chat and project agents share one mental model without adding
+controls to the conversation view. Skill entries remain metadata only; Chat does
+not load or inject `SKILL.md` bodies. It tells the model to treat durable
+project changes as Project Assistant proposal intent, not as permission to
+mutate project stores through generic tools or direct API calls. If the selected
+chat model routes to a cloud provider, that bounded project prompt context
+follows the normal model gateway route. A future chat-side proposal tool or
+slash-command shortcut can call the same Project Assistant APIs, but durable
+mutations must still stop at the explicit review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
 project list, project work, selected work-item detail, and project memory.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2766,10 +2766,11 @@ the user message and assistant output.
 - `system_prompt` — applied to tools-off turns and new task-backed Hecate Chat
   segments. When the chat is linked to a project, Hecate prepends hidden
   project workflow guidance and bounded project context before the operator
-  prompt. That guidance uses the same project/role/memory vocabulary as
-  project assignment launch context and keeps Chat conversational while telling
-  the model to treat project-planning intent as proposal-only Project
-  Assistant work; it does not grant direct project mutation rights. If the
+  prompt. That guidance uses the same project/role/skill/current-work/memory
+  vocabulary as project assignment launch context and keeps Chat conversational
+  while telling the model to treat project-planning intent as proposal-only
+  Project Assistant work; it does not grant direct project mutation rights.
+  Skill entries are metadata only and do not inject `SKILL.md` bodies. If the
   selected model routes to a cloud provider, the bounded project prompt context
   is sent through the normal model gateway route like any other chat prompt.
 - `workspace` — required when starting a task-backed Hecate Chat turn
@@ -3035,11 +3036,11 @@ snapshot does not expose the full system prompt text.
 Section values currently used by the runtime are:
 
 - `instructions` for system-prompt, prompt-context, and instruction-layer metadata
-- `skills` for resolved and skipped project skill metadata; `SKILL.md` bodies are not included
+- `skills` for resolved, skipped, or chat-visible project skill metadata; `SKILL.md` bodies are not included
 - `memory` for project memory entries
 - `workspace` for the selected workspace path
 - `project` for project identity metadata
-- `project_work` for work-item, assignment, role, execution-hint, handoff, and artifact-reference metadata
+- `project_work` for chat-visible current work metadata and assignment launch work-item, assignment, role, execution-hint, handoff, and artifact-reference metadata
 - `sources` for enabled project context-source metadata such as `workspace_doc` and `project_notes`
 - `runtime` for transcript counts, task-runtime metadata, and external-agent session metadata
 

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -221,6 +221,8 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	populateProjectRefs(&packet, session.ProjectID)
 	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
+	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), true, "Enabled project skill metadata for this direct model turn; skill bodies are not injected")
+	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), true, "Current project work metadata for this direct model turn")
 	if packet.SystemPromptIncluded {
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
@@ -266,6 +268,8 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	packet.ExecutionProfile = "chat_agent"
 	populateProjectRefs(&packet, session.ProjectID)
 	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
+	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), true, "Enabled project skill metadata for this task-backed turn; skill bodies are not injected")
+	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), true, "Current project work metadata for this task-backed turn")
 	if packet.SystemPromptIncluded {
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
@@ -613,6 +617,48 @@ func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment pro
 
 func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
 	appendProjectMemoryWithInclusion(packet, entries, true, "Enabled project memory entry")
+}
+
+func appendProjectChatSkills(packet *chat.ContextPacket, skills []projectskills.Skill, included bool, reason string) {
+	body := projectChatSkillHintText(skills, projectChatPromptSkillMaxItems)
+	if body == "" {
+		return
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionSkills, chat.ContextSource{
+		Kind:   "project_skills",
+		Label:  "Project skills",
+		Detail: fmt.Sprintf("%d enabled", len(skills)),
+		Trust:  projectskills.TrustWorkspaceSkill,
+	}, chat.ContextItem{
+		Kind:            "project_skills",
+		TrustLevel:      projectskills.TrustWorkspaceSkill,
+		Origin:          "project_skills",
+		Title:           "Project skills",
+		Body:            body,
+		Included:        included,
+		InclusionReason: reason,
+	})
+}
+
+func appendProjectChatWork(packet *chat.ContextPacket, snapshot projectChatWorkSnapshot, included bool, reason string) {
+	body := projectChatWorkHintText(snapshot, projectChatPromptWorkMaxItems, projectChatPromptAssignmentMaxItems)
+	if body == "" {
+		return
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "project_work",
+		Label:  "Project work",
+		Detail: fmt.Sprintf("%d work items, %d assignments", len(snapshot.WorkItems), len(snapshot.Assignments)),
+		Trust:  contextTrustProject,
+	}, chat.ContextItem{
+		Kind:            "project_work",
+		TrustLevel:      contextTrustProject,
+		Origin:          "project_work",
+		Title:           "Project work",
+		Body:            body,
+		Included:        included,
+		InclusionReason: reason,
+	})
 }
 
 func appendProjectMemoryForProfilePolicy(packet *chat.ContextPacket, entries []memory.Entry, profile projectworkapp.ResolvedAgentProfile) {

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -199,6 +201,110 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 			}
 			if findContextItemByOrigin(tc.packet, "mem_disabled") != nil {
 				t.Fatalf("disabled memory was included: %+v", tc.packet.Items)
+			}
+		})
+	}
+}
+
+func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
+	ctx := context.Background()
+	skillStore := projectskills.NewMemoryStore()
+	if _, err := skillStore.UpsertDiscovered(ctx, "proj_1", []projectskills.Skill{
+		{
+			ID:          "backend",
+			ProjectID:   "proj_1",
+			Title:       "Backend Skill",
+			Description: "Build backend changes.",
+			Path:        ".hecate/skills/backend/SKILL.md",
+			Enabled:     true,
+		},
+		{
+			ID:          "disabled",
+			ProjectID:   "proj_1",
+			Title:       "Disabled Skill",
+			Description: "Do not include.",
+			Path:        ".hecate/skills/disabled/SKILL.md",
+			Enabled:     false,
+		},
+	}); err != nil {
+		t.Fatalf("UpsertDiscovered skills: %v", err)
+	}
+	workStore := projectwork.NewMemoryStore()
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:          "work_chat",
+		ProjectID:   "proj_1",
+		Title:       "Project chat context",
+		Brief:       "Make linked chat aware of project work state.",
+		Status:      projectwork.WorkItemStatusReady,
+		Priority:    "high",
+		OwnerRoleID: "architect",
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_chat",
+		ProjectID:  "proj_1",
+		WorkItemID: "work_chat",
+		RoleID:     "architect",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	handler := &Handler{projectSkills: skillStore, projectWork: workStore}
+	session := chat.Session{
+		ID:        "chat_1",
+		ProjectID: "proj_1",
+		Workspace: "/tmp/hecate",
+		Messages:  []chat.Message{{ID: "u1", Role: "user", Content: "first"}},
+	}
+
+	packets := []struct {
+		name   string
+		packet chat.ContextPacket
+	}{
+		{
+			name:   "direct model",
+			packet: handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", ""),
+		},
+		{
+			name:   "hecate task",
+			packet: handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "", false),
+		},
+	}
+
+	for _, tc := range packets {
+		t.Run(tc.name, func(t *testing.T) {
+			skills := findContextItem(tc.packet, "project_skills")
+			if skills == nil {
+				t.Fatalf("project skills item not found: %+v", tc.packet.Items)
+			}
+			if skills.TrustLevel != projectskills.TrustWorkspaceSkill || !skills.Included {
+				t.Fatalf("project skills item = %+v, want included workspace skill metadata", *skills)
+			}
+			if !strings.Contains(skills.Body, "Backend Skill (backend): Build backend changes. Path: .hecate/skills/backend/SKILL.md") {
+				t.Fatalf("project skills body = %q, want backend metadata", skills.Body)
+			}
+			if strings.Contains(skills.Body, "Disabled Skill") {
+				t.Fatalf("project skills body included disabled skill: %q", skills.Body)
+			}
+
+			work := findContextItem(tc.packet, "project_work")
+			if work == nil {
+				t.Fatalf("project work item not found: %+v", tc.packet.Items)
+			}
+			if work.TrustLevel != contextTrustProject || !work.Included {
+				t.Fatalf("project work item = %+v, want included project work metadata", *work)
+			}
+			for _, want := range []string{
+				"Work item status counts: ready=1",
+				"Work item Project chat context (work_chat): status=ready, priority=high, owner_role=architect",
+				"Brief: Make linked chat aware of project work state.",
+				"Assignment asgn_chat: work_item=work_chat, role=architect, status=queued, driver=hecate_task",
+			} {
+				if !strings.Contains(work.Body, want) {
+					t.Fatalf("project work body missing %q:\n%s", want, work.Body)
+				}
 			}
 		})
 	}

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/taskstate"
@@ -189,6 +190,39 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create role: %v", err)
 	}
+	if _, err := apiHandler.projectSkills.UpsertDiscovered(context.Background(), project.ID, []projectskills.Skill{
+		{
+			ID:          "backend",
+			ProjectID:   project.ID,
+			Title:       "Backend Skill",
+			Description: "Backend changes.",
+			Path:        ".hecate/skills/backend/SKILL.md",
+			Enabled:     true,
+		},
+	}); err != nil {
+		t.Fatalf("UpsertDiscovered skills: %v", err)
+	}
+	if _, err := apiHandler.projectWork.CreateWorkItem(context.Background(), projectwork.WorkItem{
+		ID:          "work_chat_context",
+		ProjectID:   project.ID,
+		Title:       "Implement chat context",
+		Brief:       "Teach linked chat about project skills and work state.",
+		Status:      projectwork.WorkItemStatusReady,
+		Priority:    "high",
+		OwnerRoleID: "architect",
+	}); err != nil {
+		t.Fatalf("Create work item: %v", err)
+	}
+	if _, err := apiHandler.projectWork.CreateAssignment(context.Background(), projectwork.Assignment{
+		ID:         "asgn_plan",
+		ProjectID:  project.ID,
+		WorkItemID: "work_chat_context",
+		RoleID:     "architect",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+	}); err != nil {
+		t.Fatalf("Create assignment: %v", err)
+	}
 	if _, err := apiHandler.memory.Create(context.Background(), memory.Entry{
 		ID:         "mem_boundary",
 		Scope:      memory.ScopeProject,
@@ -225,6 +259,15 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 		"Assignments proposed from chat must stay queued and unstarted.",
 		"Role hints:",
 		"A Project Planner (role_planner): Shapes reviewable project work.",
+		"Project skills (metadata only; skill bodies are not loaded):",
+		"Backend Skill (backend): Backend changes. Path: .hecate/skills/backend/SKILL.md",
+		"Use skills as procedures/guidance, not as role assignments.",
+		"Project work snapshot:",
+		"Work item status counts: ready=1",
+		"- Work item Implement chat context (work_chat_context): status=ready, priority=high, owner_role=architect",
+		"Brief: Teach linked chat about project skills and work state.",
+		"Assignments:",
+		"- Assignment asgn_plan: work_item=work_chat_context, role=architect, status=queued, driver=hecate_task",
 		"Accepted project memory:",
 		"Project memory: Project Assistant boundary\nID: mem_boundary\nTrust: operator_memory",
 		"Project changes should be drafted as typed proposals and applied only after operator review.",

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -10,13 +10,19 @@ import (
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 const (
-	projectChatPromptMaxBytes       = 6 * 1024
-	projectChatPromptMemoryMaxItems = 4
-	projectChatPromptMemoryMaxBytes = 1024
-	projectChatPromptRoleMaxItems   = 8
+	projectChatPromptMaxBytes           = 6 * 1024
+	projectChatPromptMemoryMaxItems     = 4
+	projectChatPromptMemoryMaxBytes     = 1024
+	projectChatPromptRoleMaxItems       = 8
+	projectChatPromptSkillMaxItems      = 6
+	projectChatPromptWorkMaxItems       = 6
+	projectChatPromptAssignmentMaxItems = 8
+	projectChatPromptInlineMaxRunes     = 220
 )
 
 func (h *Handler) hecateChatEffectiveSystemPrompt(ctx context.Context, session chat.Session, operatorPrompt string) string {
@@ -53,6 +59,12 @@ func (h *Handler) projectChatWorkflowSystemPrompt(ctx context.Context, session c
 	sections := []string{projectChatWorkflowBoundary(*project)}
 	if roles := h.projectChatRoleHints(ctx, project.ID); roles != "" {
 		sections = append(sections, roles)
+	}
+	if skills := h.projectChatSkillHints(ctx, project.ID); skills != "" {
+		sections = append(sections, skills)
+	}
+	if work := h.projectChatWorkHints(ctx, project.ID); work != "" {
+		sections = append(sections, work)
 	}
 	if memoryText := h.projectChatMemoryPrompt(ctx, project.ID); memoryText != "" {
 		sections = append(sections, memoryText)
@@ -105,6 +117,22 @@ func (h *Handler) projectChatRoleHints(ctx context.Context, projectID string) st
 	return strings.Join(lines, "\n")
 }
 
+func (h *Handler) projectChatSkillHints(ctx context.Context, projectID string) string {
+	skills := h.projectChatEnabledSkills(ctx, projectID)
+	if len(skills) == 0 {
+		return ""
+	}
+	return projectChatSkillHintText(skills, projectChatPromptSkillMaxItems)
+}
+
+func (h *Handler) projectChatWorkHints(ctx context.Context, projectID string) string {
+	snapshot := h.projectChatWorkSnapshot(ctx, projectID)
+	if len(snapshot.WorkItems) == 0 && len(snapshot.Assignments) == 0 {
+		return ""
+	}
+	return projectChatWorkHintText(snapshot, projectChatPromptWorkMaxItems, projectChatPromptAssignmentMaxItems)
+}
+
 func (h *Handler) projectChatMemoryPrompt(ctx context.Context, projectID string) string {
 	entries := h.enabledProjectMemoryEntries(ctx, projectID)
 	if len(entries) == 0 {
@@ -143,6 +171,177 @@ func projectChatMemorySection(entry memory.Entry, remaining *int) (string, bool)
 		return "", false
 	}
 	return section, true
+}
+
+type projectChatWorkSnapshot struct {
+	WorkItems   []projectwork.WorkItem
+	Assignments []projectwork.Assignment
+}
+
+func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string) []projectskills.Skill {
+	if h == nil || h.projectSkills == nil || strings.TrimSpace(projectID) == "" {
+		return nil
+	}
+	items, err := h.projectSkills.List(ctx, strings.TrimSpace(projectID))
+	if err != nil {
+		return nil
+	}
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, item := range items {
+		if !item.Enabled {
+			continue
+		}
+		status := strings.TrimSpace(item.Status)
+		if status != "" && status != projectskills.StatusAvailable {
+			continue
+		}
+		out = append(out, item)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left := firstNonEmptyString(strings.TrimSpace(out[i].Title), strings.TrimSpace(out[i].ID))
+		right := firstNonEmptyString(strings.TrimSpace(out[j].Title), strings.TrimSpace(out[j].ID))
+		if left != right {
+			return left < right
+		}
+		return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
+	})
+	return out
+}
+
+func (h *Handler) projectChatWorkSnapshot(ctx context.Context, projectID string) projectChatWorkSnapshot {
+	if h == nil || h.projectWork == nil || strings.TrimSpace(projectID) == "" {
+		return projectChatWorkSnapshot{}
+	}
+	projectID = strings.TrimSpace(projectID)
+	workItems, err := h.projectWork.ListWorkItems(ctx, projectID)
+	if err != nil {
+		workItems = nil
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		assignments = nil
+	}
+	return projectChatWorkSnapshot{WorkItems: workItems, Assignments: assignments}
+}
+
+func projectChatSkillHintText(skills []projectskills.Skill, maxItems int) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	lines := []string{"Project skills (metadata only; skill bodies are not loaded):"}
+	for i, skill := range skills {
+		if i >= maxItems {
+			lines = append(lines, fmt.Sprintf("- %d additional enabled skills omitted.", len(skills)-i))
+			break
+		}
+		line := "- " + labelWithID(skill.Title, skill.ID)
+		details := make([]string, 0, 2)
+		if description := compactProjectChatInline(skill.Description); description != "" {
+			details = append(details, description)
+		}
+		if path := strings.TrimSpace(skill.Path); path != "" {
+			details = append(details, "Path: "+path)
+		}
+		if len(details) > 0 {
+			line += ": " + strings.Join(details, " ")
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, "Use skills as procedures/guidance, not as role assignments.")
+	return strings.Join(lines, "\n")
+}
+
+func projectChatWorkHintText(snapshot projectChatWorkSnapshot, maxWorkItems, maxAssignments int) string {
+	if len(snapshot.WorkItems) == 0 && len(snapshot.Assignments) == 0 {
+		return ""
+	}
+	lines := []string{"Project work snapshot:"}
+	if len(snapshot.WorkItems) > 0 {
+		lines = append(lines, "Work item status counts: "+projectChatWorkStatusCounts(snapshot.WorkItems))
+		included := 0
+		for _, item := range snapshot.WorkItems {
+			if included >= maxWorkItems {
+				lines = append(lines, fmt.Sprintf("- %d additional work items omitted.", len(snapshot.WorkItems)-included))
+				break
+			}
+			line := "- Work item " + labelWithID(item.Title, item.ID) + ": status=" + firstNonEmptyString(strings.TrimSpace(item.Status), projectwork.WorkItemStatusBacklog)
+			if priority := strings.TrimSpace(item.Priority); priority != "" {
+				line += ", priority=" + priority
+			}
+			if owner := strings.TrimSpace(item.OwnerRoleID); owner != "" {
+				line += ", owner_role=" + owner
+			}
+			if brief := compactProjectChatInline(item.Brief); brief != "" {
+				line += "\n  Brief: " + brief
+			}
+			lines = append(lines, line)
+			included++
+		}
+	}
+	if len(snapshot.Assignments) > 0 {
+		lines = append(lines, "Assignments:")
+		included := 0
+		for _, assignment := range snapshot.Assignments {
+			if included >= maxAssignments {
+				lines = append(lines, fmt.Sprintf("- %d additional assignments omitted.", len(snapshot.Assignments)-included))
+				break
+			}
+			line := "- Assignment " + firstNonEmptyString(strings.TrimSpace(assignment.ID), "assignment") +
+				": work_item=" + strings.TrimSpace(assignment.WorkItemID) +
+				", role=" + strings.TrimSpace(assignment.RoleID) +
+				", status=" + firstNonEmptyString(strings.TrimSpace(assignment.Status), projectwork.AssignmentStatusQueued) +
+				", driver=" + firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
+			lines = append(lines, line)
+			included++
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func projectChatWorkStatusCounts(items []projectwork.WorkItem) string {
+	if len(items) == 0 {
+		return "none"
+	}
+	counts := make(map[string]int)
+	for _, item := range items {
+		status := firstNonEmptyString(strings.TrimSpace(item.Status), projectwork.WorkItemStatusBacklog)
+		counts[status]++
+	}
+	order := []string{
+		projectwork.WorkItemStatusBacklog,
+		projectwork.WorkItemStatusReady,
+		projectwork.WorkItemStatusRunning,
+		projectwork.WorkItemStatusReview,
+		projectwork.WorkItemStatusBlocked,
+		projectwork.WorkItemStatusDone,
+		projectwork.WorkItemStatusCancelled,
+	}
+	parts := make([]string, 0, len(counts))
+	for _, status := range order {
+		if count := counts[status]; count > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", status, count))
+			delete(counts, status)
+		}
+	}
+	var extra []string
+	for status, count := range counts {
+		extra = append(extra, fmt.Sprintf("%s=%d", status, count))
+	}
+	sort.Strings(extra)
+	parts = append(parts, extra...)
+	return strings.Join(parts, ", ")
+}
+
+func compactProjectChatInline(value string) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= projectChatPromptInlineMaxRunes {
+		return value
+	}
+	return strings.TrimSpace(string(runes[:projectChatPromptInlineMaxRunes])) + " [truncated]"
 }
 
 func boundedPromptContextSection(header, body string, itemMaxBytes int, remaining *int) (string, bool) {


### PR DESCRIPTION
## Summary

- Add bounded project skill metadata and current project work/assignment hints to project-linked Hecate Chat prompts.
- Persist matching `project_skills` and `project_work` context-packet items for direct model and task-backed Hecate Chat turns.
- Restore the prompt-budget helper implementation used by the project chat prompt path, and update runtime/API docs for the simple-chat context contract.

## Behavior

Chat stays visually simple. Linked Hecate Chat can now see enabled skill metadata and current project work state, but this does not grant direct mutation authority: project changes remain proposal-only and assignments remain queued/unstarted unless the operator explicitly applies/starts them through the existing flows.

## Tests

- Focused `internal/api` project chat prompt/context tests
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `go vet ./internal/api`
- `/bin/zsh -lc "GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./..."`
- `just docs-format-check`