### PR TITLE
feat(projects): add reviewer handoff shortcut

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -224,6 +224,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   Context Inspector panel for the launch packet, then call start only from the
   operator's confirm action. This applies to normal assignment rows and
   handoff-linked starts.
+- Reviewer follow-through stays handoff-based. A request-review action may
+  prefill a handoff to a work item's `reviewer_role_ids` and carry source
+  assignment/run/chat/context refs, but creating the follow-up assignment and
+  starting it remain separate operator actions.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -304,7 +304,10 @@ transcript. When the External Agent turn settles, Hecate also best-effort
 reconciles the linked assignment row to the chat outcome, including the
 assistant `message_id` and terminal status. Handoffs created from these
 assignments can carry the source assignment, chat session, message, run, and
-context refs for provenance.
+context refs for provenance. If the work item declares reviewer roles, the
+Projects cockpit can prefill a review handoff from the External Agent
+assignment, but accepting the handoff, creating the follow-up assignment, and
+starting that assignment remain operator-controlled.
 
 Hecate validates the workspace before creating a session, sanitizes the
 environment passed to the ACP agent process, applies timeout/cancel behavior,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1276,14 +1276,18 @@ files into prompts yet. Projects also have a project-scoped skills registry
 for local `SKILL.md` metadata discovered from `.agents/skills`,
 `.hecate/skills`, and enabled guidance-linked local skill roots. The registry
 stores ids, title/description metadata, path, root, status, trust label, and
-warnings; it does not store or return skill bodies. Project work-coordination endpoints can
-persist roles, work items, assignments, and collaboration artifacts under a
-project. Assignments may record links to existing task runs or chat messages,
-but creating an assignment does not start a task, open a chat, inject context,
-or dispatch any agent. Project handoffs are structured project-scoped records
-for passing context and a recommended next action from one assignment/run/chat
-to another role or assignment. They can link artifacts, memory entries, and
-context references, but they do not launch follow-up work by themselves.
+warnings; it does not store or return skill bodies. Project work-coordination
+endpoints can persist roles, work items, assignments, and collaboration
+artifacts under a project. Assignments may record links to existing task runs
+or chat messages, but creating an assignment does not start a task, open a
+chat, inject context, or dispatch any agent. Project handoffs are structured
+project-scoped records for passing context and a recommended next action from
+one assignment/run/chat to another role or assignment. They can link artifacts,
+memory entries, and context references, but they do not launch follow-up work
+by themselves. Work-item `reviewer_role_ids` are follow-through hints for
+review handoffs: the Projects cockpit can prefill a request-review handoff to a
+reviewer role, but creating the target assignment and starting it remain
+explicit operator actions.
 Project memory entries are structured project-scoped records with
 Markdown-compatible `body` text; they are not Markdown files, and they are
 written only through explicit operator API/UI actions. Enabled project memory
@@ -1786,6 +1790,9 @@ chat sessions.
 Work items and assignments may carry `root_id` to select a concrete project
 root. Launch workspace resolution uses assignment `root_id`, then work-item
 `root_id`, then project `default_root_id`, then the first active project root.
+Work items may also carry `reviewer_role_ids`; these identify roles that are
+appropriate targets for review handoffs and do not grant permissions, enforce
+policy, or auto-dispatch review work.
 Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
 `decision_note`.
 Supported structured handoff statuses are `pending`, `accepted`, `superseded`,

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2489,6 +2489,69 @@ describe("ProjectsView cockpit", () => {
     );
   });
 
+  it("drafts reviewer handoffs from work item reviewer roles", async () => {
+    resetProjectWorkMocks();
+    const reviewRole: ProjectWorkRoleRecord = {
+      id: "reviewer_qa",
+      project_id: project.id,
+      name: "QA reviewer",
+      description: "Reviews behavior, regressions, and verification gaps.",
+      default_driver_kind: "hecate_task",
+      built_in: false,
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [role, reviewRole],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await userEvent.click(
+      within(detail).getByRole("button", {
+        name: `Request review for assignment ${hecateAssignment.id}`,
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "New handoff" });
+    expect(within(dialog).getByLabelText("Target role")).toHaveValue("reviewer_qa");
+    expect(within(dialog).getByLabelText("Title")).toHaveValue("QA reviewer review request");
+    expect(within(dialog).getByLabelText("Summary")).toHaveValue(
+      'Review Software developer\'s assignment for "Build cockpit UI".',
+    );
+    expect(within(dialog).getByLabelText("Source assignment")).toHaveValue(hecateAssignment.id);
+    expect(within(dialog).getByLabelText("Source run")).toHaveValue("run_1");
+    expect(within(dialog).getByLabelText("Context refs")).toHaveValue(
+      "ctx_assignment_1, task_1, run_1",
+    );
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save handoff" }));
+
+    await waitFor(() => {
+      expect(createProjectHandoff).toHaveBeenCalledWith(
+        project.id,
+        workItem.id,
+        expect.objectContaining({
+          source_assignment_id: hecateAssignment.id,
+          source_run_id: "run_1",
+          target_role_id: "reviewer_qa",
+          title: "QA reviewer review request",
+          status: "pending",
+          provenance_kind: "operator",
+          trust_label: "operator_reviewed",
+          context_refs: ["ctx_assignment_1", "task_1", "run_1"],
+        }),
+      );
+    });
+  });
+
   it("renders a project timeline from activity, decisions, artifacts, and memory", async () => {
     resetProjectWorkMocks();
     const onOpenTask = vi.fn();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -134,6 +134,7 @@ import {
   assignmentUpdatePayloadFromForm,
   handoffFormFromAssignment,
   handoffPayloadFromForm,
+  reviewHandoffFormFromAssignment,
   type EditAssignmentForm,
   type EditWorkItemForm,
   type HandoffForm,
@@ -1389,6 +1390,20 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               );
               setEditingHandoff("new");
             }}
+            onAddReviewHandoffFromAssignment={(assignment, reviewRole, activityItem) => {
+              if (!selectedWorkItem) return;
+              setHandoffError("");
+              setNewHandoffDraft(
+                reviewHandoffFormFromAssignment(
+                  assignment,
+                  roleByID.get(assignment.role_id) ?? null,
+                  reviewRole,
+                  selectedWorkItem,
+                  activityItem,
+                ),
+              );
+              setEditingHandoff("new");
+            }}
             onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
             onCreateWork={() => {
               setNewWorkError("");
@@ -1720,6 +1735,11 @@ type ProjectWorkspaceViewProps = {
     assignment: ProjectAssignmentRecord,
     activityItem?: ProjectActivityItemRecord,
   ) => void;
+  onAddReviewHandoffFromAssignment: (
+    assignment: ProjectAssignmentRecord,
+    reviewRole: ProjectWorkRoleRecord,
+    activityItem?: ProjectActivityItemRecord,
+  ) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
   onCreateWork: () => void;
   onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
@@ -1795,6 +1815,7 @@ function ProjectWorkspaceView({
   onAddAssignment,
   onAddHandoff,
   onAddHandoffFromAssignment,
+  onAddReviewHandoffFromAssignment,
   onCreateAssignmentFromHandoff,
   onCreateWork,
   onDeleteAssignment,
@@ -1970,6 +1991,7 @@ function ProjectWorkspaceView({
                         onAddAssignment={onAddAssignment}
                         onAddHandoff={onAddHandoff}
                         onAddHandoffFromAssignment={onAddHandoffFromAssignment}
+                        onAddReviewHandoffFromAssignment={onAddReviewHandoffFromAssignment}
                       />
                     ) : (
                       <EmptyBlock
@@ -3125,6 +3147,7 @@ function WorkItemDetail({
   onAddAssignment,
   onAddHandoff,
   onAddHandoffFromAssignment,
+  onAddReviewHandoffFromAssignment,
   onCreateAssignmentFromHandoff,
   onDeleteAssignment,
   onDeleteHandoff,
@@ -3160,6 +3183,11 @@ function WorkItemDetail({
   onAddHandoff: () => void;
   onAddHandoffFromAssignment: (
     assignment: ProjectAssignmentRecord,
+    activityItem?: ProjectActivityItemRecord,
+  ) => void;
+  onAddReviewHandoffFromAssignment: (
+    assignment: ProjectAssignmentRecord,
+    reviewRole: ProjectWorkRoleRecord,
     activityItem?: ProjectActivityItemRecord,
   ) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
@@ -3272,83 +3300,88 @@ function WorkItemDetail({
             <div style={subtleTextStyle}>No assignments recorded yet.</div>
           ) : (
             <div style={{ display: "grid", gap: 10 }}>
-              {assignments.map((assignment) => (
-                <AssignmentRow
-                  key={assignment.id}
-                  activityItem={activityByAssignmentID.get(assignment.id)}
-                  assignment={assignment}
-                  chatModel={
-                    assignment.execution?.model ||
-                    roleByID.get(assignment.role_id)?.default_model ||
-                    project?.default_model ||
-                    ""
-                  }
-                  error={assignmentErrors[assignment.id] ?? ""}
-                  onDelete={() => onDeleteAssignment(assignment)}
-                  onEdit={() => onEditAssignment(assignment)}
-                  onOpenChat={
-                    project
-                      ? () => {
-                          const executionRef = toProjectAssignmentExecutionViewModel(assignment);
-                          onOpenChat?.(
-                            executionRef.chatSessionID
-                              ? {
-                                  projectID: project.id,
-                                  chatSessionID: executionRef.chatSessionID,
-                                }
-                              : buildProjectAssignmentChatLaunchRequest({
-                                  project,
-                                  workItem,
-                                  assignment,
-                                  role: roleByID.get(assignment.role_id) ?? null,
-                                }),
-                          );
-                        }
-                      : undefined
-                  }
-                  onOpenTask={onOpenTask}
-                  onStart={() => onStartAssignment(assignment)}
-                  onCreateHandoff={() =>
-                    onAddHandoffFromAssignment(
-                      assignment,
-                      activityByAssignmentID.get(assignment.id),
-                    )
-                  }
-                  project={project}
-                  repairActions={{
-                    onManageProfiles,
-                    onManageRoles,
-                    onOpenConnections,
-                    onOpenProjectSettings: onOpenSettings,
-                  }}
-                  role={roleByID.get(assignment.role_id)}
-                  starting={startingAssignmentID === assignment.id}
-                  loadContext={
-                    project
-                      ? async () =>
-                          (
-                            await getProjectAssignmentContext(
-                              project.id,
-                              workItem.id,
-                              assignment.id,
-                            )
-                          ).data
-                      : null
-                  }
-                  loadPreflight={
-                    project
-                      ? async () =>
-                          (
-                            await getProjectAssignmentPreflight(
-                              project.id,
-                              workItem.id,
-                              assignment.id,
-                            )
-                          ).data
-                      : null
-                  }
-                />
-              ))}
+              {assignments.map((assignment) => {
+                const reviewRole = reviewerRoleForAssignment(workItem, assignment, roleByID);
+                const activityItem = activityByAssignmentID.get(assignment.id);
+                return (
+                  <AssignmentRow
+                    key={assignment.id}
+                    activityItem={activityItem}
+                    assignment={assignment}
+                    chatModel={
+                      assignment.execution?.model ||
+                      roleByID.get(assignment.role_id)?.default_model ||
+                      project?.default_model ||
+                      ""
+                    }
+                    error={assignmentErrors[assignment.id] ?? ""}
+                    onDelete={() => onDeleteAssignment(assignment)}
+                    onEdit={() => onEditAssignment(assignment)}
+                    onOpenChat={
+                      project
+                        ? () => {
+                            const executionRef = toProjectAssignmentExecutionViewModel(assignment);
+                            onOpenChat?.(
+                              executionRef.chatSessionID
+                                ? {
+                                    projectID: project.id,
+                                    chatSessionID: executionRef.chatSessionID,
+                                  }
+                                : buildProjectAssignmentChatLaunchRequest({
+                                    project,
+                                    workItem,
+                                    assignment,
+                                    role: roleByID.get(assignment.role_id) ?? null,
+                                  }),
+                            );
+                          }
+                        : undefined
+                    }
+                    onOpenTask={onOpenTask}
+                    onStart={() => onStartAssignment(assignment)}
+                    onCreateHandoff={() => onAddHandoffFromAssignment(assignment, activityItem)}
+                    onCreateReviewHandoff={
+                      reviewRole
+                        ? () =>
+                            onAddReviewHandoffFromAssignment(assignment, reviewRole, activityItem)
+                        : undefined
+                    }
+                    project={project}
+                    repairActions={{
+                      onManageProfiles,
+                      onManageRoles,
+                      onOpenConnections,
+                      onOpenProjectSettings: onOpenSettings,
+                    }}
+                    role={roleByID.get(assignment.role_id)}
+                    starting={startingAssignmentID === assignment.id}
+                    loadContext={
+                      project
+                        ? async () =>
+                            (
+                              await getProjectAssignmentContext(
+                                project.id,
+                                workItem.id,
+                                assignment.id,
+                              )
+                            ).data
+                        : null
+                    }
+                    loadPreflight={
+                      project
+                        ? async () =>
+                            (
+                              await getProjectAssignmentPreflight(
+                                project.id,
+                                workItem.id,
+                                assignment.id,
+                              )
+                            ).data
+                        : null
+                    }
+                  />
+                );
+              })}
             </div>
           )}
         </section>
@@ -3448,6 +3481,7 @@ function AssignmentRow({
   loadContext,
   loadPreflight,
   onCreateHandoff,
+  onCreateReviewHandoff,
   onDelete,
   onEdit,
   onOpenChat,
@@ -3465,6 +3499,7 @@ function AssignmentRow({
   loadContext?: (() => Promise<ContextPacketRecord>) | null;
   loadPreflight?: (() => Promise<ContextPacketRecord>) | null;
   onCreateHandoff: () => void;
+  onCreateReviewHandoff?: () => void;
   onDelete: () => void;
   onEdit: () => void;
   onOpenChat?: () => void;
@@ -3654,6 +3689,17 @@ function AssignmentRow({
           >
             <Icon d={Icons.plus} size={12} />
             Handoff
+          </button>
+        )}
+        {executionRef.hasAnyLink && onCreateReviewHandoff && (
+          <button
+            aria-label={`Request review for assignment ${assignment.id}`}
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={onCreateReviewHandoff}
+          >
+            <Icon d={Icons.check} size={12} />
+            Request review
           </button>
         )}
       </div>
@@ -4148,6 +4194,20 @@ function handoffSourceRefs(handoff: ProjectHandoffRecord): string[] {
     }
   }
   return refs;
+}
+
+function reviewerRoleForAssignment(
+  workItem: ProjectWorkItemRecord,
+  assignment: ProjectAssignmentRecord,
+  roleByID: Map<string, ProjectWorkRoleRecord>,
+): ProjectWorkRoleRecord | null {
+  for (const rawRoleID of workItem.reviewer_role_ids ?? []) {
+    const roleID = rawRoleID.trim();
+    if (!roleID || roleID === assignment.role_id) continue;
+    const role = roleByID.get(roleID);
+    if (role) return role;
+  }
+  return null;
 }
 
 function buildProjectAssignmentChatLaunchRequest({

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import type { ProjectActivityItemRecord, ProjectAssignmentRecord } from "../../types/project";
+import type {
+  ProjectActivityItemRecord,
+  ProjectAssignmentRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../../types/project";
 import {
   assignmentStatusFromValue,
   assignmentUpdatePayloadFromForm,
   handoffFormFromAssignment,
   handoffPayloadFromForm,
   handoffStatusFromValue,
+  reviewHandoffFormFromAssignment,
   workItemCreatePayloadFromForm,
   workItemPriorityFromValue,
   workItemStatusFromValue,
@@ -159,6 +165,61 @@ describe("projectWorkForms", () => {
       title: "Developer handoff",
       contextRefs: "ctx_1, task_1, run_1, msg_1",
       status: "pending",
+    });
+  });
+
+  it("drafts reviewer handoffs with target role and source evidence", () => {
+    const assignment: ProjectAssignmentRecord = {
+      id: "assign_1234567890",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "developer",
+      driver_kind: "hecate_task",
+      status: "completed",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_1",
+        run_id: "run_1",
+        context_snapshot_id: "ctx_1",
+      },
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+    const sourceRole: ProjectWorkRoleRecord = {
+      id: "developer",
+      project_id: "proj_1",
+      name: "Developer",
+      built_in: false,
+    };
+    const reviewRole: ProjectWorkRoleRecord = {
+      id: "reviewer_qa",
+      project_id: "proj_1",
+      name: "QA reviewer",
+      built_in: false,
+    };
+    const workItem: ProjectWorkItemRecord = {
+      id: "work_1",
+      project_id: "proj_1",
+      title: "Build cockpit",
+      status: "review",
+      priority: "normal",
+      reviewer_role_ids: ["reviewer_qa"],
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+
+    expect(
+      reviewHandoffFormFromAssignment(assignment, sourceRole, reviewRole, workItem),
+    ).toMatchObject({
+      sourceAssignmentID: "assign_1234567890",
+      sourceRunID: "run_1",
+      targetRoleID: "reviewer_qa",
+      title: "QA reviewer review request",
+      summary: 'Review Developer\'s assignment for "Build cockpit".',
+      contextRefs: "ctx_1, task_1, run_1",
+      status: "pending",
+      provenanceKind: "operator",
+      trustLabel: "operator_reviewed",
     });
   });
 });

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -4,6 +4,7 @@ import type {
   ProjectAssignmentExecutionRefRecord,
   ProjectAssignmentRecord,
   ProjectHandoffRecord,
+  ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectAssignmentPayload,
   UpdateProjectWorkItemPayload,
@@ -260,6 +261,27 @@ export function handoffFormFromAssignment(
     status: "pending",
     provenanceKind: "operator",
     trustLabel: "operator_reviewed",
+  };
+}
+
+export function reviewHandoffFormFromAssignment(
+  assignment: ProjectAssignmentRecord,
+  sourceRole: ProjectWorkRoleRecord | null,
+  targetRole: ProjectWorkRoleRecord,
+  workItem: ProjectWorkItemRecord,
+  activityItem?: ProjectActivityItemRecord,
+): HandoffForm {
+  const draft = handoffFormFromAssignment(assignment, sourceRole, activityItem);
+  const sourceRoleName = sourceRole?.name || assignment.role_id;
+  const targetRoleName = targetRole.name || targetRole.id;
+  const workTitle = workItem.title || workItem.id;
+  return {
+    ...draft,
+    targetRoleID: targetRole.id,
+    title: `${targetRoleName} review request`,
+    summary: `Review ${sourceRoleName}'s assignment for "${workTitle}".`,
+    recommendedNextAction:
+      "Create and start the linked review assignment, then record findings as a review artifact or follow-up handoff.",
   };
 }
 


### PR DESCRIPTION
## Summary

- Add a reviewer-aware shortcut on project assignment rows that drafts a structured review handoff to the work item's configured reviewer role.
- Preserve source assignment, run, chat/message, and context refs in the drafted handoff while keeping follow-up assignment creation and launch operator-controlled.
- Document reviewer-role follow-through semantics in runtime, External Agent, and UI agent guidance docs.

## Validation

- `cd ui && bun run test -- src/features/projects/projectWorkForms.test.ts src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects`
- `just agent-docs-check`
- `git diff --check`

Go race suite was not run because this change is UI/docs-only.