### PR TITLE
Add project readiness repair actions

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -411,13 +411,15 @@ When the Go side adds a required prop (e.g. `streamTurnCosts`), update the `setu
   Memory / Skills are workspace tabs. Needs Attention rows should route to the
   matching operator surface: settings for setup gaps, Memory for context and
   candidates, Skills for project skill registry issues, Profiles/Roles for
-  broken references, and Work Coordination for assignment/activity issues. Work
-  with Project Assistant Bootstrap through one reviewable proposal path: UI
-  helpers may refresh guidance/skills first, but they should still call the
-  normal draft/apply flow rather than mutating setup directly. Work Coordination
-  uses one Work Queue with All / activity filters plus one selected work-item
-  card; don't split the same work state across a separate Activity Inbox, Work
-  Items list, and detail card.
+  broken references, and Work Coordination for assignment/activity issues.
+  Assignment launch preflight must keep Connections as the provider/model
+  readiness repair surface while linking project-local defaults back to Project
+  Settings, Roles, and Agent Profiles. Work with Project Assistant Bootstrap
+  through one reviewable proposal path: UI helpers may refresh guidance/skills
+  first, but they should still call the normal draft/apply flow rather than
+  mutating setup directly. Work Coordination uses one Work Queue with All /
+  activity filters plus one selected work-item card; don't split the same work
+  state across a separate Activity Inbox, Work Items list, and detail card.
   Keep the Projects index as a fixed left panel; don't add or restore a
   collapsed mini-rail until the navigation pattern is redesigned.
 - **`render1()` + `render2()` in the same `it` block** — don't. React Testing Library cleanup runs between tests, not within. Split into two `it`s if you need fresh mounts.

--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -281,9 +281,11 @@ chat or names the next repair, while the provider rows carry the full
 credential, discovery, health, routing, and model-count details. The summary can
 offer safe first-step actions such as **Add provider**, **Open provider**, or
 **Refresh providers**; deeper edits still happen in the provider detail panel.
-Chats link back to Connections rather than duplicating provider-editing
-controls, except for safe one-click repairs such as accepting a
-backend-suggested model or refreshing provider readiness.
+Chats and Projects link back to Connections rather than duplicating
+provider-editing controls, except for safe one-click repairs such as accepting a
+backend-suggested model or refreshing provider readiness. Project assignment
+preflight may also point at Project Settings, Roles, or Agent Profiles when the
+bad provider/model choice came from project-local defaults.
 
 The Chats workspace consumes the same readiness model at composition time. A
 provider can be configured and healthy while the selected model is still not

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2313,9 +2313,12 @@ copy. It is operator evidence, not injected prompt content.
 The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
 chat`, and `Start from handoff` so the operator can review the effective launch
 context before dispatch. The UI disables native assignment confirmation when
-preflight reports blocked provider/model readiness, but `POST /start` remains
-the authoritative mutation path and the task runner/gateway still performs the
-actual route checks during execution.
+preflight reports blocked provider/model readiness and offers repair actions for
+Project Settings, Roles, Agent Profiles, and Connections. Project-local actions
+repair defaults that feed assignment resolution; Connections remains the
+provider/model readiness surface. `POST /start` remains the authoritative
+mutation path and the task runner/gateway still performs the actual route
+checks during execution.
 
 Unqueued, terminal, already-linked, unsupported, misconfigured, or invalid
 assignments return the same operator-facing error classes as start would use,

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -436,7 +436,11 @@ function AuthenticatedShell({
                 />
               )}
               {activeWorkspace === "projects" && (
-                <ProjectsView onOpenChat={openChatFromProject} onOpenTask={openTaskFromProject} />
+                <ProjectsView
+                  onOpenChat={openChatFromProject}
+                  onOpenConnections={() => onSelectWorkspace("connections")}
+                  onOpenTask={openTaskFromProject}
+                />
               )}
               {activeWorkspace === "connections" && <ProvidersView />}
               {activeWorkspace === "usage" && <UsageView />}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4807,7 +4807,13 @@ describe("ProjectsView cockpit", () => {
       projects: [project],
       activeProjectID: project.id,
     });
-    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+    const onOpenConnections = vi.fn();
+    render(
+      withRuntimeConsole(<ProjectsView onOpenConnections={onOpenConnections} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
 
     await userEvent.click(await screen.findByRole("button", { name: "Start" }));
     const preflight = await screen.findByRole("dialog", {
@@ -4816,9 +4822,15 @@ describe("ProjectsView cockpit", () => {
     const notice = within(preflight).getByRole("status");
     expect(within(notice).getByText("Provider/model not ready")).toBeTruthy();
     expect(notice.textContent).toContain('No routable provider reports model "dogfood-model"');
+    expect(within(preflight).getByRole("button", { name: "Open project settings" })).toBeTruthy();
+    expect(within(preflight).getByRole("button", { name: "Manage roles" })).toBeTruthy();
+    expect(within(preflight).getByRole("button", { name: "Agent profiles" })).toBeTruthy();
+    expect(within(preflight).getByRole("button", { name: "Open Connections" })).toBeTruthy();
     const confirm = within(preflight).getByRole("button", { name: "Start assignment" });
     expect(confirm).toBeDisabled();
     expect(startProjectAssignment).not.toHaveBeenCalled();
+    await userEvent.click(within(preflight).getByRole("button", { name: "Open Connections" }));
+    expect(onOpenConnections).toHaveBeenCalledTimes(1);
   });
 
   it("renders finished-only assignment timestamps without a blank started label", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -144,6 +144,7 @@ import {
 
 type Props = {
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
+  onOpenConnections?: () => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
 };
 
@@ -177,6 +178,13 @@ type AssignmentPreflightState =
 
 type AssignmentLaunchReadinessNoticeRecord = {
   detail: string;
+};
+
+type AssignmentLaunchRepairActions = {
+  onManageProfiles?: () => void;
+  onManageRoles?: () => void;
+  onOpenConnections?: () => void;
+  onOpenProjectSettings?: () => void;
 };
 
 type MemoryForm = {
@@ -259,7 +267,7 @@ const detailStyle: CSSProperties = {
   alignContent: "start",
 };
 
-export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
+export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Props) {
   const projects = useProjects();
   const providersAndModels = useProvidersAndModels();
   const settings = useSettings();
@@ -1440,6 +1448,15 @@ export function ProjectsView({ onOpenChat, onOpenTask }: Props) {
             }}
             onNewMemory={() => setEditingMemory("new")}
             onOpenChat={onOpenChat}
+            onOpenConnections={onOpenConnections}
+            onManageProfiles={() => {
+              setProfilesError("");
+              setProfilesModalOpen(true);
+            }}
+            onManageRoles={() => {
+              setRolesError("");
+              setRolesModalOpen(true);
+            }}
             onOpenSettings={() => {
               setDefaultsError("");
               setSettingsPanelOpen(true);
@@ -1747,8 +1764,11 @@ type ProjectWorkspaceViewProps = {
   onEditHandoff: (handoff: ProjectHandoffRecord) => void;
   onEditMemory: (entry: ProjectMemoryRecord) => void;
   onEditWorkItem: (item: ProjectWorkItemRecord) => void;
+  onManageProfiles: () => void;
+  onManageRoles: () => void;
   onNewMemory: () => void;
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
+  onOpenConnections?: () => void;
   onOpenSettings: () => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onPromoteCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
@@ -1819,8 +1839,11 @@ function ProjectWorkspaceView({
   onEditHandoff,
   onEditMemory,
   onEditWorkItem,
+  onManageProfiles,
+  onManageRoles,
   onNewMemory,
   onOpenChat,
+  onOpenConnections,
   onOpenSettings,
   onOpenTask,
   onPromoteCandidate,
@@ -1964,7 +1987,11 @@ function ProjectWorkspaceView({
                         onEditAssignment={onEditAssignment}
                         onEditWorkItem={onEditWorkItem}
                         onDeleteAssignment={onDeleteAssignment}
+                        onManageProfiles={onManageProfiles}
+                        onManageRoles={onManageRoles}
                         onOpenChat={onOpenChat}
+                        onOpenConnections={onOpenConnections}
+                        onOpenSettings={onOpenSettings}
                         onStartAssignment={onStartAssignment}
                         onStartHandoff={onStartHandoff}
                         onSetHandoffStatus={onSetHandoffStatus}
@@ -3761,7 +3788,11 @@ function WorkItemDetail({
   onEditAssignment,
   onEditHandoff,
   onEditWorkItem,
+  onManageProfiles,
+  onManageRoles,
   onOpenChat,
+  onOpenConnections,
+  onOpenSettings,
   onOpenTask,
   onRefresh,
   onStartAssignment,
@@ -3794,7 +3825,11 @@ function WorkItemDetail({
   onEditAssignment: (assignment: ProjectAssignmentRecord) => void;
   onEditHandoff: (handoff: ProjectHandoffRecord) => void;
   onEditWorkItem: (item: ProjectWorkItemRecord) => void;
+  onManageProfiles: () => void;
+  onManageRoles: () => void;
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
+  onOpenConnections?: () => void;
+  onOpenSettings: () => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onRefresh: () => void;
   onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
@@ -3936,6 +3971,12 @@ function WorkItemDetail({
                     )
                   }
                   project={project}
+                  repairActions={{
+                    onManageProfiles,
+                    onManageRoles,
+                    onOpenConnections,
+                    onOpenProjectSettings: onOpenSettings,
+                  }}
                   role={roleByID.get(assignment.role_id)}
                   starting={startingAssignmentID === assignment.id}
                   loadContext={
@@ -4024,6 +4065,12 @@ function WorkItemDetail({
                     onEdit={() => onEditHandoff(handoff)}
                     onSetStatus={(status) => onSetHandoffStatus(handoff, status)}
                     onStart={() => onStartHandoff(handoff)}
+                    repairActions={{
+                      onManageProfiles,
+                      onManageRoles,
+                      onOpenConnections,
+                      onOpenProjectSettings: onOpenSettings,
+                    }}
                     role={handoff.target_role_id ? roleByID.get(handoff.target_role_id) : undefined}
                     starting={startingAssignmentID === handoff.target_assignment_id}
                     loadPreflight={
@@ -4063,6 +4110,7 @@ function AssignmentRow({
   onOpenTask,
   onStart,
   project,
+  repairActions,
   role,
   starting,
 }: {
@@ -4079,6 +4127,7 @@ function AssignmentRow({
   onOpenTask?: (taskID: string, runID?: string) => void;
   onStart: () => void;
   project: ProjectRecord | null;
+  repairActions?: AssignmentLaunchRepairActions;
   role?: ProjectWorkRoleRecord;
   starting: boolean;
 }) {
@@ -4298,6 +4347,7 @@ function AssignmentRow({
           }}
           onReload={() => void openPreflight()}
           pending={starting}
+          repairActions={repairActions}
           state={preflightState}
         />
       )}
@@ -4313,6 +4363,7 @@ function AssignmentLaunchPreflightModal({
   onConfirm,
   onReload,
   pending,
+  repairActions,
   state,
 }: {
   assignmentID: string;
@@ -4322,11 +4373,19 @@ function AssignmentLaunchPreflightModal({
   onConfirm: () => void;
   onReload: () => void;
   pending: boolean;
+  repairActions?: AssignmentLaunchRepairActions;
   state: AssignmentPreflightState;
 }) {
   const ready = state.status === "ready";
   const readinessNotice = ready ? assignmentLaunchReadinessNotice(state.packet) : null;
   const canConfirm = ready && !readinessNotice;
+  const runRepairAction = useCallback(
+    (action?: () => void) => {
+      onClose();
+      action?.();
+    },
+    [onClose],
+  );
   return (
     <Modal
       title={`Assignment ${assignmentID} launch preflight`}
@@ -4369,7 +4428,13 @@ function AssignmentLaunchPreflightModal({
         {state.status === "error" ? <InlineError message={state.detail} /> : null}
         {ready ? (
           <div style={{ display: "grid", gap: 12 }}>
-            {readinessNotice && <AssignmentLaunchReadinessNotice notice={readinessNotice} />}
+            {readinessNotice && (
+              <AssignmentLaunchReadinessNotice
+                notice={readinessNotice}
+                onRepairAction={runRepairAction}
+                repairActions={repairActions}
+              />
+            )}
             <ContextInspectorPanel
               packet={state.packet}
               emptyDetail="No launch context metadata returned."
@@ -4383,12 +4448,25 @@ function AssignmentLaunchPreflightModal({
 
 function AssignmentLaunchReadinessNotice({
   notice,
+  onRepairAction,
+  repairActions,
 }: {
   notice: AssignmentLaunchReadinessNoticeRecord;
+  onRepairAction: (action?: () => void) => void;
+  repairActions?: AssignmentLaunchRepairActions;
 }) {
+  const actions = [
+    {
+      key: "project-settings",
+      label: "Open project settings",
+      onClick: repairActions?.onOpenProjectSettings,
+    },
+    { key: "roles", label: "Manage roles", onClick: repairActions?.onManageRoles },
+    { key: "profiles", label: "Agent profiles", onClick: repairActions?.onManageProfiles },
+    { key: "connections", label: "Open Connections", onClick: repairActions?.onOpenConnections },
+  ].filter((action) => action.onClick);
   return (
     <div
-      role="status"
       style={{
         background: "var(--amber-bg)",
         border: "1px solid var(--amber-border)",
@@ -4398,21 +4476,37 @@ function AssignmentLaunchReadinessNotice({
         padding: "10px 12px",
       }}
     >
-      <div
-        style={{
-          alignItems: "center",
-          color: "var(--amber)",
-          display: "flex",
-          fontWeight: 600,
-          gap: 8,
-        }}
-      >
-        <Icon d={Icons.warning} size={13} />
-        Provider/model not ready
+      <div role="status" style={{ display: "grid", gap: 6 }}>
+        <div
+          style={{
+            alignItems: "center",
+            color: "var(--amber)",
+            display: "flex",
+            fontWeight: 600,
+            gap: 8,
+          }}
+        >
+          <Icon d={Icons.warning} size={13} />
+          Provider/model not ready
+        </div>
+        <div style={{ color: "var(--amber-lo)", fontSize: 12, lineHeight: 1.45 }}>
+          {notice.detail}
+        </div>
       </div>
-      <div style={{ color: "var(--amber-lo)", fontSize: 12, lineHeight: 1.45 }}>
-        {notice.detail}
-      </div>
+      {actions.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 2 }}>
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              className="btn btn-ghost btn-sm"
+              type="button"
+              onClick={() => onRepairAction(action.onClick)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -4427,6 +4521,7 @@ function ProjectHandoffRow({
   onEdit,
   onSetStatus,
   onStart,
+  repairActions,
   role,
   starting,
 }: {
@@ -4439,6 +4534,7 @@ function ProjectHandoffRow({
   onEdit: () => void;
   onSetStatus: (status: string) => void;
   onStart: () => void;
+  repairActions?: AssignmentLaunchRepairActions;
   role?: ProjectWorkRoleRecord;
   starting: boolean;
 }) {
@@ -4586,6 +4682,7 @@ function ProjectHandoffRow({
           }}
           onReload={() => void openPreflight()}
           pending={starting}
+          repairActions={repairActions}
           state={preflightState}
         />
       )}


### PR DESCRIPTION
## Summary

- Add repair actions to blocked project assignment launch preflight for Project settings, Roles, Agent profiles, and Connections.
- Wire Projects to the shell workspace navigation so blocked provider/model readiness can jump to Connections.
- Update runtime, operator, and UI agent guidance docs for the readiness repair flow.

## Validation

- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test -- src/app/AppShell.test.tsx`
- `cd ui && bun run typecheck`
- `just agent-docs-check`
- `git diff --check`