### PR TITLE
fix(ui): harden external agent model picker detection

### DIFF
--- a/ui/src/features/chats/agentConfigOptions.test.ts
+++ b/ui/src/features/chats/agentConfigOptions.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import type { ChatConfigOptionRecord } from "../../types/chat";
 import {
   agentConfigOptionKind,
   agentConfigOptionLabel,
   externalAgentRequiresModelSelection,
   prioritizeAgentConfigOptions,
 } from "./agentConfigOptions";
+import type { ChatConfigOptionRecord } from "../../types/chat";
 
 function option(overrides: Partial<ChatConfigOptionRecord>): ChatConfigOptionRecord {
   return {
@@ -70,5 +70,89 @@ describe("agent config option helpers", () => {
       "approval_mode",
       "verbosity",
     ]);
+  });
+
+  it("prefers the exact model picker over earlier model-named decoys", () => {
+    const options: ChatConfigOptionRecord[] = [
+      option({
+        id: "model_info",
+        name: "Model info",
+        current_value: "metadata",
+      }),
+      option({
+        id: "model",
+        name: "Model",
+        category: "model",
+        current_value: "__hecate_no_model_selected",
+      }),
+    ];
+
+    expect(externalAgentRequiresModelSelection(options)).toBe(true);
+  });
+
+  it("ignores model-named decoys when the exact model picker is configured", () => {
+    const options: ChatConfigOptionRecord[] = [
+      option({
+        id: "default_model_mode",
+        name: "Default model mode",
+        current_value: "",
+      }),
+      option({
+        id: "model",
+        name: "Model",
+        category: "model",
+        current_value: "smart",
+      }),
+    ];
+
+    expect(externalAgentRequiresModelSelection(options)).toBe(false);
+  });
+
+  it("falls back to all heuristic model selects when no exact picker exists", () => {
+    const options: ChatConfigOptionRecord[] = [
+      option({
+        id: "preferred_model",
+        name: "Preferred model",
+        current_value: "fast",
+      }),
+      option({
+        id: "fallback_model",
+        name: "Fallback model",
+        current_value: "",
+      }),
+    ];
+
+    expect(externalAgentRequiresModelSelection(options)).toBe(true);
+  });
+
+  it("classifies config options by tokens instead of incidental substrings", () => {
+    expect(
+      agentConfigOptionKind(option({ id: "remodeling", name: "Remodeling", category: "" })),
+    ).toBe("other");
+    expect(agentConfigOptionKind(option({ id: "commode", name: "Commode", category: "" }))).toBe(
+      "other",
+    );
+    expect(
+      agentConfigOptionKind(option({ id: "reasoning", name: "Reasoning", category: "" })),
+    ).toBe("thought_level");
+    expect(
+      agentConfigOptionKind(
+        option({
+          id: "system_prompt",
+          name: "System prompt",
+          category: "",
+          type: "text",
+        }),
+      ),
+    ).toBe("instructions");
+  });
+
+  it("keeps model controls before mode controls", () => {
+    const sorted = prioritizeAgentConfigOptions([
+      option({ id: "auto_approve", name: "Mode", category: "mode", type: "boolean" }),
+      option({ id: "model", name: "Model", category: "model" }),
+    ]);
+
+    expect(sorted.map((option) => option.id)).toEqual(["model", "auto_approve"]);
   });
 });

--- a/ui/src/features/chats/agentConfigOptions.ts
+++ b/ui/src/features/chats/agentConfigOptions.ts
@@ -54,17 +54,18 @@ export function agentConfigOptionKind(option: ChatConfigOptionRecord): AgentConf
   if (category === "model" || category === "thought_level" || category === "mode") {
     return category;
   }
-  const key = agentConfigOptionKey(option);
-  if (key.includes("model")) return "model";
+  const tokens = agentConfigOptionTokens(option);
+  // Keep model before mode: some agent model pickers include mode-shaped
+  // labels, and the send gate depends on model pickers staying classified.
+  if (tokens.includes("model")) return "model";
   if (
-    key.includes("thought_level") ||
-    key.includes("thought level") ||
-    key.includes("thinking") ||
-    key.includes("reasoning")
+    hasTokenSequence(tokens, ["thought", "level"]) ||
+    tokens.includes("thinking") ||
+    tokens.includes("reasoning")
   ) {
     return "thought_level";
   }
-  if (key.includes("mode")) return "mode";
+  if (tokens.includes("mode")) return "mode";
   return "other";
 }
 
@@ -80,13 +81,11 @@ export function agentConfigOptionIsText(option: ChatConfigOptionRecord): boolean
 }
 
 export function agentConfigOptionIsInstructions(option: ChatConfigOptionRecord): boolean {
-  const key = agentConfigOptionKey(option);
+  const tokens = agentConfigOptionTokens(option);
   return (
-    key.includes("system_prompt") ||
-    key.includes("system prompt") ||
-    key.includes("agent_instructions") ||
-    key.includes("agent instructions") ||
-    key.includes("instructions")
+    hasTokenSequence(tokens, ["system", "prompt"]) ||
+    hasTokenSequence(tokens, ["agent", "instructions"]) ||
+    tokens.includes("instructions")
   );
 }
 
@@ -108,14 +107,34 @@ export function agentConfigOptionLabel(option: ChatConfigOptionRecord): string {
 export function externalAgentRequiresModelSelection(
   configOptions: ChatConfigOptionRecord[],
 ): boolean {
-  const option = configOptions.find(
+  const modelOptions = configOptions.filter(
     (item) => item.type === "select" && agentConfigOptionKind(item) === "model",
   );
-  if (!option) return false;
-  const value = (option.current_value ?? "").trim();
-  return value === "" || value.startsWith("__hecate_no_");
+  const exactModelOptions = modelOptions.filter(isExactModelPicker);
+  const candidates = exactModelOptions.length > 0 ? exactModelOptions : modelOptions;
+  return candidates.some((option) => {
+    const value = (option.current_value ?? "").trim();
+    return value === "" || value.startsWith("__hecate_no_");
+  });
 }
 
 function agentConfigOptionKey(option: ChatConfigOptionRecord): string {
   return `${option.id} ${option.name} ${option.category ?? ""}`.toLowerCase();
+}
+
+function agentConfigOptionTokens(option: ChatConfigOptionRecord): string[] {
+  return agentConfigOptionKey(option)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function hasTokenSequence(tokens: string[], sequence: string[]): boolean {
+  if (sequence.length === 0 || tokens.length < sequence.length) return false;
+  return tokens.some((_, index) =>
+    sequence.every((token, sequenceIndex) => tokens[index + sequenceIndex] === token),
+  );
+}
+
+function isExactModelPicker(option: ChatConfigOptionRecord): boolean {
+  return option.id.toLowerCase() === "model" || (option.category ?? "").toLowerCase() === "model";
 }


### PR DESCRIPTION
Addresses follow-up review feedback from PR #404.

- Prefer exact external-agent model pickers (`category=model` or `id=model`) before heuristic matches, so model-named decoys cannot mask an unset real picker.
- Evaluate all fallback model-like selects when no exact picker exists.
- Switch config option classification to token matching to avoid incidental substring matches like `remodeling` or `commode`.

Verification:
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/chats/agentConfigOptions.test.ts src/features/chats/ChatView.test.tsx`
- `cd ui && bun run format:check`
