### PR TITLE
Add project assignment roots and worktree creation

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -33,6 +33,12 @@ the main checkout and linked Git worktrees, while newly discovered worktree root
 stay inactive until the operator enables them. Context discovery must not treat
 nested `.worktrees`, `.claude/worktrees`, or other nested Git checkouts as
 inherited guidance for the parent root.
+Work items and assignments may select a concrete project root; launch resolution
+uses assignment root, then work-item root, then project default root, then the
+first active root. Worktree creation is an explicit operator action and is
+bounded to a direct child of the selected base root's `.worktrees/` directory
+in V1; do not create or assume sibling/nested checkout paths outside registered
+roots.
 Profile memory/source policies now control whether assignment context packets
 mark project memory and source metadata active, visible-only, or omitted. Native
 project assignments can include bounded project memory and portable `AGENTS.md`

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -340,6 +340,13 @@ Queued assignment launches now show a launch preflight context packet before
 dispatch; confirming the preview starts the native task or prepares the External
 Agent chat, while preflight itself creates no task, run, chat session, artifact,
 memory entry, or assignment update.
+Project roots now model concrete checkouts for assignment execution: work items
+and assignments can select a root by `root_id`, and launch resolution uses
+assignment root, work-item root, project default root, then first active root.
+Operators can explicitly create linked Git worktrees from an existing project
+root; V1 registers the created checkout as a project root and constrains the
+target to a direct child of the base root's `.worktrees/` directory so Hecate
+does not create arbitrary sibling or nested workspaces.
 The Projects UI also derives a compact project timeline / decision log from
 activity rows, structured handoffs, collaboration artifacts, project memory
 entries, and memory candidates; explicit decisions are only shown when existing
@@ -391,7 +398,10 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 9. Add project activity aggregation. Done for the read-only V1 inbox.
 10. Add structured handoffs. Done for memory + SQLite store parity, API, UI
     actions, and activity projection signals.
-11. Update docs, screenshots, and e2e coverage. Partial: docs, focused UI/API
+11. Add project-root selection and explicit worktree creation. Done for
+    work-item/assignment root overrides, launch preflight/start snapshots, and
+    operator-triggered Git worktree creation under `.worktrees/`.
+12. Update docs, screenshots, and e2e coverage. Partial: docs, focused UI/API
     tests, and an API-level project journey regression are updated; broad UI
     end-to-end project journeys remain beta-hardening work.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1340,6 +1340,54 @@ POST /hecate/v1/projects/proj_.../roots/discover
 }
 ```
 
+### `POST /hecate/v1/projects/{id}/roots/worktrees`
+
+Creates a linked Git worktree from an existing project root and appends the
+created checkout as a project root. This is an explicit operator action. V1
+constrains the target path to a direct child of the selected base root's
+`.worktrees/` directory so Hecate does not create sibling, nested, or arbitrary
+filesystem workspaces through this endpoint.
+
+Request fields:
+
+- `branch` is required and becomes the new worktree branch.
+- `base_root_id` selects the Git root to run `git worktree add` from; omitted
+  means project default root, then first active root, then first root.
+- `start_point` is optional and is passed to Git after the target path.
+- `path` is optional. Relative paths resolve under the base root and must be a
+  direct child of `.worktrees/`.
+- `active` defaults to `true`.
+- `set_default` makes the new root the project's `default_root_id`.
+
+```json
+POST /hecate/v1/projects/proj_.../roots/worktrees
+{
+  "base_root_id": "root_main",
+  "branch": "feature/project-roots",
+  "start_point": "origin/main",
+  "active": true,
+  "set_default": true
+}
+
+→ 201
+{
+  "object": "project",
+  "data": {
+    "id": "proj_...",
+    "default_root_id": "root_...",
+    "roots": [
+      {
+        "id": "root_...",
+        "path": "/Users/alice/src/hecate/.worktrees/feature-project-roots",
+        "kind": "git_worktree",
+        "git_branch": "feature/project-roots",
+        "active": true
+      }
+    ]
+  }
+}
+```
+
 ### `POST /hecate/v1/projects/{id}/context-sources/discover`
 
 Discovers workspace guidance metadata from active absolute project roots and
@@ -1592,6 +1640,9 @@ Supported assignment driver kinds are `hecate_task` and `external_agent`.
 Assignment start dispatches `hecate_task` assignments through the native task
 runtime and prepares `external_agent` assignments as supervised External Agent
 chat sessions.
+Work items and assignments may carry `root_id` to select a concrete project
+root. Launch workspace resolution uses assignment `root_id`, then work-item
+`root_id`, then project `default_root_id`, then the first active project root.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
 Supported structured handoff statuses are `pending`, `accepted`, `superseded`,
@@ -1977,6 +2028,7 @@ or `urgent`.
   "status": "ready",
   "priority": "high",
   "owner_role_id": "software_developer",
+  "root_id": "root_...",
   "reviewer_role_ids": ["architect", "reviewer_qa"]
 }
 ```
@@ -1994,6 +2046,7 @@ Returns:
     "status": "ready",
     "priority": "high",
     "owner_role_id": "software_developer",
+    "root_id": "root_...",
     "reviewer_role_ids": ["architect", "reviewer_qa"],
     "created_at": "2026-06-03T12:00:00Z",
     "updated_at": "2026-06-03T12:00:00Z"
@@ -2007,8 +2060,8 @@ Returns one work item or `404 not_found`.
 
 #### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}`
 
-Updates `title`, `brief`, `status`, `priority`, `owner_role_id`, or
-`reviewer_role_ids`.
+Updates `title`, `brief`, `status`, `priority`, `owner_role_id`, `root_id`, or
+`reviewer_role_ids`. An empty `root_id` clears the work-item root override.
 
 #### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}`
 
@@ -2027,6 +2080,7 @@ defaults to `hecate_task`. Optional execution links are stored under
 ```json
 {
   "role_id": "software_developer",
+  "root_id": "root_...",
   "driver_kind": "hecate_task",
   "execution_ref": {
     "kind": "task_run",
@@ -2047,6 +2101,7 @@ Returns:
     "project_id": "proj_...",
     "work_item_id": "work_...",
     "role_id": "software_developer",
+    "root_id": "root_...",
     "driver_kind": "hecate_task",
     "status": "queued",
     "execution_ref": {
@@ -2070,8 +2125,9 @@ Returns:
 
 #### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}`
 
-Updates assignment status, role, link fields, `started_at`, or `completed_at`.
-It does not mutate or start the linked Task or Chat.
+Updates assignment status, role, `root_id`, link fields, `started_at`, or
+`completed_at`. An empty `root_id` clears the assignment root override. It does
+not mutate or start the linked Task or Chat.
 
 #### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}`
 
@@ -2100,6 +2156,9 @@ start: project/work/assignment/role lookup, stored driver support, active
 execution checks, workspace resolution, resolved profile, provider/model hints
 for native assignments, External Agent adapter/options for external-agent
 assignments, skill metadata resolution, and prompt-context policy metadata.
+The packet includes a `project_work` / `project_root` item describing the
+selected root, path, Git branch/remote when known, and whether the root came
+from an assignment override, work-item default, or project default/fallback.
 
 The response is a normal `context_packet` envelope with assignment refs only;
 task, run, chat session, and message refs remain empty because preflight is

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -370,7 +370,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	return packet
 }
 
-func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, workingDirectory, provider, model, executionProfile string, profile projectworkapp.ResolvedAgentProfile, skills projectworkapp.ResolvedProjectSkills, promptContext projectworkapp.AssignmentPromptContext) chat.ContextPacket {
+func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, root projects.Root, workingDirectory, provider, model, executionProfile string, profile projectworkapp.ResolvedAgentProfile, skills projectworkapp.ResolvedProjectSkills, promptContext projectworkapp.AssignmentPromptContext) chat.ContextPacket {
 	packet := baseChatContextPacket(chat.ExecutionModeHecateTask, provider, model, workingDirectory)
 	driverKind := firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
 	includedReason := "Included in the native project assignment launch context"
@@ -419,6 +419,40 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 		Included:        true,
 		InclusionReason: includedReason,
 	})
+	rootLines := []string{
+		"Root ID: " + firstNonEmptyString(strings.TrimSpace(root.ID), "unresolved"),
+		"Path: " + firstNonEmptyString(strings.TrimSpace(workingDirectory), strings.TrimSpace(root.Path), "none"),
+		"Kind: " + firstNonEmptyString(strings.TrimSpace(root.Kind), "local"),
+	}
+	if branch := strings.TrimSpace(root.GitBranch); branch != "" {
+		rootLines = append(rootLines, "Git branch: "+branch)
+	}
+	if remote := strings.TrimSpace(root.GitRemote); remote != "" {
+		rootLines = append(rootLines, "Git remote: "+remote)
+	}
+	rootSelection := "project root fallback"
+	if strings.TrimSpace(assignment.RootID) != "" {
+		rootSelection = "assignment override"
+	} else if strings.TrimSpace(workItem.RootID) != "" {
+		rootSelection = "work item default"
+	} else if strings.TrimSpace(project.DefaultRootID) != "" && strings.TrimSpace(project.DefaultRootID) == strings.TrimSpace(root.ID) {
+		rootSelection = "project default"
+	}
+	rootLines = append(rootLines, "Selection: "+rootSelection)
+	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "project_root",
+		Label:  firstNonEmptyString(strings.TrimSpace(root.ID), "Project root"),
+		Detail: strings.TrimSpace(root.Path),
+		Trust:  "runtime",
+	}, chat.ContextItem{
+		Kind:            "project_root",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          firstNonEmptyString(strings.TrimSpace(root.ID), "project_root"),
+		Title:           "Project root",
+		Body:            strings.Join(rootLines, "\n"),
+		Included:        true,
+		InclusionReason: includedReason,
+	})
 	appendContextPacketSourceWithSection(&packet, contextSectionProjectWork, chat.ContextSource{
 		Kind:   "role",
 		Label:  firstNonEmptyString(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)),
@@ -451,6 +485,7 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			"Provider: " + firstNonEmptyString(strings.TrimSpace(provider), "auto"),
 			"Model: " + firstNonEmptyString(strings.TrimSpace(model), "project/runtime default"),
 			"Profile: " + firstNonEmptyString(strings.TrimSpace(executionProfile), "none"),
+			"Root: " + firstNonEmptyString(strings.TrimSpace(root.ID), "project default"),
 			"Role defaults: " + formatAssignmentHints([]assignmentHint{
 				{"driver", role.DefaultDriverKind},
 				{"provider", role.DefaultProvider},

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -164,11 +164,11 @@ func (h *Handler) projectHecateTaskAssignmentPreflightContext(ctx context.Contex
 	if active {
 		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusConflict, errCodeConflict, "assignment already has active execution")
 	}
-	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, role)
+	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
 	if err != nil {
 		return chat.ContextPacket{}, err
 	}
-	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
+	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Root, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
 	appendProjectAssignmentLaunchPreflight(&packet, projectwork.AssignmentDriverHecateTask, []string{
 		"Task: created on start",
 		"Run: created on start",
@@ -187,7 +187,7 @@ func (h *Handler) projectExternalAgentAssignmentPreflightContext(ctx context.Con
 	if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" {
 		return chat.ContextPacket{}, newProjectAssignmentPreflightError(http.StatusConflict, errCodeConflict, "external-agent assignment already has a prepared chat session")
 	}
-	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
 	if err != nil {
 		var launchErr projectworkapp.LaunchPlanError
 		if errors.As(err, &launchErr) && launchErr.Kind == projectworkapp.LaunchPlanAdapterNotFound {
@@ -301,12 +301,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, role)
+	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
 	if err != nil {
 		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
 		return
 	}
-	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
+	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Root, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
 	if contextPacket.ID == "" {
 		contextPacket.ID = newChatID("ctx")
 	}
@@ -370,7 +370,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) projectExternalAgentAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectworkapp.ExternalAgentAssignmentLaunchPlan, sessionID string) chat.ContextPacket {
-	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Workspace, "", "", plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, projectworkapp.AssignmentPromptContext{})
+	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Root, plan.Workspace, "", "", plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, projectworkapp.AssignmentPromptContext{})
 	packet.ExecutionMode = chat.ExecutionModeExternalAgent
 	packet.Provider = ""
 	packet.Model = ""
@@ -400,7 +400,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
-	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
 	if err != nil {
 		var launchErr projectworkapp.LaunchPlanError
 		if errors.As(err, &launchErr) && launchErr.Kind == projectworkapp.LaunchPlanAdapterNotFound {

--- a/internal/api/handler_project_roots_discovery.go
+++ b/internal/api/handler_project_roots_discovery.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -18,6 +19,15 @@ const (
 	projectRootKindGit         = "git"
 	projectRootKindGitWorktree = "git_worktree"
 )
+
+type createProjectWorktreeRootRequest struct {
+	BaseRootID string `json:"base_root_id,omitempty"`
+	Branch     string `json:"branch"`
+	Path       string `json:"path,omitempty"`
+	StartPoint string `json:"start_point,omitempty"`
+	Active     *bool  `json:"active,omitempty"`
+	SetDefault bool   `json:"set_default,omitempty"`
+}
 
 func (h *Handler) HandleDiscoverProjectRoots(w http.ResponseWriter, r *http.Request) {
 	if h.projects == nil {
@@ -51,10 +61,192 @@ func (h *Handler) HandleDiscoverProjectRoots(w http.ResponseWriter, r *http.Requ
 	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(updated)})
 }
 
+func (h *Handler) HandleCreateProjectWorktreeRoot(w http.ResponseWriter, r *http.Request) {
+	if h.projects == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
+		return
+	}
+	project, ok, err := h.projects.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	var req createProjectWorktreeRootRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	root, _, err := createProjectWorktreeRoot(r.Context(), project, req, gitrunner.NewLocalRunner())
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	updated, err := h.projects.Update(r.Context(), project.ID, func(item *projects.Project) {
+		item.Roots = append(item.Roots, root)
+		if req.SetDefault {
+			item.DefaultRootID = root.ID
+		}
+	})
+	if errors.Is(err, projects.ErrAlreadyExists) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(updated)})
+}
+
 type projectGitRunner interface {
 	IsWorkTree(context.Context, string) bool
 	Worktrees(context.Context, string) ([]gitrunner.Worktree, error)
 	Run(context.Context, string, ...string) (gitrunner.Result, error)
+}
+
+func createProjectWorktreeRoot(ctx context.Context, project projects.Project, req createProjectWorktreeRootRequest, runner projectGitRunner) (projects.Root, string, error) {
+	if runner == nil {
+		runner = gitrunner.NewLocalRunner()
+	}
+	branch := strings.TrimSpace(req.Branch)
+	if branch == "" {
+		return projects.Root{}, "", fmt.Errorf("branch is required")
+	}
+	if strings.HasPrefix(branch, "-") {
+		return projects.Root{}, "", fmt.Errorf("branch cannot start with '-'")
+	}
+	baseRoot, ok := selectProjectWorktreeBaseRoot(project, req.BaseRootID)
+	if !ok {
+		return projects.Root{}, "", fmt.Errorf("base project root not found")
+	}
+	basePath := strings.TrimSpace(baseRoot.Path)
+	if basePath == "" || !filepath.IsAbs(basePath) {
+		return projects.Root{}, "", fmt.Errorf("base project root %q must have an absolute path", baseRoot.ID)
+	}
+	info, err := os.Stat(basePath)
+	if err != nil {
+		return projects.Root{}, "", fmt.Errorf("base project root %q is not accessible: %w", baseRoot.ID, err)
+	}
+	if !info.IsDir() {
+		return projects.Root{}, "", fmt.Errorf("base project root %q is not a directory", baseRoot.ID)
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	if !runner.IsWorkTree(checkCtx, basePath) {
+		cancel()
+		return projects.Root{}, "", fmt.Errorf("base project root %q is not a git worktree", baseRoot.ID)
+	}
+	cancel()
+
+	worktreeParent := filepath.Join(basePath, ".worktrees")
+	targetPath := strings.TrimSpace(req.Path)
+	if targetPath == "" {
+		targetPath = filepath.Join(worktreeParent, safeWorktreePathSegment(branch))
+	} else if !filepath.IsAbs(targetPath) {
+		targetPath = filepath.Join(basePath, targetPath)
+	}
+	targetPath = filepath.Clean(targetPath)
+	if ok, err := pathWithin(worktreeParent, targetPath); err != nil {
+		return projects.Root{}, "", err
+	} else if !ok {
+		return projects.Root{}, "", fmt.Errorf("worktree path must be under %s", worktreeParent)
+	}
+	if filepath.Dir(targetPath) != filepath.Clean(worktreeParent) {
+		return projects.Root{}, "", fmt.Errorf("worktree path must be a direct child of %s", worktreeParent)
+	}
+	if _, err := os.Stat(targetPath); err == nil {
+		return projects.Root{}, "", fmt.Errorf("worktree path already exists: %s", targetPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return projects.Root{}, "", fmt.Errorf("worktree path could not be inspected: %w", err)
+	}
+	// This is the only raw filesystem write here: gitrunner owns the actual
+	// worktree creation after the base Git root and target boundary are validated.
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return projects.Root{}, "", fmt.Errorf("worktree parent could not be created: %w", err)
+	}
+	args := []string{"worktree", "add", "-b", branch, targetPath}
+	if startPoint := strings.TrimSpace(req.StartPoint); startPoint != "" {
+		args = append(args, startPoint)
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := runner.Run(runCtx, basePath, args...); err != nil {
+		return projects.Root{}, "", fmt.Errorf("git worktree add failed: %w", err)
+	}
+	active := true
+	if req.Active != nil {
+		active = *req.Active
+	}
+	return projects.Root{
+		ID:        newOpaqueTaskResourceID("root"),
+		Path:      targetPath,
+		Kind:      projectRootKindGitWorktree,
+		GitRemote: projectRootGitRemote(ctx, runner, targetPath),
+		GitBranch: branch,
+		Active:    active,
+	}, targetPath, nil
+}
+
+func selectProjectWorktreeBaseRoot(project projects.Project, rootID string) (projects.Root, bool) {
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		rootID = strings.TrimSpace(project.DefaultRootID)
+	}
+	if rootID != "" {
+		for _, root := range project.Roots {
+			if strings.TrimSpace(root.ID) == rootID {
+				return root, true
+			}
+		}
+		return projects.Root{}, false
+	}
+	for _, root := range project.Roots {
+		if root.Active {
+			return root, true
+		}
+	}
+	if len(project.Roots) > 0 {
+		return project.Roots[0], true
+	}
+	return projects.Root{}, false
+}
+
+func safeWorktreePathSegment(branch string) string {
+	branch = strings.TrimSpace(branch)
+	var b strings.Builder
+	for _, r := range branch {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), ".-_/ ")
+	if out == "" {
+		return "worktree"
+	}
+	return out
+}
+
+func pathWithin(parent, child string) (bool, error) {
+	parent, err := filepath.Abs(filepath.Clean(parent))
+	if err != nil {
+		return false, err
+	}
+	child, err = filepath.Abs(filepath.Clean(child))
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false, err
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))), nil
 }
 
 func discoverProjectGitWorktreeRoots(ctx context.Context, project projects.Project, runner projectGitRunner) ([]projects.Root, error) {

--- a/internal/api/handler_project_roots_discovery_test.go
+++ b/internal/api/handler_project_roots_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -65,6 +66,103 @@ func TestProjectRootsDiscovery_MergesGitWorktrees(t *testing.T) {
 	}
 	if resp.Data.DefaultRootID != "root_main" {
 		t.Fatalf("default_root_id = %q, want root_main", resp.Data.DefaultRootID)
+	}
+}
+
+func TestProjectRoots_CreateWorktreeRoot(t *testing.T) {
+	t.Parallel()
+	repo := initProjectRootDiscoveryRepo(t)
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:            "proj_roots",
+		Name:          "Roots",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   repo,
+			Kind:   "git",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots/roots/worktrees", bytes.NewReader([]byte(`{
+		"base_root_id":"root_main",
+		"branch":"feature/create-root",
+		"active":true,
+		"set_default":true
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create worktree status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode create worktree response: %v", err)
+	}
+	if len(resp.Data.Roots) != 2 {
+		t.Fatalf("roots = %+v, want main plus created worktree", resp.Data.Roots)
+	}
+	created := resp.Data.Roots[1]
+	wantPath := filepath.Join(repo, ".worktrees", "feature-create-root")
+	if created.ID == "" || created.Kind != "git_worktree" || created.GitBranch != "feature/create-root" || !created.Active || resp.Data.DefaultRootID != created.ID {
+		t.Fatalf("created root = %+v default=%q, want active default git worktree", created, resp.Data.DefaultRootID)
+	}
+	if canonicalProjectRootDiscoveryTestPath(t, created.Path) != canonicalProjectRootDiscoveryTestPath(t, wantPath) {
+		t.Fatalf("created path = %q, want %q", created.Path, wantPath)
+	}
+	branch, err := exec.Command("git", "-C", created.Path, "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatalf("git branch in created worktree: %v", err)
+	}
+	if strings.TrimSpace(string(branch)) != "feature/create-root" {
+		t.Fatalf("created worktree branch = %q, want feature/create-root", strings.TrimSpace(string(branch)))
+	}
+}
+
+func TestProjectRoots_CreateWorktreeRootRejectsOutsidePath(t *testing.T) {
+	t.Parallel()
+	repo := initProjectRootDiscoveryRepo(t)
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:            "proj_roots",
+		Name:          "Roots",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   repo,
+			Kind:   "git",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots/roots/worktrees", bytes.NewReader([]byte(`{
+		"base_root_id":"root_main",
+		"branch":"feature/outside",
+		"path":"../outside"
+	}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("outside worktree status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots/roots/worktrees", bytes.NewReader([]byte(`{
+		"base_root_id":"root_main",
+		"branch":"feature/nested",
+		"path":".worktrees/nested/feature"
+	}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("nested worktree status = %d body=%s, want 400", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -41,6 +41,7 @@ type createProjectWorkItemRequest struct {
 	Status          string   `json:"status,omitempty"`
 	Priority        string   `json:"priority,omitempty"`
 	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	RootID          string   `json:"root_id,omitempty"`
 	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
 }
 
@@ -50,12 +51,14 @@ type updateProjectWorkItemRequest struct {
 	Status          *string   `json:"status,omitempty"`
 	Priority        *string   `json:"priority,omitempty"`
 	OwnerRoleID     *string   `json:"owner_role_id,omitempty"`
+	RootID          *string   `json:"root_id,omitempty"`
 	ReviewerRoleIDs *[]string `json:"reviewer_role_ids,omitempty"`
 }
 
 type createProjectWorkAssignmentRequest struct {
 	ID           string                                     `json:"id,omitempty"`
 	RoleID       string                                     `json:"role_id"`
+	RootID       string                                     `json:"root_id,omitempty"`
 	DriverKind   string                                     `json:"driver_kind,omitempty"`
 	Status       string                                     `json:"status,omitempty"`
 	ExecutionRef *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
@@ -65,6 +68,7 @@ type createProjectWorkAssignmentRequest struct {
 
 type updateProjectWorkAssignmentRequest struct {
 	RoleID       *string                                    `json:"role_id,omitempty"`
+	RootID       *string                                    `json:"root_id,omitempty"`
 	DriverKind   *string                                    `json:"driver_kind,omitempty"`
 	Status       *string                                    `json:"status,omitempty"`
 	ExecutionRef *ProjectWorkAssignmentExecutionRefResponse `json:"execution_ref,omitempty"`
@@ -174,6 +178,7 @@ type ProjectWorkItemResponse struct {
 	Status          string                          `json:"status"`
 	Priority        string                          `json:"priority"`
 	OwnerRoleID     string                          `json:"owner_role_id,omitempty"`
+	RootID          string                          `json:"root_id,omitempty"`
 	ReviewerRoleIDs []string                        `json:"reviewer_role_ids,omitempty"`
 	Assignments     []ProjectWorkAssignmentResponse `json:"assignments,omitempty"`
 	CreatedAt       string                          `json:"created_at"`
@@ -227,6 +232,7 @@ type ProjectWorkAssignmentResponse struct {
 	ProjectID    string                                     `json:"project_id"`
 	WorkItemID   string                                     `json:"work_item_id"`
 	RoleID       string                                     `json:"role_id"`
+	RootID       string                                     `json:"root_id,omitempty"`
 	DriverKind   string                                     `json:"driver_kind"`
 	Status       string                                     `json:"status"`
 	CreatedAt    string                                     `json:"created_at"`
@@ -425,6 +431,9 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if !h.requireProjectRootRef(w, r, projectID, req.RootID) {
+		return
+	}
 	item, err := h.projectWorkApplication().CreateWorkItem(r.Context(), projectID, projectworkapp.CreateWorkItemCommand{
 		ID:              req.ID,
 		Title:           req.Title,
@@ -432,6 +441,7 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 		Status:          req.Status,
 		Priority:        req.Priority,
 		OwnerRoleID:     req.OwnerRoleID,
+		RootID:          req.RootID,
 		ReviewerRoleIDs: req.ReviewerRoleIDs,
 	})
 	if !writeProjectWorkError(w, err) {
@@ -476,12 +486,16 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if req.RootID != nil && !h.requireProjectRootRef(w, r, projectID, *req.RootID) {
+		return
+	}
 	item, err := h.projectWorkApplication().UpdateWorkItem(r.Context(), projectID, r.PathValue("work_item_id"), projectworkapp.UpdateWorkItemCommand{
 		Title:           req.Title,
 		Brief:           req.Brief,
 		Status:          req.Status,
 		Priority:        req.Priority,
 		OwnerRoleID:     req.OwnerRoleID,
+		RootID:          req.RootID,
 		ReviewerRoleIDs: req.ReviewerRoleIDs,
 	})
 	if !writeProjectWorkError(w, err) {
@@ -539,6 +553,9 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if !h.requireProjectRootRef(w, r, projectID, req.RootID) {
+		return
+	}
 	startedAt, completedAt, ok := parseProjectWorkRequestTimes(w, req.StartedAt, req.CompletedAt)
 	if !ok {
 		return
@@ -546,6 +563,7 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	item, err := h.projectWorkApplication().CreateAssignment(r.Context(), projectID, workItemID, projectworkapp.CreateAssignmentCommand{
 		ID:           req.ID,
 		RoleID:       req.RoleID,
+		RootID:       req.RootID,
 		DriverKind:   req.DriverKind,
 		Status:       req.Status,
 		ExecutionRef: projectWorkAssignmentExecutionRefFromRequest(req.ExecutionRef),
@@ -574,6 +592,9 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if req.RootID != nil && !h.requireProjectRootRef(w, r, projectID, *req.RootID) {
+		return
+	}
 	startedAt, completedAt, ok := parseProjectWorkOptionalRequestTimes(w, req.StartedAt, req.CompletedAt)
 	if !ok {
 		return
@@ -588,6 +609,7 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	}
 	item, err := h.projectWorkApplication().UpdateAssignment(r.Context(), projectID, assignmentID, projectworkapp.UpdateAssignmentCommand{
 		RoleID:       req.RoleID,
+		RootID:       req.RootID,
 		DriverKind:   req.DriverKind,
 		Status:       req.Status,
 		ExecutionRef: projectWorkAssignmentExecutionRefPtrFromRequest(req.ExecutionRef),
@@ -937,6 +959,29 @@ func (h *Handler) requireProject(w http.ResponseWriter, r *http.Request, project
 	return true
 }
 
+func (h *Handler) requireProjectRootRef(w http.ResponseWriter, r *http.Request, projectID, rootID string) bool {
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return true
+	}
+	project, ok, err := h.projects.Get(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return false
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return false
+	}
+	for _, root := range project.Roots {
+		if strings.TrimSpace(root.ID) == rootID {
+			return true
+		}
+	}
+	WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "root_id does not match a project root")
+	return false
+}
+
 func (h *Handler) requireProjectWorkItem(w http.ResponseWriter, r *http.Request, projectID, workItemID string) bool {
 	if !h.requireProject(w, r, projectID) {
 		return false
@@ -1121,6 +1166,7 @@ func renderProjectWorkItem(item projectwork.WorkItem) ProjectWorkItemResponse {
 		Status:          item.Status,
 		Priority:        item.Priority,
 		OwnerRoleID:     item.OwnerRoleID,
+		RootID:          item.RootID,
 		ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
 		CreatedAt:       formatOptionalTime(item.CreatedAt),
 		UpdatedAt:       formatOptionalTime(item.UpdatedAt),
@@ -1133,6 +1179,7 @@ func renderProjectWorkAssignment(item projectwork.Assignment) ProjectWorkAssignm
 		ProjectID:   item.ProjectID,
 		WorkItemID:  item.WorkItemID,
 		RoleID:      item.RoleID,
+		RootID:      item.RootID,
 		DriverKind:  item.DriverKind,
 		Status:      item.Status,
 		CreatedAt:   formatOptionalTime(item.CreatedAt),

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -435,6 +436,82 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_WorkAndAssignmentRootIDs(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectWorkTestServer()
+	rootA := filepath.Join(t.TempDir(), "feature")
+	rootB := filepath.Join(t.TempDir(), "review")
+	projectBody := fmt.Sprintf(`{
+		"name":"Rooted",
+		"roots":[
+			{"id":"root_feature","path":%q,"kind":"git","active":true},
+			{"id":"root_review","path":%q,"kind":"git_worktree","active":true}
+		],
+		"default_root_id":"root_feature"
+	}`, rootA, rootB)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(projectBody))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create project status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &project); err != nil {
+		t.Fatalf("decode project: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_rooted",
+		"title":"Rooted work",
+		"root_id":"root_feature"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create rooted work status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var work ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &work); err != nil {
+		t.Fatalf("decode rooted work: %v", err)
+	}
+	if work.Data.RootID != "root_feature" {
+		t.Fatalf("work root_id = %q, want root_feature", work.Data.RootID)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_rooted", bytes.NewReader([]byte(`{"root_id":"root_review"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch rooted work status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &work); err != nil {
+		t.Fatalf("decode patched rooted work: %v", err)
+	}
+	if work.Data.RootID != "root_review" {
+		t.Fatalf("patched work root_id = %q, want root_review", work.Data.RootID)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_rooted/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_rooted",
+		"role_id":"software_developer",
+		"root_id":"root_feature"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create rooted assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode rooted assignment: %v", err)
+	}
+	if assignment.Data.RootID != "root_feature" {
+		t.Fatalf("assignment root_id = %q, want root_feature", assignment.Data.RootID)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_rooted/assignments/asgn_rooted", bytes.NewReader([]byte(`{"root_id":"root_missing"}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("patch assignment invalid root status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_ProjectDeletionCleansRows(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -667,6 +744,67 @@ func TestProjectWorkAPI_PreflightAndStartShareNativeLaunchPlan(t *testing.T) {
 		t.Fatalf("task launch shape = provider/model/profile/workspace %q/%q/%q/%q, want preflight %q/%q/%q/%q",
 			task.RequestedProvider, task.RequestedModel, task.ExecutionProfile, task.WorkingDirectory,
 			preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentUsesSelectedProjectRoot(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	defaultRoot := t.TempDir()
+	workRoot := t.TempDir()
+	assignmentRoot := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: defaultRoot,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultRootID = "root_default"
+		project.Roots = []projects.Root{
+			{ID: "root_default", Path: defaultRoot, Kind: "git", Active: true},
+			{ID: "root_work", Path: workRoot, Kind: "git_worktree", GitBranch: "work-root", Active: true},
+			{ID: "root_assignment", Path: assignmentRoot, Kind: "git_worktree", GitBranch: "assignment-root", Active: true},
+		}
+	}); err != nil {
+		t.Fatalf("Update project roots: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateWorkItem(t.Context(), "proj_start", "work_start", func(item *projectwork.WorkItem) {
+		item.RootID = "root_work"
+	}); err != nil {
+		t.Fatalf("Update work root: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateAssignment(t.Context(), "proj_start", "asgn_start", func(item *projectwork.Assignment) {
+		item.RootID = "root_assignment"
+	}); err != nil {
+		t.Fatalf("Update assignment root: %v", err)
+	}
+
+	preflightResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+	preflightRoot := findRenderedContextItemByKind(preflightResp.Data, "project_root")
+	if preflightRoot == nil || !strings.Contains(preflightRoot.Body, "Root ID: root_assignment") || !strings.Contains(preflightRoot.Body, assignmentRoot) || !strings.Contains(preflightRoot.Body, "Selection: assignment override") {
+		t.Fatalf("preflight project_root item = %+v, want assignment root metadata", preflightRoot)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
+	}
+	if task.WorkingDirectory != assignmentRoot || task.SandboxAllowedRoot != assignmentRoot {
+		t.Fatalf("task workspace = (%q, %q), want assignment root %q", task.WorkingDirectory, task.SandboxAllowedRoot, assignmentRoot)
+	}
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+	startRoot := findRenderedContextItemByKind(packetResp.Data, "project_root")
+	if startRoot == nil || !strings.Contains(startRoot.Body, "Git branch: assignment-root") {
+		t.Fatalf("stored project_root item = %+v, want assignment root branch", startRoot)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -78,6 +78,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/worktrees", handler.HandleCreateProjectWorktreeRoot)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/context-sources/discover", handler.HandleDiscoverProjectContextSources)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/skills", handler.HandleProjectSkills)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/skills/discover", handler.HandleDiscoverProjectSkills)

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS %s (
 	status TEXT NOT NULL,
 	priority TEXT NOT NULL,
 	owner_role_id TEXT NOT NULL DEFAULT '',
+	root_id TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY(project_id, id)
@@ -96,6 +97,7 @@ CREATE TABLE IF NOT EXISTS %s (
 	project_id TEXT NOT NULL,
 	work_item_id TEXT NOT NULL,
 	role_id TEXT NOT NULL,
+	root_id TEXT NOT NULL DEFAULT '',
 	driver_kind TEXT NOT NULL DEFAULT 'hecate_task',
 	status TEXT NOT NULL,
 	execution_ref TEXT NOT NULL DEFAULT '{}',
@@ -154,6 +156,12 @@ CREATE TABLE IF NOT EXISTS %s (
 		return fmt.Errorf("create project handoffs table: %w", err)
 	}
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "driver_kind", `TEXT NOT NULL DEFAULT 'hecate_task'`); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, s.workItemsTbl, "root_id", `TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, s.assignmentsTbl, "root_id", `TEXT NOT NULL DEFAULT ''`); err != nil {
 		return err
 	}
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "context_packet", `TEXT NOT NULL DEFAULT ''`); err != nil {
@@ -419,7 +427,7 @@ func (s *SQLiteStore) DeleteRole(ctx context.Context, projectID, id string) erro
 func (s *SQLiteStore) ListWorkItems(ctx context.Context, projectID string, options ...ListOptions) ([]WorkItem, error) {
 	opts := normalizeListOptions(options)
 	query := fmt.Sprintf(`
-SELECT id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at
+SELECT id, project_id, title, brief, status, priority, owner_role_id, root_id, created_at, updated_at
 FROM %s
 WHERE project_id = ?
 `, s.workItemsTbl)
@@ -520,10 +528,10 @@ func (s *SQLiteStore) UpdateWorkItem(ctx context.Context, projectID, id string, 
 	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
-SET title = ?, brief = ?, status = ?, priority = ?, owner_role_id = ?, updated_at = ?
+SET title = ?, brief = ?, status = ?, priority = ?, owner_role_id = ?, root_id = ?, updated_at = ?
 WHERE project_id = ? AND id = ?`, s.workItemsTbl),
 		item.Title, item.Brief, item.Status, item.Priority, item.OwnerRoleID,
-		formatTime(item.UpdatedAt), projectID, id,
+		item.RootID, formatTime(item.UpdatedAt), projectID, id,
 	); err != nil {
 		_ = tx.Rollback()
 		return WorkItem{}, err
@@ -575,7 +583,7 @@ func (s *SQLiteStore) ListAssignments(ctx context.Context, filter AssignmentFilt
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	opts := normalizeListOptions(options)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, root_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ?`, s.assignmentsTbl)
 	args := []any{filter.ProjectID}
@@ -628,10 +636,10 @@ func (s *SQLiteStore) CreateAssignment(ctx context.Context, assignment Assignmen
 	}
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, work_item_id, role_id, driver_kind, status, execution_ref,
+	id, project_id, work_item_id, role_id, root_id, driver_kind, status, execution_ref,
 	context_packet, created_at, updated_at, started_at, completed_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
-		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID, assignment.DriverKind,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.assignmentsTbl),
+		assignment.ID, assignment.ProjectID, assignment.WorkItemID, assignment.RoleID, assignment.RootID, assignment.DriverKind,
 		assignment.Status, executionRef,
 		string(assignment.ContextPacket), formatTime(assignment.CreatedAt),
 		formatTime(assignment.UpdatedAt), formatTime(assignment.StartedAt), formatTime(assignment.CompletedAt),
@@ -681,9 +689,9 @@ func (s *SQLiteStore) UpdateAssignment(ctx context.Context, projectID, id string
 	}
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE %s
-SET role_id = ?, driver_kind = ?, status = ?, execution_ref = ?, context_packet = ?, updated_at = ?, started_at = ?, completed_at = ?
+SET role_id = ?, root_id = ?, driver_kind = ?, status = ?, execution_ref = ?, context_packet = ?, updated_at = ?, started_at = ?, completed_at = ?
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl),
-		item.RoleID, item.DriverKind, item.Status, executionRef,
+		item.RoleID, item.RootID, item.DriverKind, item.Status, executionRef,
 		string(item.ContextPacket), formatTime(item.UpdatedAt),
 		formatTime(item.StartedAt), formatTime(item.CompletedAt), projectID, id,
 	)
@@ -1040,10 +1048,10 @@ func (s *SQLiteStore) deleteWhereProject(ctx context.Context, projectID string) 
 
 func (s *SQLiteStore) insertWorkItem(ctx context.Context, tx *sql.Tx, item WorkItem) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.workItemsTbl),
+INSERT INTO %s (id, project_id, title, brief, status, priority, owner_role_id, root_id, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.workItemsTbl),
 		item.ID, item.ProjectID, item.Title, item.Brief, item.Status, item.Priority,
-		item.OwnerRoleID, formatTime(item.CreatedAt), formatTime(item.UpdatedAt),
+		item.OwnerRoleID, item.RootID, formatTime(item.CreatedAt), formatTime(item.UpdatedAt),
 	); err != nil {
 		if isSQLiteConstraint(err) {
 			return ErrDuplicate
@@ -1102,7 +1110,7 @@ WHERE project_id = ? AND id = ?`, s.rolesTbl), strings.TrimSpace(projectID), str
 
 func (s *SQLiteStore) getRequiredWorkItem(ctx context.Context, projectID, id string) (WorkItem, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, title, brief, status, priority, owner_role_id, created_at, updated_at
+SELECT id, project_id, title, brief, status, priority, owner_role_id, root_id, created_at, updated_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanWorkItem(row)
@@ -1122,7 +1130,7 @@ WHERE project_id = ? AND id = ?`, s.workItemsTbl), strings.TrimSpace(projectID),
 
 func (s *SQLiteStore) getRequiredAssignment(ctx context.Context, projectID, id string) (Assignment, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, role_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
+SELECT id, project_id, work_item_id, role_id, root_id, driver_kind, status, execution_ref, context_packet, created_at, updated_at, started_at, completed_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanAssignment(row)
@@ -1224,7 +1232,7 @@ func scanRole(row scanner) (AgentRoleProfile, error) {
 func scanWorkItem(row scanner) (WorkItem, error) {
 	var item WorkItem
 	var createdAt, updatedAt string
-	if err := row.Scan(&item.ID, &item.ProjectID, &item.Title, &item.Brief, &item.Status, &item.Priority, &item.OwnerRoleID, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.Title, &item.Brief, &item.Status, &item.Priority, &item.OwnerRoleID, &item.RootID, &createdAt, &updatedAt); err != nil {
 		return WorkItem{}, err
 	}
 	var err error
@@ -1242,8 +1250,8 @@ func scanAssignment(row scanner) (Assignment, error) {
 	var createdAt, updatedAt, startedAt, completedAt string
 	var executionRef string
 	if err := row.Scan(
-		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.DriverKind, &item.Status,
-		&executionRef, &item.ContextPacket, &createdAt, &updatedAt, &startedAt, &completedAt,
+		&item.ID, &item.ProjectID, &item.WorkItemID, &item.RoleID, &item.RootID, &item.DriverKind,
+		&item.Status, &executionRef, &item.ContextPacket, &createdAt, &updatedAt, &startedAt, &completedAt,
 	); err != nil {
 		return Assignment{}, err
 	}

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -76,6 +76,7 @@ type WorkItem struct {
 	Status          string
 	Priority        string
 	OwnerRoleID     string
+	RootID          string
 	ReviewerRoleIDs []string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
@@ -86,6 +87,7 @@ type Assignment struct {
 	ProjectID     string
 	WorkItemID    string
 	RoleID        string
+	RootID        string
 	DriverKind    string
 	Status        string
 	ExecutionRef  AssignmentExecutionRef
@@ -786,6 +788,7 @@ func normalizeWorkItem(item WorkItem, now time.Time) WorkItem {
 	item.Status = strings.TrimSpace(item.Status)
 	item.Priority = strings.TrimSpace(item.Priority)
 	item.OwnerRoleID = strings.TrimSpace(item.OwnerRoleID)
+	item.RootID = strings.TrimSpace(item.RootID)
 	item.ReviewerRoleIDs = normalizeStringList(item.ReviewerRoleIDs)
 	if item.Status == "" {
 		item.Status = WorkItemStatusBacklog
@@ -810,6 +813,7 @@ func normalizeAssignment(item Assignment, now time.Time) Assignment {
 	item.ProjectID = strings.TrimSpace(item.ProjectID)
 	item.WorkItemID = strings.TrimSpace(item.WorkItemID)
 	item.RoleID = strings.TrimSpace(item.RoleID)
+	item.RootID = strings.TrimSpace(item.RootID)
 	item.DriverKind = strings.TrimSpace(item.DriverKind)
 	item.Status = strings.TrimSpace(item.Status)
 	item.ExecutionRef = NormalizeAssignmentExecutionRef(item.ExecutionRef)

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -91,12 +91,13 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				Brief:           "Persist work coordination metadata.",
 				Priority:        "high",
 				OwnerRoleID:     "software_developer",
+				RootID:          "root_feature",
 				ReviewerRoleIDs: []string{"reviewer_qa", "architect", "reviewer_qa"},
 			})
 			if err != nil {
 				t.Fatalf("CreateWorkItem: %v", err)
 			}
-			if work.Status != WorkItemStatusBacklog || len(work.ReviewerRoleIDs) != 2 || work.ReviewerRoleIDs[0] != "architect" {
+			if work.Status != WorkItemStatusBacklog || work.RootID != "root_feature" || len(work.ReviewerRoleIDs) != 2 || work.ReviewerRoleIDs[0] != "architect" {
 				t.Fatalf("work item = %+v, want defaults and normalized reviewers", work)
 			}
 
@@ -115,12 +116,13 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 
 			updatedWork, err := store.UpdateWorkItem(ctx, "proj_alpha", "work_api", func(item *WorkItem) {
 				item.Status = WorkItemStatusReady
+				item.RootID = "root_review"
 				item.ReviewerRoleIDs = []string{"reviewer_qa"}
 			})
 			if err != nil {
 				t.Fatalf("UpdateWorkItem: %v", err)
 			}
-			if updatedWork.Status != WorkItemStatusReady || len(updatedWork.ReviewerRoleIDs) != 1 {
+			if updatedWork.Status != WorkItemStatusReady || updatedWork.RootID != "root_review" || len(updatedWork.ReviewerRoleIDs) != 1 {
 				t.Fatalf("updated work item = %+v, want ready with one reviewer", updatedWork)
 			}
 
@@ -129,6 +131,7 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				ProjectID:  "proj_alpha",
 				WorkItemID: "work_api",
 				RoleID:     "software_developer",
+				RootID:     "root_assignment",
 				ExecutionRef: AssignmentExecutionRef{
 					Kind:              AssignmentExecutionKindTaskRun,
 					TaskID:            "task_123",
@@ -140,7 +143,7 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CreateAssignment: %v", err)
 			}
-			if assignment.Status != AssignmentStatusQueued {
+			if assignment.Status != AssignmentStatusQueued || assignment.RootID != "root_assignment" {
 				t.Fatalf("assignment status = %q, want queued", assignment.Status)
 			}
 			if assignment.DriverKind != AssignmentDriverHecateTask {
@@ -157,13 +160,14 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			updatedAssignment, err := store.UpdateAssignment(ctx, "proj_alpha", "asgn_impl", func(item *Assignment) {
 				item.DriverKind = AssignmentDriverExternalAgent
 				item.Status = AssignmentStatusRunning
+				item.RootID = "root_external"
 				item.StartedAt = startedAt
 				item.ContextPacket = []byte(`{"id":"ctx_456","version":"chat.context.v1"}`)
 			})
 			if err != nil {
 				t.Fatalf("UpdateAssignment: %v", err)
 			}
-			if updatedAssignment.DriverKind != AssignmentDriverExternalAgent || updatedAssignment.Status != AssignmentStatusRunning || !updatedAssignment.StartedAt.Equal(startedAt) {
+			if updatedAssignment.DriverKind != AssignmentDriverExternalAgent || updatedAssignment.Status != AssignmentStatusRunning || updatedAssignment.RootID != "root_external" || !updatedAssignment.StartedAt.Equal(startedAt) {
 				t.Fatalf("updated assignment = %+v, want running with start time", updatedAssignment)
 			}
 			if string(updatedAssignment.ContextPacket) != `{"id":"ctx_456","version":"chat.context.v1"}` {

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -106,6 +106,7 @@ type CreateWorkItemCommand struct {
 	Status          string
 	Priority        string
 	OwnerRoleID     string
+	RootID          string
 	ReviewerRoleIDs []string
 }
 
@@ -115,12 +116,14 @@ type UpdateWorkItemCommand struct {
 	Status          *string
 	Priority        *string
 	OwnerRoleID     *string
+	RootID          *string
 	ReviewerRoleIDs *[]string
 }
 
 type CreateAssignmentCommand struct {
 	ID           string
 	RoleID       string
+	RootID       string
 	DriverKind   string
 	Status       string
 	ExecutionRef projectwork.AssignmentExecutionRef
@@ -130,6 +133,7 @@ type CreateAssignmentCommand struct {
 
 type UpdateAssignmentCommand struct {
 	RoleID       *string
+	RootID       *string
 	DriverKind   *string
 	Status       *string
 	ExecutionRef *projectwork.AssignmentExecutionRef
@@ -284,6 +288,7 @@ func (app *Application) CreateWorkItem(ctx context.Context, projectID string, cm
 		Status:          cmd.Status,
 		Priority:        cmd.Priority,
 		OwnerRoleID:     cmd.OwnerRoleID,
+		RootID:          cmd.RootID,
 		ReviewerRoleIDs: append([]string(nil), cmd.ReviewerRoleIDs...),
 	})
 }
@@ -307,6 +312,9 @@ func (app *Application) UpdateWorkItem(ctx context.Context, projectID, workItemI
 		}
 		if cmd.OwnerRoleID != nil {
 			item.OwnerRoleID = *cmd.OwnerRoleID
+		}
+		if cmd.RootID != nil {
+			item.RootID = *cmd.RootID
 		}
 		if cmd.ReviewerRoleIDs != nil {
 			item.ReviewerRoleIDs = append([]string(nil), *cmd.ReviewerRoleIDs...)
@@ -342,6 +350,7 @@ func (app *Application) CreateAssignment(ctx context.Context, projectID, workIte
 		ProjectID:    projectID,
 		WorkItemID:   workItemID,
 		RoleID:       cmd.RoleID,
+		RootID:       cmd.RootID,
 		DriverKind:   driverKind,
 		Status:       cmd.Status,
 		ExecutionRef: cmd.ExecutionRef,
@@ -357,6 +366,9 @@ func (app *Application) UpdateAssignment(ctx context.Context, projectID, assignm
 	return app.store.UpdateAssignment(ctx, projectID, assignmentID, func(item *projectwork.Assignment) {
 		if cmd.RoleID != nil {
 			item.RoleID = *cmd.RoleID
+		}
+		if cmd.RootID != nil {
+			item.RootID = *cmd.RootID
 		}
 		if cmd.DriverKind != nil {
 			item.DriverKind = *cmd.DriverKind

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -65,6 +65,7 @@ type ProjectSkillStore interface {
 type TaskAssignmentLaunchPlan struct {
 	WorkingDirectory  string
 	WorkspaceMode     string
+	Root              projects.Root
 	RequestedProvider string
 	RequestedModel    string
 	ExecutionProfile  string
@@ -75,6 +76,7 @@ type TaskAssignmentLaunchPlan struct {
 
 type ExternalAgentAssignmentLaunchPlan struct {
 	Workspace        string
+	Root             projects.Root
 	AdapterID        string
 	Adapter          agentadapters.Adapter
 	ConfigOptions    []agentcontrols.ConfigOption
@@ -141,8 +143,8 @@ func (ctx AssignmentPromptContext) SystemPrompt() string {
 	return strings.Join(ctx.Sections, "\n\n")
 }
 
-func (app *Application) ResolveTaskAssignmentLaunchPlan(ctx context.Context, project projects.Project, role projectwork.AgentRoleProfile) (TaskAssignmentLaunchPlan, error) {
-	workingDirectory, workspaceMode, err := ResolveAssignmentWorkspace(project)
+func (app *Application) ResolveTaskAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) (TaskAssignmentLaunchPlan, error) {
+	root, workingDirectory, workspaceMode, err := ResolveAssignmentWorkspace(project, workItem, assignment)
 	if err != nil {
 		return TaskAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
 	}
@@ -166,6 +168,7 @@ func (app *Application) ResolveTaskAssignmentLaunchPlan(ctx context.Context, pro
 	return TaskAssignmentLaunchPlan{
 		WorkingDirectory:  workingDirectory,
 		WorkspaceMode:     workspaceMode,
+		Root:              root,
 		RequestedProvider: requestedProvider,
 		RequestedModel:    requestedModel,
 		ExecutionProfile:  executionProfile,
@@ -175,8 +178,8 @@ func (app *Application) ResolveTaskAssignmentLaunchPlan(ctx context.Context, pro
 	}, nil
 }
 
-func (app *Application) ResolveExternalAgentAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, role projectwork.AgentRoleProfile) (ExternalAgentAssignmentLaunchPlan, error) {
-	workingDirectory, _, err := ResolveAssignmentWorkspace(project)
+func (app *Application) ResolveExternalAgentAssignmentLaunchPlan(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) (ExternalAgentAssignmentLaunchPlan, error) {
+	root, workingDirectory, _, err := ResolveAssignmentWorkspace(project, workItem, assignment)
 	if err != nil {
 		return ExternalAgentAssignmentLaunchPlan{}, launchPlanError(LaunchPlanInvalidRequest, err.Error())
 	}
@@ -202,6 +205,7 @@ func (app *Application) ResolveExternalAgentAssignmentLaunchPlan(ctx context.Con
 	}
 	return ExternalAgentAssignmentLaunchPlan{
 		Workspace:        workspace,
+		Root:             root,
 		AdapterID:        adapterID,
 		Adapter:          adapter,
 		ConfigOptions:    configOptions,
@@ -212,40 +216,47 @@ func (app *Application) ResolveExternalAgentAssignmentLaunchPlan(ctx context.Con
 	}, nil
 }
 
-func ResolveAssignmentWorkspace(project projects.Project) (string, string, error) {
-	root, ok := SelectAssignmentRoot(project)
+func ResolveAssignmentWorkspace(project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment) (projects.Root, string, string, error) {
+	root, ok := SelectAssignmentRoot(project, workItem, assignment)
 	if !ok {
-		return "", "", fmt.Errorf("project has no workspace root; add a project root before starting an assignment")
+		return projects.Root{}, "", "", fmt.Errorf("project has no workspace root; add a project root before starting an assignment")
 	}
 	path := strings.TrimSpace(root.Path)
 	if path == "" {
-		return "", "", fmt.Errorf("project root %q has no path", root.ID)
+		return projects.Root{}, "", "", fmt.Errorf("project root %q has no path", root.ID)
 	}
 	if !filepath.IsAbs(path) {
-		return "", "", fmt.Errorf("project root %q path must be absolute", root.ID)
+		return projects.Root{}, "", "", fmt.Errorf("project root %q path must be absolute", root.ID)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return "", "", fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
+		return projects.Root{}, "", "", fmt.Errorf("project root %q is not accessible: %w", root.ID, err)
 	}
 	if !info.IsDir() {
-		return "", "", fmt.Errorf("project root %q is not a directory", root.ID)
+		return projects.Root{}, "", "", fmt.Errorf("project root %q is not a directory", root.ID)
 	}
 	workspaceMode := strings.TrimSpace(project.DefaultWorkspaceMode)
 	if workspaceMode == "" {
 		workspaceMode = "ephemeral"
 	}
-	return path, workspaceMode, nil
+	return root, path, workspaceMode, nil
 }
 
-func SelectAssignmentRoot(project projects.Project) (projects.Root, bool) {
-	defaultRootID := strings.TrimSpace(project.DefaultRootID)
-	if defaultRootID != "" {
+func SelectAssignmentRoot(project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment) (projects.Root, bool) {
+	for _, id := range []string{
+		strings.TrimSpace(assignment.RootID),
+		strings.TrimSpace(workItem.RootID),
+		strings.TrimSpace(project.DefaultRootID),
+	} {
+		if id == "" {
+			continue
+		}
 		for _, root := range project.Roots {
-			if root.ID == defaultRootID {
+			if root.ID == id {
 				return root, true
 			}
 		}
+		return projects.Root{}, false
 	}
 	for _, root := range project.Roots {
 		if root.Active {

--- a/internal/projectworkapp/launch_plan_test.go
+++ b/internal/projectworkapp/launch_plan_test.go
@@ -80,7 +80,7 @@ func TestApplication_ResolveTaskAssignmentLaunchPlanAppliesProfileHintsAndPrompt
 		SkillIDs:            []string{"missing_skill"},
 	}
 
-	plan, err := app.ResolveTaskAssignmentLaunchPlan(ctx, project, role)
+	plan, err := app.ResolveTaskAssignmentLaunchPlan(ctx, project, launchPlanTestWorkItem(), launchPlanTestAssignment(), role)
 	if err != nil {
 		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestApplication_ResolveTaskAssignmentLaunchPlanRejectsMissingModel(t *testi
 	t.Parallel()
 
 	app := New(Options{})
-	_, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), projectwork.AgentRoleProfile{Name: "Builder"})
+	_, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), launchPlanTestWorkItem(), launchPlanTestAssignment(), projectwork.AgentRoleProfile{Name: "Builder"})
 	var launchErr LaunchPlanError
 	if !errors.As(err, &launchErr) || launchErr.Kind != LaunchPlanModelNotConfigured {
 		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v, want LaunchPlanModelNotConfigured", err)
@@ -137,12 +137,52 @@ func TestApplication_ResolveTaskAssignmentLaunchPlanUsesRuntimeDefaultModel(t *t
 	t.Parallel()
 
 	app := New(Options{RuntimeDefaultModel: "runtime-default"})
-	plan, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), projectwork.AgentRoleProfile{Name: "Builder"})
+	plan, err := app.ResolveTaskAssignmentLaunchPlan(context.Background(), launchPlanTestProject(t.TempDir()), launchPlanTestWorkItem(), launchPlanTestAssignment(), projectwork.AgentRoleProfile{Name: "Builder"})
 	if err != nil {
 		t.Fatalf("ResolveTaskAssignmentLaunchPlan() error = %v", err)
 	}
 	if plan.RequestedModel != "runtime-default" {
 		t.Fatalf("requested model = %q, want runtime-default", plan.RequestedModel)
+	}
+}
+
+func TestSelectAssignmentRootPrecedence(t *testing.T) {
+	t.Parallel()
+
+	project := projects.Project{
+		ID:            "proj_1",
+		DefaultRootID: "root_default",
+		Roots: []projects.Root{
+			{ID: "root_default", Path: "/workspace/default", Active: false},
+			{ID: "root_active", Path: "/workspace/active", Active: true},
+			{ID: "root_work", Path: "/workspace/work", Active: true},
+			{ID: "root_assignment", Path: "/workspace/assignment", Active: true},
+		},
+	}
+	workItem := projectwork.WorkItem{ID: "work_1", RootID: "root_work"}
+	assignment := projectwork.Assignment{ID: "asgn_1", RootID: "root_assignment"}
+
+	root, ok := SelectAssignmentRoot(project, workItem, assignment)
+	if !ok || root.ID != "root_assignment" {
+		t.Fatalf("assignment override root = %+v ok=%v, want root_assignment", root, ok)
+	}
+
+	assignment.RootID = ""
+	root, ok = SelectAssignmentRoot(project, workItem, assignment)
+	if !ok || root.ID != "root_work" {
+		t.Fatalf("work item root = %+v ok=%v, want root_work", root, ok)
+	}
+
+	workItem.RootID = ""
+	root, ok = SelectAssignmentRoot(project, workItem, assignment)
+	if !ok || root.ID != "root_default" {
+		t.Fatalf("project default root = %+v ok=%v, want root_default", root, ok)
+	}
+
+	project.DefaultRootID = ""
+	root, ok = SelectAssignmentRoot(project, workItem, assignment)
+	if !ok || root.ID != "root_active" {
+		t.Fatalf("active root fallback = %+v ok=%v, want root_active", root, ok)
 	}
 }
 
@@ -169,7 +209,7 @@ func TestApplication_ResolveExternalAgentAssignmentLaunchPlanResolvesAdapter(t *
 		DefaultAgentProfile: "prof_codex",
 	}
 
-	plan, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, launchPlanTestProject(t.TempDir()), launchPlanTestWorkItem(), role)
+	plan, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, launchPlanTestProject(t.TempDir()), launchPlanTestWorkItem(), launchPlanTestAssignment(), role)
 	if err != nil {
 		t.Fatalf("ResolveExternalAgentAssignmentLaunchPlan() error = %v", err)
 	}
@@ -247,7 +287,7 @@ func TestApplication_ResolveExternalAgentAssignmentLaunchPlanErrors(t *testing.T
 				Name:                "External implementer",
 				DefaultAgentProfile: tc.profile.ID,
 			}
-			_, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, role)
+			_, err := app.ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, launchPlanTestAssignment(), role)
 			var launchErr LaunchPlanError
 			if !errors.As(err, &launchErr) || launchErr.Kind != tc.want {
 				t.Fatalf("ResolveExternalAgentAssignmentLaunchPlan() error = %v, want %s", err, tc.want)

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -13,6 +13,7 @@ import {
   createProjectAssignment,
   createProjectHandoff,
   createProjectMemory,
+  createProjectWorktreeRoot,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
@@ -258,6 +259,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
     })),
     startProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
     createProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
+    createProjectWorktreeRoot: vi.fn(async () => ({ object: "project", data: null })),
     createProjectAssignment: vi.fn(async () => ({ object: "project_assignment", data: null })),
     createProjectWorkRole: vi.fn(async () => ({ object: "project_role", data: null })),
     updateProjectWorkRole: vi.fn(async () => ({ object: "project_role", data: null })),
@@ -1008,6 +1010,7 @@ afterEach(() => {
   vi.mocked(rejectProjectMemoryCandidate).mockReset();
   vi.mocked(startProjectAssignment).mockReset();
   vi.mocked(createProjectWorkItem).mockReset();
+  vi.mocked(createProjectWorktreeRoot).mockReset();
   vi.mocked(createProjectAssignment).mockReset();
   vi.mocked(createProjectWorkRole).mockReset();
   vi.mocked(updateProjectWorkRole).mockReset();
@@ -3758,6 +3761,49 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("sends selected project roots when creating work items", async () => {
+    resetProjectWorkMocks();
+    const rootedProject: ProjectRecord = {
+      ...project,
+      roots: [
+        ...project.roots,
+        {
+          id: "root_feature",
+          path: "/Users/alice/dev/hecate/.worktrees/feature",
+          kind: "git_worktree",
+          git_branch: "feature/project-roots",
+          active: true,
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T10:00:00Z",
+        },
+      ],
+    };
+    window.localStorage.setItem("hecate.project", rootedProject.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [rootedProject],
+      activeProjectID: rootedProject.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Work" }));
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Rooted work" },
+    });
+    fireEvent.change(screen.getByLabelText("Root"), {
+      target: { value: "root_feature" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Create work item" }));
+
+    expect(createProjectWorkItem).toHaveBeenCalledWith(rootedProject.id, {
+      title: "Rooted work",
+      brief: undefined,
+      status: "ready",
+      priority: "normal",
+      owner_role_id: "software_developer",
+      root_id: "root_feature",
+    });
+  });
+
   it("edits and deletes work items from the selected detail", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);
@@ -3788,6 +3834,7 @@ describe("ProjectsView cockpit", () => {
       status: "review",
       priority: "urgent",
       owner_role_id: "software_developer",
+      root_id: "",
       reviewer_role_ids: ["reviewer_qa"],
     });
 
@@ -3818,6 +3865,43 @@ describe("ProjectsView cockpit", () => {
     expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
       role_id: "software_developer",
       driver_kind: "external_agent",
+    });
+  });
+
+  it("sends selected project roots when creating assignments", async () => {
+    resetProjectWorkMocks();
+    const rootedProject: ProjectRecord = {
+      ...project,
+      roots: [
+        ...project.roots,
+        {
+          id: "root_feature",
+          path: "/Users/alice/dev/hecate/.worktrees/feature",
+          kind: "git_worktree",
+          git_branch: "feature/project-roots",
+          active: true,
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T10:00:00Z",
+        },
+      ],
+    };
+    window.localStorage.setItem("hecate.project", rootedProject.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [rootedProject],
+      activeProjectID: rootedProject.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    fireEvent.change(screen.getByLabelText("Root"), {
+      target: { value: "root_feature" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+
+    expect(createProjectAssignment).toHaveBeenCalledWith(rootedProject.id, workItem.id, {
+      role_id: "software_developer",
+      driver_kind: "hecate_task",
+      root_id: "root_feature",
     });
   });
 
@@ -4324,6 +4408,7 @@ describe("ProjectsView cockpit", () => {
       hecateAssignment.id,
       {
         role_id: "software_developer",
+        root_id: "",
         driver_kind: "external_agent",
         status: "running",
         execution_ref: {
@@ -4547,6 +4632,60 @@ describe("ProjectsView cockpit", () => {
         name: "Active project root /Users/alice/dev/hecate/.claude/worktrees/fix-array-sort",
       }),
     ).not.toBeChecked();
+  });
+
+  it("creates project worktrees from settings", async () => {
+    resetProjectWorkMocks();
+    const projectWithCreatedWorktree: ProjectRecord = {
+      ...project,
+      roots: [
+        ...project.roots,
+        {
+          id: "root_created",
+          path: "/Users/alice/dev/hecate/.worktrees/feature-project-roots",
+          kind: "git_worktree",
+          git_branch: "feature/project-roots",
+          active: true,
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-01T10:00:00Z",
+        },
+      ],
+      default_root_id: "root_created",
+    };
+    vi.mocked(createProjectWorktreeRoot).mockResolvedValue({
+      object: "project",
+      data: projectWithCreatedWorktree,
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Project settings" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create worktree" }));
+    const dialog = screen.getByRole("dialog", { name: "Create project worktree" });
+    fireEvent.change(within(dialog).getByLabelText("Branch"), {
+      target: { value: "feature/project-roots" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Start point"), {
+      target: { value: "origin/main" },
+    });
+    await userEvent.click(within(dialog).getByLabelText("Make default root"));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create worktree" }));
+
+    expect(createProjectWorktreeRoot).toHaveBeenCalledWith(project.id, {
+      branch: "feature/project-roots",
+      base_root_id: "root_1",
+      start_point: "origin/main",
+      path: undefined,
+      active: true,
+      set_default: true,
+    });
+    expect(
+      await screen.findAllByText("/Users/alice/dev/hecate/.worktrees/feature-project-roots"),
+    ).toHaveLength(2);
   });
 
   it("starts native Hecate assignments and refreshes detail state", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -19,6 +19,7 @@ import {
   discoverProjectContextSources,
   discoverProjectRoots,
   discoverProjectSkills,
+  createProjectWorktreeRoot,
   createProjectMemory,
   createProjectWorkRole,
   createProjectWorkItem,
@@ -85,6 +86,7 @@ import type {
   ProjectMemoryCandidateRecord,
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
+  CreateProjectWorktreeRootPayload,
   CreateProjectHandoffPayload,
   ProjectHandoffRecord,
   ProjectMemoryRecord,
@@ -154,11 +156,13 @@ type NewWorkItemForm = {
   brief: string;
   priority: string;
   ownerRoleID: string;
+  rootID: string;
 };
 
 type NewAssignmentForm = {
   roleID: string;
   driverKind: string;
+  rootID: string;
 };
 
 type EditWorkItemForm = NewWorkItemForm & {
@@ -234,6 +238,15 @@ type ProjectDefaultsForm = {
   workspaceMode: string;
   defaultRootID: string;
   roots: ProjectRootPayload[];
+};
+
+type CreateWorktreeForm = {
+  baseRootID: string;
+  branch: string;
+  startPoint: string;
+  path: string;
+  active: boolean;
+  setDefault: boolean;
 };
 
 type MemoryForm = {
@@ -385,6 +398,9 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
   const [defaultsPending, setDefaultsPending] = useState(false);
   const [defaultsError, setDefaultsError] = useState("");
   const [discoveringRoots, setDiscoveringRoots] = useState(false);
+  const [createWorktreeOpen, setCreateWorktreeOpen] = useState(false);
+  const [createWorktreePending, setCreateWorktreePending] = useState(false);
+  const [createWorktreeError, setCreateWorktreeError] = useState("");
   const [rolesModalOpen, setRolesModalOpen] = useState(false);
   const [rolesPending, setRolesPending] = useState(false);
   const [rolesError, setRolesError] = useState("");
@@ -827,6 +843,31 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     }
   }
 
+  async function handleCreateWorktreeRoot(form: CreateWorktreeForm) {
+    if (!selectedProject) return;
+    const branch = form.branch.trim();
+    if (!branch) return;
+    const payload: CreateProjectWorktreeRootPayload = {
+      branch,
+      base_root_id: form.baseRootID.trim() || undefined,
+      start_point: form.startPoint.trim() || undefined,
+      path: form.path.trim() || undefined,
+      active: form.active,
+      set_default: form.setDefault,
+    };
+    setCreateWorktreePending(true);
+    setCreateWorktreeError("");
+    try {
+      const result = await createProjectWorktreeRoot(selectedProject.id, payload);
+      projects.actions.setProjects((current) => upsertProject(current, result.data));
+      setCreateWorktreeOpen(false);
+    } catch (error) {
+      setCreateWorktreeError(errorMessage(error, "Failed to create project worktree."));
+    } finally {
+      setCreateWorktreePending(false);
+    }
+  }
+
   async function handleDiscoverContextSources() {
     if (!selectedProjectID) return;
     setDiscoveringContext(true);
@@ -1074,12 +1115,14 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setNewWorkPending(true);
     setNewWorkError("");
     try {
+      const rootID = form.rootID.trim();
       const payload = await createProjectWorkItem(selectedProjectID, {
         title,
         brief: form.brief.trim() || undefined,
         status: "ready",
         priority: form.priority || "normal",
         owner_role_id: form.ownerRoleID || undefined,
+        ...(rootID ? { root_id: rootID } : {}),
       });
       setWorkItems((current) => upsertWorkItem(current, payload.data));
       setWorkItemSummaries((current) => ({
@@ -1113,6 +1156,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
       status: form.status,
       priority: form.priority || "normal",
       owner_role_id: form.ownerRoleID,
+      root_id: form.rootID.trim(),
       reviewer_role_ids: splitRoleIDs(form.reviewerRoleIDs),
     };
     try {
@@ -1147,9 +1191,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setNewAssignmentPending(true);
     setNewAssignmentError("");
     try {
+      const rootID = form.rootID.trim();
       const payload = await createProjectAssignment(selectedProjectID, selectedWorkItemID, {
         role_id: roleID,
         driver_kind: form.driverKind || "hecate_task",
+        ...(rootID ? { root_id: rootID } : {}),
       });
       setAssignments((current) => upsertAssignment(current, payload.data));
       setNewAssignmentModalOpen(false);
@@ -1169,6 +1215,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setEditAssignmentError("");
     const patch: UpdateProjectAssignmentPayload = {
       role_id: roleID,
+      root_id: form.rootID.trim(),
       driver_kind: form.driverKind || "hecate_task",
       status: form.status || "queued",
       execution_ref: projectAssignmentExecutionRefFromForm(form),
@@ -1735,6 +1782,10 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
                 project={selectedProject}
                 rootsPending={discoveringRoots}
                 onDiscoverRoots={handleDiscoverProjectRoots}
+                onOpenCreateWorktree={() => {
+                  setCreateWorktreeError("");
+                  setCreateWorktreeOpen(true);
+                }}
                 onSave={handleSaveProjectDefaults}
               />
             </ChatRightPanel>
@@ -1774,41 +1825,57 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
           <NewWorkItemModal
             error={newWorkError}
             pending={newWorkPending}
+            project={selectedProject}
             roles={roles}
             onClose={() => setNewWorkModalOpen(false)}
             onCreate={handleCreateWorkItem}
           />
         )}
 
-        {selectedWorkItem && newAssignmentModalOpen && (
+        {selectedProject && selectedWorkItem && newAssignmentModalOpen && (
           <NewAssignmentModal
             error={newAssignmentError}
             pending={newAssignmentPending}
+            project={selectedProject}
+            workItem={selectedWorkItem}
             roles={roles}
             onClose={() => setNewAssignmentModalOpen(false)}
             onCreate={handleCreateAssignment}
           />
         )}
 
-        {editingWorkItem && (
+        {selectedProject && editingWorkItem && (
           <EditWorkItemModal
             error={editWorkError}
             item={editingWorkItem}
             pending={editWorkPending}
+            project={selectedProject}
             roles={roles}
             onClose={() => setEditingWorkItem(null)}
             onSave={handleUpdateWorkItem}
           />
         )}
 
-        {editingAssignment && (
+        {selectedProject && editingAssignment && (
           <EditAssignmentModal
             assignment={editingAssignment}
             error={editAssignmentError}
             pending={editAssignmentPending}
+            project={selectedProject}
+            workItem={selectedWorkItem}
             roles={roles}
             onClose={() => setEditingAssignment(null)}
             onSave={handleUpdateAssignment}
+          />
+        )}
+
+        {selectedProject && createWorktreeOpen && (
+          <CreateProjectWorktreeModal
+            error={createWorktreeError}
+            pending={createWorktreePending}
+            project={selectedProject}
+            onClose={() => setCreateWorktreeOpen(false)}
+            onCreate={handleCreateWorktreeRoot}
           />
         )}
 
@@ -3713,6 +3780,11 @@ function WorkItemDetail({
                   Owner {roleByID.get(workItem.owner_role_id)?.name ?? workItem.owner_role_id}
                 </span>
               )}
+              {workItem.root_id && project && (
+                <span title={projectRootTitle(project, workItem.root_id)}>
+                  Root {projectRootDisplayLabel(project, workItem.root_id)}
+                </span>
+              )}
             </div>
           </div>
           <div style={workItemHeaderActionsStyle}>
@@ -3813,6 +3885,7 @@ function WorkItemDetail({
                       activityByAssignmentID.get(assignment.id),
                     )
                   }
+                  project={project}
                   role={roleByID.get(assignment.role_id)}
                   starting={startingAssignmentID === assignment.id}
                   loadContext={
@@ -3937,6 +4010,7 @@ function ProjectSettingsPanel({
   project,
   rootsPending,
   onDiscoverRoots,
+  onOpenCreateWorktree,
   onSave,
 }: {
   agentProfiles: AgentProfileRecord[];
@@ -3949,6 +4023,7 @@ function ProjectSettingsPanel({
   project: ProjectRecord;
   rootsPending: boolean;
   onDiscoverRoots: () => void | Promise<void>;
+  onOpenCreateWorktree: () => void;
   onSave: (form: ProjectDefaultsForm) => void | Promise<void>;
 }) {
   const [form, setForm] = useState<ProjectDefaultsForm>(() =>
@@ -4174,6 +4249,13 @@ function ProjectSettingsPanel({
               </div>
               <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                 <button
+                  className="btn btn-primary btn-sm"
+                  type="button"
+                  onClick={onOpenCreateWorktree}
+                >
+                  Create worktree
+                </button>
+                <button
                   className="btn btn-ghost btn-sm"
                   type="button"
                   disabled={rootsPending}
@@ -4287,20 +4369,55 @@ function projectRootPayloadFromRecord(root: ProjectRootRecord): ProjectRootPaylo
   return payload;
 }
 
-function projectRootOptionLabel(root: ProjectRootPayload) {
+function projectRootOptionLabel(root: ProjectRootPayload | ProjectRootRecord) {
   const parts = [root.path];
   if (root.git_branch) parts.push(`git:${root.git_branch}`);
   if (root.kind) parts.push(root.kind);
   return parts.join(" · ");
 }
 
-function projectRootSummary(root: ProjectRootPayload) {
+function projectRootSummary(root: ProjectRootPayload | ProjectRootRecord) {
   const parts = [
     root.active ? "active" : "inactive",
     root.kind || "root",
     root.git_branch ? `git:${root.git_branch}` : "",
   ].filter(Boolean);
   return parts.join(" · ");
+}
+
+function ProjectRootSelect({
+  inheritLabel,
+  label = "Root",
+  project,
+  value,
+  onChange,
+}: {
+  inheritLabel: string;
+  label?: string;
+  project: ProjectRecord;
+  value: string;
+  onChange: (rootID: string) => void;
+}) {
+  if (project.roots.length === 0) return null;
+  return (
+    <label style={fieldStyle}>
+      <span style={fieldLabelStyle}>{label}</span>
+      <select
+        aria-label={label}
+        className="input"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+      >
+        <option value="">{inheritLabel}</option>
+        {project.roots.map((root) => (
+          <option key={root.id || root.path} value={root.id}>
+            {projectRootOptionLabel(root)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
 }
 
 function ProjectSettingsSection({ title, children }: { title: string; children: ReactNode }) {
@@ -4341,6 +4458,136 @@ function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null
 function normalizeWorkspaceMode(value: string) {
   if (value === "persistent" || value === "ephemeral") return value;
   return "in_place";
+}
+
+function CreateProjectWorktreeModal({
+  error,
+  pending,
+  project,
+  onClose,
+  onCreate,
+}: {
+  error: string;
+  pending: boolean;
+  project: ProjectRecord;
+  onClose: () => void;
+  onCreate: (form: CreateWorktreeForm) => void | Promise<void>;
+}) {
+  const defaultBaseRootID =
+    project.default_root_id ||
+    project.roots.find((root) => root.active)?.id ||
+    project.roots[0]?.id ||
+    "";
+  const [form, setForm] = useState<CreateWorktreeForm>({
+    baseRootID: defaultBaseRootID,
+    branch: "",
+    startPoint: "",
+    path: "",
+    active: true,
+    setDefault: false,
+  });
+  const valid = project.roots.length > 0 && form.branch.trim().length > 0;
+  return (
+    <Modal
+      title="Create project worktree"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Creating…" : "Create worktree"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        {project.roots.length === 0 && <InlineError message="Add a project root first." />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Base root</span>
+          <select
+            aria-label="Base root"
+            className="input"
+            value={form.baseRootID}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, baseRootID: event.target.value }))
+            }
+            style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+          >
+            {project.roots.map((root) => (
+              <option key={root.id || root.path} value={root.id}>
+                {projectRootOptionLabel(root)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Branch</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.branch}
+            onChange={(event) => setForm((current) => ({ ...current, branch: event.target.value }))}
+            placeholder="feature/project-worktrees"
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Start point</span>
+            <input
+              className="input"
+              value={form.startPoint}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, startPoint: event.target.value }))
+              }
+              placeholder="origin/main"
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Path</span>
+            <input
+              className="input"
+              value={form.path}
+              onChange={(event) => setForm((current) => ({ ...current, path: event.target.value }))}
+              placeholder=".worktrees/feature-project-worktrees"
+            />
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, active: event.target.checked }))
+              }
+            />
+            <span style={fieldLabelStyle}>Active root</span>
+          </label>
+          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={form.setDefault}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, setDefault: event.target.checked }))
+              }
+            />
+            <span style={fieldLabelStyle}>Make default root</span>
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
 }
 
 function ProfilesModal({
@@ -5072,12 +5319,14 @@ function RolesModal({
 function NewWorkItemModal({
   error,
   pending,
+  project,
   roles,
   onClose,
   onCreate,
 }: {
   error: string;
   pending: boolean;
+  project: ProjectRecord;
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onCreate: (form: NewWorkItemForm) => void | Promise<void>;
@@ -5087,6 +5336,7 @@ function NewWorkItemModal({
     brief: "",
     priority: "normal",
     ownerRoleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
+    rootID: "",
   });
   const valid = form.title.trim().length > 0;
   return (
@@ -5169,6 +5419,12 @@ function NewWorkItemModal({
             </select>
           </label>
         </div>
+        <ProjectRootSelect
+          inheritLabel="project default root"
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
       </form>
     </Modal>
   );
@@ -5178,6 +5434,7 @@ function EditWorkItemModal({
   error,
   item,
   pending,
+  project,
   roles,
   onClose,
   onSave,
@@ -5185,6 +5442,7 @@ function EditWorkItemModal({
   error: string;
   item: ProjectWorkItemRecord;
   pending: boolean;
+  project: ProjectRecord;
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onSave: (form: EditWorkItemForm) => void | Promise<void>;
@@ -5196,6 +5454,7 @@ function EditWorkItemModal({
     status: item.status,
     priority: item.priority || "normal",
     ownerRoleID: item.owner_role_id ?? "",
+    rootID: item.root_id ?? "",
     reviewerRoleIDs: (item.reviewer_role_ids ?? []).join(", "),
   });
   const valid = form.title.trim().length > 0;
@@ -5307,6 +5566,12 @@ function EditWorkItemModal({
             />
           </label>
         </div>
+        <ProjectRootSelect
+          inheritLabel="project default root"
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
       </form>
     </Modal>
   );
@@ -5315,12 +5580,16 @@ function EditWorkItemModal({
 function NewAssignmentModal({
   error,
   pending,
+  project,
+  workItem,
   roles,
   onClose,
   onCreate,
 }: {
   error: string;
   pending: boolean;
+  project: ProjectRecord;
+  workItem: ProjectWorkItemRecord | null;
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onCreate: (form: NewAssignmentForm) => void | Promise<void>;
@@ -5329,6 +5598,7 @@ function NewAssignmentModal({
   const [form, setForm] = useState<NewAssignmentForm>({
     roleID: defaultRole?.id ?? "",
     driverKind: defaultDriverForRole(defaultRole),
+    rootID: "",
   });
   const valid = form.roleID.trim().length > 0;
   return (
@@ -5392,6 +5662,12 @@ function NewAssignmentModal({
             <option value="external_agent">external_agent</option>
           </select>
         </label>
+        <ProjectRootSelect
+          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
         {form.driverKind === "external_agent" && (
           <div style={subtleTextStyle}>
             External assignment execution is recorded here but still starts from Chats.
@@ -5406,6 +5682,8 @@ function EditAssignmentModal({
   assignment,
   error,
   pending,
+  project,
+  workItem,
   roles,
   onClose,
   onSave,
@@ -5413,6 +5691,8 @@ function EditAssignmentModal({
   assignment: ProjectAssignmentRecord;
   error: string;
   pending: boolean;
+  project: ProjectRecord;
+  workItem: ProjectWorkItemRecord | null;
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onSave: (form: EditAssignmentForm) => void | Promise<void>;
@@ -5421,6 +5701,7 @@ function EditAssignmentModal({
     id: assignment.id,
     roleID: assignment.role_id,
     driverKind: assignment.driver_kind || "hecate_task",
+    rootID: assignment.root_id ?? "",
     status: assignment.status || "queued",
     taskID: assignment.execution_ref?.task_id ?? "",
     runID: assignment.execution_ref?.run_id ?? "",
@@ -5502,6 +5783,12 @@ function EditAssignmentModal({
             <option value="external_agent">external_agent</option>
           </select>
         </label>
+        <ProjectRootSelect
+          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
           <label style={fieldStyle}>
             <span style={fieldLabelStyle}>Task ID</span>
@@ -5805,6 +6092,7 @@ function AssignmentRow({
   onOpenChat,
   onOpenTask,
   onStart,
+  project,
   role,
   starting,
 }: {
@@ -5820,6 +6108,7 @@ function AssignmentRow({
   onOpenChat?: () => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onStart: () => void;
+  project: ProjectRecord | null;
   role?: ProjectWorkRoleRecord;
   starting: boolean;
 }) {
@@ -5987,6 +6276,11 @@ function AssignmentRow({
             {[execution.provider, execution.model].filter(Boolean).join(" / ")}
           </span>
         ) : null}
+        {assignment.root_id && project && (
+          <span className="badge badge-muted" title={projectRootTitle(project, assignment.root_id)}>
+            root {projectRootDisplayLabel(project, assignment.root_id)}
+          </span>
+        )}
         {executionRef.missing && <span className="badge badge-amber">linked run missing</span>}
         {executionRef.hasAnyLink && (
           <button
@@ -6801,6 +7095,20 @@ function formatLaunchContextBullet(label: string, value: string): string {
 
 function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
   return role?.default_driver_kind || "hecate_task";
+}
+
+function projectRootDisplayLabel(project: ProjectRecord, rootID: string): string {
+  const root = project.roots.find((item) => item.id === rootID);
+  if (!root) return shortID(rootID);
+  if (root.git_branch) return root.git_branch;
+  const parts = root.path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] || root.id;
+}
+
+function projectRootTitle(project: ProjectRecord, rootID: string): string {
+  const root = project.roots.find((item) => item.id === rootID);
+  if (!root) return rootID;
+  return projectRootOptionLabel(root);
 }
 
 function shortID(id: string): string {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -8,6 +8,7 @@ import {
   createProjectHandoff,
   createProjectMemory,
   createProjectMemoryCandidate,
+  createProjectWorktreeRoot,
   createProjectWorkRole,
   createProjectWorkItem,
   deleteChatGrant,
@@ -596,9 +597,11 @@ describe("api client", () => {
       status: "ready",
       priority: "high",
       owner_role_id: "software_developer",
+      root_id: "root_worktree",
     });
     await createProjectAssignment("proj_1", "work_1", {
       role_id: "software_developer",
+      root_id: "root_worktree",
       driver_kind: "hecate_task",
     });
 
@@ -613,6 +616,7 @@ describe("api client", () => {
           status: "ready",
           priority: "high",
           owner_role_id: "software_developer",
+          root_id: "root_worktree",
         }),
       }),
     );
@@ -623,6 +627,7 @@ describe("api client", () => {
         method: "POST",
         body: JSON.stringify({
           role_id: "software_developer",
+          root_id: "root_worktree",
           driver_kind: "hecate_task",
         }),
       }),
@@ -702,10 +707,12 @@ describe("api client", () => {
       status: "ready",
       priority: "urgent",
       owner_role_id: "frontend_engineer",
+      root_id: "",
     });
     await deleteProjectWorkItem("proj/1", "work/1");
     await updateProjectAssignment("proj/1", "work/1", "asgn/1", {
       role_id: "frontend_engineer",
+      root_id: "root_review",
       driver_kind: "external_agent",
       status: "running",
     });
@@ -721,6 +728,7 @@ describe("api client", () => {
           status: "ready",
           priority: "urgent",
           owner_role_id: "frontend_engineer",
+          root_id: "",
         }),
       }),
     );
@@ -736,6 +744,7 @@ describe("api client", () => {
         method: "PATCH",
         body: JSON.stringify({
           role_id: "frontend_engineer",
+          root_id: "root_review",
           driver_kind: "external_agent",
           status: "running",
         }),
@@ -780,6 +789,32 @@ describe("api client", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({}),
+      }),
+    );
+  });
+
+  it("creates project worktree roots", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ object: "project", data: { id: "proj_1" } }));
+
+    await createProjectWorktreeRoot("proj/1", {
+      base_root_id: "root_main",
+      branch: "feature/projects",
+      start_point: "origin/main",
+      active: true,
+      set_default: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj%2F1/roots/worktrees",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          base_root_id: "root_main",
+          branch: "feature/projects",
+          start_point: "origin/main",
+          active: true,
+          set_default: true,
+        }),
       }),
     );
   });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -56,6 +56,7 @@ import type { UsageEventsResponse, UsageSummaryResponse } from "../types/usage";
 import type { RetentionRunResponse, RetentionRunsResponse } from "../types/retention";
 import type {
   CreateProjectPayload,
+  CreateProjectWorktreeRootPayload,
   CreateProjectMemoryCandidatePayload,
   CreateProjectMemoryPayload,
   CreateProjectAssignmentPayload,
@@ -363,6 +364,19 @@ export async function discoverProjectRoots(id: string): Promise<ProjectResponse>
     {
       method: "POST",
       body: {},
+    },
+  );
+}
+
+export async function createProjectWorktreeRoot(
+  id: string,
+  payload: CreateProjectWorktreeRootPayload,
+): Promise<ProjectResponse> {
+  return fetchJSON<ProjectResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(id)}/roots/worktrees`,
+    {
+      method: "POST",
+      body: payload,
     },
   );
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -141,6 +141,7 @@ export type ProjectAssistantContextWorkItem = {
   status: string;
   priority?: string;
   owner_role_id?: string;
+  root_id?: string;
   reviewer_role_ids?: string[];
   created_at: string;
   updated_at: string;
@@ -181,6 +182,7 @@ export type ProjectAssistantContextAssignment = {
   id: string;
   work_item_id: string;
   role_id: string;
+  root_id?: string;
   driver_kind: string;
   status: string;
   execution_ref?: ProjectAssignmentExecutionRefRecord;
@@ -419,6 +421,15 @@ export type UpdateProjectPayload = Partial<CreateProjectPayload> & {
   last_opened_at?: string;
 };
 
+export type CreateProjectWorktreeRootPayload = {
+  base_root_id?: string;
+  branch: string;
+  path?: string;
+  start_point?: string;
+  active?: boolean;
+  set_default?: boolean;
+};
+
 export type ProjectWorkRoleRecord = {
   id: string;
   project_id: string;
@@ -493,6 +504,7 @@ export type ProjectWorkItemRecord = {
   status: ProjectWorkItemStatus | string;
   priority: ProjectWorkItemPriority | string;
   owner_role_id?: string;
+  root_id?: string;
   reviewer_role_ids?: string[];
   assignments?: ProjectAssignmentRecord[];
   created_at: string;
@@ -506,6 +518,7 @@ export type CreateProjectWorkItemPayload = {
   status?: ProjectWorkItemStatus | string;
   priority?: ProjectWorkItemPriority | string;
   owner_role_id?: string;
+  root_id?: string;
   reviewer_role_ids?: string[];
 };
 
@@ -558,6 +571,7 @@ export type ProjectAssignmentRecord = {
   project_id: string;
   work_item_id: string;
   role_id: string;
+  root_id?: string;
   driver_kind: ProjectAssignmentDriverKind | string;
   status: ProjectAssignmentStatus | string;
   created_at: string;
@@ -571,6 +585,7 @@ export type ProjectAssignmentRecord = {
 export type CreateProjectAssignmentPayload = {
   id?: string;
   role_id: string;
+  root_id?: string;
   driver_kind?: ProjectAssignmentDriverKind | string;
   status?: ProjectAssignmentStatus | string;
   execution_ref?: ProjectAssignmentExecutionRefRecord;


### PR DESCRIPTION
## Summary

- Add optional project root selection for work items and assignments, with memory/sqlite parity.
- Resolve assignment launch roots with assignment -> work item -> project default -> active/fallback precedence and snapshot the selected root in context packets.
- Add bounded project worktree creation under a base root's .worktrees/ directory, plus UI controls and API docs.

## Validation

- git diff --check HEAD~1..HEAD
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -count=1 -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx src/lib/api.test.ts