### PR TITLE
Expose ACP available commands in chat sessions

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -98,6 +98,11 @@ that every counted message was packed into the provider or agent prompt. Context
 packets are snapshots on assistant messages; changing project context sources,
 skills, or work records later does not rewrite old message packets.
 
+External Agent sessions may expose ACP-advertised `available_commands` on the
+session snapshot. These are agent-native slash command hints, not Hecate
+project commands; selecting one still sends ordinary prompt text to the
+external agent.
+
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct
 model calls or enter the Hecate task runtime. If tools are on but the selected

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -90,6 +90,16 @@ different agent. Hecate stores the latest reported control state with the chat
 session and sends ACP-owned changes back with ACP `session/set_config_option`;
 it does not translate those controls into Hecate provider/model settings.
 
+ACP agents may also advertise **available slash commands** with
+`available_commands_update`. Hecate stores the latest advertised command
+metadata on the chat session as `available_commands` so clients can render
+agent-native command hints. Commands are still submitted as normal
+`session/prompt` text such as `/web agent client protocol`; ACP does not define
+a separate execute-command RPC. These are external-agent-native commands, not
+Hecate-owned project mutations. Future Hecate Chat shortcuts such as `/plan` or
+`/remember` should remain intent hints that go through the usual proposal,
+validation, and operator-apply boundaries.
+
 Check discovery:
 
 ```sh

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2560,6 +2560,11 @@ starting the agent process. After the ACP session exists, agent-owned
 the first prompt. If the adapter binary is missing, unauthenticated, missing a
 required launch option, or fails its ACP handshake, session creation fails and
 Hecate removes the empty chat record.
+If an ACP agent advertises native slash commands with
+`available_commands_update`, Hecate stores the latest command metadata on the
+session as `available_commands`. Clients send those commands back as ordinary
+prompt text, for example `/web agent client protocol`; there is no separate ACP
+execute-command RPC.
 
 ```json
 POST /hecate/v1/chat/sessions
@@ -2633,6 +2638,13 @@ POST /hecate/v1/chat/sessions
         "current_value": "chosen-model-id"
       }
     ],
+    "available_commands": [
+      {
+        "name": "web",
+        "description": "Search the web",
+        "input_hint": "query"
+      }
+    ],
     "messages": []
   }
 }
@@ -2670,6 +2682,12 @@ session controls before the first prompt. Catalog launch controls can be shown
 even earlier from `GET /hecate/v1/agent-adapters`. Common `category` values
 include `model`, `mode`, and `thought_level`, but clients must handle missing
 or custom categories.
+
+External Agent sessions may also include `available_commands`, the latest ACP
+available slash command list advertised by the agent. Each item has `name`,
+optional `description`, and optional `input_hint`. The `name` is agent-owned;
+clients should render it as a slash command hint but submit the chosen command
+as normal prompt text.
 
 ### `PATCH /hecate/v1/chat/sessions/{id}`
 

--- a/internal/agentadapters/acp_chat_client.go
+++ b/internal/agentadapters/acp_chat_client.go
@@ -9,15 +9,17 @@ import (
 
 	acp "github.com/coder/acp-go-sdk"
 
+	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/internal/workspacefs"
 )
 
 type acpChatClient struct {
-	sessionID   string
-	adapterID   string
-	workspace   string
-	coordinator *ApprovalCoordinator
+	sessionID           string
+	adapterID           string
+	workspace           string
+	coordinator         *ApprovalCoordinator
+	onAvailableCommands func([]agentcontrols.Command)
 	// metrics is optional; nil-safe across every Record* call.
 	// Populated by the SessionManager when an *AgentAdapterMetrics
 	// has been wired (see SessionManager.SetAdapterMetrics).
@@ -59,6 +61,9 @@ func (c *acpChatClient) currentTurn() *acpTurn {
 }
 
 func (c *acpChatClient) SessionUpdate(_ context.Context, params acp.SessionNotification) error {
+	if params.Update.AvailableCommandsUpdate != nil && c.onAvailableCommands != nil {
+		c.onAvailableCommands(agentcontrols.FromACPCommands(params.Update.AvailableCommandsUpdate.AvailableCommands))
+	}
 	turn := c.currentTurn()
 	if turn == nil {
 		return nil

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -35,6 +35,10 @@ type acpSession struct {
 	configOptions []agentcontrols.ConfigOption
 	managedConfig map[string]struct{}
 
+	commandMu              sync.Mutex
+	availableCommands      []agentcontrols.Command
+	availableCommandsKnown bool
+
 	turnMu sync.Mutex
 
 	activeMu     sync.Mutex
@@ -94,6 +98,15 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		metrics:     metrics,
 	}
 	conn := acp.NewClientSideConnection(client, stdin, stdout)
+	session := &acpSession{
+		adapter:   adapter,
+		workspace: workspace,
+		cmd:       cmd,
+		conn:      conn,
+		client:    client,
+		logger:    sessionLogger,
+	}
+	client.onAvailableCommands = session.setAvailableCommands
 	if logger != nil {
 		conn.SetLogger(logger.With(
 			slog.String("component", "agent_adapters.acp"),
@@ -222,17 +235,10 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 			)
 		}
 	}
-	return &acpSession{
-		adapter:       adapter,
-		workspace:     workspace,
-		cmd:           cmd,
-		conn:          conn,
-		client:        client,
-		nativeID:      nativeID,
-		logger:        sessionLogger,
-		configOptions: configOptions,
-		managedConfig: managedConfig,
-	}, resumed, recovery, nil
+	session.nativeID = nativeID
+	session.configOptions = configOptions
+	session.managedConfig = managedConfig
+	return session, resumed, recovery, nil
 }
 
 func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, error) {
@@ -284,6 +290,7 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 	output, raw, usage := turn.snapshot()
 	result, err := captureACPTurnResult(ctx, s.adapter, req, s.nativeID, output, raw, usage, exitCode, started, completed, initialDiffStat, initialDiff, runErr)
 	result.ConfigOptions = s.configOptionsSnapshot()
+	result.AvailableCommands, result.AvailableCommandsUpdated = s.availableCommandsSnapshot()
 	return result, err
 }
 
@@ -374,7 +381,7 @@ func (s *acpSession) SetManagedConfigOption(req SetSessionConfigOptionRequest) (
 		}
 		options[i].CurrentValue = value
 		s.configOptions = options
-		return SetSessionConfigOptionResult{ConfigOptions: cloneConfigOptions(options)}, nil
+		return s.setSessionConfigOptionResult(cloneConfigOptions(options)), nil
 	}
 	return SetSessionConfigOptionResult{}, fmt.Errorf("config option %q not found", req.ConfigID)
 }
@@ -435,13 +442,13 @@ func (s *acpSession) SetACPModel(ctx context.Context, req SetSessionConfigOption
 	if resp.ConfigOptions != nil {
 		updated = preserveACPModelConfigOption(updated, options)
 		s.configOptions = updated
-		return SetSessionConfigOptionResult{ConfigOptions: cloneConfigOptions(updated)}, nil
+		return s.setSessionConfigOptionResult(cloneConfigOptions(updated)), nil
 	}
 	for i := range options {
 		if options[i].ID == req.ConfigID && options[i].Source == agentcontrols.ConfigOptionSourceACPModel {
 			options[i].CurrentValue = value
 			s.configOptions = options
-			return SetSessionConfigOptionResult{ConfigOptions: cloneConfigOptions(options)}, nil
+			return s.setSessionConfigOptionResult(cloneConfigOptions(options)), nil
 		}
 	}
 	return SetSessionConfigOptionResult{}, fmt.Errorf("ACP model option %q not found", req.ConfigID)
@@ -468,7 +475,16 @@ func (s *acpSession) SetConfigOption(ctx context.Context, req SetSessionConfigOp
 	}
 	options = preserveACPModelConfigOption(options, previousOptions)
 	s.setConfigOptions(options)
-	return SetSessionConfigOptionResult{ConfigOptions: options}, nil
+	return s.setSessionConfigOptionResult(options), nil
+}
+
+func (s *acpSession) setSessionConfigOptionResult(options []agentcontrols.ConfigOption) SetSessionConfigOptionResult {
+	commands, commandsUpdated := s.availableCommandsSnapshot()
+	return SetSessionConfigOptionResult{
+		ConfigOptions:            options,
+		AvailableCommands:        commands,
+		AvailableCommandsUpdated: commandsUpdated,
+	}
 }
 
 func (s *acpSession) setConfigOptions(options []agentcontrols.ConfigOption) {
@@ -490,6 +506,22 @@ func (s *acpSession) configOptionsSnapshot() []agentcontrols.ConfigOption {
 	return cloneConfigOptions(s.configOptions)
 }
 
+func (s *acpSession) setAvailableCommands(commands []agentcontrols.Command) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	s.availableCommands = cloneCommands(commands)
+	s.availableCommandsKnown = true
+}
+
+func (s *acpSession) availableCommandsSnapshot() ([]agentcontrols.Command, bool) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	if !s.availableCommandsKnown {
+		return nil, false
+	}
+	return cloneCommands(s.availableCommands), true
+}
+
 func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.ConfigOption {
 	if options == nil {
 		return nil
@@ -503,6 +535,15 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 		out[i].Options = make([]agentcontrols.ConfigSelectOption, len(options[i].Options))
 		copy(out[i].Options, options[i].Options)
 	}
+	return out
+}
+
+func cloneCommands(commands []agentcontrols.Command) []agentcontrols.Command {
+	if commands == nil {
+		return nil
+	}
+	out := make([]agentcontrols.Command, len(commands))
+	copy(out, commands)
 	return out
 }
 

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -290,7 +290,7 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 	output, raw, usage := turn.snapshot()
 	result, err := captureACPTurnResult(ctx, s.adapter, req, s.nativeID, output, raw, usage, exitCode, started, completed, initialDiffStat, initialDiff, runErr)
 	result.ConfigOptions = s.configOptionsSnapshot()
-	result.AvailableCommands, result.AvailableCommandsUpdated = s.availableCommandsSnapshot()
+	result.AvailableCommands, result.AvailableCommandsKnown = s.availableCommandsSnapshot()
 	return result, err
 }
 
@@ -479,11 +479,11 @@ func (s *acpSession) SetConfigOption(ctx context.Context, req SetSessionConfigOp
 }
 
 func (s *acpSession) setSessionConfigOptionResult(options []agentcontrols.ConfigOption) SetSessionConfigOptionResult {
-	commands, commandsUpdated := s.availableCommandsSnapshot()
+	commands, commandsKnown := s.availableCommandsSnapshot()
 	return SetSessionConfigOptionResult{
-		ConfigOptions:            options,
-		AvailableCommands:        commands,
-		AvailableCommandsUpdated: commandsUpdated,
+		ConfigOptions:          options,
+		AvailableCommands:      commands,
+		AvailableCommandsKnown: commandsKnown,
 	}
 }
 

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -130,6 +130,39 @@ func TestACPSessionConfigOptionsSnapshotPreservesNilAndEmpty(t *testing.T) {
 	}
 }
 
+func TestACPChatClientCapturesAvailableCommandsWithoutActiveTurn(t *testing.T) {
+	var got []agentcontrols.Command
+	client := &acpChatClient{
+		onAvailableCommands: func(commands []agentcontrols.Command) {
+			got = commands
+		},
+	}
+
+	err := client.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: acp.SessionId("native_session"),
+		Update: acp.SessionUpdate{
+			AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
+				SessionUpdate: "available_commands_update",
+				AvailableCommands: []acp.AvailableCommand{
+					{
+						Name:        "web",
+						Description: "Search the web",
+						Input: &acp.AvailableCommandInput{
+							Unstructured: &acp.UnstructuredCommandInput{Hint: "query"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SessionUpdate: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "web" || got[0].Description != "Search the web" || got[0].InputHint != "query" {
+		t.Fatalf("available commands = %#v, want web command", got)
+	}
+}
+
 func TestSessionManagerUsesACPModelStateForBuiltInACPAdapters(t *testing.T) {
 	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -156,15 +156,15 @@ type PrepareSessionRequest struct {
 }
 
 type PrepareSessionResult struct {
-	Adapter                  Adapter
-	DriverKind               string
-	NativeSessionID          string
-	SessionStarted           bool
-	SessionResumed           bool
-	SessionRecovery          string
-	ConfigOptions            []agentcontrols.ConfigOption
-	AvailableCommands        []agentcontrols.Command
-	AvailableCommandsUpdated bool
+	Adapter                Adapter
+	DriverKind             string
+	NativeSessionID        string
+	SessionStarted         bool
+	SessionResumed         bool
+	SessionRecovery        string
+	ConfigOptions          []agentcontrols.ConfigOption
+	AvailableCommands      []agentcontrols.Command
+	AvailableCommandsKnown bool
 }
 
 type SetSessionConfigOptionRequest struct {
@@ -175,29 +175,29 @@ type SetSessionConfigOptionRequest struct {
 }
 
 type SetSessionConfigOptionResult struct {
-	ConfigOptions            []agentcontrols.ConfigOption
-	AvailableCommands        []agentcontrols.Command
-	AvailableCommandsUpdated bool
+	ConfigOptions          []agentcontrols.ConfigOption
+	AvailableCommands      []agentcontrols.Command
+	AvailableCommandsKnown bool
 }
 
 type RunResult struct {
-	Adapter                  Adapter
-	DriverKind               string
-	NativeSessionID          string
-	SessionStarted           bool
-	SessionResumed           bool
-	SessionRecovery          string
-	Output                   string
-	RawOutput                string
-	ExitCode                 int
-	StartedAt                time.Time
-	CompletedAt              time.Time
-	DiffStat                 string
-	Diff                     string
-	Usage                    Usage
-	ConfigOptions            []agentcontrols.ConfigOption
-	AvailableCommands        []agentcontrols.Command
-	AvailableCommandsUpdated bool
+	Adapter                Adapter
+	DriverKind             string
+	NativeSessionID        string
+	SessionStarted         bool
+	SessionResumed         bool
+	SessionRecovery        string
+	Output                 string
+	RawOutput              string
+	ExitCode               int
+	StartedAt              time.Time
+	CompletedAt            time.Time
+	DiffStat               string
+	Diff                   string
+	Usage                  Usage
+	ConfigOptions          []agentcontrols.ConfigOption
+	AvailableCommands      []agentcontrols.Command
+	AvailableCommandsKnown bool
 }
 
 type Usage struct {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -156,13 +156,15 @@ type PrepareSessionRequest struct {
 }
 
 type PrepareSessionResult struct {
-	Adapter         Adapter
-	DriverKind      string
-	NativeSessionID string
-	SessionStarted  bool
-	SessionResumed  bool
-	SessionRecovery string
-	ConfigOptions   []agentcontrols.ConfigOption
+	Adapter                  Adapter
+	DriverKind               string
+	NativeSessionID          string
+	SessionStarted           bool
+	SessionResumed           bool
+	SessionRecovery          string
+	ConfigOptions            []agentcontrols.ConfigOption
+	AvailableCommands        []agentcontrols.Command
+	AvailableCommandsUpdated bool
 }
 
 type SetSessionConfigOptionRequest struct {
@@ -173,25 +175,29 @@ type SetSessionConfigOptionRequest struct {
 }
 
 type SetSessionConfigOptionResult struct {
-	ConfigOptions []agentcontrols.ConfigOption
+	ConfigOptions            []agentcontrols.ConfigOption
+	AvailableCommands        []agentcontrols.Command
+	AvailableCommandsUpdated bool
 }
 
 type RunResult struct {
-	Adapter         Adapter
-	DriverKind      string
-	NativeSessionID string
-	SessionStarted  bool
-	SessionResumed  bool
-	SessionRecovery string
-	Output          string
-	RawOutput       string
-	ExitCode        int
-	StartedAt       time.Time
-	CompletedAt     time.Time
-	DiffStat        string
-	Diff            string
-	Usage           Usage
-	ConfigOptions   []agentcontrols.ConfigOption
+	Adapter                  Adapter
+	DriverKind               string
+	NativeSessionID          string
+	SessionStarted           bool
+	SessionResumed           bool
+	SessionRecovery          string
+	Output                   string
+	RawOutput                string
+	ExitCode                 int
+	StartedAt                time.Time
+	CompletedAt              time.Time
+	DiffStat                 string
+	Diff                     string
+	Usage                    Usage
+	ConfigOptions            []agentcontrols.ConfigOption
+	AvailableCommands        []agentcontrols.Command
+	AvailableCommandsUpdated bool
 }
 
 type Usage struct {

--- a/internal/agentadapters/session_manager.go
+++ b/internal/agentadapters/session_manager.go
@@ -121,14 +121,17 @@ func (m *SessionManager) PrepareSession(ctx context.Context, req PrepareSessionR
 	if err != nil {
 		return PrepareSessionResult{}, err
 	}
+	availableCommands, availableCommandsUpdated := session.availableCommandsSnapshot()
 	return PrepareSessionResult{
-		Adapter:         adapter,
-		DriverKind:      DriverKindACP,
-		NativeSessionID: session.nativeID,
-		SessionStarted:  started,
-		SessionResumed:  resumed,
-		SessionRecovery: recovery,
-		ConfigOptions:   session.configOptionsSnapshot(),
+		Adapter:                  adapter,
+		DriverKind:               DriverKindACP,
+		NativeSessionID:          session.nativeID,
+		SessionStarted:           started,
+		SessionResumed:           resumed,
+		SessionRecovery:          recovery,
+		ConfigOptions:            session.configOptionsSnapshot(),
+		AvailableCommands:        availableCommands,
+		AvailableCommandsUpdated: availableCommandsUpdated,
 	}, nil
 }
 

--- a/internal/agentadapters/session_manager.go
+++ b/internal/agentadapters/session_manager.go
@@ -121,17 +121,17 @@ func (m *SessionManager) PrepareSession(ctx context.Context, req PrepareSessionR
 	if err != nil {
 		return PrepareSessionResult{}, err
 	}
-	availableCommands, availableCommandsUpdated := session.availableCommandsSnapshot()
+	availableCommands, availableCommandsKnown := session.availableCommandsSnapshot()
 	return PrepareSessionResult{
-		Adapter:                  adapter,
-		DriverKind:               DriverKindACP,
-		NativeSessionID:          session.nativeID,
-		SessionStarted:           started,
-		SessionResumed:           resumed,
-		SessionRecovery:          recovery,
-		ConfigOptions:            session.configOptionsSnapshot(),
-		AvailableCommands:        availableCommands,
-		AvailableCommandsUpdated: availableCommandsUpdated,
+		Adapter:                adapter,
+		DriverKind:             DriverKindACP,
+		NativeSessionID:        session.nativeID,
+		SessionStarted:         started,
+		SessionResumed:         resumed,
+		SessionRecovery:        recovery,
+		ConfigOptions:          session.configOptionsSnapshot(),
+		AvailableCommands:      availableCommands,
+		AvailableCommandsKnown: availableCommandsKnown,
 	}, nil
 }
 

--- a/internal/agentcontrols/config_options.go
+++ b/internal/agentcontrols/config_options.go
@@ -2,6 +2,7 @@ package agentcontrols
 
 import (
 	"fmt"
+	"strings"
 
 	acp "github.com/coder/acp-go-sdk"
 )
@@ -39,6 +40,16 @@ type ConfigSelectOption struct {
 	GroupName   string `json:"group_name,omitempty"`
 }
 
+// Command is Hecate's stable projection of ACP available slash commands.
+// ACP owns the command names and descriptions; Hecate keeps only the
+// operator-facing metadata needed to render hints and send the command text
+// back through session/prompt.
+type Command struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	InputHint   string `json:"input_hint,omitempty"`
+}
+
 type SetConfigOptionRequest struct {
 	SessionID string
 	ConfigID  string
@@ -63,6 +74,36 @@ func FromACPOptions(options []acp.SessionConfigOption) []ConfigOption {
 		default:
 			out = append(out, unknownACPOption(len(out)))
 		}
+	}
+	return out
+}
+
+// FromACPCommands converts ACP available commands to Hecate's stable wire
+// shape. Commands with empty names are ignored because the name is the prompt
+// token the operator sends back to the agent, usually as /name.
+func FromACPCommands(commands []acp.AvailableCommand) []Command {
+	if len(commands) == 0 {
+		return nil
+	}
+	out := make([]Command, 0, len(commands))
+	seen := make(map[string]struct{}, len(commands))
+	for _, command := range commands {
+		name := trimString(command.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, Command{
+			Name:        name,
+			Description: trimString(command.Description),
+			InputHint:   acpCommandInputHint(command.Input),
+		})
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -174,6 +215,13 @@ func categoryString(category *acp.SessionConfigOptionCategory) string {
 	return string(*category)
 }
 
+func acpCommandInputHint(input *acp.AvailableCommandInput) string {
+	if input == nil || input.Unstructured == nil {
+		return ""
+	}
+	return trimString(input.Unstructured.Hint)
+}
+
 func acpSelectSource(category string) string {
 	if category == string(acp.SessionConfigOptionCategoryModel) {
 		return ConfigOptionSourceACPModel
@@ -186,4 +234,8 @@ func derefString(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func trimString(value string) string {
+	return strings.TrimSpace(value)
 }

--- a/internal/agentcontrols/config_options_test.go
+++ b/internal/agentcontrols/config_options_test.go
@@ -91,6 +91,31 @@ func TestFromACPOptions_PreservesUnknownVariants(t *testing.T) {
 	}
 }
 
+func TestFromACPCommands_NormalizesAvailableCommands(t *testing.T) {
+	got := FromACPCommands([]acp.AvailableCommand{
+		{
+			Name:        " web ",
+			Description: " Search the web ",
+			Input: &acp.AvailableCommandInput{
+				Unstructured: &acp.UnstructuredCommandInput{Hint: " query "},
+			},
+		},
+		{Name: "web", Description: "duplicate"},
+		{Name: " "},
+		{Name: "plan"},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 commands: %#v", len(got), got)
+	}
+	if got[0].Name != "web" || got[0].Description != "Search the web" || got[0].InputHint != "query" {
+		t.Fatalf("first command = %#v, want normalized web command", got[0])
+	}
+	if got[1].Name != "plan" {
+		t.Fatalf("second command = %#v, want plan", got[1])
+	}
+}
+
 func TestBuildACPSetRequest_SelectAndBoolean(t *testing.T) {
 	selectReq, err := BuildACPSetRequest(SetConfigOptionRequest{SessionID: "sess", ConfigID: "model", Value: "smart"})
 	if err != nil {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -802,7 +802,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if result.DriverKind != "" || result.NativeSessionID != "" || result.ConfigOptions != nil || result.AvailableCommandsUpdated {
+	if result.DriverKind != "" || result.NativeSessionID != "" || result.ConfigOptions != nil || result.AvailableCommandsKnown {
 		updated, err = h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
 			if result.DriverKind != "" {
 				item.DriverKind = result.DriverKind
@@ -813,7 +813,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 			if result.ConfigOptions != nil {
 				item.ConfigOptions = result.ConfigOptions
 			}
-			if result.AvailableCommandsUpdated {
+			if result.AvailableCommandsKnown {
 				item.AvailableCommands = result.AvailableCommands
 			}
 		})

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -802,7 +802,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if result.DriverKind != "" || result.NativeSessionID != "" || result.ConfigOptions != nil {
+	if result.DriverKind != "" || result.NativeSessionID != "" || result.ConfigOptions != nil || result.AvailableCommandsUpdated {
 		updated, err = h.agentChat.UpdateSession(r.Context(), session.ID, func(item *chat.Session) {
 			if result.DriverKind != "" {
 				item.DriverKind = result.DriverKind
@@ -812,6 +812,9 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 			}
 			if result.ConfigOptions != nil {
 				item.ConfigOptions = result.ConfigOptions
+			}
+			if result.AvailableCommandsUpdated {
+				item.AvailableCommands = result.AvailableCommands
 			}
 		})
 		if err != nil {

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -116,6 +116,7 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 		MaxSessionDurationMS: limits.MaxSessionDuration.Milliseconds(),
 		IdleTimeoutMS:        limits.IdleTimeout.Milliseconds(),
 		ConfigOptions:        session.ConfigOptions,
+		AvailableCommands:    session.AvailableCommands,
 		CreatedAt:            formatOptionalTime(session.CreatedAt),
 		UpdatedAt:            formatOptionalTime(session.UpdatedAt),
 		Segments:             renderChatSegments(session),

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -828,6 +828,7 @@ type ChatSessionItem struct {
 	MaxSessionDurationMS int64                        `json:"max_session_duration_ms,omitempty"`
 	IdleTimeoutMS        int64                        `json:"idle_timeout_ms,omitempty"`
 	ConfigOptions        []agentcontrols.ConfigOption `json:"config_options,omitempty"`
+	AvailableCommands    []agentcontrols.Command      `json:"available_commands,omitempty"`
 	CreatedAt            string                       `json:"created_at,omitempty"`
 	UpdatedAt            string                       `json:"updated_at,omitempty"`
 	Segments             []ChatSegmentItem            `json:"segments,omitempty"`

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2669,32 +2669,32 @@ func (s *failingUpdateSessionStore) Delete(ctx context.Context, id string) error
 }
 
 type fakeAgentChatRunner struct {
-	output                   string
-	finalOutput              string
-	chunks                   []string
-	activities               []agentadapters.Activity
-	delay                    time.Duration
-	waitForCancel            bool
-	nativeSessionID          string
-	sessionStarted           bool
-	sessionResumed           bool
-	sessionRecovery          string
-	seenPreviousID           string
-	usage                    agentadapters.Usage
-	diffStat                 string
-	diff                     string
-	err                      error
-	prepareErr               error
-	setConfigErr             error
-	prepareRequests          []agentadapters.PrepareSessionRequest
-	runRequests              []agentadapters.RunRequest
-	prepareDeadline          time.Time
-	prepareHasDeadline       bool
-	closedSessions           []string
-	closeErr                 error
-	configOptions            []agentcontrols.ConfigOption
-	availableCommands        []agentcontrols.Command
-	availableCommandsUpdated bool
+	output                 string
+	finalOutput            string
+	chunks                 []string
+	activities             []agentadapters.Activity
+	delay                  time.Duration
+	waitForCancel          bool
+	nativeSessionID        string
+	sessionStarted         bool
+	sessionResumed         bool
+	sessionRecovery        string
+	seenPreviousID         string
+	usage                  agentadapters.Usage
+	diffStat               string
+	diff                   string
+	err                    error
+	prepareErr             error
+	setConfigErr           error
+	prepareRequests        []agentadapters.PrepareSessionRequest
+	runRequests            []agentadapters.RunRequest
+	prepareDeadline        time.Time
+	prepareHasDeadline     bool
+	closedSessions         []string
+	closeErr               error
+	configOptions          []agentcontrols.ConfigOption
+	availableCommands      []agentcontrols.Command
+	availableCommandsKnown bool
 	// activitiesAfterCancel are emitted via OnActivity after ctx is
 	// cancelled (waitForCancel only), so they sit in the stream
 	// coalescer when the run returns and exercise the trailing
@@ -2714,15 +2714,15 @@ func (r *fakeAgentChatRunner) PrepareSession(ctx context.Context, req agentadapt
 	}
 	adapter, _ := agentadapters.BuiltInByID(req.AdapterID)
 	return agentadapters.PrepareSessionResult{
-		Adapter:                  adapter,
-		DriverKind:               agentadapters.DriverKindACP,
-		NativeSessionID:          nativeSessionID,
-		SessionStarted:           r.sessionStarted,
-		SessionResumed:           r.sessionResumed,
-		SessionRecovery:          r.sessionRecovery,
-		ConfigOptions:            r.configOptions,
-		AvailableCommands:        r.availableCommands,
-		AvailableCommandsUpdated: r.availableCommandsUpdated,
+		Adapter:                adapter,
+		DriverKind:             agentadapters.DriverKindACP,
+		NativeSessionID:        nativeSessionID,
+		SessionStarted:         r.sessionStarted,
+		SessionResumed:         r.sessionResumed,
+		SessionRecovery:        r.sessionRecovery,
+		ConfigOptions:          r.configOptions,
+		AvailableCommands:      r.availableCommands,
+		AvailableCommandsKnown: r.availableCommandsKnown,
 	}, nil
 }
 
@@ -2788,23 +2788,23 @@ func (r *fakeAgentChatRunner) result(req agentadapters.RunRequest, output string
 	}
 	adapter, _ := agentadapters.BuiltInByID(req.AdapterID)
 	return agentadapters.RunResult{
-		Adapter:                  adapter,
-		DriverKind:               agentadapters.DriverKindACP,
-		NativeSessionID:          nativeSessionID,
-		SessionStarted:           r.sessionStarted,
-		SessionResumed:           r.sessionResumed,
-		SessionRecovery:          r.sessionRecovery,
-		Output:                   output,
-		RawOutput:                output,
-		ExitCode:                 exitCode,
-		StartedAt:                started,
-		CompletedAt:              time.Now().UTC(),
-		DiffStat:                 r.diffStat,
-		Diff:                     r.diff,
-		Usage:                    r.usage,
-		ConfigOptions:            r.configOptions,
-		AvailableCommands:        r.availableCommands,
-		AvailableCommandsUpdated: r.availableCommandsUpdated,
+		Adapter:                adapter,
+		DriverKind:             agentadapters.DriverKindACP,
+		NativeSessionID:        nativeSessionID,
+		SessionStarted:         r.sessionStarted,
+		SessionResumed:         r.sessionResumed,
+		SessionRecovery:        r.sessionRecovery,
+		Output:                 output,
+		RawOutput:              output,
+		ExitCode:               exitCode,
+		StartedAt:              started,
+		CompletedAt:            time.Now().UTC(),
+		DiffStat:               r.diffStat,
+		Diff:                   r.diff,
+		Usage:                  r.usage,
+		ConfigOptions:          r.configOptions,
+		AvailableCommands:      r.availableCommands,
+		AvailableCommandsKnown: r.availableCommandsKnown,
 	}
 }
 
@@ -2825,9 +2825,9 @@ func (r *fakeAgentChatRunner) SetSessionConfigOption(_ context.Context, req agen
 	}
 	r.configOptions = options
 	return agentadapters.SetSessionConfigOptionResult{
-		ConfigOptions:            options,
-		AvailableCommands:        r.availableCommands,
-		AvailableCommandsUpdated: r.availableCommandsUpdated,
+		ConfigOptions:          options,
+		AvailableCommands:      r.availableCommands,
+		AvailableCommandsKnown: r.availableCommandsKnown,
 	}, nil
 }
 
@@ -2865,7 +2865,7 @@ func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 				CurrentBool: &autoApprove,
 			},
 		},
-		availableCommandsUpdated: true,
+		availableCommandsKnown: true,
 		availableCommands: []agentcontrols.Command{
 			{Name: "web", Description: "Search the web", InputHint: "query"},
 			{Name: "plan", Description: "Create a plan"},

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2669,30 +2669,32 @@ func (s *failingUpdateSessionStore) Delete(ctx context.Context, id string) error
 }
 
 type fakeAgentChatRunner struct {
-	output             string
-	finalOutput        string
-	chunks             []string
-	activities         []agentadapters.Activity
-	delay              time.Duration
-	waitForCancel      bool
-	nativeSessionID    string
-	sessionStarted     bool
-	sessionResumed     bool
-	sessionRecovery    string
-	seenPreviousID     string
-	usage              agentadapters.Usage
-	diffStat           string
-	diff               string
-	err                error
-	prepareErr         error
-	setConfigErr       error
-	prepareRequests    []agentadapters.PrepareSessionRequest
-	runRequests        []agentadapters.RunRequest
-	prepareDeadline    time.Time
-	prepareHasDeadline bool
-	closedSessions     []string
-	closeErr           error
-	configOptions      []agentcontrols.ConfigOption
+	output                   string
+	finalOutput              string
+	chunks                   []string
+	activities               []agentadapters.Activity
+	delay                    time.Duration
+	waitForCancel            bool
+	nativeSessionID          string
+	sessionStarted           bool
+	sessionResumed           bool
+	sessionRecovery          string
+	seenPreviousID           string
+	usage                    agentadapters.Usage
+	diffStat                 string
+	diff                     string
+	err                      error
+	prepareErr               error
+	setConfigErr             error
+	prepareRequests          []agentadapters.PrepareSessionRequest
+	runRequests              []agentadapters.RunRequest
+	prepareDeadline          time.Time
+	prepareHasDeadline       bool
+	closedSessions           []string
+	closeErr                 error
+	configOptions            []agentcontrols.ConfigOption
+	availableCommands        []agentcontrols.Command
+	availableCommandsUpdated bool
 	// activitiesAfterCancel are emitted via OnActivity after ctx is
 	// cancelled (waitForCancel only), so they sit in the stream
 	// coalescer when the run returns and exercise the trailing
@@ -2712,13 +2714,15 @@ func (r *fakeAgentChatRunner) PrepareSession(ctx context.Context, req agentadapt
 	}
 	adapter, _ := agentadapters.BuiltInByID(req.AdapterID)
 	return agentadapters.PrepareSessionResult{
-		Adapter:         adapter,
-		DriverKind:      agentadapters.DriverKindACP,
-		NativeSessionID: nativeSessionID,
-		SessionStarted:  r.sessionStarted,
-		SessionResumed:  r.sessionResumed,
-		SessionRecovery: r.sessionRecovery,
-		ConfigOptions:   r.configOptions,
+		Adapter:                  adapter,
+		DriverKind:               agentadapters.DriverKindACP,
+		NativeSessionID:          nativeSessionID,
+		SessionStarted:           r.sessionStarted,
+		SessionResumed:           r.sessionResumed,
+		SessionRecovery:          r.sessionRecovery,
+		ConfigOptions:            r.configOptions,
+		AvailableCommands:        r.availableCommands,
+		AvailableCommandsUpdated: r.availableCommandsUpdated,
 	}, nil
 }
 
@@ -2784,21 +2788,23 @@ func (r *fakeAgentChatRunner) result(req agentadapters.RunRequest, output string
 	}
 	adapter, _ := agentadapters.BuiltInByID(req.AdapterID)
 	return agentadapters.RunResult{
-		Adapter:         adapter,
-		DriverKind:      agentadapters.DriverKindACP,
-		NativeSessionID: nativeSessionID,
-		SessionStarted:  r.sessionStarted,
-		SessionResumed:  r.sessionResumed,
-		SessionRecovery: r.sessionRecovery,
-		Output:          output,
-		RawOutput:       output,
-		ExitCode:        exitCode,
-		StartedAt:       started,
-		CompletedAt:     time.Now().UTC(),
-		DiffStat:        r.diffStat,
-		Diff:            r.diff,
-		Usage:           r.usage,
-		ConfigOptions:   r.configOptions,
+		Adapter:                  adapter,
+		DriverKind:               agentadapters.DriverKindACP,
+		NativeSessionID:          nativeSessionID,
+		SessionStarted:           r.sessionStarted,
+		SessionResumed:           r.sessionResumed,
+		SessionRecovery:          r.sessionRecovery,
+		Output:                   output,
+		RawOutput:                output,
+		ExitCode:                 exitCode,
+		StartedAt:                started,
+		CompletedAt:              time.Now().UTC(),
+		DiffStat:                 r.diffStat,
+		Diff:                     r.diff,
+		Usage:                    r.usage,
+		ConfigOptions:            r.configOptions,
+		AvailableCommands:        r.availableCommands,
+		AvailableCommandsUpdated: r.availableCommandsUpdated,
 	}
 }
 
@@ -2818,7 +2824,11 @@ func (r *fakeAgentChatRunner) SetSessionConfigOption(_ context.Context, req agen
 		}
 	}
 	r.configOptions = options
-	return agentadapters.SetSessionConfigOptionResult{ConfigOptions: options}, nil
+	return agentadapters.SetSessionConfigOptionResult{
+		ConfigOptions:            options,
+		AvailableCommands:        r.availableCommands,
+		AvailableCommandsUpdated: r.availableCommandsUpdated,
+	}, nil
 }
 
 func (r *fakeAgentChatRunner) CloseSession(_ context.Context, sessionID string) error {
@@ -2855,6 +2865,11 @@ func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 				CurrentBool: &autoApprove,
 			},
 		},
+		availableCommandsUpdated: true,
+		availableCommands: []agentcontrols.Command{
+			{Name: "web", Description: "Search the web", InputHint: "query"},
+			{Name: "plan", Description: "Create a plan"},
+		},
 	}
 	apiHandler.SetAgentChatRunner(runner)
 	handler := NewServer(logger, apiHandler)
@@ -2883,9 +2898,15 @@ func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 	if got := created.Data.ConfigOptions; len(got) != 2 || got[0].CurrentValue != "fast" || got[1].CurrentBool == nil || *got[1].CurrentBool {
 		t.Fatalf("config options after create = %#v, want fast model and auto_approve false", got)
 	}
+	if got := created.Data.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[0].InputHint != "query" {
+		t.Fatalf("available commands after create = %#v, want web and plan", got)
+	}
 	afterRun := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"hello"}`))
 	if got := afterRun.Data.ConfigOptions; len(got) != 2 || got[0].CurrentValue != "fast" || got[1].CurrentBool == nil || *got[1].CurrentBool {
 		t.Fatalf("config options after run = %#v, want fast model and auto_approve false", got)
+	}
+	if got := afterRun.Data.AvailableCommands; len(got) != 2 || got[1].Name != "plan" {
+		t.Fatalf("available commands after run = %#v, want persisted commands", got)
 	}
 	if got := runner.runRequests[0].ConfigOptions; len(got) != 2 || got[0].CurrentValue != "fast" {
 		t.Fatalf("run request config options = %#v, want fast model", got)
@@ -2894,6 +2915,9 @@ func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 	updated := decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/model", `{"value":"smart"}`))
 	if got := updated.Data.ConfigOptions; len(got) != 2 || got[0].CurrentValue != "smart" {
 		t.Fatalf("config options after select set = %#v, want smart option", got)
+	}
+	if got := updated.Data.AvailableCommands; len(got) != 2 || got[0].Name != "web" {
+		t.Fatalf("available commands after select set = %#v, want preserved commands", got)
 	}
 
 	updated = decodeRecorder[ChatSessionResponse](t, performRequest(t, handler, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/config-options/auto_approve", `{"value":true}`))

--- a/internal/chat/conformance_test.go
+++ b/internal/chat/conformance_test.go
@@ -37,6 +37,10 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreDeepCopiesConfigOptions(t, factory(t))
 	})
+	t.Run(name+"/AvailableCommandsRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		runStoreAvailableCommandsRoundTrip(t, factory(t))
+	})
 	t.Run(name+"/DeleteByProjectID", func(t *testing.T) {
 		t.Parallel()
 		runStoreDeleteByProjectID(t, factory(t))

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -57,9 +57,9 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		fmt.Sprintf(
 			`INSERT INTO %s (
 				id, title, project_id, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
-				status, task_id, latest_run_id, provider, model, capabilities, config_options, rtk_enabled, turns_used, created_at, updated_at
+				status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, created_at, updated_at
 			 )
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 			   title = excluded.title,
 			   project_id = excluded.project_id,
@@ -75,6 +75,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 			   model = excluded.model,
 			   capabilities = excluded.capabilities,
 			   config_options = excluded.config_options,
+			   available_commands = excluded.available_commands,
 			   rtk_enabled = excluded.rtk_enabled,
 			   updated_at = excluded.updated_at`,
 			s.sessionsTable,
@@ -94,6 +95,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		session.Model,
 		marshalModelCapabilities(session.Capabilities),
 		marshalConfigOptions(session.ConfigOptions),
+		marshalCommands(session.AvailableCommands),
 		session.RTKEnabled,
 		session.TurnsUsed,
 		session.CreatedAt.UTC(),
@@ -121,12 +123,12 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		ctx,
 		fmt.Sprintf(
 			`SELECT s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
-			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at,
+			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at,
 			        COUNT(m.id) AS message_count
 			 FROM %s AS s
 			 LEFT JOIN %s AS m ON m.session_id = s.id
 			 GROUP BY s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
-			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at
+			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at
 			 ORDER BY s.updated_at DESC, s.created_at DESC`,
 			s.sessionsTable,
 			s.messagesTable,
@@ -143,6 +145,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		var messageCount int
 		var capabilities string
 		var configOptions string
+		var availableCommands string
 		if err := rows.Scan(
 			&session.ID,
 			&session.Title,
@@ -159,6 +162,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 			&session.Model,
 			&capabilities,
 			&configOptions,
+			&availableCommands,
 			&session.RTKEnabled,
 			&session.TurnsUsed,
 			&session.CreatedAt,
@@ -169,6 +173,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		}
 		session.Capabilities = unmarshalModelCapabilities(capabilities)
 		session.ConfigOptions = unmarshalConfigOptions(configOptions)
+		session.AvailableCommands = unmarshalCommands(availableCommands)
 		if session.AgentID == "" {
 			session.AgentID = DefaultAgentID
 		}
@@ -236,7 +241,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, update func(
 		fmt.Sprintf(
 			`UPDATE %s SET
 			   title = ?, project_id = ?, agent_id = ?, driver_kind = ?, native_session_id = ?, workspace = ?, workspace_branch = ?,
-			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, rtk_enabled = ?, turns_used = ?, updated_at = ?
+			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, available_commands = ?, rtk_enabled = ?, turns_used = ?, updated_at = ?
 			 WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -254,6 +259,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, update func(
 		session.Model,
 		marshalModelCapabilities(session.Capabilities),
 		marshalConfigOptions(session.ConfigOptions),
+		marshalCommands(session.AvailableCommands),
 		session.RTKEnabled,
 		session.TurnsUsed,
 		session.UpdatedAt.UTC(),
@@ -523,6 +529,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		{name: "model", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "capabilities", definition: "TEXT NOT NULL DEFAULT '{}'"},
 		{name: "config_options", definition: "TEXT NOT NULL DEFAULT '[]'"},
+		{name: "available_commands", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "rtk_enabled", definition: "INTEGER NOT NULL DEFAULT 0"},
 	} {
 		if err := s.ensureSessionColumn(ctx, column.name, column.definition); err != nil {
@@ -585,11 +592,12 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	var session Session
 	var capabilities string
 	var configOptions string
+	var availableCommands string
 	err := s.client.DB().QueryRowContext(
 		ctx,
 		fmt.Sprintf(
 			`SELECT id, title, project_id, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
-			        status, task_id, latest_run_id, provider, model, capabilities, config_options, rtk_enabled, turns_used, created_at, updated_at
+			        status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, created_at, updated_at
 			 FROM %s WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -610,6 +618,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 		&session.Model,
 		&capabilities,
 		&configOptions,
+		&availableCommands,
 		&session.RTKEnabled,
 		&session.TurnsUsed,
 		&session.CreatedAt,
@@ -626,6 +635,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	}
 	session.Capabilities = unmarshalModelCapabilities(capabilities)
 	session.ConfigOptions = unmarshalConfigOptions(configOptions)
+	session.AvailableCommands = unmarshalCommands(availableCommands)
 	messages, err := s.loadMessages(ctx, id)
 	if err != nil {
 		return Session{}, err
@@ -1022,6 +1032,29 @@ func unmarshalConfigOptions(raw string) []agentcontrols.ConfigOption {
 		return nil
 	}
 	return options
+}
+
+func marshalCommands(commands []agentcontrols.Command) string {
+	if len(commands) == 0 {
+		return "[]"
+	}
+	data, err := json.Marshal(commands)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}
+
+func unmarshalCommands(raw string) []agentcontrols.Command {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var commands []agentcontrols.Command
+	if err := json.Unmarshal([]byte(raw), &commands); err != nil {
+		return nil
+	}
+	return commands
 }
 
 func updateSessionAfterMessage(ctx context.Context, tx txRunner, table string, sessionID string, message Message) error {

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -22,15 +22,16 @@ type Session struct {
 	Workspace       string
 	// WorkspaceBranch is captured when the session is created so API
 	// snapshots don't spawn git on every streamed update.
-	WorkspaceBranch string
-	Status          string
-	TaskID          string
-	LatestRunID     string
-	Provider        string
-	Model           string
-	Capabilities    types.ModelCapabilities
-	ConfigOptions   []agentcontrols.ConfigOption
-	RTKEnabled      bool
+	WorkspaceBranch   string
+	Status            string
+	TaskID            string
+	LatestRunID       string
+	Provider          string
+	Model             string
+	Capabilities      types.ModelCapabilities
+	ConfigOptions     []agentcontrols.ConfigOption
+	AvailableCommands []agentcontrols.Command
+	RTKEnabled        bool
 	// TurnsUsed counts how many user→assistant round-trips have completed
 	// (successfully or with failure) in this session. Used to enforce the
 	// HECATE_CHAT_MAX_TURNS_PER_SESSION ceiling.
@@ -415,6 +416,7 @@ func (s *MemoryStore) UpdateMessage(_ context.Context, sessionID string, message
 
 func cloneSession(session Session) Session {
 	session.ConfigOptions = cloneConfigOptions(session.ConfigOptions)
+	session.AvailableCommands = cloneCommands(session.AvailableCommands)
 	session.Messages = append([]Message(nil), session.Messages...)
 	for i := range session.Messages {
 		session.Messages[i].Activities = append([]Activity(nil), session.Messages[i].Activities...)
@@ -437,6 +439,15 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 		out[i].Options = make([]agentcontrols.ConfigSelectOption, len(options[i].Options))
 		copy(out[i].Options, options[i].Options)
 	}
+	return out
+}
+
+func cloneCommands(commands []agentcontrols.Command) []agentcontrols.Command {
+	if commands == nil {
+		return nil
+	}
+	out := make([]agentcontrols.Command, len(commands))
+	copy(out, commands)
 	return out
 }
 

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -391,6 +391,48 @@ func runStoreDeepCopiesConfigOptions(t *testing.T, store Store) {
 	}
 }
 
+func runStoreAvailableCommandsRoundTrip(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := store.Create(ctx, Session{
+		ID:        "chat_commands",
+		Title:     "Commands",
+		AgentID:   "codex",
+		Workspace: "/tmp/hecate",
+		AvailableCommands: []agentcontrols.Command{
+			{Name: "web", Description: "Search the web", InputHint: "query"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.AvailableCommands[0].Name = "mutated"
+	got, ok, err := store.Get(ctx, "chat_commands")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if len(got.AvailableCommands) != 1 || got.AvailableCommands[0].Name != "web" || got.AvailableCommands[0].InputHint != "query" {
+		t.Fatalf("stored commands = %#v, want web command", got.AvailableCommands)
+	}
+	got.AvailableCommands[0].Description = "mutated"
+	again, _, err := store.Get(ctx, "chat_commands")
+	if err != nil {
+		t.Fatalf("Get again: %v", err)
+	}
+	if again.AvailableCommands[0].Description != "Search the web" {
+		t.Fatalf("stored command mutated through get snapshot: %#v", again.AvailableCommands)
+	}
+	updated, err := store.UpdateSession(ctx, "chat_commands", func(item *Session) {
+		item.AvailableCommands = []agentcontrols.Command{}
+	})
+	if err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+	if updated.AvailableCommands == nil || len(updated.AvailableCommands) != 0 {
+		t.Fatalf("updated commands = %#v, want non-nil empty slice", updated.AvailableCommands)
+	}
+}
+
 func runStoreDeleteByProjectID(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -300,7 +300,7 @@ func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionComm
 		item.DriverKind = prepared.DriverKind
 		item.NativeSessionID = prepared.NativeSessionID
 		item.ConfigOptions = prepared.ConfigOptions
-		if prepared.AvailableCommandsUpdated {
+		if prepared.AvailableCommandsKnown {
 			item.AvailableCommands = prepared.AvailableCommands
 		}
 	})
@@ -381,7 +381,7 @@ func (app *Application) SetConfigOption(ctx context.Context, cmd SetConfigOption
 	}
 	session, err := app.store.UpdateSession(ctx, cmd.Session.ID, func(item *chat.Session) {
 		item.ConfigOptions = result.ConfigOptions
-		if result.AvailableCommandsUpdated {
+		if result.AvailableCommandsKnown {
 			item.AvailableCommands = result.AvailableCommands
 		}
 	})

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -300,6 +300,9 @@ func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionComm
 		item.DriverKind = prepared.DriverKind
 		item.NativeSessionID = prepared.NativeSessionID
 		item.ConfigOptions = prepared.ConfigOptions
+		if prepared.AvailableCommandsUpdated {
+			item.AvailableCommands = prepared.AvailableCommands
+		}
 	})
 	if err != nil {
 		app.cleanupExternalSession(sessionID)
@@ -378,6 +381,9 @@ func (app *Application) SetConfigOption(ctx context.Context, cmd SetConfigOption
 	}
 	session, err := app.store.UpdateSession(ctx, cmd.Session.ID, func(item *chat.Session) {
 		item.ConfigOptions = result.ConfigOptions
+		if result.AvailableCommandsUpdated {
+			item.AvailableCommands = result.AvailableCommands
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/ui/src/app/state/reconcileChatSession.test.ts
+++ b/ui/src/app/state/reconcileChatSession.test.ts
@@ -108,37 +108,44 @@ describe("reconcileChatSession", () => {
     expect(reconcileChatSession(prev, nextEmpty).messages).toBe(nextEmpty.messages);
   });
 
-  it("reuses segments and config_options when deep-equal", () => {
+  it("reuses segments, config_options, and available_commands when deep-equal", () => {
     const segments = [{ id: "s1", execution_mode: "external_agent", message_count: 1 }];
     const configOptions = [{ id: "c1", name: "Mode", type: "select", current_value: "auto" }];
+    const availableCommands = [{ name: "web", description: "Search the web", input_hint: "query" }];
     const prev = session("chat-1", [message("m1", "hi")], {
       segments: [{ id: "s1", execution_mode: "external_agent", message_count: 1 }],
       config_options: [{ id: "c1", name: "Mode", type: "select", current_value: "auto" }],
+      available_commands: [{ name: "web", description: "Search the web", input_hint: "query" }],
     });
     const next = session("chat-1", [message("m1", "hi")], {
       segments,
       config_options: configOptions,
+      available_commands: availableCommands,
     });
 
     const result = reconcileChatSession(prev, next);
 
     expect(result.segments).toBe(prev.segments);
     expect(result.config_options).toBe(prev.config_options);
+    expect(result.available_commands).toBe(prev.available_commands);
   });
 
-  it("takes next segments and config_options when they changed", () => {
+  it("takes next segments, config_options, and available_commands when they changed", () => {
     const prev = session("chat-1", [message("m1", "hi")], {
       segments: [{ id: "s1", execution_mode: "external_agent", message_count: 1 }],
       config_options: [{ id: "c1", name: "Mode", type: "select", current_value: "auto" }],
+      available_commands: [{ name: "web" }],
     });
     const next = session("chat-1", [message("m1", "hi")], {
       segments: [{ id: "s1", execution_mode: "external_agent", message_count: 2 }],
       config_options: [{ id: "c1", name: "Mode", type: "select", current_value: "plan" }],
+      available_commands: [{ name: "plan" }],
     });
 
     const result = reconcileChatSession(prev, next);
 
     expect(result.segments).toBe(next.segments);
     expect(result.config_options).toBe(next.config_options);
+    expect(result.available_commands).toBe(next.available_commands);
   });
 });

--- a/ui/src/app/state/reconcileChatSession.ts
+++ b/ui/src/app/state/reconcileChatSession.ts
@@ -36,6 +36,7 @@ export function reconcileChatSession(
     messages: reconcileMessages(prev.messages, next.messages),
     segments: reuseIfEqual(prev.segments, next.segments),
     config_options: reuseIfEqual(prev.config_options, next.config_options),
+    available_commands: reuseIfEqual(prev.available_commands, next.available_commands),
   };
 }
 

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -163,6 +163,12 @@ export type ChatConfigOptionRecord = {
   options?: ChatConfigSelectOptionRecord[];
 };
 
+export type ChatAvailableCommandRecord = {
+  name: string;
+  description?: string;
+  input_hint?: string;
+};
+
 export type ChatSessionRecord = {
   id: string;
   title: string;
@@ -187,6 +193,7 @@ export type ChatSessionRecord = {
   created_at?: string;
   updated_at?: string;
   config_options?: ChatConfigOptionRecord[];
+  available_commands?: ChatAvailableCommandRecord[];
   segments?: ChatSegmentRecord[];
   messages?: ChatMessageRecord[];
 };


### PR DESCRIPTION
## Summary

- Capture ACP `available_commands_update` notifications as stable Hecate `available_commands` metadata on external-agent chat sessions.
- Persist available commands across memory/sqlite stores and expose them on full chat-session API snapshots.
- Add TypeScript session types and reconciliation identity handling so the UI can consume agent-native command hints later without changing the composer in this PR.
- Document the command boundary: ACP slash commands are external-agent-native prompt text; Hecate-owned `/plan`-style shortcuts should remain intent hints that still go through proposal/validation/operator-apply boundaries.

## Self-review notes

- Empty ACP command updates are tracked separately from “no update,” so agents can clear stale command lists.
- Commands are metadata only. Hecate does not add a direct execute-command API and does not hard-code vendor-specific command names.
- This PR intentionally avoids composer autocomplete or Hecate-owned slash shortcuts; it only creates the plumbing needed for those later.
- Unrelated local changes in provider catalog / provider UI files are not included in this branch.

## Tests

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/agentcontrols ./internal/agentadapters ./internal/chat ./internal/chatapp`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestAgentChatExternalConfigOptionsRoundTrip|TestAgentChatExternal'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/agentcontrols ./internal/agentadapters ./internal/chat ./internal/chatapp ./internal/api`
- `bun run typecheck`
- `bun run test -- src/app/state/reconcileChatSession.test.ts`
- `go vet ./internal/agentcontrols ./internal/agentadapters ./internal/chat ./internal/chatapp ./internal/api`
- `just docs-format-check`
- `bun run test`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
