### PR TITLE
Add project proposal slash command

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -21,13 +21,16 @@ chats for the active project. When an open chat is linked to a project, the chat
 header exposes a compact project shortcut that selects that project and opens
 the Projects workspace. Project-linked Hecate Chat also exposes a compact
 composer action that deterministically drafts a Project Assistant proposal from
-the current message and hands it to the Projects review surface. That handoff
-is proposal data only; it does not send a chat message, create project records,
-call the model-backed draft path, or apply the proposal. Deleting a project also
-deletes its project-scoped chat
-transcripts. Unprojected chats and chats in other projects stay untouched.
-The Projects review card preserves the originating request and chat session id
-for operator inspection and exposes an **Open source chat** action.
+the current message and hands it to the Projects review surface. The same path
+is available as the Hecate-owned `/proposal <request>` chat command for
+operators who prefer a slash-command flow; selecting `/proposal` only inserts
+the command scaffold, and submitting it drafts from the text after the command.
+That handoff is proposal data only; it does not send a chat message, create
+project records, call the model-backed draft path, or apply the proposal.
+Deleting a project also deletes its project-scoped chat transcripts.
+Unprojected chats and chats in other projects stay untouched. The Projects
+review card preserves the originating request and chat session id for operator
+inspection and exposes an **Open source chat** action.
 
 Hecate Chat treats model/provider readiness as part of composition, not a
 send-time surprise. If no configured provider has routable models, the empty
@@ -111,7 +114,9 @@ External Agent sessions may expose ACP-advertised `available_commands` on the
 session snapshot. These are agent-native slash command hints, not Hecate
 project commands; selecting one still sends ordinary prompt text to the
 external agent. The operator UI may show these hints while the composer starts
-with `/`; choosing a hint only inserts the slash command text.
+with `/`; choosing a hint only inserts the slash command text. Hecate-owned
+chat commands, such as `/proposal`, are separate local shortcuts and must still
+route through Hecate's proposal, validation, and operator-apply boundaries.
 
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -112,9 +112,9 @@ agent-native command hints. Commands are still submitted as normal
 a separate execute-command RPC. The operator UI can surface the advertised list
 when the composer starts with `/`, but choosing an item only inserts the command
 text. These are external-agent-native commands, not Hecate-owned project
-mutations. Future Hecate Chat shortcuts such as `/plan` or `/remember` should
-remain intent hints that go through the usual proposal, validation, and
-operator-apply boundaries.
+mutations. Hecate Chat shortcuts such as `/proposal` are separate local UI
+commands, not ACP commands; they should remain intent hints that go through the
+usual proposal, validation, and operator-apply boundaries.
 
 Check discovery:
 

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -41,11 +41,13 @@ run, assignment, or agent session.
 
 Project-linked Hecate Chat has a compact `Draft proposal` composer action for
 turning the current draft message into the same Project Assistant proposal
-shape. That chat-session route derives `project_id` from the linked session
-instead of accepting it from the request body, always uses deterministic
-drafting, and hands the proposal to the Projects workspace for review. It does
-not append a chat message, call the model-backed draft path, create work
-records, or apply the proposal.
+shape. The same deterministic handoff is available as `/proposal <request>` in
+the chat composer; choosing the slash-command hint only inserts `/proposal `,
+and submitting it drafts from the text after the command. That chat-session
+route derives `project_id` from the linked session instead of accepting it from
+the request body, always uses deterministic drafting, and hands the proposal to
+the Projects workspace for review. It does not append a chat message, call the
+model-backed draft path, create work records, or apply the proposal.
 
 When Projects consumes a chat-drafted proposal handoff, the review card shows
 the source as `drafted from chat`, preserves the originating request text and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2798,7 +2798,9 @@ accepts the deterministic draft fields `request`, optional `work_item_id`,
 optional `role_id`, and optional `driver_kind`; Hecate derives the project from
 the chat session and rejects unprojected or external-agent sessions. The
 endpoint always uses deterministic drafting and returns
-`project_assistant.proposal` data only. It does not call the model-backed draft
+`project_assistant.proposal` data only. The operator UI exposes it through the
+compact `Draft proposal` composer action and the Hecate-owned
+`/proposal <request>` slash command. It does not call the model-backed draft
 path, append chat messages, create project records, or apply the proposal; UI
 clients should hand the response to the Projects Project Assistant review/apply
 surface. Clients may carry local source metadata, such as the request text and

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -340,7 +340,7 @@ test("New chat creates an external-agent session with controls before the first 
   await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText("Fast");
   const composer = page.getByRole("textbox", { name: "Message" });
   await composer.fill("/");
-  const commands = page.getByRole("listbox", { name: "External agent commands" });
+  const commands = page.getByRole("listbox", { name: "Message commands" });
   await expect(commands.getByRole("option", { name: "Insert /web command" })).toBeVisible();
   await expect(commands).toContainText("Search the web");
   await commands.getByRole("option", { name: "Insert /web command" }).click();

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -42,6 +42,11 @@ import { mergeAgentConfigOptions } from "./agentConfigOptions";
 const COMPOSER_TEXTAREA_MAX_LINES = 10;
 const COMPOSER_TEXTAREA_MIN_HEIGHT = 42;
 const COMMAND_SUGGESTION_LIMIT = 6;
+const PROJECT_PROPOSAL_COMMAND = {
+  name: "proposal",
+  description: "Draft a Project Assistant proposal",
+  inputHint: "request",
+};
 type ComposerTextareaNumericStyle =
   | "paddingTop"
   | "paddingBottom"
@@ -55,6 +60,13 @@ type HecateProviderOption = {
   kind?: string;
   configured?: boolean;
   disabledReason?: string;
+};
+
+type MessageCommandSuggestion = {
+  kind: "external_agent" | "project_proposal";
+  name: string;
+  description?: string;
+  inputHint?: string;
 };
 
 export type ChatComposerProps = {
@@ -110,7 +122,7 @@ export type ChatComposerProps = {
   onNavigate?: (workspace: "connections" | "runs" | "overview" | "settings" | "projects") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
-  onDraftProjectProposal?: () => void;
+  onDraftProjectProposal?: (request?: string) => void;
 };
 
 export function ChatComposer(props: ChatComposerProps) {
@@ -236,21 +248,40 @@ export function ChatComposer(props: ChatComposerProps) {
   const commandListboxID = useId();
   const [commandPickerDismissed, setCommandPickerDismissed] = useState(false);
   const [activeCommandIndex, setActiveCommandIndex] = useState(0);
-  const commandQuery = externalAgentCommandQuery(message);
+  const commandQuery = messageCommandQuery(message);
   const commandSuggestions = useMemo(() => {
-    if (!isExternalAgentChat || commandQuery === null) return [];
-    const commands = activeChatSession?.available_commands ?? [];
+    if (commandQuery === null) return [];
     const query = commandQuery.toLowerCase();
-    return commands
-      .filter((command) => externalAgentCommandName(command) !== "")
-      .filter((command) => externalAgentCommandName(command).toLowerCase().startsWith(query))
-      .slice(0, COMMAND_SUGGESTION_LIMIT);
-  }, [activeChatSession?.available_commands, commandQuery, isExternalAgentChat]);
+    const suggestions: MessageCommandSuggestion[] = [];
+
+    if (projectProposalAvailable && PROJECT_PROPOSAL_COMMAND.name.startsWith(query)) {
+      suggestions.push({ ...PROJECT_PROPOSAL_COMMAND, kind: "project_proposal" });
+    }
+
+    if (isExternalAgentChat) {
+      const commands = activeChatSession?.available_commands ?? [];
+      suggestions.push(
+        ...commands
+          .map((command) => ({
+            kind: "external_agent" as const,
+            name: externalAgentCommandName(command),
+            description: command.description,
+            inputHint: command.input_hint,
+          }))
+          .filter((command) => command.name !== "")
+          .filter((command) => command.name.toLowerCase().startsWith(query)),
+      );
+    }
+
+    return suggestions.slice(0, COMMAND_SUGGESTION_LIMIT);
+  }, [
+    activeChatSession?.available_commands,
+    commandQuery,
+    isExternalAgentChat,
+    projectProposalAvailable,
+  ]);
   const commandPickerVisible =
-    composerVisible &&
-    isExternalAgentChat &&
-    !commandPickerDismissed &&
-    commandSuggestions.length > 0;
+    composerVisible && !commandPickerDismissed && commandSuggestions.length > 0;
   const activeCommandOptionID = commandPickerVisible
     ? `${commandListboxID}-option-${activeCommandIndex}`
     : undefined;
@@ -342,8 +373,8 @@ export function ChatComposer(props: ChatComposerProps) {
     return true;
   }
 
-  function selectCommandSuggestion(command: ChatAvailableCommandRecord) {
-    const nextMessage = externalAgentCommandInsertion(command);
+  function selectCommandSuggestion(command: MessageCommandSuggestion) {
+    const nextMessage = messageCommandInsertion(command);
     if (!nextMessage) return;
     messageHistoryCursorRef.current = null;
     messageHistoryPendingTextRef.current = nextMessage;
@@ -400,6 +431,19 @@ export function ChatComposer(props: ChatComposerProps) {
   }
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+    const proposalRequest = projectProposalCommandRequest(message);
+    if (proposalRequest !== null && projectProposalAvailable && onDraftProjectProposal) {
+      e.preventDefault();
+      if (!proposalRequest) {
+        settingsActions.setNoticeMessage("error", "Add a request after /proposal.");
+        return;
+      }
+      onDraftProjectProposal(proposalRequest);
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+      }
+      return;
+    }
     void chatActions.submitChat(e);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -624,7 +668,7 @@ export function ChatComposer(props: ChatComposerProps) {
               <div
                 id={commandListboxID}
                 role="listbox"
-                aria-label="External agent commands"
+                aria-label="Message commands"
                 style={{
                   position: "absolute",
                   left: 0,
@@ -641,11 +685,11 @@ export function ChatComposer(props: ChatComposerProps) {
                 }}
               >
                 {commandSuggestions.map((command, index) => {
-                  const commandText = externalAgentCommandInsertion(command).trim();
+                  const commandText = messageCommandInsertion(command).trim();
                   const selected = index === activeCommandIndex;
                   return (
                     <div
-                      key={`${externalAgentCommandName(command)}:${index}`}
+                      key={`${command.kind}:${command.name}:${index}`}
                       id={`${commandListboxID}-option-${index}`}
                       role="option"
                       aria-label={`Insert ${commandText} command`}
@@ -691,7 +735,7 @@ export function ChatComposer(props: ChatComposerProps) {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        {externalAgentCommandDetail(command)}
+                        {messageCommandDetail(command)}
                       </span>
                     </div>
                   );
@@ -900,7 +944,7 @@ export function ChatComposer(props: ChatComposerProps) {
                   aria-label="Draft Project Assistant proposal from message"
                   disabled={projectProposalDrafting}
                   title="Draft a Project Assistant proposal from this message"
-                  onClick={onDraftProjectProposal}
+                  onClick={() => onDraftProjectProposal()}
                   style={{
                     flexShrink: 0,
                     fontFamily: "var(--font-mono)",
@@ -971,7 +1015,7 @@ function numericStyleValue(element: HTMLElement, property: ComposerTextareaNumer
   return Number.parseFloat(window.getComputedStyle(element)[property]) || 0;
 }
 
-function externalAgentCommandQuery(message: string): string | null {
+function messageCommandQuery(message: string): string | null {
   if (!message.startsWith("/")) return null;
   const query = message.slice(1);
   if (/\s/.test(query)) return null;
@@ -982,15 +1026,22 @@ function externalAgentCommandName(command: ChatAvailableCommandRecord) {
   return command.name.trim().replace(/^\/+/, "");
 }
 
-function externalAgentCommandInsertion(command: ChatAvailableCommandRecord) {
-  const name = externalAgentCommandName(command);
+function messageCommandInsertion(command: MessageCommandSuggestion) {
+  const name = command.name;
   return name ? `/${name} ` : "";
 }
 
-function externalAgentCommandDetail(command: ChatAvailableCommandRecord) {
+function messageCommandDetail(command: MessageCommandSuggestion) {
   const description = command.description?.trim();
   if (description) return description;
-  return command.input_hint?.trim() ?? "";
+  return command.inputHint?.trim() ?? "";
+}
+
+function projectProposalCommandRequest(message: string): string | null {
+  if (!message.startsWith("/")) return null;
+  const match = message.match(/^\/proposal(?:\s+([\s\S]*))?$/i);
+  if (!match) return null;
+  return (match[1] ?? "").trim();
 }
 
 export function ChatErrorPanel({

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1015,6 +1015,8 @@ function numericStyleValue(element: HTMLElement, property: ComposerTextareaNumer
   return Number.parseFloat(window.getComputedStyle(element)[property]) || 0;
 }
 
+// Picker parsing and submit routing are intentionally separate: the picker
+// reads an in-progress command token, while submit routing needs full args.
 function messageCommandQuery(message: string): string | null {
   if (!message.startsWith("/")) return null;
   const query = message.slice(1);

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2991,7 +2991,7 @@ describe("ChatView input", () => {
 
     const textarea = screen.getByRole("textbox", { name: "Message" });
     const picker = screen.getByRole("combobox", { name: "Message command picker" });
-    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
     expect(picker).toHaveAttribute("aria-expanded", "true");
     expect(textarea).toHaveAttribute("aria-controls", commands.id);
     expect(picker).toHaveAttribute("aria-controls", commands.id);
@@ -3036,7 +3036,7 @@ describe("ChatView input", () => {
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
     expect(within(commands).getByRole("option", { name: "Insert /web command" })).toBeTruthy();
     expect(within(commands).queryByRole("option", { name: "Insert /plan command" })).toBeNull();
   });
@@ -3065,11 +3065,11 @@ describe("ChatView input", () => {
 
     const textarea = screen.getByRole("textbox", { name: "Message" });
     const picker = screen.getByRole("combobox", { name: "Message command picker" });
-    expect(screen.getByRole("listbox", { name: "External agent commands" })).toBeTruthy();
+    expect(screen.getByRole("listbox", { name: "Message commands" })).toBeTruthy();
 
     fireEvent.keyDown(textarea, { key: "Escape" });
 
-    expect(screen.queryByRole("listbox", { name: "External agent commands" })).toBeNull();
+    expect(screen.queryByRole("listbox", { name: "Message commands" })).toBeNull();
     expect(picker).toHaveAttribute("aria-expanded", "false");
   });
 
@@ -3102,7 +3102,7 @@ describe("ChatView input", () => {
 
     const textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
     fireEvent.keyDown(textarea, { key: "ArrowDown" });
-    const commands = screen.getByRole("listbox", { name: "External agent commands" });
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
     expect(within(commands).getByRole("option", { selected: true })).toHaveAttribute(
       "aria-label",
       "Insert /plan command",
@@ -3135,7 +3135,144 @@ describe("ChatView input", () => {
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    expect(screen.queryByLabelText("External agent commands")).toBeNull();
+    expect(screen.queryByRole("listbox", { name: "Message commands" })).toBeNull();
+  });
+
+  it("suggests the project proposal slash command for project-linked Hecate chats", async () => {
+    const setMessage = vi.fn();
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/",
+        activeChatSession: {
+          id: "chat_project_commands",
+          title: "Project chat",
+          agent_id: "hecate",
+          execution_mode: "hecate_task",
+          project_id: "proj_1",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { setMessage },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
+
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
+    expect(
+      within(commands).getByRole("option", { name: "Insert /proposal command" }),
+    ).toHaveTextContent("/proposal");
+    expect(within(commands).getByText("Draft a Project Assistant proposal")).toBeTruthy();
+
+    const user = userEvent.setup();
+    await user.click(within(commands).getByRole("option", { name: "Insert /proposal command" }));
+
+    expect(setMessage).toHaveBeenLastCalledWith("/proposal ");
+  });
+
+  it("does not add Hecate project commands to External Agent command hints", () => {
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      message: "/",
+      activeChatSession: {
+        id: "external_project_commands",
+        title: "External project chat",
+        agent_id: "claude_code",
+        driver_kind: "acp",
+        execution_mode: "external_agent",
+        project_id: "proj_1",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: [{ name: "web", description: "Search the web" }],
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
+
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
+    expect(within(commands).getByRole("option", { name: "Insert /web command" })).toBeTruthy();
+    expect(within(commands).queryByRole("option", { name: "Insert /proposal command" })).toBeNull();
+  });
+
+  it("drafts a Project Assistant proposal with /proposal without sending chat", async () => {
+    const selectProject = vi.fn(async () => undefined);
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const onNavigate = vi.fn();
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/proposal Plan next project work",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          project_id: "proj_1",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { selectProject, setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(draftChatProjectAssistant).toHaveBeenCalledWith("s1", {
+        request: "Plan next project work",
+      });
+    });
+    expect(submitChat).not.toHaveBeenCalled();
+    expect(selectProject).toHaveBeenCalledWith("proj_1");
+    expect(onNavigate).toHaveBeenCalledWith("projects");
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(readProjectAssistantChatHandoff()).toMatchObject({
+      project_id: "proj_1",
+      request: "Plan next project work",
+      source_session_id: "s1",
+      proposal: { id: "pa_chat" },
+    });
+  });
+
+  it("requires text after the /proposal command", () => {
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/proposal",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          project_id: "proj_1",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(draftChatProjectAssistant).not.toHaveBeenCalled();
+    expect(submitChat).not.toHaveBeenCalled();
   });
 
   it("browses previous user messages with ArrowUp and ArrowDown", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -557,10 +557,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     onNavigate?.("projects");
   }
 
-  async function draftProjectProposalFromChat() {
+  async function draftProjectProposalFromChat(explicitRequest?: string) {
     const sessionID = activeSessionID.trim();
     const projectID = activeSessionProjectID.trim();
-    const request = state.message.trim();
+    const request = (explicitRequest ?? state.message).trim();
     if (!sessionID || !projectID || !request || projectProposalDrafting) return;
     setProjectProposalDrafting(true);
     try {
@@ -1033,7 +1033,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                 projectProposalAvailable={projectProposalAvailable}
                 projectProposalDrafting={projectProposalDrafting}
                 messageHistory={messageHistory}
-                onDraftProjectProposal={() => void draftProjectProposalFromChat()}
+                onDraftProjectProposal={(request) => void draftProjectProposalFromChat(request)}
                 onNavigate={onNavigate}
                 onOpenTask={onOpenTask}
                 onOpenTrace={onOpenTrace}


### PR DESCRIPTION
## Summary

- Add a Hecate-owned `/proposal <request>` composer command for project-linked Hecate chats.
- Route the command through the existing deterministic chat Project Assistant draft handoff without sending a chat message or changing apply payloads.
- Keep ACP-advertised External Agent commands separate and update docs for the command/proposal boundary.

## Tests

- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/features/chats/ChatView.test.tsx`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`

No Go tests run; this PR changes only UI and docs.