### PR TITLE
refactor(ui): extract project settings panels

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -174,8 +174,9 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
 - Projects UI keeps Project Assistant orchestration in
   `useProjectAssistantController`; do not put propose/apply/bootstrap request
   state back into `ProjectsView`. The workspace rendering branches live behind
-  `ProjectWorkspaceView`, while project state loading and mutations stay in the
-  parent page.
+  `ProjectWorkspaceView`, and project defaults/root editing lives in
+  `ProjectSettingsPanel` plus `CreateProjectWorktreeModal`, while project state
+  loading and mutations stay in the parent page.
 - External Agent readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/ui/src/features/projects/CreateProjectWorktreeModal.test.tsx
+++ b/ui/src/features/projects/CreateProjectWorktreeModal.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectRecord, ProjectRootRecord } from "../../types/project";
+import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_main",
+    path: "/workspace/main",
+    kind: "workspace",
+    active: true,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [
+      root({ id: "root_main", path: "/workspace/main", active: true }),
+      root({
+        id: "root_default",
+        path: "/workspace/default",
+        kind: "git_worktree",
+        git_branch: "main",
+        active: true,
+      }),
+    ],
+    default_root_id: "root_default",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+  };
+}
+
+describe("CreateProjectWorktreeModal", () => {
+  it("submits a worktree request from the selected project root defaults", async () => {
+    const onCreate = vi.fn();
+
+    render(
+      <CreateProjectWorktreeModal
+        error=""
+        pending={false}
+        project={project()}
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "Create worktree" });
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Branch"), {
+      target: { value: "feature/project-settings" },
+    });
+    fireEvent.change(screen.getByLabelText("Start point"), {
+      target: { value: "origin/master" },
+    });
+    fireEvent.change(screen.getByLabelText("Path"), {
+      target: { value: ".worktrees/project-settings" },
+    });
+    await userEvent.click(screen.getByLabelText("Make default root"));
+    await userEvent.click(createButton);
+
+    expect(onCreate).toHaveBeenCalledWith({
+      baseRootID: "root_default",
+      branch: "feature/project-settings",
+      startPoint: "origin/master",
+      path: ".worktrees/project-settings",
+      active: true,
+      setDefault: true,
+    });
+  });
+});

--- a/ui/src/features/projects/CreateProjectWorktreeModal.tsx
+++ b/ui/src/features/projects/CreateProjectWorktreeModal.tsx
@@ -1,0 +1,147 @@
+import { useState, type CSSProperties } from "react";
+
+import type { ProjectRecord } from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import { projectRootOptionLabel, type CreateWorktreeForm } from "./projectSettings";
+
+export function CreateProjectWorktreeModal({
+  error,
+  pending,
+  project,
+  onClose,
+  onCreate,
+}: {
+  error: string;
+  pending: boolean;
+  project: ProjectRecord;
+  onClose: () => void;
+  onCreate: (form: CreateWorktreeForm) => void | Promise<void>;
+}) {
+  const defaultBaseRootID =
+    project.default_root_id ||
+    project.roots.find((root) => root.active)?.id ||
+    project.roots[0]?.id ||
+    "";
+  const [form, setForm] = useState<CreateWorktreeForm>({
+    baseRootID: defaultBaseRootID,
+    branch: "",
+    startPoint: "",
+    path: "",
+    active: true,
+    setDefault: false,
+  });
+  const valid = project.roots.length > 0 && form.branch.trim().length > 0;
+  return (
+    <Modal
+      title="Create project worktree"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Creating…" : "Create worktree"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        {project.roots.length === 0 && <InlineError message="Add a project root first." />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Base root</span>
+          <select
+            aria-label="Base root"
+            className="input"
+            value={form.baseRootID}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, baseRootID: event.target.value }))
+            }
+            style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+          >
+            {project.roots.map((root) => (
+              <option key={root.id || root.path} value={root.id}>
+                {projectRootOptionLabel(root)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Branch</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.branch}
+            onChange={(event) => setForm((current) => ({ ...current, branch: event.target.value }))}
+            placeholder="feature/project-worktrees"
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Start point</span>
+            <input
+              className="input"
+              value={form.startPoint}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, startPoint: event.target.value }))
+              }
+              placeholder="origin/main"
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Path</span>
+            <input
+              className="input"
+              value={form.path}
+              onChange={(event) => setForm((current) => ({ ...current, path: event.target.value }))}
+              placeholder=".worktrees/feature-project-worktrees"
+            />
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, active: event.target.checked }))
+              }
+            />
+            <span style={fieldLabelStyle}>Active root</span>
+          </label>
+          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={form.setDefault}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, setDefault: event.target.checked }))
+              }
+            />
+            <span style={fieldLabelStyle}>Make default root</span>
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+const fieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};

--- a/ui/src/features/projects/ProjectSettingsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectRecord, ProjectRootRecord } from "../../types/project";
+import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_main",
+    path: "/workspace/main",
+    kind: "workspace",
+    active: true,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [
+      root({ id: "root_main", path: "/workspace/main", active: true }),
+      root({
+        id: "root_feature",
+        path: "/workspace/feature",
+        kind: "git_worktree",
+        git_branch: "feature/project-settings",
+        active: false,
+      }),
+    ],
+    default_root_id: "root_main",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ProjectSettingsPanel", () => {
+  it("saves editable defaults and updates the workspace preview from form roots", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <ProjectSettingsPanel
+        agentProfiles={[]}
+        agentProfilesError=""
+        error=""
+        models={[]}
+        pending={false}
+        providerOptions={[]}
+        providerPresets={[]}
+        project={project()}
+        rootsPending={false}
+        onDiscoverRoots={vi.fn()}
+        onOpenCreateWorktree={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Default project root"), {
+      target: { value: "root_feature" },
+    });
+
+    expect(screen.getAllByText("/workspace/feature")).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save defaults" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultRootID: "root_feature",
+        roots: expect.arrayContaining([
+          expect.objectContaining({ id: "root_feature", active: true }),
+        ]),
+      }),
+    );
+  });
+});

--- a/ui/src/features/projects/ProjectSettingsPanel.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.tsx
@@ -1,0 +1,422 @@
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+
+import { projectDefaultWorkspaceFromRoots } from "../../lib/project-workspace";
+import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { ModelRecord } from "../../types/model";
+import type { ProjectRecord } from "../../types/project";
+import type { ProviderPresetRecord } from "../../types/provider";
+import {
+  Icon,
+  Icons,
+  InlineError,
+  ModelPicker,
+  ProviderPicker,
+  type ProviderOption,
+} from "../shared/ui";
+import {
+  normalizeWorkspaceMode,
+  projectDefaultsFormFromProject,
+  projectRootOptionLabel,
+  projectRootSummary,
+  type ProjectDefaultsForm,
+} from "./projectSettings";
+
+export function ProjectSettingsPanel({
+  agentProfiles,
+  agentProfilesError,
+  error,
+  models,
+  pending,
+  providerOptions,
+  providerPresets,
+  project,
+  rootsPending,
+  onDiscoverRoots,
+  onOpenCreateWorktree,
+  onSave,
+}: {
+  agentProfiles: AgentProfileRecord[];
+  agentProfilesError: string;
+  error: string;
+  models: ModelRecord[];
+  pending: boolean;
+  providerOptions: ProviderOption[];
+  providerPresets: ProviderPresetRecord[];
+  project: ProjectRecord;
+  rootsPending: boolean;
+  onDiscoverRoots: () => void | Promise<void>;
+  onOpenCreateWorktree: () => void;
+  onSave: (form: ProjectDefaultsForm) => void | Promise<void>;
+}) {
+  const [form, setForm] = useState<ProjectDefaultsForm>(() =>
+    projectDefaultsFormFromProject(project),
+  );
+  useEffect(() => {
+    setForm(projectDefaultsFormFromProject(project));
+  }, [project]);
+  const scopedModels = useMemo(() => {
+    if (!form.provider) return models;
+    return models.filter((model) => model.metadata?.provider === form.provider);
+  }, [form.provider, models]);
+  const selectedProfile = useMemo(
+    () => agentProfiles.find((profile) => profile.id === form.defaultAgentProfile) ?? null,
+    [agentProfiles, form.defaultAgentProfile],
+  );
+
+  function handleProviderChange(provider: string) {
+    setForm((current) => {
+      const nextModels = provider
+        ? models.filter((model) => model.metadata?.provider === provider)
+        : models;
+      const modelStillValid =
+        current.model &&
+        nextModels.some(
+          (model) =>
+            model.id === current.model && (!provider || model.metadata?.provider === provider),
+        );
+      return {
+        ...current,
+        provider,
+        model: modelStillValid ? current.model : "",
+      };
+    });
+  }
+  function handleDefaultRootChange(rootID: string) {
+    setForm((current) => ({
+      ...current,
+      defaultRootID: rootID,
+      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active: true } : root)),
+    }));
+  }
+  function handleRootActiveChange(rootID: string, active: boolean) {
+    setForm((current) => ({
+      ...current,
+      defaultRootID: !active && current.defaultRootID === rootID ? "" : current.defaultRootID,
+      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active } : root)),
+    }));
+  }
+  const submitForm = () => onSave(form);
+
+  const workspace = projectDefaultWorkspaceFromRoots(form.roots, form.defaultRootID);
+  const rootCount = form.roots.length;
+
+  return (
+    <div
+      style={{
+        background: "var(--bg1)",
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          borderBottom: "1px solid var(--border)",
+          padding: "14px 14px 12px",
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 12, fontWeight: 650, color: "var(--t0)" }}>Project settings</div>
+          <div
+            style={{
+              marginTop: 4,
+              fontSize: 11,
+              color: "var(--t3)",
+              lineHeight: 1.45,
+            }}
+          >
+            Controls defaults for future native project assignments. Existing task runs keep the
+            settings they started with.
+          </div>
+        </div>
+      </div>
+      <div style={{ overflowY: "auto", padding: 14, display: "grid", gap: 14 }}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submitForm();
+          }}
+          style={{ display: "grid", gap: 14 }}
+        >
+          {error && <InlineError message={error} />}
+          {agentProfilesError && <InlineError message={agentProfilesError} />}
+          <ProjectSettingsSection title="Assignment defaults">
+            <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
+              Native Hecate assignments copy these defaults when creating the backing task.
+            </div>
+            <div style={{ display: "grid", gap: 12 }}>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Provider and model</span>
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                  <ProviderPicker
+                    value={form.provider}
+                    onChange={handleProviderChange}
+                    options={providerOptions}
+                    emptyLabel={
+                      providerOptions.length === 0 ? "no providers configured" : "select provider"
+                    }
+                  />
+                  <ModelPicker
+                    value={form.model}
+                    onChange={(model) => setForm((current) => ({ ...current, model }))}
+                    models={scopedModels}
+                    presets={providerPresets}
+                    includeAll
+                    allLabel="inherit runtime default"
+                    showProvider={!form.provider}
+                  />
+                </div>
+              </div>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Agent profile</span>
+                <select
+                  aria-label="Default agent profile"
+                  className="input"
+                  value={form.defaultAgentProfile}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      defaultAgentProfile: event.target.value,
+                    }))
+                  }
+                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+                >
+                  <option value="">built-in project_assignment</option>
+                  {agentProfiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name || profile.id} ({profile.id})
+                    </option>
+                  ))}
+                </select>
+                <ProfilePosturePreview profile={selectedProfile} />
+              </div>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Workspace mode</span>
+                <div style={{ position: "relative", width: "100%" }}>
+                  <select
+                    aria-label="Workspace mode"
+                    className="input"
+                    value={normalizeWorkspaceMode(form.workspaceMode)}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, workspaceMode: event.target.value }))
+                    }
+                    style={{
+                      appearance: "none",
+                      cursor: "pointer",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 12,
+                      minHeight: 36,
+                      paddingRight: 34,
+                    }}
+                  >
+                    <option value="in_place">in_place</option>
+                    <option value="persistent">persistent</option>
+                    <option value="ephemeral">ephemeral</option>
+                  </select>
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      alignItems: "center",
+                      color: "var(--t2)",
+                      display: "inline-flex",
+                      height: "100%",
+                      pointerEvents: "none",
+                      position: "absolute",
+                      right: 11,
+                      top: 0,
+                    }}
+                  >
+                    <Icon d={Icons.chevD} size={12} />
+                  </span>
+                </div>
+              </div>
+              <button
+                className="btn btn-primary"
+                type="submit"
+                disabled={pending}
+                style={{ width: "100%", justifyContent: "center" }}
+              >
+                {pending ? "Saving…" : "Save defaults"}
+              </button>
+            </div>
+          </ProjectSettingsSection>
+          <ProjectSettingsSection title="Project context">
+            <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
+              Project roots are concrete checkouts. Linked worktrees discovered from Git stay
+              inactive until enabled here.
+            </div>
+            <div style={{ display: "grid", gap: 12, marginBottom: 14 }}>
+              <div style={fieldStyle}>
+                <span style={fieldLabelStyle}>Default root</span>
+                <select
+                  aria-label="Default project root"
+                  className="input"
+                  value={form.defaultRootID}
+                  onChange={(event) => handleDefaultRootChange(event.target.value)}
+                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+                >
+                  <option value="">no default root</option>
+                  {form.roots.map((root) => (
+                    <option key={root.id || root.path} value={root.id ?? ""}>
+                      {projectRootOptionLabel(root)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  className="btn btn-primary btn-sm"
+                  type="button"
+                  onClick={onOpenCreateWorktree}
+                >
+                  Create worktree
+                </button>
+                <button
+                  className="btn btn-ghost btn-sm"
+                  type="button"
+                  disabled={rootsPending}
+                  onClick={() => void onDiscoverRoots()}
+                >
+                  {rootsPending ? "Discovering…" : "Discover worktrees"}
+                </button>
+                <span style={subtleTextStyle}>
+                  {rootCount === 0
+                    ? "No roots configured."
+                    : `${rootCount} root${rootCount === 1 ? "" : "s"}`}
+                </span>
+              </div>
+              {form.roots.length > 0 && (
+                <div style={{ display: "grid", gap: 8 }}>
+                  {form.roots.map((root) => {
+                    const rootID = root.id ?? root.path;
+                    const isDefault = form.defaultRootID !== "" && root.id === form.defaultRootID;
+                    return (
+                      <label
+                        key={rootID}
+                        style={{
+                          border: "1px solid var(--border)",
+                          borderRadius: 8,
+                          display: "grid",
+                          gap: 5,
+                          padding: "9px 10px",
+                        }}
+                      >
+                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <input
+                            aria-label={`Active project root ${root.path}`}
+                            type="checkbox"
+                            checked={Boolean(root.active)}
+                            onChange={(event) =>
+                              handleRootActiveChange(root.id ?? "", event.target.checked)
+                            }
+                          />
+                          <span
+                            style={{
+                              color: "var(--t1)",
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 11,
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {root.path}
+                          </span>
+                        </span>
+                        <span style={{ ...subtleTextStyle, paddingLeft: 22 }}>
+                          {projectRootSummary(root)}
+                          {isDefault ? " · default" : ""}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 5,
+                fontSize: 11,
+                color: "var(--t3)",
+                lineHeight: 1.45,
+              }}
+            >
+              <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+                <span style={{ color: "var(--t3)", fontSize: 11, minWidth: 78 }}>Workspace</span>
+                <span
+                  title={workspace}
+                  style={{
+                    color: "var(--t1)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {workspace || "No default root"}
+                </span>
+              </div>
+            </div>
+          </ProjectSettingsSection>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ProjectSettingsSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <div className="kicker" style={{ marginBottom: 7 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null }) {
+  if (!profile) {
+    return (
+      <div style={{ ...subtleTextStyle, marginTop: 4 }}>
+        Uses the built-in project_assignment posture until a saved profile is selected.
+      </div>
+    );
+  }
+  const details = [
+    profile.surface,
+    profile.execution_profile ? `profile ${profile.execution_profile}` : "",
+    profile.provider_hint || profile.model_hint
+      ? `hints ${[profile.provider_hint, profile.model_hint].filter(Boolean).join("/")}`
+      : "",
+    `tools ${profile.tools_enabled ? "on" : "off"}`,
+    `writes ${profile.writes_allowed ? "on" : "off"}`,
+    `network ${profile.network_allowed ? "on" : "off"}`,
+    `approval ${profile.approval_policy}`,
+    `memory ${profile.project_memory_policy}`,
+    `sources ${profile.context_source_policy}`,
+  ].filter(Boolean);
+  return <div style={{ ...subtleTextStyle, marginTop: 4 }}>{details.join(" · ")}</div>;
+}
+
+const subtleTextStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.4,
+};
+
+const fieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -56,10 +56,7 @@ import {
   updateProjectWorkItem,
 } from "../../lib/api";
 import { formatAbsoluteTime } from "../../lib/format";
-import {
-  projectDefaultWorkspace,
-  projectDefaultWorkspaceFromRoots,
-} from "../../lib/project-workspace";
+import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import { providerDisplayName } from "../../lib/provider-utils";
 import { ChatRightPanel } from "../chats/ChatRightPanel";
 import { ContextInspectorModalTrigger, ContextInspectorPanel } from "../shared/ContextInspector";
@@ -81,6 +78,7 @@ import {
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
+import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
 import { useProjectAssistantController } from "./useProjectAssistantController";
 import type {
   ProjectAssignmentRecord,
@@ -96,8 +94,6 @@ import type {
   ProjectSkillRecord,
   ProjectAssignmentExecutionRefRecord,
   ProjectRecord,
-  ProjectRootPayload,
-  ProjectRootRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectAssignmentPayload,
@@ -110,8 +106,6 @@ import type {
   CreateAgentProfilePayload,
   UpdateAgentProfilePayload,
 } from "../../types/agent-profile";
-import type { ModelRecord } from "../../types/model";
-import type { ProviderPresetRecord } from "../../types/provider";
 import type { ContextPacketRecord } from "../../types/context";
 import {
   Badge,
@@ -121,10 +115,14 @@ import {
   Icons,
   InlineError,
   Modal,
-  ModelPicker,
-  ProviderPicker,
   type ProviderOption,
 } from "../shared/ui";
+import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
+import {
+  projectRootOptionLabel,
+  type CreateWorktreeForm,
+  type ProjectDefaultsForm,
+} from "./projectSettings";
 
 type Props = {
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
@@ -232,24 +230,6 @@ type HandoffForm = {
   status: string;
   provenanceKind: string;
   trustLabel: string;
-};
-
-type ProjectDefaultsForm = {
-  provider: string;
-  model: string;
-  defaultAgentProfile: string;
-  workspaceMode: string;
-  defaultRootID: string;
-  roots: ProjectRootPayload[];
-};
-
-type CreateWorktreeForm = {
-  baseRootID: string;
-  branch: string;
-  startPoint: string;
-  path: string;
-  active: boolean;
-  setDefault: boolean;
 };
 
 type MemoryForm = {
@@ -4212,392 +4192,6 @@ function WorkItemDetail({
   );
 }
 
-function ProjectSettingsPanel({
-  agentProfiles,
-  agentProfilesError,
-  error,
-  models,
-  pending,
-  providerOptions,
-  providerPresets,
-  project,
-  rootsPending,
-  onDiscoverRoots,
-  onOpenCreateWorktree,
-  onSave,
-}: {
-  agentProfiles: AgentProfileRecord[];
-  agentProfilesError: string;
-  error: string;
-  models: ModelRecord[];
-  pending: boolean;
-  providerOptions: ProviderOption[];
-  providerPresets: ProviderPresetRecord[];
-  project: ProjectRecord;
-  rootsPending: boolean;
-  onDiscoverRoots: () => void | Promise<void>;
-  onOpenCreateWorktree: () => void;
-  onSave: (form: ProjectDefaultsForm) => void | Promise<void>;
-}) {
-  const [form, setForm] = useState<ProjectDefaultsForm>(() =>
-    projectDefaultsFormFromProject(project),
-  );
-  useEffect(() => {
-    setForm(projectDefaultsFormFromProject(project));
-  }, [project]);
-  const scopedModels = useMemo(() => {
-    if (!form.provider) return models;
-    return models.filter((model) => model.metadata?.provider === form.provider);
-  }, [form.provider, models]);
-  const selectedProfile = useMemo(
-    () => agentProfiles.find((profile) => profile.id === form.defaultAgentProfile) ?? null,
-    [agentProfiles, form.defaultAgentProfile],
-  );
-
-  function handleProviderChange(provider: string) {
-    setForm((current) => {
-      const nextModels = provider
-        ? models.filter((model) => model.metadata?.provider === provider)
-        : models;
-      const modelStillValid =
-        current.model &&
-        nextModels.some(
-          (model) =>
-            model.id === current.model && (!provider || model.metadata?.provider === provider),
-        );
-      return {
-        ...current,
-        provider,
-        model: modelStillValid ? current.model : "",
-      };
-    });
-  }
-  function handleDefaultRootChange(rootID: string) {
-    setForm((current) => ({
-      ...current,
-      defaultRootID: rootID,
-      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active: true } : root)),
-    }));
-  }
-  function handleRootActiveChange(rootID: string, active: boolean) {
-    setForm((current) => ({
-      ...current,
-      defaultRootID: !active && current.defaultRootID === rootID ? "" : current.defaultRootID,
-      roots: current.roots.map((root) => (root.id === rootID ? { ...root, active } : root)),
-    }));
-  }
-  const submitForm = () => onSave(form);
-
-  const workspace = projectDefaultWorkspaceFromRoots(form.roots, form.defaultRootID);
-  const rootCount = form.roots.length;
-
-  return (
-    <div
-      style={{
-        background: "var(--bg1)",
-        display: "flex",
-        flexDirection: "column",
-        flex: 1,
-        minHeight: 0,
-        minWidth: 0,
-      }}
-    >
-      <div
-        style={{
-          borderBottom: "1px solid var(--border)",
-          padding: "14px 14px 12px",
-          display: "flex",
-          alignItems: "flex-start",
-          justifyContent: "space-between",
-          gap: 12,
-        }}
-      >
-        <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 12, fontWeight: 650, color: "var(--t0)" }}>Project settings</div>
-          <div
-            style={{
-              marginTop: 4,
-              fontSize: 11,
-              color: "var(--t3)",
-              lineHeight: 1.45,
-            }}
-          >
-            Controls defaults for future native project assignments. Existing task runs keep the
-            settings they started with.
-          </div>
-        </div>
-      </div>
-      <div style={{ overflowY: "auto", padding: 14, display: "grid", gap: 14 }}>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            void submitForm();
-          }}
-          style={{ display: "grid", gap: 14 }}
-        >
-          {error && <InlineError message={error} />}
-          {agentProfilesError && <InlineError message={agentProfilesError} />}
-          <ProjectSettingsSection title="Assignment defaults">
-            <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
-              Native Hecate assignments copy these defaults when creating the backing task.
-            </div>
-            <div style={{ display: "grid", gap: 12 }}>
-              <div style={fieldStyle}>
-                <span style={fieldLabelStyle}>Provider and model</span>
-                <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                  <ProviderPicker
-                    value={form.provider}
-                    onChange={handleProviderChange}
-                    options={providerOptions}
-                    emptyLabel={
-                      providerOptions.length === 0 ? "no providers configured" : "select provider"
-                    }
-                  />
-                  <ModelPicker
-                    value={form.model}
-                    onChange={(model) => setForm((current) => ({ ...current, model }))}
-                    models={scopedModels}
-                    presets={providerPresets}
-                    includeAll
-                    allLabel="inherit runtime default"
-                    showProvider={!form.provider}
-                  />
-                </div>
-              </div>
-              <div style={fieldStyle}>
-                <span style={fieldLabelStyle}>Agent profile</span>
-                <select
-                  aria-label="Default agent profile"
-                  className="input"
-                  value={form.defaultAgentProfile}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      defaultAgentProfile: event.target.value,
-                    }))
-                  }
-                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
-                >
-                  <option value="">built-in project_assignment</option>
-                  {agentProfiles.map((profile) => (
-                    <option key={profile.id} value={profile.id}>
-                      {profile.name || profile.id} ({profile.id})
-                    </option>
-                  ))}
-                </select>
-                <ProfilePosturePreview profile={selectedProfile} />
-              </div>
-              <div style={fieldStyle}>
-                <span style={fieldLabelStyle}>Workspace mode</span>
-                <div style={{ position: "relative", width: "100%" }}>
-                  <select
-                    aria-label="Workspace mode"
-                    className="input"
-                    value={normalizeWorkspaceMode(form.workspaceMode)}
-                    onChange={(event) =>
-                      setForm((current) => ({ ...current, workspaceMode: event.target.value }))
-                    }
-                    style={{
-                      appearance: "none",
-                      cursor: "pointer",
-                      fontFamily: "var(--font-mono)",
-                      fontSize: 12,
-                      minHeight: 36,
-                      paddingRight: 34,
-                    }}
-                  >
-                    <option value="in_place">in_place</option>
-                    <option value="persistent">persistent</option>
-                    <option value="ephemeral">ephemeral</option>
-                  </select>
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      alignItems: "center",
-                      color: "var(--t2)",
-                      display: "inline-flex",
-                      height: "100%",
-                      pointerEvents: "none",
-                      position: "absolute",
-                      right: 11,
-                      top: 0,
-                    }}
-                  >
-                    <Icon d={Icons.chevD} size={12} />
-                  </span>
-                </div>
-              </div>
-              <button
-                className="btn btn-primary"
-                type="submit"
-                disabled={pending}
-                style={{ width: "100%", justifyContent: "center" }}
-              >
-                {pending ? "Saving…" : "Save defaults"}
-              </button>
-            </div>
-          </ProjectSettingsSection>
-          <ProjectSettingsSection title="Project context">
-            <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
-              Project roots are concrete checkouts. Linked worktrees discovered from Git stay
-              inactive until enabled here.
-            </div>
-            <div style={{ display: "grid", gap: 12, marginBottom: 14 }}>
-              <div style={fieldStyle}>
-                <span style={fieldLabelStyle}>Default root</span>
-                <select
-                  aria-label="Default project root"
-                  className="input"
-                  value={form.defaultRootID}
-                  onChange={(event) => handleDefaultRootChange(event.target.value)}
-                  style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
-                >
-                  <option value="">no default root</option>
-                  {form.roots.map((root) => (
-                    <option key={root.id || root.path} value={root.id ?? ""}>
-                      {projectRootOptionLabel(root)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                <button
-                  className="btn btn-primary btn-sm"
-                  type="button"
-                  onClick={onOpenCreateWorktree}
-                >
-                  Create worktree
-                </button>
-                <button
-                  className="btn btn-ghost btn-sm"
-                  type="button"
-                  disabled={rootsPending}
-                  onClick={() => void onDiscoverRoots()}
-                >
-                  {rootsPending ? "Discovering…" : "Discover worktrees"}
-                </button>
-                <span style={subtleTextStyle}>
-                  {rootCount === 0
-                    ? "No roots configured."
-                    : `${rootCount} root${rootCount === 1 ? "" : "s"}`}
-                </span>
-              </div>
-              {form.roots.length > 0 && (
-                <div style={{ display: "grid", gap: 8 }}>
-                  {form.roots.map((root) => {
-                    const rootID = root.id ?? root.path;
-                    const isDefault = form.defaultRootID !== "" && root.id === form.defaultRootID;
-                    return (
-                      <label
-                        key={rootID}
-                        style={{
-                          border: "1px solid var(--border)",
-                          borderRadius: 8,
-                          display: "grid",
-                          gap: 5,
-                          padding: "9px 10px",
-                        }}
-                      >
-                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                          <input
-                            aria-label={`Active project root ${root.path}`}
-                            type="checkbox"
-                            checked={Boolean(root.active)}
-                            onChange={(event) =>
-                              handleRootActiveChange(root.id ?? "", event.target.checked)
-                            }
-                          />
-                          <span
-                            style={{
-                              color: "var(--t1)",
-                              fontFamily: "var(--font-mono)",
-                              fontSize: 11,
-                              wordBreak: "break-all",
-                            }}
-                          >
-                            {root.path}
-                          </span>
-                        </span>
-                        <span style={{ ...subtleTextStyle, paddingLeft: 22 }}>
-                          {projectRootSummary(root)}
-                          {isDefault ? " · default" : ""}
-                        </span>
-                      </label>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-            <div
-              style={{
-                display: "grid",
-                gap: 5,
-                fontSize: 11,
-                color: "var(--t3)",
-                lineHeight: 1.45,
-              }}
-            >
-              <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
-                <span style={{ color: "var(--t3)", fontSize: 11, minWidth: 78 }}>Workspace</span>
-                <span
-                  title={workspace}
-                  style={{
-                    color: "var(--t1)",
-                    fontFamily: "var(--font-mono)",
-                    fontSize: 11,
-                    wordBreak: "break-all",
-                  }}
-                >
-                  {workspace || "No default root"}
-                </span>
-              </div>
-            </div>
-          </ProjectSettingsSection>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-function projectDefaultsFormFromProject(project: ProjectRecord): ProjectDefaultsForm {
-  return {
-    provider: project.default_provider ?? "",
-    model: project.default_model ?? "",
-    defaultAgentProfile: project.default_agent_profile ?? "",
-    workspaceMode: project.default_workspace_mode || "in_place",
-    defaultRootID: project.default_root_id || project.roots[0]?.id || "",
-    roots: project.roots.map(projectRootPayloadFromRecord),
-  };
-}
-
-function projectRootPayloadFromRecord(root: ProjectRootRecord): ProjectRootPayload {
-  const payload: ProjectRootPayload = {
-    id: root.id,
-    path: root.path,
-    kind: root.kind,
-    active: root.active,
-  };
-  if (root.git_remote) payload.git_remote = root.git_remote;
-  if (root.git_branch) payload.git_branch = root.git_branch;
-  return payload;
-}
-
-function projectRootOptionLabel(root: ProjectRootPayload | ProjectRootRecord) {
-  const parts = [root.path];
-  if (root.git_branch) parts.push(`git:${root.git_branch}`);
-  if (root.kind) parts.push(root.kind);
-  return parts.join(" · ");
-}
-
-function projectRootSummary(root: ProjectRootPayload | ProjectRootRecord) {
-  const parts = [
-    root.active ? "active" : "inactive",
-    root.kind || "root",
-    root.git_branch ? `git:${root.git_branch}` : "",
-  ].filter(Boolean);
-  return parts.join(" · ");
-}
-
 function ProjectRootSelect({
   inheritLabel,
   label = "Root",
@@ -4630,176 +4224,6 @@ function ProjectRootSelect({
         ))}
       </select>
     </label>
-  );
-}
-
-function ProjectSettingsSection({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section>
-      <div className="kicker" style={{ marginBottom: 7 }}>
-        {title}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null }) {
-  if (!profile) {
-    return (
-      <div style={{ ...subtleTextStyle, marginTop: 4 }}>
-        Uses the built-in project_assignment posture until a saved profile is selected.
-      </div>
-    );
-  }
-  const details = [
-    profile.surface,
-    profile.execution_profile ? `profile ${profile.execution_profile}` : "",
-    profile.provider_hint || profile.model_hint
-      ? `hints ${[profile.provider_hint, profile.model_hint].filter(Boolean).join("/")}`
-      : "",
-    `tools ${profile.tools_enabled ? "on" : "off"}`,
-    `writes ${profile.writes_allowed ? "on" : "off"}`,
-    `network ${profile.network_allowed ? "on" : "off"}`,
-    `approval ${profile.approval_policy}`,
-    `memory ${profile.project_memory_policy}`,
-    `sources ${profile.context_source_policy}`,
-  ].filter(Boolean);
-  return <div style={{ ...subtleTextStyle, marginTop: 4 }}>{details.join(" · ")}</div>;
-}
-
-function normalizeWorkspaceMode(value: string) {
-  if (value === "persistent" || value === "ephemeral") return value;
-  return "in_place";
-}
-
-function CreateProjectWorktreeModal({
-  error,
-  pending,
-  project,
-  onClose,
-  onCreate,
-}: {
-  error: string;
-  pending: boolean;
-  project: ProjectRecord;
-  onClose: () => void;
-  onCreate: (form: CreateWorktreeForm) => void | Promise<void>;
-}) {
-  const defaultBaseRootID =
-    project.default_root_id ||
-    project.roots.find((root) => root.active)?.id ||
-    project.roots[0]?.id ||
-    "";
-  const [form, setForm] = useState<CreateWorktreeForm>({
-    baseRootID: defaultBaseRootID,
-    branch: "",
-    startPoint: "",
-    path: "",
-    active: true,
-    setDefault: false,
-  });
-  const valid = project.roots.length > 0 && form.branch.trim().length > 0;
-  return (
-    <Modal
-      title="Create project worktree"
-      onClose={onClose}
-      width={560}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onCreate(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Creating…" : "Create worktree"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onCreate(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        {project.roots.length === 0 && <InlineError message="Add a project root first." />}
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Base root</span>
-          <select
-            aria-label="Base root"
-            className="input"
-            value={form.baseRootID}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, baseRootID: event.target.value }))
-            }
-            style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
-          >
-            {project.roots.map((root) => (
-              <option key={root.id || root.path} value={root.id}>
-                {projectRootOptionLabel(root)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Branch</span>
-          <input
-            className="input"
-            autoFocus
-            value={form.branch}
-            onChange={(event) => setForm((current) => ({ ...current, branch: event.target.value }))}
-            placeholder="feature/project-worktrees"
-          />
-        </label>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Start point</span>
-            <input
-              className="input"
-              value={form.startPoint}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, startPoint: event.target.value }))
-              }
-              placeholder="origin/main"
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Path</span>
-            <input
-              className="input"
-              value={form.path}
-              onChange={(event) => setForm((current) => ({ ...current, path: event.target.value }))}
-              placeholder=".worktrees/feature-project-worktrees"
-            />
-          </label>
-        </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
-            <input
-              type="checkbox"
-              checked={form.active}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, active: event.target.checked }))
-              }
-            />
-            <span style={fieldLabelStyle}>Active root</span>
-          </label>
-          <label style={{ ...fieldStyle, display: "flex", flexDirection: "row", gap: 8 }}>
-            <input
-              type="checkbox"
-              checked={form.setDefault}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, setDefault: event.target.checked }))
-              }
-            />
-            <span style={fieldLabelStyle}>Make default root</span>
-          </label>
-        </div>
-      </form>
-    </Modal>
   );
 }
 

--- a/ui/src/features/projects/projectSettings.ts
+++ b/ui/src/features/projects/projectSettings.ts
@@ -1,0 +1,63 @@
+import type { ProjectRecord, ProjectRootPayload, ProjectRootRecord } from "../../types/project";
+
+export type ProjectDefaultsForm = {
+  provider: string;
+  model: string;
+  defaultAgentProfile: string;
+  workspaceMode: string;
+  defaultRootID: string;
+  roots: ProjectRootPayload[];
+};
+
+export type CreateWorktreeForm = {
+  baseRootID: string;
+  branch: string;
+  startPoint: string;
+  path: string;
+  active: boolean;
+  setDefault: boolean;
+};
+
+export function projectDefaultsFormFromProject(project: ProjectRecord): ProjectDefaultsForm {
+  return {
+    provider: project.default_provider ?? "",
+    model: project.default_model ?? "",
+    defaultAgentProfile: project.default_agent_profile ?? "",
+    workspaceMode: project.default_workspace_mode || "in_place",
+    defaultRootID: project.default_root_id || project.roots[0]?.id || "",
+    roots: project.roots.map(projectRootPayloadFromRecord),
+  };
+}
+
+function projectRootPayloadFromRecord(root: ProjectRootRecord): ProjectRootPayload {
+  const payload: ProjectRootPayload = {
+    id: root.id,
+    path: root.path,
+    kind: root.kind,
+    active: root.active,
+  };
+  if (root.git_remote) payload.git_remote = root.git_remote;
+  if (root.git_branch) payload.git_branch = root.git_branch;
+  return payload;
+}
+
+export function projectRootOptionLabel(root: ProjectRootPayload | ProjectRootRecord) {
+  const parts = [root.path];
+  if (root.git_branch) parts.push(`git:${root.git_branch}`);
+  if (root.kind) parts.push(root.kind);
+  return parts.join(" · ");
+}
+
+export function projectRootSummary(root: ProjectRootPayload | ProjectRootRecord) {
+  const parts = [
+    root.active ? "active" : "inactive",
+    root.kind || "root",
+    root.git_branch ? `git:${root.git_branch}` : "",
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+export function normalizeWorkspaceMode(value: string) {
+  if (value === "persistent" || value === "ephemeral") return value;
+  return "in_place";
+}


### PR DESCRIPTION
## Summary
- Extract project settings/default-root editing into ProjectSettingsPanel
- Extract create-worktree form into CreateProjectWorktreeModal
- Move shared project settings/root helpers into projectSettings.ts and add focused component tests
- Update UI agent guidance for the new boundary

## Tests
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/projects/ProjectSettingsPanel.test.tsx src/features/projects/CreateProjectWorktreeModal.test.tsx src/features/projects/ProjectsView.test.tsx -t "creates project worktrees from settings|discovers project worktrees from settings|ProjectSettingsPanel|CreateProjectWorktreeModal"
- cd ui && bun run test
- just agent-docs-check
- just docs-format-check