### PR TITLE
Draft assistant proposals from linked chats

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -19,7 +19,11 @@ project is selected in the Chats sidebar, new Hecate and External Agent chat
 sessions are created with that `project_id`, and the chat list shows only chats
 for the active project. When an open chat is linked to a project, the chat
 header exposes a compact project shortcut that selects that project and opens
-the Projects workspace. Deleting a project also deletes its project-scoped chat
+the Projects workspace. Project-linked Hecate Chat also exposes a compact
+composer action that drafts a Project Assistant proposal from the current
+message and hands it to the Projects review surface. That handoff is proposal
+data only; it does not send a chat message, create project records, or apply
+the proposal. Deleting a project also deletes its project-scoped chat
 transcripts. Unprojected chats and chats in other projects stay untouched.
 
 Hecate Chat treats model/provider readiness as part of composition, not a

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -20,10 +20,11 @@ sessions are created with that `project_id`, and the chat list shows only chats
 for the active project. When an open chat is linked to a project, the chat
 header exposes a compact project shortcut that selects that project and opens
 the Projects workspace. Project-linked Hecate Chat also exposes a compact
-composer action that drafts a Project Assistant proposal from the current
-message and hands it to the Projects review surface. That handoff is proposal
-data only; it does not send a chat message, create project records, or apply
-the proposal. Deleting a project also deletes its project-scoped chat
+composer action that deterministically drafts a Project Assistant proposal from
+the current message and hands it to the Projects review surface. That handoff
+is proposal data only; it does not send a chat message, create project records,
+call the model-backed draft path, or apply the proposal. Deleting a project also
+deletes its project-scoped chat
 transcripts. Unprojected chats and chats in other projects stay untouched.
 
 Hecate Chat treats model/provider readiness as part of composition, not a

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -42,9 +42,10 @@ run, assignment, or agent session.
 Project-linked Hecate Chat has a compact `Draft proposal` composer action for
 turning the current draft message into the same Project Assistant proposal
 shape. That chat-session route derives `project_id` from the linked session
-instead of accepting it from the request body, drafts proposal data only, and
-hands the proposal to the Projects workspace for review. It does not append a
-chat message, create work records, or apply the proposal.
+instead of accepting it from the request body, always uses deterministic
+drafting, and hands the proposal to the Projects workspace for review. It does
+not append a chat message, call the model-backed draft path, create work
+records, or apply the proposal.
 
 ## Authority boundary
 
@@ -503,8 +504,8 @@ project changes as Project Assistant proposal intent, not as permission to
 mutate project stores through generic tools or direct API calls. If the selected
 chat model routes to a cloud provider, that bounded project prompt context
 follows the normal model gateway route. Chat-side proposal drafting calls the
-Project Assistant draft API only; durable mutations must still stop at the
-explicit Projects review/apply card.
+deterministic Project Assistant draft path only; durable mutations must still
+stop at the explicit Projects review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
 project list, project work, selected work-item detail, and project memory.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -6,9 +6,10 @@ reviewable project proposal or submit typed actions directly, Hecate validates
 the proposal, the operator inspects the exact change set, and apply revalidates
 current server state before any durable mutation.
 
-It is not a broad chat persona in v0. Hecate Chat can call the same proposal and
-apply API later, but the action system lives in core so every surface follows
-the same validation, confirmation, and audit rules.
+It is not a broad chat persona in v0. Project-linked Hecate Chat can draft a
+Project Assistant proposal from the current composer text, but review and apply
+stay in the Projects workspace. The action system lives in core so every
+surface follows the same validation, confirmation, and audit rules.
 
 ## Current decisions
 
@@ -37,6 +38,13 @@ selected work item, the draft queues an assignment for that work. Without a
 selected work item, the draft creates a new project work item. In both cases
 `Draft proposal` creates reviewable data only; it does not create a chat, task,
 run, assignment, or agent session.
+
+Project-linked Hecate Chat has a compact `Draft proposal` composer action for
+turning the current draft message into the same Project Assistant proposal
+shape. That chat-session route derives `project_id` from the linked session
+instead of accepting it from the request body, drafts proposal data only, and
+hands the proposal to the Projects workspace for review. It does not append a
+chat message, create work records, or apply the proposal.
 
 ## Authority boundary
 
@@ -494,9 +502,9 @@ not load or inject `SKILL.md` bodies. It tells the model to treat durable
 project changes as Project Assistant proposal intent, not as permission to
 mutate project stores through generic tools or direct API calls. If the selected
 chat model routes to a cloud provider, that bounded project prompt context
-follows the normal model gateway route. A future chat-side proposal tool or
-slash-command shortcut can call the same Project Assistant APIs, but durable
-mutations must still stop at the explicit review/apply card.
+follows the normal model gateway route. Chat-side proposal drafting calls the
+Project Assistant draft API only; durable mutations must still stop at the
+explicit Projects review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
 project list, project work, selected work-item detail, and project memory.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2661,10 +2661,12 @@ safety model.
 
 `POST /hecate/v1/chat/sessions/{id}/project-assistant/draft` is the Chat
 handoff variant for project-linked Hecate Chat sessions. The request body
-matches `/project-assistant/draft` except it omits `project_id`; Hecate derives
-the project from the chat session and rejects unprojected or external-agent
-sessions. The endpoint returns `project_assistant.proposal` data only. It does
-not append chat messages, create project records, or apply the proposal; UI
+accepts the deterministic draft fields `request`, optional `work_item_id`,
+optional `role_id`, and optional `driver_kind`; Hecate derives the project from
+the chat session and rejects unprojected or external-agent sessions. The
+endpoint always uses deterministic drafting and returns
+`project_assistant.proposal` data only. It does not call the model-backed draft
+path, append chat messages, create project records, or apply the proposal; UI
 clients should hand the response to the Projects Project Assistant review/apply
 surface.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2633,6 +2633,7 @@ Endpoints:
 - `POST /hecate/v1/project-assistant/draft`
 - `POST /hecate/v1/project-assistant/propose`
 - `POST /hecate/v1/project-assistant/apply`
+- `POST /hecate/v1/chat/sessions/{id}/project-assistant/draft`
 
 `context` returns the v0 item-limited and body-budgeted project packet plus the
 inspectable Auto role/driver selection that `draft` will use. It includes
@@ -2657,6 +2658,15 @@ cannot carry `task_id`, `run_id`, `chat_session_id`, `message_id`, or
 [`project-assistant.md`](project-assistant.md) for the context and draft
 requests, proposal schema, supported action kinds, confirmation behavior, and
 safety model.
+
+`POST /hecate/v1/chat/sessions/{id}/project-assistant/draft` is the Chat
+handoff variant for project-linked Hecate Chat sessions. The request body
+matches `/project-assistant/draft` except it omits `project_id`; Hecate derives
+the project from the chat session and rejects unprojected or external-agent
+sessions. The endpoint returns `project_assistant.proposal` data only. It does
+not append chat messages, create project records, or apply the proposal; UI
+clients should hand the response to the Projects Project Assistant review/apply
+surface.
 
 ## Chat session endpoints
 

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -34,9 +34,6 @@ type chatProjectAssistantDraftRequest struct {
 	Request    string `json:"request"`
 	RoleID     string `json:"role_id,omitempty"`
 	DriverKind string `json:"driver_kind,omitempty"`
-	DraftMode  string `json:"draft_mode,omitempty"`
-	Provider   string `json:"provider,omitempty"`
-	Model      string `json:"model,omitempty"`
 }
 
 type projectAssistantContextRequest struct {
@@ -138,9 +135,7 @@ func (h *Handler) HandleChatProjectAssistantDraft(w http.ResponseWriter, r *http
 		Request:    req.Request,
 		RoleID:     req.RoleID,
 		DriverKind: req.DriverKind,
-		DraftMode:  req.DraftMode,
-		Provider:   firstNonEmpty(req.Provider, session.Provider),
-		Model:      firstNonEmpty(req.Model, session.Model),
+		DraftMode:  projectassistant.DraftModeDeterministic,
 		RequestID:  RequestIDFromContext(r.Context()),
 		TraceID:    requestTraceID(r),
 	})

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
@@ -19,6 +20,16 @@ type projectAssistantProposeRequest struct {
 
 type projectAssistantDraftRequest struct {
 	ProjectID  string `json:"project_id"`
+	WorkItemID string `json:"work_item_id,omitempty"`
+	Request    string `json:"request"`
+	RoleID     string `json:"role_id,omitempty"`
+	DriverKind string `json:"driver_kind,omitempty"`
+	DraftMode  string `json:"draft_mode,omitempty"`
+	Provider   string `json:"provider,omitempty"`
+	Model      string `json:"model,omitempty"`
+}
+
+type chatProjectAssistantDraftRequest struct {
 	WorkItemID string `json:"work_item_id,omitempty"`
 	Request    string `json:"request"`
 	RoleID     string `json:"role_id,omitempty"`
@@ -79,6 +90,57 @@ func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Req
 		DraftMode:  req.DraftMode,
 		Provider:   req.Provider,
 		Model:      req.Model,
+		RequestID:  RequestIDFromContext(r.Context()),
+		TraceID:    requestTraceID(r),
+	})
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.proposal",
+		"data":   proposal,
+	})
+}
+
+func (h *Handler) HandleChatProjectAssistantDraft(w http.ResponseWriter, r *http.Request) {
+	result, err := h.chatApplication().GetSession(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if writeChatAppError(w, err) {
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	session := result.Session
+	if isExternalChatSession(session) {
+		WriteError(w, http.StatusConflict, errCodeRuntimeMismatch, "Project Assistant chat drafts are available for Hecate Chat sessions")
+		return
+	}
+	projectID := strings.TrimSpace(session.ProjectID)
+	if projectID == "" {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "Project Assistant chat drafts require a project-linked chat session")
+		return
+	}
+	var req chatProjectAssistantDraftRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid chat project assistant draft request")
+		return
+	}
+	req.Request = strings.TrimSpace(req.Request)
+	if req.Request == "" {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request is required")
+		return
+	}
+	proposal, err := h.projectAssistantApplication().Draft(r.Context(), projectassistantapp.DraftCommand{
+		ProjectID:  projectID,
+		WorkItemID: req.WorkItemID,
+		Request:    req.Request,
+		RoleID:     req.RoleID,
+		DriverKind: req.DriverKind,
+		DraftMode:  req.DraftMode,
+		Provider:   firstNonEmpty(req.Provider, session.Provider),
+		Model:      firstNonEmpty(req.Model, session.Model),
 		RequestID:  RequestIDFromContext(r.Context()),
 		TraceID:    requestTraceID(r),
 	})

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -233,6 +233,114 @@ func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantAPI_ChatDraftDerivesProjectFromSession(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_chat_draft", Name: "Chat Draft Project"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	session, err := handler.agentChat.Create(t.Context(), chat.Session{
+		ID:        "chat_pa_draft",
+		Title:     "Project chat",
+		ProjectID: project.ID,
+		AgentID:   chat.DefaultAgentID,
+		Provider:  "ollama",
+		Model:     "qwen2.5-coder",
+		Status:    "idle",
+	})
+	if err != nil {
+		t.Fatalf("Create chat: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/"+session.ID+"/project-assistant/draft", bytes.NewReader([]byte(`{
+		"request":"Plan next project work\nCapture a reviewable task."
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chat draft status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode chat draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || len(proposed.Data.Actions) != 1 {
+		t.Fatalf("chat draft response = %+v, want one proposal action", proposed)
+	}
+	if proposed.Data.Actions[0].Kind != projectassistant.ActionCreateWorkItem {
+		t.Fatalf("action kind = %q, want create_work_item", proposed.Data.Actions[0].Kind)
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(proposed.Data.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patch["project_id"] != project.ID || patch["title"] != "Plan next project work" {
+		t.Fatalf("patch = %+v, want linked project and request-derived title", patch)
+	}
+	updatedSession, ok, err := handler.agentChat.Get(t.Context(), session.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get chat = ok %v err %v", ok, err)
+	}
+	if len(updatedSession.Messages) != 0 {
+		t.Fatalf("chat messages = %+v, want draft route not to append messages", updatedSession.Messages)
+	}
+	workItems, err := handler.projectWork.ListWorkItems(t.Context(), project.ID)
+	if err != nil {
+		t.Fatalf("ListWorkItems: %v", err)
+	}
+	if len(workItems) != 0 {
+		t.Fatalf("work items = %+v, want draft route not to mutate project work", workItems)
+	}
+}
+
+func TestProjectAssistantAPI_ChatDraftRequiresLinkedHecateSession(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	if _, err := handler.agentChat.Create(t.Context(), chat.Session{
+		ID:      "chat_unlinked",
+		Title:   "No project",
+		AgentID: chat.DefaultAgentID,
+		Status:  "idle",
+	}); err != nil {
+		t.Fatalf("Create unlinked chat: %v", err)
+	}
+	if _, err := handler.agentChat.Create(t.Context(), chat.Session{
+		ID:        "chat_external",
+		Title:     "External",
+		ProjectID: "proj_unused",
+		AgentID:   "claude_code",
+		Status:    "idle",
+	}); err != nil {
+		t.Fatalf("Create external chat: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/chat_unlinked/project-assistant/draft", strings.NewReader(`{"request":"Plan work"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unlinked status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	var unlinked projectAssistantErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &unlinked); err != nil {
+		t.Fatalf("decode unlinked error: %v", err)
+	}
+	if unlinked.Error.Type != errCodeInvalidRequest {
+		t.Fatalf("unlinked error type = %q, want %s", unlinked.Error.Type, errCodeInvalidRequest)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/chat_external/project-assistant/draft", strings.NewReader(`{"request":"Plan work"}`)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("external status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var external projectAssistantErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &external); err != nil {
+		t.Fatalf("decode external error: %v", err)
+	}
+	if external.Error.Type != errCodeRuntimeMismatch {
+		t.Fatalf("external error type = %q, want %s", external.Error.Type, errCodeRuntimeMismatch)
+	}
+}
+
 func TestProjectAssistantAPI_DraftBootstrapProposal(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantTestHandler()

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -255,7 +255,10 @@ func TestProjectAssistantAPI_ChatDraftDerivesProjectFromSession(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/"+session.ID+"/project-assistant/draft", bytes.NewReader([]byte(`{
-		"request":"Plan next project work\nCapture a reviewable task."
+		"request":"Plan next project work\nCapture a reviewable task.",
+		"draft_mode":"model",
+		"provider":"openai",
+		"model":"gpt-test"
 	}`))))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("chat draft status = %d body=%s, want 200", rec.Code, rec.Body.String())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,6 +141,7 @@ func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/chat/sessions/{id}/settings", handler.HandleSetAgentChatSettings)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/config-options/{config_id}", handler.HandleSetAgentChatConfigOption)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/messages", handler.HandleCreateChatMessage)
+	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/project-assistant/draft", handler.HandleChatProjectAssistantDraft)
 	mux.HandleFunc("GET /hecate/v1/chat/sessions/{id}/workspace-diff", handler.HandleChatWorkspaceDiff)
 	mux.HandleFunc("GET /hecate/v1/chat/sessions/{id}/workspace-files", handler.HandleChatWorkspaceFiles)
 	mux.HandleFunc("GET /hecate/v1/chat/sessions/{id}/workspace-diff/files/{path...}", handler.HandleChatWorkspaceFileDiff)

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -99,6 +99,8 @@ export type ChatComposerProps = {
   activeHecateRunID: string;
   // Filtered to the active session — ChatView already does the filter.
   activeQueuedChatMessages: QueuedChatMessage[];
+  projectProposalAvailable?: boolean;
+  projectProposalDrafting?: boolean;
 
   // User-message history feeds the arrow-key recall, derived in
   // ChatView from visibleMessages.
@@ -108,6 +110,7 @@ export type ChatComposerProps = {
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings" | "projects") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
+  onDraftProjectProposal?: () => void;
 };
 
 export function ChatComposer(props: ChatComposerProps) {
@@ -173,10 +176,13 @@ export function ChatComposer(props: ChatComposerProps) {
     activeHecateTaskID,
     activeHecateRunID,
     activeQueuedChatMessages,
+    projectProposalAvailable = false,
+    projectProposalDrafting = false,
     messageHistory,
     onNavigate,
     onOpenTask,
     onOpenTrace,
+    onDraftProjectProposal,
   } = props;
   const activeExternalAgentID =
     activeChatSession?.agent_id && activeChatSession.agent_id !== "hecate"
@@ -885,6 +891,26 @@ export function ChatComposer(props: ChatComposerProps) {
                   }}
                 >
                   Stop
+                </button>
+              )}
+              {projectProposalAvailable && onDraftProjectProposal && (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  aria-label="Draft Project Assistant proposal from message"
+                  disabled={projectProposalDrafting}
+                  title="Draft a Project Assistant proposal from this message"
+                  onClick={onDraftProjectProposal}
+                  style={{
+                    flexShrink: 0,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    padding: "2px 6px",
+                    color: "var(--teal)",
+                  }}
+                >
+                  <Icon d={Icons.projects} size={12} />
+                  {projectProposalDrafting ? "Drafting..." : "Draft proposal"}
                 </button>
               )}
             </span>

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -5639,7 +5639,6 @@ describe("ChatView session title", () => {
     await waitFor(() => {
       expect(draftChatProjectAssistant).toHaveBeenCalledWith("s1", {
         request: "Plan next project work",
-        draft_mode: "deterministic",
       });
     });
     expect(selectProject).toHaveBeenCalledWith("proj_1");

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3,7 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ChatView } from "./ChatView";
-import { discoverLocalProviders } from "../../lib/api";
+import { discoverLocalProviders, draftChatProjectAssistant } from "../../lib/api";
+import { readProjectAssistantChatHandoff } from "../../lib/project-assistant-chat-handoff";
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
@@ -21,11 +22,28 @@ vi.mock("../../lib/api", async (importOriginal) => {
   return {
     ...actual,
     discoverLocalProviders: vi.fn(async () => ({ object: "local_provider_discovery", data: [] })),
+    draftChatProjectAssistant: vi.fn(async () => ({
+      object: "project_assistant.proposal",
+      data: {
+        id: "pa_chat",
+        title: "Plan next project work",
+        summary: "Create a work item from chat.",
+        actions: [
+          {
+            kind: "create_work_item",
+            target: { project_id: "proj_1" },
+            patch: { project_id: "proj_1", title: "Plan next project work" },
+          },
+        ],
+        requires_confirmation: true,
+      },
+    })),
   };
 });
 
 afterEach(() => {
   localStorage.removeItem("hecate.chat.rightPanelWidth");
+  sessionStorage.removeItem("hecate.projectAssistant.chatDraft");
   if (originalNavigatorClipboardDescriptor) {
     Object.defineProperty(navigator, "clipboard", originalNavigatorClipboardDescriptor);
   } else {
@@ -35,6 +53,23 @@ afterEach(() => {
   vi.mocked(discoverLocalProviders).mockResolvedValue({
     object: "local_provider_discovery",
     data: [],
+  });
+  vi.mocked(draftChatProjectAssistant).mockReset();
+  vi.mocked(draftChatProjectAssistant).mockResolvedValue({
+    object: "project_assistant.proposal",
+    data: {
+      id: "pa_chat",
+      title: "Plan next project work",
+      summary: "Create a work item from chat.",
+      actions: [
+        {
+          kind: "create_work_item",
+          target: { project_id: "proj_1" },
+          patch: { project_id: "proj_1", title: "Plan next project work" },
+        },
+      ],
+      requires_confirmation: true,
+    },
   });
 });
 
@@ -5560,6 +5595,62 @@ describe("ChatView session title", () => {
 
     expect(selectProject).toHaveBeenCalledWith("proj_1");
     expect(onNavigate).toHaveBeenCalledWith("projects");
+  });
+
+  it("drafts a Project Assistant proposal from a project-linked Hecate chat message", async () => {
+    const selectProject = vi.fn(async () => undefined);
+    const setMessage = vi.fn();
+    const onNavigate = vi.fn();
+    const project: ProjectRecord = {
+      id: "proj_1",
+      name: "Hecate",
+      roots: [],
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    };
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        message: "Plan next project work",
+        projects: [project],
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          project_id: "proj_1",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+          provider_calls: [],
+        } as any,
+      },
+      { selectProject, setMessage },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Draft Project Assistant proposal from message" }),
+    );
+
+    await waitFor(() => {
+      expect(draftChatProjectAssistant).toHaveBeenCalledWith("s1", {
+        request: "Plan next project work",
+        draft_mode: "deterministic",
+      });
+    });
+    expect(selectProject).toHaveBeenCalledWith("proj_1");
+    expect(onNavigate).toHaveBeenCalledWith("projects");
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(readProjectAssistantChatHandoff()).toMatchObject({
+      project_id: "proj_1",
+      request: "Plan next project work",
+      source_session_id: "s1",
+      proposal: { id: "pa_chat" },
+    });
   });
 
   it("does not show the project shortcut for unprojected chats", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -566,7 +566,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     try {
       const payload = await draftChatProjectAssistant(sessionID, {
         request,
-        draft_mode: "deterministic",
       });
       const handoffWritten = writeProjectAssistantChatHandoff({
         project_id: projectID,

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -18,7 +18,8 @@ import {
   useWiredSettingsActions,
   useWiredDashboardActions,
 } from "../../app/state/coordinators/wired";
-import { discoverLocalProviders } from "../../lib/api";
+import { discoverLocalProviders, draftChatProjectAssistant } from "../../lib/api";
+import { writeProjectAssistantChatHandoff } from "../../lib/project-assistant-chat-handoff";
 import {
   modelSelectionHasNoToolCalling,
   resolveChatSetupRepairState,
@@ -171,6 +172,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   const [quickLocalProviders, setQuickLocalProviders] = useState<LocalProviderDiscoveryRecord[]>(
     [],
   );
+  const [projectProposalDrafting, setProjectProposalDrafting] = useState(false);
 
   function updateRightPanelWidth(width: number) {
     setRightPanelWidth(width);
@@ -528,6 +530,13 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
       isHecateAgentChat &&
       (!hecateChatModelReady ||
         (!hecateAgentToolsDisabledForModel && !state.agentWorkspace.trim())));
+  const projectProposalAvailable =
+    selectedChatReady &&
+    isHecateChat &&
+    !agentBusy &&
+    Boolean(activeSessionProjectID) &&
+    Boolean(onNavigate) &&
+    Boolean(state.message.trim());
 
   function openAgentSetup(adapterID = activeAgentAdapterID) {
     try {
@@ -546,6 +555,48 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     if (!projectID) return;
     void projects.actions.selectProject(projectID);
     onNavigate?.("projects");
+  }
+
+  async function draftProjectProposalFromChat() {
+    const sessionID = activeSessionID.trim();
+    const projectID = activeSessionProjectID.trim();
+    const request = state.message.trim();
+    if (!sessionID || !projectID || !request || projectProposalDrafting) return;
+    setProjectProposalDrafting(true);
+    try {
+      const payload = await draftChatProjectAssistant(sessionID, {
+        request,
+        draft_mode: "deterministic",
+      });
+      const handoffWritten = writeProjectAssistantChatHandoff({
+        project_id: projectID,
+        proposal: payload.data,
+        request,
+        source_session_id: sessionID,
+        created_at: new Date().toISOString(),
+      });
+      if (!handoffWritten) {
+        settingsActions.setNoticeMessage(
+          "error",
+          "Failed to hand off the proposal to Projects. Try drafting again.",
+        );
+        return;
+      }
+      runtime.actions.setMessage("");
+      void projects.actions.selectProject(projectID);
+      onNavigate?.("projects");
+      settingsActions.setNoticeMessage(
+        "success",
+        "Project Assistant proposal drafted. Review it in Projects.",
+      );
+    } catch (error) {
+      settingsActions.setNoticeMessage(
+        "error",
+        error instanceof Error ? error.message : "Failed to draft Project Assistant proposal.",
+      );
+    } finally {
+      setProjectProposalDrafting(false);
+    }
   }
 
   useEffect(() => {
@@ -980,7 +1031,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                 activeHecateTaskID={activeHecateTaskID}
                 activeHecateRunID={activeHecateRunID}
                 activeQueuedChatMessages={activeQueuedChatMessages}
+                projectProposalAvailable={projectProposalAvailable}
+                projectProposalDrafting={projectProposalDrafting}
                 messageHistory={messageHistory}
+                onDraftProjectProposal={() => void draftProjectProposalFromChat()}
                 onNavigate={onNavigate}
                 onOpenTask={onOpenTask}
                 onOpenTrace={onOpenTrace}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -58,6 +58,10 @@ import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
 } from "../../test/runtime-console-fixture";
+import {
+  readProjectAssistantChatHandoff,
+  writeProjectAssistantChatHandoff,
+} from "../../lib/project-assistant-chat-handoff";
 import launchContextContractRaw from "../../test/fixtures/launch-context-v1-contract.json";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type {
@@ -998,6 +1002,7 @@ function expectLaunchContextContract(text: string) {
 
 afterEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   vi.mocked(getProjectActivity).mockReset();
   vi.mocked(getProjectWorkRoles).mockReset();
   vi.mocked(getProjectWorkItems).mockReset();
@@ -1354,6 +1359,47 @@ describe("ProjectsView cockpit", () => {
     expect(await within(assistant).findByText("Applied 1 action from pa_test.")).toBeTruthy();
     expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
     expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
+  });
+
+  it("loads a chat-drafted Project Assistant proposal into the review panel", async () => {
+    resetProjectWorkMocks();
+    window.localStorage.setItem("hecate.project", project.id);
+    writeProjectAssistantChatHandoff({
+      project_id: project.id,
+      request: "Plan next project work",
+      source_session_id: "chat_1",
+      proposal: {
+        id: "pa_chat",
+        title: "Plan next project work",
+        summary: "Create a work item from chat.",
+        requires_confirmation: true,
+        actions: [
+          {
+            kind: "create_work_item",
+            target: { project_id: project.id },
+            patch: {
+              project_id: project.id,
+              title: "Plan next project work",
+              brief: "Capture a reviewable task from chat.",
+              status: "ready",
+            },
+          },
+        ],
+      },
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    expect(
+      (await within(assistant).findAllByText("Plan next project work")).length,
+    ).toBeGreaterThan(0);
+    expect(within(assistant).getByText("Create work item")).toBeTruthy();
+    expect(draftProjectAssistant).not.toHaveBeenCalled();
+    expect(readProjectAssistantChatHandoff()).toBeNull();
   });
 
   it("can request model-backed Project Assistant drafts", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -47,6 +47,10 @@ import {
   updateProjectWorkItem,
 } from "../../lib/api";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
+import {
+  clearProjectAssistantChatHandoff,
+  readProjectAssistantChatHandoff,
+} from "../../lib/project-assistant-chat-handoff";
 import { providerDisplayName } from "../../lib/provider-utils";
 import { ChatRightPanel } from "../chats/ChatRightPanel";
 import {
@@ -538,6 +542,16 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   useEffect(() => {
     assistant.dismiss();
   }, [assistant.dismiss, selectedProjectID, selectedWorkItemID]);
+
+  useEffect(() => {
+    if (!selectedProjectID) return;
+    if (workLoadState !== "loaded" && workLoadState !== "error") return;
+    const handoff = readProjectAssistantChatHandoff();
+    if (!handoff || handoff.project_id !== selectedProjectID) return;
+    assistant.loadProposal(handoff.proposal);
+    setWorkspaceTab("work");
+    clearProjectAssistantChatHandoff();
+  }, [assistant.loadProposal, selectedProjectID, selectedWorkItemID, workLoadState]);
 
   function startRename(project: ProjectRecord) {
     setRenamingProjectID(project.id);

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -551,7 +551,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     assistant.loadProposal(handoff.proposal);
     setWorkspaceTab("work");
     clearProjectAssistantChatHandoff();
-  }, [assistant.loadProposal, selectedProjectID, selectedWorkItemID, workLoadState]);
+  }, [assistant.loadProposal, selectedProjectID, workLoadState]);
 
   function startRename(project: ProjectRecord) {
     setRenamingProjectID(project.id);

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -134,6 +134,16 @@ export function useProjectAssistantController(options: Options) {
     [options.project, options.selectedWorkItem],
   );
 
+  const loadProposal = useCallback((nextProposal: ProjectAssistantProposal) => {
+    setProposal(nextProposal);
+    setApplyResult(null);
+    setContext(null);
+    setContextError("");
+    setContextStatus("idle");
+    setError("");
+    setStatus("idle");
+  }, []);
+
   const apply = useCallback(async () => {
     if (!options.selectedProjectID || !proposal) return;
     const currentProposal = proposal;
@@ -191,6 +201,7 @@ export function useProjectAssistantController(options: Options) {
     dismiss,
     error,
     inspectContext,
+    loadProposal,
     proposal,
     propose,
     status,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -66,6 +66,7 @@ import type {
   CreateProjectWorkItemPayload,
   ProjectAssistantApplyPayload,
   ProjectAssistantApplyResponse,
+  ProjectAssistantChatDraftPayload,
   ProjectAssistantContextPayload,
   ProjectAssistantContextResponse,
   ProjectAssistantDraftPayload,
@@ -425,6 +426,19 @@ export async function draftProjectAssistant(
     method: "POST",
     body: payload,
   });
+}
+
+export async function draftChatProjectAssistant(
+  sessionID: string,
+  payload: ProjectAssistantChatDraftPayload,
+): Promise<ProjectAssistantProposalResponse> {
+  return fetchJSON<ProjectAssistantProposalResponse>(
+    `${HECATE_API}/chat/sessions/${encodeURIComponent(sessionID)}/project-assistant/draft`,
+    {
+      method: "POST",
+      body: payload,
+    },
+  );
 }
 
 export async function applyProjectAssistant(

--- a/ui/src/lib/project-assistant-chat-handoff.test.ts
+++ b/ui/src/lib/project-assistant-chat-handoff.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearProjectAssistantChatHandoff,
+  readProjectAssistantChatHandoff,
+  writeProjectAssistantChatHandoff,
+} from "./project-assistant-chat-handoff";
+import type { ProjectAssistantProposal } from "../types/project";
+
+const proposal: ProjectAssistantProposal = {
+  id: "pa_1",
+  title: "Plan next work",
+  summary: "Create a project work item.",
+  requires_confirmation: true,
+  actions: [
+    {
+      kind: "create_work_item",
+      target: { project_id: "proj_1" },
+      patch: { project_id: "proj_1", title: "Plan next work" },
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.sessionStorage.clear();
+});
+
+describe("Project Assistant chat handoff", () => {
+  it("round-trips a proposal through sessionStorage", () => {
+    expect(
+      writeProjectAssistantChatHandoff({
+        project_id: "proj_1",
+        proposal,
+        request: "Plan next work",
+        source_session_id: "chat_1",
+        created_at: "2026-06-13T00:00:00Z",
+      }),
+    ).toBe(true);
+
+    expect(readProjectAssistantChatHandoff()).toMatchObject({
+      project_id: "proj_1",
+      request: "Plan next work",
+      source_session_id: "chat_1",
+      proposal: { id: "pa_1", actions: [{ kind: "create_work_item" }] },
+    });
+
+    clearProjectAssistantChatHandoff();
+    expect(readProjectAssistantChatHandoff()).toBeNull();
+  });
+
+  it("returns false when sessionStorage rejects the handoff write", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    expect(writeProjectAssistantChatHandoff({ project_id: "proj_1", proposal })).toBe(false);
+  });
+
+  it("drops malformed stored proposals", () => {
+    window.sessionStorage.setItem(
+      "hecate.projectAssistant.chatDraft",
+      JSON.stringify({ project_id: "proj_1", proposal: { id: "pa_bad" } }),
+    );
+
+    expect(readProjectAssistantChatHandoff()).toBeNull();
+  });
+});

--- a/ui/src/lib/project-assistant-chat-handoff.ts
+++ b/ui/src/lib/project-assistant-chat-handoff.ts
@@ -1,0 +1,57 @@
+import type { ProjectAssistantProposal } from "../types/project";
+
+const PROJECT_ASSISTANT_CHAT_HANDOFF_KEY = "hecate.projectAssistant.chatDraft";
+
+export type ProjectAssistantChatHandoff = {
+  project_id: string;
+  proposal: ProjectAssistantProposal;
+  request?: string;
+  source_session_id?: string;
+  created_at?: string;
+};
+
+export function writeProjectAssistantChatHandoff(handoff: ProjectAssistantChatHandoff): boolean {
+  try {
+    sessionStorage.setItem(PROJECT_ASSISTANT_CHAT_HANDOFF_KEY, JSON.stringify(handoff));
+    return true;
+  } catch {
+    // Transient navigation handoff only. The proposal can be drafted again.
+    return false;
+  }
+}
+
+export function readProjectAssistantChatHandoff(): ProjectAssistantChatHandoff | null {
+  try {
+    const raw = sessionStorage.getItem(PROJECT_ASSISTANT_CHAT_HANDOFF_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ProjectAssistantChatHandoff>;
+    const proposal = parsed.proposal as Partial<ProjectAssistantProposal> | undefined;
+    if (
+      typeof parsed.project_id !== "string" ||
+      !parsed.project_id.trim() ||
+      !proposal ||
+      typeof proposal !== "object" ||
+      !Array.isArray(proposal.actions)
+    ) {
+      return null;
+    }
+    return {
+      project_id: parsed.project_id,
+      proposal: proposal as ProjectAssistantProposal,
+      request: typeof parsed.request === "string" ? parsed.request : undefined,
+      source_session_id:
+        typeof parsed.source_session_id === "string" ? parsed.source_session_id : undefined,
+      created_at: typeof parsed.created_at === "string" ? parsed.created_at : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearProjectAssistantChatHandoff() {
+  try {
+    sessionStorage.removeItem(PROJECT_ASSISTANT_CHAT_HANDOFF_KEY);
+  } catch {
+    // Best effort.
+  }
+}

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -283,6 +283,8 @@ export type ProjectAssistantDraftPayload = ProjectAssistantContextPayload & {
   model?: string;
 };
 
+export type ProjectAssistantChatDraftPayload = Omit<ProjectAssistantDraftPayload, "project_id">;
+
 export type ProjectAssistantApplyPayload = {
   proposal: ProjectAssistantProposal;
   confirm?: boolean;

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -283,7 +283,7 @@ export type ProjectAssistantDraftPayload = ProjectAssistantContextPayload & {
   model?: string;
 };
 
-export type ProjectAssistantChatDraftPayload = Omit<ProjectAssistantDraftPayload, "project_id">;
+export type ProjectAssistantChatDraftPayload = Omit<ProjectAssistantContextPayload, "project_id">;
 
 export type ProjectAssistantApplyPayload = {
   proposal: ProjectAssistantProposal;


### PR DESCRIPTION
## Summary
- add a chat-scoped Project Assistant draft endpoint that derives the project from a linked Hecate Chat session and returns proposal data only
- add a compact Chat composer action that drafts a deterministic proposal and hands it to the Projects review/apply surface through a transient session handoff
- document the chat-to-proposal boundary and add backend/UI/helper regression coverage

## Tests
- `gofmt -w internal/api/handler_project_assistant.go internal/api/handler_project_assistant_test.go internal/api/server.go`
- `go vet ./internal/api ./internal/projectassistant ./internal/projectassistantapp`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-chat-proposals/.gocache go test ./internal/api ./internal/projectassistant ./internal/projectassistantapp`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-chat-proposals/.gocache go test -race -timeout 10m ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/lib/project-assistant-chat-handoff.test.ts src/features/chats/ChatView.test.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`