### PR TITLE
feat(projects): expose project work linkage on task runs

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -154,6 +154,10 @@ eligible. `exclude` means the runner skips that compatibility layer for the
 task; native project assignments set this so profile context-source policy
 controls any workspace-instruction body inclusion.
 
+Task responses also include `work_item_id` and `assignment_id` when a
+project-work assignment created the task. These fields are inspection links only
+and do not replace the task's generic `origin_kind` / `origin_id` fields.
+
 `execution_profile` applies task-create defaults:
 
 | Profile        | Defaults                                                                                                                                                              |
@@ -165,6 +169,9 @@ controls any workspace-instruction body inclusion.
 
 `task_run` carries the cost figures the operator UI surfaces:
 
+- `project_id` / `work_item_id` / `assignment_id` — project-work inspection
+  links when Hecate can derive them from the parent task or the run context
+  packet refs.
 - `total_cost_micros_usd` — this run's LLM spend (after routing).
 - `prior_cost_micros_usd` — cumulative spend of every prior run in this run's resume chain. Cumulative-across-task = `prior + total`.
 - `model` / `provider` / `provider_kind` — what was actually used (after routing). May differ from the task's `requested_*` when the operator picked auto. Agent-loop runs preserve these fields for both streaming and non-streaming model turns.
@@ -2339,6 +2346,9 @@ For `driver_kind="hecate_task"`, starting verifies that the project, work item,
 assignment, and role exist, then
 creates a normal Task with `execution_kind="agent_loop"`,
 `origin_kind="project_work_item"`, and `origin_id` set to the work item ID. The
+task response also exposes `work_item_id` and `assignment_id` for direct
+inspection, and the created run response exposes `project_id`, `work_item_id`,
+and `assignment_id` from the parent task and stored context packet refs. The
 task title, prompt, and system prompt are composed from a visible launch-context
 block covering project, work item, assignment, role, execution hints, role
 defaults, project defaults, and any profile-activated prompt context. Project

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -628,6 +628,18 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	if task.ExecutionKind != "agent_loop" || task.OriginKind != "project_work_item" || task.OriginID != "work_start" {
 		t.Fatalf("task execution/origin = %q %q/%q, want agent_loop project_work_item/work_start", task.ExecutionKind, task.OriginKind, task.OriginID)
 	}
+	if task.ProjectID != "proj_start" || task.WorkItemID != "work_start" || task.AssignmentID != "asgn_start" {
+		t.Fatalf("task project linkage = project %q work %q assignment %q, want proj_start/work_start/asgn_start", task.ProjectID, task.WorkItemID, task.AssignmentID)
+	}
+	client := newAPITestClient(t, server)
+	taskResp := mustRequestJSON[TaskResponse](client, http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID, "")
+	if taskResp.Data.ProjectID != "proj_start" || taskResp.Data.WorkItemID != "work_start" || taskResp.Data.AssignmentID != "asgn_start" {
+		t.Fatalf("task response linkage = project %q work %q assignment %q, want proj_start/work_start/asgn_start", taskResp.Data.ProjectID, taskResp.Data.WorkItemID, taskResp.Data.AssignmentID)
+	}
+	runResp := mustRequestJSON[TaskRunResponse](client, http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID, "")
+	if runResp.Data.ProjectID != "proj_start" || runResp.Data.WorkItemID != "work_start" || runResp.Data.AssignmentID != "asgn_start" {
+		t.Fatalf("run response linkage = project %q work %q assignment %q, want proj_start/work_start/asgn_start", runResp.Data.ProjectID, runResp.Data.WorkItemID, runResp.Data.AssignmentID)
+	}
 	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "implementation" {
 		t.Fatalf("task provider/model/profile = %q/%q/%q, want role defaults", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
 	}

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/taskapp"
 	"github.com/hecatehq/hecate/internal/taskstate"
@@ -246,7 +247,7 @@ func (h *Handler) HandleStartTask(w http.ResponseWriter, r *http.Request) {
 	}
 	WriteJSON(w, http.StatusOK, TaskRunResponse{
 		Object: "task_run",
-		Data:   renderTaskRun(result.Run),
+		Data:   renderTaskRun(result.Run, result.Task),
 	})
 }
 
@@ -273,7 +274,7 @@ func (h *Handler) HandleTaskRuns(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]TaskRunItem, 0, len(runs))
 	for _, run := range runs {
-		items = append(items, renderTaskRun(run))
+		items = append(items, renderTaskRun(run, task))
 	}
 	WriteJSON(w, http.StatusOK, TaskRunsResponse{
 		Object: "task_runs",
@@ -298,7 +299,7 @@ func (h *Handler) HandleTaskRun(w http.ResponseWriter, r *http.Request) {
 
 	WriteJSON(w, http.StatusOK, TaskRunResponse{
 		Object: "task_run",
-		Data:   renderTaskRun(run),
+		Data:   renderTaskRun(run, task),
 	})
 }
 
@@ -598,6 +599,8 @@ func renderTaskItem(task types.Task) TaskItem {
 		Title:                       task.Title,
 		Prompt:                      task.Prompt,
 		ProjectID:                   task.ProjectID,
+		WorkItemID:                  task.WorkItemID,
+		AssignmentID:                task.AssignmentID,
 		SystemPrompt:                task.SystemPrompt,
 		WorkspaceSystemPromptPolicy: task.WorkspaceSystemPromptPolicy,
 		ExecutionProfile:            task.ExecutionProfile,
@@ -714,7 +717,7 @@ func loadTaskItemCounts(ctx context.Context, store taskstate.Store, taskID strin
 	return counts
 }
 
-func renderTaskRun(run types.TaskRun) TaskRunItem {
+func renderTaskRun(run types.TaskRun, parentTasks ...types.Task) TaskRunItem {
 	item := TaskRunItem{
 		ID:                 run.ID,
 		TaskID:             run.TaskID,
@@ -737,6 +740,18 @@ func renderTaskRun(run types.TaskRun) TaskRunItem {
 		RootSpanID:         run.RootSpanID,
 		OtelStatusCode:     run.OtelStatusCode,
 		OtelStatusMessage:  run.OtelStatusMessage,
+	}
+	if len(parentTasks) > 0 {
+		task := parentTasks[0]
+		item.ProjectID = task.ProjectID
+		item.WorkItemID = task.WorkItemID
+		item.AssignmentID = task.AssignmentID
+	}
+	if packet, ok, err := chatcontext.FromTaskRun(run); err == nil && ok && packet.Refs != nil {
+		refs := chatcontext.Refs(*packet.Refs)
+		item.ProjectID = firstNonEmptyString(refs.ProjectID, item.ProjectID)
+		item.WorkItemID = firstNonEmptyString(refs.WorkItemID, item.WorkItemID)
+		item.AssignmentID = firstNonEmptyString(refs.AssignmentID, item.AssignmentID)
 	}
 	if !run.StartedAt.IsZero() {
 		item.StartedAt = run.StartedAt.UTC().Format(time.RFC3339Nano)

--- a/internal/api/handler_tasks_lifecycle.go
+++ b/internal/api/handler_tasks_lifecycle.go
@@ -171,7 +171,7 @@ func (h *Handler) HandleCancelTaskRun(w http.ResponseWriter, r *http.Request) {
 	}
 	WriteJSON(w, http.StatusOK, TaskRunResponse{
 		Object: "task_run",
-		Data:   renderTaskRun(run),
+		Data:   renderTaskRun(run, task),
 	})
 }
 
@@ -193,7 +193,7 @@ func (h *Handler) HandleRetryTaskRun(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
+	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run, result.Task)})
 }
 
 func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +221,7 @@ func (h *Handler) HandleResumeTaskRun(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
+	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run, result.Task)})
 }
 
 func (h *Handler) HandleContinueTaskRun(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +258,7 @@ func (h *Handler) HandleContinueTaskRun(w http.ResponseWriter, r *http.Request) 
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, msg)
 		return
 	}
-	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
+	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run, result.Task)})
 }
 
 // HandleRetryTaskRunFromTurn re-runs an agent_loop run from turn N,
@@ -303,5 +303,5 @@ func (h *Handler) HandleRetryTaskRunFromTurn(w http.ResponseWriter, r *http.Requ
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, msg)
 		return
 	}
-	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run)})
+	WriteJSON(w, http.StatusOK, TaskRunResponse{Object: "task_run", Data: renderTaskRun(result.Run, result.Task)})
 }

--- a/internal/api/handler_tasks_render_test.go
+++ b/internal/api/handler_tasks_render_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestRenderTaskRunUsesParentTaskProjectLinkage(t *testing.T) {
+	t.Parallel()
+
+	item := renderTaskRun(types.TaskRun{
+		ID:     "run_1",
+		TaskID: "task_1",
+		Status: "running",
+	}, types.Task{
+		ID:           "task_1",
+		ProjectID:    "proj_1",
+		WorkItemID:   "work_1",
+		AssignmentID: "asgn_1",
+	})
+	if item.ProjectID != "proj_1" || item.WorkItemID != "work_1" || item.AssignmentID != "asgn_1" {
+		t.Fatalf("run linkage = project %q work %q assignment %q, want proj_1/work_1/asgn_1", item.ProjectID, item.WorkItemID, item.AssignmentID)
+	}
+}

--- a/internal/api/task_run_stream_projector.go
+++ b/internal/api/task_run_stream_projector.go
@@ -49,6 +49,10 @@ func (p taskRunStreamProjector) terminalLiveState(ctx context.Context, taskID, r
 }
 
 func (p taskRunStreamProjector) liveState(ctx context.Context, taskID, runID string) (TaskRunStreamEventData, error) {
+	task, taskFound, err := p.store.GetTask(ctx, taskID)
+	if err != nil {
+		return TaskRunStreamEventData{}, err
+	}
 	run, found, err := p.store.GetRun(ctx, taskID, runID)
 	if err != nil {
 		return TaskRunStreamEventData{}, err
@@ -89,8 +93,12 @@ func (p taskRunStreamProjector) liveState(ctx context.Context, taskID, runID str
 		approvalItems = append(approvalItems, renderTaskApproval(approval))
 	}
 	activityItems := buildTaskActivityItems(stepItems, artifactItems, approvalItems, run)
+	runItem := renderTaskRun(run)
+	if taskFound {
+		runItem = renderTaskRun(run, task)
+	}
 	return TaskRunStreamEventData{
-		Run:       renderTaskRun(run),
+		Run:       runItem,
 		Steps:     stepItems,
 		Artifacts: artifactItems,
 		Activity:  activityItems,

--- a/internal/api/task_run_stream_projector_test.go
+++ b/internal/api/task_run_stream_projector_test.go
@@ -49,6 +49,48 @@ func TestTaskRunStreamProjector_TurnCompletedMergesOverlayWithLiveState(t *testi
 	}
 }
 
+func TestTaskRunStreamProjector_LiveStateUsesParentTaskProjectLinkage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	now := time.Now().UTC()
+	if _, err := store.CreateTask(ctx, types.Task{
+		ID:           "task-project",
+		Title:        "task-project",
+		Prompt:       "projector test",
+		Status:       "running",
+		ProjectID:    "proj_1",
+		WorkItemID:   "work_1",
+		AssignmentID: "asgn_1",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := store.CreateRun(ctx, types.TaskRun{
+		ID:        "run-project",
+		TaskID:    "task-project",
+		Number:    1,
+		Status:    "running",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	projector := newTaskRunStreamProjector(store)
+
+	state, err := projector.projectEvent(ctx, "task-project", "run-project", types.TaskRunEvent{
+		Sequence:  8,
+		EventType: "run.updated",
+	})
+	if err != nil {
+		t.Fatalf("projectEvent() error = %v", err)
+	}
+	if state.Run.ProjectID != "proj_1" || state.Run.WorkItemID != "work_1" || state.Run.AssignmentID != "asgn_1" {
+		t.Fatalf("stream run linkage = project %q work %q assignment %q, want proj_1/work_1/asgn_1", state.Run.ProjectID, state.Run.WorkItemID, state.Run.AssignmentID)
+	}
+}
+
 func TestTaskRunStreamProjector_DoesNotTopUpSnapshotApprovals(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -190,6 +190,8 @@ type TaskItem struct {
 	Title                       string `json:"title"`
 	Prompt                      string `json:"prompt"`
 	ProjectID                   string `json:"project_id,omitempty"`
+	WorkItemID                  string `json:"work_item_id,omitempty"`
+	AssignmentID                string `json:"assignment_id,omitempty"`
 	SystemPrompt                string `json:"system_prompt,omitempty"`
 	WorkspaceSystemPromptPolicy string `json:"workspace_system_prompt_policy,omitempty"`
 	ExecutionProfile            string `json:"execution_profile,omitempty"`
@@ -243,6 +245,9 @@ type TaskItem struct {
 type TaskRunItem struct {
 	ID                 string `json:"id"`
 	TaskID             string `json:"task_id"`
+	ProjectID          string `json:"project_id,omitempty"`
+	WorkItemID         string `json:"work_item_id,omitempty"`
+	AssignmentID       string `json:"assignment_id,omitempty"`
 	Number             int    `json:"number"`
 	Status             string `json:"status"`
 	Orchestrator       string `json:"orchestrator,omitempty"`

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -409,6 +409,8 @@ func NewAssignmentTask(taskID string, project projects.Project, workItem project
 		Title:                       AssignmentTaskTitle(workItem, role),
 		Prompt:                      AssignmentPrompt(project, workItem, assignment, role),
 		ProjectID:                   project.ID,
+		WorkItemID:                  workItem.ID,
+		AssignmentID:                assignment.ID,
 		SystemPrompt:                AssignmentSystemPrompt(project, role, plan.Profile, plan.PromptContext),
 		WorkspaceSystemPromptPolicy: types.WorkspaceSystemPromptExclude,
 		ExecutionKind:               "agent_loop",

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -13,6 +13,11 @@ type Task struct {
 	// created from a project-scoped surface (manual Tasks, Hecate Chat,
 	// or project assignments). Empty means the task is unscoped.
 	ProjectID string
+	// WorkItemID and AssignmentID link a task to the project work records
+	// that created it. Empty means the task was project-scoped without a
+	// project assignment.
+	WorkItemID   string
+	AssignmentID string
 	// SystemPrompt is the per-task agent system prompt. When set, it
 	// becomes the narrowest layer in the composition: global default →
 	// workspace CLAUDE.md/AGENTS.md → this. Concatenated, broadest

--- a/ui/src/types/task.ts
+++ b/ui/src/types/task.ts
@@ -3,6 +3,8 @@ export type TaskRecord = {
   title: string;
   prompt: string;
   project_id?: string;
+  work_item_id?: string;
+  assignment_id?: string;
   // Per-task agent_loop system prompt — narrowest layer in the
   // composition (global → workspace CLAUDE.md/AGENTS.md → this).
   system_prompt?: string;
@@ -76,6 +78,9 @@ export type TaskResponse = {
 export type TaskRunRecord = {
   id: string;
   task_id: string;
+  project_id?: string;
+  work_item_id?: string;
+  assignment_id?: string;
   number: number;
   status: string;
   orchestrator?: string;


### PR DESCRIPTION
## Summary

- Add project work linkage fields to task and task-run API responses.
- Persist work item and assignment IDs on tasks created from project assignments.
- Keep live task-run stream snapshots consistent by rendering with parent task linkage when available.
- Mirror the response fields in UI types and document the runtime API contract.

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/api ./internal/projectworkapp ./internal/taskstate`
- `go vet ./internal/api ./internal/projectworkapp ./internal/taskstate`
- `cd ui && bun run typecheck`
- `git diff --check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
- `just agent-docs-check`

## Notes

This came out of a dogfood project assignment followed by a separate review assignment. The reviewer found the stream-snapshot consistency gap, which is included in this branch.