### PR TITLE
Align command picker E2E selectors

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -340,10 +340,10 @@ test("New chat creates an external-agent session with controls before the first 
   await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText("Fast");
   const composer = page.getByRole("textbox", { name: "Message" });
   await composer.fill("/");
-  const commands = page.getByRole("group", { name: "External agent commands" });
-  await expect(commands.getByRole("button", { name: "Insert /web command" })).toBeVisible();
+  const commands = page.getByRole("listbox", { name: "External agent commands" });
+  await expect(commands.getByRole("option", { name: "Insert /web command" })).toBeVisible();
   await expect(commands).toContainText("Search the web");
-  await commands.getByRole("button", { name: "Insert /web command" }).click();
+  await commands.getByRole("option", { name: "Insert /web command" }).click();
   await expect(composer).toHaveValue("/web ");
 
   await page.getByRole("button", { name: "Choose agent for new chat" }).click();


### PR DESCRIPTION
## Summary

- Updates the external-agent command picker Playwright assertion to match the accessible `listbox` / `option` roles introduced by the accessibility follow-up.
- Fixes the merged PR #377 TypeScript E2E failure where the test still queried the previous `group` / `button` shape.

## Tests

- `cd ui && bun run test:e2e -- -g "New chat creates an external-agent session with controls before the first prompt"`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `git diff --check`
- `cd ui && bun run test:e2e`
- `just docs-format-check`