### PR TITLE
feat(projects): surface assignment launch readiness

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2299,10 +2299,23 @@ from an assignment override, work-item default, or project default/fallback.
 The response is a normal `context_packet` envelope with assignment refs only;
 task, run, chat session, and message refs remain empty because preflight is
 inspect-only. The packet includes a `runtime` / `launch_preflight` item with
-`included=false` describing what will be created on confirm. The Projects
-cockpit uses this endpoint before `Start assignment`, `Prepare chat`, and
-`Start from handoff` so the operator can review the effective launch context
-before dispatch.
+`included=false` describing what will be created on confirm. For native Hecate
+task assignments, the packet also includes a `runtime` / `launch_readiness`
+item when the gateway is wired. That item snapshots the resolved provider/model
+readiness using the same reason and repair vocabulary as `metadata.readiness`
+on `/v1/models`: `Ready: false` means the selected model is not currently
+routable through the configured providers and should be repaired before start.
+Its body is human-readable, and `metadata` carries stable keys such as `ready`,
+`status`, `provider`, `model`, `matched_provider`, `reason`, `message`, and
+`operator_action` for clients that need to gate UI actions without parsing
+copy. It is operator evidence, not injected prompt content.
+
+The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
+chat`, and `Start from handoff` so the operator can review the effective launch
+context before dispatch. The UI disables native assignment confirmation when
+preflight reports blocked provider/model readiness, but `POST /start` remains
+the authoritative mutation path and the task runner/gateway still performs the
+actual route checks during execution.
 
 Unqueued, terminal, already-linked, unsupported, misconfigured, or invalid
 assignments return the same operator-facing error classes as start would use,
@@ -2332,7 +2345,9 @@ context-source policy. Role default provider/model/profile override
 project defaults for the backing task when configured; project
 provider/model/workspace settings remain the fallback. Provider and model
 defaults are route hints, so catalog/routing validation happens during task
-start instead of role save. The workspace root must
+start instead of role save. Preflight snapshots the selected model's current
+readiness so the operator can fix stale provider/model defaults before a task
+and run are created. The workspace root must
 resolve to an absolute existing project root before a task is created; missing
 or defaultless roots return `400 invalid_request`. A missing model returns
 `422 model_not_configured`.
@@ -2345,7 +2360,10 @@ assignment with `execution_ref.task_id`, latest `execution_ref.run_id`, status,
 and timestamps before returning the updated assignment:
 
 The persisted context packet records the resolved profile and applies its
-project memory/context-source policies. `include` / `include_enabled` make the
+project memory/context-source policies. For native assignments, it also records
+the same `runtime` / `launch_readiness` metadata captured by preflight so later
+run-context inspection can show what provider/model readiness looked like when
+the assignment was started. `include` / `include_enabled` make the
 enabled project records active in the packet and add a `prompt_context`
 instructions item summarizing what was loaded into the native assignment prompt.
 `visible_only` / `inherit` keep records inspect-only, and `exclude` omits them

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -149,6 +149,7 @@ func renderChatContextPacket(packet chat.ContextPacket) *ChatContextPacketItem {
 			BodyRef:         item.BodyRef,
 			Included:        item.Included,
 			InclusionReason: item.InclusionReason,
+			Metadata:        cloneContextItemMetadata(item.Metadata),
 		})
 	}
 	var refs *ChatContextRefsItem
@@ -178,6 +179,17 @@ func renderChatContextPacket(packet chat.ContextPacket) *ChatContextPacketItem {
 		Sources:              sources,
 		Items:                items,
 	}
+}
+
+func cloneContextItemMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		out[key] = value
+	}
+	return out
 }
 
 type agentChatSegmentBuilder struct {

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -169,6 +169,9 @@ func (h *Handler) projectHecateTaskAssignmentPreflightContext(ctx context.Contex
 		return chat.ContextPacket{}, err
 	}
 	packet := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Root, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
+	if err := h.appendProjectAssignmentLaunchReadiness(ctx, &packet, plan.RequestedProvider, plan.RequestedModel); err != nil {
+		return chat.ContextPacket{}, err
+	}
 	appendProjectAssignmentLaunchPreflight(&packet, projectwork.AssignmentDriverHecateTask, []string{
 		"Task: created on start",
 		"Run: created on start",
@@ -307,6 +310,9 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	contextPacket := h.projectAssignmentContextPacket(ctx, project, workItem, assignment, role, plan.Root, plan.WorkingDirectory, plan.RequestedProvider, plan.RequestedModel, plan.ExecutionProfile, plan.Profile, plan.ResolvedSkills, plan.PromptContext)
+	if err := h.appendProjectAssignmentLaunchReadiness(ctx, &contextPacket, plan.RequestedProvider, plan.RequestedModel); err != nil {
+		h.logProjectAssignmentLaunchReadinessError(ctx, err)
+	}
 	if contextPacket.ID == "" {
 		contextPacket.ID = newChatID("ctx")
 	}
@@ -535,6 +541,96 @@ func appendProjectAssignmentLaunchPreflight(packet *chat.ContextPacket, driverKi
 		Included:        false,
 		InclusionReason: "Preflight metadata for operator review before assignment start",
 	})
+}
+
+func (h *Handler) appendProjectAssignmentLaunchReadiness(ctx context.Context, packet *chat.ContextPacket, provider, model string) error {
+	if h.service == nil {
+		return nil
+	}
+	result, err := h.service.ProviderModelReadiness(ctx, provider, model)
+	if err != nil {
+		return err
+	}
+	appendProjectAssignmentLaunchReadinessItem(packet, result.Readiness.ToModelReadiness())
+	return nil
+}
+
+func (h *Handler) logProjectAssignmentLaunchReadinessError(ctx context.Context, err error) {
+	if h == nil || h.logger == nil || err == nil {
+		return
+	}
+	h.logger.WarnContext(ctx, "project_assignment.launch_readiness.failed", "error", err)
+}
+
+func appendProjectAssignmentLaunchReadinessItem(packet *chat.ContextPacket, readiness types.ModelReadiness) {
+	status := firstNonEmptyString(strings.TrimSpace(readiness.Status), "unknown")
+	body := []string{
+		fmt.Sprintf("Ready: %t", readiness.Ready),
+		"Status: " + status,
+		"Provider: " + firstNonEmptyString(strings.TrimSpace(readiness.Provider), "auto"),
+		"Model: " + firstNonEmptyString(strings.TrimSpace(readiness.Model), "none"),
+	}
+	if readiness.MatchedProvider != "" {
+		body = append(body, "Matched provider: "+readiness.MatchedProvider)
+	}
+	if readiness.Reason != "" {
+		body = append(body, "Reason: "+readiness.Reason)
+	}
+	if readiness.Message != "" {
+		body = append(body, "Message: "+readiness.Message)
+	}
+	if readiness.OperatorAction != "" {
+		body = append(body, "Operator action: "+readiness.OperatorAction)
+	}
+	if readiness.ProviderStatus != "" {
+		body = append(body, "Provider status: "+readiness.ProviderStatus)
+	}
+	if readiness.ProviderBlockedReason != "" {
+		body = append(body, "Provider blocked reason: "+readiness.ProviderBlockedReason)
+	}
+	if len(readiness.SuggestedModels) > 0 {
+		body = append(body, "Suggested models: "+strings.Join(readiness.SuggestedModels, ", "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionRuntime, chat.ContextSource{
+		Kind:   "launch_readiness",
+		Label:  "Launch readiness",
+		Detail: status,
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "launch_readiness",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          "project_assignment.launch_readiness",
+		Title:           "Launch readiness",
+		Body:            strings.Join(body, "\n"),
+		Included:        false,
+		InclusionReason: "Provider/model readiness metadata for operator review before assignment start",
+		Metadata:        projectAssignmentLaunchReadinessMetadata(readiness, status),
+	})
+}
+
+func projectAssignmentLaunchReadinessMetadata(readiness types.ModelReadiness, status string) map[string]string {
+	metadata := map[string]string{
+		"ready":         fmt.Sprintf("%t", readiness.Ready),
+		"routing_ready": fmt.Sprintf("%t", readiness.RoutingReady),
+		"status":        strings.TrimSpace(status),
+		"provider":      firstNonEmptyString(strings.TrimSpace(readiness.Provider), "auto"),
+		"model":         strings.TrimSpace(readiness.Model),
+	}
+	setMetadata := func(key, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			metadata[key] = value
+		}
+	}
+	setMetadata("matched_provider", readiness.MatchedProvider)
+	setMetadata("reason", readiness.Reason)
+	setMetadata("message", readiness.Message)
+	setMetadata("operator_action", readiness.OperatorAction)
+	setMetadata("provider_status", readiness.ProviderStatus)
+	setMetadata("provider_blocked_reason", readiness.ProviderBlockedReason)
+	if len(readiness.SuggestedModels) > 0 {
+		setMetadata("suggested_models", strings.Join(readiness.SuggestedModels, ", "))
+	}
+	return metadata
 }
 
 func formatProjectExternalAgentConfigOptions(options []agentcontrols.ConfigOption) string {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
+	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -35,6 +36,13 @@ import (
 
 func newProjectWorkTestServer() (*Handler, http.Handler) {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkTestServerWithProviders(items ...providers.Provider) (*Handler, http.Handler) {
+	handler := newTestAPIHandlerWithSettings(quietLogger(), items, config.Config{}, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
@@ -703,6 +711,58 @@ func TestProjectWorkAPI_PreflightAssignmentReturnsLaunchContextWithoutSideEffect
 	}
 }
 
+func TestProjectWorkAPI_PreflightAssignmentShowsBlockedModelReadiness(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{
+		name:         "openai",
+		defaultModel: "gpt-4o-mini",
+	})
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultProvider = ""
+		project.DefaultModel = "dogfood-model"
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+	readiness := findRenderedContextItemByKind(packetResp.Data, "launch_readiness")
+	if readiness == nil || readiness.Section != contextSectionRuntime || readiness.Included {
+		t.Fatalf("readiness item = %+v, want inspect-only runtime launch readiness", readiness)
+	}
+	if readiness.Metadata["ready"] != "false" || readiness.Metadata["status"] != "blocked" || readiness.Metadata["reason"] != "model_not_discovered" {
+		t.Fatalf("readiness metadata = %+v, want blocked model_not_discovered", readiness.Metadata)
+	}
+	for _, want := range []string{
+		"Ready: false",
+		"Status: blocked",
+		"Provider: auto",
+		"Model: dogfood-model",
+		"Reason: model_not_discovered",
+		"No routable provider reports model \"dogfood-model\".",
+		"Operator action:",
+	} {
+		if !strings.Contains(readiness.Body, want) {
+			t.Fatalf("readiness body = %q, want %q", readiness.Body, want)
+		}
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.TaskID != "" || packetResp.Data.Refs.RunID != "" {
+		t.Fatalf("preflight refs = %+v, want no task/run side effects", packetResp.Data.Refs)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by blocked readiness preflight", tasks)
+	}
+}
+
 func TestProjectWorkAPI_PreflightAndStartShareNativeLaunchPlan(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -744,6 +804,54 @@ func TestProjectWorkAPI_PreflightAndStartShareNativeLaunchPlan(t *testing.T) {
 		t.Fatalf("task launch shape = provider/model/profile/workspace %q/%q/%q/%q, want preflight %q/%q/%q/%q",
 			task.RequestedProvider, task.RequestedModel, task.ExecutionProfile, task.WorkingDirectory,
 			preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace)
+	}
+}
+
+func TestProjectWorkAPI_PreflightAndStartSnapshotModelReadiness(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{
+		name:     "anthropic",
+		response: &types.ChatResponse{},
+		capabilities: providers.Capabilities{
+			Name:         "anthropic",
+			Kind:         providers.KindCloud,
+			DefaultModel: "claude-sonnet-4",
+			Models:       []string{"claude-sonnet-4"},
+		},
+	})
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	client := newAPITestClient(t, server)
+	preflight := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+	preflightReadiness := findRenderedContextItemByKind(preflight.Data, "launch_readiness")
+	if preflightReadiness == nil || !strings.Contains(preflightReadiness.Body, "Ready: true") || !strings.Contains(preflightReadiness.Body, "Matched provider: anthropic") {
+		t.Fatalf("preflight readiness = %+v, want ready anthropic metadata", preflightReadiness)
+	}
+	if preflightReadiness.Metadata["ready"] != "true" || preflightReadiness.Metadata["matched_provider"] != "anthropic" {
+		t.Fatalf("preflight readiness metadata = %+v, want ready anthropic", preflightReadiness.Metadata)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	started := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+	startedReadiness := findRenderedContextItemByKind(started.Data, "launch_readiness")
+	if startedReadiness == nil {
+		t.Fatal("started context missing launch_readiness item")
+	}
+	if startedReadiness.Body != preflightReadiness.Body {
+		t.Fatalf("started readiness body = %q, want preflight body %q", startedReadiness.Body, preflightReadiness.Body)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -934,15 +934,16 @@ type ChatContextSourceItem struct {
 }
 
 type ChatContextItem struct {
-	Section         string `json:"section,omitempty"`
-	Kind            string `json:"kind"`
-	TrustLevel      string `json:"trust_level"`
-	Origin          string `json:"origin"`
-	Title           string `json:"title"`
-	Body            string `json:"body,omitempty"`
-	BodyRef         string `json:"body_ref,omitempty"`
-	Included        bool   `json:"included"`
-	InclusionReason string `json:"inclusion_reason,omitempty"`
+	Section         string            `json:"section,omitempty"`
+	Kind            string            `json:"kind"`
+	TrustLevel      string            `json:"trust_level"`
+	Origin          string            `json:"origin"`
+	Title           string            `json:"title"`
+	Body            string            `json:"body,omitempty"`
+	BodyRef         string            `json:"body_ref,omitempty"`
+	Included        bool              `json:"included"`
+	InclusionReason string            `json:"inclusion_reason,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
 type ChatContextPacketResponse struct {

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -154,15 +154,16 @@ type ContextSource struct {
 }
 
 type ContextItem struct {
-	Section         string `json:"section,omitempty"`
-	Kind            string `json:"kind"`
-	TrustLevel      string `json:"trust_level"`
-	Origin          string `json:"origin"`
-	Title           string `json:"title"`
-	Body            string `json:"body,omitempty"`
-	BodyRef         string `json:"body_ref,omitempty"`
-	Included        bool   `json:"included"`
-	InclusionReason string `json:"inclusion_reason,omitempty"`
+	Section         string            `json:"section,omitempty"`
+	Kind            string            `json:"kind"`
+	TrustLevel      string            `json:"trust_level"`
+	Origin          string            `json:"origin"`
+	Title           string            `json:"title"`
+	Body            string            `json:"body,omitempty"`
+	BodyRef         string            `json:"body_ref,omitempty"`
+	Included        bool              `json:"included"`
+	InclusionReason string            `json:"inclusion_reason,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
 func (packet ContextPacket) Empty() bool {
@@ -440,8 +441,22 @@ func cloneSession(session Session) Session {
 		}
 		session.Messages[i].Context.Sources = append([]ContextSource(nil), session.Messages[i].Context.Sources...)
 		session.Messages[i].Context.Items = append([]ContextItem(nil), session.Messages[i].Context.Items...)
+		for j := range session.Messages[i].Context.Items {
+			session.Messages[i].Context.Items[j].Metadata = cloneStringMap(session.Messages[i].Context.Items[j].Metadata)
+		}
 	}
 	return session
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func cloneMCPApp(app *MCPApp) *MCPApp {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4731,6 +4731,96 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
+  it("blocks native assignment confirmation when launch readiness is blocked", async () => {
+    resetProjectWorkMocks();
+    const queuedAssignment = {
+      ...hecateAssignment,
+      status: "running",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        status: "queued",
+      },
+      execution: { ...hecateAssignment.execution, status: "queued" },
+    };
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [queuedAssignment],
+    });
+    vi.mocked(getProjectAssignmentPreflight).mockResolvedValueOnce({
+      object: "context_packet",
+      data: {
+        id: "ctx_preflight_blocked",
+        execution_mode: "hecate_task",
+        provider: "",
+        model: "dogfood-model",
+        execution_profile: "implementation",
+        workspace: "/tmp/hecate-project",
+        refs: {
+          project_id: project.id,
+          work_item_id: workItem.id,
+          assignment_id: hecateAssignment.id,
+          role_id: role.id,
+        },
+        items: [
+          {
+            section: "runtime",
+            kind: "launch_readiness",
+            trust_level: "runtime_state",
+            origin: "project_assignment.launch_readiness",
+            title: "Launch readiness",
+            body: [
+              "Ready: false",
+              "Status: blocked",
+              "Provider: auto",
+              "Model: dogfood-model",
+              "Reason: model_not_discovered",
+              'Message: No routable provider reports model "dogfood-model".',
+              "Operator action: Pick one of the discovered models.",
+            ].join("\n"),
+            included: false,
+            metadata: {
+              ready: "false",
+              status: "blocked",
+              provider: "auto",
+              model: "dogfood-model",
+              reason: "model_not_discovered",
+              message: 'No routable provider reports model "dogfood-model".',
+              operator_action: "Pick one of the discovered models.",
+            },
+          },
+          {
+            section: "runtime",
+            kind: "launch_preflight",
+            trust_level: "runtime_state",
+            origin: "project_assignment.preflight",
+            title: "Launch preflight",
+            body: "Preview only: no task, run, chat session, memory entry, artifact, or assignment update has been created.\nTask: created on start\nRun: created on start",
+            included: false,
+          },
+        ],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Start" }));
+    const preflight = await screen.findByRole("dialog", {
+      name: "Assignment asgn_1 launch preflight",
+    });
+    const notice = within(preflight).getByRole("status");
+    expect(within(notice).getByText("Provider/model not ready")).toBeTruthy();
+    expect(notice.textContent).toContain('No routable provider reports model "dogfood-model"');
+    const confirm = within(preflight).getByRole("button", { name: "Start assignment" });
+    expect(confirm).toBeDisabled();
+    expect(startProjectAssignment).not.toHaveBeenCalled();
+  });
+
   it("renders finished-only assignment timestamps without a blank started label", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -194,6 +194,10 @@ type AssignmentPreflightState =
   | { status: "ready"; packet: ContextPacketRecord }
   | { status: "error"; detail: string };
 
+type AssignmentLaunchReadinessNoticeRecord = {
+  detail: string;
+};
+
 function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
   if (form.taskID.trim() || form.runID.trim()) return "task_run";
   if (form.chatSessionID.trim() || form.messageID.trim()) return "chat_session";
@@ -5238,6 +5242,8 @@ function AssignmentLaunchPreflightModal({
   state: AssignmentPreflightState;
 }) {
   const ready = state.status === "ready";
+  const readinessNotice = ready ? assignmentLaunchReadinessNotice(state.packet) : null;
+  const canConfirm = ready && !readinessNotice;
   return (
     <Modal
       title={`Assignment ${assignmentID} launch preflight`}
@@ -5255,7 +5261,12 @@ function AssignmentLaunchPreflightModal({
             className="btn btn-primary"
             type="button"
             onClick={onConfirm}
-            disabled={!ready || pending}
+            disabled={!canConfirm || pending}
+            title={
+              readinessNotice
+                ? "Fix the provider/model readiness issue before starting this assignment."
+                : undefined
+            }
           >
             {pending ? loadingLabel : confirmLabel}
           </button>
@@ -5274,13 +5285,52 @@ function AssignmentLaunchPreflightModal({
         ) : null}
         {state.status === "error" ? <InlineError message={state.detail} /> : null}
         {ready ? (
-          <ContextInspectorPanel
-            packet={state.packet}
-            emptyDetail="No launch context metadata returned."
-          />
+          <div style={{ display: "grid", gap: 12 }}>
+            {readinessNotice && <AssignmentLaunchReadinessNotice notice={readinessNotice} />}
+            <ContextInspectorPanel
+              packet={state.packet}
+              emptyDetail="No launch context metadata returned."
+            />
+          </div>
         ) : null}
       </div>
     </Modal>
+  );
+}
+
+function AssignmentLaunchReadinessNotice({
+  notice,
+}: {
+  notice: AssignmentLaunchReadinessNoticeRecord;
+}) {
+  return (
+    <div
+      role="status"
+      style={{
+        background: "var(--amber-bg)",
+        border: "1px solid var(--amber-border)",
+        borderRadius: "var(--radius-sm)",
+        display: "grid",
+        gap: 6,
+        padding: "10px 12px",
+      }}
+    >
+      <div
+        style={{
+          alignItems: "center",
+          color: "var(--amber)",
+          display: "flex",
+          fontWeight: 600,
+          gap: 8,
+        }}
+      >
+        <Icon d={Icons.warning} size={13} />
+        Provider/model not ready
+      </div>
+      <div style={{ color: "var(--amber-lo)", fontSize: 12, lineHeight: 1.45 }}>
+        {notice.detail}
+      </div>
+    </div>
   );
 }
 
@@ -5976,6 +6026,32 @@ function rememberRightPanelWidth(width: number) {
 
 function splitRoleIDs(value: string): string[] {
   return splitIDs(value);
+}
+
+function assignmentLaunchReadinessNotice(
+  packet: ContextPacketRecord,
+): AssignmentLaunchReadinessNoticeRecord | null {
+  const item = packet.items?.find((candidate) => candidate.kind === "launch_readiness");
+  if (!item) return null;
+  const ready = (item.metadata?.ready || contextBodyField(item.body || "", "Ready")).toLowerCase();
+  if (ready !== "false") return null;
+  const message = item.metadata?.message || contextBodyField(item.body || "", "Message");
+  const action =
+    item.metadata?.operator_action || contextBodyField(item.body || "", "Operator action");
+  const reason = item.metadata?.reason || contextBodyField(item.body || "", "Reason");
+  const detail = [message, action].filter(Boolean).join(" ");
+  return {
+    detail: detail || reason || "The selected provider/model cannot be routed for this assignment.",
+  };
+}
+
+function contextBodyField(body: string, label: string): string {
+  const prefix = `${label}:`;
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith(prefix)) return line.slice(prefix.length).trim();
+  }
+  return "";
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/ui/src/types/context.ts
+++ b/ui/src/types/context.ts
@@ -26,6 +26,7 @@ export type ContextPacketItemRecord = {
   body_ref?: string;
   included: boolean;
   inclusion_reason?: string;
+  metadata?: Record<string, string>;
 };
 
 export type ContextPacketRecord = {


### PR DESCRIPTION
## Summary

- add native project assignment launch readiness metadata to preflight context packets
- persist the same readiness evidence into native assignment run context snapshots
- show a provider/model readiness warning in the Projects preflight modal and disable confirmation when the selected route is blocked

## Why

Dogfood Run 0 showed that assignment preflight could look healthy while start immediately created a task/run that failed on an unroutable model. This makes provider/model readiness visible before dispatch while keeping `POST /start` as the authoritative mutation path.

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `go vet ./internal/api`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `just agent-docs-check`
- `git diff --check`