### PR TITLE
fix(projects): reconcile external assignment lifecycle

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -164,10 +164,11 @@ launch planning or start orchestration back to the broad
 or External Agent adapter/options separately for preview and dispatch.
 
 Project activity is a read/projection surface with split ownership:
-`internal/projectworkapp` owns assignment execution refs, task/run projection,
-blocking signals, bucket/status summaries, stale/missing detection, and
-canonical linked runtime ids. `internal/api/handler_project_activity.go` owns
-HTTP response DTOs, linked-chat loading/rendering, and artifact/handoff grouping.
+`internal/projectworkapp` owns assignment execution refs, task/run and
+chat-session projection, External Agent assignment reconciliation, blocking
+signals, bucket/status summaries, stale/missing detection, and canonical linked
+runtime ids. `internal/api/handler_project_activity.go` owns HTTP response DTOs,
+linked-chat loading/rendering, and artifact/handoff grouping.
 Do not rebuild assignment activity decisions in UI or handlers from raw
 `task_id`/`run_id`/`chat_session_id`; use the `execution_ref` / projection seams.
 

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -297,11 +297,14 @@ linked External Agent chat session, records assignment/profile/workspace context
 and stores the session link on the assignment. It does not append a visible chat
 message, create a `message_id`, or send the assignment prompt automatically; the
 operator stays in control of the first turn from the linked chat. Project
-activity rows project the linked chat's session status, latest message status,
-adapter identity, and missing-session diagnostics so the Projects cockpit can
-show follow-through state without embedding the full chat transcript. Handoffs
-created from these assignments can carry the source assignment, chat session,
-message, run, and context refs for provenance.
+assignment and activity rows project the linked chat's latest assistant-message
+status, session status, adapter identity, and missing-session diagnostics so the
+Projects cockpit can show follow-through state without embedding the full chat
+transcript. When the External Agent turn settles, Hecate also best-effort
+reconciles the linked assignment row to the chat outcome, including the
+assistant `message_id` and terminal status. Handoffs created from these
+assignments can carry the source assignment, chat session, message, run, and
+context refs for provenance.
 
 Hecate validates the workspace before creating a session, sanitizes the
 environment passed to the ACP agent process, applies timeout/cancel behavior,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1796,8 +1796,8 @@ Assignment responses are projected from linked canonical task/run state when
 `execution_ref.run_id` point at a Hecate task run. If
 `execution_ref.task_id` is present and `execution_ref.run_id` is empty, Hecate
 uses that task's `latest_run_id` when available. The stored assignment row is
-coordination metadata; reads do not mutate the task, run, or assignment rows.
-Run statuses map directly into assignment statuses:
+coordination metadata; task/run reads do not mutate the task, run, or
+assignment rows. Run statuses map directly into assignment statuses:
 
 | Task/run status     | Project assignment status |
 | ------------------- | ------------------------- |
@@ -1815,6 +1815,24 @@ explicit project-work terminal status instead of being overwritten by stale
 runtime state. The `execution` summary may include `task_status`, `run_status`,
 projected `status`, pending approval count, step/approval/artifact counts,
 model/provider, last error, run timestamps, and trace ID.
+
+External Agent assignments use the linked project-scoped chat session as their
+canonical execution state when `execution_ref.kind="chat_session"` and
+`execution_ref.chat_session_id` points at a Chat in the same project.
+Assignment reads project the latest assistant-message status first, then the
+session status, so a stale session summary cannot keep a completed assistant
+turn in the active bucket. Chat-backed projections update
+`execution_ref.status`, `execution_ref.message_id`, `execution_ref.trace_id`,
+and assignment `completed_at` when available; they do not include a task-run
+`execution` summary. Missing chats, chat-store lookup errors, or cross-project
+chat links are treated as missing execution refs instead of exposing foreign
+chat metadata.
+
+When an External Agent chat turn reaches `completed`, `failed`, or
+`cancelled`, Hecate also performs a best-effort reconciliation pass that
+updates linked project assignment rows. This makes the durable assignment
+status catch up with the chat outcome without making the chat response fail if
+project metadata reconciliation is temporarily unavailable.
 
 Assignments include `execution_ref`, the canonical compact execution link for
 UI clients and API callers. It prefers projected execution data when available

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -468,6 +468,7 @@ func (h *Handler) reconcileAgentChatStore(ctx context.Context) {
 	}
 	if count > 0 {
 		telemetry.Info(h.logger, ctx, "agent chat reconciliation completed", slog.Int("interrupted_runs", count))
+		h.reconcileProjectAssignmentsForAllChats(ctx)
 	}
 }
 

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -831,6 +831,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 	} else {
 		h.logger.WarnContext(r.Context(), "chat.turn_counter_increment_failed", "session_id", session.ID, "error", incErr)
 	}
+	h.reconcileProjectAssignmentsForChat(r.Context(), updated)
 	h.agentChatLive.publishSession(updated)
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
 }

--- a/internal/api/handler_chat_idle.go
+++ b/internal/api/handler_chat_idle.go
@@ -72,6 +72,10 @@ func (h *Handler) closeIdleChatSessions(ctx context.Context, timeout time.Durati
 			continue
 		}
 		h.annotateChatIdleTimeout(ctx, session.ID, timeout, now)
+		if latest, ok, getErr := h.agentChat.Get(ctx, session.ID); getErr == nil && ok {
+			updated = latest
+		}
+		h.reconcileProjectAssignmentsForChat(ctx, updated)
 		h.agentChatLive.publishSession(updated)
 	}
 }

--- a/internal/api/handler_chat_project_work.go
+++ b/internal/api/handler_chat_project_work.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/chat"
+)
+
+func (h *Handler) reconcileProjectAssignmentsForChat(ctx context.Context, session chat.Session) {
+	if h == nil || h.projectWork == nil || strings.TrimSpace(session.ProjectID) == "" || strings.TrimSpace(session.ID) == "" {
+		return
+	}
+	if _, err := h.projectWorkApplication().ReconcileChatSessionAssignments(ctx, session); err != nil && h.logger != nil {
+		h.logger.WarnContext(ctx, "project.assignment_chat_reconcile_failed",
+			slog.String("project_id", session.ProjectID),
+			slog.String("chat_session_id", session.ID),
+			slog.Any("error", err),
+		)
+	}
+}
+
+func (h *Handler) reconcileProjectAssignmentsForAllChats(ctx context.Context) {
+	if h == nil || h.agentChat == nil || h.projectWork == nil {
+		return
+	}
+	sessions, err := h.agentChat.List(ctx)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.WarnContext(ctx, "project.assignment_chat_reconcile_list_failed", slog.Any("error", err))
+		}
+		return
+	}
+	for _, summary := range sessions {
+		if strings.TrimSpace(summary.ProjectID) == "" {
+			continue
+		}
+		session, ok, err := h.agentChat.Get(ctx, summary.ID)
+		if err != nil || !ok {
+			if err != nil && h.logger != nil {
+				h.logger.WarnContext(ctx, "project.assignment_chat_reconcile_get_failed", slog.String("chat_session_id", summary.ID), slog.Any("error", err))
+			}
+			continue
+		}
+		h.reconcileProjectAssignmentsForChat(ctx, session)
+	}
+}

--- a/internal/api/handler_project_work_projection.go
+++ b/internal/api/handler_project_work_projection.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
@@ -45,21 +46,57 @@ func (h *Handler) renderProjectedProjectWorkAssignment(ctx context.Context, item
 	if err != nil {
 		return ProjectWorkAssignmentResponse{}, err
 	}
-	if projection == nil {
+	if projection != nil {
+		response.Execution = renderProjectWorkAssignmentExecution(projection.Execution)
+		if projection.Status != "" {
+			response.Status = projection.Status
+		}
+		if response.StartedAt == "" && !projection.StartedAt.IsZero() {
+			response.StartedAt = formatOptionalTime(projection.StartedAt)
+		}
+		if response.CompletedAt == "" && !projection.CompletedAt.IsZero() {
+			response.CompletedAt = formatOptionalTime(projection.CompletedAt)
+		}
+		response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefFor(item, &projection.Execution, response.Status))
 		return response, nil
 	}
-	response.Execution = renderProjectWorkAssignmentExecution(projection.Execution)
-	if projection.Status != "" {
-		response.Status = projection.Status
+
+	chatProjection := h.projectAssignmentChatProjection(ctx, item)
+	if chatProjection == nil {
+		return response, nil
 	}
-	if response.StartedAt == "" && !projection.StartedAt.IsZero() {
-		response.StartedAt = formatOptionalTime(projection.StartedAt)
+	if chatProjection.Status != "" {
+		response.Status = chatProjection.Status
 	}
-	if response.CompletedAt == "" && !projection.CompletedAt.IsZero() {
-		response.CompletedAt = formatOptionalTime(projection.CompletedAt)
+	if response.StartedAt == "" && !chatProjection.StartedAt.IsZero() {
+		response.StartedAt = formatOptionalTime(chatProjection.StartedAt)
 	}
-	response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefFor(item, &projection.Execution, response.Status))
+	if response.CompletedAt == "" && !chatProjection.CompletedAt.IsZero() {
+		response.CompletedAt = formatOptionalTime(chatProjection.CompletedAt)
+	}
+	response.ExecutionRef = renderProjectWorkAssignmentExecutionRef(projectworkapp.AssignmentExecutionRefForChat(item, chatProjection, response.Status))
 	return response, nil
+}
+
+func (h *Handler) projectAssignmentChatProjection(ctx context.Context, item projectwork.Assignment) *projectworkapp.AssignmentChatProjection {
+	ref := projectwork.NormalizeAssignmentExecutionRef(item.ExecutionRef)
+	chatSessionID := strings.TrimSpace(ref.ChatSessionID)
+	if chatSessionID == "" {
+		return nil
+	}
+	missing := &projectworkapp.AssignmentChatProjection{
+		ChatSessionID: chatSessionID,
+		Status:        item.Status,
+		Missing:       true,
+	}
+	if h == nil || h.agentChat == nil {
+		return missing
+	}
+	session, ok, err := h.agentChat.Get(ctx, chatSessionID)
+	if err != nil || !ok || strings.TrimSpace(session.ProjectID) != strings.TrimSpace(item.ProjectID) {
+		return missing
+	}
+	return projectworkapp.ProjectAssignmentChatExecution(item, session)
 }
 
 func renderProjectWorkAssignmentExecution(execution projectworkapp.AssignmentExecutionSummary) *ProjectWorkAssignmentExecutionResponse {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1631,6 +1631,74 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	}
 }
 
+func TestProjectWorkAPI_ExternalAgentChatTurnReconcilesAssignmentStatus(t *testing.T) {
+	t.Parallel()
+
+	handler, server := newProjectWorkTestServer()
+	handler.SetAgentChatRunner(&fakeAgentChatRunner{output: "implementation complete"})
+	ctx := t.Context()
+	workspace := t.TempDir()
+	if _, err := handler.projects.Create(ctx, projects.Project{ID: "proj_chat_reconcile", Name: "Chat reconcile"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{ID: "role_chat_reconcile", ProjectID: "proj_chat_reconcile", Name: "External implementer"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_chat_reconcile", ProjectID: "proj_chat_reconcile", Title: "Reconcile chat"}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.agentChat.Create(ctx, chat.Session{
+		ID:              "chat_project_reconcile",
+		ProjectID:       "proj_chat_reconcile",
+		AgentID:         "codex",
+		DriverKind:      agentadapters.DriverKindACP,
+		NativeSessionID: "native_project_reconcile",
+		Workspace:       workspace,
+		Status:          "idle",
+	}); err != nil {
+		t.Fatalf("Create chat session: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_chat_reconcile",
+		ProjectID:  "proj_chat_reconcile",
+		WorkItemID: "work_chat_reconcile",
+		RoleID:     "role_chat_reconcile",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_project_reconcile",
+			Status:        projectwork.AssignmentStatusRunning,
+		},
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/chat_project_reconcile/messages", strings.NewReader(`{"content":"finish the assignment"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create chat message status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var chatResp ChatSessionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &chatResp); err != nil {
+		t.Fatalf("decode chat response: %v", err)
+	}
+	if chatResp.Data.Status != "completed" {
+		t.Fatalf("chat status = %q, want completed", chatResp.Data.Status)
+	}
+
+	assignments, err := handler.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: "proj_chat_reconcile", WorkItemID: "work_chat_reconcile"})
+	if err != nil {
+		t.Fatalf("ListAssignments: %v", err)
+	}
+	if len(assignments) != 1 {
+		t.Fatalf("assignments = %+v, want one linked assignment", assignments)
+	}
+	if assignments[0].Status != projectwork.AssignmentStatusCompleted || assignments[0].ExecutionRef.MessageID == "" || assignments[0].ExecutionRef.Status != projectwork.AssignmentStatusCompleted {
+		t.Fatalf("stored assignment = %+v, want reconciled completed chat assignment", assignments[0])
+	}
+}
+
 func TestProjectWorkAPI_PreflightExternalAgentAssignmentShowsSessionTargetWithoutPreparing(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -2592,6 +2660,15 @@ func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 			}
 			assertProjectWorkStatusForTest(t, server, "work_manual_terminal", projectwork.WorkItemStatusBlocked)
 
+			external := getProjectWorkAssignmentForTest(t, server, "work_external_chat", "asgn_external_chat")
+			externalRef := assignmentExecutionRefForTest(t, external)
+			if external.Status != projectwork.AssignmentStatusCompleted || external.CompletedAt == "" || external.Execution != nil {
+				t.Fatalf("external chat assignment = %+v, want projected completed chat without task execution summary", external)
+			}
+			if externalRef.Kind != projectwork.AssignmentExecutionKindChatSession || externalRef.ChatSessionID != "chat_external_projection" || externalRef.MessageID != "msg_external_done" || externalRef.Status != projectwork.AssignmentStatusCompleted {
+				t.Fatalf("external chat execution_ref = %+v, want completed linked chat ref", externalRef)
+			}
+
 			assertProjectWorkStatusForTest(t, server, "work_mixed", projectwork.WorkItemStatusBlocked)
 			assertProjectWorkListStatusForTest(t, server, "work_mixed", projectwork.WorkItemStatusBlocked)
 		})
@@ -2683,8 +2760,8 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			if external.Assignment.ExecutionRef == nil || external.Assignment.ExecutionRef.Kind != "chat_session" || external.LinkedChatID != external.Assignment.ExecutionRef.ChatSessionID {
 				t.Fatalf("external execution_ref = %+v linked_chat=%q, want chat-session ref", external.Assignment.ExecutionRef, external.LinkedChatID)
 			}
-			if external.BlockingSignal != "running" || external.StatusSummary != "linked chat · running · assistant completed · 2 messages" {
-				t.Fatalf("external activity = %+v, want linked chat running summary", external)
+			if external.BlockingSignal != "completed" || external.StatusSummary != "linked chat · running · assistant completed · 2 messages" {
+				t.Fatalf("external activity = %+v, want linked chat completed summary", external)
 			}
 
 			missingChat := findProjectActivityItemForTest(t, allProjectActivityItemsForTest(response.Data), "asgn_missing_chat")

--- a/internal/projectworkapp/activity.go
+++ b/internal/projectworkapp/activity.go
@@ -142,6 +142,9 @@ func ProjectActivityStatusSummary(input ActivityAssignmentInput, signal string) 
 		if input.ArtifactCount > 0 {
 			return fmt.Sprintf("completed with %d artifact%s", input.ArtifactCount, pluralSuffix(input.ArtifactCount))
 		}
+		if input.LinkedChat != nil {
+			return ProjectActivityLinkedChatSummary(input.LinkedChat)
+		}
 		return "completed"
 	default:
 		if input.LinkedChat != nil && input.LinkedChat.Missing {
@@ -156,14 +159,17 @@ func ProjectActivityProjectedStatus(input ActivityAssignmentInput) string {
 		if input.LinkedChat.Missing {
 			return "stale_unknown"
 		}
-		if status := strings.TrimSpace(input.LinkedChat.Status); status != "" && status != "idle" {
+		if status := AssignmentStatusFromChatStatus(input.LinkedChat.LatestStatus); AssignmentIsTerminal(status) {
 			return status
 		}
-		if status := strings.TrimSpace(input.LinkedChat.LatestStatus); status != "" {
+		if status := AssignmentStatusFromChatStatus(input.LinkedChat.Status); status != "" {
 			return status
 		}
 		if strings.TrimSpace(input.LinkedChat.Status) == "idle" {
 			return firstNonEmpty(activityExecutionStatus(input), input.Status, projectwork.AssignmentStatusRunning)
+		}
+		if status := AssignmentStatusFromChatStatus(input.LinkedChat.LatestStatus); status != "" {
+			return status
 		}
 	}
 	return firstNonEmpty(activityExecutionStatus(input), input.Status)

--- a/internal/projectworkapp/activity_test.go
+++ b/internal/projectworkapp/activity_test.go
@@ -81,8 +81,8 @@ func TestProjectActivityAssignmentState_LinkedChatAndCompletedSummaries(t *testi
 			MessageCount: 2,
 		},
 	})
-	if chatState.BlockingSignal != "running" || chatState.StatusSummary != "linked chat · running · assistant completed · 2 messages" || chatState.Bucket != "active" {
-		t.Fatalf("chat state = %+v, want active linked-chat summary", chatState)
+	if chatState.BlockingSignal != "completed" || chatState.StatusSummary != "linked chat · running · assistant completed · 2 messages" || chatState.Bucket != "completed" {
+		t.Fatalf("chat state = %+v, want completed linked-chat summary", chatState)
 	}
 
 	completed := ProjectActivityAssignmentState(ActivityAssignmentInput{

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -108,6 +108,55 @@ func TestApplication_UpdateAssignmentAppliesOptionalFields(t *testing.T) {
 	}
 }
 
+func TestApplication_ReconcileChatSessionAssignmentsUpdatesLinkedExternalAssignment(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	app := newTestApplication(store)
+	base := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_1", Title: "Build"}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{
+		ID:         "asgn_1",
+		RoleID:     "software_developer",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_1",
+			Status:        projectwork.AssignmentStatusRunning,
+		},
+		StartedAt: base,
+	}); err != nil {
+		t.Fatalf("CreateAssignment() error = %v", err)
+	}
+
+	result, err := app.ReconcileChatSessionAssignments(ctx, chat.Session{
+		ID:        "chat_1",
+		ProjectID: "proj_1",
+		Status:    "running",
+		UpdatedAt: base.Add(2 * time.Minute),
+		Messages: []chat.Message{
+			{ID: "msg_done", Role: "assistant", Status: "completed", TraceID: "trace_chat", StartedAt: base.Add(time.Minute), CompletedAt: base.Add(2 * time.Minute)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileChatSessionAssignments() error = %v", err)
+	}
+	if len(result.Updated) != 1 {
+		t.Fatalf("updated assignments = %d, want 1", len(result.Updated))
+	}
+	updated := result.Updated[0]
+	if updated.Status != projectwork.AssignmentStatusCompleted || updated.ExecutionRef.MessageID != "msg_done" || updated.ExecutionRef.Status != projectwork.AssignmentStatusCompleted {
+		t.Fatalf("updated assignment = %+v, want completed chat linkage", updated)
+	}
+	if updated.CompletedAt.IsZero() {
+		t.Fatalf("updated assignment completed_at is zero, want chat completion timestamp")
+	}
+}
+
 func TestApplication_NilStore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projectworkapp/chat_projection.go
+++ b/internal/projectworkapp/chat_projection.go
@@ -1,0 +1,117 @@
+package projectworkapp
+
+import (
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type AssignmentChatProjection struct {
+	ChatSessionID string
+	MessageID     string
+	Status        string
+	TraceID       string
+	StartedAt     time.Time
+	CompletedAt   time.Time
+	ProjectedAt   time.Time
+	Missing       bool
+}
+
+func ProjectAssignmentChatExecution(assignment projectwork.Assignment, session chat.Session) *AssignmentChatProjection {
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	chatSessionID := strings.TrimSpace(ref.ChatSessionID)
+	if chatSessionID == "" {
+		return nil
+	}
+	projection := &AssignmentChatProjection{
+		ChatSessionID: chatSessionID,
+		Status:        assignment.Status,
+		StartedAt:     assignment.StartedAt,
+		CompletedAt:   assignment.CompletedAt,
+	}
+	if strings.TrimSpace(session.ID) != chatSessionID {
+		projection.Missing = true
+		return projection
+	}
+
+	latest := LatestAssignmentChatMessage(session)
+	status, projectedAt := assignmentStatusFromChatSession(session, latest)
+	if status != "" {
+		projection.Status = ProjectedAssignmentStatus(assignment, status, projectedAt)
+		projection.ProjectedAt = projectedAt
+	}
+	if latest != nil {
+		projection.MessageID = latest.ID
+		projection.TraceID = latest.TraceID
+		projection.StartedAt = FirstNonZeroTime(assignment.StartedAt, latest.StartedAt, latest.CreatedAt)
+		if AssignmentIsTerminal(projection.Status) {
+			projection.CompletedAt = FirstNonZeroTime(assignment.CompletedAt, latest.CompletedAt, projectedAt)
+		}
+	} else if AssignmentIsTerminal(projection.Status) {
+		projection.CompletedAt = FirstNonZeroTime(assignment.CompletedAt, session.UpdatedAt, projectedAt)
+	}
+	return projection
+}
+
+func AssignmentExecutionRefForChat(assignment projectwork.Assignment, projection *AssignmentChatProjection, status string) *AssignmentExecutionRef {
+	if projection == nil {
+		return AssignmentExecutionRefFor(assignment, nil, status)
+	}
+	ref := AssignmentExecutionRefFor(assignment, nil, firstNonEmpty(status, projection.Status))
+	if ref == nil {
+		ref = &AssignmentExecutionRef{}
+	}
+	ref.Kind = projectwork.AssignmentExecutionKindChatSession
+	ref.ChatSessionID = firstNonEmpty(projection.ChatSessionID, ref.ChatSessionID)
+	ref.MessageID = firstNonEmpty(projection.MessageID, ref.MessageID)
+	ref.Status = firstNonEmpty(status, projection.Status, ref.Status)
+	ref.TraceID = firstNonEmpty(projection.TraceID, ref.TraceID)
+	ref.Missing = projection.Missing
+	if ref.ChatSessionID == "" {
+		return nil
+	}
+	return ref
+}
+
+func LatestAssignmentChatMessage(session chat.Session) *chat.Message {
+	for i := len(session.Messages) - 1; i >= 0; i-- {
+		if strings.TrimSpace(session.Messages[i].ID) == "" || strings.TrimSpace(session.Messages[i].Role) != "assistant" {
+			continue
+		}
+		return &session.Messages[i]
+	}
+	return nil
+}
+
+func AssignmentStatusFromChatStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case "queued":
+		return projectwork.AssignmentStatusQueued
+	case "running":
+		return projectwork.AssignmentStatusRunning
+	case "awaiting_approval":
+		return projectwork.AssignmentStatusAwaitingApproval
+	case "completed":
+		return projectwork.AssignmentStatusCompleted
+	case "failed":
+		return projectwork.AssignmentStatusFailed
+	case "cancelled", "closed":
+		return projectwork.AssignmentStatusCancelled
+	default:
+		return ""
+	}
+}
+
+func assignmentStatusFromChatSession(session chat.Session, latest *chat.Message) (string, time.Time) {
+	if latest != nil {
+		if status := AssignmentStatusFromChatStatus(latest.Status); status != "" {
+			return status, FirstNonZeroTime(latest.CompletedAt, latest.StartedAt, latest.CreatedAt, session.UpdatedAt, session.CreatedAt)
+		}
+	}
+	if status := AssignmentStatusFromChatStatus(session.Status); status != "" {
+		return status, FirstNonZeroTime(session.UpdatedAt, session.CreatedAt)
+	}
+	return "", FirstNonZeroTime(session.UpdatedAt, session.CreatedAt)
+}

--- a/internal/projectworkapp/projection_test.go
+++ b/internal/projectworkapp/projection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -109,6 +110,42 @@ func TestAssignmentExecutionRefFor_RawChatAndContextLinks(t *testing.T) {
 	}, nil, projectwork.AssignmentStatusQueued)
 	if contextRef == nil || contextRef.Kind != AssignmentExecutionKindContextSnapshot || contextRef.ContextSnapshotID != "ctx_1" {
 		t.Fatalf("context ref = %+v, want context-snapshot ref", contextRef)
+	}
+}
+
+func TestProjectAssignmentChatExecution_UsesLatestAssistantTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	assignment := projectwork.Assignment{
+		ID:     "asgn_chat",
+		Status: projectwork.AssignmentStatusRunning,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_1",
+		},
+		UpdatedAt: base,
+	}
+	session := chat.Session{
+		ID:        "chat_1",
+		Status:    "running",
+		UpdatedAt: base.Add(time.Minute),
+		Messages: []chat.Message{
+			{ID: "msg_user", Role: "user", Status: "completed", CreatedAt: base.Add(time.Second)},
+			{ID: "msg_assistant", Role: "assistant", Status: "completed", TraceID: "trace_chat", StartedAt: base.Add(2 * time.Second), CompletedAt: base.Add(3 * time.Second)},
+		},
+	}
+
+	projection := ProjectAssignmentChatExecution(assignment, session)
+	if projection == nil {
+		t.Fatal("ProjectAssignmentChatExecution() = nil, want chat projection")
+	}
+	if projection.Status != projectwork.AssignmentStatusCompleted || projection.MessageID != "msg_assistant" || projection.TraceID != "trace_chat" {
+		t.Fatalf("projection = %+v, want completed latest assistant metadata", projection)
+	}
+	ref := AssignmentExecutionRefForChat(assignment, projection, projection.Status)
+	if ref == nil || ref.Kind != AssignmentExecutionKindChatSession || ref.ChatSessionID != "chat_1" || ref.MessageID != "msg_assistant" || ref.Status != projectwork.AssignmentStatusCompleted || ref.TraceID != "trace_chat" {
+		t.Fatalf("chat execution ref = %+v, want completed chat ref", ref)
 	}
 }
 

--- a/internal/projectworkapp/reconcile.go
+++ b/internal/projectworkapp/reconcile.go
@@ -1,0 +1,60 @@
+package projectworkapp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type ReconcileChatSessionAssignmentsResult struct {
+	Updated []projectwork.Assignment
+}
+
+func (app *Application) ReconcileChatSessionAssignments(ctx context.Context, session chat.Session) (ReconcileChatSessionAssignmentsResult, error) {
+	if app == nil || app.store == nil {
+		return ReconcileChatSessionAssignmentsResult{}, ErrStoreNotConfigured
+	}
+	projectID := strings.TrimSpace(session.ProjectID)
+	sessionID := strings.TrimSpace(session.ID)
+	if projectID == "" || sessionID == "" {
+		return ReconcileChatSessionAssignmentsResult{}, nil
+	}
+	assignments, err := app.store.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return ReconcileChatSessionAssignmentsResult{}, err
+	}
+	var result ReconcileChatSessionAssignmentsResult
+	for _, assignment := range assignments {
+		ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+		if strings.TrimSpace(ref.ChatSessionID) != sessionID {
+			continue
+		}
+		projection := ProjectAssignmentChatExecution(assignment, session)
+		if projection == nil || projection.Missing || strings.TrimSpace(projection.Status) == "" {
+			continue
+		}
+		updated, err := app.store.UpdateAssignment(ctx, projectID, assignment.ID, func(item *projectwork.Assignment) {
+			current := ProjectAssignmentChatExecution(*item, session)
+			if current == nil || current.Missing || strings.TrimSpace(current.Status) == "" {
+				return
+			}
+			item.Status = current.Status
+			if ref := AssignmentExecutionRefForChat(*item, current, current.Status); ref != nil {
+				item.ExecutionRef = projectwork.NormalizeAssignmentExecutionRef(*ref)
+			}
+			if item.StartedAt.IsZero() && !current.StartedAt.IsZero() {
+				item.StartedAt = current.StartedAt
+			}
+			if AssignmentIsTerminal(current.Status) {
+				item.CompletedAt = FirstNonZeroTime(item.CompletedAt, current.CompletedAt, current.ProjectedAt, app.now().UTC())
+			}
+		})
+		if err != nil {
+			return result, err
+		}
+		result.Updated = append(result.Updated, updated)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary

This fixes the dogfood finding where an External Agent assignment could remain durably `running` after the linked chat turn had already completed.

Changes:
- project chat-backed assignments from linked project chat state, preferring the latest assistant message over stale session summary state
- best-effort reconcile linked assignment rows when External Agent chat turns settle
- keep missing, errored, and cross-project chat links scoped as missing execution refs
- update runtime/API docs and backend agent guidance for the projection/reconciliation boundary

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/projectworkapp`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(AssignmentExecutionProjection|ProjectActivity|ExternalAgentChatTurnReconcilesAssignmentStatus)'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api ./internal/projectworkapp ./internal/projectwork ./internal/chat`
- `go vet ./internal/api ./internal/projectworkapp`
- `just agent-docs-check`
- `git diff --check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`