### PR TITLE
Add generic project evidence links

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -253,6 +253,11 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   deliberate operator action through the work-item update path. The guided
   closeout button should stay disabled while blockers remain; the existing
   edit-work-item status field is the manual override path.
+- Project evidence is generic provenance, not a GitHub/project-management
+  assumption. Evidence-link artifacts may represent source docs, tickets,
+  design files, deployments, PRs, meeting notes, local references, or other
+  operator-provided proof. UI copy should say "evidence" or "source", not
+  "GitHub" or "code", unless the specific artifact metadata says so.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1834,8 +1834,8 @@ root. Launch workspace resolution uses assignment `root_id`, then work-item
 Work items may also carry `reviewer_role_ids`; these identify roles that are
 appropriate targets for review handoffs and do not grant permissions, enforce
 policy, or auto-dispatch review work.
-Supported collaboration artifact kinds are `brief`, `handoff`, `review`, and
-`decision_note`.
+Supported collaboration artifact kinds are `brief`, `handoff`, `review`,
+`decision_note`, and `evidence_link`.
 Supported structured handoff statuses are `pending`, `accepted`, `superseded`,
 and `dismissed`.
 
@@ -2666,6 +2666,28 @@ Operators can create a separate handoff from the review artifact when follow-up
 is needed. The UI may also offer a shortcut that creates the handoff and queued
 follow-up assignment together, but it still records the handoff first and does
 not start the assignment automatically.
+
+The Projects cockpit uses `kind="evidence_link"` artifacts to attach generic
+external or local evidence to a work item. Evidence links are intentionally not
+GitHub- or code-specific: a link can point at a source document, research
+artifact, ticket, deployment, pull request, design file, meeting note, or any
+other operator-provided reference. Evidence link metadata is stored only as
+project provenance; Hecate does not fetch the URL, grant access to the external
+system, or treat the provider as policy authority. Evidence links may carry:
+
+- `evidence_source_kind` — free-form source category such as `source_document`,
+  `pull_request`, `ticket`, `deployment`, `design_file`, or `meeting_note`.
+- `evidence_url` — optional URL or locator string.
+- `evidence_external_id` — optional external identifier when a URL is not the
+  best reference.
+- `evidence_provider` — optional source system label such as `github`, `figma`,
+  `jira`, `docs`, or `local`.
+- `evidence_trust_label` — provenance/trust label, defaulting to
+  `operator_provided`.
+
+An evidence link requires `body` plus either `evidence_url` or
+`evidence_external_id`. Non-evidence artifacts clear these evidence fields on
+write.
 
 ```json
 {

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2677,7 +2677,9 @@ system, or treat the provider as policy authority. Evidence links may carry:
 
 - `evidence_source_kind` — free-form source category such as `source_document`,
   `pull_request`, `ticket`, `deployment`, `design_file`, or `meeting_note`.
-- `evidence_url` — optional URL or locator string.
+- `evidence_url` — optional URL or locator string. Hecate stores this
+  operator-provided value as-is; clients must validate the scheme before
+  rendering it as a clickable link.
 - `evidence_external_id` — optional external identifier when a URL is not the
   best reference.
 - `evidence_provider` — optional source system label such as `github`, `figma`,

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -87,6 +87,11 @@ type createProjectWorkArtifactRequest struct {
 	Title                  string `json:"title,omitempty"`
 	Body                   string `json:"body"`
 	AuthorRoleID           string `json:"author_role_id,omitempty"`
+	EvidenceSourceKind     string `json:"evidence_source_kind,omitempty"`
+	EvidenceURL            string `json:"evidence_url,omitempty"`
+	EvidenceExternalID     string `json:"evidence_external_id,omitempty"`
+	EvidenceProvider       string `json:"evidence_provider,omitempty"`
+	EvidenceTrustLabel     string `json:"evidence_trust_label,omitempty"`
 	ReviewedAssignmentID   string `json:"reviewed_assignment_id,omitempty"`
 	ReviewVerdict          string `json:"review_verdict,omitempty"`
 	ReviewRisk             string `json:"review_risk,omitempty"`
@@ -266,6 +271,11 @@ type ProjectWorkArtifactResponse struct {
 	Title                  string `json:"title,omitempty"`
 	Body                   string `json:"body"`
 	AuthorRoleID           string `json:"author_role_id,omitempty"`
+	EvidenceSourceKind     string `json:"evidence_source_kind,omitempty"`
+	EvidenceURL            string `json:"evidence_url,omitempty"`
+	EvidenceExternalID     string `json:"evidence_external_id,omitempty"`
+	EvidenceProvider       string `json:"evidence_provider,omitempty"`
+	EvidenceTrustLabel     string `json:"evidence_trust_label,omitempty"`
 	ReviewedAssignmentID   string `json:"reviewed_assignment_id,omitempty"`
 	ReviewVerdict          string `json:"review_verdict,omitempty"`
 	ReviewRisk             string `json:"review_risk,omitempty"`
@@ -756,6 +766,11 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 		Title:                  req.Title,
 		Body:                   req.Body,
 		AuthorRoleID:           req.AuthorRoleID,
+		EvidenceSourceKind:     req.EvidenceSourceKind,
+		EvidenceURL:            req.EvidenceURL,
+		EvidenceExternalID:     req.EvidenceExternalID,
+		EvidenceProvider:       req.EvidenceProvider,
+		EvidenceTrustLabel:     req.EvidenceTrustLabel,
 		ReviewedAssignmentID:   req.ReviewedAssignmentID,
 		ReviewVerdict:          req.ReviewVerdict,
 		ReviewRisk:             req.ReviewRisk,
@@ -1257,6 +1272,11 @@ func renderProjectWorkArtifact(item projectwork.CollaborationArtifact) ProjectWo
 		Title:                  item.Title,
 		Body:                   item.Body,
 		AuthorRoleID:           item.AuthorRoleID,
+		EvidenceSourceKind:     item.EvidenceSourceKind,
+		EvidenceURL:            item.EvidenceURL,
+		EvidenceExternalID:     item.EvidenceExternalID,
+		EvidenceProvider:       item.EvidenceProvider,
+		EvidenceTrustLabel:     item.EvidenceTrustLabel,
 		ReviewedAssignmentID:   item.ReviewedAssignmentID,
 		ReviewVerdict:          item.ReviewVerdict,
 		ReviewRisk:             item.ReviewRisk,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -442,6 +442,22 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_evidence",
+		"kind":"evidence_link",
+		"title":"Operator source document",
+		"body":"Source document used to validate the work item outcome.",
+		"evidence_source_kind":"source_document",
+		"evidence_url":"https://example.invalid/docs/hecate-work",
+		"evidence_external_id":"DOC-42",
+		"evidence_provider":"docs",
+		"evidence_trust_label":"operator_provided"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create evidence artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_backend/artifacts", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list artifacts status = %d body=%s, want 200", rec.Code, rec.Body.String())
@@ -450,8 +466,11 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &artifacts); err != nil {
 		t.Fatalf("decode artifacts: %v", err)
 	}
-	if len(artifacts.Data) != 1 || artifacts.Data[0].ID != "art_handoff" {
-		t.Fatalf("artifacts = %+v, want created artifact", artifacts.Data)
+	if len(artifacts.Data) != 2 || artifacts.Data[0].ID != "art_handoff" || artifacts.Data[1].ID != "art_evidence" {
+		t.Fatalf("artifacts = %+v, want handoff and evidence artifacts", artifacts.Data)
+	}
+	if artifacts.Data[1].Kind != projectwork.ArtifactKindEvidenceLink || artifacts.Data[1].EvidenceURL == "" || artifacts.Data[1].EvidenceExternalID != "DOC-42" || artifacts.Data[1].EvidenceProvider != "docs" {
+		t.Fatalf("evidence artifact = %+v, want evidence metadata", artifacts.Data[1])
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/projectwork/sqlite.go
+++ b/internal/projectwork/sqlite.go
@@ -133,6 +133,11 @@ CREATE TABLE IF NOT EXISTS %s (
 	title TEXT NOT NULL DEFAULT '',
 	body TEXT NOT NULL,
 	author_role_id TEXT NOT NULL DEFAULT '',
+	evidence_source_kind TEXT NOT NULL DEFAULT '',
+	evidence_url TEXT NOT NULL DEFAULT '',
+	evidence_external_id TEXT NOT NULL DEFAULT '',
+	evidence_provider TEXT NOT NULL DEFAULT '',
+	evidence_trust_label TEXT NOT NULL DEFAULT '',
 	reviewed_assignment_id TEXT NOT NULL DEFAULT '',
 	review_verdict TEXT NOT NULL DEFAULT '',
 	review_risk TEXT NOT NULL DEFAULT '',
@@ -191,6 +196,11 @@ CREATE TABLE IF NOT EXISTS %s (
 		name       string
 		definition string
 	}{
+		{name: "evidence_source_kind", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "evidence_url", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "evidence_external_id", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "evidence_provider", definition: `TEXT NOT NULL DEFAULT ''`},
+		{name: "evidence_trust_label", definition: `TEXT NOT NULL DEFAULT ''`},
 		{name: "reviewed_assignment_id", definition: `TEXT NOT NULL DEFAULT ''`},
 		{name: "review_verdict", definition: `TEXT NOT NULL DEFAULT ''`},
 		{name: "review_risk", definition: `TEXT NOT NULL DEFAULT ''`},
@@ -761,7 +771,7 @@ func (s *SQLiteStore) ListArtifacts(ctx context.Context, filter ArtifactFilter) 
 	filter.WorkItemID = strings.TrimSpace(filter.WorkItemID)
 	filter.AssignmentID = strings.TrimSpace(filter.AssignmentID)
 	query := fmt.Sprintf(`
-SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, evidence_source_kind, evidence_url, evidence_external_id, evidence_provider, evidence_trust_label, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
 FROM %s
 WHERE project_id = ?`, s.artifactsTbl)
 	args := []any{filter.ProjectID}
@@ -828,10 +838,11 @@ func (s *SQLiteStore) CreateArtifact(ctx context.Context, artifact Collaboration
 	}
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
-	id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.artifactsTbl),
+	id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, evidence_source_kind, evidence_url, evidence_external_id, evidence_provider, evidence_trust_label, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.artifactsTbl),
 		artifact.ID, artifact.ProjectID, artifact.WorkItemID, artifact.AssignmentID,
 		artifact.Kind, artifact.Title, artifact.Body, artifact.AuthorRoleID,
+		artifact.EvidenceSourceKind, artifact.EvidenceURL, artifact.EvidenceExternalID, artifact.EvidenceProvider, artifact.EvidenceTrustLabel,
 		artifact.ReviewedAssignmentID, artifact.ReviewVerdict, artifact.ReviewRisk, boolToDB(artifact.ReviewFollowUpRequired),
 		formatTime(artifact.CreatedAt), formatTime(artifact.UpdatedAt),
 	)
@@ -1163,7 +1174,7 @@ WHERE project_id = ? AND id = ?`, s.assignmentsTbl), strings.TrimSpace(projectID
 
 func (s *SQLiteStore) getRequiredArtifact(ctx context.Context, projectID, id string) (CollaborationArtifact, error) {
 	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
-SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
+SELECT id, project_id, work_item_id, assignment_id, kind, title, body, author_role_id, evidence_source_kind, evidence_url, evidence_external_id, evidence_provider, evidence_trust_label, reviewed_assignment_id, review_verdict, review_risk, review_follow_up_required, created_at, updated_at
 FROM %s
 WHERE project_id = ? AND id = ?`, s.artifactsTbl), strings.TrimSpace(projectID), strings.TrimSpace(id))
 	item, err := scanArtifact(row)
@@ -1299,7 +1310,7 @@ func scanArtifact(row scanner) (CollaborationArtifact, error) {
 	var item CollaborationArtifact
 	var createdAt, updatedAt string
 	var reviewFollowUpRequired int
-	if err := row.Scan(&item.ID, &item.ProjectID, &item.WorkItemID, &item.AssignmentID, &item.Kind, &item.Title, &item.Body, &item.AuthorRoleID, &item.ReviewedAssignmentID, &item.ReviewVerdict, &item.ReviewRisk, &reviewFollowUpRequired, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&item.ID, &item.ProjectID, &item.WorkItemID, &item.AssignmentID, &item.Kind, &item.Title, &item.Body, &item.AuthorRoleID, &item.EvidenceSourceKind, &item.EvidenceURL, &item.EvidenceExternalID, &item.EvidenceProvider, &item.EvidenceTrustLabel, &item.ReviewedAssignmentID, &item.ReviewVerdict, &item.ReviewRisk, &reviewFollowUpRequired, &createdAt, &updatedAt); err != nil {
 		return CollaborationArtifact{}, err
 	}
 	item.ReviewFollowUpRequired = reviewFollowUpRequired != 0

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -37,6 +37,7 @@ const (
 	ArtifactKindHandoff      = "handoff"
 	ArtifactKindReview       = "review"
 	ArtifactKindDecisionNote = "decision_note"
+	ArtifactKindEvidenceLink = "evidence_link"
 
 	// Keep review enum values in sync with the Projects UI REVIEW_VERDICTS /
 	// REVIEW_RISKS lists; the API rejects values outside this server set.
@@ -49,6 +50,8 @@ const (
 	ReviewRiskMedium  = "medium"
 	ReviewRiskHigh    = "high"
 	ReviewRiskUnknown = "unknown"
+
+	EvidenceTrustOperatorProvided = "operator_provided"
 
 	HandoffStatusPending    = "pending"
 	HandoffStatusAccepted   = "accepted"
@@ -132,6 +135,11 @@ type CollaborationArtifact struct {
 	Title                  string
 	Body                   string
 	AuthorRoleID           string
+	EvidenceSourceKind     string
+	EvidenceURL            string
+	EvidenceExternalID     string
+	EvidenceProvider       string
+	EvidenceTrustLabel     string
 	ReviewedAssignmentID   string
 	ReviewVerdict          string
 	ReviewRisk             string
@@ -898,6 +906,25 @@ func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationA
 	item.Title = strings.TrimSpace(item.Title)
 	item.Body = strings.TrimSpace(item.Body)
 	item.AuthorRoleID = strings.TrimSpace(item.AuthorRoleID)
+	item.EvidenceSourceKind = strings.TrimSpace(item.EvidenceSourceKind)
+	item.EvidenceURL = strings.TrimSpace(item.EvidenceURL)
+	item.EvidenceExternalID = strings.TrimSpace(item.EvidenceExternalID)
+	item.EvidenceProvider = strings.TrimSpace(item.EvidenceProvider)
+	item.EvidenceTrustLabel = strings.TrimSpace(item.EvidenceTrustLabel)
+	if item.Kind != ArtifactKindEvidenceLink {
+		item.EvidenceSourceKind = ""
+		item.EvidenceURL = ""
+		item.EvidenceExternalID = ""
+		item.EvidenceProvider = ""
+		item.EvidenceTrustLabel = ""
+	} else {
+		if item.EvidenceSourceKind == "" {
+			item.EvidenceSourceKind = "external"
+		}
+		if item.EvidenceTrustLabel == "" {
+			item.EvidenceTrustLabel = EvidenceTrustOperatorProvided
+		}
+	}
 	item.ReviewedAssignmentID = strings.TrimSpace(item.ReviewedAssignmentID)
 	item.ReviewVerdict = strings.TrimSpace(item.ReviewVerdict)
 	item.ReviewRisk = strings.TrimSpace(item.ReviewRisk)
@@ -1046,6 +1073,9 @@ func validateArtifact(item CollaborationArtifact) error {
 	if item.Body == "" {
 		return fmt.Errorf("%w: artifact body is required", ErrInvalid)
 	}
+	if item.Kind == ArtifactKindEvidenceLink && item.EvidenceURL == "" && item.EvidenceExternalID == "" {
+		return fmt.Errorf("%w: evidence_url or evidence_external_id is required for evidence links", ErrInvalid)
+	}
 	if item.ReviewVerdict != "" && !validReviewVerdict(item.ReviewVerdict) {
 		return fmt.Errorf("%w: unsupported review_verdict %q", ErrInvalid, item.ReviewVerdict)
 	}
@@ -1118,7 +1148,7 @@ func validAssignmentStatus(status string) bool {
 
 func validArtifactKind(kind string) bool {
 	switch kind {
-	case ArtifactKindBrief, ArtifactKindHandoff, ArtifactKindReview, ArtifactKindDecisionNote:
+	case ArtifactKindBrief, ArtifactKindHandoff, ArtifactKindReview, ArtifactKindDecisionNote, ArtifactKindEvidenceLink:
 		return true
 	default:
 		return false

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -207,6 +207,11 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 				Kind:                   ArtifactKindBrief,
 				Title:                  "Implementation note",
 				Body:                   "This is not a review.",
+				EvidenceSourceKind:     "pull_request",
+				EvidenceURL:            "https://example.invalid/pr/1",
+				EvidenceExternalID:     "PR 1",
+				EvidenceProvider:       "github",
+				EvidenceTrustLabel:     "operator_provided",
 				ReviewedAssignmentID:   "asgn_impl",
 				ReviewVerdict:          ReviewVerdictBlocked,
 				ReviewRisk:             ReviewRiskHigh,
@@ -218,11 +223,36 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if briefArtifact.ReviewedAssignmentID != "" || briefArtifact.ReviewVerdict != "" || briefArtifact.ReviewRisk != "" || briefArtifact.ReviewFollowUpRequired {
 				t.Fatalf("non-review artifact = %+v, want review fields cleared", briefArtifact)
 			}
+			if briefArtifact.EvidenceSourceKind != "" || briefArtifact.EvidenceURL != "" || briefArtifact.EvidenceExternalID != "" || briefArtifact.EvidenceProvider != "" || briefArtifact.EvidenceTrustLabel != "" {
+				t.Fatalf("non-evidence artifact = %+v, want evidence fields cleared", briefArtifact)
+			}
+			evidenceArtifact, err := store.CreateArtifact(ctx, CollaborationArtifact{
+				ID:                 "art_evidence",
+				ProjectID:          "proj_alpha",
+				WorkItemID:         "work_api",
+				AssignmentID:       "asgn_impl",
+				Kind:               ArtifactKindEvidenceLink,
+				Title:              "Implementation PR",
+				Body:               "Implementation evidence for the project work item.",
+				EvidenceSourceKind: "pull_request",
+				EvidenceURL:        "https://example.invalid/hecate/pull/399",
+				EvidenceExternalID: "PR 399",
+				EvidenceProvider:   "github",
+			})
+			if err != nil {
+				t.Fatalf("CreateArtifact evidence: %v", err)
+			}
+			if evidenceArtifact.EvidenceSourceKind != "pull_request" || evidenceArtifact.EvidenceURL == "" || evidenceArtifact.EvidenceExternalID != "PR 399" || evidenceArtifact.EvidenceProvider != "github" || evidenceArtifact.EvidenceTrustLabel != EvidenceTrustOperatorProvided {
+				t.Fatalf("evidence artifact = %+v, want normalized evidence metadata", evidenceArtifact)
+			}
 			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_bad_verdict", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Invalid verdict.", ReviewVerdict: "ship_it"}); !errors.Is(err, ErrInvalid) {
 				t.Fatalf("CreateArtifact invalid review_verdict error = %v, want ErrInvalid", err)
 			}
 			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_bad_risk", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Invalid risk.", ReviewRisk: "spicy"}); !errors.Is(err, ErrInvalid) {
 				t.Fatalf("CreateArtifact invalid review_risk error = %v, want ErrInvalid", err)
+			}
+			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_bad_evidence", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindEvidenceLink, Body: "Missing link target."}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("CreateArtifact invalid evidence link error = %v, want ErrInvalid", err)
 			}
 			if _, err := store.CreateArtifact(ctx, CollaborationArtifact{ID: "art_missing_reviewed", ProjectID: "proj_alpha", WorkItemID: "work_api", AssignmentID: "asgn_impl", Kind: ArtifactKindReview, Body: "Missing reviewed assignment.", ReviewedAssignmentID: "asgn_missing"}); !errors.Is(err, ErrNotFound) {
 				t.Fatalf("CreateArtifact missing reviewed_assignment_id error = %v, want ErrNotFound", err)
@@ -303,14 +333,33 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListArtifacts: %v", err)
 			}
-			if len(artifacts) != 2 || artifacts[0].ID != "art_brief" || artifacts[1].ID != "art_note" {
-				t.Fatalf("artifacts = %+v, want created review and note artifacts", artifacts)
+			if len(artifacts) != 3 {
+				t.Fatalf("artifacts = %+v, want created review, note, and evidence artifacts", artifacts)
 			}
-			if artifacts[0].ReviewVerdict != ReviewVerdictChangesRequested || artifacts[0].ReviewRisk != ReviewRiskMedium || !artifacts[0].ReviewFollowUpRequired {
-				t.Fatalf("listed review artifact = %+v, want structured review fields", artifacts[0])
+			artifactsByID := make(map[string]CollaborationArtifact, len(artifacts))
+			for _, artifact := range artifacts {
+				artifactsByID[artifact.ID] = artifact
 			}
-			if artifacts[1].ReviewedAssignmentID != "" || artifacts[1].ReviewVerdict != "" || artifacts[1].ReviewRisk != "" || artifacts[1].ReviewFollowUpRequired {
-				t.Fatalf("listed non-review artifact = %+v, want review fields cleared", artifacts[1])
+			reviewArtifact, ok := artifactsByID["art_brief"]
+			if !ok {
+				t.Fatalf("artifacts = %+v, want review artifact", artifacts)
+			}
+			noteArtifact, ok := artifactsByID["art_note"]
+			if !ok {
+				t.Fatalf("artifacts = %+v, want note artifact", artifacts)
+			}
+			listedEvidenceArtifact, ok := artifactsByID["art_evidence"]
+			if !ok {
+				t.Fatalf("artifacts = %+v, want evidence artifact", artifacts)
+			}
+			if reviewArtifact.ReviewVerdict != ReviewVerdictChangesRequested || reviewArtifact.ReviewRisk != ReviewRiskMedium || !reviewArtifact.ReviewFollowUpRequired {
+				t.Fatalf("listed review artifact = %+v, want structured review fields", reviewArtifact)
+			}
+			if noteArtifact.ReviewedAssignmentID != "" || noteArtifact.ReviewVerdict != "" || noteArtifact.ReviewRisk != "" || noteArtifact.ReviewFollowUpRequired {
+				t.Fatalf("listed non-review artifact = %+v, want review fields cleared", noteArtifact)
+			}
+			if listedEvidenceArtifact.EvidenceSourceKind != "pull_request" || listedEvidenceArtifact.EvidenceExternalID != "PR 399" || listedEvidenceArtifact.EvidenceTrustLabel != EvidenceTrustOperatorProvided {
+				t.Fatalf("listed evidence artifact = %+v, want evidence metadata", listedEvidenceArtifact)
 			}
 			handoffs, err := store.ListHandoffs(ctx, HandoffFilter{ProjectID: "proj_alpha", WorkItemID: "work_api"})
 			if err != nil {
@@ -570,6 +619,64 @@ INSERT INTO `+assignmentsTbl+` (
 	}
 	if assignments[0].ExecutionRef.TaskID != "task_legacy" || assignments[0].ExecutionRef.RunID != "run_legacy" || assignments[0].ExecutionRef.ContextSnapshotID != "ctx_legacy" {
 		t.Fatalf("assignment execution_ref = %+v, want legacy columns folded into canonical ref", assignments[0].ExecutionRef)
+	}
+}
+
+func TestSQLiteStore_AddsArtifactEvidenceColumnsToExistingTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "projectwork.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	artifactsTbl := client.QualifiedTable("project_work_artifacts")
+	if _, err := client.DB().ExecContext(ctx, `
+CREATE TABLE `+artifactsTbl+` (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	work_item_id TEXT NOT NULL,
+	assignment_id TEXT NOT NULL DEFAULT '',
+	kind TEXT NOT NULL,
+	title TEXT NOT NULL DEFAULT '',
+	body TEXT NOT NULL,
+	author_role_id TEXT NOT NULL DEFAULT '',
+	reviewed_assignment_id TEXT NOT NULL DEFAULT '',
+	review_verdict TEXT NOT NULL DEFAULT '',
+	review_risk TEXT NOT NULL DEFAULT '',
+	review_follow_up_required INTEGER NOT NULL DEFAULT 0,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY(project_id, id)
+)`); err != nil {
+		t.Fatalf("create legacy artifacts table: %v", err)
+	}
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := client.DB().ExecContext(ctx, `
+INSERT INTO `+artifactsTbl+` (
+	id, project_id, work_item_id, kind, title, body, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"art_legacy", "proj_alpha", "work_alpha", ArtifactKindDecisionNote, "Legacy note", "Older schema.", now, now,
+	); err != nil {
+		t.Fatalf("insert legacy artifact: %v", err)
+	}
+
+	store, err := NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	artifacts, err := store.ListArtifacts(ctx, ArtifactFilter{ProjectID: "proj_alpha"})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(artifacts) != 1 || artifacts[0].ID != "art_legacy" {
+		t.Fatalf("artifacts = %+v, want legacy artifact", artifacts)
+	}
+	if artifacts[0].EvidenceSourceKind != "" || artifacts[0].EvidenceURL != "" || artifacts[0].EvidenceExternalID != "" || artifacts[0].EvidenceProvider != "" || artifacts[0].EvidenceTrustLabel != "" {
+		t.Fatalf("legacy artifact evidence fields = %+v, want empty backfill", artifacts[0])
 	}
 }
 

--- a/ui/src/features/projects/ProjectEvidenceLinkModal.tsx
+++ b/ui/src/features/projects/ProjectEvidenceLinkModal.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+import type { ProjectAssignmentRecord } from "../../types/project";
+import { InlineError, Modal } from "../shared/ui";
+import type { EvidenceLinkForm } from "./projectWorkForms";
+import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWorkModalStyles";
+
+type ProjectEvidenceLinkModalProps = {
+  assignments: ProjectAssignmentRecord[];
+  error: string;
+  pending: boolean;
+  onClose: () => void;
+  onSave: (form: EvidenceLinkForm) => void | Promise<void>;
+};
+
+export function ProjectEvidenceLinkModal({
+  assignments,
+  error,
+  pending,
+  onClose,
+  onSave,
+}: ProjectEvidenceLinkModalProps) {
+  const [form, setForm] = useState<EvidenceLinkForm>({
+    assignmentID: "",
+    title: "",
+    sourceKind: "external",
+    url: "",
+    externalID: "",
+    provider: "",
+    trustLabel: "operator_provided",
+    summary: "",
+  });
+  const valid =
+    form.title.trim().length > 0 &&
+    form.summary.trim().length > 0 &&
+    (form.url.trim().length > 0 || form.externalID.trim().length > 0);
+  return (
+    <Modal
+      title="Record evidence"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          type="button"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          {pending ? "Recording..." : "Record evidence"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        {error && <InlineError message={error} />}
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Title</span>
+          <input
+            className="input"
+            autoFocus
+            value={form.title}
+            onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+            placeholder="Source document, ticket, deployment, design file, or note"
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: fieldGridColumns, gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Source kind</span>
+            <input
+              className="input"
+              value={form.sourceKind}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceKind: event.target.value }))
+              }
+              placeholder="external"
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Provider</span>
+            <input
+              className="input"
+              value={form.provider}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, provider: event.target.value }))
+              }
+              placeholder="docs, figma, jira, local, github"
+            />
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>URL</span>
+          <input
+            className="input"
+            value={form.url}
+            onChange={(event) => setForm((current) => ({ ...current, url: event.target.value }))}
+            placeholder="https://..."
+          />
+        </label>
+        <div style={{ display: "grid", gridTemplateColumns: fieldGridColumns, gap: 10 }}>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>External id</span>
+            <input
+              className="input"
+              value={form.externalID}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, externalID: event.target.value }))
+              }
+              placeholder="DOC-12, release-2026-06-13, PR 399"
+            />
+          </label>
+          <label style={projectWorkFieldStyle}>
+            <span style={projectWorkFieldLabelStyle}>Trust label</span>
+            <input
+              className="input"
+              value={form.trustLabel}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, trustLabel: event.target.value }))
+              }
+              placeholder="operator_provided"
+            />
+          </label>
+        </div>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Assignment</span>
+          <select
+            className="input"
+            value={form.assignmentID}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, assignmentID: event.target.value }))
+            }
+          >
+            <option value="">Work item evidence</option>
+            {assignments.map((assignment) => (
+              <option key={assignment.id} value={assignment.id}>
+                {assignment.role_id} / {assignment.status}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={projectWorkFieldStyle}>
+          <span style={projectWorkFieldLabelStyle}>Summary</span>
+          <textarea
+            className="input"
+            value={form.summary}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, summary: event.target.value }))
+            }
+            rows={4}
+            style={{ resize: "vertical", minHeight: 96 }}
+          />
+        </label>
+      </form>
+    </Modal>
+  );
+}
+
+const fieldGridColumns = "repeat(auto-fit, minmax(180px, 1fr))";

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -464,6 +464,25 @@ describe("ProjectWorkItemDetail", () => {
     expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
   });
 
+  it("renders unsafe evidence locators as text instead of links", () => {
+    renderDetail({
+      assignments: [],
+      artifacts: [
+        artifact({
+          id: "art_unsafe_evidence",
+          kind: "evidence_link",
+          title: "Operator locator",
+          body: "Operator-provided locator.",
+          evidence_source_kind: "source_document",
+          evidence_url: "javascript:alert(1)",
+        }),
+      ],
+    });
+
+    expect(screen.getByText("javascript:alert(1)")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "javascript:alert(1)" })).toBeNull();
+  });
+
   it("disables review artifact follow-up actions while an assignment shortcut is pending", () => {
     renderDetail({
       assignments: [],

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -176,6 +176,7 @@ function renderDetail(overrides: Partial<ProjectWorkItemDetailProps> = {}) {
   const assign = assignment();
   const handlers = {
     onAddAssignment: vi.fn(),
+    onAddEvidenceLink: vi.fn(),
     onAddHandoff: vi.fn(),
     onAddHandoffFromAssignment: vi.fn(),
     onAddHandoffFromReviewArtifact: vi.fn(),
@@ -433,6 +434,34 @@ describe("ProjectWorkItemDetail", () => {
     expect(screen.getByText("Changes requested")).toBeTruthy();
     expect(screen.getByText("risk Medium")).toBeTruthy();
     expect(screen.getByText("follow-up required")).toBeTruthy();
+  });
+
+  it("renders evidence link metadata and delegates evidence creation", async () => {
+    const { handlers } = renderDetail({
+      assignments: [],
+      artifacts: [
+        artifact({
+          id: "art_evidence",
+          kind: "evidence_link",
+          title: "Source document",
+          body: "Research source for this work.",
+          evidence_source_kind: "source_document",
+          evidence_url: "https://example.invalid/source",
+          evidence_external_id: "DOC-42",
+          evidence_provider: "docs",
+          evidence_trust_label: "operator_provided",
+        }),
+      ],
+    });
+
+    expect(screen.getByText("source_document")).toBeTruthy();
+    expect(screen.getByText("operator_provided")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "https://example.invalid/source" })).toBeTruthy();
+    expect(screen.getByText("provider docs · external DOC-42")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Evidence" }));
+
+    expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
   });
 
   it("disables review artifact follow-up actions while an assignment shortcut is pending", () => {

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -79,6 +79,7 @@ export type ProjectWorkItemDetailProps = {
   loading: boolean;
   onAddAssignment: () => void;
   onAddHandoff: () => void;
+  onAddEvidenceLink: () => void;
   onAddHandoffFromAssignment: (
     assignment: ProjectAssignmentRecord,
     activityItem?: ProjectActivityItemRecord,
@@ -128,6 +129,7 @@ export function ProjectWorkItemDetail({
   detailError,
   loading,
   onAddAssignment,
+  onAddEvidenceLink,
   onAddHandoff,
   onAddHandoffFromAssignment,
   onAddReviewHandoffFromAssignment,
@@ -362,6 +364,15 @@ export function ProjectWorkItemDetail({
           <div style={workItemSectionHeaderStyle}>
             <div style={sectionLabelStyle}>Collaboration Artifacts</div>
             <span className="badge badge-muted">{artifacts.length}</span>
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={onAddEvidenceLink}
+              style={{ marginLeft: "auto" }}
+            >
+              <Icon d={Icons.plus} size={12} />
+              Evidence
+            </button>
           </div>
           {artifacts.length === 0 ? (
             <div style={subtleTextStyle}>No collaboration artifacts recorded yet.</div>
@@ -385,6 +396,12 @@ export function ProjectWorkItemDetail({
                       )}
                       {artifact.kind === "review" && artifact.review_follow_up_required && (
                         <span className="badge badge-amber">follow-up required</span>
+                      )}
+                      {artifact.kind === "evidence_link" && artifact.evidence_source_kind && (
+                        <span className="badge badge-muted">{artifact.evidence_source_kind}</span>
+                      )}
+                      {artifact.kind === "evidence_link" && artifact.evidence_trust_label && (
+                        <span className="badge badge-muted">{artifact.evidence_trust_label}</span>
                       )}
                       <span style={{ ...titleStyle, flex: 1, minWidth: 0 }}>
                         {artifact.title || artifact.id}
@@ -420,6 +437,9 @@ export function ProjectWorkItemDetail({
                     >
                       {artifact.body}
                     </div>
+                    {artifact.kind === "evidence_link" && (
+                      <EvidenceArtifactMetadata artifact={artifact} />
+                    )}
                   </div>
                 );
               })}
@@ -489,6 +509,30 @@ export function ProjectWorkItemDetail({
       </article>
     </div>
   );
+}
+
+function EvidenceArtifactMetadata({ artifact }: { artifact: ProjectCollaborationArtifactRecord }) {
+  const details = [
+    artifact.evidence_provider ? `provider ${artifact.evidence_provider}` : "",
+    artifact.evidence_external_id ? `external ${artifact.evidence_external_id}` : "",
+  ].filter(Boolean);
+  return (
+    <div style={evidenceArtifactMetadataStyle}>
+      {artifact.evidence_url && isLinkableEvidenceURL(artifact.evidence_url) && (
+        <a href={artifact.evidence_url} target="_blank" rel="noreferrer">
+          {artifact.evidence_url}
+        </a>
+      )}
+      {artifact.evidence_url && !isLinkableEvidenceURL(artifact.evidence_url) && (
+        <span>{artifact.evidence_url}</span>
+      )}
+      {details.length > 0 && <span>{details.join(" · ")}</span>}
+    </div>
+  );
+}
+
+function isLinkableEvidenceURL(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
 }
 
 function WorkItemCloseoutPanel({
@@ -1629,6 +1673,17 @@ const closeoutListStyle: CSSProperties = {
   lineHeight: 1.45,
   margin: "8px 0 0",
   paddingLeft: 18,
+};
+
+const evidenceArtifactMetadataStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  marginTop: 8,
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.4,
+  overflowWrap: "anywhere",
 };
 
 const workItemSectionHeaderStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -82,6 +82,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
   const handlers = {
     onActivityBucketChange: vi.fn(),
     onAddAssignment: vi.fn(),
+    onAddEvidenceLink: vi.fn(),
     onAddHandoff: vi.fn(),
     onAddHandoffFromAssignment: vi.fn(),
     onAddHandoffFromReviewArtifact: vi.fn(),

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -66,6 +66,7 @@ export type ProjectWorkspaceViewProps = {
   memoryLoadState: LoadState;
   onActivityBucketChange: (bucket: ProjectActivityBucketKey) => void;
   onAddAssignment: () => void;
+  onAddEvidenceLink: () => void;
   onAddHandoff: () => void;
   onAddHandoffFromAssignment: (
     assignment: ProjectAssignmentRecord,
@@ -155,6 +156,7 @@ export function ProjectWorkspaceView({
   memoryLoadState,
   onActivityBucketChange,
   onAddAssignment,
+  onAddEvidenceLink,
   onAddHandoff,
   onAddHandoffFromAssignment,
   onAddReviewHandoffFromAssignment,
@@ -349,6 +351,7 @@ export function ProjectWorkspaceView({
                         startingAssignmentID={startingAssignmentID}
                         workItem={selectedWorkItem}
                         onAddAssignment={onAddAssignment}
+                        onAddEvidenceLink={onAddEvidenceLink}
                         onAddHandoff={onAddHandoff}
                         onAddHandoffFromAssignment={onAddHandoffFromAssignment}
                         onAddReviewHandoffFromAssignment={onAddReviewHandoffFromAssignment}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2811,6 +2811,70 @@ describe("ProjectsView cockpit", () => {
     );
   });
 
+  it("records neutral evidence links from the selected work item", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(createProjectCollaborationArtifact).mockResolvedValue({
+      object: "project_collaboration_artifact",
+      data: {
+        id: "art_evidence_new",
+        project_id: project.id,
+        work_item_id: workItem.id,
+        kind: "evidence_link",
+        title: "Research source",
+        body: "Source document used to validate this work.",
+        evidence_source_kind: "source_document",
+        evidence_url: "https://example.invalid/research",
+        evidence_external_id: "DOC-42",
+        evidence_provider: "docs",
+        evidence_trust_label: "operator_provided",
+        created_at: "2026-06-02T12:10:00Z",
+        updated_at: "2026-06-02T12:10:00Z",
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
+    const detail = await screen.findByRole("region", { name: "Selected work item" });
+    await userEvent.click(within(detail).getByRole("button", { name: "Evidence" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Record evidence" });
+    fireEvent.change(within(dialog).getByLabelText("Title"), {
+      target: { value: "Research source" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Source kind"), {
+      target: { value: "source_document" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Provider"), {
+      target: { value: "docs" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("URL"), {
+      target: { value: "https://example.invalid/research" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("External id"), {
+      target: { value: "DOC-42" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Summary"), {
+      target: { value: "Source document used to validate this work." },
+    });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Record evidence" }));
+
+    expect(createProjectCollaborationArtifact).toHaveBeenCalledWith(project.id, workItem.id, {
+      kind: "evidence_link",
+      title: "Research source",
+      body: "Source document used to validate this work.",
+      evidence_source_kind: "source_document",
+      evidence_url: "https://example.invalid/research",
+      evidence_external_id: "DOC-42",
+      evidence_provider: "docs",
+      evidence_trust_label: "operator_provided",
+    });
+  });
+
   it("drafts follow-up handoffs from review artifacts", async () => {
     resetProjectWorkMocks();
     const reviewAssignment: ProjectAssignmentRecord = {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -95,6 +95,7 @@ import type {
 import type { AgentProfileRecord } from "../../types/agent-profile";
 import { ConfirmModal, Icon, Icons, InlineError, type ProviderOption } from "../shared/ui";
 import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
+import { ProjectEvidenceLinkModal } from "./ProjectEvidenceLinkModal";
 import { type CreateWorktreeForm, type ProjectDefaultsForm } from "./projectSettings";
 import {
   profileCreatePayloadFromForm,
@@ -107,6 +108,7 @@ import {
 import {
   assignmentCreatePayloadFromForm,
   assignmentUpdatePayloadFromForm,
+  evidenceLinkPayloadFromForm,
   handoffFormFromAssignment,
   handoffFormFromReviewArtifact,
   handoffPayloadFromForm,
@@ -115,6 +117,7 @@ import {
   reviewHandoffFormFromAssignment,
   type EditAssignmentForm,
   type EditWorkItemForm,
+  type EvidenceLinkForm,
   type HandoffForm,
   type NewAssignmentForm,
   type NewWorkItemForm,
@@ -227,6 +230,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [handoffError, setHandoffError] = useState("");
   const [handoffActionID, setHandoffActionID] = useState("");
   const [artifactActionID, setArtifactActionID] = useState("");
+  const [evidenceLinkModalOpen, setEvidenceLinkModalOpen] = useState(false);
+  const [evidenceLinkPending, setEvidenceLinkPending] = useState(false);
+  const [evidenceLinkError, setEvidenceLinkError] = useState("");
   const [reviewArtifactDraft, setReviewArtifactDraft] = useState<ReviewArtifactForm | null>(null);
   const [reviewArtifactPending, setReviewArtifactPending] = useState(false);
   const [reviewArtifactError, setReviewArtifactError] = useState("");
@@ -1081,6 +1087,30 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     }
   }
 
+  async function handleSaveEvidenceLink(form: EvidenceLinkForm) {
+    if (!selectedProjectID || !selectedWorkItemID) return;
+    const payload = evidenceLinkPayloadFromForm(form);
+    if (!payload.title?.trim() || !payload.body.trim()) return;
+    if (!payload.evidence_url?.trim() && !payload.evidence_external_id?.trim()) return;
+    setEvidenceLinkPending(true);
+    setEvidenceLinkError("");
+    try {
+      const res = await createProjectCollaborationArtifact(
+        selectedProjectID,
+        selectedWorkItemID,
+        payload,
+      );
+      setArtifacts((current) => upsertArtifact(current, res.data));
+      setEvidenceLinkModalOpen(false);
+      await loadWorkItemDetail(selectedProjectID, selectedWorkItemID);
+      await loadWorkForProject(selectedProjectID, selectedWorkItemID);
+    } catch (error) {
+      setEvidenceLinkError(errorMessage(error, "Failed to record evidence."));
+    } finally {
+      setEvidenceLinkPending(false);
+    }
+  }
+
   async function handleSetHandoffStatus(handoff: ProjectHandoffRecord, status: string) {
     if (!selectedProjectID || !selectedWorkItemID) return;
     setHandoffActionID(handoff.id);
@@ -1386,6 +1416,10 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               setNewAssignmentError("");
               setNewAssignmentModalOpen(true);
             }}
+            onAddEvidenceLink={() => {
+              setEvidenceLinkError("");
+              setEvidenceLinkModalOpen(true);
+            }}
             onAddHandoff={() => {
               setHandoffError("");
               setNewHandoffDraft(null);
@@ -1677,6 +1711,19 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               setReviewArtifactError("");
             }}
             onSave={handleSaveReviewArtifact}
+          />
+        )}
+
+        {evidenceLinkModalOpen && selectedWorkItem && (
+          <ProjectEvidenceLinkModal
+            assignments={assignments}
+            error={evidenceLinkError}
+            pending={evidenceLinkPending}
+            onClose={() => {
+              setEvidenceLinkModalOpen(false);
+              setEvidenceLinkError("");
+            }}
+            onSave={handleSaveEvidenceLink}
           />
         )}
 

--- a/ui/src/features/projects/projectWorkForms.test.ts
+++ b/ui/src/features/projects/projectWorkForms.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
   assignmentStatusFromValue,
   assignmentUpdatePayloadFromForm,
+  evidenceLinkPayloadFromForm,
   handoffFormFromAssignment,
   handoffFormFromReviewArtifact,
   handoffPayloadFromForm,
@@ -302,6 +303,30 @@ describe("projectWorkForms", () => {
         "Follow-up:",
         "Fix empty state copy.",
       ].join("\n"),
+    });
+  });
+
+  it("builds evidence link payloads with neutral metadata", () => {
+    expect(
+      evidenceLinkPayloadFromForm({
+        assignmentID: "",
+        title: "Research source",
+        sourceKind: " source_document ",
+        url: " https://example.invalid/research ",
+        externalID: " DOC-42 ",
+        provider: " docs ",
+        trustLabel: "",
+        summary: " Source used to validate this work. ",
+      }),
+    ).toEqual({
+      kind: "evidence_link",
+      title: "Research source",
+      body: "Source used to validate this work.",
+      evidence_source_kind: "source_document",
+      evidence_url: "https://example.invalid/research",
+      evidence_external_id: "DOC-42",
+      evidence_provider: "docs",
+      evidence_trust_label: "operator_provided",
     });
   });
 

--- a/ui/src/features/projects/projectWorkForms.ts
+++ b/ui/src/features/projects/projectWorkForms.ts
@@ -110,6 +110,17 @@ export type ReviewArtifactForm = {
   followUp: string;
 };
 
+export type EvidenceLinkForm = {
+  assignmentID: string;
+  title: string;
+  sourceKind: string;
+  url: string;
+  externalID: string;
+  provider: string;
+  trustLabel: string;
+  summary: string;
+};
+
 export function defaultDriverForRole(role: ProjectWorkRoleRecord | null): string {
   return role?.default_driver_kind || "hecate_task";
 }
@@ -348,6 +359,22 @@ export function reviewArtifactPayloadFromForm(
     review_verdict: form.verdict,
     review_risk: form.risk,
     review_follow_up_required: reviewFollowUpRequired(form),
+  };
+}
+
+export function evidenceLinkPayloadFromForm(
+  form: EvidenceLinkForm,
+): CreateProjectCollaborationArtifactPayload {
+  return {
+    assignment_id: form.assignmentID.trim() || undefined,
+    kind: "evidence_link",
+    title: form.title.trim() || "Evidence link",
+    body: form.summary.trim(),
+    evidence_source_kind: form.sourceKind.trim() || "external",
+    evidence_url: form.url.trim() || undefined,
+    evidence_external_id: form.externalID.trim() || undefined,
+    evidence_provider: form.provider.trim() || undefined,
+    evidence_trust_label: form.trustLabel.trim() || "operator_provided",
   };
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -597,7 +597,12 @@ export type CreateProjectAssignmentPayload = {
 
 export type UpdateProjectAssignmentPayload = Partial<CreateProjectAssignmentPayload>;
 
-export type ProjectCollaborationArtifactKind = "brief" | "handoff" | "review" | "decision_note";
+export type ProjectCollaborationArtifactKind =
+  | "brief"
+  | "handoff"
+  | "review"
+  | "decision_note"
+  | "evidence_link";
 
 export type ProjectCollaborationArtifactRecord = {
   id: string;
@@ -608,6 +613,11 @@ export type ProjectCollaborationArtifactRecord = {
   title?: string;
   body: string;
   author_role_id?: string;
+  evidence_source_kind?: string;
+  evidence_url?: string;
+  evidence_external_id?: string;
+  evidence_provider?: string;
+  evidence_trust_label?: string;
   reviewed_assignment_id?: string;
   review_verdict?: string;
   review_risk?: string;
@@ -623,6 +633,11 @@ export type CreateProjectCollaborationArtifactPayload = {
   title?: string;
   body: string;
   author_role_id?: string;
+  evidence_source_kind?: string;
+  evidence_url?: string;
+  evidence_external_id?: string;
+  evidence_provider?: string;
+  evidence_trust_label?: string;
   reviewed_assignment_id?: string;
   review_verdict?: string;
   review_risk?: string;


### PR DESCRIPTION
## Summary

- add generic `evidence_link` collaboration artifacts for project work items
- persist evidence metadata across memory, SQLite, and Postgres-backed stores
- add a Projects UI flow for recording and rendering neutral evidence/source links
- document evidence as generic project provenance, not GitHub- or code-specific state

## Verification

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectwork`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test -race -timeout 10m ./...`
- `go vet ./internal/projectwork ./internal/api`
- `cd ui && bun run test -- src/features/projects/projectWorkForms.test.ts src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-format-check`
- `just agent-docs-check`
- `git diff --check`
