### PR TITLE
Clarify guided project setup

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -100,11 +100,11 @@ permission model.
   ids, kinds, locators, trust labels, categories, and metadata notes, but it
   must not fetch source URLs, read local paths, execute source references, or
   treat source metadata as durable memory.
-- Bootstrap drafts may create memory candidates from project context-source
+- Bootstrap-mode setup drafts may create memory candidates from project context-source
   metadata, using `suggested_source_kind: "context_source"` and source refs back
   to the discovered source. Those candidates record provenance only; operators
   must review and edit/promote them before they become durable memory.
-- Bootstrap drafts may suggest project roles from enabled, available records in
+- Bootstrap-mode setup drafts may suggest project roles from enabled, available records in
   the project skills registry. Applying the proposal creates role records with
   `skill_ids` references only; it does not read or inject `SKILL.md` bodies,
   install skills, run scripts, grant tools, or change approval policy. Disabled,
@@ -247,13 +247,13 @@ and existing memory/candidate source refs. It does not treat host-specific
 guidance as Hecate policy authority, call a model, create durable memory, start
 tasks, or launch agents.
 
-In the operator UI, **Bootstrap project** is the project onboarding action, not a
+In the operator UI, **Set up project** is the project onboarding action, not a
 regular draft mode. It refreshes workspace guidance context sources, refreshes
 the project skills registry, then requests a project-scoped Bootstrap draft.
-Rootless projects skip workspace discovery naturally and can still use Bootstrap
-to propose roles, first work, and memory candidates from existing project
-metadata. Projects with no work items use Bootstrap as their primary onboarding
-action before showing the full work cockpit.
+Rootless projects skip workspace discovery naturally and can still use setup to
+propose roles, first work, and memory candidates from existing project metadata.
+Projects with no work items use setup as their primary onboarding action before
+showing the full work cockpit.
 The resulting proposal is still review/apply gated and does not attach to the
 currently selected work item.
 
@@ -487,7 +487,7 @@ The first visible UI should stay small and inspectable:
 - keep the workspace tabs as one stable row below the composer; narrow surfaces
   may scroll the tab strip, but should not wrap tabs into a second row;
 - keep the request and primary draft action in the first row; route controls,
-  bootstrap, and context inspection stay secondary so the assistant reads as a
+  setup, and context inspection stay secondary so the assistant reads as a
   project command band rather than a work-detail editor;
 - keep route controls contextual, with an automatic choice for the common path;
 - show context details only after explicit inspection, and proposal cards with
@@ -501,9 +501,9 @@ The first visible UI should stay small and inspectable:
 The Projects cockpit exposes this contract at the top of the project workspace.
 V0 uses a composer-style request box that drafts typed proposals from the
 selected project/work item. The `Rules` draft option uses deterministic server
-logic; `Bootstrap` proposes project setup records from guidance and skill
-registry metadata; the `Assistant` draft option asks the project default model
-to author the same typed proposal shape.
+logic; the project setup path uses Bootstrap mode to propose setup records from
+guidance and skill registry metadata; the `Assistant` draft option asks the
+project default model to author the same typed proposal shape.
 
 Hecate Chat stays visually simple. Project-linked Hecate Chat turns receive
 hidden project workflow guidance and bounded project context so the model can

--- a/internal/projectassistant/bootstrap.go
+++ b/internal/projectassistant/bootstrap.go
@@ -23,14 +23,14 @@ func (s *Service) draftBootstrap(ctx context.Context, input DraftInput, draftCon
 	actions = append(actions, skillActions...)
 	warnings = append(warnings, skillWarnings...)
 	if draftContext.SelectedWork != nil {
-		warnings = append(warnings, "Bootstrap drafts are project-scoped; selected work context was ignored.")
+		warnings = append(warnings, "Project setup proposals are project-scoped; selected work context was ignored.")
 	}
 	if len(actions) == 0 {
-		return Proposal{}, fmt.Errorf("%w: no enabled guidance sources or local skill files found for bootstrap", ErrInvalid)
+		return Proposal{}, fmt.Errorf("%w: no enabled guidance sources or local skill files found for project setup", ErrInvalid)
 	}
 
 	proposal, err := s.Propose(ctx, ProposalInput{
-		Title:   fmt.Sprintf("Bootstrap %s guidance", firstNonEmpty(draftContext.Project.Name, projectID)),
+		Title:   fmt.Sprintf("Set up %s guidance", firstNonEmpty(draftContext.Project.Name, projectID)),
 		Summary: "Create reviewable memory candidates from discovered guidance metadata and suggest project roles from local skill files.",
 		Actions: actions,
 		TraceID: strings.TrimSpace(input.TraceID),
@@ -58,7 +58,7 @@ func bootstrapGuidanceActions(projectID string, draftContext DraftContext) ([]Ac
 			continue
 		}
 		if len(actions) >= bootstrapGuidanceActionLimit {
-			warnings = append(warnings, fmt.Sprintf("Skipped additional guidance sources after %d bootstrap memory candidates.", bootstrapGuidanceActionLimit))
+			warnings = append(warnings, fmt.Sprintf("Skipped additional guidance sources after %d setup memory candidates.", bootstrapGuidanceActionLimit))
 			break
 		}
 		actions = append(actions, bootstrapGuidanceAction(projectID, source))
@@ -150,7 +150,7 @@ func bootstrapSkillRoleActions(projectID string, draftContext DraftContext) ([]A
 	var actions []Action
 	var warnings []string
 	if len(draftContext.Skills) == 0 {
-		warnings = append(warnings, "No project skills are registered yet; run project skill discovery before Bootstrap can suggest skill roles.")
+		warnings = append(warnings, "No project skills are registered yet; run project skill discovery before setup can suggest skill roles.")
 		return actions, warnings
 	}
 	for _, skill := range draftContext.Skills {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -186,7 +186,7 @@ func TestService_DraftBootstrapCreatesGuidanceAndSkillRoleProposalAcrossStores(t
 
 			proposal, err := fixture.service.Draft(ctx, DraftInput{
 				ProjectID: project.ID,
-				Request:   "Bootstrap project guidance",
+				Request:   "Set up project guidance",
 				DraftMode: DraftModeBootstrap,
 				TraceID:   "trace_bootstrap",
 			})
@@ -195,6 +195,9 @@ func TestService_DraftBootstrapCreatesGuidanceAndSkillRoleProposalAcrossStores(t
 			}
 			if proposal.TraceID != "trace_bootstrap" || !proposal.RequiresConfirmation {
 				t.Fatalf("proposal trace/confirmation = %q/%v, want trace and confirmation", proposal.TraceID, proposal.RequiresConfirmation)
+			}
+			if proposal.Title != "Set up Bootstrap Project guidance" {
+				t.Fatalf("proposal title = %q, want setup title", proposal.Title)
 			}
 			if len(proposal.Actions) != 2 {
 				t.Fatalf("actions = %+v, want guidance candidate and skill role", proposal.Actions)
@@ -297,7 +300,7 @@ func TestService_DraftBootstrapIgnoresRepoSpecificDocsAISkills(t *testing.T) {
 
 	proposal, err := fixture.service.Draft(ctx, DraftInput{
 		ProjectID: project.ID,
-		Request:   "Bootstrap project guidance",
+		Request:   "Set up project guidance",
 		DraftMode: DraftModeBootstrap,
 	})
 	if err != nil {
@@ -382,7 +385,7 @@ func TestService_DraftBootstrapUsesRegisteredSkillDirsFromGuidanceReferences(t *
 
 	proposal, err := fixture.service.Draft(ctx, DraftInput{
 		ProjectID: project.ID,
-		Request:   "Bootstrap project guidance",
+		Request:   "Set up project guidance",
 		DraftMode: DraftModeBootstrap,
 	})
 	if err != nil {

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -121,14 +121,14 @@ export function ProjectAssistantPanel({
           <div style={assistantOnboardingCopyStyle}>
             <div style={sectionLabelStyle}>Project setup</div>
             <div style={setupPromptTitleStyle}>
-              {setupStarted ? "Create the first work item" : "Bootstrap project context"}
+              {setupStarted ? "Create the first work item" : "Set up project context"}
             </div>
             <div style={{ ...subtleTextStyle, marginTop: 4 }}>
               {setupStarted
                 ? "Project guidance or roles already exist. Inspect context or add the first reviewable work item."
                 : bootstrapPending
-                  ? "Discovering local guidance and preparing a reviewable setup proposal."
-                  : "Discover guidance, skills, and role suggestions before drafting project work."}
+                  ? "Discovering guidance and skills, then preparing a reviewable setup proposal."
+                  : "Discover guidance and skills, suggest roles, and prepare setup actions for review."}
             </div>
           </div>
           <div style={assistantOnboardingActionsStyle}>
@@ -151,7 +151,7 @@ export function ProjectAssistantPanel({
                 onClick={onBootstrap}
               >
                 <Icon d={Icons.refresh} size={14} />
-                {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
+                {bootstrapPending ? "Setting up..." : "Set up project"}
               </button>
             )}
           </div>
@@ -524,7 +524,7 @@ function projectAssistantDraftMode(
 
 function projectAssistantBootstrapForm(): ProjectAssistantDraftForm {
   return {
-    request: "Bootstrap project guidance",
+    request: "Set up project guidance",
     roleID: PROJECT_ASSISTANT_AUTO,
     driverKind: PROJECT_ASSISTANT_AUTO,
     draftMode: "bootstrap",

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -191,7 +191,7 @@ describe("ProjectWorkspaceView", () => {
     expect(screen.getByText("Optional; attach files when this project needs them.")).toBeTruthy();
     expect(screen.getByText("optional")).toBeTruthy();
 
-    await userEvent.click(screen.getByRole("button", { name: "Bootstrap project" }));
+    await userEvent.click(screen.getByRole("button", { name: "Set up project" }));
     await userEvent.click(screen.getByRole("button", { name: "Create work" }));
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -579,17 +579,21 @@ function ProjectOnboardingPanel({
     },
     {
       label: "Sources and memory",
-      detail: `${contextSourceCount} sources · ${skillCount} skills`,
+      detail: hasGuidance
+        ? `${contextSourceCount} sources · ${skillCount} skills`
+        : hasRoot
+          ? "Setup can discover workspace guidance and local skills."
+          : "Add sources manually, or attach a workspace when files matter.",
       done: hasGuidance,
     },
     {
       label: "Roles",
-      detail: roleCount > 0 ? `${roleCount} roles` : "Bootstrap or add roles.",
+      detail: roleCount > 0 ? `${roleCount} roles` : "Setup can suggest roles from skills.",
       done: roleCount > 0,
     },
     {
       label: "First work item",
-      detail: "No work items yet",
+      detail: "Create the first reviewable task after setup.",
       done: false,
     },
   ];
@@ -601,8 +605,8 @@ function ProjectOnboardingPanel({
           <div style={projectOnboardingTitleStyle}>Set up {project.name}</div>
         </div>
         <div style={projectOnboardingDetailStyle}>
-          Create a durable coordination space for planning, evidence, roles, and reviewable work.
-          Attach local files only when this project needs a workspace.
+          Let Hecate discover safe project metadata, suggest roles, and prepare setup actions for
+          review. Attach local files only when this project needs a workspace.
         </div>
         <div style={projectOnboardingActionsStyle}>
           <button
@@ -612,7 +616,7 @@ function ProjectOnboardingPanel({
             onClick={onBootstrap}
           >
             <Icon d={Icons.refresh} size={13} />
-            {bootstrapPending ? "Bootstrapping..." : "Bootstrap project"}
+            {bootstrapPending ? "Setting up..." : "Set up project"}
           </button>
           <button className="btn btn-ghost btn-sm" type="button" onClick={onCreateWork}>
             <Icon d={Icons.plus} size={13} />

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1093,7 +1093,7 @@ describe("ProjectsView index", () => {
 
     expect(await screen.findByRole("region", { name: "Project onboarding" })).toBeTruthy();
     expect(screen.getByText("Set up Hecate")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Bootstrap project" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Set up project" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Projects" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open project Hecate" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Collapse projects panel" })).toBeNull();
@@ -1104,16 +1104,16 @@ describe("ProjectsView index", () => {
     expect(screen.queryByRole("region", { name: "Work coordination" })).toBeNull();
     expect(screen.queryByText("No work items for this project.")).toBeNull();
 
-    await user.click(screen.getByRole("button", { name: "Bootstrap project" }));
+    await user.click(screen.getByRole("button", { name: "Set up project" }));
     await waitFor(() => {
       expect(draftProjectAssistant).toHaveBeenCalledWith({
         project_id: project.id,
-        request: "Bootstrap project guidance",
+        request: "Set up project guidance",
         draft_mode: "bootstrap",
       });
     });
     const assistant = await screen.findByRole("region", { name: "Project Assistant" });
-    expect(within(assistant).queryByRole("button", { name: "Bootstrap project" })).toBeNull();
+    expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
     expect(within(assistant).getByRole("button", { name: "Dismiss proposal" })).toBeTruthy();
     expect(within(assistant).queryByLabelText("Request")).toBeNull();
     expect(within(assistant).queryByRole("button", { name: "Draft proposal" })).toBeNull();
@@ -1157,7 +1157,7 @@ describe("ProjectsView index", () => {
     expect(screen.getByRole("tablist", { name: "Project workspace views" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Work coordination" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Work" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Bootstrap project" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Set up project" })).toBeNull();
     expect(screen.getByRole("button", { name: "Inspect context" })).toBeTruthy();
     expect(screen.queryByLabelText("Request")).toBeNull();
     expect(screen.queryByRole("button", { name: "Draft proposal" })).toBeNull();
@@ -1574,7 +1574,7 @@ describe("ProjectsView cockpit", () => {
     const assistant = await screen.findByRole("region", { name: "Project Assistant" });
 
     expect(within(assistant).queryByText("Project onboarding")).toBeNull();
-    expect(within(assistant).queryByRole("button", { name: "Bootstrap project" })).toBeNull();
+    expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
     expect(within(assistant).queryByRole("option", { name: "Bootstrap" })).toBeNull();
   });
 
@@ -1594,7 +1594,7 @@ describe("ProjectsView cockpit", () => {
     expect(within(assistant).getByText("Selected work: Build cockpit UI")).toBeTruthy();
     expect(within(assistant).getByLabelText("Request")).toBeTruthy();
     expect(within(assistant).queryByText("Project setup")).toBeNull();
-    expect(within(assistant).queryByRole("button", { name: "Bootstrap project" })).toBeNull();
+    expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
   });
 
   it("discovers guidance and skills before drafting project bootstrap proposals", async () => {
@@ -1641,14 +1641,14 @@ describe("ProjectsView cockpit", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
     const onboarding = await screen.findByRole("region", { name: "Project onboarding" });
-    await user.click(within(onboarding).getByRole("button", { name: "Bootstrap project" }));
+    await user.click(within(onboarding).getByRole("button", { name: "Set up project" }));
 
     await waitFor(() => {
       expect(discoverProjectContextSources).toHaveBeenCalledWith(project.id);
       expect(discoverProjectSkills).toHaveBeenCalledWith(project.id);
       expect(draftProjectAssistant).toHaveBeenCalledWith({
         project_id: project.id,
-        request: "Bootstrap project guidance",
+        request: "Set up project guidance",
         draft_mode: "bootstrap",
       });
     });
@@ -1810,12 +1810,12 @@ describe("ProjectsView cockpit", () => {
     expect(within(onboarding).getByText("Set up Hecate")).toBeTruthy();
     expect(screen.queryByRole("region", { name: "Project Assistant" })).toBeNull();
     expect(screen.queryByText("No work items for this project.")).toBeNull();
-    await user.click(within(onboarding).getByRole("button", { name: "Bootstrap project" }));
+    await user.click(within(onboarding).getByRole("button", { name: "Set up project" }));
 
     await waitFor(() => {
       expect(draftProjectAssistant).toHaveBeenCalledWith({
         project_id: project.id,
-        request: "Bootstrap project guidance",
+        request: "Set up project guidance",
         draft_mode: "bootstrap",
       });
     });

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1561,7 +1561,7 @@ describe("ProjectsView cockpit", () => {
     });
   });
 
-  it("keeps bootstrap out of the draft mode once project setup exists", async () => {
+  it("keeps project setup out of selected-work drafting once setup exists", async () => {
     resetProjectWorkMocks();
     window.localStorage.setItem("hecate.project", project.id);
     const state = createRuntimeConsoleFixture({
@@ -1574,8 +1574,11 @@ describe("ProjectsView cockpit", () => {
     const assistant = await screen.findByRole("region", { name: "Project Assistant" });
 
     expect(within(assistant).queryByText("Project onboarding")).toBeNull();
+    expect(within(assistant).queryByText("Set up project context")).toBeNull();
     expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
-    expect(within(assistant).queryByRole("option", { name: "Bootstrap" })).toBeNull();
+    expect(within(assistant).getByLabelText("Draft")).toBeTruthy();
+    expect(within(assistant).getByRole("option", { name: "Rules" })).toBeTruthy();
+    expect(within(assistant).getByRole("option", { name: "Assistant" })).toBeTruthy();
   });
 
   it("keeps selected-work drafting separate from project onboarding", async () => {

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -101,7 +101,7 @@ export function useProjectAssistantController(options: Options) {
       const payload = await draftProjectAssistant(
         projectAssistantDraftPayload(
           {
-            request: "Bootstrap project guidance",
+            request: "Set up project guidance",
             roleID: PROJECT_ASSISTANT_AUTO,
             driverKind: PROJECT_ASSISTANT_AUTO,
             draftMode: "bootstrap",


### PR DESCRIPTION
## Summary

- Rename the operator-facing project onboarding action from "Bootstrap project" to "Set up project" while preserving the internal `draft_mode: "bootstrap"` contract.
- Clarify onboarding and Project Assistant copy around safe discovery, role suggestions, and review-gated setup actions.
- Align setup proposal title/warnings, runtime docs, and tests with the new product language.

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/projectassistant`
- `go vet ./internal/projectassistant`
- `cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-check`
