### PR TITLE
feat(projects): improve review workflow

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -241,9 +241,11 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   record-review button yet. Keep the record action separate from follow-up
   handoff creation; review artifacts may offer an explicit follow-up assignment
   action, but it must create/link the handoff first and leave execution start as
-  a separate operator action. Verdict/risk are body text, not structured query
-  fields, and the UI must not mark work done, blocked, or dispatched from the
-  artifact body without an explicit operator action.
+  a separate operator action. Review artifacts can carry structured
+  `review_verdict`, `review_risk`, `review_follow_up_required`, and
+  `reviewed_assignment_id` fields for triage, but the UI must not mark work
+  done, blocked, or dispatched from those fields without an explicit operator
+  action.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -237,11 +237,12 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   starting it remain separate operator actions.
 - Review outcomes are `kind="review"` collaboration artifacts. The V1 cockpit
   entry point is an assignment whose role appears in the work item's
-  `reviewer_role_ids`; work without configured reviewer roles has no generic
-  record-review button yet. Keep the record action separate from follow-up
-  handoff creation; review artifacts may offer an explicit follow-up assignment
-  action, but it must create/link the handoff first and leave execution start as
-  a separate operator action. Review artifacts can carry structured
+  `reviewer_role_ids`; work without configured reviewer roles should surface
+  setup guidance instead of a generic record-review button. Keep the record
+  action separate from follow-up handoff creation; review artifacts may offer an
+  explicit follow-up assignment action, but it must create/link the handoff
+  first and leave execution start as a separate operator action. Review
+  artifacts can carry structured
   `review_verdict`, `review_risk`, `review_follow_up_required`, and
   `reviewed_assignment_id` fields for triage, but the UI must not mark work
   done, blocked, or dispatched from those fields without an explicit operator

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2596,12 +2596,26 @@ after a review assignment. In V1 the cockpit exposes this action only for
 assignments whose role appears in the work item's `reviewer_role_ids`; callers
 can still create any collaboration artifact through this endpoint. The current
 V1 body is Markdown-compatible text with verdict, risk, summary, verification,
-and follow-up sections. Hecate stores verdict/risk as body text, not structured
-artifact fields, and does not interpret the verdict, mutate work-item status, or
-auto-dispatch follow-up work. Operators can create a separate handoff from the
-review artifact when follow-up is needed. The UI may also offer a shortcut that
-creates the handoff and queued follow-up assignment together, but it still
-records the handoff first and does not start the assignment automatically.
+and follow-up sections, and review artifacts may also carry structured review
+metadata:
+
+- `reviewed_assignment_id` — optional assignment being reviewed. When supplied
+  it must refer to an assignment on the same work item.
+- `review_verdict` — optional `approved`, `changes_requested`, `blocked`, or
+  `risk`.
+- `review_risk` — optional `low`, `medium`, `high`, or `unknown`.
+- `review_follow_up_required` — optional boolean used by Projects attention
+  surfaces.
+
+The review verdict/risk enum values are validated by the runtime and mirrored
+by the Projects UI picker.
+
+Hecate records these fields for filtering and operator triage, but does not
+mutate work-item status or auto-dispatch follow-up work from the verdict.
+Operators can create a separate handoff from the review artifact when follow-up
+is needed. The UI may also offer a shortcut that creates the handoff and queued
+follow-up assignment together, but it still records the handoff first and does
+not start the assignment automatically.
 
 ```json
 {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -81,12 +81,16 @@ type startProjectWorkAssignmentRequest struct {
 }
 
 type createProjectWorkArtifactRequest struct {
-	ID           string `json:"id,omitempty"`
-	AssignmentID string `json:"assignment_id,omitempty"`
-	Kind         string `json:"kind"`
-	Title        string `json:"title,omitempty"`
-	Body         string `json:"body"`
-	AuthorRoleID string `json:"author_role_id,omitempty"`
+	ID                     string `json:"id,omitempty"`
+	AssignmentID           string `json:"assignment_id,omitempty"`
+	Kind                   string `json:"kind"`
+	Title                  string `json:"title,omitempty"`
+	Body                   string `json:"body"`
+	AuthorRoleID           string `json:"author_role_id,omitempty"`
+	ReviewedAssignmentID   string `json:"reviewed_assignment_id,omitempty"`
+	ReviewVerdict          string `json:"review_verdict,omitempty"`
+	ReviewRisk             string `json:"review_risk,omitempty"`
+	ReviewFollowUpRequired bool   `json:"review_follow_up_required,omitempty"`
 }
 
 type createProjectHandoffRequest struct {
@@ -254,16 +258,20 @@ type ProjectWorkArtifactEnvelope struct {
 }
 
 type ProjectWorkArtifactResponse struct {
-	ID           string `json:"id"`
-	ProjectID    string `json:"project_id"`
-	WorkItemID   string `json:"work_item_id"`
-	AssignmentID string `json:"assignment_id,omitempty"`
-	Kind         string `json:"kind"`
-	Title        string `json:"title,omitempty"`
-	Body         string `json:"body"`
-	AuthorRoleID string `json:"author_role_id,omitempty"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+	ID                     string `json:"id"`
+	ProjectID              string `json:"project_id"`
+	WorkItemID             string `json:"work_item_id"`
+	AssignmentID           string `json:"assignment_id,omitempty"`
+	Kind                   string `json:"kind"`
+	Title                  string `json:"title,omitempty"`
+	Body                   string `json:"body"`
+	AuthorRoleID           string `json:"author_role_id,omitempty"`
+	ReviewedAssignmentID   string `json:"reviewed_assignment_id,omitempty"`
+	ReviewVerdict          string `json:"review_verdict,omitempty"`
+	ReviewRisk             string `json:"review_risk,omitempty"`
+	ReviewFollowUpRequired bool   `json:"review_follow_up_required,omitempty"`
+	CreatedAt              string `json:"created_at"`
+	UpdatedAt              string `json:"updated_at"`
 }
 
 type ProjectHandoffsResponse struct {
@@ -740,14 +748,18 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 		id = newOpaqueTaskResourceID("art")
 	}
 	item, err := h.projectWork.CreateArtifact(r.Context(), projectwork.CollaborationArtifact{
-		ID:           id,
-		ProjectID:    projectID,
-		WorkItemID:   workItemID,
-		AssignmentID: req.AssignmentID,
-		Kind:         req.Kind,
-		Title:        req.Title,
-		Body:         req.Body,
-		AuthorRoleID: req.AuthorRoleID,
+		ID:                     id,
+		ProjectID:              projectID,
+		WorkItemID:             workItemID,
+		AssignmentID:           req.AssignmentID,
+		Kind:                   req.Kind,
+		Title:                  req.Title,
+		Body:                   req.Body,
+		AuthorRoleID:           req.AuthorRoleID,
+		ReviewedAssignmentID:   req.ReviewedAssignmentID,
+		ReviewVerdict:          req.ReviewVerdict,
+		ReviewRisk:             req.ReviewRisk,
+		ReviewFollowUpRequired: req.ReviewFollowUpRequired,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -1237,16 +1249,20 @@ func renderProjectWorkAssignmentExecutionRef(ref *projectworkapp.AssignmentExecu
 
 func renderProjectWorkArtifact(item projectwork.CollaborationArtifact) ProjectWorkArtifactResponse {
 	return ProjectWorkArtifactResponse{
-		ID:           item.ID,
-		ProjectID:    item.ProjectID,
-		WorkItemID:   item.WorkItemID,
-		AssignmentID: item.AssignmentID,
-		Kind:         item.Kind,
-		Title:        item.Title,
-		Body:         item.Body,
-		AuthorRoleID: item.AuthorRoleID,
-		CreatedAt:    formatOptionalTime(item.CreatedAt),
-		UpdatedAt:    formatOptionalTime(item.UpdatedAt),
+		ID:                     item.ID,
+		ProjectID:              item.ProjectID,
+		WorkItemID:             item.WorkItemID,
+		AssignmentID:           item.AssignmentID,
+		Kind:                   item.Kind,
+		Title:                  item.Title,
+		Body:                   item.Body,
+		AuthorRoleID:           item.AuthorRoleID,
+		ReviewedAssignmentID:   item.ReviewedAssignmentID,
+		ReviewVerdict:          item.ReviewVerdict,
+		ReviewRisk:             item.ReviewRisk,
+		ReviewFollowUpRequired: item.ReviewFollowUpRequired,
+		CreatedAt:              formatOptionalTime(item.CreatedAt),
+		UpdatedAt:              formatOptionalTime(item.UpdatedAt),
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -254,6 +254,29 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_review",
+		"assignment_id":"asgn_backend",
+		"reviewed_assignment_id":"asgn_backend",
+		"kind":"review",
+		"title":"Backend review",
+		"body":"Verdict: Changes requested",
+		"author_role_id":"reviewer_qa",
+		"review_verdict":"changes_requested",
+		"review_risk":"medium",
+		"review_follow_up_required":true
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create review artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &artifact); err != nil {
+		t.Fatalf("decode review artifact: %v", err)
+	}
+	if artifact.Data.ReviewedAssignmentID != "asgn_backend" || artifact.Data.ReviewVerdict != "changes_requested" || artifact.Data.ReviewRisk != "medium" || !artifact.Data.ReviewFollowUpRequired {
+		t.Fatalf("review artifact = %+v, want structured review fields", artifact.Data)
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/handoffs", bytes.NewReader([]byte(`{
 		"id":"handoff_backend",
 		"source_assignment_id":"asgn_backend",

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -120,6 +120,10 @@ CREATE TABLE IF NOT EXISTS %s (
 	title TEXT NOT NULL DEFAULT '',
 	body TEXT NOT NULL,
 	author_role_id TEXT NOT NULL DEFAULT '',
+	reviewed_assignment_id TEXT NOT NULL DEFAULT '',
+	review_verdict TEXT NOT NULL DEFAULT '',
+	review_risk TEXT NOT NULL DEFAULT '',
+	review_follow_up_required INTEGER NOT NULL DEFAULT 0,
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY(project_id, id)
@@ -169,6 +173,19 @@ CREATE TABLE IF NOT EXISTS %s (
 	}
 	if err := s.ensureColumn(ctx, s.assignmentsTbl, "execution_ref", `TEXT NOT NULL DEFAULT '{}'`); err != nil {
 		return err
+	}
+	for _, column := range []struct {
+		name       string
+		definition string
+	}{
+		{name: "reviewed_assignment_id", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "review_verdict", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "review_risk", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "review_follow_up_required", definition: `INTEGER NOT NULL DEFAULT 0`},
+	} {
+		if err := s.ensureColumn(ctx, s.artifactsTbl, column.name, column.definition); err != nil {
+			return err
+		}
 	}
 	if err := s.migrateAssignmentExecutionRefs(ctx); err != nil {
 		return err
@@ -753,7 +770,7 @@ func (s *SQLiteStore) ListArtifacts(ctx context.Context, filter ArtifactFilter) 
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	filter.AssignmentID = strings.TrimSpace(filter.AssignmentID)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
 FROM %s
 WHERE project_id = ?`, s.artifactsTbl)
 	args := []any{filter.ProjectID}
@@ -806,12 +823,25 @@ func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact Collaboration
 			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
 		}
 	}
+	if artifact.ReviewedAssignmentID != "" {
+		assignment, err := s.getRequiredAssignment(ctx, artifact.ProjectID, artifact.ReviewedAssignmentID)
+		if errors.Is(err, ErrNotFound) {
+			return CollaborationArtifact{}, fmt.Errorf("%w: reviewed assignment not found", err)
+		}
+		if err != nil {
+			return CollaborationArtifact{}, err
+		}
+		if assignment.WorkItemID != artifact.WorkItemID {
+			return CollaborationArtifact{}, fmt.Errorf("%w: reviewed assignment not found", ErrNotFound)
+		}
+	}
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.artifactsTbl),
+	id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.artifactsTbl),
 		artifact.ID, artifact.ProjectID, artifact.WorkItemID, artifact.AssignmentID,
 		artifact.Kind, artifact.Title, artifact.Body, artifact.AuthorRoleID,
+		artifact.ReviewedAssignmentID, artifact.ReviewVerdict, artifact.ReviewRisk, boolToDB(artifact.ReviewFollowUpRequired),
 		formatTime(artifact.CreatedAt), formatTime(artifact.UpdatedAt),
 	)
 	if err != nil {
@@ -1142,7 +1172,7 @@ WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID
 
 func (s *SQLiteStore) getRequiredArtifact(ctx context.Context, projectID, id string) (CollaborationArtifact, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, created_at, updated_at
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.artifactsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanArtifact(row)
@@ -1277,9 +1307,11 @@ func scanAssignment(row scanner) (Assignment, error) {
 func scanArtifact(row scanner) (CollaborationArtifact, error) {
 	var item CollaborationArtifact
 	var createdAt, updatedAt string
-	if err := row.Scan(&item.ID, &item.ProjectID, &item.WorkItemID, &item.AssignmentID, &item.Kind, &item.Title, &item.Body, &item.AuthorRoleID, &createdAt, &updatedAt); err != nil {
+	var reviewFollowUpRequired int
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.WorkItemID, &item.AssignmentID, &item.Kind, &item.Title, &item.Body, &item.AuthorRoleID, &item.ReviewedAssignmentID, &item.ReviewVerdict, &item.ReviewRisk, &reviewFollowUpRequired, &createdAt, &updatedAt); err != nil {
 		return CollaborationArtifact{}, err
 	}
+	item.ReviewFollowUpRequired = reviewFollowUpRequired != 0
 	var err error
 	if item.CreatedAt, err = parseTime(createdAt); err != nil {
 		return CollaborationArtifact{}, err
@@ -1288,6 +1320,13 @@ func scanArtifact(row scanner) (CollaborationArtifact, error) {
 		return CollaborationArtifact{}, err
 	}
 	return item, nil
+}
+
+func boolToDB(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func scanHandoff(row scanner) (Handoff, error) {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -38,6 +38,18 @@ const (
 	ArtifactKindReview       = "review"
 	ArtifactKindDecisionNote = "decision_note"
 
+	// Keep review enum values in sync with the Projects UI REVIEW_VERDICTS /
+	// REVIEW_RISKS lists; the API rejects values outside this server set.
+	ReviewVerdictApproved         = "approved"
+	ReviewVerdictChangesRequested = "changes_requested"
+	ReviewVerdictBlocked          = "blocked"
+	ReviewVerdictRisk             = "risk"
+
+	ReviewRiskLow     = "low"
+	ReviewRiskMedium  = "medium"
+	ReviewRiskHigh    = "high"
+	ReviewRiskUnknown = "unknown"
+
 	HandoffStatusPending    = "pending"
 	HandoffStatusAccepted   = "accepted"
 	HandoffStatusSuperseded = "superseded"
@@ -112,16 +124,20 @@ type AssignmentExecutionRef struct {
 }
 
 type CollaborationArtifact struct {
-	ID           string
-	ProjectID    string
-	WorkItemID   string
-	AssignmentID string
-	Kind         string
-	Title        string
-	Body         string
-	AuthorRoleID string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID                     string
+	ProjectID              string
+	WorkItemID             string
+	AssignmentID           string
+	Kind                   string
+	Title                  string
+	Body                   string
+	AuthorRoleID           string
+	ReviewedAssignmentID   string
+	ReviewVerdict          string
+	ReviewRisk             string
+	ReviewFollowUpRequired bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
 }
 
 type Handoff struct {
@@ -581,6 +597,12 @@ func (s *MemoryStore) CreateArtifact(_ context.Context, artifact CollaborationAr
 			return CollaborationArtifact{}, fmt.Errorf("%w: assignment not found", ErrNotFound)
 		}
 	}
+	if artifact.ReviewedAssignmentID != "" {
+		assignment, ok := s.assignments[assignmentKey(artifact.ProjectID, artifact.ReviewedAssignmentID)]
+		if !ok || assignment.WorkItemID != artifact.WorkItemID {
+			return CollaborationArtifact{}, fmt.Errorf("%w: reviewed assignment not found", ErrNotFound)
+		}
+	}
 	key := artifactKey(artifact.ProjectID, artifact.ID)
 	if _, exists := s.artifacts[key]; exists {
 		return CollaborationArtifact{}, ErrDuplicate
@@ -876,6 +898,15 @@ func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationA
 	item.Title = strings.TrimSpace(item.Title)
 	item.Body = strings.TrimSpace(item.Body)
 	item.AuthorRoleID = strings.TrimSpace(item.AuthorRoleID)
+	item.ReviewedAssignmentID = strings.TrimSpace(item.ReviewedAssignmentID)
+	item.ReviewVerdict = strings.TrimSpace(item.ReviewVerdict)
+	item.ReviewRisk = strings.TrimSpace(item.ReviewRisk)
+	if item.Kind != ArtifactKindReview {
+		item.ReviewedAssignmentID = ""
+		item.ReviewVerdict = ""
+		item.ReviewRisk = ""
+		item.ReviewFollowUpRequired = false
+	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -1015,7 +1046,31 @@ func validateArtifact(item CollaborationArtifact) error {
 	if item.Body == "" {
 		return fmt.Errorf("%w: artifact body is required", ErrInvalid)
 	}
+	if item.ReviewVerdict != "" && !validReviewVerdict(item.ReviewVerdict) {
+		return fmt.Errorf("%w: unsupported review_verdict %q", ErrInvalid, item.ReviewVerdict)
+	}
+	if item.ReviewRisk != "" && !validReviewRisk(item.ReviewRisk) {
+		return fmt.Errorf("%w: unsupported review_risk %q", ErrInvalid, item.ReviewRisk)
+	}
 	return nil
+}
+
+func validReviewVerdict(verdict string) bool {
+	switch verdict {
+	case ReviewVerdictApproved, ReviewVerdictChangesRequested, ReviewVerdictBlocked, ReviewVerdictRisk:
+		return true
+	default:
+		return false
+	}
+}
+
+func validReviewRisk(risk string) bool {
+	switch risk {
+	case ReviewRiskLow, ReviewRiskMedium, ReviewRiskHigh, ReviewRiskUnknown:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateHandoff(item Handoff) error {

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -180,20 +180,64 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			}
 
 			artifact, err := store.CreateArtifact(ctx, CollaborationArtifact{
-				ID:           "art_brief",
-				ProjectID:    "proj_alpha",
-				WorkItemID:   "work_api",
-				AssignmentID: "asgn_impl",
-				Kind:         ArtifactKindBrief,
-				Title:        "Implementation brief",
-				Body:         "Build the backend substrate only.",
-				AuthorRoleID: "product_manager",
+				ID:                     "art_brief",
+				ProjectID:              "proj_alpha",
+				WorkItemID:             "work_api",
+				AssignmentID:           "asgn_impl",
+				Kind:                   ArtifactKindReview,
+				Title:                  "Implementation review",
+				Body:                   "Changes requested.",
+				AuthorRoleID:           "reviewer_qa",
+				ReviewedAssignmentID:   "asgn_impl",
+				ReviewVerdict:          ReviewVerdictChangesRequested,
+				ReviewRisk:             ReviewRiskMedium,
+				ReviewFollowUpRequired: true,
 			})
 			if err != nil {
 				t.Fatalf("CreateArtifact: %v", err)
 			}
-			if artifact.Kind != ArtifactKindBrief || artifact.Body == "" {
-				t.Fatalf("artifact = %+v, want brief artifact", artifact)
+			if artifact.Kind != ArtifactKindReview || artifact.ReviewedAssignmentID != "asgn_impl" || artifact.ReviewVerdict != ReviewVerdictChangesRequested || artifact.ReviewRisk != ReviewRiskMedium || !artifact.ReviewFollowUpRequired {
+				t.Fatalf("artifact = %+v, want structured review artifact", artifact)
+			}
+			briefArtifact, err := store.CreateArtifact(ctx, CollaborationArtifact{
+				ID:                     "art_note",
+				ProjectID:              "proj_alpha",
+				WorkItemID:             "work_api",
+				AssignmentID:           "asgn_impl",
+				Kind:                   ArtifactKindBrief,
+				Title:                  "Implementation note",
+				Body:                   "This is not a review.",
+				ReviewedAssignmentID:   "asgn_impl",
+				ReviewVerdict:          ReviewVerdictBlocked,
+				ReviewRisk:             ReviewRiskHigh,
+				ReviewFollowUpRequired: true,
+			})
+			if err != nil {
+				t.Fatalf("CreateArtifact non-review with review fields: %v", err)
+			}
+			if briefArtifact.ReviewedAssignmentID != "" || briefArtifact.ReviewVerdict != "" || briefArtifact.ReviewRisk != "" || briefArtifact.ReviewFollowUpRequired {
+				t.Fatalf("non-review artifact = %+v, want review fields cleared", briefArtifact)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_bad_verdict", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Invalid verdict.", ReviewVerdict: "ship_it"}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("CreateArtifact invalid review_verdict error = %v, want ErrInvalid", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_bad_risk", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Invalid risk.", ReviewRisk: "spicy"}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("CreateArtifact invalid review_risk error = %v, want ErrInvalid", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_missing_reviewed", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Missing reviewed assignment.", ReviewedAssignmentID: "asgn_missing"}); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("CreateArtifact missing reviewed_assignment_id error = %v, want ErrNotFound", err)
+			}
+			if _, err := store.CreateWorkItem(ctx, WorkItem{ID: "work_other", ProjectID: "proj_alpha", Title: "Other work"}); err != nil {
+				t.Fatalf("CreateWorkItem other: %v", err)
+			}
+			if _, err := store.CreateAssignment(ctx, Assignment{ID: "asgn_other", ProjectID: "proj_alpha", WorkItemID: "work_other", RoleID: "software_developer"}); err != nil {
+				t.Fatalf("CreateAssignment other: %v", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_cross_reviewed", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Cross-work reviewed assignment.", ReviewedAssignmentID: "asgn_other"}); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("CreateArtifact cross-work reviewed_assignment_id error = %v, want ErrNotFound", err)
+			}
+			if err := store.DeleteWorkItem(ctx, "proj_alpha", "work_other"); err != nil {
+				t.Fatalf("DeleteWorkItem other: %v", err)
 			}
 
 			handoff, err := store.CreateHandoff(ctx, Handoff{
@@ -259,8 +303,14 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListArtifacts: %v", err)
 			}
-			if len(artifacts) != 1 || artifacts[0].ID != "art_brief" {
-				t.Fatalf("artifacts = %+v, want created artifact", artifacts)
+			if len(artifacts) != 2 || artifacts[0].ID != "art_brief" || artifacts[1].ID != "art_note" {
+				t.Fatalf("artifacts = %+v, want created review and note artifacts", artifacts)
+			}
+			if artifacts[0].ReviewVerdict != ReviewVerdictChangesRequested || artifacts[0].ReviewRisk != ReviewRiskMedium || !artifacts[0].ReviewFollowUpRequired {
+				t.Fatalf("listed review artifact = %+v, want structured review fields", artifacts[0])
+			}
+			if artifacts[1].ReviewedAssignmentID != "" || artifacts[1].ReviewVerdict != "" || artifacts[1].ReviewRisk != "" || artifacts[1].ReviewFollowUpRequired {
+				t.Fatalf("listed non-review artifact = %+v, want review fields cleared", artifacts[1])
 			}
 			handoffs, err := store.ListHandoffs(ctx, HandoffFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
 			if err != nil {

--- a/ui/src/features/projects/ProjectHealthPanel.test.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.test.tsx
@@ -45,6 +45,7 @@ function renderPanel(overrides: Partial<Parameters<typeof ProjectHealthPanel>[0]
       detail: "Open the work item.",
       status: "running",
       workItemID: "work_1",
+      actionLabel: "Open review",
     },
     {
       id: "task_1:item",
@@ -111,7 +112,8 @@ describe("ProjectHealthPanel", () => {
     expect(handlers.onAttentionDefaults).not.toHaveBeenCalled();
 
     await openMenu();
-    await userEvent.click(screen.getByRole("button", { name: "Open attention details" }));
+    expect(screen.getByText("Open review")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Open review" }));
     expect(handlers.onAttentionWorkItem).toHaveBeenCalledWith("work_1");
 
     await openMenu();

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -190,13 +190,17 @@ function ProjectHealthAttentionRow({
           <button
             className="btn btn-ghost btn-sm project-attention-item-action"
             type="button"
-            aria-label="Open attention details"
+            aria-label={
+              item.bucket
+                ? "Open attention details"
+                : (item.actionLabel ?? "Open attention details")
+            }
             onClick={(event) => {
               event.stopPropagation();
               onSelectWorkItem(item.workItemID!);
             }}
           >
-            Details
+            {item.bucket ? "Details" : (item.actionLabel ?? "Details")}
           </button>
         )}
         {item.taskID && (

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -308,6 +308,31 @@ describe("ProjectWorkItemDetail", () => {
     expect(handlers.onAddReviewArtifactFromAssignment).toHaveBeenCalledWith(reviewerAssignment);
   });
 
+  it("guides setup when a work item has no reviewer roles", async () => {
+    const item = workItem({ reviewer_role_ids: [] });
+    const { handlers } = renderDetail({
+      workItem: item,
+    });
+
+    expect(screen.getByText("No reviewer roles configured")).toBeTruthy();
+    expect(screen.getByText(/Add at least one reviewer role/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit reviewers" }));
+    await userEvent.click(screen.getByRole("button", { name: "Manage roles" }));
+
+    expect(handlers.onEditWorkItem).toHaveBeenCalledWith(item);
+    expect(handlers.onManageRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it("guides setup when configured reviewer roles are missing", () => {
+    renderDetail({
+      workItem: workItem({ reviewer_role_ids: ["missing_reviewer"] }),
+    });
+
+    expect(screen.getByText("Reviewer role reference missing")).toBeTruthy();
+    expect(screen.getByText(/missing_reviewer/)).toBeTruthy();
+  });
+
   it("loads launch preflight before starting an assignment", async () => {
     const { handlers } = renderDetail();
 

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -358,6 +358,23 @@ describe("ProjectWorkItemDetail", () => {
     expect(handlers.onCreateAssignmentFromReviewArtifact).toHaveBeenCalledWith(reviewArtifact);
   });
 
+  it("renders structured review artifact outcome badges", () => {
+    renderDetail({
+      assignments: [],
+      artifacts: [
+        artifact({
+          review_verdict: "changes_requested",
+          review_risk: "medium",
+          review_follow_up_required: true,
+        }),
+      ],
+    });
+
+    expect(screen.getByText("Changes requested")).toBeTruthy();
+    expect(screen.getByText("risk Medium")).toBeTruthy();
+    expect(screen.getByText("follow-up required")).toBeTruthy();
+  });
+
   it("disables review artifact follow-up actions while an assignment shortcut is pending", () => {
     renderDetail({
       assignments: [],

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -29,6 +29,12 @@ import {
   projectRootTitle,
   workStatusLabel,
 } from "./projectDisplay";
+import {
+  reviewRiskFromValue,
+  reviewRiskLabel,
+  reviewVerdictFromValue,
+  reviewVerdictLabel,
+} from "./projectWorkForms";
 import { firstNonEmpty, shortID } from "./projectUtils";
 
 export type ProjectAssignmentChatLaunchRequest = {
@@ -342,6 +348,19 @@ export function ProjectWorkItemDetail({
                   <div key={artifact.id} style={artifactStyle}>
                     <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
                       <span className="badge badge-muted">{artifact.kind}</span>
+                      {artifact.kind === "review" && artifact.review_verdict && (
+                        <span className="badge badge-muted">
+                          {reviewVerdictLabel(reviewVerdictFromValue(artifact.review_verdict))}
+                        </span>
+                      )}
+                      {artifact.kind === "review" && artifact.review_risk && (
+                        <span className="badge badge-muted">
+                          risk {reviewRiskLabel(reviewRiskFromValue(artifact.review_risk))}
+                        </span>
+                      )}
+                      {artifact.kind === "review" && artifact.review_follow_up_required && (
+                        <span className="badge badge-amber">follow-up required</span>
+                      )}
                       <span style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
                         {artifact.title || artifact.id}
                       </span>

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -219,6 +219,12 @@ export function ProjectWorkItemDetail({
               </span>
             )}
           </div>
+          <ReviewerSetupNotice
+            onEditWorkItem={() => onEditWorkItem(workItem)}
+            onManageRoles={onManageRoles}
+            roleByID={roleByID}
+            workItem={workItem}
+          />
         </section>
         <section style={workItemCardSectionStyle}>
           <div style={workItemSectionHeaderStyle}>
@@ -462,6 +468,51 @@ export function ProjectWorkItemDetail({
           )}
         </section>
       </article>
+    </div>
+  );
+}
+
+function ReviewerSetupNotice({
+  onEditWorkItem,
+  onManageRoles,
+  roleByID,
+  workItem,
+}: {
+  onEditWorkItem: () => void;
+  onManageRoles: () => void;
+  roleByID: Map<string, ProjectWorkRoleRecord>;
+  workItem: ProjectWorkItemRecord;
+}) {
+  const reviewerRoleIDs = (workItem.reviewer_role_ids ?? [])
+    .map((roleID) => roleID.trim())
+    .filter(Boolean);
+  const missingRoleIDs = reviewerRoleIDs.filter((roleID) => !roleByID.has(roleID));
+  if (reviewerRoleIDs.length > 0 && missingRoleIDs.length === 0) return null;
+  const missingReviewerRoles = missingRoleIDs.length > 0;
+  return (
+    <div style={reviewerSetupNoticeStyle}>
+      <div style={{ minWidth: 0 }}>
+        <div style={titleStyle}>
+          {missingReviewerRoles
+            ? "Reviewer role reference missing"
+            : "No reviewer roles configured"}
+        </div>
+        <div style={subtleTextStyle}>
+          {missingReviewerRoles
+            ? `Review recording needs these roles to exist: ${missingRoleIDs.join(", ")}.`
+            : "Add at least one reviewer role to enable review requests and review artifact recording for this work item."}
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button className="btn btn-ghost btn-sm" type="button" onClick={onEditWorkItem}>
+          <Icon d={Icons.edit} size={12} />
+          Edit reviewers
+        </button>
+        <button className="btn btn-ghost btn-sm" type="button" onClick={onManageRoles}>
+          <Icon d={Icons.user} size={12} />
+          Manage roles
+        </button>
+      </div>
     </div>
   );
 }
@@ -1478,6 +1529,20 @@ const workItemBriefTextStyle: CSSProperties = {
   margin: "8px 0 0",
   maxWidth: 860,
   overflowWrap: "anywhere",
+};
+
+const reviewerSetupNoticeStyle: CSSProperties = {
+  alignItems: "center",
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 10,
+  justifyContent: "space-between",
+  marginTop: 10,
+  minWidth: 0,
+  padding: "9px 10px",
 };
 
 const workItemCardSectionStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2659,6 +2659,27 @@ describe("ProjectsView cockpit", () => {
       object: "project_assignments",
       data: [reviewAssignment],
     });
+    vi.mocked(getProjectHandoffs).mockResolvedValue({
+      object: "project_handoffs",
+      data: [
+        {
+          id: "handoff_review",
+          project_id: project.id,
+          work_item_id: workItem.id,
+          source_assignment_id: hecateAssignment.id,
+          target_assignment_id: reviewAssignment.id,
+          title: "QA reviewer review request",
+          summary: "Review the implementation.",
+          recommended_next_action: "Record findings as a review artifact.",
+          status: "accepted",
+          provenance_kind: "operator",
+          trust_label: "operator_reviewed",
+          created_at: "2026-06-02T11:00:00Z",
+          updated_at: "2026-06-02T11:05:00Z",
+          status_changed_at: "2026-06-02T11:05:00Z",
+        },
+      ],
+    });
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
       projects: [project],
@@ -2702,6 +2723,10 @@ describe("ProjectsView cockpit", () => {
           assignment_id: "asgn_review",
           author_role_id: "reviewer_qa",
           kind: "review",
+          reviewed_assignment_id: hecateAssignment.id,
+          review_follow_up_required: true,
+          review_risk: "medium",
+          review_verdict: "changes_requested",
           title: "QA reviewer review",
           body: expect.stringContaining("Verdict: Changes requested"),
         }),

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1395,6 +1395,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
                   assignment,
                   roleByID.get(assignment.role_id) ?? null,
                   selectedWorkItem,
+                  handoffs,
                 ),
               );
             }}

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -309,6 +309,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
         memoryCandidates,
         {
           agentProfiles,
+          artifacts,
           roles,
           skills: projectSkills,
         },
@@ -316,6 +317,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     [
       activity,
       agentProfiles,
+      artifacts,
       memoryCandidates,
       memoryEntries,
       projectSkills,

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -5,6 +5,7 @@ import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
+  ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
   ProjectRecord,
   ProjectSkillRecord,
@@ -145,12 +146,54 @@ describe("projectInsights", () => {
       "defaults",
       "context",
       "memory_candidates",
+      "reviews",
       "handoffs",
       "stale",
     ]);
     expect(metric?.label).toBe("Recent handoffs");
     expect(metric?.value).toBe(1);
     expect(metric?.detail).toBe("1 recent accepted, 1 superseded, 1 dismissed");
+  });
+
+  it("surfaces structured review follow-up artifacts in health", () => {
+    const project = readyProject();
+    const work = {
+      id: "work_review",
+      project_id: project.id,
+      title: "Review cockpit flow",
+      status: "review",
+      priority: "normal",
+      created_at: "2026-06-04T10:00:00Z",
+      updated_at: "2026-06-04T10:00:00Z",
+    };
+    const health = buildProjectHealthSummary(project, null, [work], [], [], {
+      artifacts: [
+        reviewArtifact({
+          id: "art_review_1",
+          work_item_id: work.id,
+          title: "QA review",
+          reviewed_assignment_id: "asgn_impl",
+          review_verdict: "changes_requested",
+          review_risk: "medium",
+          review_follow_up_required: true,
+        }),
+      ],
+    });
+    const reviewMetric = projectHealthMetrics(health).find((item) => item.key === "reviews");
+
+    expect(health.reviews).toMatchObject({
+      total: 1,
+      followUpRequired: 1,
+      changesRequested: 1,
+    });
+    expect(reviewMetric?.value).toBe(1);
+    expect(health.attention).toContainEqual(
+      expect.objectContaining({
+        title: "Review follow-up: Review cockpit flow",
+        detail: expect.stringContaining("changes requested"),
+        workItemID: work.id,
+      }),
+    );
   });
 
   it("surfaces blocked external-agent assignments with chat refs", () => {
@@ -266,6 +309,24 @@ function projectSkill(patch: Partial<ProjectSkillRecord> = {}): ProjectSkillReco
     source_context_source_ids: ["ctx_1"],
     warnings: [],
     discovered_at: "2026-06-04T10:00:00Z",
+    created_at: "2026-06-04T10:00:00Z",
+    updated_at: "2026-06-04T10:00:00Z",
+    ...patch,
+  };
+}
+
+function reviewArtifact(
+  patch: Partial<ProjectCollaborationArtifactRecord> = {},
+): ProjectCollaborationArtifactRecord {
+  return {
+    id: "art_review",
+    project_id: "proj_ready",
+    work_item_id: "work_1",
+    assignment_id: "asgn_review",
+    kind: "review",
+    title: "Review",
+    body: "Verdict: Changes requested",
+    author_role_id: "reviewer_qa",
     created_at: "2026-06-04T10:00:00Z",
     updated_at: "2026-06-04T10:00:00Z",
     ...patch,

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -55,6 +55,7 @@ export type ProjectHealthMetric = {
     | "stale"
     | "defaults"
     | "context"
+    | "reviews"
     | "handoffs"
     | "memory_candidates";
   label: string;
@@ -97,11 +98,18 @@ export type ProjectHealthSummary = {
     superseded: number;
     dismissed: number;
   };
+  reviews: {
+    total: number;
+    followUpRequired: number;
+    blocked: number;
+    changesRequested: number;
+  };
   attention: ProjectHealthAttention[];
 };
 
 export type ProjectHealthSummaryOptions = {
   agentProfiles?: AgentProfileRecord[];
+  artifacts?: ProjectCollaborationArtifactRecord[];
   roles?: ProjectWorkRoleRecord[];
   skills?: ProjectSkillRecord[];
 };
@@ -225,6 +233,7 @@ export function buildProjectHealthSummary(
   ).length;
   const memoryCandidateSummary = summarizeProjectMemoryCandidates(memoryCandidates);
   const handoffSummary = summarizeProjectHandoffs(activityItems);
+  const reviewSummary = summarizeReviewArtifacts(options.artifacts ?? []);
   const missingDefaults = Boolean(project && (!project.default_provider || !project.default_model));
   const missingProjectRoot = Boolean(
     project &&
@@ -290,6 +299,10 @@ export function buildProjectHealthSummary(
       actionLabel: "View recent",
     });
   }
+  const firstReviewFollowUp = reviewFollowUpAttentionItem(options.artifacts ?? [], workItems);
+  if (firstReviewFollowUp) {
+    attention.push(firstReviewFollowUp);
+  }
   const firstStale = staleItems[0];
   if (firstStale) {
     attention.push(
@@ -343,6 +356,7 @@ export function buildProjectHealthSummary(
     enabledContextSources,
     memoryCandidates: memoryCandidateSummary,
     handoffs: handoffSummary,
+    reviews: reviewSummary,
     attention: uniqueAttention(attention).slice(0, 5),
   };
 }
@@ -370,6 +384,13 @@ export function projectHealthMetrics(health: ProjectHealthSummary): ProjectHealt
       value: health.memoryCandidates.pending,
       status: health.memoryCandidates.pending > 0 ? "awaiting_approval" : "completed",
       detail: `${health.memoryCandidates.promoted} promoted, ${health.memoryCandidates.rejected} rejected`,
+    },
+    {
+      key: "reviews",
+      label: "Review follow-up",
+      value: health.reviews.followUpRequired,
+      status: health.reviews.followUpRequired > 0 ? "awaiting_approval" : "completed",
+      detail: `${health.reviews.blocked} blocked, ${health.reviews.changesRequested} changes requested`,
     },
     {
       key: "handoffs",
@@ -483,6 +504,54 @@ function summarizeProjectHandoffs(
       return summary;
     },
     { total: 0, pending: 0, accepted: 0, superseded: 0, dismissed: 0 },
+  );
+}
+
+function summarizeReviewArtifacts(
+  artifacts: ProjectCollaborationArtifactRecord[],
+): ProjectHealthSummary["reviews"] {
+  return artifacts.reduce<ProjectHealthSummary["reviews"]>(
+    (summary, artifact) => {
+      if (artifact.kind !== "review") return summary;
+      summary.total += 1;
+      if (reviewArtifactRequiresFollowUp(artifact)) summary.followUpRequired += 1;
+      if (artifact.review_verdict === "blocked") summary.blocked += 1;
+      if (artifact.review_verdict === "changes_requested") summary.changesRequested += 1;
+      return summary;
+    },
+    { total: 0, followUpRequired: 0, blocked: 0, changesRequested: 0 },
+  );
+}
+
+function reviewFollowUpAttentionItem(
+  artifacts: ProjectCollaborationArtifactRecord[],
+  workItems: ProjectWorkItemRecord[],
+): ProjectHealthAttention | null {
+  const workByID = new Map(workItems.map((item) => [item.id, item]));
+  const artifact = artifacts.find(reviewArtifactRequiresFollowUp);
+  if (!artifact) return null;
+  const workItem = workByID.get(artifact.work_item_id);
+  const verdict = artifact.review_verdict ? artifact.review_verdict.replaceAll("_", " ") : "review";
+  const risk = artifact.review_risk ? `risk ${artifact.review_risk}` : "";
+  const reviewed = artifact.reviewed_assignment_id
+    ? `reviewed ${artifact.reviewed_assignment_id}`
+    : "";
+  return {
+    id: `${artifact.id}:review-follow-up`,
+    title: `Review follow-up: ${workItem?.title ?? artifact.title ?? artifact.id}`,
+    detail: [artifact.title || artifact.id, verdict, risk, reviewed].filter(Boolean).join(" · "),
+    status: artifact.review_verdict === "blocked" ? "blocked" : "awaiting_approval",
+    workItemID: artifact.work_item_id,
+    actionLabel: "Open review",
+  };
+}
+
+function reviewArtifactRequiresFollowUp(artifact: ProjectCollaborationArtifactRecord): boolean {
+  return (
+    artifact.kind === "review" &&
+    (artifact.review_follow_up_required === true ||
+      artifact.review_verdict === "blocked" ||
+      artifact.review_verdict === "changes_requested")
   );
 }
 

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -251,6 +251,24 @@ describe("projectWorkForms", () => {
       assignment,
       { id: "reviewer_qa", project_id: "proj_1", name: "QA reviewer", built_in: false },
       workItem,
+      [
+        {
+          id: "handoff_review",
+          project_id: "proj_1",
+          work_item_id: "work_1",
+          source_assignment_id: "assign_impl",
+          target_assignment_id: "assign_review",
+          title: "Review request",
+          summary: "Review implementation.",
+          recommended_next_action: "Record review.",
+          status: "accepted",
+          provenance_kind: "operator",
+          trust_label: "operator_reviewed",
+          created_at: "2026-06-12T00:00:00Z",
+          updated_at: "2026-06-12T00:00:00Z",
+          status_changed_at: "2026-06-12T00:00:00Z",
+        },
+      ],
     );
 
     expect(
@@ -266,6 +284,10 @@ describe("projectWorkForms", () => {
       assignment_id: "assign_review",
       author_role_id: "reviewer_qa",
       kind: "review",
+      reviewed_assignment_id: "assign_impl",
+      review_follow_up_required: true,
+      review_risk: "medium",
+      review_verdict: "changes_requested",
       title: "QA reviewer review",
       body: [
         "Verdict: Changes requested",

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -41,6 +41,8 @@ export type AssignmentStatus = (typeof ASSIGNMENT_STATUSES)[number];
 export const HANDOFF_STATUSES = ["pending", "accepted", "superseded", "dismissed"] as const;
 export type HandoffStatus = (typeof HANDOFF_STATUSES)[number];
 
+// Keep these values in sync with internal/projectwork review constants; the
+// server rejects review artifacts that use values outside its enum set.
 export const REVIEW_VERDICTS = ["approved", "changes_requested", "blocked", "risk"] as const;
 export type ReviewVerdict = (typeof REVIEW_VERDICTS)[number];
 
@@ -98,6 +100,7 @@ export type HandoffForm = {
 
 export type ReviewArtifactForm = {
   assignmentID: string;
+  reviewedAssignmentID: string;
   authorRoleID: string;
   title: string;
   verdict: ReviewVerdict;
@@ -316,10 +319,12 @@ export function reviewArtifactFormFromAssignment(
   assignment: ProjectAssignmentRecord,
   role: ProjectWorkRoleRecord | null,
   workItem: ProjectWorkItemRecord,
+  handoffs: ProjectHandoffRecord[] = [],
 ): ReviewArtifactForm {
   const roleName = role?.name || assignment.role_id;
   return {
     assignmentID: assignment.id,
+    reviewedAssignmentID: reviewedAssignmentIDForReviewAssignment(assignment, handoffs),
     authorRoleID: assignment.role_id,
     title: `${roleName} review`,
     verdict: "approved",
@@ -339,6 +344,10 @@ export function reviewArtifactPayloadFromForm(
     kind: "review",
     title: form.title.trim() || "Review",
     body: reviewArtifactBodyFromForm(form),
+    reviewed_assignment_id: form.reviewedAssignmentID.trim() || undefined,
+    review_verdict: form.verdict,
+    review_risk: form.risk,
+    review_follow_up_required: reviewFollowUpRequired(form),
   };
 }
 
@@ -383,7 +392,22 @@ function reviewArtifactBodyFromForm(form: ReviewArtifactForm): string {
   ].join("\n");
 }
 
-function reviewVerdictLabel(verdict: ReviewVerdict): string {
+function reviewedAssignmentIDForReviewAssignment(
+  assignment: ProjectAssignmentRecord,
+  handoffs: ProjectHandoffRecord[],
+): string {
+  const handoff = handoffs.find(
+    (item) => item.target_assignment_id === assignment.id && item.source_assignment_id,
+  );
+  return handoff?.source_assignment_id ?? "";
+}
+
+export function reviewFollowUpRequired(form: ReviewArtifactForm): boolean {
+  if (form.verdict === "changes_requested" || form.verdict === "blocked") return true;
+  return form.followUp.trim().length > 0;
+}
+
+export function reviewVerdictLabel(verdict: ReviewVerdict): string {
   switch (verdict) {
     case "changes_requested":
       return "Changes requested";
@@ -396,7 +420,7 @@ function reviewVerdictLabel(verdict: ReviewVerdict): string {
   }
 }
 
-function reviewRiskLabel(risk: ReviewRisk): string {
+export function reviewRiskLabel(risk: ReviewRisk): string {
   switch (risk) {
     case "low":
       return "Low";

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -408,6 +408,10 @@ describe("api client", () => {
       title: "QA review",
       body: "Verdict: Approved",
       author_role_id: "reviewer_qa",
+      reviewed_assignment_id: "asgn/source",
+      review_verdict: "approved",
+      review_risk: "low",
+      review_follow_up_required: false,
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -420,6 +424,10 @@ describe("api client", () => {
           title: "QA review",
           body: "Verdict: Approved",
           author_role_id: "reviewer_qa",
+          reviewed_assignment_id: "asgn/source",
+          review_verdict: "approved",
+          review_risk: "low",
+          review_follow_up_required: false,
         }),
       }),
     );

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -608,6 +608,10 @@ export type ProjectCollaborationArtifactRecord = {
   title?: string;
   body: string;
   author_role_id?: string;
+  reviewed_assignment_id?: string;
+  review_verdict?: string;
+  review_risk?: string;
+  review_follow_up_required?: boolean;
   created_at: string;
   updated_at: string;
 };
@@ -619,6 +623,10 @@ export type CreateProjectCollaborationArtifactPayload = {
   title?: string;
   body: string;
   author_role_id?: string;
+  reviewed_assignment_id?: string;
+  review_verdict?: string;
+  review_risk?: string;
+  review_follow_up_required?: boolean;
 };
 
 export type ProjectHandoffStatus = "pending" | "accepted" | "superseded" | "dismissed";


### PR DESCRIPTION
## Summary
- store review artifact verdict, risk, follow-up, and reviewed-assignment links as structured fields across memory, sqlite, API, and UI
- surface structured review follow-up in project health and Needs Attention
- guide operators to configure reviewer roles when review recording is unavailable

## Tests
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...
- cd ui && bun run test
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- just agent-docs-check
- git diff --check

Note: the first sandboxed race-suite attempt failed because local httptest servers could not bind to ::1. The same race suite passed outside the sandbox.