### PR TITLE
Suggest external agent slash commands in chat

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -101,7 +101,8 @@ skills, or work records later does not rewrite old message packets.
 External Agent sessions may expose ACP-advertised `available_commands` on the
 session snapshot. These are agent-native slash command hints, not Hecate
 project commands; selecting one still sends ordinary prompt text to the
-external agent.
+external agent. The operator UI may show these hints while the composer starts
+with `/`; choosing a hint only inserts the slash command text.
 
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -95,10 +95,12 @@ ACP agents may also advertise **available slash commands** with
 metadata on the chat session as `available_commands` so clients can render
 agent-native command hints. Commands are still submitted as normal
 `session/prompt` text such as `/web agent client protocol`; ACP does not define
-a separate execute-command RPC. These are external-agent-native commands, not
-Hecate-owned project mutations. Future Hecate Chat shortcuts such as `/plan` or
-`/remember` should remain intent hints that go through the usual proposal,
-validation, and operator-apply boundaries.
+a separate execute-command RPC. The operator UI can surface the advertised list
+when the composer starts with `/`, but choosing an item only inserts the command
+text. These are external-agent-native commands, not Hecate-owned project
+mutations. Future Hecate Chat shortcuts such as `/plan` or `/remember` should
+remain intent hints that go through the usual proposal, validation, and
+operator-apply boundaries.
 
 Check discovery:
 

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -311,6 +311,10 @@ test("New chat creates an external-agent session with controls before the first 
               ],
             },
           ],
+          available_commands: [
+            { name: "web", description: "Search the web", input_hint: "query" },
+            { name: "plan", description: "Create a plan" },
+          ],
           messages: [],
         },
       }),
@@ -334,6 +338,14 @@ test("New chat creates an external-agent session with controls before the first 
       workspace: "/tmp/hecate-e2e",
     });
   await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText("Fast");
+  const composer = page.getByRole("textbox", { name: "Message" });
+  await composer.fill("/");
+  const commands = page.getByRole("group", { name: "External agent commands" });
+  await expect(commands.getByRole("button", { name: "Insert /web command" })).toBeVisible();
+  await expect(commands).toContainText("Search the web");
+  await commands.getByRole("button", { name: "Insert /web command" }).click();
+  await expect(composer).toHaveValue("/web ");
+
   await page.getByRole("button", { name: "Choose agent for new chat" }).click();
   await expect(page.getByRole("option", { name: /Codex/ })).toHaveAttribute(
     "aria-selected",

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject, type SyntheticEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject, type SyntheticEvent } from "react";
 
 import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
@@ -13,7 +13,7 @@ import { describeGatewayError, formatErrorCode } from "../../lib/error-diagnosti
 import { usePersistedState } from "../../lib/persistedState";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
 import { providerDisplayName } from "../../lib/provider-utils";
-import type { ChatConfigOptionRecord } from "../../types/chat";
+import type { ChatAvailableCommandRecord, ChatConfigOptionRecord } from "../../types/chat";
 import type { ModelRecord } from "../../types/model";
 import type {
   ConfiguredProviderRecord,
@@ -33,6 +33,7 @@ import { mergeAgentConfigOptions } from "./agentConfigOptions";
 
 const COMPOSER_TEXTAREA_MAX_LINES = 10;
 const COMPOSER_TEXTAREA_MIN_HEIGHT = 42;
+const COMMAND_SUGGESTION_LIMIT = 6;
 type ComposerTextareaNumericStyle =
   | "paddingTop"
   | "paddingBottom"
@@ -218,6 +219,34 @@ export function ChatComposer(props: ChatComposerProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const messageHistoryCursorRef = useRef<number | null>(null);
   const messageHistoryPendingTextRef = useRef("");
+  const [commandPickerDismissed, setCommandPickerDismissed] = useState(false);
+  const [activeCommandIndex, setActiveCommandIndex] = useState(0);
+  const commandQuery = externalAgentCommandQuery(message);
+  const commandSuggestions = useMemo(() => {
+    if (!isExternalAgentChat || commandQuery === null) return [];
+    const commands = activeChatSession?.available_commands ?? [];
+    const query = commandQuery.toLowerCase();
+    return commands
+      .filter((command) => externalAgentCommandName(command) !== "")
+      .filter((command) => externalAgentCommandName(command).toLowerCase().startsWith(query))
+      .slice(0, COMMAND_SUGGESTION_LIMIT);
+  }, [activeChatSession?.available_commands, commandQuery, isExternalAgentChat]);
+  const commandPickerVisible =
+    composerVisible &&
+    isExternalAgentChat &&
+    !commandPickerDismissed &&
+    commandSuggestions.length > 0;
+
+  useEffect(() => {
+    setCommandPickerDismissed(false);
+    setActiveCommandIndex(0);
+  }, [activeSessionID, commandQuery]);
+
+  useEffect(() => {
+    setActiveCommandIndex((current) =>
+      commandSuggestions.length === 0 ? 0 : Math.min(current, commandSuggestions.length - 1),
+    );
+  }, [commandSuggestions.length]);
 
   // Reset history navigation on session change. Scroll-side reset
   // lives in ChatView since it concerns the transcript surface.
@@ -295,7 +324,46 @@ export function ChatComposer(props: ChatComposerProps) {
     return true;
   }
 
+  function selectCommandSuggestion(command: ChatAvailableCommandRecord) {
+    const nextMessage = externalAgentCommandInsertion(command);
+    if (!nextMessage) return;
+    messageHistoryCursorRef.current = null;
+    messageHistoryPendingTextRef.current = nextMessage;
+    setCommandPickerDismissed(true);
+    setComposerText(nextMessage, true);
+  }
+
+  function handleCommandPickerKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (!commandPickerVisible) return false;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setCommandPickerDismissed(true);
+      return true;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveCommandIndex((current) => (current + 1) % commandSuggestions.length);
+      return true;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveCommandIndex(
+        (current) => (current - 1 + commandSuggestions.length) % commandSuggestions.length,
+      );
+      return true;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      const command = commandSuggestions[activeCommandIndex];
+      if (!command) return false;
+      e.preventDefault();
+      selectCommandSuggestion(command);
+      return true;
+    }
+    return false;
+  }
+
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (handleCommandPickerKey(e)) return;
     if (handleMessageHistoryKey(e)) return;
     if (e.key !== "Enter") return;
     const modPressed = isMac ? e.metaKey : e.ctrlKey;
@@ -529,6 +597,81 @@ export function ChatComposer(props: ChatComposerProps) {
               position: "relative",
             }}
           >
+            {commandPickerVisible && (
+              <div
+                role="group"
+                aria-label="External agent commands"
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  right: 44,
+                  bottom: "calc(100% + 6px)",
+                  zIndex: 5,
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-sm)",
+                  background: "var(--bg2)",
+                  boxShadow: "0 10px 28px rgba(0, 0, 0, 0.28)",
+                  padding: 4,
+                  display: "grid",
+                  gap: 2,
+                }}
+              >
+                {commandSuggestions.map((command, index) => {
+                  const commandText = externalAgentCommandInsertion(command).trim();
+                  const selected = index === activeCommandIndex;
+                  return (
+                    <button
+                      key={`${externalAgentCommandName(command)}:${index}`}
+                      type="button"
+                      aria-label={`Insert ${commandText} command`}
+                      aria-current={selected ? "true" : undefined}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => selectCommandSuggestion(command)}
+                      style={{
+                        width: "100%",
+                        border: "none",
+                        borderRadius: "var(--radius-sm)",
+                        background: selected ? "var(--bg4)" : "transparent",
+                        color: "var(--t0)",
+                        cursor: "pointer",
+                        display: "grid",
+                        gridTemplateColumns: "minmax(84px, auto) minmax(0, 1fr)",
+                        alignItems: "center",
+                        gap: 10,
+                        padding: "7px 8px",
+                        textAlign: "left",
+                      }}
+                    >
+                      <span
+                        style={{
+                          color: selected ? "var(--teal)" : "var(--t1)",
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 12,
+                          minWidth: 0,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {commandText}
+                      </span>
+                      <span
+                        style={{
+                          color: "var(--t3)",
+                          fontSize: 12,
+                          minWidth: 0,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {externalAgentCommandDetail(command)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
             <textarea
               ref={textareaRef}
               aria-label="Message"
@@ -777,6 +920,28 @@ function composerTextareaMaxHeight(textarea: HTMLTextAreaElement) {
 
 function numericStyleValue(element: HTMLElement, property: ComposerTextareaNumericStyle) {
   return Number.parseFloat(window.getComputedStyle(element)[property]) || 0;
+}
+
+function externalAgentCommandQuery(message: string): string | null {
+  if (!message.startsWith("/")) return null;
+  const query = message.slice(1);
+  if (/\s/.test(query)) return null;
+  return query;
+}
+
+function externalAgentCommandName(command: ChatAvailableCommandRecord) {
+  return command.name.trim().replace(/^\/+/, "");
+}
+
+function externalAgentCommandInsertion(command: ChatAvailableCommandRecord) {
+  const name = externalAgentCommandName(command);
+  return name ? `/${name} ` : "";
+}
+
+function externalAgentCommandDetail(command: ChatAvailableCommandRecord) {
+  const description = command.description?.trim();
+  if (description) return description;
+  return command.input_hint?.trim() ?? "";
 }
 
 export function ChatErrorPanel({

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useRef, useState, type RefObject, type SyntheticEvent } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+  type SyntheticEvent,
+} from "react";
 
 import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
@@ -219,6 +227,7 @@ export function ChatComposer(props: ChatComposerProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const messageHistoryCursorRef = useRef<number | null>(null);
   const messageHistoryPendingTextRef = useRef("");
+  const commandListboxID = useId();
   const [commandPickerDismissed, setCommandPickerDismissed] = useState(false);
   const [activeCommandIndex, setActiveCommandIndex] = useState(0);
   const commandQuery = externalAgentCommandQuery(message);
@@ -236,6 +245,9 @@ export function ChatComposer(props: ChatComposerProps) {
     isExternalAgentChat &&
     !commandPickerDismissed &&
     commandSuggestions.length > 0;
+  const activeCommandOptionID = commandPickerVisible
+    ? `${commandListboxID}-option-${activeCommandIndex}`
+    : undefined;
 
   useEffect(() => {
     setCommandPickerDismissed(false);
@@ -591,6 +603,11 @@ export function ChatComposer(props: ChatComposerProps) {
             </div>
           )}
           <div
+            role="combobox"
+            aria-controls={commandPickerVisible ? commandListboxID : undefined}
+            aria-expanded={commandPickerVisible}
+            aria-haspopup="listbox"
+            aria-label="Message command picker"
             style={{
               maxWidth: 820,
               margin: "0 auto",
@@ -599,7 +616,8 @@ export function ChatComposer(props: ChatComposerProps) {
           >
             {commandPickerVisible && (
               <div
-                role="group"
+                id={commandListboxID}
+                role="listbox"
                 aria-label="External agent commands"
                 style={{
                   position: "absolute",
@@ -620,12 +638,14 @@ export function ChatComposer(props: ChatComposerProps) {
                   const commandText = externalAgentCommandInsertion(command).trim();
                   const selected = index === activeCommandIndex;
                   return (
-                    <button
+                    <div
                       key={`${externalAgentCommandName(command)}:${index}`}
-                      type="button"
+                      id={`${commandListboxID}-option-${index}`}
+                      role="option"
                       aria-label={`Insert ${commandText} command`}
-                      aria-current={selected ? "true" : undefined}
+                      aria-selected={selected}
                       onMouseDown={(event) => event.preventDefault()}
+                      onMouseEnter={() => setActiveCommandIndex(index)}
                       onClick={() => selectCommandSuggestion(command)}
                       style={{
                         width: "100%",
@@ -667,7 +687,7 @@ export function ChatComposer(props: ChatComposerProps) {
                       >
                         {externalAgentCommandDetail(command)}
                       </span>
-                    </button>
+                    </div>
                   );
                 })}
               </div>
@@ -675,6 +695,9 @@ export function ChatComposer(props: ChatComposerProps) {
             <textarea
               ref={textareaRef}
               aria-label="Message"
+              aria-activedescendant={activeCommandOptionID}
+              aria-controls={commandPickerVisible ? commandListboxID : undefined}
+              aria-haspopup="listbox"
               value={message}
               onChange={(e) => handleMessageChange(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2911,6 +2911,100 @@ describe("ChatView input", () => {
     expect(setMessage).toHaveBeenCalledWith("h");
   });
 
+  it("suggests external-agent slash commands and inserts the selected command", async () => {
+    const setMessage = vi.fn();
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        agentAdapterID: "claude_code",
+        message: "/",
+        activeChatSession: {
+          id: "chat_commands",
+          title: "Agent commands",
+          agent_id: "claude_code",
+          driver_kind: "acp",
+          execution_mode: "external_agent",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          available_commands: [
+            { name: "web", description: "Search the web", input_hint: "query" },
+            { name: "plan", description: "Create a plan" },
+          ],
+          messages: [],
+        },
+      },
+      { setMessage },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const commands = screen.getByLabelText("External agent commands");
+    expect(within(commands).getByRole("button", { name: "Insert /web command" })).toHaveTextContent(
+      "/web",
+    );
+    expect(within(commands).getByText("Search the web")).toBeTruthy();
+
+    const user = userEvent.setup();
+    await user.click(within(commands).getByRole("button", { name: "Insert /web command" }));
+
+    expect(setMessage).toHaveBeenLastCalledWith("/web ");
+  });
+
+  it("selects external-agent slash commands with Enter without sending", () => {
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        agentAdapterID: "claude_code",
+        message: "/",
+        activeChatSession: {
+          id: "chat_commands",
+          title: "Agent commands",
+          agent_id: "claude_code",
+          driver_kind: "acp",
+          execution_mode: "external_agent",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          available_commands: [
+            { name: "web", description: "Search the web" },
+            { name: "plan", description: "Create a plan" },
+          ],
+          messages: [],
+        },
+      },
+      { setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(setMessage).toHaveBeenLastCalledWith("/plan ");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("does not show slash command suggestions for Hecate Chat", () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
+      message: "/",
+      activeChatSession: {
+        id: "chat_hecate",
+        title: "Hecate",
+        agent_id: "hecate",
+        execution_mode: "hecate_task",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: [{ name: "plan", description: "Create a plan" }],
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    expect(screen.queryByLabelText("External agent commands")).toBeNull();
+  });
+
   it("browses previous user messages with ArrowUp and ArrowDown", () => {
     const setMessage = vi.fn();
     const { state, actions } = setup(

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2937,16 +2937,88 @@ describe("ChatView input", () => {
     );
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    const commands = screen.getByLabelText("External agent commands");
-    expect(within(commands).getByRole("button", { name: "Insert /web command" })).toHaveTextContent(
+    const textarea = screen.getByRole("textbox", { name: "Message" });
+    const picker = screen.getByRole("combobox", { name: "Message command picker" });
+    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    expect(picker).toHaveAttribute("aria-expanded", "true");
+    expect(textarea).toHaveAttribute("aria-controls", commands.id);
+    expect(picker).toHaveAttribute("aria-controls", commands.id);
+    expect(within(commands).getByRole("option", { name: "Insert /web command" })).toHaveTextContent(
       "/web",
+    );
+    expect(within(commands).getByRole("option", { selected: true })).toHaveAttribute(
+      "aria-label",
+      "Insert /web command",
+    );
+    expect(textarea).toHaveAttribute(
+      "aria-activedescendant",
+      within(commands).getByRole("option", { selected: true }).id,
     );
     expect(within(commands).getByText("Search the web")).toBeTruthy();
 
     const user = userEvent.setup();
-    await user.click(within(commands).getByRole("button", { name: "Insert /web command" }));
+    await user.click(within(commands).getByRole("option", { name: "Insert /web command" }));
 
     expect(setMessage).toHaveBeenLastCalledWith("/web ");
+  });
+
+  it("filters external-agent slash commands by typed prefix", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      message: "/w",
+      activeChatSession: {
+        id: "chat_commands",
+        title: "Agent commands",
+        agent_id: "claude_code",
+        driver_kind: "acp",
+        execution_mode: "external_agent",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: [
+          { name: "web", description: "Search the web" },
+          { name: "plan", description: "Create a plan" },
+        ],
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    expect(within(commands).getByRole("option", { name: "Insert /web command" })).toBeTruthy();
+    expect(within(commands).queryByRole("option", { name: "Insert /plan command" })).toBeNull();
+  });
+
+  it("dismisses external-agent slash command suggestions with Escape", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      message: "/",
+      activeChatSession: {
+        id: "chat_commands",
+        title: "Agent commands",
+        agent_id: "claude_code",
+        driver_kind: "acp",
+        execution_mode: "external_agent",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: [
+          { name: "web", description: "Search the web" },
+          { name: "plan", description: "Create a plan" },
+        ],
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const textarea = screen.getByRole("textbox", { name: "Message" });
+    const picker = screen.getByRole("combobox", { name: "Message command picker" });
+    expect(screen.getByRole("listbox", { name: "External agent commands" })).toBeTruthy();
+
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox", { name: "External agent commands" })).toBeNull();
+    expect(picker).toHaveAttribute("aria-expanded", "false");
   });
 
   it("selects external-agent slash commands with Enter without sending", () => {
@@ -2978,6 +3050,15 @@ describe("ChatView input", () => {
 
     const textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    expect(within(commands).getByRole("option", { selected: true })).toHaveAttribute(
+      "aria-label",
+      "Insert /plan command",
+    );
+    expect(textarea).toHaveAttribute(
+      "aria-activedescendant",
+      within(commands).getByRole("option", { selected: true }).id,
+    );
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(setMessage).toHaveBeenLastCalledWith("/plan ");


### PR DESCRIPTION
## Summary

- Adds a lightweight external-agent slash command picker in the Chat composer when the active ACP session advertises `available_commands` and the draft starts with `/`.
- Keeps commands as insertion-only hints: selecting one writes `/command ` into the composer, and sending still uses the normal prompt path.
- Documents the UI behavior alongside the ACP command boundary.

## Tests

- `cd ui && bun run test -- src/features/chats/ChatView.test.tsx`
- `cd ui && bun run test:e2e -- -g "New chat creates an external-agent session with controls before the first prompt"`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`
- `cd ui && bun run test:e2e`