### PR TITLE
Bound project work context reads for Hecate Chat

### DIFF
--- a/docs/runtime/agent-runtime.md
+++ b/docs/runtime/agent-runtime.md
@@ -21,7 +21,7 @@ Providers without streaming fall back to the normal non-streaming chat call.
 When a Hecate Chat session is linked to a project, Hecate keeps the Chat UI
 simple and injects project workflow guidance into the effective system prompt
 for project-linked turns. The prompt uses the same project, role, skill,
-current-work, and accepted-memory vocabulary as project assignment launch
+active-work, and accepted-memory vocabulary as project assignment launch
 context, and tells the model to treat planning/assignment/handoff/memory
 requests as proposal-only Project Assistant intent. Skill entries are metadata
 only; `SKILL.md` bodies are not injected by the simple chat path. The guidance

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -87,7 +87,7 @@ visible transcript message count for that turn, the legacy high-level
 optional `body` / `body_ref`, `included`, and `inclusion_reason`. Current items
 cover visible metadata only: system prompt presence, transcript count, enabled
 project context-source metadata, enabled project skill metadata, current
-project work metadata, accepted project memory, workspace path metadata, Hecate
+active project work metadata, accepted project memory, workspace path metadata, Hecate
 task-runtime state, and external-agent session metadata. It deliberately does
 not persist full system prompts, raw transcript text, file contents, `SKILL.md`
 bodies, or agent-private prompt packing. External Agent packets explicitly note

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -487,7 +487,7 @@ Hecate Chat stays visually simple. Project-linked Hecate Chat turns receive
 hidden project workflow guidance and bounded project context so the model can
 infer when an operator is asking for planning, assignment, handoff, or memory
 work. That guidance uses the same project, role, enabled skill metadata,
-current work-state, and accepted-memory vocabulary as project assignment launch
+active work-state, and accepted-memory vocabulary as project assignment launch
 context, so Chat and project agents share one mental model without adding
 controls to the conversation view. Skill entries remain metadata only; Chat does
 not load or inject `SKILL.md` bodies. It tells the model to treat durable

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2766,7 +2766,7 @@ the user message and assistant output.
 - `system_prompt` — applied to tools-off turns and new task-backed Hecate Chat
   segments. When the chat is linked to a project, Hecate prepends hidden
   project workflow guidance and bounded project context before the operator
-  prompt. That guidance uses the same project/role/skill/current-work/memory
+  prompt. That guidance uses the same project/role/skill/active-work/memory
   vocabulary as project assignment launch context and keeps Chat conversational
   while telling the model to treat project-planning intent as proposal-only
   Project Assistant work; it does not grant direct project mutation rights.
@@ -3040,7 +3040,7 @@ Section values currently used by the runtime are:
 - `memory` for project memory entries
 - `workspace` for the selected workspace path
 - `project` for project identity metadata
-- `project_work` for chat-visible current work metadata and assignment launch work-item, assignment, role, execution-hint, handoff, and artifact-reference metadata
+- `project_work` for chat-visible active work metadata and assignment launch work-item, assignment, role, execution-hint, handoff, and artifact-reference metadata
 - `sources` for enabled project context-source metadata such as `workspace_doc` and `project_notes`
 - `runtime` for transcript counts, task-runtime metadata, and external-agent session metadata
 

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -648,7 +648,7 @@ func appendProjectChatWork(packet *chat.ContextPacket, snapshot projectChatWorkS
 	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "project_work",
 		Label:  "Project work",
-		Detail: fmt.Sprintf("%d work items, %d assignments", len(snapshot.WorkItems), len(snapshot.Assignments)),
+		Detail: fmt.Sprintf("%d active work items, %d active assignments", len(snapshot.WorkItems), len(snapshot.Assignments)),
 		Trust:  contextTrustProject,
 	}, chat.ContextItem{
 		Kind:            "project_work",

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -241,6 +242,15 @@ func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateWorkItem: %v", err)
 	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_done",
+		ProjectID: "proj_1",
+		Title:     "Already done",
+		Brief:     "Completed work should not enter active chat context.",
+		Status:    projectwork.WorkItemStatusDone,
+	}); err != nil {
+		t.Fatalf("Create done work item: %v", err)
+	}
 	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
 		ID:         "asgn_chat",
 		ProjectID:  "proj_1",
@@ -250,6 +260,16 @@ func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 		Status:     projectwork.AssignmentStatusQueued,
 	}); err != nil {
 		t.Fatalf("CreateAssignment: %v", err)
+	}
+	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_done",
+		ProjectID:  "proj_1",
+		WorkItemID: "work_chat",
+		RoleID:     "reviewer_qa",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("Create completed assignment: %v", err)
 	}
 	handler := &Handler{projectSkills: skillStore, projectWork: workStore}
 	session := chat.Session{
@@ -297,7 +317,7 @@ func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 				t.Fatalf("project work item = %+v, want included project work metadata", *work)
 			}
 			for _, want := range []string{
-				"Work item status counts: ready=1",
+				"Shown active work item status counts: ready=1",
 				"Work item Project chat context (work_chat): status=ready, priority=high, owner_role=architect",
 				"Brief: Make linked chat aware of project work state.",
 				"Assignment asgn_chat: work_item=work_chat, role=architect, status=queued, driver=hecate_task",
@@ -306,7 +326,79 @@ func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 					t.Fatalf("project work body missing %q:\n%s", want, work.Body)
 				}
 			}
+			for _, excluded := range []string{"work_done", "asgn_done"} {
+				if strings.Contains(work.Body, excluded) {
+					t.Fatalf("project work body included inactive work %q:\n%s", excluded, work.Body)
+				}
+			}
 		})
+	}
+}
+
+func TestProjectChatWorkSnapshotUsesActiveBoundedLists(t *testing.T) {
+	ctx := context.Background()
+	workStore := projectwork.NewMemoryStore()
+	for idx := 0; idx < projectChatPromptWorkMaxItems+1; idx++ {
+		workID := fmt.Sprintf("work_%02d", idx)
+		if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+			ID:        workID,
+			ProjectID: "proj_1",
+			Title:     fmt.Sprintf("Active work %02d", idx),
+			Status:    projectwork.WorkItemStatusReady,
+		}); err != nil {
+			t.Fatalf("CreateWorkItem(%s): %v", workID, err)
+		}
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_done",
+		ProjectID: "proj_1",
+		Title:     "Done work",
+		Status:    projectwork.WorkItemStatusDone,
+	}); err != nil {
+		t.Fatalf("Create done work item: %v", err)
+	}
+	for idx := 0; idx < projectChatPromptAssignmentMaxItems+1; idx++ {
+		assignmentID := fmt.Sprintf("asgn_%02d", idx)
+		if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
+			ID:         assignmentID,
+			ProjectID:  "proj_1",
+			WorkItemID: "work_00",
+			RoleID:     "architect",
+			Status:     projectwork.AssignmentStatusQueued,
+		}); err != nil {
+			t.Fatalf("CreateAssignment(%s): %v", assignmentID, err)
+		}
+	}
+	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_completed",
+		ProjectID:  "proj_1",
+		WorkItemID: "work_00",
+		RoleID:     "reviewer_qa",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("Create completed assignment: %v", err)
+	}
+
+	snapshot := (&Handler{projectWork: workStore}).projectChatWorkSnapshot(ctx, "proj_1")
+	if len(snapshot.WorkItems) != projectChatPromptWorkMaxItems || !snapshot.WorkItemsTruncated {
+		t.Fatalf("work snapshot = len %d truncated %v, want max %d with truncation", len(snapshot.WorkItems), snapshot.WorkItemsTruncated, projectChatPromptWorkMaxItems)
+	}
+	if len(snapshot.Assignments) != projectChatPromptAssignmentMaxItems || !snapshot.AssignmentsTruncated {
+		t.Fatalf("assignment snapshot = len %d truncated %v, want max %d with truncation", len(snapshot.Assignments), snapshot.AssignmentsTruncated, projectChatPromptAssignmentMaxItems)
+	}
+	body := projectChatWorkHintText(snapshot, projectChatPromptWorkMaxItems, projectChatPromptAssignmentMaxItems)
+	for _, want := range []string{
+		"Additional active work items omitted.",
+		"Additional active assignments omitted.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("snapshot body missing %q:\n%s", want, body)
+		}
+	}
+	for _, excluded := range []string{"work_done", "asgn_completed"} {
+		if strings.Contains(body, excluded) {
+			t.Fatalf("snapshot body included inactive record %q:\n%s", excluded, body)
+		}
 	}
 }
 

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -213,6 +213,15 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create work item: %v", err)
 	}
+	if _, err := apiHandler.projectWork.CreateWorkItem(context.Background(), projectwork.WorkItem{
+		ID:        "work_done",
+		ProjectID: project.ID,
+		Title:     "Already done",
+		Brief:     "Completed work should not enter the active chat hint.",
+		Status:    projectwork.WorkItemStatusDone,
+	}); err != nil {
+		t.Fatalf("Create done work item: %v", err)
+	}
 	if _, err := apiHandler.projectWork.CreateAssignment(context.Background(), projectwork.Assignment{
 		ID:         "asgn_plan",
 		ProjectID:  project.ID,
@@ -222,6 +231,16 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 		Status:     projectwork.AssignmentStatusQueued,
 	}); err != nil {
 		t.Fatalf("Create assignment: %v", err)
+	}
+	if _, err := apiHandler.projectWork.CreateAssignment(context.Background(), projectwork.Assignment{
+		ID:         "asgn_done",
+		ProjectID:  project.ID,
+		WorkItemID: "work_chat_context",
+		RoleID:     "reviewer_qa",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("Create completed assignment: %v", err)
 	}
 	if _, err := apiHandler.memory.Create(context.Background(), memory.Entry{
 		ID:         "mem_boundary",
@@ -262,11 +281,11 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 		"Project skills (metadata only; skill bodies are not loaded):",
 		"Backend Skill (backend): Backend changes. Path: .hecate/skills/backend/SKILL.md",
 		"Use skills as procedures/guidance, not as role assignments.",
-		"Project work snapshot:",
-		"Work item status counts: ready=1",
+		"Active project work snapshot:",
+		"Shown active work item status counts: ready=1",
 		"- Work item Implement chat context (work_chat_context): status=ready, priority=high, owner_role=architect",
 		"Brief: Teach linked chat about project skills and work state.",
-		"Assignments:",
+		"Active assignments:",
 		"- Assignment asgn_plan: work_item=work_chat_context, role=architect, status=queued, driver=hecate_task",
 		"Accepted project memory:",
 		"Project memory: Project Assistant boundary\nID: mem_boundary\nTrust: operator_memory",
@@ -275,6 +294,11 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	} {
 		if !strings.Contains(backingTask.SystemPrompt, want) {
 			t.Fatalf("task system_prompt missing %q:\n%s", want, backingTask.SystemPrompt)
+		}
+	}
+	for _, excluded := range []string{"work_done", "asgn_done"} {
+		if strings.Contains(backingTask.SystemPrompt, excluded) {
+			t.Fatalf("task system_prompt included inactive work %q:\n%s", excluded, backingTask.SystemPrompt)
 		}
 	}
 }

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -25,6 +25,21 @@ const (
 	projectChatPromptInlineMaxRunes     = 220
 )
 
+var (
+	projectChatPromptWorkItemStatuses = []string{
+		projectwork.WorkItemStatusBacklog,
+		projectwork.WorkItemStatusReady,
+		projectwork.WorkItemStatusRunning,
+		projectwork.WorkItemStatusReview,
+		projectwork.WorkItemStatusBlocked,
+	}
+	projectChatPromptAssignmentStatuses = []string{
+		projectwork.AssignmentStatusQueued,
+		projectwork.AssignmentStatusRunning,
+		projectwork.AssignmentStatusAwaitingApproval,
+	}
+)
+
 func (h *Handler) hecateChatEffectiveSystemPrompt(ctx context.Context, session chat.Session, operatorPrompt string) string {
 	operatorPrompt = strings.TrimSpace(operatorPrompt)
 	projectPrompt := h.projectChatWorkflowSystemPrompt(ctx, session)
@@ -174,8 +189,10 @@ func projectChatMemorySection(entry memory.Entry, remaining *int) (string, bool)
 }
 
 type projectChatWorkSnapshot struct {
-	WorkItems   []projectwork.WorkItem
-	Assignments []projectwork.Assignment
+	WorkItems            []projectwork.WorkItem
+	Assignments          []projectwork.Assignment
+	WorkItemsTruncated   bool
+	AssignmentsTruncated bool
 }
 
 func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string) []projectskills.Skill {
@@ -213,15 +230,34 @@ func (h *Handler) projectChatWorkSnapshot(ctx context.Context, projectID string)
 		return projectChatWorkSnapshot{}
 	}
 	projectID = strings.TrimSpace(projectID)
-	workItems, err := h.projectWork.ListWorkItems(ctx, projectID)
+	workItems, err := h.projectWork.ListWorkItems(ctx, projectID, projectwork.ListOptions{
+		Statuses: projectChatPromptWorkItemStatuses,
+		Limit:    projectChatPromptWorkMaxItems + 1,
+	})
 	if err != nil {
 		workItems = nil
 	}
-	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	workItemsTruncated := len(workItems) > projectChatPromptWorkMaxItems
+	if workItemsTruncated {
+		workItems = workItems[:projectChatPromptWorkMaxItems]
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID}, projectwork.ListOptions{
+		Statuses: projectChatPromptAssignmentStatuses,
+		Limit:    projectChatPromptAssignmentMaxItems + 1,
+	})
 	if err != nil {
 		assignments = nil
 	}
-	return projectChatWorkSnapshot{WorkItems: workItems, Assignments: assignments}
+	assignmentsTruncated := len(assignments) > projectChatPromptAssignmentMaxItems
+	if assignmentsTruncated {
+		assignments = assignments[:projectChatPromptAssignmentMaxItems]
+	}
+	return projectChatWorkSnapshot{
+		WorkItems:            workItems,
+		Assignments:          assignments,
+		WorkItemsTruncated:   workItemsTruncated,
+		AssignmentsTruncated: assignmentsTruncated,
+	}
 }
 
 func projectChatSkillHintText(skills []projectskills.Skill, maxItems int) string {
@@ -255,13 +291,13 @@ func projectChatWorkHintText(snapshot projectChatWorkSnapshot, maxWorkItems, max
 	if len(snapshot.WorkItems) == 0 && len(snapshot.Assignments) == 0 {
 		return ""
 	}
-	lines := []string{"Project work snapshot:"}
+	lines := []string{"Active project work snapshot:"}
 	if len(snapshot.WorkItems) > 0 {
-		lines = append(lines, "Work item status counts: "+projectChatWorkStatusCounts(snapshot.WorkItems))
+		lines = append(lines, "Shown active work item status counts: "+projectChatWorkStatusCounts(snapshot.WorkItems))
 		included := 0
 		for _, item := range snapshot.WorkItems {
 			if included >= maxWorkItems {
-				lines = append(lines, fmt.Sprintf("- %d additional work items omitted.", len(snapshot.WorkItems)-included))
+				lines = append(lines, "- Additional active work items omitted.")
 				break
 			}
 			line := "- Work item " + labelWithID(item.Title, item.ID) + ": status=" + firstNonEmptyString(strings.TrimSpace(item.Status), projectwork.WorkItemStatusBacklog)
@@ -277,13 +313,16 @@ func projectChatWorkHintText(snapshot projectChatWorkSnapshot, maxWorkItems, max
 			lines = append(lines, line)
 			included++
 		}
+		if snapshot.WorkItemsTruncated {
+			lines = append(lines, "- Additional active work items omitted.")
+		}
 	}
 	if len(snapshot.Assignments) > 0 {
-		lines = append(lines, "Assignments:")
+		lines = append(lines, "Active assignments:")
 		included := 0
 		for _, assignment := range snapshot.Assignments {
 			if included >= maxAssignments {
-				lines = append(lines, fmt.Sprintf("- %d additional assignments omitted.", len(snapshot.Assignments)-included))
+				lines = append(lines, "- Additional active assignments omitted.")
 				break
 			}
 			line := "- Assignment " + firstNonEmptyString(strings.TrimSpace(assignment.ID), "assignment") +
@@ -293,6 +332,9 @@ func projectChatWorkHintText(snapshot projectChatWorkSnapshot, maxWorkItems, max
 				", driver=" + firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
 			lines = append(lines, line)
 			included++
+		}
+		if snapshot.AssignmentsTruncated {
+			lines = append(lines, "- Additional active assignments omitted.")
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -416,12 +416,26 @@ func (s *SQLiteStore) DeleteRole(ctx context.Context, projectID, id string) erro
 	return requireAffected(res)
 }
 
-func (s *SQLiteStore) ListWorkItems(ctx context.Context, projectID string) ([]WorkItem, error) {
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+func (s *SQLiteStore) ListWorkItems(ctx context.Context, projectID string, options ...ListOptions) ([]WorkItem, error) {
+	opts := normalizeListOptions(options)
+	query := fmt.Sprintf(`
 SELECT id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at
 FROM %s
 WHERE project_id = ?
-ORDER BY updated_at DESC, id ASC`, s.workItemsTbl), strings.TrimSpace(projectID))
+`, s.workItemsTbl)
+	args := []any{strings.TrimSpace(projectID)}
+	if len(opts.Statuses) > 0 {
+		query += ` AND status IN (` + sqlPlaceholders(len(opts.Statuses)) + `)`
+		for _, status := range opts.Statuses {
+			args = append(args, status)
+		}
+	}
+	query += ` ORDER BY updated_at DESC, id ASC`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -556,9 +570,10 @@ func (s *SQLiteStore) DeleteWorkItem(ctx context.Context, projectID, id string) 
 	return tx.Commit()
 }
 
-func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilter) ([]Assignment, error) {
+func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilter, options ...ListOptions) ([]Assignment, error) {
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	opts := normalizeListOptions(options)
 	query := fmt.Sprintf(`
 SELECT id, project_id, work_item_id, role_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
@@ -568,7 +583,17 @@ WHERE project_id = ?`, s.assignmentsTbl)
 		query += ` AND work_item_id = ?`
 		args = append(args, filter.WorkItemID)
 	}
+	if len(opts.Statuses) > 0 {
+		query += ` AND status IN (` + sqlPlaceholders(len(opts.Statuses)) + `)`
+		for _, status := range opts.Statuses {
+			args = append(args, status)
+		}
+	}
 	query += ` ORDER BY created_at ASC, id ASC`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -1303,6 +1328,17 @@ func requireAffected(res sql.Result) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+func sqlPlaceholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	items := make([]string, count)
+	for idx := range items {
+		items[idx] = "?"
+	}
+	return strings.Join(items, ", ")
 }
 
 func isSQLiteConstraint(err error) bool {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -153,6 +153,11 @@ type AssignmentFilter struct {
 	WorkItemID string
 }
 
+type ListOptions struct {
+	Limit    int
+	Statuses []string
+}
+
 type ArtifactFilter struct {
 	ProjectID    string
 	WorkItemID   string
@@ -171,12 +176,12 @@ type Store interface {
 	CreateRole(ctx context.Context, role AgentRoleProfile) (AgentRoleProfile, error)
 	UpdateRole(ctx context.Context, projectID, id string, update func(*AgentRoleProfile)) (AgentRoleProfile, error)
 	DeleteRole(ctx context.Context, projectID, id string) error
-	ListWorkItems(ctx context.Context, projectID string) ([]WorkItem, error)
+	ListWorkItems(ctx context.Context, projectID string, options ...ListOptions) ([]WorkItem, error)
 	CreateWorkItem(ctx context.Context, item WorkItem) (WorkItem, error)
 	GetWorkItem(ctx context.Context, projectID, id string) (WorkItem, bool, error)
 	UpdateWorkItem(ctx context.Context, projectID, id string, update func(*WorkItem)) (WorkItem, error)
 	DeleteWorkItem(ctx context.Context, projectID, id string) error
-	ListAssignments(ctx context.Context, filter AssignmentFilter) ([]Assignment, error)
+	ListAssignments(ctx context.Context, filter AssignmentFilter, options ...ListOptions) ([]Assignment, error)
 	CreateAssignment(ctx context.Context, assignment Assignment) (Assignment, error)
 	UpdateAssignment(ctx context.Context, projectID, id string, update func(*Assignment)) (Assignment, error)
 	DeleteAssignment(ctx context.Context, projectID, workItemID, id string) error
@@ -328,18 +333,25 @@ func (s *MemoryStore) DeleteRole(_ context.Context, projectID, id string) error 
 	return nil
 }
 
-func (s *MemoryStore) ListWorkItems(_ context.Context, projectID string) ([]WorkItem, error) {
+func (s *MemoryStore) ListWorkItems(_ context.Context, projectID string, options ...ListOptions) ([]WorkItem, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	projectID = strings.TrimSpace(projectID)
+	opts := normalizeListOptions(options)
+	statuses := listStatusSet(opts.Statuses)
 	items := make([]WorkItem, 0, len(s.workItems))
 	for _, item := range s.workItems {
 		if item.ProjectID == projectID {
+			if len(statuses) > 0 {
+				if _, ok := statuses[item.Status]; !ok {
+					continue
+				}
+			}
 			items = append(items, cloneWorkItem(item))
 		}
 	}
 	sortWorkItems(items)
-	return items, nil
+	return limitWorkItems(items, opts.Limit), nil
 }
 
 func (s *MemoryStore) CreateWorkItem(_ context.Context, item WorkItem) (WorkItem, error) {
@@ -425,11 +437,13 @@ func (s *MemoryStore) DeleteWorkItem(_ context.Context, projectID, id string) er
 	return nil
 }
 
-func (s *MemoryStore) ListAssignments(_ context.Context, filter AssignmentFilter) ([]Assignment, error) {
+func (s *MemoryStore) ListAssignments(_ context.Context, filter AssignmentFilter, options ...ListOptions) ([]Assignment, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	filter.ProjectID = strings.TrimSpace(filter.ProjectID)
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
+	opts := normalizeListOptions(options)
+	statuses := listStatusSet(opts.Statuses)
 	items := make([]Assignment, 0, len(s.assignments))
 	for _, item := range s.assignments {
 		if item.ProjectID != filter.ProjectID {
@@ -438,10 +452,15 @@ func (s *MemoryStore) ListAssignments(_ context.Context, filter AssignmentFilter
 		if filter.WorkItemID != "" && item.WorkItemID != filter.WorkItemID {
 			continue
 		}
+		if len(statuses) > 0 {
+			if _, ok := statuses[item.Status]; !ok {
+				continue
+			}
+		}
 		items = append(items, cloneAssignment(item))
 	}
 	sortAssignments(items)
-	return items, nil
+	return limitAssignments(items, opts.Limit), nil
 }
 
 func (s *MemoryStore) CreateAssignment(_ context.Context, assignment Assignment) (Assignment, error) {
@@ -1084,6 +1103,46 @@ func normalizeStringList(values []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func normalizeListOptions(options []ListOptions) ListOptions {
+	var out ListOptions
+	for _, option := range options {
+		if option.Limit > 0 {
+			out.Limit = option.Limit
+		}
+		out.Statuses = append(out.Statuses, option.Statuses...)
+	}
+	out.Statuses = normalizeStringList(out.Statuses)
+	return out
+}
+
+func listStatusSet(statuses []string) map[string]struct{} {
+	if len(statuses) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(statuses))
+	for _, status := range statuses {
+		status = strings.TrimSpace(status)
+		if status != "" {
+			out[status] = struct{}{}
+		}
+	}
+	return out
+}
+
+func limitWorkItems(items []WorkItem, limit int) []WorkItem {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return items[:limit]
+}
+
+func limitAssignments(items []Assignment, limit int) []Assignment {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return items[:limit]
 }
 
 func roleKey(projectID, id string) string {

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -373,6 +373,80 @@ func TestStoreConformance_ProjectCleanup(t *testing.T) {
 	}
 }
 
+func TestStoreConformance_ListOptionsLimitAndStatuses(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: func(t *testing.T) Store { return newSQLiteTestStore(t) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tc.new(t)
+			for _, item := range []WorkItem{
+				{ID: "work_backlog", ProjectID: "proj_alpha", Title: "Backlog", Status: WorkItemStatusBacklog},
+				{ID: "work_ready", ProjectID: "proj_alpha", Title: "Ready", Status: WorkItemStatusReady},
+				{ID: "work_done", ProjectID: "proj_alpha", Title: "Done", Status: WorkItemStatusDone},
+			} {
+				if _, err := store.CreateWorkItem(ctx, item); err != nil {
+					t.Fatalf("CreateWorkItem(%s): %v", item.ID, err)
+				}
+			}
+			activeWork, err := store.ListWorkItems(ctx, "proj_alpha", ListOptions{
+				Statuses: []string{WorkItemStatusReady, WorkItemStatusBacklog},
+			})
+			if err != nil {
+				t.Fatalf("ListWorkItems(active): %v", err)
+			}
+			if len(activeWork) != 2 || workItemIDExists(activeWork, "work_done") {
+				t.Fatalf("active work items = %+v, want ready/backlog only", activeWork)
+			}
+			limitedWork, err := store.ListWorkItems(ctx, "proj_alpha", ListOptions{
+				Statuses: []string{WorkItemStatusReady, WorkItemStatusBacklog},
+				Limit:    1,
+			})
+			if err != nil {
+				t.Fatalf("ListWorkItems(limited): %v", err)
+			}
+			if len(limitedWork) != 1 || limitedWork[0].Status == WorkItemStatusDone {
+				t.Fatalf("limited work items = %+v, want one active item", limitedWork)
+			}
+
+			for _, assignment := range []Assignment{
+				{ID: "asgn_queued", ProjectID: "proj_alpha", WorkItemID: "work_ready", RoleID: "architect", Status: AssignmentStatusQueued},
+				{ID: "asgn_running", ProjectID: "proj_alpha", WorkItemID: "work_ready", RoleID: "software_developer", Status: AssignmentStatusRunning},
+				{ID: "asgn_completed", ProjectID: "proj_alpha", WorkItemID: "work_ready", RoleID: "reviewer_qa", Status: AssignmentStatusCompleted},
+			} {
+				if _, err := store.CreateAssignment(ctx, assignment); err != nil {
+					t.Fatalf("CreateAssignment(%s): %v", assignment.ID, err)
+				}
+			}
+			activeAssignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha"}, ListOptions{
+				Statuses: []string{AssignmentStatusQueued, AssignmentStatusRunning},
+			})
+			if err != nil {
+				t.Fatalf("ListAssignments(active): %v", err)
+			}
+			if len(activeAssignments) != 2 || assignmentIDExists(activeAssignments, "asgn_completed") {
+				t.Fatalf("active assignments = %+v, want queued/running only", activeAssignments)
+			}
+			limitedAssignments, err := store.ListAssignments(ctx, AssignmentFilter{ProjectID: "proj_alpha"}, ListOptions{
+				Statuses: []string{AssignmentStatusQueued, AssignmentStatusRunning},
+				Limit:    1,
+			})
+			if err != nil {
+				t.Fatalf("ListAssignments(limited): %v", err)
+			}
+			if len(limitedAssignments) != 1 || limitedAssignments[0].Status == AssignmentStatusCompleted {
+				t.Fatalf("limited assignments = %+v, want one active assignment", limitedAssignments)
+			}
+		})
+	}
+}
+
 func TestMemoryStore_UpdateRejectsIDChanges(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -523,6 +597,24 @@ func newSQLiteTestStore(t *testing.T) *SQLiteStore {
 func roleIDExists(roles []AgentRoleProfile, id string) bool {
 	for _, role := range roles {
 		if role.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func workItemIDExists(items []WorkItem, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func assignmentIDExists(items []Assignment, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to the project-linked Hecate Chat context work from #371.

- Add optional `projectwork.ListOptions` for status-filtered, limited work-item and assignment reads while preserving existing store call sites.
- Use active-status `limit+1` reads for project-linked chat work snapshots, so the prompt path no longer reads every SQLite work item/assignment before render-time capping.
- Update chat context docs/copy to describe the injected project work state as active work metadata, and add regressions for active filtering/truncation.

## Self-review notes

- SQLite now pushes `status IN (...)` and `LIMIT ?` into the query, which keeps persistent prompt-build cost flat for this path.
- The memory store still scans its in-process maps before applying the same options. That is acceptable for the local memory tier and keeps behavior consistent with SQLite; the reviewer concern was primarily the persistent list path growing without a bound.
- Existing API/activity/list callers remain unbounded because they should continue returning the full requested collection.

## Tests

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/projectwork ./internal/api -run 'TestStoreConformance_ListOptionsLimitAndStatuses|TestProjectChatWorkSnapshotUsesActiveBoundedLists|TestHecateAgentChatProjectSessionInjectsProposalGuidance|TestChatContextPacketsIncludeProjectSkillAndWorkMetadata'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/projectwork ./internal/api`
- `go vet ./internal/projectwork ./internal/api`
- `just docs-format-check`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
