### PR TITLE
Support rootless project onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,10 @@ for the deeper contracts.
 ## Project, Context, And Memory Flow
 
 The newer Hecate shape starts with projects. A project is the durable local
-identity for a codebase or work area. A workspace is the concrete filesystem
-root used by a chat, task, or external-agent session.
+identity for a work area: code, research, writing, design, ops, planning, or
+support. A project can start without a workspace; a workspace is the concrete
+filesystem root used later by a chat, task, or external-agent session when local
+files matter.
 
 ```mermaid
 flowchart LR

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -258,6 +258,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   design files, deployments, PRs, meeting notes, local references, or other
   operator-provided proof. UI copy should say "evidence" or "source", not
   "GitHub" or "code", unless the specific artifact metadata says so.
+- Projects are durable work areas, not necessarily repos. Creation and
+  onboarding should allow a name/purpose without a workspace root; root, Git,
+  worktree, `AGENTS.md`, and skills affordances are code/file-backed options,
+  not prerequisites for every project.
 - **Stable provider ordering.** Do not sort provider lists by health, blocked state, or availability unless explicitly asked. Fixed alphabetical/preset order within each section.
 - Runtime metadata first-class, not tucked in debug crumbs.
 - Trace and failure details readable without scanning raw JSON first.

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -14,10 +14,10 @@ enters the native agent task runtime. Codex, Claude Code, Cursor Agent, and Grok
 the same picker create **External Agent** sessions.
 
 Chats may also belong to a **Project**. Projects are optional durable identities
-for a codebase or work area; **No project** remains a valid chat scope. When a
-project is selected in the Chats sidebar, new Hecate and External Agent chat
-sessions are created with that `project_id`, and the chat list shows only chats
-for the active project. When an open chat is linked to a project, the chat
+for a work area, not only a codebase; **No project** remains a valid chat scope.
+When a project is selected in the Chats sidebar, new Hecate and External Agent
+chat sessions are created with that `project_id`, and the chat list shows only
+chats for the active project. When an open chat is linked to a project, the chat
 header exposes a compact project shortcut that selects that project and opens
 the Projects workspace. Project-linked Hecate Chat also exposes a compact
 composer action that deterministically drafts a Project Assistant proposal from

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -244,9 +244,11 @@ tasks, or launch agents.
 
 In the operator UI, **Bootstrap project** is the project onboarding action, not a
 regular draft mode. It refreshes workspace guidance context sources, refreshes
-the project skills registry, then requests a project-scoped Bootstrap draft. The
-Projects with a workspace root but no work items use Bootstrap as their primary
-onboarding action before showing the full work cockpit.
+the project skills registry, then requests a project-scoped Bootstrap draft.
+Rootless projects skip workspace discovery naturally and can still use Bootstrap
+to propose roles, first work, and memory candidates from existing project
+metadata. Projects with no work items use Bootstrap as their primary onboarding
+action before showing the full work cockpit.
 The resulting proposal is still review/apply gated and does not attach to the
 currently selected work item.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1312,10 +1312,12 @@ bodies are sent to that provider as normal task prompt content.
 
 ## Project endpoints
 
-Projects are the durable Hecate identity for a codebase or work area. A project
-can remember one or more concrete workspace roots and future defaults such as
-provider, model, agent profile, tools posture, workspace mode, system prompt,
-compact command-output preference, and trusted context-source metadata.
+Projects are the durable Hecate identity for a work area: code, research,
+writing, design, ops, planning, support, or any other operator-coordinated
+effort. A project can exist without a workspace root. When local files or code
+matter, it can remember one or more concrete workspace roots and future defaults
+such as provider, model, agent profile, tools posture, workspace mode, system
+prompt, compact command-output preference, and trusted context-source metadata.
 
 The project catalog implementation is intentionally lightweight:
 `GET`/`POST`/`PATCH`/`DELETE /hecate/v1/projects` work, and
@@ -1422,9 +1424,11 @@ paths are unique across all projects. Duplicate project names or root paths
 return `409 conflict`.
 
 Projects may be created without a workspace by omitting both `workspace_path`
-and `roots`. For the common one-workspace case, send `workspace_path` and
-optionally `workspace_kind`; Hecate creates one active root and makes it the
-default root. For advanced multi-root setup, send `roots` directly.
+and `roots`; this is the normal shape for planning, research, writing, ops, or
+design projects that do not start from local files. For the common
+one-workspace case, send `workspace_path` and optionally `workspace_kind`;
+Hecate creates one active root and makes it the default root. For advanced
+multi-root setup, send `roots` directly.
 `workspace_path` cannot be combined with `roots` or an explicit
 `default_root_id`.
 

--- a/ui/src/app/state/projects.test.tsx
+++ b/ui/src/app/state/projects.test.tsx
@@ -3,17 +3,10 @@ import { type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProjectsProvider, useProjects } from "./projects";
-import {
-  chooseWorkspaceDirectory,
-  createProject,
-  deleteProject,
-  getProjects,
-  updateProject,
-} from "../../lib/api";
+import { createProject, deleteProject, getProjects, updateProject } from "../../lib/api";
 import type { ProjectRecord } from "../../types/project";
 
 vi.mock("../../lib/api", () => ({
-  chooseWorkspaceDirectory: vi.fn(),
   createProject: vi.fn(),
   deleteProject: vi.fn(),
   getProjects: vi.fn(),
@@ -44,7 +37,6 @@ function wrapper({ children }: { children: ReactNode }) {
 describe("ProjectsProvider", () => {
   beforeEach(() => {
     window.localStorage.clear();
-    vi.mocked(chooseWorkspaceDirectory).mockReset();
     vi.mocked(createProject).mockReset();
     vi.mocked(deleteProject).mockReset();
     vi.mocked(getProjects).mockReset();
@@ -110,6 +102,27 @@ describe("ProjectsProvider", () => {
     await waitFor(() => {
       expect(window.localStorage.getItem("hecate.project")).toBe(project.id);
     });
+  });
+
+  it("creates a rootless project and selects it", async () => {
+    const created = { ...project, id: "proj_research", name: "Research", roots: [] };
+    vi.mocked(createProject).mockResolvedValue({ object: "project", data: created });
+    const { result } = renderHook(() => useProjects(), { wrapper });
+
+    await act(async () => {
+      await result.current.actions.createProject({
+        name: " Research ",
+        description: " Durable research workspace. ",
+      });
+    });
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: "Research",
+      description: "Durable research workspace.",
+    });
+    expect(result.current.state.projects).toEqual([created]);
+    expect(result.current.activeProjectID).toBe("proj_research");
+    expect(window.localStorage.getItem("hecate.project")).toBe("proj_research");
   });
 
   it("renames a project and upserts the returned record", async () => {

--- a/ui/src/app/state/projects.tsx
+++ b/ui/src/app/state/projects.tsx
@@ -7,14 +7,13 @@ import { createContext, useCallback, useContext, useMemo, useReducer, type React
 
 import { applyOverride, CoordinatorOverridesContext } from "./coordinators/overrides";
 import {
-  chooseWorkspaceDirectory,
   createProject as createProjectRequest,
   deleteProject as deleteProjectRequest,
   getProjects as getProjectsRequest,
   updateProject as updateProjectRequest,
 } from "../../lib/api";
 import { parseStoredString, usePersistedState } from "../../lib/persistedState";
-import type { ProjectRecord } from "../../types/project";
+import type { CreateProjectPayload, ProjectRecord } from "../../types/project";
 
 const ACTIVE_PROJECT_STORAGE_KEY = "hecate.project";
 
@@ -33,7 +32,7 @@ export type ProjectsActions = {
   setActiveProjectID: (id: string) => void;
   loadProjects: () => Promise<void>;
   selectProject: (id: string) => Promise<void>;
-  createProjectFromFolder: () => Promise<ProjectRecord | null>;
+  createProject: (payload: CreateProjectPayload) => Promise<ProjectRecord | null>;
   renameProject: (id: string, name: string) => Promise<void>;
   deleteProject: (id: string) => Promise<boolean>;
 };
@@ -150,34 +149,30 @@ export function ProjectsProvider({
     [setActiveProjectIDState],
   );
 
-  const createProjectFromFolder = useCallback(async (): Promise<ProjectRecord | null> => {
-    dispatch({ type: "error/set", value: "" });
-    try {
-      const workspace = await chooseWorkspaceDirectory();
-      const root = workspace.data.path.trim();
-      if (!root) return null;
-      const payload = await createProjectRequest({
-        name: projectNameFromPath(root),
-        roots: [
-          {
-            path: root,
-            kind: "local",
-            git_branch: workspace.data.branch || undefined,
-            active: true,
-          },
-        ],
-      });
-      dispatch({ type: "projects/set", next: (current) => upsertProject(current, payload.data) });
-      setActiveProjectIDState(payload.data.id);
-      return payload.data;
-    } catch (error) {
-      dispatch({
-        type: "error/set",
-        value: error instanceof Error ? error.message : "Failed to create project.",
-      });
-      return null;
-    }
-  }, [setActiveProjectIDState]);
+  const createProject = useCallback(
+    async (payload: CreateProjectPayload): Promise<ProjectRecord | null> => {
+      const name = payload.name.trim();
+      if (!name) return null;
+      dispatch({ type: "error/set", value: "" });
+      try {
+        const created = await createProjectRequest({
+          ...payload,
+          name,
+          description: payload.description?.trim() || undefined,
+        });
+        dispatch({ type: "projects/set", next: (current) => upsertProject(current, created.data) });
+        setActiveProjectIDState(created.data.id);
+        return created.data;
+      } catch (error) {
+        dispatch({
+          type: "error/set",
+          value: error instanceof Error ? error.message : "Failed to create project.",
+        });
+        return null;
+      }
+    },
+    [setActiveProjectIDState],
+  );
 
   const renameProject = useCallback(async (id: string, name: string) => {
     const projectID = id.trim();
@@ -229,7 +224,7 @@ export function ProjectsProvider({
       setActiveProjectID,
       loadProjects,
       selectProject,
-      createProjectFromFolder,
+      createProject,
       renameProject,
       deleteProject,
     }),
@@ -240,7 +235,7 @@ export function ProjectsProvider({
       setActiveProjectID,
       loadProjects,
       selectProject,
-      createProjectFromFolder,
+      createProject,
       renameProject,
       deleteProject,
     ],
@@ -279,10 +274,4 @@ function upsertProject(projects: ProjectRecord[], project: ProjectRecord): Proje
   const next = projects.slice();
   next[index] = project;
   return next;
-}
-
-function projectNameFromPath(path: string): string {
-  const trimmed = path.replace(/\/+$/, "");
-  const segments = trimmed.split("/").filter(Boolean);
-  return segments.at(-1) || "Untitled project";
 }

--- a/ui/src/features/projects/CreateProjectModal.test.tsx
+++ b/ui/src/features/projects/CreateProjectModal.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { CreateProjectModal } from "./CreateProjectModal";
+
+describe("CreateProjectModal", () => {
+  it("creates a rootless project from name and purpose", async () => {
+    const onSave = vi.fn();
+    render(
+      <CreateProjectModal
+        error=""
+        pending={false}
+        onChooseWorkspace={vi.fn(async () => null)}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Create project" });
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Launch plan" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Purpose"), {
+      target: { value: "Coordinate the launch narrative and approvals." },
+    });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create project" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      name: "Launch plan",
+      description: "Coordinate the launch narrative and approvals.",
+      rootPath: "",
+      rootGitBranch: "",
+    });
+  });
+
+  it("can choose an optional workspace folder without requiring code", async () => {
+    const onChooseWorkspace = vi.fn(async () => ({
+      path: "/Users/alice/dev/hecate",
+      branch: "main",
+    }));
+    render(
+      <CreateProjectModal
+        error=""
+        pending={false}
+        onChooseWorkspace={onChooseWorkspace}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Create project" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Choose folder" }));
+
+    await waitFor(() => {
+      expect(within(dialog).getByLabelText("Name")).toHaveValue("hecate");
+    });
+    expect(within(dialog).getByLabelText("Folder path")).toHaveValue("/Users/alice/dev/hecate");
+    expect(within(dialog).getByLabelText("Git branch")).toHaveValue("main");
+  });
+});

--- a/ui/src/features/projects/CreateProjectModal.tsx
+++ b/ui/src/features/projects/CreateProjectModal.tsx
@@ -1,0 +1,178 @@
+import { useState, type CSSProperties } from "react";
+
+import { Icon, Icons, InlineError, Modal } from "../shared/ui";
+import type { CreateProjectForm } from "./projectSettings";
+import { projectNameFromPath } from "./projectUtils";
+
+type WorkspaceChoice = {
+  path: string;
+  branch?: string;
+};
+
+type CreateProjectModalProps = {
+  error: string;
+  pending: boolean;
+  onChooseWorkspace: () => Promise<WorkspaceChoice | null>;
+  onClose: () => void;
+  onSave: (form: CreateProjectForm) => void | Promise<void>;
+};
+
+export function CreateProjectModal({
+  error,
+  pending,
+  onChooseWorkspace,
+  onClose,
+  onSave,
+}: CreateProjectModalProps) {
+  const [form, setForm] = useState<CreateProjectForm>({
+    name: "",
+    description: "",
+    rootPath: "",
+    rootGitBranch: "",
+  });
+  const [choosingWorkspace, setChoosingWorkspace] = useState(false);
+  const [chooseError, setChooseError] = useState("");
+  const valid = form.name.trim().length > 0;
+
+  async function handleChooseWorkspace() {
+    setChoosingWorkspace(true);
+    setChooseError("");
+    try {
+      const choice = await onChooseWorkspace();
+      if (!choice) return;
+      setForm((current) => ({
+        ...current,
+        name: current.name.trim() || projectNameFromPath(choice.path),
+        rootPath: choice.path,
+        rootGitBranch: choice.branch ?? "",
+      }));
+    } catch (err) {
+      setChooseError(err instanceof Error ? err.message : "Failed to choose workspace folder.");
+    } finally {
+      setChoosingWorkspace(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Create project"
+      onClose={onClose}
+      width={560}
+      footer={
+        <button
+          className="btn btn-primary"
+          disabled={pending || !valid}
+          onClick={() => void onSave(form)}
+          style={{ justifyContent: "center", width: "100%" }}
+          type="button"
+        >
+          {pending ? "Creating..." : "Create project"}
+        </button>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) void onSave(form);
+        }}
+        style={{ display: "grid", gap: 13 }}
+      >
+        {error && <InlineError message={error} />}
+        {chooseError && <InlineError message={chooseError} />}
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Name</span>
+          <input
+            autoFocus
+            className="input"
+            onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            placeholder="Research brief, launch plan, Hecate"
+            value={form.name}
+          />
+        </label>
+        <label style={fieldStyle}>
+          <span style={fieldLabelStyle}>Purpose</span>
+          <textarea
+            className="input"
+            onChange={(event) =>
+              setForm((current) => ({ ...current, description: event.target.value }))
+            }
+            placeholder="What this project coordinates. Optional, but useful for non-code work."
+            rows={3}
+            style={{ minHeight: 80, resize: "vertical" }}
+            value={form.description}
+          />
+        </label>
+        <section style={workspaceSectionStyle}>
+          <div style={{ minWidth: 0 }}>
+            <div style={fieldLabelStyle}>Workspace source</div>
+            <div style={hintStyle}>
+              Optional. Leave empty for planning, research, writing, ops, or design projects that do
+              not start from a local folder.
+            </div>
+          </div>
+          <button
+            className="btn btn-ghost btn-sm"
+            disabled={choosingWorkspace}
+            onClick={() => void handleChooseWorkspace()}
+            type="button"
+          >
+            <Icon d={Icons.folder} size={13} />
+            {choosingWorkspace ? "Choosing..." : "Choose folder"}
+          </button>
+        </section>
+        <div style={{ display: "grid", gap: 10 }}>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Folder path</span>
+            <input
+              className="input"
+              onChange={(event) =>
+                setForm((current) => ({ ...current, rootPath: event.target.value }))
+              }
+              placeholder="/Users/alice/projects/example"
+              value={form.rootPath}
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Git branch</span>
+            <input
+              className="input"
+              onChange={(event) =>
+                setForm((current) => ({ ...current, rootGitBranch: event.target.value }))
+              }
+              placeholder="Optional; filled when detected"
+              value={form.rootGitBranch}
+            />
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+const fieldStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+};
+
+const hintStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.45,
+  marginTop: 4,
+};
+
+const workspaceSectionStyle: CSSProperties = {
+  alignItems: "flex-start",
+  borderTop: "1px solid var(--border)",
+  display: "flex",
+  gap: 12,
+  justifyContent: "space-between",
+  paddingTop: 13,
+};

--- a/ui/src/features/projects/ProjectScopePanel.tsx
+++ b/ui/src/features/projects/ProjectScopePanel.tsx
@@ -1,9 +1,12 @@
 import { useState, type CSSProperties, type ReactNode } from "react";
 
 import { useProjects } from "../../app/state/projects";
+import { chooseWorkspaceDirectory } from "../../lib/api";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type { ProjectRecord } from "../../types/project";
 import { ConfirmModal, Icon, Icons } from "../shared/ui";
+import { CreateProjectModal } from "./CreateProjectModal";
+import { createProjectPayloadFromForm, type CreateProjectForm } from "./projectSettings";
 
 type ProjectScopePanelProps = {
   noProjectDetail: string;
@@ -38,6 +41,9 @@ export function ProjectScopePanel({
   const [projectRenameValue, setProjectRenameValue] = useState("");
   const [hoveredProjectID, setHoveredProjectID] = useState<string | null>(null);
   const [deleteProjectID, setDeleteProjectID] = useState<string | null>(null);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  const [createProjectPending, setCreateProjectPending] = useState(false);
+  const [createProjectError, setCreateProjectError] = useState("");
   const activeProject =
     projects.activeProjectID === ""
       ? null
@@ -68,6 +74,33 @@ export function ProjectScopePanel({
     onProjectSelected?.(projectID, project);
   }
 
+  async function handleCreateProject(form: CreateProjectForm) {
+    const payload = createProjectPayloadFromForm(form);
+    if (!payload.name) {
+      setCreateProjectError("Project name is required.");
+      return;
+    }
+    setCreateProjectPending(true);
+    setCreateProjectError("");
+    try {
+      const created = await projects.actions.createProject(payload);
+      if (!created) return;
+      setCreateProjectOpen(false);
+      setProjectsExpanded(false);
+      onProjectSelected?.(created.id, created);
+    } finally {
+      setCreateProjectPending(false);
+    }
+  }
+
+  async function handleChooseWorkspace() {
+    const workspace = await chooseWorkspaceDirectory();
+    return {
+      path: workspace.data.path,
+      branch: workspace.data.branch || undefined,
+    };
+  }
+
   return (
     <>
       <div style={{ padding: "8px 8px 6px", borderBottom: "1px solid var(--border)" }}>
@@ -76,7 +109,9 @@ export function ProjectScopePanel({
           expanded={projectsExpanded}
           label="Projects"
           onAction={() => {
-            void projects.actions.createProjectFromFolder();
+            setCreateProjectError("");
+            projects.actions.setError("");
+            setCreateProjectOpen(true);
           }}
           onToggle={() => setProjectsExpanded((value) => !value)}
         />
@@ -135,6 +170,18 @@ export function ProjectScopePanel({
           </div>
         )}
       </div>
+      {createProjectOpen && (
+        <CreateProjectModal
+          error={createProjectError || projects.state.error}
+          pending={createProjectPending}
+          onChooseWorkspace={handleChooseWorkspace}
+          onClose={() => {
+            setCreateProjectOpen(false);
+            setCreateProjectError("");
+          }}
+          onSave={handleCreateProject}
+        />
+      )}
       {pendingDeleteProject && (
         <ConfirmModal
           danger

--- a/ui/src/features/projects/ProjectSettingsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.test.tsx
@@ -1,9 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ProjectRecord, ProjectRootRecord } from "../../types/project";
 import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
+import { chooseWorkspaceDirectory } from "../../lib/api";
+
+vi.mock("../../lib/api", () => ({
+  chooseWorkspaceDirectory: vi.fn(),
+}));
 
 function root(overrides: Partial<ProjectRootRecord>): ProjectRootRecord {
   return {
@@ -39,6 +44,10 @@ function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
 }
 
 describe("ProjectSettingsPanel", () => {
+  beforeEach(() => {
+    vi.mocked(chooseWorkspaceDirectory).mockReset();
+  });
+
   it("saves editable defaults and updates the workspace preview from form roots", async () => {
     const onSave = vi.fn();
 
@@ -73,6 +82,51 @@ describe("ProjectSettingsPanel", () => {
         roots: expect.arrayContaining([
           expect.objectContaining({ id: "root_feature", active: true }),
         ]),
+      }),
+    );
+  });
+
+  it("adds an optional folder root to rootless projects", async () => {
+    const onSave = vi.fn();
+    vi.mocked(chooseWorkspaceDirectory).mockResolvedValue({
+      object: "workspace_dialog",
+      data: { path: "/workspace/research", branch: "" },
+    });
+
+    render(
+      <ProjectSettingsPanel
+        agentProfiles={[]}
+        agentProfilesError=""
+        error=""
+        models={[]}
+        pending={false}
+        providerOptions={[]}
+        providerPresets={[]}
+        project={project({ roots: [], default_root_id: "" })}
+        rootsPending={false}
+        onDiscoverRoots={vi.fn()}
+        onOpenCreateWorktree={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByText("No roots configured.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create worktree" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Discover worktrees" })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add folder" }));
+    expect(await screen.findAllByText("/workspace/research")).toHaveLength(2);
+    await userEvent.click(screen.getByRole("button", { name: "Save defaults" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roots: [
+          expect.objectContaining({
+            path: "/workspace/research",
+            kind: "local",
+            active: true,
+          }),
+        ],
       }),
     );
   });

--- a/ui/src/features/projects/ProjectSettingsPanel.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 
+import { chooseWorkspaceDirectory } from "../../lib/api";
 import { projectDefaultWorkspaceFromRoots } from "../../lib/project-workspace";
 import type { AgentProfileRecord } from "../../types/agent-profile";
 import type { ModelRecord } from "../../types/model";
@@ -51,6 +52,7 @@ export function ProjectSettingsPanel({
   const [form, setForm] = useState<ProjectDefaultsForm>(() =>
     projectDefaultsFormFromProject(project),
   );
+  const [rootChooseError, setRootChooseError] = useState("");
   useEffect(() => {
     setForm(projectDefaultsFormFromProject(project));
   }, [project]);
@@ -94,6 +96,30 @@ export function ProjectSettingsPanel({
       defaultRootID: !active && current.defaultRootID === rootID ? "" : current.defaultRootID,
       roots: current.roots.map((root) => (root.id === rootID ? { ...root, active } : root)),
     }));
+  }
+  async function handleChooseRoot() {
+    setRootChooseError("");
+    try {
+      const workspace = await chooseWorkspaceDirectory();
+      const path = workspace.data.path.trim();
+      if (!path) return;
+      setForm((current) => {
+        if (current.roots.some((root) => root.path.trim() === path)) return current;
+        const nextRoot = {
+          path,
+          kind: "local",
+          git_branch: workspace.data.branch || undefined,
+          active: true,
+        };
+        return {
+          ...current,
+          defaultRootID: current.defaultRootID,
+          roots: [...current.roots, nextRoot],
+        };
+      });
+    } catch (err) {
+      setRootChooseError(err instanceof Error ? err.message : "Failed to choose workspace folder.");
+    }
   }
   const submitForm = () => onSave(form);
 
@@ -145,6 +171,7 @@ export function ProjectSettingsPanel({
           style={{ display: "grid", gap: 14 }}
         >
           {error && <InlineError message={error} />}
+          {rootChooseError && <InlineError message={rootChooseError} />}
           {agentProfilesError && <InlineError message={agentProfilesError} />}
           <ProjectSettingsSection title="Assignment defaults">
             <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
@@ -248,8 +275,8 @@ export function ProjectSettingsPanel({
           </ProjectSettingsSection>
           <ProjectSettingsSection title="Project context">
             <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
-              Project roots are concrete checkouts. Linked worktrees discovered from Git stay
-              inactive until enabled here.
+              Project roots are optional local folders or checkouts. Use them when this project
+              needs local files, code, or workspace guidance.
             </div>
             <div style={{ display: "grid", gap: 12, marginBottom: 14 }}>
               <div style={fieldStyle}>
@@ -273,6 +300,14 @@ export function ProjectSettingsPanel({
                 <button
                   className="btn btn-primary btn-sm"
                   type="button"
+                  onClick={() => void handleChooseRoot()}
+                >
+                  Add folder
+                </button>
+                <button
+                  className="btn btn-ghost btn-sm"
+                  type="button"
+                  disabled={rootCount === 0}
                   onClick={onOpenCreateWorktree}
                 >
                   Create worktree
@@ -280,7 +315,7 @@ export function ProjectSettingsPanel({
                 <button
                   className="btn btn-ghost btn-sm"
                   type="button"
-                  disabled={rootsPending}
+                  disabled={rootsPending || rootCount === 0}
                   onClick={() => void onDiscoverRoots()}
                 >
                   {rootsPending ? "Discovering…" : "Discover worktrees"}

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -180,8 +180,9 @@ describe("ProjectWorkspaceView", () => {
     });
 
     expect(screen.getByText("Set up Console")).toBeTruthy();
-    expect(screen.getByText("Workspace root")).toBeTruthy();
-    expect(screen.getByText("Missing")).toBeTruthy();
+    expect(screen.getByText("Workspace source")).toBeTruthy();
+    expect(screen.getByText("Optional; attach files when this project needs them.")).toBeTruthy();
+    expect(screen.getByText("optional")).toBeTruthy();
 
     await userEvent.click(screen.getByRole("button", { name: "Bootstrap project" }));
     await userEvent.click(screen.getByRole("button", { name: "Create work" }));

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -522,13 +522,23 @@ function ProjectOnboardingPanel({
   skillCount: number;
 }) {
   const hasRoot = project.roots.some((root) => root.active !== false && root.path);
+  const workspace = projectDefaultWorkspace(project);
+  const hasPurpose = Boolean(project.description?.trim());
   const hasDefaults = Boolean(project.default_provider && project.default_model);
   const hasGuidance = contextSourceCount > 0 || skillCount > 0;
   const checks = [
     {
-      label: "Workspace root",
-      detail: hasRoot ? projectDefaultWorkspace(project) || "Ready" : "Missing",
-      done: hasRoot,
+      label: "Project purpose",
+      detail: hasPurpose ? project.description?.trim() || "Ready" : "Add a short purpose.",
+      done: hasPurpose,
+    },
+    {
+      label: "Workspace source",
+      detail: hasRoot
+        ? workspace || "Ready"
+        : "Optional; attach files when this project needs them.",
+      done: true,
+      optional: !hasRoot,
     },
     {
       label: "Provider and model",
@@ -536,13 +546,18 @@ function ProjectOnboardingPanel({
       done: hasDefaults,
     },
     {
-      label: "Guidance and skills",
+      label: "Sources and memory",
       detail: `${contextSourceCount} sources · ${skillCount} skills`,
       done: hasGuidance,
     },
     {
-      label: "Roles and first work",
-      detail: `${roleCount} roles · no work items`,
+      label: "Roles",
+      detail: roleCount > 0 ? `${roleCount} roles` : "Bootstrap or add roles.",
+      done: roleCount > 0,
+    },
+    {
+      label: "First work item",
+      detail: "No work items yet",
       done: false,
     },
   ];
@@ -554,8 +569,8 @@ function ProjectOnboardingPanel({
           <div style={projectOnboardingTitleStyle}>Set up {project.name}</div>
         </div>
         <div style={projectOnboardingDetailStyle}>
-          Create reviewable setup actions from this workspace: roles, guidance, skills, and first
-          work.
+          Create a durable coordination space for planning, evidence, roles, and reviewable work.
+          Attach local files only when this project needs a workspace.
         </div>
         <div style={projectOnboardingActionsStyle}>
           <button
@@ -584,7 +599,7 @@ function ProjectOnboardingPanel({
               className={check.done ? "badge badge-green" : "badge badge-muted"}
               style={projectOnboardingCheckBadgeStyle}
             >
-              {check.done ? "ready" : "todo"}
+              {check.optional ? "optional" : check.done ? "ready" : "todo"}
             </span>
             <div style={{ minWidth: 0 }}>
               <div style={titleStyle}>{check.label}</div>

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1245,6 +1245,7 @@ describe("ProjectsView index", () => {
     });
     expect(screen.getByText("No projects yet")).toBeTruthy();
     expect(screen.getByText("Add a project to begin")).toBeTruthy();
+    expect(screen.getByText(/Create a project for any durable work area/)).toBeTruthy();
     expect(screen.queryByRole("tablist", { name: "Project workspace views" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Project settings" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Work" })).toBeNull();
@@ -1267,7 +1268,7 @@ describe("ProjectsView index", () => {
     const user = userEvent.setup();
     const actions = {
       ...createRuntimeConsoleActions(),
-      createProjectFromFolder: vi.fn(async () => project),
+      createProject: vi.fn(async () => project),
       renameProject: vi.fn(async () => undefined),
       deleteProject: vi.fn(async () => true),
       selectProject: vi.fn(async () => undefined),
@@ -1279,7 +1280,20 @@ describe("ProjectsView index", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions }));
 
     await user.click(screen.getByRole("button", { name: "Add" }));
-    expect(actions.createProjectFromFolder).toHaveBeenCalled();
+    const createDialog = await screen.findByRole("dialog", { name: "Create project" });
+    fireEvent.change(within(createDialog).getByLabelText("Name"), {
+      target: { value: "Research notebook" },
+    });
+    fireEvent.change(within(createDialog).getByLabelText("Purpose"), {
+      target: { value: "Coordinate research sources." },
+    });
+    await user.click(within(createDialog).getByRole("button", { name: "Create project" }));
+    expect(actions.createProject).toHaveBeenCalledWith({
+      name: "Research notebook",
+      description: "Coordinate research sources.",
+    });
+    expect(actions.selectProject).toHaveBeenCalledWith(project.id);
+    actions.selectProject.mockClear();
 
     await user.click(screen.getByRole("button", { name: "Rename project Hecate" }));
     const renameInput = screen.getByLabelText("Rename Hecate");

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -5,6 +5,7 @@ import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
+  chooseWorkspaceDirectory,
   createAgentProfile,
   createProjectAssignment,
   createProjectCollaborationArtifact,
@@ -59,6 +60,7 @@ import {
   type ProjectHealthAttention,
 } from "./projectInsights";
 import { EditAssignmentModal, NewAssignmentModal } from "./ProjectAssignmentModals";
+import { CreateProjectModal } from "./CreateProjectModal";
 import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
 import { ProjectHandoffModal } from "./ProjectHandoffModal";
 import { ProjectHealthPanel } from "./ProjectHealthPanel";
@@ -96,7 +98,12 @@ import type { AgentProfileRecord } from "../../types/agent-profile";
 import { ConfirmModal, Icon, Icons, InlineError, type ProviderOption } from "../shared/ui";
 import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
 import { ProjectEvidenceLinkModal } from "./ProjectEvidenceLinkModal";
-import { type CreateWorktreeForm, type ProjectDefaultsForm } from "./projectSettings";
+import {
+  createProjectPayloadFromForm,
+  type CreateProjectForm,
+  type CreateWorktreeForm,
+  type ProjectDefaultsForm,
+} from "./projectSettings";
 import {
   profileCreatePayloadFromForm,
   profileUpdatePayloadFromForm,
@@ -185,6 +192,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [hoveredProjectID, setHoveredProjectID] = useState("");
   const [deleteProjectID, setDeleteProjectID] = useState("");
   const [deletePending, setDeletePending] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  const [createProjectPending, setCreateProjectPending] = useState(false);
+  const [createProjectError, setCreateProjectError] = useState("");
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
   const { rightPanelWidth, setRightPanelWidth } = useStoredRightPanelWidth();
   const [defaultsPending, setDefaultsPending] = useState(false);
@@ -657,6 +667,32 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     } finally {
       setCreateWorktreePending(false);
     }
+  }
+
+  async function handleCreateProject(form: CreateProjectForm) {
+    const payload = createProjectPayloadFromForm(form);
+    if (!payload.name) {
+      setCreateProjectError("Project name is required.");
+      return;
+    }
+    setCreateProjectPending(true);
+    setCreateProjectError("");
+    try {
+      const created = await projects.actions.createProject(payload);
+      if (!created) return;
+      setCreateProjectOpen(false);
+      openProject(created.id);
+    } finally {
+      setCreateProjectPending(false);
+    }
+  }
+
+  async function handleChooseProjectWorkspace() {
+    const workspace = await chooseWorkspaceDirectory();
+    return {
+      path: workspace.data.path,
+      branch: workspace.data.branch || undefined,
+    };
   }
 
   async function handleDiscoverContextSources() {
@@ -1283,7 +1319,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     projects.state.projects.length === 0 ? "Add a project to begin" : "Select a project";
   const projectEmptyDetail =
     projects.state.projects.length === 0
-      ? "Choose a workspace folder from the project list to create the first durable project record."
+      ? "Create a project from a name and purpose. A local folder is optional and can be attached now or later."
       : "Choose a project from the list to view its work, memory, skills, and settings.";
 
   return (
@@ -1298,7 +1334,11 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             <button
               className="btn btn-primary btn-sm"
               type="button"
-              onClick={() => void projects.actions.createProjectFromFolder()}
+              onClick={() => {
+                setCreateProjectError("");
+                projects.actions.setError("");
+                setCreateProjectOpen(true);
+              }}
             >
               <Icon d={Icons.folder} size={13} />
               Add
@@ -1320,7 +1360,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
           {!projects.state.loading && projects.state.projects.length === 0 && (
             <ProjectEmptyBlock
               title="No projects yet"
-              detail="Add a workspace folder to create the first durable project record."
+              detail="Create a project for any durable work area. Add a folder only when the project needs local files or code."
             />
           )}
           {projects.state.projects.map((project) => (
@@ -1656,6 +1696,19 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             project={selectedProject}
             onClose={() => setCreateWorktreeOpen(false)}
             onCreate={handleCreateWorktreeRoot}
+          />
+        )}
+
+        {createProjectOpen && (
+          <CreateProjectModal
+            error={createProjectError || projects.state.error}
+            pending={createProjectPending}
+            onChooseWorkspace={handleChooseProjectWorkspace}
+            onClose={() => {
+              setCreateProjectOpen(false);
+              setCreateProjectError("");
+            }}
+            onSave={handleCreateProject}
           />
         )}
 

--- a/ui/src/features/projects/projectSettings.test.ts
+++ b/ui/src/features/projects/projectSettings.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { createProjectPayloadFromForm } from "./projectSettings";
+
+describe("projectSettings", () => {
+  it("maps rootless project creation forms without roots", () => {
+    expect(
+      createProjectPayloadFromForm({
+        name: " Launch plan ",
+        description: " Coordinate release work. ",
+        rootPath: "",
+        rootGitBranch: "",
+      }),
+    ).toEqual({
+      name: "Launch plan",
+      description: "Coordinate release work.",
+    });
+  });
+
+  it("maps optional workspace roots when provided", () => {
+    expect(
+      createProjectPayloadFromForm({
+        name: "Hecate",
+        description: "",
+        rootPath: " /Users/alice/dev/hecate ",
+        rootGitBranch: " main ",
+      }),
+    ).toEqual({
+      name: "Hecate",
+      roots: [
+        {
+          path: "/Users/alice/dev/hecate",
+          kind: "local",
+          git_branch: "main",
+          active: true,
+        },
+      ],
+    });
+  });
+});

--- a/ui/src/features/projects/projectSettings.ts
+++ b/ui/src/features/projects/projectSettings.ts
@@ -1,4 +1,16 @@
-import type { ProjectRecord, ProjectRootPayload, ProjectRootRecord } from "../../types/project";
+import type {
+  CreateProjectPayload,
+  ProjectRecord,
+  ProjectRootPayload,
+  ProjectRootRecord,
+} from "../../types/project";
+
+export type CreateProjectForm = {
+  name: string;
+  description: string;
+  rootPath: string;
+  rootGitBranch: string;
+};
 
 export type ProjectDefaultsForm = {
   provider: string;
@@ -17,6 +29,26 @@ export type CreateWorktreeForm = {
   active: boolean;
   setDefault: boolean;
 };
+
+export function createProjectPayloadFromForm(form: CreateProjectForm): CreateProjectPayload {
+  const rootPath = form.rootPath.trim();
+  const payload: CreateProjectPayload = {
+    name: form.name.trim(),
+  };
+  const description = form.description.trim();
+  if (description) payload.description = description;
+  if (rootPath) {
+    payload.roots = [
+      {
+        path: rootPath,
+        kind: "local",
+        git_branch: form.rootGitBranch.trim() || undefined,
+        active: true,
+      },
+    ];
+  }
+  return payload;
+}
 
 export function projectDefaultsFormFromProject(project: ProjectRecord): ProjectDefaultsForm {
   return {

--- a/ui/src/features/projects/projectUtils.ts
+++ b/ui/src/features/projects/projectUtils.ts
@@ -21,3 +21,9 @@ export function firstNonEmpty(...values: Array<string | undefined | null>): stri
   }
   return "";
 }
+
+export function projectNameFromPath(path: string): string {
+  const trimmed = path.trim().replace(/[/\\]+$/, "");
+  const segments = trimmed.split(/[/\\]/).filter(Boolean);
+  return segments.at(-1) || "Untitled project";
+}

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -29,7 +29,7 @@ import type {
   ProviderPresetRecord,
   ProviderRecord,
 } from "../types/provider";
-import type { ProjectRecord } from "../types/project";
+import type { CreateProjectPayload, ProjectRecord } from "../types/project";
 import type { RetentionRunData } from "../types/retention";
 import type { HealthResponse, RuntimeHeaders } from "../types/runtime";
 import type { UsageEventRecord, UsageSummaryResponse } from "../types/usage";
@@ -243,7 +243,7 @@ export type RuntimeConsoleFixtureActions = {
   setActiveProjectID: (id: string) => void;
   loadProjects: () => Promise<void>;
   selectProject: (id: string) => Promise<void>;
-  createProjectFromFolder: () => Promise<ProjectRecord | null>;
+  createProject: (payload: CreateProjectPayload) => Promise<ProjectRecord | null>;
   renameProject: (id: string, name: string) => Promise<void>;
   deleteProject: (id: string) => Promise<boolean>;
   getChatApproval: (sessionID: string, approvalID: string) => Promise<unknown>;
@@ -318,7 +318,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setActiveProjectID: () => undefined,
     loadProjects: async () => undefined,
     selectProject: async () => undefined,
-    createProjectFromFolder: async () => null,
+    createProject: async () => null,
     renameProject: async () => undefined,
     deleteProject: async () => true,
     getChatApproval: async () => null,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -192,7 +192,7 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
     projectsSlice: {
       setActiveProjectID: actions.setActiveProjectID,
       loadProjects: actions.loadProjects,
-      createProjectFromFolder: actions.createProjectFromFolder,
+      createProject: actions.createProject,
       selectProject: actions.selectProject,
       renameProject: actions.renameProject,
       deleteProject: actions.deleteProject,


### PR DESCRIPTION
## Summary

- add a generic Create project modal for name/purpose-first projects with optional folder attachment
- let Projects, Chats, and Tasks create rootless projects through the shared project scope flow
- make project onboarding and settings root-aware: workspace roots are optional, attachable later, and worktree/discovery actions require an existing root
- update runtime, user-facing, and AI guidance docs to describe Projects as durable work areas, not only repos or codebases

## Verification

- `cd ui && bun run test -- src/app/state/projects.test.tsx src/features/projects/CreateProjectModal.test.tsx src/features/projects/projectSettings.test.ts src/features/projects/ProjectSettingsPanel.test.tsx src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run test`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-format-check`
- `just agent-docs-check`
- `git diff --check`
