### PR TITLE
refactor(projects): extract project assistant app and UI controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,12 @@ internal/
                           command shaping, id defaults, driver defaults,
                           store error boundaries, execution refs, activity
                           projection/status signals
+  projectassistant/     Project Assistant proposal domain: context building,
+                          deterministic/model/bootstrap drafting, validation,
+                          confirmed apply semantics
+  projectassistantapp/  Project Assistant application layer used by API
+                          handlers: cached service boundary, store/LLM wiring,
+                          context/draft/propose/apply commands
   providerapp/          settings provider application layer used by API handlers:
                           settings status, policy rules, provider
                           create/update/delete, API key rotate/clear

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -171,6 +171,15 @@ HTTP response DTOs, linked-chat loading/rendering, and artifact/handoff grouping
 Do not rebuild assignment activity decisions in UI or handlers from raw
 `task_id`/`run_id`/`chat_session_id`; use the `execution_ref` / projection seams.
 
+Project Assistant HTTP handlers call `internal/projectassistantapp.Application`
+for context, draft, propose, and apply commands. Keep service construction,
+store/LLM wiring, and in-process partial-apply progress behind that cached app
+boundary. `internal/projectassistant` owns proposal-domain behavior: context
+building, deterministic/model/bootstrap drafting, action validation, and
+confirmed apply semantics. Handlers should parse/render/map errors only; do not
+rebuild Project Assistant stores or call `projectassistant.NewService` directly
+from API code.
+
 ### Change chat-session / ACP adapter behavior
 
 Chat sessions separate ownership from turn execution:

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/hecatehq/hecate/internal/chatapp"
 	"github.com/hecatehq/hecate/internal/modelapp"
+	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/internal/providerapp"
 	"github.com/hecatehq/hecate/internal/taskapp"
@@ -67,6 +68,27 @@ func (h *Handler) projectWorkApplication() *projectworkapp.Application {
 		RuntimeDefaultModel: h.config.Router.DefaultModel,
 		IDGenerator:         newOpaqueTaskResourceID,
 	})
+}
+
+func (h *Handler) projectAssistantApplication() *projectassistantapp.Application {
+	if h == nil {
+		return projectassistantapp.New(projectassistantapp.Options{})
+	}
+	h.projectAssistantMu.Lock()
+	defer h.projectAssistantMu.Unlock()
+	if h.projectAssistant == nil {
+		h.projectAssistant = projectassistantapp.New(projectassistantapp.Options{
+			Projects:         h.projects,
+			Chats:            h.agentChat,
+			Work:             h.projectWork,
+			ProjectSkills:    h.projectSkills,
+			Memory:           h.memory,
+			MemoryCandidates: h.memoryCandidates,
+			LLM:              gatewayAgentLLMClient{service: h.service},
+			IDGenerator:      newOpaqueTaskResourceID,
+		})
+	}
+	return h.projectAssistant
 }
 
 func (h *Handler) modelApplication() *modelapp.Application {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/profiler"
-	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -52,7 +52,7 @@ type Handler struct {
 	projectWork              projectwork.Store
 	projectSkills            projectskills.Store
 	projectAssistantMu       sync.Mutex
-	projectAssistant         *projectassistant.Service
+	projectAssistant         *projectassistantapp.Application
 	agentProfiles            agentprofiles.Store
 	agentChatRunner          agentadapters.Runner
 	agentChatLive            *agentChatLive

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -46,7 +47,7 @@ func (h *Handler) HandleProjectAssistantContext(w http.ResponseWriter, r *http.R
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant context request")
 		return
 	}
-	context, err := h.projectAssistantService().Context(r.Context(), projectassistant.ContextInput{
+	context, err := h.projectAssistantApplication().Context(r.Context(), projectassistantapp.ContextCommand{
 		ProjectID:  req.ProjectID,
 		WorkItemID: req.WorkItemID,
 		Request:    req.Request,
@@ -69,7 +70,7 @@ func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Req
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant draft request")
 		return
 	}
-	proposal, err := h.projectAssistantService().Draft(r.Context(), projectassistant.DraftInput{
+	proposal, err := h.projectAssistantApplication().Draft(r.Context(), projectassistantapp.DraftCommand{
 		ProjectID:  req.ProjectID,
 		WorkItemID: req.WorkItemID,
 		Request:    req.Request,
@@ -97,7 +98,7 @@ func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.R
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant proposal request")
 		return
 	}
-	proposal, err := h.projectAssistantService().Propose(r.Context(), projectassistant.ProposalInput{
+	proposal, err := h.projectAssistantApplication().Propose(r.Context(), projectassistantapp.ProposeCommand{
 		ID:      req.ID,
 		Title:   req.Title,
 		Summary: req.Summary,
@@ -120,7 +121,10 @@ func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Req
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant apply request")
 		return
 	}
-	result, err := h.projectAssistantService().Apply(r.Context(), req.Proposal, req.Confirm)
+	result, err := h.projectAssistantApplication().Apply(r.Context(), projectassistantapp.ApplyCommand{
+		Proposal: req.Proposal,
+		Confirm:  req.Confirm,
+	})
 	if err != nil {
 		writeProjectAssistantApplyError(w, err)
 		return
@@ -129,23 +133,6 @@ func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Req
 		"object": "project_assistant.apply_result",
 		"data":   result,
 	})
-}
-
-func (h *Handler) projectAssistantService() *projectassistant.Service {
-	h.projectAssistantMu.Lock()
-	defer h.projectAssistantMu.Unlock()
-	if h.projectAssistant == nil {
-		h.projectAssistant = projectassistant.NewService(projectassistant.Stores{
-			Projects:         h.projects,
-			Chats:            h.agentChat,
-			Work:             h.projectWork,
-			ProjectSkills:    h.projectSkills,
-			Memory:           h.memory,
-			MemoryCandidates: h.memoryCandidates,
-			LLM:              gatewayAgentLLMClient{service: h.service},
-		}, newOpaqueTaskResourceID)
-	}
-	return h.projectAssistant
 }
 
 func writeProjectAssistantApplyError(w http.ResponseWriter, err error) {

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -1,0 +1,126 @@
+package projectassistantapp
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type Application struct {
+	service *projectassistant.Service
+}
+
+type Options struct {
+	Projects         projects.Store
+	Chats            chat.Store
+	Work             projectwork.Store
+	ProjectSkills    projectskills.Store
+	Memory           memory.Store
+	MemoryCandidates memory.CandidateStore
+	LLM              projectassistant.LLMClient
+	IDGenerator      projectassistant.IDGenerator
+}
+
+type ContextCommand struct {
+	ProjectID  string
+	WorkItemID string
+	Request    string
+	RoleID     string
+	DriverKind string
+}
+
+type DraftCommand struct {
+	ProjectID  string
+	WorkItemID string
+	Request    string
+	RoleID     string
+	DriverKind string
+	DraftMode  string
+	Provider   string
+	Model      string
+	RequestID  string
+	TraceID    string
+}
+
+type ProposeCommand struct {
+	ID      string
+	Title   string
+	Summary string
+	Actions []projectassistant.Action
+	TraceID string
+}
+
+type ApplyCommand struct {
+	Proposal projectassistant.Proposal
+	Confirm  bool
+}
+
+func New(options Options) *Application {
+	return &Application{
+		service: projectassistant.NewService(projectassistant.Stores{
+			Projects:         options.Projects,
+			Chats:            options.Chats,
+			Work:             options.Work,
+			ProjectSkills:    options.ProjectSkills,
+			Memory:           options.Memory,
+			MemoryCandidates: options.MemoryCandidates,
+			LLM:              options.LLM,
+		}, options.IDGenerator),
+	}
+}
+
+func (app *Application) Context(ctx context.Context, command ContextCommand) (projectassistant.DraftContext, error) {
+	if app == nil || app.service == nil {
+		return projectassistant.DraftContext{}, projectassistant.ErrStoreNotConfigured
+	}
+	return app.service.Context(ctx, projectassistant.ContextInput{
+		ProjectID:  command.ProjectID,
+		WorkItemID: command.WorkItemID,
+		Request:    command.Request,
+		RoleID:     command.RoleID,
+		DriverKind: command.DriverKind,
+	})
+}
+
+func (app *Application) Draft(ctx context.Context, command DraftCommand) (projectassistant.Proposal, error) {
+	if app == nil || app.service == nil {
+		return projectassistant.Proposal{}, projectassistant.ErrStoreNotConfigured
+	}
+	return app.service.Draft(ctx, projectassistant.DraftInput{
+		ProjectID:  command.ProjectID,
+		WorkItemID: command.WorkItemID,
+		Request:    command.Request,
+		RoleID:     command.RoleID,
+		DriverKind: command.DriverKind,
+		DraftMode:  command.DraftMode,
+		Provider:   command.Provider,
+		Model:      command.Model,
+		RequestID:  command.RequestID,
+		TraceID:    command.TraceID,
+	})
+}
+
+func (app *Application) Propose(ctx context.Context, command ProposeCommand) (projectassistant.Proposal, error) {
+	if app == nil || app.service == nil {
+		return projectassistant.Proposal{}, projectassistant.ErrStoreNotConfigured
+	}
+	return app.service.Propose(ctx, projectassistant.ProposalInput{
+		ID:      command.ID,
+		Title:   command.Title,
+		Summary: command.Summary,
+		Actions: command.Actions,
+		TraceID: command.TraceID,
+	})
+}
+
+func (app *Application) Apply(ctx context.Context, command ApplyCommand) (projectassistant.ApplyResult, error) {
+	if app == nil || app.service == nil {
+		return projectassistant.ApplyResult{}, projectassistant.ErrStoreNotConfigured
+	}
+	return app.service.Apply(ctx, command.Proposal, command.Confirm)
+}

--- a/internal/projectassistantapp/application_test.go
+++ b/internal/projectassistantapp/application_test.go
@@ -1,0 +1,125 @@
+package projectassistantapp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestApplication_ContextDelegatesToProjectAssistantService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Hecate"}); err != nil {
+		t.Fatalf("Create(project) error = %v", err)
+	}
+	if _, err := workStore.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:        "role_pm",
+		ProjectID: "proj_1",
+		Name:      "Product Manager",
+	}); err != nil {
+		t.Fatalf("CreateRole() error = %v", err)
+	}
+	workItem, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:          "work_1",
+		ProjectID:   "proj_1",
+		Title:       "Plan work",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: "role_pm",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	app := New(Options{Projects: projectStore, Work: workStore})
+
+	got, err := app.Context(ctx, ContextCommand{
+		ProjectID:  "proj_1",
+		WorkItemID: workItem.ID,
+		Request:    "Queue the owner",
+	})
+	if err != nil {
+		t.Fatalf("Context() error = %v", err)
+	}
+	if got.Project.ID != "proj_1" || got.SelectedWork == nil || got.SelectedWork.ID != "work_1" {
+		t.Fatalf("context = %+v, want project and selected work", got)
+	}
+	if got.Selection.RoleID != "role_pm" || got.Selection.DriverKind != projectwork.AssignmentDriverHecateTask {
+		t.Fatalf("selection = %+v, want owner role and Hecate task default", got.Selection)
+	}
+}
+
+func TestApplication_ProposeUsesIDGeneratorAndTrace(t *testing.T) {
+	t.Parallel()
+
+	app := New(Options{IDGenerator: func(prefix string) string { return prefix + "_fixed" }})
+	proposal, err := app.Propose(context.Background(), ProposeCommand{
+		Title:   "Create role",
+		Summary: "Create a role proposal.",
+		TraceID: "trace_1",
+		Actions: []projectassistant.Action{{
+			Kind:   projectassistant.ActionCreateRole,
+			Target: map[string]string{"project_id": "proj_1"},
+			Patch:  rawJSON(t, map[string]any{"id": "role_1", "name": "Reviewer"}),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Propose() error = %v", err)
+	}
+	if proposal.ID != "pa_fixed" || proposal.TraceID != "trace_1" || !proposal.RequiresConfirmation {
+		t.Fatalf("proposal = %+v, want generated id, trace, and confirmation", proposal)
+	}
+}
+
+func TestApplication_ApplyKeepsProgressInCachedApplication(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	app := New(Options{
+		Projects:    projectStore,
+		IDGenerator: func(prefix string) string { return prefix + "_fixed" },
+	})
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply",
+		Title:                "Create project",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind:   projectassistant.ActionCreateProject,
+			Target: map[string]string{"project_id": "proj_created"},
+			Patch:  rawJSON(t, map[string]any{"id": "proj_created", "name": "Created"}),
+		}},
+	}
+
+	if _, err := app.Apply(ctx, ApplyCommand{Proposal: proposal}); !errors.Is(err, projectassistant.ErrConfirmationRequired) {
+		t.Fatalf("Apply(unconfirmed) error = %v, want ErrConfirmationRequired", err)
+	}
+	result, err := app.Apply(ctx, ApplyCommand{Proposal: proposal, Confirm: true})
+	if err != nil {
+		t.Fatalf("Apply(confirmed) error = %v", err)
+	}
+	if !result.Applied || len(result.Actions) != 1 || result.Actions[0].ID != "proj_created" {
+		t.Fatalf("apply result = %+v, want created project", result)
+	}
+	if _, ok, err := projectStore.Get(ctx, "proj_created"); err != nil || !ok {
+		t.Fatalf("created project ok=%v err=%v, want persisted", ok, err)
+	}
+	if _, err := app.Apply(ctx, ApplyCommand{Proposal: proposal, Confirm: true}); !errors.Is(err, projectassistant.ErrConflict) {
+		t.Fatalf("Apply(repeated) error = %v, want ErrConflict", err)
+	}
+}
+
+func rawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal(%#v) error = %v", value, err)
+	}
+	return data
+}

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -13,15 +13,12 @@ import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
-  applyProjectAssistant,
   createAgentProfile,
   createProjectAssignment,
   createProjectHandoff,
   discoverProjectContextSources,
   discoverProjectRoots,
   discoverProjectSkills,
-  draftProjectAssistant,
-  getProjectAssistantContext,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
@@ -79,21 +76,12 @@ import {
   toProjectAssignmentEvidenceViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
-import {
-  PROJECT_ASSISTANT_AUTO,
-  ProjectAssistantPanel,
-  type ProjectAssistantDraftForm,
-  type ProjectAssistantStatus,
-} from "./ProjectAssistantPanel";
+import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
+import { useProjectAssistantController } from "./useProjectAssistantController";
 import type {
   ProjectAssignmentRecord,
   ProjectActivityData,
   ProjectActivityItemRecord,
-  ProjectAssistantApplyResult,
-  ProjectAssistantContextPayload,
-  ProjectAssistantContextRecord,
-  ProjectAssistantDraftPayload,
-  ProjectAssistantProposal,
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
@@ -439,17 +427,6 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [assignmentErrors, setAssignmentErrors] = useState<Record<string, string>>({});
   const [startingAssignmentID, setStartingAssignmentID] = useState("");
   const startingAssignmentIDsRef = useRef<Set<string>>(new Set());
-  const [assistantProposal, setAssistantProposal] = useState<ProjectAssistantProposal | null>(null);
-  const [assistantApplyResult, setAssistantApplyResult] =
-    useState<ProjectAssistantApplyResult | null>(null);
-  const [assistantContext, setAssistantContext] = useState<ProjectAssistantContextRecord | null>(
-    null,
-  );
-  const [assistantContextStatus, setAssistantContextStatus] = useState<LoadState>("idle");
-  const [assistantContextError, setAssistantContextError] = useState("");
-  const [assistantStatus, setAssistantStatus] = useState<ProjectAssistantStatus>("idle");
-  const [assistantError, setAssistantError] = useState("");
-  const [assistantBootstrapPending, setAssistantBootstrapPending] = useState(false);
 
   function updateRightPanelWidth(width: number) {
     setRightPanelWidth(width);
@@ -736,6 +713,26 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }, []);
 
+  const assistant = useProjectAssistantController({
+    project: selectedProject,
+    selectedProjectID,
+    selectedWorkItemID,
+    selectedWorkItem,
+    onProjectDiscovered: (project) => {
+      projects.actions.setProjects((current) => upsertProject(current, project));
+    },
+    onSkillsDiscovered: setProjectSkills,
+    onSkillsLoadState: setSkillsLoadState,
+    onDiscoveringContext: setDiscoveringContext,
+    onDiscoveringSkills: setDiscoveringSkills,
+    onMemoryError: setMemoryError,
+    onSkillsError: setSkillsError,
+    refreshProjects: projects.actions.loadProjects,
+    loadWorkForProject,
+    loadWorkItemDetail,
+    loadProjectMemory,
+  });
+
   useEffect(() => {
     void loadWorkForProject(selectedProjectID);
   }, [loadWorkForProject, selectedProjectID]);
@@ -754,14 +751,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   }, [loadWorkItemDetail, selectedProjectID, selectedWorkItemID]);
 
   useEffect(() => {
-    setAssistantProposal(null);
-    setAssistantApplyResult(null);
-    setAssistantContext(null);
-    setAssistantContextError("");
-    setAssistantContextStatus("idle");
-    setAssistantError("");
-    setAssistantStatus("idle");
-  }, [selectedProjectID, selectedWorkItemID]);
+    assistant.dismiss();
+  }, [assistant.dismiss, selectedProjectID, selectedWorkItemID]);
 
   function openProject(projectID: string) {
     if (projectID !== selectedProjectID) {
@@ -1345,123 +1336,6 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
-  async function handleProjectAssistantPropose(form: ProjectAssistantDraftForm) {
-    if (!selectedProject) return;
-    setAssistantStatus("proposing");
-    setAssistantError("");
-    setAssistantApplyResult(null);
-    try {
-      const proposal = await draftProjectAssistant(
-        projectAssistantDraftPayload(form, selectedProject.id, selectedWorkItem?.id),
-      );
-      setAssistantProposal(proposal.data);
-      setAssistantStatus("idle");
-    } catch (error) {
-      setAssistantStatus("idle");
-      setAssistantError(errorMessage(error, "Failed to draft Project Assistant proposal."));
-    }
-  }
-
-  async function handleProjectAssistantBootstrap() {
-    if (!selectedProjectID) return;
-    const projectID = selectedProjectID;
-    setAssistantBootstrapPending(true);
-    setAssistantStatus("proposing");
-    setAssistantError("");
-    setAssistantProposal(null);
-    setAssistantApplyResult(null);
-    setMemoryError("");
-    setSkillsError("");
-    setDiscoveringContext(true);
-    setDiscoveringSkills(true);
-    try {
-      const projectPayload = await discoverProjectContextSources(projectID);
-      projects.actions.setProjects((current) => upsertProject(current, projectPayload.data));
-      const skillsPayload = await discoverProjectSkills(projectID);
-      setProjectSkills(skillsPayload.data ?? []);
-      setSkillsLoadState("loaded");
-      const proposal = await draftProjectAssistant(
-        projectAssistantDraftPayload(
-          {
-            request: "Bootstrap project guidance",
-            roleID: PROJECT_ASSISTANT_AUTO,
-            driverKind: PROJECT_ASSISTANT_AUTO,
-            draftMode: "bootstrap",
-          },
-          projectID,
-        ),
-      );
-      setAssistantProposal(proposal.data);
-      setAssistantContext(null);
-      setAssistantContextError("");
-      setAssistantContextStatus("idle");
-    } catch (error) {
-      setAssistantError(errorMessage(error, "Failed to bootstrap project assistant context."));
-    } finally {
-      setDiscoveringContext(false);
-      setDiscoveringSkills(false);
-      setAssistantBootstrapPending(false);
-      setAssistantStatus("idle");
-    }
-  }
-
-  async function handleProjectAssistantContext(form: ProjectAssistantDraftForm) {
-    if (!selectedProject) return;
-    setAssistantContextStatus("loading");
-    setAssistantContextError("");
-    try {
-      const payload = await getProjectAssistantContext(
-        projectAssistantContextPayload(form, selectedProject.id, selectedWorkItem?.id),
-      );
-      setAssistantContext(payload.data);
-      setAssistantContextStatus("loaded");
-    } catch (error) {
-      setAssistantContext(null);
-      setAssistantContextStatus("error");
-      setAssistantContextError(errorMessage(error, "Failed to inspect Project Assistant context."));
-    }
-  }
-
-  async function handleProjectAssistantApply() {
-    if (!selectedProjectID || !assistantProposal) return;
-    const proposal = assistantProposal;
-    setAssistantStatus("applying");
-    setAssistantError("");
-    try {
-      const payload = await applyProjectAssistant({ proposal, confirm: true });
-      setAssistantApplyResult(payload.data);
-      setAssistantProposal(null);
-      setAssistantStatus("applied");
-      await projects.actions.loadProjects();
-      const preferredWorkItemID =
-        projectAssistantResultWorkItemID(payload.data) || selectedWorkItemID;
-      const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, preferredWorkItemID);
-      if (refreshedWorkItemID) {
-        await loadWorkItemDetail(selectedProjectID, refreshedWorkItemID);
-      }
-      await loadProjectMemory(selectedProjectID);
-    } catch (error) {
-      setAssistantStatus("idle");
-      setAssistantError(projectAssistantApplyErrorMessage(error, proposal));
-      if (error instanceof ApiError && (error.status === 404 || error.status === 409)) {
-        const refreshedWorkItemID = await loadWorkForProject(selectedProjectID, selectedWorkItemID);
-        if (refreshedWorkItemID) {
-          await loadWorkItemDetail(selectedProjectID, refreshedWorkItemID);
-        }
-      }
-    }
-  }
-
-  function dismissProjectAssistantProposal() {
-    setAssistantProposal(null);
-    setAssistantApplyResult(null);
-    setAssistantContext(null);
-    setAssistantContextError("");
-    setAssistantContextStatus("idle");
-    setAssistantError("");
-    setAssistantStatus("idle");
-  }
-
   async function handleStartAssignment(
     assignment: ProjectAssignmentRecord,
     workItemID = selectedWorkItemID,
@@ -1502,8 +1376,8 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     Boolean(selectedProject) &&
     workLoadState === "loaded" &&
     workItems.length === 0 &&
-    !assistantProposal &&
-    !assistantApplyResult;
+    !assistant.proposal &&
+    !assistant.applyResult;
   const projectEmptyTitle =
     projects.state.projects.length === 0 ? "Add a project to begin" : "Select a project";
   const projectEmptyDetail =
@@ -1617,12 +1491,12 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                 <section style={domainSectionStyle} aria-label="Project workspace">
                   {projectNeedsOnboarding ? (
                     <ProjectOnboardingPanel
-                      bootstrapPending={assistantBootstrapPending}
+                      bootstrapPending={assistant.bootstrapPending}
                       contextSourceCount={
                         (selectedProject.context_sources ?? []).filter((source) => source.enabled)
                           .length
                       }
-                      onBootstrap={() => void handleProjectAssistantBootstrap()}
+                      onBootstrap={() => void assistant.bootstrap()}
                       onCreateWork={() => {
                         setNewWorkError("");
                         setNewWorkModalOpen(true);
@@ -1638,21 +1512,21 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                   ) : (
                     <>
                       <ProjectAssistantPanel
-                        applyResult={assistantApplyResult}
-                        bootstrapPending={assistantBootstrapPending}
-                        context={assistantContext}
-                        contextError={assistantContextError}
-                        contextStatus={assistantContextStatus}
-                        error={assistantError}
-                        onApply={() => void handleProjectAssistantApply()}
-                        onBootstrap={() => void handleProjectAssistantBootstrap()}
-                        onInspectContext={(form) => void handleProjectAssistantContext(form)}
-                        onDismiss={dismissProjectAssistantProposal}
-                        onPropose={(form) => void handleProjectAssistantPropose(form)}
+                        applyResult={assistant.applyResult}
+                        bootstrapPending={assistant.bootstrapPending}
+                        context={assistant.context}
+                        contextError={assistant.contextError}
+                        contextStatus={assistant.contextStatus}
+                        error={assistant.error}
+                        onApply={() => void assistant.apply()}
+                        onBootstrap={() => void assistant.bootstrap()}
+                        onInspectContext={(form) => void assistant.inspectContext(form)}
+                        onDismiss={assistant.dismiss}
+                        onPropose={(form) => void assistant.propose(form)}
                         project={selectedProject}
-                        proposal={assistantProposal}
+                        proposal={assistant.proposal}
                         roles={roles}
-                        status={assistantStatus}
+                        status={assistant.status}
                         workItem={selectedWorkItem}
                       />
                       <ProjectWorkspaceTabs
@@ -6494,96 +6368,6 @@ function summarizeAssignments(assignments: ProjectAssignmentRecord[]): WorkItemS
     },
     { assignmentCount: 0, activeCount: 0, failedCount: 0, completedCount: 0 },
   );
-}
-
-function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): string {
-  for (const action of result.actions) {
-    const workItemID = action.data?.work_item_id;
-    if (workItemID) return workItemID;
-  }
-  return "";
-}
-
-function projectAssistantContextPayload(
-  form: ProjectAssistantDraftForm,
-  projectID: string,
-  workItemID?: string,
-): ProjectAssistantContextPayload {
-  const roleID = form.roleID === PROJECT_ASSISTANT_AUTO ? "" : form.roleID.trim();
-  const driverKind = form.driverKind === PROJECT_ASSISTANT_AUTO ? "" : form.driverKind.trim();
-  return {
-    project_id: projectID,
-    ...(workItemID ? { work_item_id: workItemID } : {}),
-    request: form.request,
-    ...(roleID ? { role_id: roleID } : {}),
-    ...(driverKind ? { driver_kind: driverKind } : {}),
-  };
-}
-
-function projectAssistantDraftPayload(
-  form: ProjectAssistantDraftForm,
-  projectID: string,
-  workItemID?: string,
-): ProjectAssistantDraftPayload {
-  const payload: ProjectAssistantDraftPayload = projectAssistantContextPayload(
-    form,
-    projectID,
-    workItemID,
-  );
-  if (form.draftMode !== "deterministic") {
-    payload.draft_mode = form.draftMode;
-  }
-  return payload;
-}
-
-function projectAssistantApplyErrorMessage(
-  error: unknown,
-  proposal?: ProjectAssistantProposal,
-): string {
-  if (error instanceof ApiError) {
-    const partialMessage = projectAssistantPartialApplyErrorMessage(error, proposal);
-    if (partialMessage) return partialMessage;
-    if (error.status === 404) {
-      return "Project Assistant could not find a proposal target. The project may have changed; refresh project work and draft the proposal again.";
-    }
-    if (error.status === 409) {
-      return "Project Assistant could not apply because the proposal is stale, conflicts with current project state, or was already applied. Refresh project work and draft it again.";
-    }
-  }
-  return errorMessage(error, "Failed to apply Project Assistant proposal.");
-}
-
-function projectAssistantPartialApplyErrorMessage(
-  error: ApiError,
-  proposal?: ProjectAssistantProposal,
-): string {
-  const failedActionIndex = projectAssistantFailedActionIndex(error.fields.failed_action_index);
-  const partialResult = projectAssistantPartialResult(error.fields.partial_result);
-  if (failedActionIndex === null || !partialResult) return "";
-  const appliedCount = partialResult.actions.length;
-  const totalCount = proposal?.actions.length ?? Math.max(appliedCount, failedActionIndex + 1);
-  return `Project Assistant applied ${appliedCount} of ${totalCount} actions, then failed at action ${failedActionIndex + 1}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
-}
-
-function projectAssistantFailedActionIndex(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
-}
-
-function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyResult | null {
-  if (!value || typeof value !== "object") return null;
-  const result = value as Partial<ProjectAssistantApplyResult>;
-  if (
-    typeof result.proposal_id !== "string" ||
-    typeof result.applied !== "boolean" ||
-    !Array.isArray(result.actions)
-  ) {
-    return null;
-  }
-  return {
-    proposal_id: result.proposal_id,
-    applied: result.applied,
-    actions: result.actions,
-  };
 }
 
 function emptyRoleForm(): RoleForm {

--- a/ui/src/features/projects/useProjectAssistantController.test.ts
+++ b/ui/src/features/projects/useProjectAssistantController.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "../../lib/api";
+import type { ProjectAssistantProposal } from "../../types/project";
+import {
+  projectAssistantApplyErrorMessage,
+  projectAssistantContextPayload,
+  projectAssistantDraftPayload,
+  projectAssistantResultWorkItemID,
+} from "./useProjectAssistantController";
+
+describe("Project Assistant controller helpers", () => {
+  it("builds context and draft payloads from panel form state", () => {
+    const form = {
+      request: "Queue review",
+      roleID: "role_review",
+      driverKind: "external_agent",
+      draftMode: "model" as const,
+    };
+
+    expect(projectAssistantContextPayload(form, "proj_1", "work_1")).toEqual({
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      request: "Queue review",
+      role_id: "role_review",
+      driver_kind: "external_agent",
+    });
+    expect(projectAssistantDraftPayload(form, "proj_1", "work_1")).toEqual({
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      request: "Queue review",
+      role_id: "role_review",
+      driver_kind: "external_agent",
+      draft_mode: "model",
+    });
+  });
+
+  it("omits auto role, auto driver, and deterministic draft mode", () => {
+    const form = {
+      request: "Create work",
+      roleID: "__auto__",
+      driverKind: "__auto__",
+      draftMode: "deterministic" as const,
+    };
+
+    expect(projectAssistantDraftPayload(form, "proj_1")).toEqual({
+      project_id: "proj_1",
+      request: "Create work",
+    });
+  });
+
+  it("prefers applied work item ids when choosing refresh target", () => {
+    expect(
+      projectAssistantResultWorkItemID({
+        proposal_id: "pa_1",
+        applied: true,
+        actions: [
+          { kind: "create_role", id: "role_1", data: { project_id: "proj_1" } },
+          {
+            kind: "create_assignment",
+            id: "asgn_1",
+            data: { project_id: "proj_1", work_item_id: "work_2" },
+          },
+        ],
+      }),
+    ).toBe("work_2");
+  });
+
+  it("renders conflict and partial apply errors with proposal context", () => {
+    expect(projectAssistantApplyErrorMessage(new ApiError("conflict", 409, "conflict"))).toContain(
+      "proposal is stale",
+    );
+
+    const proposal: ProjectAssistantProposal = {
+      id: "pa_partial",
+      title: "Apply two",
+      summary: "",
+      requires_confirmation: true,
+      actions: [
+        { kind: "create_assignment", patch: {} },
+        { kind: "create_memory_candidate", patch: {} },
+      ],
+    };
+    const partial = projectAssistantApplyErrorMessage(
+      new ApiError("partial", 409, "conflict", {
+        fields: {
+          failed_action_index: 1,
+          partial_result: {
+            proposal_id: "pa_partial",
+            applied: false,
+            actions: [{ kind: "create_assignment", id: "asgn_1" }],
+          },
+        },
+      }),
+      proposal,
+    );
+    expect(partial).toContain("applied 1 of 2 actions");
+    expect(partial).toContain("failed at action 2");
+  });
+});

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -1,0 +1,296 @@
+import { useCallback, useState } from "react";
+
+import {
+  ApiError,
+  applyProjectAssistant,
+  discoverProjectContextSources,
+  discoverProjectSkills,
+  draftProjectAssistant,
+  getProjectAssistantContext,
+} from "../../lib/api";
+import type {
+  ProjectAssistantApplyResult,
+  ProjectAssistantContextPayload,
+  ProjectAssistantContextRecord,
+  ProjectAssistantDraftPayload,
+  ProjectAssistantProposal,
+  ProjectRecord,
+  ProjectSkillRecord,
+  ProjectWorkItemRecord,
+} from "../../types/project";
+import { PROJECT_ASSISTANT_AUTO, type ProjectAssistantDraftForm } from "./ProjectAssistantPanel";
+
+type LoadState = "idle" | "loading" | "loaded" | "error";
+type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
+
+type Options = {
+  project: ProjectRecord | null;
+  selectedProjectID: string;
+  selectedWorkItemID: string;
+  selectedWorkItem: ProjectWorkItemRecord | null;
+  onProjectDiscovered: (project: ProjectRecord) => void;
+  onSkillsDiscovered: (skills: ProjectSkillRecord[]) => void;
+  onSkillsLoadState: (state: LoadState) => void;
+  onDiscoveringContext: (discovering: boolean) => void;
+  onDiscoveringSkills: (discovering: boolean) => void;
+  onMemoryError: (message: string) => void;
+  onSkillsError: (message: string) => void;
+  refreshProjects: () => Promise<void>;
+  loadWorkForProject: (projectID: string, preferredWorkItemID?: string) => Promise<string>;
+  loadWorkItemDetail: (projectID: string, workItemID: string) => Promise<void>;
+  loadProjectMemory: (projectID: string) => Promise<void>;
+};
+
+export function useProjectAssistantController(options: Options) {
+  const [proposal, setProposal] = useState<ProjectAssistantProposal | null>(null);
+  const [applyResult, setApplyResult] = useState<ProjectAssistantApplyResult | null>(null);
+  const [context, setContext] = useState<ProjectAssistantContextRecord | null>(null);
+  const [contextStatus, setContextStatus] = useState<LoadState>("idle");
+  const [contextError, setContextError] = useState("");
+  const [status, setStatus] = useState<ProjectAssistantStatus>("idle");
+  const [error, setError] = useState("");
+  const [bootstrapPending, setBootstrapPending] = useState(false);
+
+  const propose = useCallback(
+    async (form: ProjectAssistantDraftForm) => {
+      if (!options.project) return;
+      setStatus("proposing");
+      setError("");
+      setApplyResult(null);
+      try {
+        const payload = await draftProjectAssistant(
+          projectAssistantDraftPayload(form, options.project.id, options.selectedWorkItem?.id),
+        );
+        setProposal(payload.data);
+        setStatus("idle");
+      } catch (err) {
+        setStatus("idle");
+        setError(errorMessage(err, "Failed to draft Project Assistant proposal."));
+      }
+    },
+    [options.project, options.selectedWorkItem],
+  );
+
+  const bootstrap = useCallback(async () => {
+    if (!options.selectedProjectID) return;
+    const projectID = options.selectedProjectID;
+    setBootstrapPending(true);
+    setStatus("proposing");
+    setError("");
+    setProposal(null);
+    setApplyResult(null);
+    options.onMemoryError("");
+    options.onSkillsError("");
+    options.onDiscoveringContext(true);
+    options.onDiscoveringSkills(true);
+    try {
+      const projectPayload = await discoverProjectContextSources(projectID);
+      options.onProjectDiscovered(projectPayload.data);
+      const skillsPayload = await discoverProjectSkills(projectID);
+      options.onSkillsDiscovered(skillsPayload.data ?? []);
+      options.onSkillsLoadState("loaded");
+      const payload = await draftProjectAssistant(
+        projectAssistantDraftPayload(
+          {
+            request: "Bootstrap project guidance",
+            roleID: PROJECT_ASSISTANT_AUTO,
+            driverKind: PROJECT_ASSISTANT_AUTO,
+            draftMode: "bootstrap",
+          },
+          projectID,
+        ),
+      );
+      setProposal(payload.data);
+      setContext(null);
+      setContextError("");
+      setContextStatus("idle");
+    } catch (err) {
+      setError(errorMessage(err, "Failed to bootstrap project assistant context."));
+    } finally {
+      options.onDiscoveringContext(false);
+      options.onDiscoveringSkills(false);
+      setBootstrapPending(false);
+      setStatus("idle");
+    }
+  }, [options]);
+
+  const inspectContext = useCallback(
+    async (form: ProjectAssistantDraftForm) => {
+      if (!options.project) return;
+      setContextStatus("loading");
+      setContextError("");
+      try {
+        const payload = await getProjectAssistantContext(
+          projectAssistantContextPayload(form, options.project.id, options.selectedWorkItem?.id),
+        );
+        setContext(payload.data);
+        setContextStatus("loaded");
+      } catch (err) {
+        setContext(null);
+        setContextStatus("error");
+        setContextError(errorMessage(err, "Failed to inspect Project Assistant context."));
+      }
+    },
+    [options.project, options.selectedWorkItem],
+  );
+
+  const apply = useCallback(async () => {
+    if (!options.selectedProjectID || !proposal) return;
+    const currentProposal = proposal;
+    setStatus("applying");
+    setError("");
+    try {
+      const payload = await applyProjectAssistant({ proposal: currentProposal, confirm: true });
+      setApplyResult(payload.data);
+      setProposal(null);
+      setStatus("applied");
+      await options.refreshProjects();
+      const preferredWorkItemID =
+        projectAssistantResultWorkItemID(payload.data) || options.selectedWorkItemID;
+      const refreshedWorkItemID = await options.loadWorkForProject(
+        options.selectedProjectID,
+        preferredWorkItemID,
+      );
+      if (refreshedWorkItemID) {
+        await options.loadWorkItemDetail(options.selectedProjectID, refreshedWorkItemID);
+      }
+      await options.loadProjectMemory(options.selectedProjectID);
+    } catch (err) {
+      setStatus("idle");
+      setError(projectAssistantApplyErrorMessage(err, currentProposal));
+      if (err instanceof ApiError && (err.status === 404 || err.status === 409)) {
+        const refreshedWorkItemID = await options.loadWorkForProject(
+          options.selectedProjectID,
+          options.selectedWorkItemID,
+        );
+        if (refreshedWorkItemID) {
+          await options.loadWorkItemDetail(options.selectedProjectID, refreshedWorkItemID);
+        }
+      }
+    }
+  }, [options, proposal]);
+
+  const dismiss = useCallback(() => {
+    setProposal(null);
+    setApplyResult(null);
+    setContext(null);
+    setContextError("");
+    setContextStatus("idle");
+    setError("");
+    setStatus("idle");
+  }, []);
+
+  return {
+    apply,
+    applyResult,
+    bootstrap,
+    bootstrapPending,
+    context,
+    contextError,
+    contextStatus,
+    dismiss,
+    error,
+    inspectContext,
+    proposal,
+    propose,
+    status,
+  };
+}
+
+export function projectAssistantResultWorkItemID(result: ProjectAssistantApplyResult): string {
+  for (const action of result.actions) {
+    const workItemID = action.data?.work_item_id;
+    if (workItemID) return workItemID;
+  }
+  return "";
+}
+
+export function projectAssistantContextPayload(
+  form: ProjectAssistantDraftForm,
+  projectID: string,
+  workItemID?: string,
+): ProjectAssistantContextPayload {
+  const roleID = form.roleID === PROJECT_ASSISTANT_AUTO ? "" : form.roleID.trim();
+  const driverKind = form.driverKind === PROJECT_ASSISTANT_AUTO ? "" : form.driverKind.trim();
+  return {
+    project_id: projectID,
+    ...(workItemID ? { work_item_id: workItemID } : {}),
+    request: form.request,
+    ...(roleID ? { role_id: roleID } : {}),
+    ...(driverKind ? { driver_kind: driverKind } : {}),
+  };
+}
+
+export function projectAssistantDraftPayload(
+  form: ProjectAssistantDraftForm,
+  projectID: string,
+  workItemID?: string,
+): ProjectAssistantDraftPayload {
+  const payload: ProjectAssistantDraftPayload = projectAssistantContextPayload(
+    form,
+    projectID,
+    workItemID,
+  );
+  if (form.draftMode !== "deterministic") {
+    payload.draft_mode = form.draftMode;
+  }
+  return payload;
+}
+
+export function projectAssistantApplyErrorMessage(
+  error: unknown,
+  proposal?: ProjectAssistantProposal,
+): string {
+  if (error instanceof ApiError) {
+    const partialMessage = projectAssistantPartialApplyErrorMessage(error, proposal);
+    if (partialMessage) return partialMessage;
+    if (error.status === 404) {
+      return "Project Assistant could not find a proposal target. The project may have changed; refresh project work and draft the proposal again.";
+    }
+    if (error.status === 409) {
+      return "Project Assistant could not apply because the proposal is stale, conflicts with current project state, or was already applied. Refresh project work and draft it again.";
+    }
+  }
+  return errorMessage(error, "Failed to apply Project Assistant proposal.");
+}
+
+function projectAssistantPartialApplyErrorMessage(
+  error: ApiError,
+  proposal?: ProjectAssistantProposal,
+): string {
+  const failedActionIndex = projectAssistantFailedActionIndex(error.fields.failed_action_index);
+  const partialResult = projectAssistantPartialResult(error.fields.partial_result);
+  if (failedActionIndex === null || !partialResult) return "";
+  const appliedCount = partialResult.actions.length;
+  const totalCount = proposal?.actions.length ?? Math.max(appliedCount, failedActionIndex + 1);
+  return `Project Assistant applied ${appliedCount} of ${totalCount} actions, then failed at action ${failedActionIndex + 1}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
+}
+
+function projectAssistantFailedActionIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyResult | null {
+  if (!value || typeof value !== "object") return null;
+  const result = value as Partial<ProjectAssistantApplyResult>;
+  if (
+    typeof result.proposal_id !== "string" ||
+    typeof result.applied !== "boolean" ||
+    !Array.isArray(result.actions)
+  ) {
+    return null;
+  }
+  return {
+    proposal_id: result.proposal_id,
+    applied: result.applied,
+    actions: result.actions,
+  };
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    return error.userMessage || error.message || fallback;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}


### PR DESCRIPTION
## Summary

- add an internal `projectassistantapp` application seam so API handlers delegate Project Assistant context/draft/propose/apply orchestration instead of constructing the service directly
- keep Project Assistant service caching/progress behavior behind the app boundary and update backend agent guidance/codebase map
- extract Project Assistant UI state, payload construction, bootstrap/context/propose/apply flows, and error handling into `useProjectAssistantController`
- preserve the new project onboarding panel while wiring it through the extracted controller

## Verification

- `GOCACHE="$PWD/.gocache" go test ./internal/projectassistantapp ./internal/projectassistant`
- `GOCACHE="$PWD/.gocache" go vet ./internal/projectassistantapp ./internal/projectassistant ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `GOCACHE="$PWD/.gocache" go test -tags e2e -run "Test(ProjectActivityProjection|ProjectAssignmentPreflightStartLaunchPlan|ChatSessionApplicationLayerLifecycle)E2E" ./e2e`
- `just agent-docs-check`
- `just docs-format-check`
- `just check-links`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/useProjectAssistantController.test.ts src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`