### PR TITLE
Show chat source for assistant proposals

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -26,6 +26,8 @@ is proposal data only; it does not send a chat message, create project records,
 call the model-backed draft path, or apply the proposal. Deleting a project also
 deletes its project-scoped chat
 transcripts. Unprojected chats and chats in other projects stay untouched.
+The Projects review card preserves the originating request and chat session id
+for operator inspection and exposes an **Open source chat** action.
 
 Hecate Chat treats model/provider readiness as part of composition, not a
 send-time surprise. If no configured provider has routable models, the empty

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -47,6 +47,12 @@ drafting, and hands the proposal to the Projects workspace for review. It does
 not append a chat message, call the model-backed draft path, create work
 records, or apply the proposal.
 
+When Projects consumes a chat-drafted proposal handoff, the review card shows
+the source as `drafted from chat`, preserves the originating request text and
+chat session id, and offers an `Open source chat` action. That source context is
+transient UI handoff metadata; applying the proposal still sends only the typed
+proposal through the normal explicit apply path.
+
 ## Authority boundary
 
 Project Assistant is a proposal author, not the project orchestrator. It can

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2670,7 +2670,9 @@ endpoint always uses deterministic drafting and returns
 `project_assistant.proposal` data only. It does not call the model-backed draft
 path, append chat messages, create project records, or apply the proposal; UI
 clients should hand the response to the Projects Project Assistant review/apply
-surface.
+surface. Clients may carry local source metadata, such as the request text and
+chat session id, for review UI navigation; that metadata is not part of the
+proposal apply payload.
 
 ## Chat session endpoints
 

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -8,6 +8,7 @@ import type {
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
+import { formatAbsoluteTime } from "../../lib/format";
 import { CopyableID, Icon, Icons, InlineError } from "../shared/ui";
 
 export const PROJECT_ASSISTANT_AUTO = "__auto__";
@@ -24,6 +25,7 @@ export type ProjectAssistantContextStatus = "idle" | "loading" | "loaded" | "err
 
 type Props = {
   applyResult: ProjectAssistantApplyResult | null;
+  chatDraftSource?: ProjectAssistantChatDraftSource | null;
   context: ProjectAssistantContextRecord | null;
   contextError: string;
   contextStatus: ProjectAssistantContextStatus;
@@ -32,6 +34,7 @@ type Props = {
   onBootstrap: () => void;
   onDismiss: () => void;
   onInspectContext: (form: ProjectAssistantDraftForm) => void;
+  onOpenSourceChat?: () => void;
   onPropose: (form: ProjectAssistantDraftForm) => void;
   project: ProjectRecord | null;
   proposal: ProjectAssistantProposal | null;
@@ -41,8 +44,15 @@ type Props = {
   workItem: ProjectWorkItemRecord | null;
 };
 
+export type ProjectAssistantChatDraftSource = {
+  request?: string;
+  sourceSessionID?: string;
+  createdAt?: string;
+};
+
 export function ProjectAssistantPanel({
   applyResult,
+  chatDraftSource,
   context,
   contextError,
   contextStatus,
@@ -51,6 +61,7 @@ export function ProjectAssistantPanel({
   onBootstrap,
   onDismiss,
   onInspectContext,
+  onOpenSourceChat,
   onPropose,
   project,
   proposal,
@@ -253,6 +264,12 @@ export function ProjectAssistantPanel({
               <CopyableID text={proposal.trace_id} compact />
             </div>
           )}
+          {chatDraftSource && (
+            <ProjectAssistantChatDraftSourcePanel
+              source={chatDraftSource}
+              onOpenChat={onOpenSourceChat}
+            />
+          )}
           {proposal.warnings && proposal.warnings.length > 0 && (
             <div style={assistantWarningsStyle}>
               {proposal.warnings.map((warning) => (
@@ -292,6 +309,37 @@ export function ProjectAssistantPanel({
         </div>
       )}
     </section>
+  );
+}
+
+function ProjectAssistantChatDraftSourcePanel({
+  onOpenChat,
+  source,
+}: {
+  onOpenChat?: () => void;
+  source: ProjectAssistantChatDraftSource;
+}) {
+  const createdAt = formatAbsoluteTime(source.createdAt);
+  return (
+    <div style={assistantSourceStyle} aria-label="Proposal source">
+      <div style={assistantSourceHeaderStyle}>
+        <span className="badge badge-muted">drafted from chat</span>
+        {createdAt && <span style={subtleTextStyle}>{createdAt}</span>}
+        {source.sourceSessionID && onOpenChat && (
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenChat}>
+            <Icon d={Icons.chat} size={12} />
+            Open source chat
+          </button>
+        )}
+      </div>
+      {source.request && <div style={assistantSourceRequestStyle}>{source.request}</div>}
+      {source.sourceSessionID && (
+        <div style={metaLineStyle}>
+          <span>Chat</span>
+          <CopyableID text={source.sourceSessionID} compact />
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -701,6 +749,33 @@ const assistantWarningsStyle: CSSProperties = {
   fontSize: 12,
   gap: 4,
   padding: "8px 9px",
+};
+
+const assistantSourceStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 7,
+  minWidth: 0,
+  padding: "8px 9px",
+};
+
+const assistantSourceHeaderStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "space-between",
+  minWidth: 0,
+};
+
+const assistantSourceRequestStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  lineHeight: 1.45,
+  overflowWrap: "anywhere",
+  whiteSpace: "pre-wrap",
 };
 
 const assistantActionListStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -232,6 +232,7 @@ export function ProjectWorkspaceView({
                 <ProjectAssistantPanel
                   applyResult={assistant.applyResult}
                   bootstrapPending={assistant.bootstrapPending}
+                  chatDraftSource={assistant.chatDraftSource}
                   context={assistant.context}
                   contextError={assistant.contextError}
                   contextStatus={assistant.contextStatus}
@@ -240,6 +241,15 @@ export function ProjectWorkspaceView({
                   onBootstrap={() => void assistant.bootstrap()}
                   onInspectContext={(form) => void assistant.inspectContext(form)}
                   onDismiss={assistant.dismiss}
+                  onOpenSourceChat={
+                    assistant.chatDraftSource?.sourceSessionID && onOpenChat
+                      ? () =>
+                          onOpenChat({
+                            projectID: project.id,
+                            chatSessionID: assistant.chatDraftSource?.sourceSessionID,
+                          })
+                      : undefined
+                  }
                   onPropose={(form) => void assistant.propose(form)}
                   project={project}
                   proposal={assistant.proposal}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1366,29 +1366,30 @@ describe("ProjectsView cockpit", () => {
     const user = userEvent.setup();
     const onOpenChat = vi.fn();
     window.localStorage.setItem("hecate.project", project.id);
+    const chatProposal = {
+      id: "pa_chat",
+      title: "Plan next project work",
+      summary: "Create a work item from chat.",
+      requires_confirmation: true,
+      actions: [
+        {
+          kind: "create_work_item",
+          target: { project_id: project.id },
+          patch: {
+            project_id: project.id,
+            title: "Plan next project work",
+            brief: "Capture a reviewable task from chat.",
+            status: "ready",
+          },
+        },
+      ],
+    };
     writeProjectAssistantChatHandoff({
       project_id: project.id,
       request: "Plan next project work",
       source_session_id: "chat_1",
       created_at: "2026-06-13T00:00:00Z",
-      proposal: {
-        id: "pa_chat",
-        title: "Plan next project work",
-        summary: "Create a work item from chat.",
-        requires_confirmation: true,
-        actions: [
-          {
-            kind: "create_work_item",
-            target: { project_id: project.id },
-            patch: {
-              project_id: project.id,
-              title: "Plan next project work",
-              brief: "Capture a reviewable task from chat.",
-              status: "ready",
-            },
-          },
-        ],
-      },
+      proposal: chatProposal,
     });
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -1416,6 +1417,59 @@ describe("ProjectsView cockpit", () => {
     expect(within(assistant).getByText("Create work item")).toBeTruthy();
     expect(draftProjectAssistant).not.toHaveBeenCalled();
     expect(readProjectAssistantChatHandoff()).toBeNull();
+
+    await user.click(within(assistant).getByRole("button", { name: "Apply proposal" }));
+
+    await waitFor(() => {
+      expect(applyProjectAssistant).toHaveBeenCalledWith({
+        proposal: chatProposal,
+        confirm: true,
+      });
+    });
+  });
+
+  it("clears chat source metadata when a fresh Project Assistant draft replaces the proposal", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", project.id);
+    writeProjectAssistantChatHandoff({
+      project_id: project.id,
+      request: "Plan next project work",
+      source_session_id: "chat_1",
+      proposal: {
+        id: "pa_chat",
+        title: "Plan next project work",
+        summary: "Create a work item from chat.",
+        requires_confirmation: true,
+        actions: [
+          {
+            kind: "create_work_item",
+            target: { project_id: project.id },
+            patch: { project_id: project.id, title: "Plan next project work" },
+          },
+        ],
+      },
+    });
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    expect(await within(assistant).findByLabelText("Proposal source")).toBeTruthy();
+
+    await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
+
+    await waitFor(() => {
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        work_item_id: workItem.id,
+        request: "Queue Software developer for Build cockpit UI",
+      });
+    });
+    expect(await within(assistant).findByText("Create assignment")).toBeTruthy();
+    expect(within(assistant).queryByLabelText("Proposal source")).toBeNull();
   });
 
   it("can request model-backed Project Assistant drafts", async () => {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1363,11 +1363,14 @@ describe("ProjectsView cockpit", () => {
 
   it("loads a chat-drafted Project Assistant proposal into the review panel", async () => {
     resetProjectWorkMocks();
+    const user = userEvent.setup();
+    const onOpenChat = vi.fn();
     window.localStorage.setItem("hecate.project", project.id);
     writeProjectAssistantChatHandoff({
       project_id: project.id,
       request: "Plan next project work",
       source_session_id: "chat_1",
+      created_at: "2026-06-13T00:00:00Z",
       proposal: {
         id: "pa_chat",
         title: "Plan next project work",
@@ -1391,9 +1394,22 @@ describe("ProjectsView cockpit", () => {
       projects: [project],
       activeProjectID: project.id,
     });
-    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+    render(
+      withRuntimeConsole(<ProjectsView onOpenChat={onOpenChat} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
 
     const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    const source = await within(assistant).findByLabelText("Proposal source");
+    expect(within(source).getByText("drafted from chat")).toBeTruthy();
+    expect(within(source).getByText("Plan next project work")).toBeTruthy();
+    await user.click(within(source).getByRole("button", { name: "Open source chat" }));
+    expect(onOpenChat).toHaveBeenCalledWith({
+      projectID: project.id,
+      chatSessionID: "chat_1",
+    });
     expect(
       (await within(assistant).findAllByText("Plan next project work")).length,
     ).toBeGreaterThan(0);

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -549,7 +549,13 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     if (workLoadState !== "loaded" && workLoadState !== "error") return;
     const handoff = readProjectAssistantChatHandoff();
     if (!handoff || handoff.project_id !== selectedProjectID) return;
-    assistant.loadProposal(handoff.proposal);
+    assistant.loadProposal(handoff.proposal, {
+      chatDraftSource: {
+        request: handoff.request,
+        sourceSessionID: handoff.source_session_id,
+        createdAt: handoff.created_at,
+      },
+    });
     setWorkspaceTab("work");
     clearProjectAssistantChatHandoff();
   }, [assistant.loadProposal, selectedProjectID, workLoadState]);

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -18,7 +18,11 @@ import type {
   ProjectSkillRecord,
   ProjectWorkItemRecord,
 } from "../../types/project";
-import { PROJECT_ASSISTANT_AUTO, type ProjectAssistantDraftForm } from "./ProjectAssistantPanel";
+import {
+  PROJECT_ASSISTANT_AUTO,
+  type ProjectAssistantChatDraftSource,
+  type ProjectAssistantDraftForm,
+} from "./ProjectAssistantPanel";
 
 type LoadState = "idle" | "loading" | "loaded" | "error";
 type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
@@ -43,6 +47,9 @@ type Options = {
 
 export function useProjectAssistantController(options: Options) {
   const [proposal, setProposal] = useState<ProjectAssistantProposal | null>(null);
+  const [chatDraftSource, setChatDraftSource] = useState<ProjectAssistantChatDraftSource | null>(
+    null,
+  );
   const [applyResult, setApplyResult] = useState<ProjectAssistantApplyResult | null>(null);
   const [context, setContext] = useState<ProjectAssistantContextRecord | null>(null);
   const [contextStatus, setContextStatus] = useState<LoadState>("idle");
@@ -62,6 +69,7 @@ export function useProjectAssistantController(options: Options) {
           projectAssistantDraftPayload(form, options.project.id, options.selectedWorkItem?.id),
         );
         setProposal(payload.data);
+        setChatDraftSource(null);
         setStatus("idle");
       } catch (err) {
         setStatus("idle");
@@ -78,6 +86,7 @@ export function useProjectAssistantController(options: Options) {
     setStatus("proposing");
     setError("");
     setProposal(null);
+    setChatDraftSource(null);
     setApplyResult(null);
     options.onMemoryError("");
     options.onSkillsError("");
@@ -101,6 +110,7 @@ export function useProjectAssistantController(options: Options) {
         ),
       );
       setProposal(payload.data);
+      setChatDraftSource(null);
       setContext(null);
       setContextError("");
       setContextStatus("idle");
@@ -134,15 +144,22 @@ export function useProjectAssistantController(options: Options) {
     [options.project, options.selectedWorkItem],
   );
 
-  const loadProposal = useCallback((nextProposal: ProjectAssistantProposal) => {
-    setProposal(nextProposal);
-    setApplyResult(null);
-    setContext(null);
-    setContextError("");
-    setContextStatus("idle");
-    setError("");
-    setStatus("idle");
-  }, []);
+  const loadProposal = useCallback(
+    (
+      nextProposal: ProjectAssistantProposal,
+      sourceOptions?: { chatDraftSource?: ProjectAssistantChatDraftSource | null },
+    ) => {
+      setProposal(nextProposal);
+      setChatDraftSource(sourceOptions?.chatDraftSource ?? null);
+      setApplyResult(null);
+      setContext(null);
+      setContextError("");
+      setContextStatus("idle");
+      setError("");
+      setStatus("idle");
+    },
+    [],
+  );
 
   const apply = useCallback(async () => {
     if (!options.selectedProjectID || !proposal) return;
@@ -153,6 +170,7 @@ export function useProjectAssistantController(options: Options) {
       const payload = await applyProjectAssistant({ proposal: currentProposal, confirm: true });
       setApplyResult(payload.data);
       setProposal(null);
+      setChatDraftSource(null);
       setStatus("applied");
       await options.refreshProjects();
       const preferredWorkItemID =
@@ -182,6 +200,7 @@ export function useProjectAssistantController(options: Options) {
 
   const dismiss = useCallback(() => {
     setProposal(null);
+    setChatDraftSource(null);
     setApplyResult(null);
     setContext(null);
     setContextError("");
@@ -195,6 +214,7 @@ export function useProjectAssistantController(options: Options) {
     applyResult,
     bootstrap,
     bootstrapPending,
+    chatDraftSource,
     context,
     contextError,
     contextStatus,


### PR DESCRIPTION
## Summary
- preserve chat-draft source metadata with Project Assistant proposals in the Projects review panel
- render the originating request, chat session id, and an Open source chat action without changing the apply payload
- document the transient source metadata boundary for chat-to-proposal handoffs

## Tests
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx src/features/projects/useProjectAssistantController.test.ts src/features/projects/ProjectWorkspaceView.test.tsx`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`

No Go packages changed in this slice.