### PR TITLE
fix(ui): keep external agent config controls visible

### DIFF
--- a/ui/src/features/chats/ChatAgentControls.test.tsx
+++ b/ui/src/features/chats/ChatAgentControls.test.tsx
@@ -288,73 +288,78 @@ describe("ExternalAgentConfigControls", () => {
     expect(onChange).toHaveBeenCalledWith("a1", "model", "model-a");
   });
 
-  it("keeps Grok Build ACP model and thinking controls prominent when categories are missing", () => {
-    render(
-      <ExternalAgentConfigControls
-        placement="composer"
-        session={{
-          id: "grok_chat",
-          agent_id: "grok_build",
-          config_options: [
-            {
-              id: "web_search",
-              name: "Web search",
-              type: "select",
-              current_value: "auto",
-              options: [
-                { value: "off", name: "Off" },
-                { value: "auto", name: "Auto" },
-              ],
-            },
-            {
-              id: "verbosity",
-              name: "Verbosity",
-              type: "select",
-              current_value: "normal",
-              options: [
-                { value: "normal", name: "Normal" },
-                { value: "detailed", name: "Detailed" },
-              ],
-            },
-            {
-              id: "model",
-              name: "Model",
-              type: "select",
-              current_value: "grok-code-fast-1",
-              options: [
-                { value: "grok-code-fast-1", name: "Grok Code Fast 1" },
-                { value: "grok-code-pro-1", name: "Grok Code Pro 1" },
-              ],
-            },
-            {
-              id: "thinking_level",
-              name: "Level of thinking",
-              type: "select",
-              current_value: "medium",
-              options: [
-                { value: "low", name: "Low" },
-                { value: "medium", name: "Medium" },
-                { value: "high", name: "High" },
-              ],
-            },
-            {
-              id: "approval_mode",
-              name: "Approval mode",
-              type: "select",
-              current_value: "ask",
-              options: [
-                { value: "ask", name: "Ask" },
-                { value: "auto", name: "Auto" },
-              ],
-            },
-          ],
-        }}
-        onChange={async () => true}
-      />,
-    );
+  it("keeps ACP model and thinking controls prominent for every external agent", () => {
+    const agentIDs = ["codex", "claude_code", "cursor_agent", "grok_build"];
 
-    expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Grok Code Fast 1");
-    expect(screen.getByRole("button", { name: "Level of thinking" })).toHaveTextContent("Medium");
-    expect(screen.queryByRole("button", { name: "Verbosity" })).toBeNull();
+    for (const agentID of agentIDs) {
+      const view = render(
+        <ExternalAgentConfigControls
+          placement="composer"
+          session={{
+            id: `${agentID}_chat`,
+            agent_id: agentID,
+            config_options: [
+              {
+                id: "web_search",
+                name: "Web search",
+                type: "select",
+                current_value: "auto",
+                options: [
+                  { value: "off", name: "Off" },
+                  { value: "auto", name: "Auto" },
+                ],
+              },
+              {
+                id: "verbosity",
+                name: "Verbosity",
+                type: "select",
+                current_value: "normal",
+                options: [
+                  { value: "normal", name: "Normal" },
+                  { value: "detailed", name: "Detailed" },
+                ],
+              },
+              {
+                id: "model",
+                name: "Model",
+                type: "select",
+                current_value: "agent-model-fast",
+                options: [
+                  { value: "agent-model-fast", name: "Agent Model Fast" },
+                  { value: "agent-model-pro", name: "Agent Model Pro" },
+                ],
+              },
+              {
+                id: "thinking_level",
+                name: "Level of thinking",
+                type: "select",
+                current_value: "medium",
+                options: [
+                  { value: "low", name: "Low" },
+                  { value: "medium", name: "Medium" },
+                  { value: "high", name: "High" },
+                ],
+              },
+              {
+                id: "approval_mode",
+                name: "Approval mode",
+                type: "select",
+                current_value: "ask",
+                options: [
+                  { value: "ask", name: "Ask" },
+                  { value: "auto", name: "Auto" },
+                ],
+              },
+            ],
+          }}
+          onChange={async () => true}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Agent Model Fast");
+      expect(screen.getByRole("button", { name: "Level of thinking" })).toHaveTextContent("Medium");
+      expect(screen.queryByRole("button", { name: "Verbosity" })).toBeNull();
+      view.unmount();
+    }
   });
 });

--- a/ui/src/features/chats/ChatAgentControls.test.tsx
+++ b/ui/src/features/chats/ChatAgentControls.test.tsx
@@ -287,4 +287,74 @@ describe("ExternalAgentConfigControls", () => {
 
     expect(onChange).toHaveBeenCalledWith("a1", "model", "model-a");
   });
+
+  it("keeps Grok Build ACP model and thinking controls prominent when categories are missing", () => {
+    render(
+      <ExternalAgentConfigControls
+        placement="composer"
+        session={{
+          id: "grok_chat",
+          agent_id: "grok_build",
+          config_options: [
+            {
+              id: "web_search",
+              name: "Web search",
+              type: "select",
+              current_value: "auto",
+              options: [
+                { value: "off", name: "Off" },
+                { value: "auto", name: "Auto" },
+              ],
+            },
+            {
+              id: "verbosity",
+              name: "Verbosity",
+              type: "select",
+              current_value: "normal",
+              options: [
+                { value: "normal", name: "Normal" },
+                { value: "detailed", name: "Detailed" },
+              ],
+            },
+            {
+              id: "model",
+              name: "Model",
+              type: "select",
+              current_value: "grok-code-fast-1",
+              options: [
+                { value: "grok-code-fast-1", name: "Grok Code Fast 1" },
+                { value: "grok-code-pro-1", name: "Grok Code Pro 1" },
+              ],
+            },
+            {
+              id: "thinking_level",
+              name: "Level of thinking",
+              type: "select",
+              current_value: "medium",
+              options: [
+                { value: "low", name: "Low" },
+                { value: "medium", name: "Medium" },
+                { value: "high", name: "High" },
+              ],
+            },
+            {
+              id: "approval_mode",
+              name: "Approval mode",
+              type: "select",
+              current_value: "ask",
+              options: [
+                { value: "ask", name: "Ask" },
+                { value: "auto", name: "Auto" },
+              ],
+            },
+          ],
+        }}
+        onChange={async () => true}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Grok Code Fast 1");
+    expect(screen.getByRole("button", { name: "Level of thinking" })).toHaveTextContent("Medium");
+    expect(screen.queryByRole("button", { name: "Verbosity" })).toBeNull();
+  });
 });

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -973,8 +973,9 @@ function ExternalAgentTextConfigControl({
 
 function prioritizeAgentConfigOptions(options: ChatConfigOptionRecord[]): ChatConfigOptionRecord[] {
   const priority = (option: ChatConfigOptionRecord) => {
-    if (agentConfigOptionIsInstructions(option)) return -1;
-    switch (option.category) {
+    switch (agentConfigOptionKind(option)) {
+      case "instructions":
+        return -1;
       case "model":
         return 0;
       case "thought_level":
@@ -986,6 +987,28 @@ function prioritizeAgentConfigOptions(options: ChatConfigOptionRecord[]): ChatCo
     }
   };
   return [...options].sort((a, b) => priority(a) - priority(b) || a.name.localeCompare(b.name));
+}
+
+type AgentConfigOptionKind = "instructions" | "model" | "thought_level" | "mode" | "other";
+
+function agentConfigOptionKind(option: ChatConfigOptionRecord): AgentConfigOptionKind {
+  if (agentConfigOptionIsInstructions(option)) return "instructions";
+  const category = (option.category ?? "").toLowerCase();
+  if (category === "model" || category === "thought_level" || category === "mode") {
+    return category;
+  }
+  const key = agentConfigOptionKey(option);
+  if (key.includes("model")) return "model";
+  if (
+    key.includes("thought_level") ||
+    key.includes("thought level") ||
+    key.includes("thinking") ||
+    key.includes("reasoning")
+  ) {
+    return "thought_level";
+  }
+  if (key.includes("mode")) return "mode";
+  return "other";
 }
 
 function agentConfigOptionIsText(option: ChatConfigOptionRecord): boolean {
@@ -1000,7 +1023,7 @@ function agentConfigOptionIsText(option: ChatConfigOptionRecord): boolean {
 }
 
 function agentConfigOptionIsInstructions(option: ChatConfigOptionRecord): boolean {
-  const key = `${option.id} ${option.name} ${option.category ?? ""}`.toLowerCase();
+  const key = agentConfigOptionKey(option);
   return (
     key.includes("system_prompt") ||
     key.includes("system prompt") ||
@@ -1011,8 +1034,9 @@ function agentConfigOptionIsInstructions(option: ChatConfigOptionRecord): boolea
 }
 
 function agentConfigOptionLabel(option: ChatConfigOptionRecord): string {
-  if (agentConfigOptionIsInstructions(option)) return "instructions";
-  switch (option.category) {
+  switch (agentConfigOptionKind(option)) {
+    case "instructions":
+      return "instructions";
     case "model":
       return "model";
     case "thought_level":
@@ -1022,6 +1046,10 @@ function agentConfigOptionLabel(option: ChatConfigOptionRecord): string {
     default:
       return option.name || option.id;
   }
+}
+
+function agentConfigOptionKey(option: ChatConfigOptionRecord): string {
+  return `${option.id} ${option.name} ${option.category ?? ""}`.toLowerCase();
 }
 
 export function LockedHecateModelSnapshot({

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -9,6 +9,12 @@ import type { DropdownPickerOption, ProviderOption } from "../shared/ui";
 import { focusDropdownItem, focusInitialDropdownItem } from "../shared/dropdownKeyboard";
 import { useFloatingDropdownStyle } from "../shared/useFloatingDropdownStyle";
 import { useFloatingMenu } from "../shared/useFloatingMenu";
+import {
+  agentConfigOptionIsInstructions,
+  agentConfigOptionIsText,
+  agentConfigOptionLabel,
+  prioritizeAgentConfigOptions,
+} from "./agentConfigOptions";
 
 const HECATE_CHAT_AGENT_OPTION = { id: "hecate", label: "Hecate" } as const;
 
@@ -969,87 +975,6 @@ function ExternalAgentTextConfigControl({
       </button>
     </div>
   );
-}
-
-function prioritizeAgentConfigOptions(options: ChatConfigOptionRecord[]): ChatConfigOptionRecord[] {
-  const priority = (option: ChatConfigOptionRecord) => {
-    switch (agentConfigOptionKind(option)) {
-      case "instructions":
-        return -1;
-      case "model":
-        return 0;
-      case "thought_level":
-        return 1;
-      case "mode":
-        return 2;
-      default:
-        return 3;
-    }
-  };
-  return [...options].sort((a, b) => priority(a) - priority(b) || a.name.localeCompare(b.name));
-}
-
-type AgentConfigOptionKind = "instructions" | "model" | "thought_level" | "mode" | "other";
-
-function agentConfigOptionKind(option: ChatConfigOptionRecord): AgentConfigOptionKind {
-  if (agentConfigOptionIsInstructions(option)) return "instructions";
-  const category = (option.category ?? "").toLowerCase();
-  if (category === "model" || category === "thought_level" || category === "mode") {
-    return category;
-  }
-  const key = agentConfigOptionKey(option);
-  if (key.includes("model")) return "model";
-  if (
-    key.includes("thought_level") ||
-    key.includes("thought level") ||
-    key.includes("thinking") ||
-    key.includes("reasoning")
-  ) {
-    return "thought_level";
-  }
-  if (key.includes("mode")) return "mode";
-  return "other";
-}
-
-function agentConfigOptionIsText(option: ChatConfigOptionRecord): boolean {
-  const type = option.type.toLowerCase();
-  return (
-    type === "text" ||
-    type === "textarea" ||
-    type === "string" ||
-    type === "prompt" ||
-    type === "multiline"
-  );
-}
-
-function agentConfigOptionIsInstructions(option: ChatConfigOptionRecord): boolean {
-  const key = agentConfigOptionKey(option);
-  return (
-    key.includes("system_prompt") ||
-    key.includes("system prompt") ||
-    key.includes("agent_instructions") ||
-    key.includes("agent instructions") ||
-    key.includes("instructions")
-  );
-}
-
-function agentConfigOptionLabel(option: ChatConfigOptionRecord): string {
-  switch (agentConfigOptionKind(option)) {
-    case "instructions":
-      return "instructions";
-    case "model":
-      return "model";
-    case "thought_level":
-      return "reasoning";
-    case "mode":
-      return "mode";
-    default:
-      return option.name || option.id;
-  }
-}
-
-function agentConfigOptionKey(option: ChatConfigOptionRecord): string {
-  return `${option.id} ${option.name} ${option.category ?? ""}`.toLowerCase();
 }
 
 export function LockedHecateModelSnapshot({

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -204,51 +204,37 @@ describe("ChatView input", () => {
     ]);
   }, 10_000);
 
-  it("shows Grok Build model controls before the first external-agent session exists", async () => {
-    const { state, actions } = setup({
-      chatTarget: "external_agent",
-      agentAdapterID: "grok_build",
-      newChatAgentID: "grok_build",
-      agentWorkspace: "/tmp/hecate",
-      activeChatSessionID: "",
-      activeChatSession: null,
-      agentAdapters: [
-        {
-          id: "grok_build",
-          name: "Grok Build",
-          kind: "acp",
-          command: "grok",
-          available: true,
-          status: "available",
-          cost_mode: "external",
-          config_options: [
-            {
-              id: "model",
-              name: "Model",
-              category: "model",
-              type: "select",
-              current_value: "__hecate_no_model_selected__",
-              options: [
-                { value: "__hecate_no_model_selected__", name: "Pick a model" },
-                { value: "model-a", name: "Model A" },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+  it("waits for a Grok Build ACP session before showing session config controls", async () => {
+    const createChatSession = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        agentAdapterID: "grok_build",
+        newChatAgentID: "grok_build",
+        agentWorkspace: "/tmp/hecate",
+        activeChatSessionID: "",
+        activeChatSession: null,
+        agentAdapters: [
+          {
+            id: "grok_build",
+            name: "Grok Build",
+            kind: "acp",
+            command: "grok",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+      },
+      { createChatSession },
+    );
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /New Grok Build chat/i }));
 
-    const modelPicker = await screen.findByRole("button", { name: "Model" });
-    expect(modelPicker).toHaveTextContent("Pick a model");
-
-    await user.click(modelPicker);
-    await user.click(screen.getByRole("option", { name: /Model A/ }));
-
-    expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Model A");
+    expect(createChatSession).toHaveBeenCalledWith({ agentID: "grok_build", projectID: "" });
+    expect(screen.queryByRole("button", { name: "Model" })).toBeNull();
   });
 
   it("creates a Grok Build chat before the launch model is selected", async () => {
@@ -421,7 +407,7 @@ describe("ChatView input", () => {
     expect(createChatSession).toHaveBeenCalledWith({ agentID: "hecate", projectID: "" });
   });
 
-  it("shows Grok Build model controls for an existing session without persisted config options", async () => {
+  it("shows Grok Build session-owned model and thinking controls", async () => {
     const { state, actions } = setup({
       chatTarget: "external_agent",
       agentAdapterID: "codex",
@@ -432,7 +418,59 @@ describe("ChatView input", () => {
         title: "Grok work",
         workspace: "/tmp/hecate",
         status: "idle",
-        config_options: [],
+        config_options: [
+          {
+            id: "web_search",
+            name: "Web search",
+            type: "select",
+            current_value: "auto",
+            options: [
+              { value: "off", name: "Off" },
+              { value: "auto", name: "Auto" },
+            ],
+          },
+          {
+            id: "verbosity",
+            name: "Verbosity",
+            type: "select",
+            current_value: "normal",
+            options: [
+              { value: "normal", name: "Normal" },
+              { value: "detailed", name: "Detailed" },
+            ],
+          },
+          {
+            id: "model",
+            name: "Model",
+            type: "select",
+            current_value: "grok-code-fast-1",
+            options: [
+              { value: "grok-code-fast-1", name: "Grok Code Fast 1" },
+              { value: "grok-code-pro-1", name: "Grok Code Pro 1" },
+            ],
+          },
+          {
+            id: "thinking_level",
+            name: "Level of thinking",
+            type: "select",
+            current_value: "medium",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+            ],
+          },
+          {
+            id: "approval_mode",
+            name: "Approval mode",
+            type: "select",
+            current_value: "ask",
+            options: [
+              { value: "ask", name: "Ask" },
+              { value: "auto", name: "Auto" },
+            ],
+          },
+        ],
         messages: [],
       } as any,
       agentAdapters: [
@@ -444,37 +482,16 @@ describe("ChatView input", () => {
           available: true,
           status: "available",
           cost_mode: "external",
-          config_options: [
-            {
-              id: "model",
-              name: "Model",
-              category: "model",
-              type: "select",
-              current_value: "__hecate_no_model_selected__",
-              options: [
-                { value: "__hecate_no_model_selected__", name: "Pick a model" },
-                { value: "grok-latest", name: "Grok Latest" },
-              ],
-            },
-            {
-              id: "reasoning_effort",
-              name: "Reasoning",
-              category: "thought_level",
-              type: "select",
-              current_value: "__hecate_no_reasoning_selected__",
-              options: [
-                { value: "__hecate_no_reasoning_selected__", name: "Pick reasoning" },
-                { value: "high", name: "High" },
-              ],
-            },
-          ],
         },
       ],
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    expect(await screen.findByRole("button", { name: "Model" })).toHaveTextContent("Pick a model");
-    expect(screen.getByRole("button", { name: "Reasoning" })).toHaveTextContent("Pick reasoning");
+    expect(await screen.findByRole("button", { name: "Model" })).toHaveTextContent(
+      "Grok Code Fast 1",
+    );
+    expect(screen.getByRole("button", { name: "Level of thinking" })).toHaveTextContent("Medium");
+    expect(screen.queryByRole("button", { name: "Verbosity" })).toBeNull();
     expect(screen.getByRole("textbox", { name: "Message" })).toBeTruthy();
   });
 

--- a/ui/src/features/chats/agentConfigOptions.test.ts
+++ b/ui/src/features/chats/agentConfigOptions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatConfigOptionRecord } from "../../types/chat";
+import {
+  agentConfigOptionKind,
+  agentConfigOptionLabel,
+  externalAgentRequiresModelSelection,
+  prioritizeAgentConfigOptions,
+} from "./agentConfigOptions";
+
+function option(overrides: Partial<ChatConfigOptionRecord>): ChatConfigOptionRecord {
+  return {
+    id: "option",
+    name: "Option",
+    type: "select",
+    ...overrides,
+  };
+}
+
+describe("agent config option helpers", () => {
+  it("classifies common ACP controls from category, id, or name", () => {
+    expect(
+      agentConfigOptionKind(option({ id: "native_model", name: "Native", category: "model" })),
+    ).toBe("model");
+    expect(agentConfigOptionKind(option({ id: "model", name: "Model" }))).toBe("model");
+    expect(agentConfigOptionKind(option({ id: "thinking_level", name: "Level of thinking" }))).toBe(
+      "thought_level",
+    );
+    expect(
+      agentConfigOptionKind(option({ id: "reasoning_effort", name: "Reasoning effort" })),
+    ).toBe("thought_level");
+    expect(agentConfigOptionKind(option({ id: "approval_mode", name: "Approval mode" }))).toBe(
+      "mode",
+    );
+    expect(agentConfigOptionKind(option({ id: "system_prompt", name: "System prompt" }))).toBe(
+      "instructions",
+    );
+  });
+
+  it("uses one classifier for labels and model-required detection", () => {
+    const model = option({
+      id: "model",
+      name: "Model",
+      current_value: "__hecate_no_model_selected__",
+    });
+    const thinking = option({
+      id: "thinking_level",
+      name: "Level of thinking",
+      current_value: "medium",
+    });
+
+    expect(agentConfigOptionLabel(model)).toBe("model");
+    expect(agentConfigOptionLabel(thinking)).toBe("reasoning");
+    expect(externalAgentRequiresModelSelection([thinking, model])).toBe(true);
+  });
+
+  it("prioritizes common controls before generic controls without relying on categories", () => {
+    const ordered = prioritizeAgentConfigOptions([
+      option({ id: "verbosity", name: "Verbosity" }),
+      option({ id: "approval_mode", name: "Approval mode" }),
+      option({ id: "thinking_level", name: "Level of thinking" }),
+      option({ id: "model", name: "Model" }),
+      option({ id: "system_prompt", name: "System prompt" }),
+    ]);
+
+    expect(ordered.map((item) => item.id)).toEqual([
+      "system_prompt",
+      "model",
+      "thinking_level",
+      "approval_mode",
+      "verbosity",
+    ]);
+  });
+});

--- a/ui/src/features/chats/agentConfigOptions.ts
+++ b/ui/src/features/chats/agentConfigOptions.ts
@@ -1,5 +1,7 @@
 import type { ChatConfigOptionRecord } from "../../types/chat";
 
+export type AgentConfigOptionKind = "instructions" | "model" | "thought_level" | "mode" | "other";
+
 export function mergeAgentConfigOptions(
   catalogOptions: ChatConfigOptionRecord[],
   sessionOptions: ChatConfigOptionRecord[],
@@ -26,14 +28,94 @@ export function mergeAgentConfigOptions(
   return merged;
 }
 
+export function prioritizeAgentConfigOptions(
+  options: ChatConfigOptionRecord[],
+): ChatConfigOptionRecord[] {
+  const priority = (option: ChatConfigOptionRecord) => {
+    switch (agentConfigOptionKind(option)) {
+      case "instructions":
+        return -1;
+      case "model":
+        return 0;
+      case "thought_level":
+        return 1;
+      case "mode":
+        return 2;
+      default:
+        return 3;
+    }
+  };
+  return [...options].sort((a, b) => priority(a) - priority(b) || a.name.localeCompare(b.name));
+}
+
+export function agentConfigOptionKind(option: ChatConfigOptionRecord): AgentConfigOptionKind {
+  if (agentConfigOptionIsInstructions(option)) return "instructions";
+  const category = (option.category ?? "").toLowerCase();
+  if (category === "model" || category === "thought_level" || category === "mode") {
+    return category;
+  }
+  const key = agentConfigOptionKey(option);
+  if (key.includes("model")) return "model";
+  if (
+    key.includes("thought_level") ||
+    key.includes("thought level") ||
+    key.includes("thinking") ||
+    key.includes("reasoning")
+  ) {
+    return "thought_level";
+  }
+  if (key.includes("mode")) return "mode";
+  return "other";
+}
+
+export function agentConfigOptionIsText(option: ChatConfigOptionRecord): boolean {
+  const type = option.type.toLowerCase();
+  return (
+    type === "text" ||
+    type === "textarea" ||
+    type === "string" ||
+    type === "prompt" ||
+    type === "multiline"
+  );
+}
+
+export function agentConfigOptionIsInstructions(option: ChatConfigOptionRecord): boolean {
+  const key = agentConfigOptionKey(option);
+  return (
+    key.includes("system_prompt") ||
+    key.includes("system prompt") ||
+    key.includes("agent_instructions") ||
+    key.includes("agent instructions") ||
+    key.includes("instructions")
+  );
+}
+
+export function agentConfigOptionLabel(option: ChatConfigOptionRecord): string {
+  switch (agentConfigOptionKind(option)) {
+    case "instructions":
+      return "instructions";
+    case "model":
+      return "model";
+    case "thought_level":
+      return "reasoning";
+    case "mode":
+      return "mode";
+    default:
+      return option.name || option.id;
+  }
+}
+
 export function externalAgentRequiresModelSelection(
   configOptions: ChatConfigOptionRecord[],
 ): boolean {
-  const option = configOptions.find((item) => {
-    const key = `${item.id} ${item.name} ${item.category ?? ""}`.toLowerCase();
-    return item.type === "select" && (key.includes("model") || item.category === "model");
-  });
+  const option = configOptions.find(
+    (item) => item.type === "select" && agentConfigOptionKind(item) === "model",
+  );
   if (!option) return false;
   const value = (option.current_value ?? "").trim();
   return value === "" || value.startsWith("__hecate_no_");
+}
+
+function agentConfigOptionKey(option: ChatConfigOptionRecord): string {
+  return `${option.id} ${option.name} ${option.category ?? ""}`.toLowerCase();
 }


### PR DESCRIPTION
## Summary

- classify external-agent config options from category, id, and name so ACP model/thinking controls stay visible even when category hints are missing
- share config option helper logic between composer rendering and model-required detection
- update Grok/session tests and add all-agent coverage for Codex, Claude Code, Cursor Agent, and Grok Build

## Verification

- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
