### PR TITLE
feat(projects): record review outcomes

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -235,6 +235,13 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   prefill a handoff to a work item's `reviewer_role_ids` and carry source
   assignment/run/chat/context refs, but creating the follow-up assignment and
   starting it remain separate operator actions.
+- Review outcomes are `kind="review"` collaboration artifacts. The V1 cockpit
+  entry point is an assignment whose role appears in the work item's
+  `reviewer_role_ids`; work without configured reviewer roles has no generic
+  record-review button yet. Keep the record action separate from follow-up
+  handoff creation; verdict/risk are body text, not structured query fields, and
+  the UI must not mark work done, blocked, or dispatched from the artifact body
+  without an explicit operator action.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2591,6 +2591,16 @@ Creates a collaboration artifact. `kind` and `body` are required.
 `assignment_id` is optional; when supplied it must refer to an assignment on
 the same work item.
 
+The Projects cockpit uses `kind="review"` artifacts to record reviewer outcomes
+after a review assignment. In V1 the cockpit exposes this action only for
+assignments whose role appears in the work item's `reviewer_role_ids`; callers
+can still create any collaboration artifact through this endpoint. The current
+V1 body is Markdown-compatible text with verdict, risk, summary, verification,
+and follow-up sections. Hecate stores verdict/risk as body text, not structured
+artifact fields, and does not interpret the verdict, mutate work-item status, or
+auto-dispatch follow-up work. Operators can create a separate handoff from the
+review artifact when follow-up is needed.
+
 ```json
 {
   "kind": "handoff",

--- a/ui/src/features/projects/ProjectReviewArtifactModal.tsx
+++ b/ui/src/features/projects/ProjectReviewArtifactModal.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+
+import type { ProjectAssignmentRecord, ProjectWorkRoleRecord } from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import {
+  REVIEW_RISKS,
+  REVIEW_VERDICTS,
+  reviewRiskFromValue,
+  reviewVerdictFromValue,
+  type ReviewArtifactForm,
+} from "./projectWorkForms";
+import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+import { shortID } from "./projectUtils";
+
+type ProjectReviewArtifactModalProps = {
+  assignments: ProjectAssignmentRecord[];
+  draft: ReviewArtifactForm;
+  error: string;
+  pending: boolean;
+  roles: ProjectWorkRoleRecord[];
+  onClose: () => void;
+  onSave: (form: ReviewArtifactForm) => void | Promise<void>;
+};
+
+export function ProjectReviewArtifactModal({
+  assignments,
+  draft,
+  error,
+  pending,
+  roles,
+  onClose,
+  onSave,
+}: ProjectReviewArtifactModalProps) {
+  const [form, setForm] = useState<ReviewArtifactForm>(draft);
+  const valid = form.title.trim().length > 0 && form.summary.trim().length > 0;
+  return (
+    <Modal
+      title="Record review"
+      onClose={onClose}
+      width={620}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Saving..." : "Save review"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Verdict</span>
+            <select
+              className="input"
+              value={form.verdict}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  verdict: reviewVerdictFromValue(event.target.value),
+                }))
+              }
+            >
+              {REVIEW_VERDICTS.map((verdict) => (
+                <option key={verdict} value={verdict}>
+                  {verdict.replaceAll("_", " ")}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Risk</span>
+            <select
+              className="input"
+              value={form.risk}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  risk: reviewRiskFromValue(event.target.value),
+                }))
+              }
+            >
+              {REVIEW_RISKS.map((risk) => (
+                <option key={risk} value={risk}>
+                  {risk}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Assignment</span>
+            <select
+              className="input"
+              value={form.assignmentID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, assignmentID: event.target.value }))
+              }
+            >
+              <option value="">No assignment</option>
+              {assignments.map((assignment) => (
+                <option key={assignment.id} value={assignment.id}>
+                  {shortID(assignment.id)} · {assignment.role_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Author role</span>
+            <select
+              className="input"
+              value={form.authorRoleID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, authorRoleID: event.target.value }))
+              }
+            >
+              <option value="">No author role</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.id}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Summary</span>
+          <textarea
+            className="input"
+            value={form.summary}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, summary: event.target.value }))
+            }
+            rows={4}
+            style={{ resize: "vertical", minHeight: 90 }}
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Verification</span>
+          <textarea
+            className="input"
+            value={form.verification}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, verification: event.target.value }))
+            }
+            rows={3}
+            style={{ resize: "vertical", minHeight: 76 }}
+          />
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Follow-up</span>
+          <textarea
+            className="input"
+            value={form.followUp}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, followUp: event.target.value }))
+            }
+            rows={3}
+            style={{ resize: "vertical", minHeight: 76 }}
+          />
+        </label>
+      </form>
+    </Modal>
+  );
+}

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -159,6 +159,8 @@ function renderDetail(overrides: Partial<ProjectWorkItemDetailProps> = {}) {
     onAddAssignment: vi.fn(),
     onAddHandoff: vi.fn(),
     onAddHandoffFromAssignment: vi.fn(),
+    onAddHandoffFromReviewArtifact: vi.fn(),
+    onAddReviewArtifactFromAssignment: vi.fn(),
     onAddReviewHandoffFromAssignment: vi.fn(),
     onCreateAssignmentFromHandoff: vi.fn(),
     onDeleteAssignment: vi.fn(),
@@ -259,6 +261,30 @@ describe("ProjectWorkItemDetail", () => {
       reviewer,
       undefined,
     );
+  });
+
+  it("only exposes review recording for assignments owned by reviewer roles", async () => {
+    const developer = role();
+    const reviewer = role({ id: "architect", name: "Architect reviewer" });
+    const developerAssignment = assignment({ id: "assign_dev", role_id: "developer" });
+    const reviewerAssignment = assignment({ id: "assign_review", role_id: "architect" });
+    const { handlers } = renderDetail({
+      assignments: [developerAssignment, reviewerAssignment],
+      roleByID: new Map([
+        [developer.id, developer],
+        [reviewer.id, reviewer],
+      ]),
+      workItem: workItem({ reviewer_role_ids: ["architect"] }),
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Record review for assignment assign_dev" }),
+    ).toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Record review for assignment assign_review" }),
+    );
+
+    expect(handlers.onAddReviewArtifactFromAssignment).toHaveBeenCalledWith(reviewerAssignment);
   });
 
   it("loads launch preflight before starting an assignment", async () => {

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -77,6 +77,8 @@ export type ProjectWorkItemDetailProps = {
     reviewRole: ProjectWorkRoleRecord,
     activityItem?: ProjectActivityItemRecord,
   ) => void;
+  onAddReviewArtifactFromAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onAddHandoffFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
   onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
   onDeleteHandoff: (handoff: ProjectHandoffRecord) => void;
@@ -114,6 +116,8 @@ export function ProjectWorkItemDetail({
   onAddHandoff,
   onAddHandoffFromAssignment,
   onAddReviewHandoffFromAssignment,
+  onAddReviewArtifactFromAssignment,
+  onAddHandoffFromReviewArtifact,
   onCreateAssignmentFromHandoff,
   onDeleteAssignment,
   onDeleteHandoff,
@@ -227,6 +231,11 @@ export function ProjectWorkItemDetail({
               {assignments.map((assignment) => {
                 const activityItem = activityByAssignmentID.get(assignment.id);
                 const reviewRole = reviewerRoleForAssignment(workItem, assignment, roleByID);
+                const reviewAuthorRole = reviewAuthorRoleForAssignment(
+                  workItem,
+                  assignment,
+                  roleByID,
+                );
                 return (
                   <AssignmentRow
                     key={assignment.id}
@@ -268,6 +277,11 @@ export function ProjectWorkItemDetail({
                       reviewRole
                         ? () =>
                             onAddReviewHandoffFromAssignment(assignment, reviewRole, activityItem)
+                        : undefined
+                    }
+                    onCreateReviewArtifact={
+                      reviewAuthorRole
+                        ? () => onAddReviewArtifactFromAssignment(assignment)
                         : undefined
                     }
                     project={project}
@@ -322,7 +336,20 @@ export function ProjectWorkItemDetail({
                 <div key={artifact.id} style={artifactStyle}>
                   <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
                     <span className="badge badge-muted">{artifact.kind}</span>
-                    <span style={titleStyle}>{artifact.title || artifact.id}</span>
+                    <span style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
+                      {artifact.title || artifact.id}
+                    </span>
+                    {artifact.kind === "review" && (
+                      <button
+                        aria-label={`Create follow-up from review artifact ${artifact.id}`}
+                        className="btn btn-ghost btn-sm"
+                        type="button"
+                        onClick={() => onAddHandoffFromReviewArtifact(artifact)}
+                      >
+                        <Icon d={Icons.plus} size={12} />
+                        Follow-up
+                      </button>
+                    )}
                   </div>
                   <div style={{ marginTop: 6, fontSize: 12, color: "var(--t2)", lineHeight: 1.45 }}>
                     {artifact.body}
@@ -406,6 +433,7 @@ function AssignmentRow({
   loadPreflight,
   onCreateHandoff,
   onCreateReviewHandoff,
+  onCreateReviewArtifact,
   onDelete,
   onEdit,
   onOpenChat,
@@ -424,6 +452,7 @@ function AssignmentRow({
   loadPreflight?: (() => Promise<ContextPacketRecord>) | null;
   onCreateHandoff: () => void;
   onCreateReviewHandoff?: () => void;
+  onCreateReviewArtifact?: () => void;
   onDelete: () => void;
   onEdit: () => void;
   onOpenChat?: () => void;
@@ -624,6 +653,17 @@ function AssignmentRow({
           >
             <Icon d={Icons.check} size={12} />
             Request review
+          </button>
+        )}
+        {onCreateReviewArtifact && (
+          <button
+            aria-label={`Record review for assignment ${assignment.id}`}
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={onCreateReviewArtifact}
+          >
+            <Icon d={Icons.check} size={12} />
+            Record review
           </button>
         )}
       </div>
@@ -1116,6 +1156,16 @@ function reviewerRoleForAssignment(
     if (role) return role;
   }
   return null;
+}
+
+function reviewAuthorRoleForAssignment(
+  workItem: ProjectWorkItemRecord,
+  assignment: ProjectAssignmentRecord,
+  roleByID: Map<string, ProjectWorkRoleRecord>,
+): ProjectWorkRoleRecord | null {
+  const reviewerIDs = new Set((workItem.reviewer_role_ids ?? []).map((roleID) => roleID.trim()));
+  if (!reviewerIDs.has(assignment.role_id)) return null;
+  return roleByID.get(assignment.role_id) ?? null;
 }
 
 export function buildProjectAssignmentChatLaunchRequest({

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -84,6 +84,8 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     onAddAssignment: vi.fn(),
     onAddHandoff: vi.fn(),
     onAddHandoffFromAssignment: vi.fn(),
+    onAddHandoffFromReviewArtifact: vi.fn(),
+    onAddReviewArtifactFromAssignment: vi.fn(),
     onAddReviewHandoffFromAssignment: vi.fn(),
     onCreateAssignmentFromHandoff: vi.fn(),
     onCreateWork: vi.fn(),

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -75,6 +75,8 @@ export type ProjectWorkspaceViewProps = {
     reviewRole: ProjectWorkRoleRecord,
     activityItem?: ProjectActivityItemRecord,
   ) => void;
+  onAddReviewArtifactFromAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onAddHandoffFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
   onCreateWork: () => void;
   onDeleteAssignment: (assignment: ProjectAssignmentRecord) => void;
@@ -151,6 +153,8 @@ export function ProjectWorkspaceView({
   onAddHandoff,
   onAddHandoffFromAssignment,
   onAddReviewHandoffFromAssignment,
+  onAddReviewArtifactFromAssignment,
+  onAddHandoffFromReviewArtifact,
   onCreateAssignmentFromHandoff,
   onCreateWork,
   onDeleteAssignment,
@@ -327,6 +331,8 @@ export function ProjectWorkspaceView({
                         onAddHandoff={onAddHandoff}
                         onAddHandoffFromAssignment={onAddHandoffFromAssignment}
                         onAddReviewHandoffFromAssignment={onAddReviewHandoffFromAssignment}
+                        onAddReviewArtifactFromAssignment={onAddReviewArtifactFromAssignment}
+                        onAddHandoffFromReviewArtifact={onAddHandoffFromReviewArtifact}
                       />
                     ) : (
                       <ProjectEmptyBlock

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -10,6 +10,7 @@ import {
   ApiError,
   applyProjectAssistant,
   createAgentProfile,
+  createProjectCollaborationArtifact,
   createProjectAssignment,
   createProjectHandoff,
   createProjectMemory,
@@ -241,6 +242,10 @@ vi.mock("../../lib/api", async (importOriginal) => {
       },
     })),
     createProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
+    createProjectCollaborationArtifact: vi.fn(async () => ({
+      object: "project_collaboration_artifact",
+      data: null,
+    })),
     updateProjectHandoff: vi.fn(async () => ({ object: "project_handoff", data: null })),
     updateProjectHandoffStatus: vi.fn(async () => ({ object: "project_handoff", data: null })),
     deleteProjectHandoff: vi.fn(async () => undefined),
@@ -833,6 +838,21 @@ function resetProjectWorkMocks() {
       status_changed_at: "2026-06-02T12:00:00Z",
     },
   });
+  vi.mocked(createProjectCollaborationArtifact).mockResolvedValue({
+    object: "project_collaboration_artifact",
+    data: {
+      id: "art_review_new",
+      project_id: project.id,
+      work_item_id: workItem.id,
+      assignment_id: "asgn_review",
+      kind: "review",
+      title: "QA reviewer review",
+      body: "Verdict: Approved",
+      author_role_id: "reviewer_qa",
+      created_at: "2026-06-02T12:10:00Z",
+      updated_at: "2026-06-02T12:10:00Z",
+    },
+  });
   vi.mocked(updateProjectHandoff).mockResolvedValue({
     object: "project_handoff",
     data: {
@@ -998,6 +1018,7 @@ afterEach(() => {
   vi.mocked(draftProjectAssistant).mockReset();
   vi.mocked(applyProjectAssistant).mockReset();
   vi.mocked(createProjectHandoff).mockReset();
+  vi.mocked(createProjectCollaborationArtifact).mockReset();
   vi.mocked(updateProjectHandoff).mockReset();
   vi.mocked(updateProjectHandoffStatus).mockReset();
   vi.mocked(deleteProjectHandoff).mockReset();
@@ -2547,6 +2568,171 @@ describe("ProjectsView cockpit", () => {
           provenance_kind: "operator",
           trust_label: "operator_reviewed",
           context_refs: ["ctx_assignment_1", "task_1", "run_1"],
+        }),
+      );
+    });
+  });
+
+  it("records review artifacts from reviewer assignments", async () => {
+    resetProjectWorkMocks();
+    const reviewRole: ProjectWorkRoleRecord = {
+      id: "reviewer_qa",
+      project_id: project.id,
+      name: "QA reviewer",
+      description: "Reviews behavior, regressions, and verification gaps.",
+      default_driver_kind: "hecate_task",
+      built_in: false,
+    };
+    const reviewAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_review",
+      role_id: "reviewer_qa",
+      status: "completed",
+      execution_ref: {
+        kind: "task_run",
+        task_id: "task_review",
+        run_id: "run_review",
+        status: "completed",
+      },
+      execution: undefined,
+      completed_at: "2026-06-02T12:00:00Z",
+    };
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_roles",
+      data: [role, reviewRole],
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, status: "review", assignments: [reviewAssignment] }],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: { ...workItem, status: "review", assignments: [reviewAssignment] },
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [reviewAssignment],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
+    );
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await userEvent.click(
+      within(detail).getByRole("button", {
+        name: `Record review for assignment ${reviewAssignment.id}`,
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "Record review" });
+    expect(within(dialog).getByLabelText("Assignment")).toHaveValue("asgn_review");
+    expect(within(dialog).getByLabelText("Author role")).toHaveValue("reviewer_qa");
+    fireEvent.change(within(dialog).getByLabelText("Verdict"), {
+      target: { value: "changes_requested" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Risk"), { target: { value: "medium" } });
+    fireEvent.change(within(dialog).getByLabelText("Summary"), {
+      target: { value: "Empty-state layout needs one more pass." },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Verification"), {
+      target: { value: "Ran project UI tests." },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Follow-up"), {
+      target: { value: "Update the empty-state spacing." },
+    });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save review" }));
+
+    await waitFor(() => {
+      expect(createProjectCollaborationArtifact).toHaveBeenCalledWith(
+        project.id,
+        workItem.id,
+        expect.objectContaining({
+          assignment_id: "asgn_review",
+          author_role_id: "reviewer_qa",
+          kind: "review",
+          title: "QA reviewer review",
+          body: expect.stringContaining("Verdict: Changes requested"),
+        }),
+      );
+    });
+    expect(createProjectCollaborationArtifact).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      expect.objectContaining({
+        body: expect.stringContaining("Follow-up:\nUpdate the empty-state spacing."),
+      }),
+    );
+  });
+
+  it("drafts follow-up handoffs from review artifacts", async () => {
+    resetProjectWorkMocks();
+    const reviewAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      id: "asgn_review",
+      role_id: "reviewer_qa",
+      status: "completed",
+      execution_ref: undefined,
+      execution: undefined,
+    };
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [hecateAssignment, reviewAssignment],
+    });
+    vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({
+      object: "project_collaboration_artifacts",
+      data: [
+        {
+          id: "art_review",
+          project_id: project.id,
+          work_item_id: workItem.id,
+          assignment_id: "asgn_review",
+          kind: "review",
+          title: "QA reviewer review",
+          body: "Verdict: Changes requested\n\nFollow-up:\nUpdate empty-state spacing.",
+          author_role_id: "reviewer_qa",
+          created_at: "2026-06-02T12:10:00Z",
+          updated_at: "2026-06-02T12:10:00Z",
+        },
+      ],
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await waitFor(() => {
+      expect(within(detail).getByText("QA reviewer review")).toBeTruthy();
+    });
+    await userEvent.click(
+      within(detail).getByRole("button", {
+        name: "Create follow-up from review artifact art_review",
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "New handoff" });
+    expect(within(dialog).getByLabelText("Source assignment")).toHaveValue("asgn_review");
+    expect(within(dialog).getByLabelText("Target role")).toHaveValue("software_developer");
+    expect(within(dialog).getByLabelText("Artifact IDs")).toHaveValue("art_review");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save handoff" }));
+
+    await waitFor(() => {
+      expect(createProjectHandoff).toHaveBeenCalledWith(
+        project.id,
+        workItem.id,
+        expect.objectContaining({
+          source_assignment_id: "asgn_review",
+          target_role_id: "software_developer",
+          linked_artifact_ids: ["art_review"],
+          title: "QA reviewer review follow-up",
         }),
       );
     });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -7,6 +7,7 @@ import {
   ApiError,
   createAgentProfile,
   createProjectAssignment,
+  createProjectCollaborationArtifact,
   createProjectHandoff,
   discoverProjectContextSources,
   discoverProjectRoots,
@@ -58,6 +59,7 @@ import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
 import { ProjectHandoffModal } from "./ProjectHandoffModal";
 import { ProjectHealthPanel } from "./ProjectHealthPanel";
 import { ProjectMemoryModal, type MemoryForm } from "./ProjectMemoryPanel";
+import { ProjectReviewArtifactModal } from "./ProjectReviewArtifactModal";
 import { type ProjectAssignmentChatLaunchRequest } from "./ProjectWorkItemDetail";
 import {
   ProjectEmptyBlock,
@@ -102,13 +104,17 @@ import {
   assignmentCreatePayloadFromForm,
   assignmentUpdatePayloadFromForm,
   handoffFormFromAssignment,
+  handoffFormFromReviewArtifact,
   handoffPayloadFromForm,
+  reviewArtifactFormFromAssignment,
+  reviewArtifactPayloadFromForm,
   reviewHandoffFormFromAssignment,
   type EditAssignmentForm,
   type EditWorkItemForm,
   type HandoffForm,
   type NewAssignmentForm,
   type NewWorkItemForm,
+  type ReviewArtifactForm,
   workItemCreatePayloadFromForm,
   workItemUpdatePayloadFromForm,
 } from "./projectWorkForms";
@@ -215,6 +221,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [handoffPending, setHandoffPending] = useState(false);
   const [handoffError, setHandoffError] = useState("");
   const [handoffActionID, setHandoffActionID] = useState("");
+  const [reviewArtifactDraft, setReviewArtifactDraft] = useState<ReviewArtifactForm | null>(null);
+  const [reviewArtifactPending, setReviewArtifactPending] = useState(false);
+  const [reviewArtifactError, setReviewArtifactError] = useState("");
   const [workLoadState, setWorkLoadState] = useState<LoadState>("idle");
   const [detailLoadState, setDetailLoadState] = useState<LoadState>("idle");
   const [workError, setWorkError] = useState("");
@@ -1006,6 +1015,29 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     }
   }
 
+  async function handleSaveReviewArtifact(form: ReviewArtifactForm) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const payload = reviewArtifactPayloadFromForm(form);
+    if (!payload.title?.trim() || !payload.body.trim()) return;
+    setReviewArtifactPending(true);
+    setReviewArtifactError("");
+    try {
+      const res = await createProjectCollaborationArtifact(
+        selectedProjectID,
+        selectedWorkItemID,
+        payload,
+      );
+      setArtifacts((current) => upsertArtifact(current, res.data));
+      setReviewArtifactDraft(null);
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setReviewArtifactError(errorMessage(error, "Failed to save review artifact."));
+    } finally {
+      setReviewArtifactPending(false);
+    }
+  }
+
   async function handleSetHandoffStatus(handoff: ProjectHandoffRecord, status: string) {
     if (!selectedProjectID || !selectedWorkItemID) return;
     setHandoffActionID(handoff.id);
@@ -1306,6 +1338,23 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               );
               setEditingHandoff("new");
             }}
+            onAddReviewArtifactFromAssignment={(assignment) => {
+              if (!selectedWorkItem) return;
+              setReviewArtifactError("");
+              setReviewArtifactDraft(
+                reviewArtifactFormFromAssignment(
+                  assignment,
+                  roleByID.get(assignment.role_id) ?? null,
+                  selectedWorkItem,
+                ),
+              );
+            }}
+            onAddHandoffFromReviewArtifact={(artifact) => {
+              if (!selectedWorkItem) return;
+              setHandoffError("");
+              setNewHandoffDraft(handoffFormFromReviewArtifact(artifact, selectedWorkItem));
+              setEditingHandoff("new");
+            }}
             onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
             onCreateWork={() => {
               setNewWorkError("");
@@ -1529,6 +1578,22 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               setNewHandoffDraft(null);
             }}
             onSave={handleSaveHandoff}
+          />
+        )}
+
+        {reviewArtifactDraft && selectedWorkItem && (
+          <ProjectReviewArtifactModal
+            key={`${reviewArtifactDraft.assignmentID}:${reviewArtifactDraft.authorRoleID}`}
+            assignments={assignments}
+            draft={reviewArtifactDraft}
+            error={reviewArtifactError}
+            pending={reviewArtifactPending}
+            roles={roles}
+            onClose={() => {
+              setReviewArtifactDraft(null);
+              setReviewArtifactError("");
+            }}
+            onSave={handleSaveReviewArtifact}
           />
         )}
 
@@ -1943,6 +2008,23 @@ function upsertAssignment(items: ProjectAssignmentRecord[], item: ProjectAssignm
   const next = items.slice();
   next[index] = item;
   return next;
+}
+
+function upsertArtifact(
+  items: ProjectCollaborationArtifactRecord[],
+  item: ProjectCollaborationArtifactRecord,
+) {
+  const index = items.findIndex((current) => current.id === item.id);
+  const next = index === -1 ? [item, ...items] : items.slice();
+  if (index !== -1) {
+    next[index] = item;
+  }
+  return next.sort((left, right) => {
+    const byTime = (right.updated_at || right.created_at).localeCompare(
+      left.updated_at || left.created_at,
+    );
+    return byTime || left.id.localeCompare(right.id);
+  });
 }
 
 function upsertHandoff(items: ProjectHandoffRecord[], item: ProjectHandoffRecord) {

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type {
   ProjectActivityItemRecord,
   ProjectAssignmentRecord,
+  ProjectCollaborationArtifactRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
@@ -10,9 +11,12 @@ import {
   assignmentStatusFromValue,
   assignmentUpdatePayloadFromForm,
   handoffFormFromAssignment,
+  handoffFormFromReviewArtifact,
   handoffPayloadFromForm,
   handoffStatusFromValue,
   reviewHandoffFormFromAssignment,
+  reviewArtifactFormFromAssignment,
+  reviewArtifactPayloadFromForm,
   workItemCreatePayloadFromForm,
   workItemPriorityFromValue,
   workItemStatusFromValue,
@@ -220,6 +224,95 @@ describe("projectWorkForms", () => {
       status: "pending",
       provenanceKind: "operator",
       trustLabel: "operator_reviewed",
+    });
+  });
+
+  it("builds review artifact payloads with a consistent body template", () => {
+    const assignment: ProjectAssignmentRecord = {
+      id: "assign_review",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      role_id: "reviewer_qa",
+      driver_kind: "hecate_task",
+      status: "completed",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+    const workItem: ProjectWorkItemRecord = {
+      id: "work_1",
+      project_id: "proj_1",
+      title: "Build cockpit",
+      status: "review",
+      priority: "normal",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+    const form = reviewArtifactFormFromAssignment(
+      assignment,
+      { id: "reviewer_qa", project_id: "proj_1", name: "QA reviewer", built_in: false },
+      workItem,
+    );
+
+    expect(
+      reviewArtifactPayloadFromForm({
+        ...form,
+        verdict: "changes_requested",
+        risk: "medium",
+        summary: "Behavior is mostly correct, but empty state needs polish.",
+        verification: "Ran focused UI tests.",
+        followUp: "Fix empty state copy.",
+      }),
+    ).toEqual({
+      assignment_id: "assign_review",
+      author_role_id: "reviewer_qa",
+      kind: "review",
+      title: "QA reviewer review",
+      body: [
+        "Verdict: Changes requested",
+        "Risk: Medium",
+        "",
+        "Summary:",
+        "Behavior is mostly correct, but empty state needs polish.",
+        "",
+        "Verification:",
+        "Ran focused UI tests.",
+        "",
+        "Follow-up:",
+        "Fix empty state copy.",
+      ].join("\n"),
+    });
+  });
+
+  it("drafts follow-up handoffs from review artifacts", () => {
+    const artifact: ProjectCollaborationArtifactRecord = {
+      id: "art_review",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      assignment_id: "assign_review",
+      kind: "review",
+      title: "QA reviewer review",
+      body: "Verdict: Changes requested",
+      author_role_id: "reviewer_qa",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+    const workItem: ProjectWorkItemRecord = {
+      id: "work_1",
+      project_id: "proj_1",
+      title: "Build cockpit",
+      status: "review",
+      priority: "normal",
+      owner_role_id: "software_developer",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-12T00:00:00Z",
+    };
+
+    expect(handoffFormFromReviewArtifact(artifact, workItem)).toMatchObject({
+      sourceAssignmentID: "assign_review",
+      targetRoleID: "software_developer",
+      title: "QA reviewer review follow-up",
+      linkedArtifactIDs: "art_review",
+      status: "pending",
     });
   });
 });

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -1,7 +1,9 @@
 import type {
+  CreateProjectCollaborationArtifactPayload,
   CreateProjectHandoffPayload,
   ProjectActivityItemRecord,
   ProjectAssignmentExecutionRefRecord,
+  ProjectCollaborationArtifactRecord,
   ProjectAssignmentRecord,
   ProjectHandoffRecord,
   ProjectWorkItemRecord,
@@ -38,6 +40,12 @@ export type AssignmentStatus = (typeof ASSIGNMENT_STATUSES)[number];
 
 export const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"] as const;
 export type HandoffStatus = (typeof HANDOFF_STATUSES)[number];
+
+export const REVIEW_VERDICTS = ["approved", "changes_requested", "blocked", "risk"] as const;
+export type ReviewVerdict = (typeof REVIEW_VERDICTS)[number];
+
+export const REVIEW_RISKS = ["low", "medium", "high", "unknown"] as const;
+export type ReviewRisk = (typeof REVIEW_RISKS)[number];
 
 export type NewWorkItemForm = {
   title: string;
@@ -88,6 +96,17 @@ export type HandoffForm = {
   trustLabel: string;
 };
 
+export type ReviewArtifactForm = {
+  assignmentID: string;
+  authorRoleID: string;
+  title: string;
+  verdict: ReviewVerdict;
+  risk: ReviewRisk;
+  summary: string;
+  verification: string;
+  followUp: string;
+};
+
 export function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
   return role?.default_driver_kind || "hecate_task";
 }
@@ -106,6 +125,14 @@ export function assignmentStatusFromValue(value: string | undefined | null): Ass
 
 export function handoffStatusFromValue(value: string | undefined | null): HandoffStatus {
   return choiceFromValue(HANDOFF_STATUSES, value, "pending");
+}
+
+export function reviewVerdictFromValue(value: string | undefined | null): ReviewVerdict {
+  return choiceFromValue(REVIEW_VERDICTS, value, "approved");
+}
+
+export function reviewRiskFromValue(value: string | undefined | null): ReviewRisk {
+  return choiceFromValue(REVIEW_RISKS, value, "unknown");
 }
 
 export function projectAssignmentExecutionKindFromForm(form: EditAssignmentForm) {
@@ -283,6 +310,103 @@ export function reviewHandoffFormFromAssignment(
     recommendedNextAction:
       "Create and start the linked review assignment, then record findings as a review artifact or follow-up handoff.",
   };
+}
+
+export function reviewArtifactFormFromAssignment(
+  assignment: ProjectAssignmentRecord,
+  role: ProjectWorkRoleRecord | null,
+  workItem: ProjectWorkItemRecord,
+): ReviewArtifactForm {
+  const roleName = role?.name || assignment.role_id;
+  return {
+    assignmentID: assignment.id,
+    authorRoleID: assignment.role_id,
+    title: `${roleName} review`,
+    verdict: "approved",
+    risk: "unknown",
+    summary: `Review outcome for "${workItem.title || workItem.id}".`,
+    verification: "",
+    followUp: "",
+  };
+}
+
+export function reviewArtifactPayloadFromForm(
+  form: ReviewArtifactForm,
+): CreateProjectCollaborationArtifactPayload {
+  return {
+    assignment_id: form.assignmentID.trim(),
+    author_role_id: form.authorRoleID.trim(),
+    kind: "review",
+    title: form.title.trim() || "Review",
+    body: reviewArtifactBodyFromForm(form),
+  };
+}
+
+export function handoffFormFromReviewArtifact(
+  artifact: ProjectCollaborationArtifactRecord,
+  workItem: ProjectWorkItemRecord,
+): HandoffForm {
+  return {
+    id: "",
+    sourceAssignmentID: artifact.assignment_id ?? "",
+    sourceRunID: "",
+    sourceChatSessionID: "",
+    sourceMessageID: "",
+    targetRoleID: workItem.owner_role_id ?? "",
+    targetAssignmentID: "",
+    title: `${artifact.title || "Review"} follow-up`,
+    summary: `Follow up on review artifact ${artifact.title || artifact.id}.`,
+    recommendedNextAction:
+      "Create a follow-up assignment for requested changes, or dismiss this handoff if no follow-up is needed.",
+    linkedArtifactIDs: artifact.id,
+    linkedMemoryIDs: "",
+    contextRefs: "",
+    status: "pending",
+    provenanceKind: "operator",
+    trustLabel: "operator_reviewed",
+  };
+}
+
+function reviewArtifactBodyFromForm(form: ReviewArtifactForm): string {
+  return [
+    `Verdict: ${reviewVerdictLabel(form.verdict)}`,
+    `Risk: ${reviewRiskLabel(form.risk)}`,
+    "",
+    "Summary:",
+    form.summary.trim() || "No summary recorded.",
+    "",
+    "Verification:",
+    form.verification.trim() || "Not recorded.",
+    "",
+    "Follow-up:",
+    form.followUp.trim() || "None recorded.",
+  ].join("\n");
+}
+
+function reviewVerdictLabel(verdict: ReviewVerdict): string {
+  switch (verdict) {
+    case "changes_requested":
+      return "Changes requested";
+    case "blocked":
+      return "Blocked";
+    case "risk":
+      return "Risk noted";
+    case "approved":
+      return "Approved";
+  }
+}
+
+function reviewRiskLabel(risk: ReviewRisk): string {
+  switch (risk) {
+    case "low":
+      return "Low";
+    case "medium":
+      return "Medium";
+    case "high":
+      return "High";
+    case "unknown":
+      return "Unknown";
+  }
 }
 
 function choiceFromValue<T extends readonly string[]>(

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -4,6 +4,7 @@ import {
   buildRequestOptions,
   cancelChatApproval,
   chatCompletions,
+  createProjectCollaborationArtifact,
   createProjectAssignment,
   createProjectHandoff,
   createProjectMemory,
@@ -392,6 +393,35 @@ describe("api client", () => {
       4,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs/handoff%2F1",
       expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("creates project collaboration artifacts", async () => {
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ object: "project_collaboration_artifact", data: { id: "art/1" } }),
+    );
+
+    await createProjectCollaborationArtifact("proj/1", "work/1", {
+      kind: "review",
+      assignment_id: "asgn/1",
+      title: "QA review",
+      body: "Verdict: Approved",
+      author_role_id: "reviewer_qa",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          kind: "review",
+          assignment_id: "asgn/1",
+          title: "QA review",
+          body: "Verdict: Approved",
+          author_role_id: "reviewer_qa",
+        }),
+      }),
     );
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -56,6 +56,7 @@ import type { UsageEventsResponse, UsageSummaryResponse } from "../types/usage";
 import type { RetentionRunResponse, RetentionRunsResponse } from "../types/retention";
 import type {
   CreateProjectPayload,
+  CreateProjectCollaborationArtifactPayload,
   CreateProjectWorktreeRootPayload,
   CreateProjectMemoryCandidatePayload,
   CreateProjectMemoryPayload,
@@ -73,6 +74,7 @@ import type {
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
   ProjectActivityResponse,
+  ProjectCollaborationArtifactResponse,
   ProjectCollaborationArtifactsResponse,
   ProjectHandoffResponse,
   ProjectHandoffsResponse,
@@ -738,6 +740,17 @@ export async function getProjectCollaborationArtifacts(
 ): Promise<ProjectCollaborationArtifactsResponse> {
   return fetchJSON<ProjectCollaborationArtifactsResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/artifacts`,
+  );
+}
+
+export async function createProjectCollaborationArtifact(
+  projectID: string,
+  workItemID: string,
+  payload: CreateProjectCollaborationArtifactPayload,
+): Promise<ProjectCollaborationArtifactResponse> {
+  return fetchJSON<ProjectCollaborationArtifactResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/artifacts`,
+    { method: "POST", body: payload },
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -610,6 +610,15 @@ export type ProjectCollaborationArtifactRecord = {
   updated_at: string;
 };
 
+export type CreateProjectCollaborationArtifactPayload = {
+  id?: string;
+  assignment_id?: string;
+  kind: ProjectCollaborationArtifactKind | string;
+  title?: string;
+  body: string;
+  author_role_id?: string;
+};
+
 export type ProjectHandoffStatus = "pending" | "accepted" | "superseded" | "dismissed";
 
 export type ProjectHandoffRecord = {
@@ -807,6 +816,11 @@ export type ProjectAssignmentResponse = {
 export type ProjectCollaborationArtifactsResponse = {
   object: string;
   data: ProjectCollaborationArtifactRecord[];
+};
+
+export type ProjectCollaborationArtifactResponse = {
+  object: string;
+  data: ProjectCollaborationArtifactRecord;
 };
 
 export type ProjectHandoffsResponse = {


### PR DESCRIPTION
## Summary

- Add typed UI support for creating project collaboration artifacts.
- Add a Projects review modal that records reviewer outcomes as kind="review" artifacts with verdict, risk, summary, verification, and follow-up sections.
- Let operators create a follow-up handoff from a review artifact while keeping assignment creation and launch explicit.
- Document review artifact semantics in runtime/API and UI agent guidance docs.

## Validation

- cd ui && bun run test -- src/lib/api.test.ts src/features/projects/projectWorkForms.test.ts src/features/projects/ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/projects
- just agent-docs-check
- git diff --check

Go race suite was not run because this change is UI/docs-only.
