### PR TITLE
refactor(ui): share project utility helpers

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -183,7 +183,9 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   in `projectWorkForms.ts`; keep project state loading and mutations in the
   parent page. Changes to these extracted modal seams need focused tests for the
   component and shared form helpers, plus parent-page tests only when loading or
-  mutation orchestration changes.
+  mutation orchestration changes. Shared project UI string/id helpers live in
+  `projectUtils.ts`; status option lists and form-safe status normalization live
+  in `projectWorkForms.ts`.
 - External Agent readiness belongs in Connections and in the picker
   diagnostics: distinguish missing binaries, auth/billing problems, unsupported
   versions, and managed-launcher issues without sending users to raw logs first.

--- a/ui/src/features/projects/ProjectAssignmentModals.tsx
+++ b/ui/src/features/projects/ProjectAssignmentModals.tsx
@@ -10,6 +10,7 @@ import { InlineError, Modal } from "../shared/ui";
 import { ProjectRootSelect } from "./ProjectRootSelect";
 import {
   ASSIGNMENT_STATUSES,
+  assignmentStatusFromValue,
   defaultDriverForRole,
   type EditAssignmentForm,
   type NewAssignmentForm,
@@ -149,7 +150,7 @@ export function EditAssignmentModal({
     roleID: assignment.role_id,
     driverKind: assignment.driver_kind || "hecate_task",
     rootID: assignment.root_id ?? "",
-    status: assignment.status || "queued",
+    status: assignmentStatusFromValue(assignment.status),
     taskID: assignment.execution_ref?.task_id ?? "",
     runID: assignment.execution_ref?.run_id ?? "",
     chatSessionID: assignment.execution_ref?.chat_session_id ?? "",
@@ -206,7 +207,10 @@ export function EditAssignmentModal({
               className="input"
               value={form.status}
               onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
+                setForm((current) => ({
+                  ...current,
+                  status: assignmentStatusFromValue(event.target.value),
+                }))
               }
             >
               {ASSIGNMENT_STATUSES.map((status) => (

--- a/ui/src/features/projects/ProjectHandoffModal.tsx
+++ b/ui/src/features/projects/ProjectHandoffModal.tsx
@@ -6,8 +6,14 @@ import type {
   ProjectWorkRoleRecord,
 } from "../../types/project";
 import { InlineError, Modal } from "../shared/ui";
-import { HANDOFF_STATUSES, handoffFormFromRecord, type HandoffForm } from "./projectWorkForms";
+import {
+  HANDOFF_STATUSES,
+  handoffFormFromRecord,
+  handoffStatusFromValue,
+  type HandoffForm,
+} from "./projectWorkForms";
 import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+import { shortID } from "./projectUtils";
 
 type ProjectHandoffModalProps = {
   assignments: ProjectAssignmentRecord[];
@@ -155,7 +161,10 @@ export function ProjectHandoffModal({
               className="input"
               value={form.status}
               onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
+                setForm((current) => ({
+                  ...current,
+                  status: handoffStatusFromValue(event.target.value),
+                }))
               }
             >
               {HANDOFF_STATUSES.map((status) => (
@@ -239,9 +248,4 @@ export function ProjectHandoffModal({
       </form>
     </Modal>
   );
-}
-
-function shortID(id: string): string {
-  if (id.length <= 12) return id;
-  return id.slice(0, 10) + "...";
 }

--- a/ui/src/features/projects/ProjectSkillPicker.tsx
+++ b/ui/src/features/projects/ProjectSkillPicker.tsx
@@ -3,7 +3,6 @@ import {
   projectSkillBadgeClass,
   projectSkillSelectionWarnings,
   sortProjectSkillsForPicker,
-  splitIDs,
   uniqueSkillIDs,
 } from "./projectProfilesRoles";
 import {
@@ -12,6 +11,7 @@ import {
   profileRoleSubtleTextStyle,
   profileRoleTitleStyle,
 } from "./projectProfileRoleStyles";
+import { splitIDs } from "./projectUtils";
 
 type ProjectSkillPickerProps = {
   disabled?: boolean;

--- a/ui/src/features/projects/ProjectWorkItemModals.tsx
+++ b/ui/src/features/projects/ProjectWorkItemModals.tsx
@@ -12,6 +12,8 @@ import {
   WORK_ITEM_STATUSES,
   type EditWorkItemForm,
   type NewWorkItemForm,
+  workItemPriorityFromValue,
+  workItemStatusFromValue,
 } from "./projectWorkForms";
 import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
 
@@ -93,7 +95,10 @@ export function NewWorkItemModal({
               className="input"
               value={form.priority}
               onChange={(event) =>
-                setForm((current) => ({ ...current, priority: event.target.value }))
+                setForm((current) => ({
+                  ...current,
+                  priority: workItemPriorityFromValue(event.target.value),
+                }))
               }
             >
               <option value="low">low</option>
@@ -154,8 +159,8 @@ export function EditWorkItemModal({
     id: item.id,
     title: item.title,
     brief: item.brief ?? "",
-    status: item.status,
-    priority: item.priority || "normal",
+    status: workItemStatusFromValue(item.status),
+    priority: workItemPriorityFromValue(item.priority),
     ownerRoleID: item.owner_role_id ?? "",
     rootID: item.root_id ?? "",
     reviewerRoleIDs: (item.reviewer_role_ids ?? []).join(", "),
@@ -212,7 +217,10 @@ export function EditWorkItemModal({
               className="input"
               value={form.status}
               onChange={(event) =>
-                setForm((current) => ({ ...current, status: event.target.value }))
+                setForm((current) => ({
+                  ...current,
+                  status: workItemStatusFromValue(event.target.value),
+                }))
               }
             >
               {WORK_ITEM_STATUSES.map((status) => (
@@ -228,7 +236,10 @@ export function EditWorkItemModal({
               className="input"
               value={form.priority}
               onChange={(event) =>
-                setForm((current) => ({ ...current, priority: event.target.value }))
+                setForm((current) => ({
+                  ...current,
+                  priority: workItemPriorityFromValue(event.target.value),
+                }))
               }
             >
               {WORK_ITEM_PRIORITIES.map((priority) => (

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -141,6 +141,7 @@ import {
   workItemCreatePayloadFromForm,
   workItemUpdatePayloadFromForm,
 } from "./projectWorkForms";
+import { firstNonEmpty, shortID } from "./projectUtils";
 
 type Props = {
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
@@ -4980,14 +4981,6 @@ function projectAssignmentLaunchDraft({
   return lines.join("\n");
 }
 
-function firstNonEmpty(...values: Array<string | undefined | null>): string {
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed) return trimmed;
-  }
-  return "";
-}
-
 function labelWithID(label: string | undefined, id: string): string {
   const cleanLabel = label?.trim();
   const cleanID = id.trim();
@@ -5024,11 +5017,6 @@ function projectRootTitle(project: ProjectRecord, rootID: string): string {
   const root = project.roots.find((item) => item.id === rootID);
   if (!root) return rootID;
   return projectRootOptionLabel(root);
-}
-
-function shortID(id: string): string {
-  if (id.length <= 12) return id;
-  return id.slice(0, 10) + "...";
 }
 
 function upsertRole(items: ProjectWorkRoleRecord[], item: ProjectWorkRoleRecord) {

--- a/ui/src/features/projects/projectAssignmentViewModels.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.ts
@@ -1,4 +1,5 @@
 import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
+import { firstNonEmpty } from "./projectUtils";
 
 export type ProjectAssignmentExecutionKind =
   | "task_run"
@@ -204,12 +205,4 @@ function addEvidenceWarning(warnings: string[], value: string) {
   const trimmed = value.trim();
   if (!trimmed || warnings.includes(trimmed)) return;
   warnings.push(trimmed);
-}
-
-function firstNonEmpty(...values: Array<string | undefined | null>): string {
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed) return trimmed;
-  }
-  return "";
 }

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -18,6 +18,7 @@ import {
   toProjectActivityItemViewModel,
   toProjectAssignmentExecutionViewModel,
 } from "./projectAssignmentViewModels";
+import { firstNonEmpty } from "./projectUtils";
 
 export type ProjectActivityBucketKey = "all" | "active" | "blocked" | "completed" | "recent";
 
@@ -754,12 +755,4 @@ function activityAttention(
     chatID: execution.chatSessionID,
     actionLabel,
   };
-}
-
-function firstNonEmpty(...values: Array<string | undefined | null>): string {
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed) return trimmed;
-  }
-  return "";
 }

--- a/ui/src/features/projects/projectProfilesRoles.ts
+++ b/ui/src/features/projects/projectProfilesRoles.ts
@@ -4,6 +4,7 @@ import type {
   UpdateAgentProfilePayload,
 } from "../../types/agent-profile";
 import type { ProjectRecord, ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
+import { splitIDs } from "./projectUtils";
 
 export type AgentProfileForm = {
   id: string;
@@ -211,13 +212,6 @@ export function projectSkillStatusRank(status: string): number {
     default:
       return 4;
   }
-}
-
-export function splitIDs(value: string): string[] {
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
 }
 
 export function uniqueSkillIDs(ids: string[]): string[] {

--- a/ui/src/features/projects/projectUtils.test.ts
+++ b/ui/src/features/projects/projectUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { firstNonEmpty, shortID, splitIDs, splitRoleIDs } from "./projectUtils";
+
+describe("projectUtils", () => {
+  it("splits comma-separated ids and drops empty entries", () => {
+    expect(splitIDs(" role_a, , role_b ,, role_c ")).toEqual(["role_a", "role_b", "role_c"]);
+    expect(splitRoleIDs(" reviewer, architect ")).toEqual(["reviewer", "architect"]);
+  });
+
+  it("shortens long ids without changing compact ids", () => {
+    expect(shortID("assign_123")).toBe("assign_123");
+    expect(shortID("assign_1234567890")).toBe("assign_123...");
+  });
+
+  it("returns the first non-empty trimmed string", () => {
+    expect(firstNonEmpty(undefined, "   ", null, " value ", "later")).toBe("value");
+    expect(firstNonEmpty(undefined, "", null)).toBe("");
+  });
+});

--- a/ui/src/features/projects/projectUtils.ts
+++ b/ui/src/features/projects/projectUtils.ts
@@ -1,0 +1,23 @@
+export function splitIDs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function splitRoleIDs(value: string): string[] {
+  return splitIDs(value);
+}
+
+export function shortID(id: string): string {
+  if (id.length <= 12) return id;
+  return id.slice(0, 10) + "...";
+}
+
+export function firstNonEmpty(...values: Array<string | undefined | null>): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return "";
+}

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
 import {
+  assignmentStatusFromValue,
   assignmentUpdatePayloadFromForm,
   handoffFormFromAssignment,
   handoffPayloadFromForm,
+  handoffStatusFromValue,
   workItemCreatePayloadFromForm,
+  workItemPriorityFromValue,
+  workItemStatusFromValue,
 } from "./projectWorkForms";
 
 describe("projectWorkForms", () => {
@@ -14,7 +18,7 @@ describe("projectWorkForms", () => {
       workItemCreatePayloadFromForm({
         title: "  Build cockpit  ",
         brief: "  Ship the UI slice  ",
-        priority: "",
+        priority: "normal",
         ownerRoleID: "",
         rootID: " root_main ",
       }),
@@ -35,7 +39,7 @@ describe("projectWorkForms", () => {
         roleID: " developer ",
         driverKind: "",
         rootID: " root_main ",
-        status: "",
+        status: "queued",
         taskID: " task_1 ",
         runID: " run_1 ",
         chatSessionID: "",
@@ -72,7 +76,7 @@ describe("projectWorkForms", () => {
         linkedArtifactIDs: " art_1, art_2 ",
         linkedMemoryIDs: " mem_1 ",
         contextRefs: " ctx_1, task_1 ",
-        status: "",
+        status: "pending",
         provenanceKind: "",
         trustLabel: "",
       }),
@@ -93,6 +97,17 @@ describe("projectWorkForms", () => {
       provenance_kind: "operator",
       trust_label: "operator_reviewed",
     });
+  });
+
+  it("normalizes backend status and priority strings into form-safe options", () => {
+    expect(workItemStatusFromValue(" review ")).toBe("review");
+    expect(workItemStatusFromValue("unknown")).toBe("ready");
+    expect(workItemPriorityFromValue("urgent")).toBe("urgent");
+    expect(workItemPriorityFromValue("unknown")).toBe("normal");
+    expect(assignmentStatusFromValue("awaiting_approval")).toBe("awaiting_approval");
+    expect(assignmentStatusFromValue("paused")).toBe("queued");
+    expect(handoffStatusFromValue("accepted")).toBe("accepted");
+    expect(handoffStatusFromValue("unknown")).toBe("pending");
   });
 
   it("drafts handoff forms from assignment execution evidence", () => {

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -9,11 +9,39 @@ import type {
   UpdateProjectWorkItemPayload,
 } from "../../types/project";
 import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
+import { splitIDs, splitRoleIDs } from "./projectUtils";
+
+export const WORK_ITEM_STATUSES = [
+  "backlog",
+  "ready",
+  "running",
+  "review",
+  "blocked",
+  "done",
+  "cancelled",
+] as const;
+export type WorkItemStatus = (typeof WORK_ITEM_STATUSES)[number];
+
+export const WORK_ITEM_PRIORITIES = ["low", "normal", "high", "urgent"] as const;
+export type WorkItemPriority = (typeof WORK_ITEM_PRIORITIES)[number];
+
+export const ASSIGNMENT_STATUSES = [
+  "queued",
+  "running",
+  "awaiting_approval",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+export type AssignmentStatus = (typeof ASSIGNMENT_STATUSES)[number];
+
+export const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"] as const;
+export type HandoffStatus = (typeof HANDOFF_STATUSES)[number];
 
 export type NewWorkItemForm = {
   title: string;
   brief: string;
-  priority: string;
+  priority: WorkItemPriority;
   ownerRoleID: string;
   rootID: string;
 };
@@ -26,13 +54,13 @@ export type NewAssignmentForm = {
 
 export type EditWorkItemForm = NewWorkItemForm & {
   id: string;
-  status: string;
+  status: WorkItemStatus;
   reviewerRoleIDs: string;
 };
 
 export type EditAssignmentForm = NewAssignmentForm & {
   id: string;
-  status: string;
+  status: AssignmentStatus;
   taskID: string;
   runID: string;
   chatSessionID: string;
@@ -54,33 +82,29 @@ export type HandoffForm = {
   linkedArtifactIDs: string;
   linkedMemoryIDs: string;
   contextRefs: string;
-  status: string;
+  status: HandoffStatus;
   provenanceKind: string;
   trustLabel: string;
 };
 
-export const WORK_ITEM_STATUSES = [
-  "backlog",
-  "ready",
-  "running",
-  "review",
-  "blocked",
-  "done",
-  "cancelled",
-];
-export const WORK_ITEM_PRIORITIES = ["low", "normal", "high", "urgent"];
-export const ASSIGNMENT_STATUSES = [
-  "queued",
-  "running",
-  "awaiting_approval",
-  "completed",
-  "failed",
-  "cancelled",
-];
-export const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"];
-
 export function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
   return role?.default_driver_kind || "hecate_task";
+}
+
+export function workItemStatusFromValue(value: string | undefined | null): WorkItemStatus {
+  return choiceFromValue(WORK_ITEM_STATUSES, value, "ready");
+}
+
+export function workItemPriorityFromValue(value: string | undefined | null): WorkItemPriority {
+  return choiceFromValue(WORK_ITEM_PRIORITIES, value, "normal");
+}
+
+export function assignmentStatusFromValue(value: string | undefined | null): AssignmentStatus {
+  return choiceFromValue(ASSIGNMENT_STATUSES, value, "queued");
+}
+
+export function handoffStatusFromValue(value: string | undefined | null): HandoffStatus {
+  return choiceFromValue(HANDOFF_STATUSES, value, "pending");
 }
 
 export function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
@@ -115,7 +139,7 @@ export function workItemCreatePayloadFromForm(form: NewWorkItemForm) {
     title: form.title.trim(),
     brief: form.brief.trim() || undefined,
     status: "ready",
-    priority: form.priority || "normal",
+    priority: form.priority,
     owner_role_id: form.ownerRoleID || undefined,
     ...(rootID ? { root_id: rootID } : {}),
   };
@@ -128,7 +152,7 @@ export function workItemUpdatePayloadFromForm(
     title: form.title.trim(),
     brief: form.brief.trim(),
     status: form.status,
-    priority: form.priority || "normal",
+    priority: form.priority,
     owner_role_id: form.ownerRoleID,
     root_id: form.rootID.trim(),
     reviewer_role_ids: splitRoleIDs(form.reviewerRoleIDs),
@@ -151,7 +175,7 @@ export function assignmentUpdatePayloadFromForm(
     role_id: form.roleID.trim(),
     root_id: form.rootID.trim(),
     driver_kind: form.driverKind || "hecate_task",
-    status: form.status || "queued",
+    status: form.status,
     execution_ref: projectAssignmentExecutionRefFromForm(form),
   };
 }
@@ -170,7 +194,7 @@ export function handoffPayloadFromForm(form: HandoffForm): CreateProjectHandoffP
     linked_artifact_ids: splitIDs(form.linkedArtifactIDs),
     linked_memory_ids: splitIDs(form.linkedMemoryIDs),
     context_refs: splitIDs(form.contextRefs),
-    status: form.status || "pending",
+    status: form.status,
     provenance_kind: form.provenanceKind.trim() || "operator",
     trust_label: form.trustLabel.trim() || "operator_reviewed",
   };
@@ -191,7 +215,7 @@ export function handoffFormFromRecord(handoff: ProjectHandoffRecord | null): Han
     linkedArtifactIDs: (handoff?.linked_artifact_ids ?? []).join(", "),
     linkedMemoryIDs: (handoff?.linked_memory_ids ?? []).join(", "),
     contextRefs: (handoff?.context_refs ?? []).join(", "),
-    status: handoff?.status ?? "pending",
+    status: handoffStatusFromValue(handoff?.status),
     provenanceKind: handoff?.provenance_kind ?? "operator",
     trustLabel: handoff?.trust_label ?? "operator_reviewed",
   };
@@ -239,13 +263,13 @@ export function handoffFormFromAssignment(
   };
 }
 
-export function splitRoleIDs(value: string): string[] {
-  return splitIDs(value);
-}
-
-export function splitIDs(value: string): string[] {
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
+function choiceFromValue<T extends readonly string[]>(
+  values: T,
+  value: string | undefined | null,
+  fallback: T[number],
+): T[number] {
+  const candidate = value?.trim();
+  return candidate && (values as readonly string[]).includes(candidate)
+    ? (candidate as T[number])
+    : fallback;
 }


### PR DESCRIPTION
## Summary

- add shared project UI utilities for id splitting, short ids, and first non-empty text selection
- replace duplicated project helper implementations across project forms, view models, insights, and the main Projects view
- make project work/assignment/handoff status options const-asserted and normalize backend strings at modal/form boundaries
- add focused utility and status-normalization tests; update UI agent guidance for the new seam

## Verification

- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run test -- src/features/projects/projectUtils.test.ts src/features/projects/projectWorkForms.test.ts src/features/projects/ProjectWorkItemModals.test.tsx src/features/projects/ProjectAssignmentModals.test.tsx src/features/projects/ProjectHandoffModal.test.tsx src/features/projects/projectAssignmentViewModels.test.ts src/features/projects/projectInsights.test.ts
- cd ui && bun run test
- just agent-docs-check
- just docs-format-check
