### PR TITLE
Harden MCP App CSP metadata

### DIFF
--- a/docs/runtime/mcp.md
+++ b/docs/runtime/mcp.md
@@ -371,8 +371,8 @@ The Go tests cover initialize capabilities, tool `_meta` passthrough,
 `structuredContent`, `resources/read`, visibility filtering, app-resource
 capture on tool calls, registry discovery, and chat activity projection. The UI
 test pins inline rendering, sandbox attributes, the Apps JSON-RPC host bridge,
-tool-input/tool-result delivery, iframe resizing, and the no-empty-iframe error
-fallback.
+tool-input/tool-result delivery, iframe resizing, CSP source filtering, and the
+no-empty-iframe error fallback.
 
 ### Approval policy
 
@@ -411,6 +411,11 @@ Hecate maintains a shared client cache so multiple tasks targeting the same upst
 `GET /hecate/v1/mcp/registry/servers` queries the read-only MCP Registry REST API. It defaults to `https://registry.modelcontextprotocol.io` and forwards the registry's list/search filters: `search`, `cursor`, `limit`, `updated_since`, `version`, and `include_deleted`. `registry_url` can point at a private registry, but the endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected before Hecate performs any outbound fetch.
 
 The response keeps registry server metadata intact (`server`, `_meta`) and adds Hecate-specific `install_hints`. A `streamable-http` remote with a URL gets a ready-to-probe `hecate_config` containing `name`, `url`, and header placeholders such as `$MCP_AUTHORIZATION`. Package entries and legacy `sse` remotes remain visible for discovery, but Hecate does not treat them as one-click runnable configs. Operators still review the selected config and can use `POST /hecate/v1/mcp/probe` to inspect the actual tool catalog before adding it to a task.
+
+Registry discovery is API-only for the initial MCP Apps PR. The UI follow-up
+should present registry search results, install hints, required secret
+placeholders, and a probe-before-use review step together instead of silently
+adding servers to Chat.
 
 ### Resource limits
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -1066,6 +1066,63 @@ describe("TranscriptMessageRow", () => {
     expect(frame.srcdoc).toContain("https://cdn.example.com");
   });
 
+  it("filters unsafe MCP App CSP sources from resource metadata", () => {
+    const activities = [
+      weatherMCPAppActivity({
+        resource_meta: {
+          ui: {
+            csp: {
+              resourceDomains: [
+                "https://cdn.example.com/assets",
+                "http://localhost:5173/static/app.js",
+                "*",
+                "'unsafe-eval'",
+                "javascript:alert(1)",
+                "http://cdn.example.com",
+                "http://127.example.com/static/app.js",
+              ],
+              connectDomains: [
+                "https://api.example.com/v1",
+                "wss://events.example.com/socket",
+                "ws://localhost:4000/socket",
+                "http://127.0.0.1:8787/mcp",
+                "http://api.example.com",
+                "http://127.0.0.1.example.com/mcp",
+              ],
+              frameDomains: [
+                "https://frames.example.com/embed",
+                "http://localhost:4173/frame",
+                "http://frames.example.com/embed",
+              ],
+              baseUriDomains: ["https://base.example.com/path", "data:"],
+            },
+          },
+        },
+      }),
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    const frame = screen.getByTestId("mcp-app-frame") as HTMLIFrameElement;
+    const csp = frame.srcdoc.match(/Content-Security-Policy" content="([^"]+)"/)?.[1] ?? "";
+    expect(csp).toContain(
+      "script-src 'self' 'unsafe-inline' https://cdn.example.com http://localhost:5173",
+    );
+    expect(csp).toContain(
+      "connect-src https://api.example.com wss://events.example.com ws://localhost:4000 http://127.0.0.1:8787",
+    );
+    expect(csp).toContain("frame-src https://frames.example.com http://localhost:4173");
+    expect(csp).toContain("base-uri https://base.example.com");
+    expect(csp).not.toContain("*");
+    expect(csp).not.toContain("unsafe-eval");
+    expect(csp).not.toContain("javascript:");
+    expect(csp).not.toContain("http://cdn.example.com");
+    expect(csp).not.toContain("http://api.example.com");
+    expect(csp).not.toContain("http://frames.example.com");
+    expect(csp).not.toContain("http://127.example.com");
+    expect(csp).not.toContain("http://127.0.0.1.example.com");
+  });
+
   it("exchanges initialization and tool payloads with inline MCP Apps", () => {
     const activities = [
       weatherMCPAppActivity({

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -694,10 +694,10 @@ function cspMetadata(meta: unknown): {
   const ui = objectRecord(objectRecord(meta).ui);
   const csp = objectRecord(ui.csp);
   return {
-    connectDomains: stringArray(csp.connectDomains),
-    resourceDomains: stringArray(csp.resourceDomains),
-    frameDomains: stringArray(csp.frameDomains),
-    baseUriDomains: stringArray(csp.baseUriDomains),
+    connectDomains: cspSourceArray(csp.connectDomains, "connect"),
+    resourceDomains: cspSourceArray(csp.resourceDomains, "resource"),
+    frameDomains: cspSourceArray(csp.frameDomains, "frame"),
+    baseUriDomains: cspSourceArray(csp.baseUriDomains, "base"),
   };
 }
 
@@ -720,12 +720,48 @@ function stringRecord(value: unknown): Record<string, string> {
   return objectRecord(value) as Record<string, string>;
 }
 
-function stringArray(value: unknown): string[] {
+type CSPSourceKind = "resource" | "connect" | "frame" | "base";
+
+function cspSourceArray(value: unknown, kind: CSPSourceKind): string[] {
   if (!Array.isArray(value)) return [];
-  return value.filter(
-    (item): item is string =>
-      typeof item === "string" && item.trim() !== "" && /^[^\s;]+$/.test(item),
-  );
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const source = cspSource(item, kind);
+    if (!source || seen.has(source)) continue;
+    seen.add(source);
+    out.push(source);
+  }
+  return out;
+}
+
+function cspSource(value: unknown, kind: CSPSourceKind): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (trimmed === "" || !/^[^\s;]+$/.test(trimmed)) return "";
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return "";
+  }
+  if (parsed.protocol === "https:") return parsed.origin;
+  if (kind === "connect" && parsed.protocol === "wss:") return parsed.origin;
+  if (
+    (parsed.protocol === "http:" || parsed.protocol === "ws:") &&
+    isLoopbackHost(parsed.hostname)
+  ) {
+    return parsed.origin;
+  }
+  return "";
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  const parts = normalized.split(".");
+  if (parts.length !== 4 || parts[0] !== "127") return false;
+  return parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
 }
 
 function escapeHTMLAttribute(value: string): string {


### PR DESCRIPTION
## Summary

- Normalize MCP App CSP metadata to origin-only sources before injecting the iframe policy.
- Allow HTTPS/WSS plus local loopback HTTP/WS where appropriate, and reject wildcard, keyword, javascript, and non-loopback cleartext sources.
- Document CSP source filtering and note that MCP Registry discovery remains API-only for the initial MCP Apps work, with UI discovery/install review as a follow-up.

## Tests

- `cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `just docs-format-check`
- `git diff --check`

## Self-review

- Tightened loopback handling so hostnames such as `127.example.com` are not treated as local addresses.
- Followed up on review suggestions by pinning `wss:`/`ws:` kind gating and IPv6 loopback handling for `http://[::1]` / `ws://[::1]` sources.
