### PR TITLE
refactor(ui): extract project work modals

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -181,7 +181,9 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   assignment, and handoff editing lives in `ProjectWorkItemModals`,
   `ProjectAssignmentModals`, and `ProjectHandoffModal`, with payload/ref shaping
   in `projectWorkForms.ts`; keep project state loading and mutations in the
-  parent page.
+  parent page. Changes to these extracted modal seams need focused tests for the
+  component and shared form helpers, plus parent-page tests only when loading or
+  mutation orchestration changes.
 - External Agent readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -177,8 +177,11 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   `ProjectWorkspaceView`, and project defaults/root editing lives in
   `ProjectSettingsPanel` plus `CreateProjectWorktreeModal`. Agent profile and
   project role editing lives in `ProfilesModal` and `RolesModal`, with shared
-  profile/role form mapping in `projectProfilesRoles.ts`; keep project state
-  loading and mutations in the parent page.
+  profile/role form mapping in `projectProfilesRoles.ts`. Work item,
+  assignment, and handoff editing lives in `ProjectWorkItemModals`,
+  `ProjectAssignmentModals`, and `ProjectHandoffModal`, with payload/ref shaping
+  in `projectWorkForms.ts`; keep project state loading and mutations in the
+  parent page.
 - External Agent readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/ui/src/features/projects/ProjectAssignmentModals.test.tsx
+++ b/ui/src/features/projects/ProjectAssignmentModals.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ProjectAssignmentRecord,
+  ProjectRecord,
+  ProjectRootRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { EditAssignmentModal, NewAssignmentModal } from "./ProjectAssignmentModals";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_main",
+    path: "/workspace/main",
+    kind: "workspace",
+    active: true,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [root({ id: "root_main", path: "/workspace/main" })],
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+  };
+}
+
+function role(overrides: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRecord {
+  return {
+    id: "software_developer",
+    project_id: "proj_1",
+    name: "Software developer",
+    default_driver_kind: "hecate_task",
+    built_in: false,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function workItem(overrides: Partial<ProjectWorkItemRecord> = {}): ProjectWorkItemRecord {
+  return {
+    id: "work_1",
+    project_id: "proj_1",
+    title: "Build cockpit",
+    status: "ready",
+    priority: "normal",
+    root_id: "root_main",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function assignment(overrides: Partial<ProjectAssignmentRecord> = {}): ProjectAssignmentRecord {
+  return {
+    id: "assign_1",
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    role_id: "software_developer",
+    root_id: "root_main",
+    driver_kind: "hecate_task",
+    status: "queued",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ProjectAssignmentModals", () => {
+  it("creates assignments and follows selected role driver defaults", async () => {
+    const onCreate = vi.fn();
+
+    render(
+      <NewAssignmentModal
+        error=""
+        pending={false}
+        project={project()}
+        workItem={workItem()}
+        roles={[
+          role(),
+          role({
+            id: "researcher",
+            name: "Researcher",
+            default_driver_kind: "external_agent",
+          }),
+        ]}
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Role"), { target: { value: "researcher" } });
+    expect(screen.getByLabelText("Driver")).toHaveValue("external_agent");
+    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      roleID: "researcher",
+      driverKind: "external_agent",
+      rootID: "",
+    });
+  });
+
+  it("edits canonical assignment execution reference fields", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <EditAssignmentModal
+        assignment={assignment({
+          execution_ref: {
+            kind: "task_run",
+            task_id: "task_old",
+            run_id: "run_old",
+          },
+        })}
+        error=""
+        pending={false}
+        project={project()}
+        workItem={workItem()}
+        roles={[role()]}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    await userEvent.clear(screen.getByLabelText("Task ID"));
+    await userEvent.type(screen.getByLabelText("Task ID"), "task_new");
+    await userEvent.clear(screen.getByLabelText("Run ID"));
+    await userEvent.type(screen.getByLabelText("Run ID"), "run_new");
+    await userEvent.type(screen.getByLabelText("Context snapshot ID"), "ctx_new");
+    await userEvent.click(screen.getByRole("button", { name: "Save assignment" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "assign_1",
+        taskID: "task_new",
+        runID: "run_new",
+        contextSnapshotID: "ctx_new",
+      }),
+    );
+  });
+});

--- a/ui/src/features/projects/ProjectAssignmentModals.tsx
+++ b/ui/src/features/projects/ProjectAssignmentModals.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+
+import type {
+  ProjectAssignmentRecord,
+  ProjectRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import { ProjectRootSelect } from "./ProjectRootSelect";
+import {
+  ASSIGNMENT_STATUSES,
+  defaultDriverForRole,
+  type EditAssignmentForm,
+  type NewAssignmentForm,
+} from "./projectWorkForms";
+import {
+  projectWorkFieldLabelStyle,
+  projectWorkFieldStyle,
+  projectWorkSubtleTextStyle,
+} from "./projectWorkModalStyles";
+
+type NewAssignmentModalProps = {
+  error: string;
+  pending: boolean;
+  project: ProjectRecord;
+  workItem: ProjectWorkItemRecord | null;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onCreate: (form: NewAssignmentForm) => void | Promise<void>;
+};
+
+export function NewAssignmentModal({
+  error,
+  pending,
+  project,
+  workItem,
+  roles,
+  onClose,
+  onCreate,
+}: NewAssignmentModalProps) {
+  const defaultRole = roles.find((role) => role.id === "software_developer") ?? roles[0] ?? null;
+  const [form, setForm] = useState<NewAssignmentForm>({
+    roleID: defaultRole?.id ?? "",
+    driverKind: defaultDriverForRole(defaultRole),
+    rootID: "",
+  });
+  const valid = form.roleID.trim().length > 0;
+  return (
+    <Modal
+      title="Add assignment"
+      onClose={onClose}
+      width={520}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Adding…" : "Add assignment"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Role</span>
+          <select
+            className="input"
+            autoFocus
+            value={form.roleID}
+            onChange={(event) => {
+              const roleID = event.target.value;
+              const role = roles.find((item) => item.id === roleID) ?? null;
+              setForm((current) => ({
+                ...current,
+                roleID,
+                driverKind: defaultDriverForRole(role),
+              }));
+            }}
+          >
+            {roles.map((role) => (
+              <option key={role.id} value={role.id}>
+                {role.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Driver</span>
+          <select
+            className="input"
+            value={form.driverKind}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, driverKind: event.target.value }))
+            }
+          >
+            <option value="hecate_task">hecate_task</option>
+            <option value="external_agent">external_agent</option>
+          </select>
+        </label>
+        <ProjectRootSelect
+          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
+        {form.driverKind === "external_agent" && (
+          <div style={projectWorkSubtleTextStyle}>
+            External assignment execution is recorded here but still starts from Chats.
+          </div>
+        )}
+      </form>
+    </Modal>
+  );
+}
+
+type EditAssignmentModalProps = {
+  assignment: ProjectAssignmentRecord;
+  error: string;
+  pending: boolean;
+  project: ProjectRecord;
+  workItem: ProjectWorkItemRecord | null;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: EditAssignmentForm) => void | Promise<void>;
+};
+
+export function EditAssignmentModal({
+  assignment,
+  error,
+  pending,
+  project,
+  workItem,
+  roles,
+  onClose,
+  onSave,
+}: EditAssignmentModalProps) {
+  const [form, setForm] = useState<EditAssignmentForm>({
+    id: assignment.id,
+    roleID: assignment.role_id,
+    driverKind: assignment.driver_kind || "hecate_task",
+    rootID: assignment.root_id ?? "",
+    status: assignment.status || "queued",
+    taskID: assignment.execution_ref?.task_id ?? "",
+    runID: assignment.execution_ref?.run_id ?? "",
+    chatSessionID: assignment.execution_ref?.chat_session_id ?? "",
+    messageID: assignment.execution_ref?.message_id ?? "",
+    contextSnapshotID: assignment.execution_ref?.context_snapshot_id ?? "",
+  });
+  const valid = form.roleID.trim().length > 0;
+  return (
+    <Modal
+      title="Edit assignment"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save assignment"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Role</span>
+            <select
+              className="input"
+              autoFocus
+              value={form.roleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, roleID: event.target.value }))
+              }
+            >
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {ASSIGNMENT_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Driver</span>
+          <select
+            className="input"
+            value={form.driverKind}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, driverKind: event.target.value }))
+            }
+          >
+            <option value="hecate_task">hecate_task</option>
+            <option value="external_agent">external_agent</option>
+          </select>
+        </label>
+        <ProjectRootSelect
+          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Task ID</span>
+            <input
+              className="input"
+              value={form.taskID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, taskID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Run ID</span>
+            <input
+              className="input"
+              value={form.runID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, runID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Chat session ID</span>
+            <input
+              className="input"
+              value={form.chatSessionID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, chatSessionID: event.target.value }))
+              }
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Message ID</span>
+            <input
+              className="input"
+              value={form.messageID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, messageID: event.target.value }))
+              }
+            />
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Context snapshot ID</span>
+          <input
+            className="input"
+            value={form.contextSnapshotID}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, contextSnapshotID: event.target.value }))
+            }
+          />
+        </label>
+        <div style={projectWorkSubtleTextStyle}>
+          Editing assignment metadata does not mutate or cancel linked task, run, or chat execution.
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/ui/src/features/projects/ProjectHandoffModal.test.tsx
+++ b/ui/src/features/projects/ProjectHandoffModal.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ProjectAssignmentRecord,
+  ProjectHandoffRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { ProjectHandoffModal } from "./ProjectHandoffModal";
+
+function role(overrides: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRecord {
+  return {
+    id: "reviewer",
+    project_id: "proj_1",
+    name: "Reviewer",
+    built_in: false,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function assignment(overrides: Partial<ProjectAssignmentRecord> = {}): ProjectAssignmentRecord {
+  return {
+    id: "assign_1234567890",
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    role_id: "developer",
+    driver_kind: "hecate_task",
+    status: "queued",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function handoff(overrides: Partial<ProjectHandoffRecord> = {}): ProjectHandoffRecord {
+  return {
+    id: "handoff_1",
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    title: "QA review",
+    summary: "Ready for QA.",
+    recommended_next_action: "Verify the behavior.",
+    status: "pending",
+    provenance_kind: "operator",
+    trust_label: "operator_reviewed",
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    status_changed_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ProjectHandoffModal", () => {
+  it("creates a handoff with source assignment and target role", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <ProjectHandoffModal
+        assignments={[assignment()]}
+        error=""
+        handoff={null}
+        pending={false}
+        roles={[role()]}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Title"), "QA review");
+    await userEvent.type(screen.getByLabelText("Summary"), "Ready for test.");
+    await userEvent.type(screen.getByLabelText("Recommended next action"), "Run regression.");
+    fireEvent.change(screen.getByLabelText("Source assignment"), {
+      target: { value: "assign_1234567890" },
+    });
+    fireEvent.change(screen.getByLabelText("Target role"), { target: { value: "reviewer" } });
+    await userEvent.type(screen.getByLabelText("Artifact IDs"), "art_1, art_2");
+    await userEvent.click(screen.getByRole("button", { name: "Save handoff" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceAssignmentID: "assign_1234567890",
+        targetRoleID: "reviewer",
+        title: "QA review",
+        summary: "Ready for test.",
+        recommendedNextAction: "Run regression.",
+        linkedArtifactIDs: "art_1, art_2",
+      }),
+    );
+  });
+
+  it("edits an existing handoff status", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <ProjectHandoffModal
+        assignments={[assignment()]}
+        error=""
+        handoff={handoff({ target_role_id: "reviewer" })}
+        pending={false}
+        roles={[role()]}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "accepted" } });
+    await userEvent.click(screen.getByRole("button", { name: "Save handoff" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "handoff_1",
+        status: "accepted",
+        targetRoleID: "reviewer",
+      }),
+    );
+  });
+});

--- a/ui/src/features/projects/ProjectHandoffModal.tsx
+++ b/ui/src/features/projects/ProjectHandoffModal.tsx
@@ -1,0 +1,247 @@
+import { useState } from "react";
+
+import type {
+  ProjectAssignmentRecord,
+  ProjectHandoffRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import { HANDOFF_STATUSES, handoffFormFromRecord, type HandoffForm } from "./projectWorkForms";
+import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+
+type ProjectHandoffModalProps = {
+  assignments: ProjectAssignmentRecord[];
+  draft?: HandoffForm | null;
+  error: string;
+  handoff: ProjectHandoffRecord | null;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: HandoffForm) => void | Promise<void>;
+};
+
+export function ProjectHandoffModal({
+  assignments,
+  draft,
+  error,
+  handoff,
+  pending,
+  roles,
+  onClose,
+  onSave,
+}: ProjectHandoffModalProps) {
+  const [form, setForm] = useState<HandoffForm>(() => draft ?? handoffFormFromRecord(handoff));
+  const valid =
+    form.title.trim().length > 0 &&
+    form.summary.trim().length > 0 &&
+    form.recommendedNextAction.trim().length > 0;
+  return (
+    <Modal
+      title={handoff ? "Edit handoff" : "New handoff"}
+      onClose={onClose}
+      width={620}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save handoff"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+            placeholder="QA review handoff"
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Summary</span>
+          <textarea
+            className="input"
+            value={form.summary}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, summary: event.target.value }))
+            }
+            rows={4}
+            style={{ resize: "vertical", minHeight: 90 }}
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Recommended next action</span>
+          <textarea
+            className="input"
+            value={form.recommendedNextAction}
+            onChange={(event) =>
+              setForm((current) => ({
+                ...current,
+                recommendedNextAction: event.target.value,
+              }))
+            }
+            rows={3}
+            style={{ resize: "vertical", minHeight: 76 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Source assignment</span>
+            <select
+              className="input"
+              value={form.sourceAssignmentID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceAssignmentID: event.target.value }))
+              }
+            >
+              <option value="">No source assignment</option>
+              {assignments.map((assignment) => (
+                <option key={assignment.id} value={assignment.id}>
+                  {shortID(assignment.id)} · {assignment.role_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Target role</span>
+            <select
+              className="input"
+              value={form.targetRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, targetRoleID: event.target.value }))
+              }
+            >
+              <option value="">No target role</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Target assignment</span>
+            <select
+              className="input"
+              value={form.targetAssignmentID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, targetAssignmentID: event.target.value }))
+              }
+            >
+              <option value="">No target assignment</option>
+              {assignments.map((assignment) => (
+                <option key={assignment.id} value={assignment.id}>
+                  {shortID(assignment.id)} · {assignment.role_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {HANDOFF_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Source run</span>
+            <input
+              className="input"
+              value={form.sourceRunID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceRunID: event.target.value }))
+              }
+              placeholder="run_..."
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Source chat</span>
+            <input
+              className="input"
+              value={form.sourceChatSessionID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceChatSessionID: event.target.value }))
+              }
+              placeholder="chat_..."
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Source message</span>
+            <input
+              className="input"
+              value={form.sourceMessageID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceMessageID: event.target.value }))
+              }
+              placeholder="msg_..."
+            />
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Artifact IDs</span>
+            <input
+              className="input"
+              value={form.linkedArtifactIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, linkedArtifactIDs: event.target.value }))
+              }
+              placeholder="art_1, art_2"
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Memory IDs</span>
+            <input
+              className="input"
+              value={form.linkedMemoryIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, linkedMemoryIDs: event.target.value }))
+              }
+              placeholder="mem_1"
+            />
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Context refs</span>
+          <input
+            className="input"
+            value={form.contextRefs}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, contextRefs: event.target.value }))
+            }
+            placeholder="ctx_1, task/run/context"
+          />
+        </label>
+      </form>
+    </Modal>
+  );
+}
+
+function shortID(id: string): string {
+  if (id.length <= 12) return id;
+  return id.slice(0, 10) + "...";
+}

--- a/ui/src/features/projects/ProjectRootSelect.test.tsx
+++ b/ui/src/features/projects/ProjectRootSelect.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectRecord, ProjectRootRecord } from "../../types/project";
+import { ProjectRootSelect } from "./ProjectRootSelect";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_main",
+    path: "/workspace/main",
+    kind: "workspace",
+    active: true,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [
+      root({ id: "root_main", path: "/workspace/main", git_branch: "main" }),
+      root({
+        id: "root_feature",
+        path: "/workspace/feature",
+        kind: "git_worktree",
+        git_branch: "feature/ui",
+      }),
+    ],
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ProjectRootSelect", () => {
+  it("renders nothing when the project has no roots", () => {
+    const { container } = render(
+      <ProjectRootSelect
+        inheritLabel="Use work item root"
+        project={project({ roots: [] })}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("emits the selected root id with labelled root options", () => {
+    const onChange = vi.fn();
+
+    render(
+      <ProjectRootSelect
+        inheritLabel="Use work item root"
+        label="Assignment root"
+        project={project()}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: "Use work item root" })).toHaveValue("");
+    expect(
+      screen.getByRole("option", { name: "/workspace/feature · git:feature/ui · git_worktree" }),
+    ).toHaveValue("root_feature");
+
+    fireEvent.change(screen.getByLabelText("Assignment root"), {
+      target: { value: "root_feature" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("root_feature");
+  });
+});

--- a/ui/src/features/projects/ProjectRootSelect.tsx
+++ b/ui/src/features/projects/ProjectRootSelect.tsx
@@ -1,0 +1,40 @@
+import type { ProjectRecord } from "../../types/project";
+import { projectRootOptionLabel } from "./projectSettings";
+import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+
+type ProjectRootSelectProps = {
+  inheritLabel: string;
+  label?: string;
+  project: ProjectRecord;
+  value: string;
+  onChange: (rootID: string) => void;
+};
+
+export function ProjectRootSelect({
+  inheritLabel,
+  label = "Root",
+  project,
+  value,
+  onChange,
+}: ProjectRootSelectProps) {
+  if (project.roots.length === 0) return null;
+  return (
+    <label style={projectWorkFieldStyle}>
+      <span style={projectWorkFieldLabelStyle}>{label}</span>
+      <select
+        aria-label={label}
+        className="input"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
+      >
+        <option value="">{inheritLabel}</option>
+        {project.roots.map((root) => (
+          <option key={root.id || root.path} value={root.id}>
+            {projectRootOptionLabel(root)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/ui/src/features/projects/ProjectWorkItemModals.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemModals.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ProjectRecord,
+  ProjectRootRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { EditWorkItemModal, NewWorkItemModal } from "./ProjectWorkItemModals";
+
+function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
+  return {
+    id: "root_main",
+    path: "/workspace/main",
+    kind: "workspace",
+    active: true,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [
+      root({ id: "root_main", path: "/workspace/main" }),
+      root({ id: "root_feature", path: "/workspace/feature", kind: "git_worktree" }),
+    ],
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function role(overrides: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRecord {
+  return {
+    id: "software_developer",
+    project_id: "proj_1",
+    name: "Software developer",
+    built_in: false,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function workItem(overrides: Partial<ProjectWorkItemRecord> = {}): ProjectWorkItemRecord {
+  return {
+    id: "work_1",
+    project_id: "proj_1",
+    title: "Build cockpit",
+    brief: "Ship the first slice.",
+    status: "ready",
+    priority: "normal",
+    owner_role_id: "software_developer",
+    root_id: "root_main",
+    reviewer_role_ids: ["architect"],
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ProjectWorkItemModals", () => {
+  it("creates work items with default owner role and selected root", async () => {
+    const onCreate = vi.fn();
+
+    render(
+      <NewWorkItemModal
+        error=""
+        pending={false}
+        project={project()}
+        roles={[role(), role({ id: "architect", name: "Architect" })]}
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Title"), "Implement project queue");
+    await userEvent.type(screen.getByLabelText("Brief"), "Keep parent orchestration thin.");
+    fireEvent.change(screen.getByLabelText("Root"), { target: { value: "root_feature" } });
+    await userEvent.click(screen.getByRole("button", { name: "Create work item" }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      title: "Implement project queue",
+      brief: "Keep parent orchestration thin.",
+      priority: "normal",
+      ownerRoleID: "software_developer",
+      rootID: "root_feature",
+    });
+  });
+
+  it("edits work item metadata including reviewer roles", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <EditWorkItemModal
+        error=""
+        item={workItem()}
+        pending={false}
+        project={project()}
+        roles={[role(), role({ id: "architect", name: "Architect" })]}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "review" } });
+    await userEvent.clear(screen.getByLabelText("Reviewer roles"));
+    await userEvent.type(screen.getByLabelText("Reviewer roles"), "architect, reviewer_qa");
+    await userEvent.click(screen.getByRole("button", { name: "Save work item" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "work_1",
+        status: "review",
+        reviewerRoleIDs: "architect, reviewer_qa",
+      }),
+    );
+  });
+});

--- a/ui/src/features/projects/ProjectWorkItemModals.tsx
+++ b/ui/src/features/projects/ProjectWorkItemModals.tsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+
+import type {
+  ProjectRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import { ProjectRootSelect } from "./ProjectRootSelect";
+import {
+  WORK_ITEM_PRIORITIES,
+  WORK_ITEM_STATUSES,
+  type EditWorkItemForm,
+  type NewWorkItemForm,
+} from "./projectWorkForms";
+import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+
+type NewWorkItemModalProps = {
+  error: string;
+  pending: boolean;
+  project: ProjectRecord;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onCreate: (form: NewWorkItemForm) => void | Promise<void>;
+};
+
+export function NewWorkItemModal({
+  error,
+  pending,
+  project,
+  roles,
+  onClose,
+  onCreate,
+}: NewWorkItemModalProps) {
+  const [form, setForm] = useState<NewWorkItemForm>({
+    title: "",
+    brief: "",
+    priority: "normal",
+    ownerRoleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
+    rootID: "",
+  });
+  const valid = form.title.trim().length > 0;
+  return (
+    <Modal
+      title="New work item"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onCreate(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Creating…" : "Create work item"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onCreate(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+            placeholder="Implement project cockpit"
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Brief</span>
+          <textarea
+            className="input"
+            value={form.brief}
+            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
+            rows={5}
+            placeholder="Describe the outcome, constraints, and handoff expectations."
+            style={{ resize: "vertical", minHeight: 110 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Priority</span>
+            <select
+              className="input"
+              value={form.priority}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, priority: event.target.value }))
+              }
+            >
+              <option value="low">low</option>
+              <option value="normal">normal</option>
+              <option value="high">high</option>
+              <option value="urgent">urgent</option>
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Owner role</span>
+            <select
+              className="input"
+              value={form.ownerRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
+              }
+            >
+              <option value="">No owner</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <ProjectRootSelect
+          inheritLabel="project default root"
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
+      </form>
+    </Modal>
+  );
+}
+
+type EditWorkItemModalProps = {
+  error: string;
+  item: ProjectWorkItemRecord;
+  pending: boolean;
+  project: ProjectRecord;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: EditWorkItemForm) => void | Promise<void>;
+};
+
+export function EditWorkItemModal({
+  error,
+  item,
+  pending,
+  project,
+  roles,
+  onClose,
+  onSave,
+}: EditWorkItemModalProps) {
+  const [form, setForm] = useState<EditWorkItemForm>({
+    id: item.id,
+    title: item.title,
+    brief: item.brief ?? "",
+    status: item.status,
+    priority: item.priority || "normal",
+    ownerRoleID: item.owner_role_id ?? "",
+    rootID: item.root_id ?? "",
+    reviewerRoleIDs: (item.reviewer_role_ids ?? []).join(", "),
+  });
+  const valid = form.title.trim().length > 0;
+  return (
+    <Modal
+      title="Edit work item"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving…" : "Save work item"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Brief</span>
+          <textarea
+            className="input"
+            value={form.brief}
+            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
+            rows={5}
+            style={{ resize: "vertical", minHeight: 110 }}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Status</span>
+            <select
+              className="input"
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, status: event.target.value }))
+              }
+            >
+              {WORK_ITEM_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Priority</span>
+            <select
+              className="input"
+              value={form.priority}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, priority: event.target.value }))
+              }
+            >
+              {WORK_ITEM_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Owner role</span>
+            <select
+              className="input"
+              value={form.ownerRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
+              }
+            >
+              <option value="">No owner</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Reviewer roles</span>
+            <input
+              className="input"
+              value={form.reviewerRoleIDs}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, reviewerRoleIDs: event.target.value }))
+              }
+              placeholder="reviewer_qa, architect"
+            />
+          </label>
+        </div>
+        <ProjectRootSelect
+          inheritLabel="project default root"
+          project={project}
+          value={form.rootID}
+          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
+        />
+      </form>
+    </Modal>
+  );
+}

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -78,8 +78,11 @@ import {
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
+import { EditAssignmentModal, NewAssignmentModal } from "./ProjectAssignmentModals";
 import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
+import { ProjectHandoffModal } from "./ProjectHandoffModal";
 import { ProfilesModal } from "./ProfilesModal";
+import { EditWorkItemModal, NewWorkItemModal } from "./ProjectWorkItemModals";
 import { RolesModal } from "./RolesModal";
 import { useProjectAssistantController } from "./useProjectAssistantController";
 import type {
@@ -90,18 +93,14 @@ import type {
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
   CreateProjectWorktreeRootPayload,
-  CreateProjectHandoffPayload,
   ProjectHandoffRecord,
   ProjectMemoryRecord,
   ProjectSkillRecord,
-  ProjectAssignmentExecutionRefRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
-  UpdateProjectAssignmentPayload,
   UpdateProjectPayload,
   UpdateProjectSkillPayload,
-  UpdateProjectWorkItemPayload,
 } from "../../types/project";
 import type { AgentProfileRecord } from "../../types/agent-profile";
 import type { ContextPacketRecord } from "../../types/context";
@@ -126,10 +125,22 @@ import {
   profileUpdatePayloadFromForm,
   projectSkillStatusRank,
   rolePayloadFromForm,
-  splitIDs,
   type AgentProfileForm,
   type RoleForm,
 } from "./projectProfilesRoles";
+import {
+  assignmentCreatePayloadFromForm,
+  assignmentUpdatePayloadFromForm,
+  handoffFormFromAssignment,
+  handoffPayloadFromForm,
+  type EditAssignmentForm,
+  type EditWorkItemForm,
+  type HandoffForm,
+  type NewAssignmentForm,
+  type NewWorkItemForm,
+  workItemCreatePayloadFromForm,
+  workItemUpdatePayloadFromForm,
+} from "./projectWorkForms";
 
 type Props = {
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
@@ -159,36 +170,6 @@ type LoadState = "idle" | "loading" | "loaded" | "error";
 
 type ProjectWorkspaceTab = "work" | "timeline" | "memory" | "skills";
 
-type NewWorkItemForm = {
-  title: string;
-  brief: string;
-  priority: string;
-  ownerRoleID: string;
-  rootID: string;
-};
-
-type NewAssignmentForm = {
-  roleID: string;
-  driverKind: string;
-  rootID: string;
-};
-
-type EditWorkItemForm = NewWorkItemForm & {
-  id: string;
-  status: string;
-  reviewerRoleIDs: string;
-};
-
-type EditAssignmentForm = NewAssignmentForm & {
-  id: string;
-  status: string;
-  taskID: string;
-  runID: string;
-  chatSessionID: string;
-  messageID: string;
-  contextSnapshotID: string;
-};
-
 type AssignmentPreflightState =
   | { status: "idle" | "loading" }
   | { status: "ready"; packet: ContextPacketRecord }
@@ -196,51 +177,6 @@ type AssignmentPreflightState =
 
 type AssignmentLaunchReadinessNoticeRecord = {
   detail: string;
-};
-
-function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
-  if (form.taskID.trim() || form.runID.trim()) return "task_run";
-  if (form.chatSessionID.trim() || form.messageID.trim()) return "chat_session";
-  if (form.contextSnapshotID.trim()) return "context_snapshot";
-  return "none";
-}
-
-function projectAssignmentExecutionRefFromForm(
-  form: EditAssignmentForm,
-): ProjectAssignmentExecutionRefRecord {
-  const ref: ProjectAssignmentExecutionRefRecord = {
-    kind: projectAssignmentExecutionKindFromForm(form),
-  };
-  const taskID = form.taskID.trim();
-  const runID = form.runID.trim();
-  const chatSessionID = form.chatSessionID.trim();
-  const messageID = form.messageID.trim();
-  const contextSnapshotID = form.contextSnapshotID.trim();
-  if (taskID) ref.task_id = taskID;
-  if (runID) ref.run_id = runID;
-  if (chatSessionID) ref.chat_session_id = chatSessionID;
-  if (messageID) ref.message_id = messageID;
-  if (contextSnapshotID) ref.context_snapshot_id = contextSnapshotID;
-  return ref;
-}
-
-type HandoffForm = {
-  id: string;
-  sourceAssignmentID: string;
-  sourceRunID: string;
-  sourceChatSessionID: string;
-  sourceMessageID: string;
-  targetRoleID: string;
-  targetAssignmentID: string;
-  title: string;
-  summary: string;
-  recommendedNextAction: string;
-  linkedArtifactIDs: string;
-  linkedMemoryIDs: string;
-  contextRefs: string;
-  status: string;
-  provenanceKind: string;
-  trustLabel: string;
 };
 
 type MemoryForm = {
@@ -258,25 +194,6 @@ type SkillForm = {
   trustLabel: string;
 };
 
-const WORK_ITEM_STATUSES = [
-  "backlog",
-  "ready",
-  "running",
-  "review",
-  "blocked",
-  "done",
-  "cancelled",
-];
-const WORK_ITEM_PRIORITIES = ["low", "normal", "high", "urgent"];
-const ASSIGNMENT_STATUSES = [
-  "queued",
-  "running",
-  "awaiting_approval",
-  "completed",
-  "failed",
-  "cancelled",
-];
-const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"];
 const MEMORY_TRUST_LABELS = [
   "operator_memory",
   "generated_summary",
@@ -1074,15 +991,10 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setNewWorkPending(true);
     setNewWorkError("");
     try {
-      const rootID = form.rootID.trim();
-      const payload = await createProjectWorkItem(selectedProjectID, {
-        title,
-        brief: form.brief.trim() || undefined,
-        status: "ready",
-        priority: form.priority || "normal",
-        owner_role_id: form.ownerRoleID || undefined,
-        ...(rootID ? { root_id: rootID } : {}),
-      });
+      const payload = await createProjectWorkItem(
+        selectedProjectID,
+        workItemCreatePayloadFromForm(form),
+      );
       setWorkItems((current) => upsertWorkItem(current, payload.data));
       setWorkItemSummaries((current) => ({
         ...current,
@@ -1109,15 +1021,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!title) return;
     setEditWorkPending(true);
     setEditWorkError("");
-    const patch: UpdateProjectWorkItemPayload = {
-      title,
-      brief: form.brief.trim(),
-      status: form.status,
-      priority: form.priority || "normal",
-      owner_role_id: form.ownerRoleID,
-      root_id: form.rootID.trim(),
-      reviewer_role_ids: splitRoleIDs(form.reviewerRoleIDs),
-    };
+    const patch = workItemUpdatePayloadFromForm(form);
     try {
       const payload = await updateProjectWorkItem(selectedProjectID, form.id, patch);
       setWorkItems((current) => upsertWorkItem(current, payload.data));
@@ -1150,12 +1054,11 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     setNewAssignmentPending(true);
     setNewAssignmentError("");
     try {
-      const rootID = form.rootID.trim();
-      const payload = await createProjectAssignment(selectedProjectID, selectedWorkItemID, {
-        role_id: roleID,
-        driver_kind: form.driverKind || "hecate_task",
-        ...(rootID ? { root_id: rootID } : {}),
-      });
+      const payload = await createProjectAssignment(
+        selectedProjectID,
+        selectedWorkItemID,
+        assignmentCreatePayloadFromForm(form),
+      );
       setAssignments((current) => upsertAssignment(current, payload.data));
       setNewAssignmentModalOpen(false);
       await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
@@ -1172,13 +1075,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     if (!roleID) return;
     setEditAssignmentPending(true);
     setEditAssignmentError("");
-    const patch: UpdateProjectAssignmentPayload = {
-      role_id: roleID,
-      root_id: form.rootID.trim(),
-      driver_kind: form.driverKind || "hecate_task",
-      status: form.status || "queued",
-      execution_ref: projectAssignmentExecutionRefFromForm(form),
-    };
+    const patch = assignmentUpdatePayloadFromForm(form);
     try {
       const payload = await updateProjectAssignment(
         selectedProjectID,
@@ -1214,23 +1111,7 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
     const summary = form.summary.trim();
     const recommendedNextAction = form.recommendedNextAction.trim();
     if (!title || !summary || !recommendedNextAction) return;
-    const payload: CreateProjectHandoffPayload = {
-      source_assignment_id: form.sourceAssignmentID.trim(),
-      source_run_id: form.sourceRunID.trim(),
-      source_chat_session_id: form.sourceChatSessionID.trim(),
-      source_message_id: form.sourceMessageID.trim(),
-      target_role_id: form.targetRoleID.trim(),
-      target_assignment_id: form.targetAssignmentID.trim(),
-      title,
-      summary,
-      recommended_next_action: recommendedNextAction,
-      linked_artifact_ids: splitIDs(form.linkedArtifactIDs),
-      linked_memory_ids: splitIDs(form.linkedMemoryIDs),
-      context_refs: splitIDs(form.contextRefs),
-      status: form.status || "pending",
-      provenance_kind: form.provenanceKind.trim() || "operator",
-      trust_label: form.trustLabel.trim() || "operator_reviewed",
-    };
+    const payload = handoffPayloadFromForm(form);
     setHandoffPending(true);
     setHandoffError("");
     try {
@@ -4168,804 +4049,6 @@ function WorkItemDetail({
   );
 }
 
-function ProjectRootSelect({
-  inheritLabel,
-  label = "Root",
-  project,
-  value,
-  onChange,
-}: {
-  inheritLabel: string;
-  label?: string;
-  project: ProjectRecord;
-  value: string;
-  onChange: (rootID: string) => void;
-}) {
-  if (project.roots.length === 0) return null;
-  return (
-    <label style={fieldStyle}>
-      <span style={fieldLabelStyle}>{label}</span>
-      <select
-        aria-label={label}
-        className="input"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
-      >
-        <option value="">{inheritLabel}</option>
-        {project.roots.map((root) => (
-          <option key={root.id || root.path} value={root.id}>
-            {projectRootOptionLabel(root)}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function NewWorkItemModal({
-  error,
-  pending,
-  project,
-  roles,
-  onClose,
-  onCreate,
-}: {
-  error: string;
-  pending: boolean;
-  project: ProjectRecord;
-  roles: ProjectWorkRoleRecord[];
-  onClose: () => void;
-  onCreate: (form: NewWorkItemForm) => void | Promise<void>;
-}) {
-  const [form, setForm] = useState<NewWorkItemForm>({
-    title: "",
-    brief: "",
-    priority: "normal",
-    ownerRoleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
-    rootID: "",
-  });
-  const valid = form.title.trim().length > 0;
-  return (
-    <Modal
-      title="New work item"
-      onClose={onClose}
-      width={560}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onCreate(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Creating…" : "Create work item"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onCreate(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Title</span>
-          <input
-            className="input"
-            autoFocus
-            value={form.title}
-            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
-            placeholder="Implement project cockpit"
-          />
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Brief</span>
-          <textarea
-            className="input"
-            value={form.brief}
-            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
-            rows={5}
-            placeholder="Describe the outcome, constraints, and handoff expectations."
-            style={{ resize: "vertical", minHeight: 110 }}
-          />
-        </label>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Priority</span>
-            <select
-              className="input"
-              value={form.priority}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, priority: event.target.value }))
-              }
-            >
-              <option value="low">low</option>
-              <option value="normal">normal</option>
-              <option value="high">high</option>
-              <option value="urgent">urgent</option>
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Owner role</span>
-            <select
-              className="input"
-              value={form.ownerRoleID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
-              }
-            >
-              <option value="">No owner</option>
-              {roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <ProjectRootSelect
-          inheritLabel="project default root"
-          project={project}
-          value={form.rootID}
-          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
-        />
-      </form>
-    </Modal>
-  );
-}
-
-function EditWorkItemModal({
-  error,
-  item,
-  pending,
-  project,
-  roles,
-  onClose,
-  onSave,
-}: {
-  error: string;
-  item: ProjectWorkItemRecord;
-  pending: boolean;
-  project: ProjectRecord;
-  roles: ProjectWorkRoleRecord[];
-  onClose: () => void;
-  onSave: (form: EditWorkItemForm) => void | Promise<void>;
-}) {
-  const [form, setForm] = useState<EditWorkItemForm>({
-    id: item.id,
-    title: item.title,
-    brief: item.brief ?? "",
-    status: item.status,
-    priority: item.priority || "normal",
-    ownerRoleID: item.owner_role_id ?? "",
-    rootID: item.root_id ?? "",
-    reviewerRoleIDs: (item.reviewer_role_ids ?? []).join(", "),
-  });
-  const valid = form.title.trim().length > 0;
-  return (
-    <Modal
-      title="Edit work item"
-      onClose={onClose}
-      width={560}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onSave(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Saving…" : "Save work item"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onSave(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Title</span>
-          <input
-            className="input"
-            autoFocus
-            value={form.title}
-            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
-          />
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Brief</span>
-          <textarea
-            className="input"
-            value={form.brief}
-            onChange={(event) => setForm((current) => ({ ...current, brief: event.target.value }))}
-            rows={5}
-            style={{ resize: "vertical", minHeight: 110 }}
-          />
-        </label>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Status</span>
-            <select
-              className="input"
-              value={form.status}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
-              }
-            >
-              {WORK_ITEM_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Priority</span>
-            <select
-              className="input"
-              value={form.priority}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, priority: event.target.value }))
-              }
-            >
-              {WORK_ITEM_PRIORITIES.map((priority) => (
-                <option key={priority} value={priority}>
-                  {priority}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Owner role</span>
-            <select
-              className="input"
-              value={form.ownerRoleID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, ownerRoleID: event.target.value }))
-              }
-            >
-              <option value="">No owner</option>
-              {roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Reviewer roles</span>
-            <input
-              className="input"
-              value={form.reviewerRoleIDs}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, reviewerRoleIDs: event.target.value }))
-              }
-              placeholder="reviewer_qa, architect"
-            />
-          </label>
-        </div>
-        <ProjectRootSelect
-          inheritLabel="project default root"
-          project={project}
-          value={form.rootID}
-          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
-        />
-      </form>
-    </Modal>
-  );
-}
-
-function NewAssignmentModal({
-  error,
-  pending,
-  project,
-  workItem,
-  roles,
-  onClose,
-  onCreate,
-}: {
-  error: string;
-  pending: boolean;
-  project: ProjectRecord;
-  workItem: ProjectWorkItemRecord | null;
-  roles: ProjectWorkRoleRecord[];
-  onClose: () => void;
-  onCreate: (form: NewAssignmentForm) => void | Promise<void>;
-}) {
-  const defaultRole = roles.find((role) => role.id === "software_developer") ?? roles[0] ?? null;
-  const [form, setForm] = useState<NewAssignmentForm>({
-    roleID: defaultRole?.id ?? "",
-    driverKind: defaultDriverForRole(defaultRole),
-    rootID: "",
-  });
-  const valid = form.roleID.trim().length > 0;
-  return (
-    <Modal
-      title="Add assignment"
-      onClose={onClose}
-      width={520}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onCreate(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Adding…" : "Add assignment"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onCreate(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Role</span>
-          <select
-            className="input"
-            autoFocus
-            value={form.roleID}
-            onChange={(event) => {
-              const roleID = event.target.value;
-              const role = roles.find((item) => item.id === roleID) ?? null;
-              setForm((current) => ({
-                ...current,
-                roleID,
-                driverKind: defaultDriverForRole(role),
-              }));
-            }}
-          >
-            {roles.map((role) => (
-              <option key={role.id} value={role.id}>
-                {role.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Driver</span>
-          <select
-            className="input"
-            value={form.driverKind}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, driverKind: event.target.value }))
-            }
-          >
-            <option value="hecate_task">hecate_task</option>
-            <option value="external_agent">external_agent</option>
-          </select>
-        </label>
-        <ProjectRootSelect
-          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
-          project={project}
-          value={form.rootID}
-          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
-        />
-        {form.driverKind === "external_agent" && (
-          <div style={subtleTextStyle}>
-            External assignment execution is recorded here but still starts from Chats.
-          </div>
-        )}
-      </form>
-    </Modal>
-  );
-}
-
-function EditAssignmentModal({
-  assignment,
-  error,
-  pending,
-  project,
-  workItem,
-  roles,
-  onClose,
-  onSave,
-}: {
-  assignment: ProjectAssignmentRecord;
-  error: string;
-  pending: boolean;
-  project: ProjectRecord;
-  workItem: ProjectWorkItemRecord | null;
-  roles: ProjectWorkRoleRecord[];
-  onClose: () => void;
-  onSave: (form: EditAssignmentForm) => void | Promise<void>;
-}) {
-  const [form, setForm] = useState<EditAssignmentForm>({
-    id: assignment.id,
-    roleID: assignment.role_id,
-    driverKind: assignment.driver_kind || "hecate_task",
-    rootID: assignment.root_id ?? "",
-    status: assignment.status || "queued",
-    taskID: assignment.execution_ref?.task_id ?? "",
-    runID: assignment.execution_ref?.run_id ?? "",
-    chatSessionID: assignment.execution_ref?.chat_session_id ?? "",
-    messageID: assignment.execution_ref?.message_id ?? "",
-    contextSnapshotID: assignment.execution_ref?.context_snapshot_id ?? "",
-  });
-  const valid = form.roleID.trim().length > 0;
-  return (
-    <Modal
-      title="Edit assignment"
-      onClose={onClose}
-      width={560}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onSave(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Saving…" : "Save assignment"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onSave(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Role</span>
-            <select
-              className="input"
-              autoFocus
-              value={form.roleID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, roleID: event.target.value }))
-              }
-            >
-              {roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Status</span>
-            <select
-              className="input"
-              value={form.status}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
-              }
-            >
-              {ASSIGNMENT_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Driver</span>
-          <select
-            className="input"
-            value={form.driverKind}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, driverKind: event.target.value }))
-            }
-          >
-            <option value="hecate_task">hecate_task</option>
-            <option value="external_agent">external_agent</option>
-          </select>
-        </label>
-        <ProjectRootSelect
-          inheritLabel={workItem?.root_id ? "work item root" : "work item/project root"}
-          project={project}
-          value={form.rootID}
-          onChange={(rootID) => setForm((current) => ({ ...current, rootID }))}
-        />
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Task ID</span>
-            <input
-              className="input"
-              value={form.taskID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, taskID: event.target.value }))
-              }
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Run ID</span>
-            <input
-              className="input"
-              value={form.runID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, runID: event.target.value }))
-              }
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Chat session ID</span>
-            <input
-              className="input"
-              value={form.chatSessionID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, chatSessionID: event.target.value }))
-              }
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Message ID</span>
-            <input
-              className="input"
-              value={form.messageID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, messageID: event.target.value }))
-              }
-            />
-          </label>
-        </div>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Context snapshot ID</span>
-          <input
-            className="input"
-            value={form.contextSnapshotID}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, contextSnapshotID: event.target.value }))
-            }
-          />
-        </label>
-        <div style={subtleTextStyle}>
-          Editing assignment metadata does not mutate or cancel linked task, run, or chat execution.
-        </div>
-      </form>
-    </Modal>
-  );
-}
-
-function ProjectHandoffModal({
-  assignments,
-  draft,
-  error,
-  handoff,
-  pending,
-  roles,
-  onClose,
-  onSave,
-}: {
-  assignments: ProjectAssignmentRecord[];
-  draft?: HandoffForm | null;
-  error: string;
-  handoff: ProjectHandoffRecord | null;
-  pending: boolean;
-  roles: ProjectWorkRoleRecord[];
-  onClose: () => void;
-  onSave: (form: HandoffForm) => void | Promise<void>;
-}) {
-  const [form, setForm] = useState<HandoffForm>(() => draft ?? handoffFormFromRecord(handoff));
-  const valid =
-    form.title.trim().length > 0 &&
-    form.summary.trim().length > 0 &&
-    form.recommendedNextAction.trim().length > 0;
-  return (
-    <Modal
-      title={handoff ? "Edit handoff" : "New handoff"}
-      onClose={onClose}
-      width={620}
-      footer={
-        <button
-          className="btn btn-primary"
-          type="button"
-          disabled={pending || !valid}
-          onClick={() => void onSave(form)}
-          style={{ width: "100%", justifyContent: "center" }}
-        >
-          {pending ? "Saving…" : "Save handoff"}
-        </button>
-      }
-    >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (valid) void onSave(form);
-        }}
-        style={{ display: "grid", gap: 12 }}
-      >
-        {error && <InlineError message={error} />}
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Title</span>
-          <input
-            className="input"
-            autoFocus
-            value={form.title}
-            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
-            placeholder="QA review handoff"
-          />
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Summary</span>
-          <textarea
-            className="input"
-            value={form.summary}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, summary: event.target.value }))
-            }
-            rows={4}
-            style={{ resize: "vertical", minHeight: 90 }}
-          />
-        </label>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Recommended next action</span>
-          <textarea
-            className="input"
-            value={form.recommendedNextAction}
-            onChange={(event) =>
-              setForm((current) => ({
-                ...current,
-                recommendedNextAction: event.target.value,
-              }))
-            }
-            rows={3}
-            style={{ resize: "vertical", minHeight: 76 }}
-          />
-        </label>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Source assignment</span>
-            <select
-              className="input"
-              value={form.sourceAssignmentID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, sourceAssignmentID: event.target.value }))
-              }
-            >
-              <option value="">No source assignment</option>
-              {assignments.map((assignment) => (
-                <option key={assignment.id} value={assignment.id}>
-                  {shortID(assignment.id)} · {assignment.role_id}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Target role</span>
-            <select
-              className="input"
-              value={form.targetRoleID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, targetRoleID: event.target.value }))
-              }
-            >
-              <option value="">No target role</option>
-              {roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Target assignment</span>
-            <select
-              className="input"
-              value={form.targetAssignmentID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, targetAssignmentID: event.target.value }))
-              }
-            >
-              <option value="">No target assignment</option>
-              {assignments.map((assignment) => (
-                <option key={assignment.id} value={assignment.id}>
-                  {shortID(assignment.id)} · {assignment.role_id}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Status</span>
-            <select
-              className="input"
-              value={form.status}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
-              }
-            >
-              {HANDOFF_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Source run</span>
-            <input
-              className="input"
-              value={form.sourceRunID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, sourceRunID: event.target.value }))
-              }
-              placeholder="run_..."
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Source chat</span>
-            <input
-              className="input"
-              value={form.sourceChatSessionID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, sourceChatSessionID: event.target.value }))
-              }
-              placeholder="chat_..."
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Source message</span>
-            <input
-              className="input"
-              value={form.sourceMessageID}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, sourceMessageID: event.target.value }))
-              }
-              placeholder="msg_..."
-            />
-          </label>
-        </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Artifact IDs</span>
-            <input
-              className="input"
-              value={form.linkedArtifactIDs}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, linkedArtifactIDs: event.target.value }))
-              }
-              placeholder="art_1, art_2"
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={fieldLabelStyle}>Memory IDs</span>
-            <input
-              className="input"
-              value={form.linkedMemoryIDs}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, linkedMemoryIDs: event.target.value }))
-              }
-              placeholder="mem_1"
-            />
-          </label>
-        </div>
-        <label style={fieldStyle}>
-          <span style={fieldLabelStyle}>Context refs</span>
-          <input
-            className="input"
-            value={form.contextRefs}
-            onChange={(event) =>
-              setForm((current) => ({ ...current, contextRefs: event.target.value }))
-            }
-            placeholder="ctx_1, task/run/context"
-          />
-        </label>
-      </form>
-    </Modal>
-  );
-}
-
 function AssignmentRow({
   activityItem,
   assignment,
@@ -5605,69 +4688,6 @@ function skillFormFromRecord(skill: ProjectSkillRecord): SkillForm {
   };
 }
 
-function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): HandoffForm {
-  return {
-    id: handoff?.id ?? "",
-    sourceAssignmentID: handoff?.source_assignment_id ?? "",
-    sourceRunID: handoff?.source_run_id ?? "",
-    sourceChatSessionID: handoff?.source_chat_session_id ?? "",
-    sourceMessageID: handoff?.source_message_id ?? "",
-    targetRoleID: handoff?.target_role_id ?? "",
-    targetAssignmentID: handoff?.target_assignment_id ?? "",
-    title: handoff?.title ?? "",
-    summary: handoff?.summary ?? "",
-    recommendedNextAction: handoff?.recommended_next_action ?? "",
-    linkedArtifactIDs: (handoff?.linked_artifact_ids ?? []).join(", "),
-    linkedMemoryIDs: (handoff?.linked_memory_ids ?? []).join(", "),
-    contextRefs: (handoff?.context_refs ?? []).join(", "),
-    status: handoff?.status ?? "pending",
-    provenanceKind: handoff?.provenance_kind ?? "operator",
-    trustLabel: handoff?.trust_label ?? "operator_reviewed",
-  };
-}
-
-function handoffFormFromAssignment(
-  assignment: ProjectAssignmentRecord,
-  role: ProjectWorkRoleRecord | null,
-  activityItem?: ProjectActivityItemRecord,
-): HandoffForm {
-  const execution = toProjectAssignmentExecutionViewModel(assignment);
-  const sourceChatSessionID = execution.chatSessionID;
-  const sourceRunID = execution.runID;
-  const sourceMessageID =
-    execution.messageID ||
-    activityItem?.linked_message_id ||
-    activityItem?.linked_chat?.latest_message_id ||
-    "";
-  const contextRefs = [
-    execution.contextSnapshotID,
-    execution.taskID,
-    sourceRunID,
-    sourceChatSessionID,
-    sourceMessageID,
-  ]
-    .filter(Boolean)
-    .join(", ");
-  return {
-    id: "",
-    sourceAssignmentID: assignment.id,
-    sourceRunID,
-    sourceChatSessionID,
-    sourceMessageID,
-    targetRoleID: "",
-    targetAssignmentID: "",
-    title: `${role?.name || assignment.role_id} handoff`,
-    summary: "",
-    recommendedNextAction: "",
-    linkedArtifactIDs: "",
-    linkedMemoryIDs: "",
-    contextRefs,
-    status: "pending",
-    provenanceKind: "operator",
-    trustLabel: "operator_reviewed",
-  };
-}
-
 function linkedChatStatusTitle(linkedChat: NonNullable<ProjectActivityItemRecord["linked_chat"]>) {
   return [
     linkedChat.title,
@@ -5895,10 +4915,6 @@ function formatLaunchContextBullet(label: string, value: string): string {
   return continuation ? `- ${label}: ${firstLine}\n${continuation}` : `- ${label}: ${firstLine}`;
 }
 
-function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
-  return role?.default_driver_kind || "hecate_task";
-}
-
 function projectRootDisplayLabel(project: ProjectRecord, rootID: string): string {
   const root = project.roots.find((item) => item.id === rootID);
   if (!root) return shortID(rootID);
@@ -6022,10 +5038,6 @@ function rememberRightPanelWidth(width: number) {
   } catch {
     // Best-effort preference only.
   }
-}
-
-function splitRoleIDs(value: string): string[] {
-  return splitIDs(value);
 }
 
 function assignmentLaunchReadinessNotice(

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
+import {
+  assignmentUpdatePayloadFromForm,
+  handoffFormFromAssignment,
+  handoffPayloadFromForm,
+  workItemCreatePayloadFromForm,
+} from "./projectWorkForms";
+
+describe("projectWorkForms", () => {
+  it("builds work item create payloads with trimmed optional fields", () => {
+    expect(
+      workItemCreatePayloadFromForm({
+        title: "  Build cockpit  ",
+        brief: "  Ship the UI slice  ",
+        priority: "",
+        ownerRoleID: "",
+        rootID: " root_main ",
+      }),
+    ).toEqual({
+      title: "Build cockpit",
+      brief: "Ship the UI slice",
+      status: "ready",
+      priority: "normal",
+      owner_role_id: undefined,
+      root_id: "root_main",
+    });
+  });
+
+  it("builds canonical assignment execution refs from edit form fields", () => {
+    expect(
+      assignmentUpdatePayloadFromForm({
+        id: "assign_1",
+        roleID: " developer ",
+        driverKind: "",
+        rootID: " root_main ",
+        status: "",
+        taskID: " task_1 ",
+        runID: " run_1 ",
+        chatSessionID: "",
+        messageID: "",
+        contextSnapshotID: " ctx_1 ",
+      }),
+    ).toEqual({
+      role_id: "developer",
+      root_id: "root_main",
+      driver_kind: "hecate_task",
+      status: "queued",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        context_snapshot_id: "ctx_1",
+      },
+    });
+  });
+
+  it("builds handoff payloads with split reference lists and defaults", () => {
+    expect(
+      handoffPayloadFromForm({
+        id: "handoff_1",
+        sourceAssignmentID: " assign_1 ",
+        sourceRunID: " run_1 ",
+        sourceChatSessionID: " chat_1 ",
+        sourceMessageID: " msg_1 ",
+        targetRoleID: " reviewer ",
+        targetAssignmentID: " assign_2 ",
+        title: " Review it ",
+        summary: " Summary ",
+        recommendedNextAction: " Test it ",
+        linkedArtifactIDs: " art_1, art_2 ",
+        linkedMemoryIDs: " mem_1 ",
+        contextRefs: " ctx_1, task_1 ",
+        status: "",
+        provenanceKind: "",
+        trustLabel: "",
+      }),
+    ).toEqual({
+      source_assignment_id: "assign_1",
+      source_run_id: "run_1",
+      source_chat_session_id: "chat_1",
+      source_message_id: "msg_1",
+      target_role_id: "reviewer",
+      target_assignment_id: "assign_2",
+      title: "Review it",
+      summary: "Summary",
+      recommended_next_action: "Test it",
+      linked_artifact_ids: ["art_1", "art_2"],
+      linked_memory_ids: ["mem_1"],
+      context_refs: ["ctx_1", "task_1"],
+      status: "pending",
+      provenance_kind: "operator",
+      trust_label: "operator_reviewed",
+    });
+  });
+
+  it("drafts handoff forms from assignment execution evidence", () => {
+    const assignment: ProjectAssignmentRecord = {
+      id: "assign_1234567890",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "hecate_task",
+      status: "completed",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        context_snapshot_id: "ctx_1",
+      },
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+    const activity: ProjectActivityItemRecord = {
+      id: "activity_1",
+      project_id: "proj_1",
+      work_item: {
+        id: "work_1",
+        title: "Build cockpit",
+        status: "ready",
+        priority: "normal",
+      },
+      assignment,
+      role: { id: "developer", project_id: "proj_1", name: "Developer", built_in: false },
+      status: "completed",
+      blocking_signal: "completed",
+      status_summary: "completed",
+      linked_message_id: "msg_1",
+      artifact_summary: { count: 0 },
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+
+    expect(
+      handoffFormFromAssignment(
+        assignment,
+        { id: "developer", project_id: "proj_1", name: "Developer", built_in: false },
+        activity,
+      ),
+    ).toMatchObject({
+      sourceAssignmentID: "assign_1234567890",
+      sourceRunID: "run_1",
+      sourceMessageID: "msg_1",
+      title: "Developer handoff",
+      contextRefs: "ctx_1, task_1, run_1, msg_1",
+      status: "pending",
+    });
+  });
+});

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -1,0 +1,251 @@
+import type {
+  CreateProjectHandoffPayload,
+  ProjectActivityItemRecord,
+  ProjectAssignmentExecutionRefRecord,
+  ProjectAssignmentRecord,
+  ProjectHandoffRecord,
+  ProjectWorkRoleRecord,
+  UpdateProjectAssignmentPayload,
+  UpdateProjectWorkItemPayload,
+} from "../../types/project";
+import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
+
+export type NewWorkItemForm = {
+  title: string;
+  brief: string;
+  priority: string;
+  ownerRoleID: string;
+  rootID: string;
+};
+
+export type NewAssignmentForm = {
+  roleID: string;
+  driverKind: string;
+  rootID: string;
+};
+
+export type EditWorkItemForm = NewWorkItemForm & {
+  id: string;
+  status: string;
+  reviewerRoleIDs: string;
+};
+
+export type EditAssignmentForm = NewAssignmentForm & {
+  id: string;
+  status: string;
+  taskID: string;
+  runID: string;
+  chatSessionID: string;
+  messageID: string;
+  contextSnapshotID: string;
+};
+
+export type HandoffForm = {
+  id: string;
+  sourceAssignmentID: string;
+  sourceRunID: string;
+  sourceChatSessionID: string;
+  sourceMessageID: string;
+  targetRoleID: string;
+  targetAssignmentID: string;
+  title: string;
+  summary: string;
+  recommendedNextAction: string;
+  linkedArtifactIDs: string;
+  linkedMemoryIDs: string;
+  contextRefs: string;
+  status: string;
+  provenanceKind: string;
+  trustLabel: string;
+};
+
+export const WORK_ITEM_STATUSES = [
+  "backlog",
+  "ready",
+  "running",
+  "review",
+  "blocked",
+  "done",
+  "cancelled",
+];
+export const WORK_ITEM_PRIORITIES = ["low", "normal", "high", "urgent"];
+export const ASSIGNMENT_STATUSES = [
+  "queued",
+  "running",
+  "awaiting_approval",
+  "completed",
+  "failed",
+  "cancelled",
+];
+export const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"];
+
+export function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
+  return role?.default_driver_kind || "hecate_task";
+}
+
+export function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
+  if (form.taskID.trim() || form.runID.trim()) return "task_run";
+  if (form.chatSessionID.trim() || form.messageID.trim()) return "chat_session";
+  if (form.contextSnapshotID.trim()) return "context_snapshot";
+  return "none";
+}
+
+export function projectAssignmentExecutionRefFromForm(
+  form: EditAssignmentForm,
+): ProjectAssignmentExecutionRefRecord {
+  const ref: ProjectAssignmentExecutionRefRecord = {
+    kind: projectAssignmentExecutionKindFromForm(form),
+  };
+  const taskID = form.taskID.trim();
+  const runID = form.runID.trim();
+  const chatSessionID = form.chatSessionID.trim();
+  const messageID = form.messageID.trim();
+  const contextSnapshotID = form.contextSnapshotID.trim();
+  if (taskID) ref.task_id = taskID;
+  if (runID) ref.run_id = runID;
+  if (chatSessionID) ref.chat_session_id = chatSessionID;
+  if (messageID) ref.message_id = messageID;
+  if (contextSnapshotID) ref.context_snapshot_id = contextSnapshotID;
+  return ref;
+}
+
+export function workItemCreatePayloadFromForm(form: NewWorkItemForm) {
+  const rootID = form.rootID.trim();
+  return {
+    title: form.title.trim(),
+    brief: form.brief.trim() || undefined,
+    status: "ready",
+    priority: form.priority || "normal",
+    owner_role_id: form.ownerRoleID || undefined,
+    ...(rootID ? { root_id: rootID } : {}),
+  };
+}
+
+export function workItemUpdatePayloadFromForm(
+  form: EditWorkItemForm,
+): UpdateProjectWorkItemPayload {
+  return {
+    title: form.title.trim(),
+    brief: form.brief.trim(),
+    status: form.status,
+    priority: form.priority || "normal",
+    owner_role_id: form.ownerRoleID,
+    root_id: form.rootID.trim(),
+    reviewer_role_ids: splitRoleIDs(form.reviewerRoleIDs),
+  };
+}
+
+export function assignmentCreatePayloadFromForm(form: NewAssignmentForm) {
+  const rootID = form.rootID.trim();
+  return {
+    role_id: form.roleID.trim(),
+    driver_kind: form.driverKind || "hecate_task",
+    ...(rootID ? { root_id: rootID } : {}),
+  };
+}
+
+export function assignmentUpdatePayloadFromForm(
+  form: EditAssignmentForm,
+): UpdateProjectAssignmentPayload {
+  return {
+    role_id: form.roleID.trim(),
+    root_id: form.rootID.trim(),
+    driver_kind: form.driverKind || "hecate_task",
+    status: form.status || "queued",
+    execution_ref: projectAssignmentExecutionRefFromForm(form),
+  };
+}
+
+export function handoffPayloadFromForm(form: HandoffForm): CreateProjectHandoffPayload {
+  return {
+    source_assignment_id: form.sourceAssignmentID.trim(),
+    source_run_id: form.sourceRunID.trim(),
+    source_chat_session_id: form.sourceChatSessionID.trim(),
+    source_message_id: form.sourceMessageID.trim(),
+    target_role_id: form.targetRoleID.trim(),
+    target_assignment_id: form.targetAssignmentID.trim(),
+    title: form.title.trim(),
+    summary: form.summary.trim(),
+    recommended_next_action: form.recommendedNextAction.trim(),
+    linked_artifact_ids: splitIDs(form.linkedArtifactIDs),
+    linked_memory_ids: splitIDs(form.linkedMemoryIDs),
+    context_refs: splitIDs(form.contextRefs),
+    status: form.status || "pending",
+    provenance_kind: form.provenanceKind.trim() || "operator",
+    trust_label: form.trustLabel.trim() || "operator_reviewed",
+  };
+}
+
+export function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): HandoffForm {
+  return {
+    id: handoff?.id ?? "",
+    sourceAssignmentID: handoff?.source_assignment_id ?? "",
+    sourceRunID: handoff?.source_run_id ?? "",
+    sourceChatSessionID: handoff?.source_chat_session_id ?? "",
+    sourceMessageID: handoff?.source_message_id ?? "",
+    targetRoleID: handoff?.target_role_id ?? "",
+    targetAssignmentID: handoff?.target_assignment_id ?? "",
+    title: handoff?.title ?? "",
+    summary: handoff?.summary ?? "",
+    recommendedNextAction: handoff?.recommended_next_action ?? "",
+    linkedArtifactIDs: (handoff?.linked_artifact_ids ?? []).join(", "),
+    linkedMemoryIDs: (handoff?.linked_memory_ids ?? []).join(", "),
+    contextRefs: (handoff?.context_refs ?? []).join(", "),
+    status: handoff?.status ?? "pending",
+    provenanceKind: handoff?.provenance_kind ?? "operator",
+    trustLabel: handoff?.trust_label ?? "operator_reviewed",
+  };
+}
+
+export function handoffFormFromAssignment(
+  assignment: ProjectAssignmentRecord,
+  role: ProjectWorkRoleRecord | null,
+  activityItem?: ProjectActivityItemRecord,
+): HandoffForm {
+  const execution = toProjectAssignmentExecutionViewModel(assignment);
+  const sourceChatSessionID = execution.chatSessionID;
+  const sourceRunID = execution.runID;
+  const sourceMessageID =
+    execution.messageID ||
+    activityItem?.linked_message_id ||
+    activityItem?.linked_chat?.latest_message_id ||
+    "";
+  const contextRefs = [
+    execution.contextSnapshotID,
+    execution.taskID,
+    sourceRunID,
+    sourceChatSessionID,
+    sourceMessageID,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return {
+    id: "",
+    sourceAssignmentID: assignment.id,
+    sourceRunID,
+    sourceChatSessionID,
+    sourceMessageID,
+    targetRoleID: "",
+    targetAssignmentID: "",
+    title: `${role?.name || assignment.role_id} handoff`,
+    summary: "",
+    recommendedNextAction: "",
+    linkedArtifactIDs: "",
+    linkedMemoryIDs: "",
+    contextRefs,
+    status: "pending",
+    provenanceKind: "operator",
+    trustLabel: "operator_reviewed",
+  };
+}
+
+export function splitRoleIDs(value: string): string[] {
+  return splitIDs(value);
+}
+
+export function splitIDs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/ui/src/features/projects/projectWorkModalStyles.ts
+++ b/ui/src/features/projects/projectWorkModalStyles.ts
@@ -1,0 +1,19 @@
+import type { CSSProperties } from "react";
+
+export const projectWorkFieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+export const projectWorkFieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};
+
+export const projectWorkSubtleTextStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.4,
+};


### PR DESCRIPTION
## Summary

- extract project work item, assignment, handoff, and shared root selector UI out of ProjectsView
- move project work payload/ref shaping into projectWorkForms helpers
- add focused form/helper, modal, and root-selector tests
- update UI agent guidance for the project modal seams and their expected focused tests

## Verification

- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run test
- cd ui && bun run test -- src/features/projects/projectWorkForms.test.ts src/features/projects/ProjectRootSelect.test.tsx src/features/projects/ProjectWorkItemModals.test.tsx src/features/projects/ProjectAssignmentModals.test.tsx src/features/projects/ProjectHandoffModal.test.tsx
- just agent-docs-check
- just docs-format-check
