### PR TITLE
feat(ui): expand chat slash commands

### DIFF
--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -127,6 +127,12 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   submits another prompt, queue it locally in the composer and send it after
   the task finishes, is stopped, or reaches a terminal approval outcome. Do not
   pretend that local queue is durable before the message is submitted.
+- Hecate-owned chat slash commands are local UI shortcuts, not External Agent
+  ACP commands. Keep project-shaping commands (`/proposal`, `/plan`, `/work`,
+  `/handoff`, `/review`) on the Project Assistant proposal/confirmation rail;
+  navigation commands such as `/diff`, `/model`, `/settings`, `/status`,
+  `/task`, `/project`, and `/connections` may open Hecate UI surfaces but must
+  not send prompt text or mutate project records directly.
 - Use the shared `features/transcript` primitives for runtime storytelling.
   Task Detail and Hecate Chat should share `TranscriptActivityTimeline` labels
   and Details grouping instead of growing separate task/activity renderers.

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -118,11 +118,33 @@ project commands; selecting one still sends ordinary prompt text to the
 external agent. The operator UI may show these hints while the composer starts
 with `/`; choosing a hint only inserts the slash command text. Hecate-owned
 chat commands are separate local shortcuts and must still route through
-Hecate's proposal, validation, and operator-apply boundaries. Current
-Hecate-owned commands are `/proposal`, `/plan`, `/work`, `/handoff`, `/review`,
-`/diff`, `/model`, `/settings`, `/status`, `/task`, `/project`, and
-`/connections`. The project commands draft Project Assistant proposals; the
-navigation commands open Hecate UI surfaces without sending a chat message.
+Hecate's proposal, validation, and operator-apply boundaries.
+
+### Hecate-owned chat commands
+
+Hecate-owned commands are local UI shortcuts in Hecate Chat. They are not ACP
+commands and they do not run when submitted to an External Agent chat. Project
+commands draft Project Assistant proposals; navigation commands open Hecate UI
+surfaces without sending a chat message.
+
+| Command               | Available when                          | Behavior                                                                    |
+| --------------------- | --------------------------------------- | --------------------------------------------------------------------------- |
+| `/proposal <request>` | Hecate Chat is linked to a project      | Drafts a Project Assistant proposal from the request.                       |
+| `/plan <request>`     | Hecate Chat is linked to a project      | Drafts a Project Assistant plan proposal from the request.                  |
+| `/work <request>`     | Hecate Chat is linked to a project      | Drafts a project-work proposal from the request.                            |
+| `/handoff <request>`  | Hecate Chat is linked to a project      | Drafts a project handoff proposal from the request.                         |
+| `/review <request>`   | Hecate Chat is linked to a project      | Drafts a project review proposal from the request.                          |
+| `/diff`               | Hecate Chat has a workspace             | Opens the workspace changes panel.                                          |
+| `/model`              | Hecate Chat is open                     | Opens chat settings focused on provider/model controls.                     |
+| `/settings`           | Hecate Chat is open                     | Opens the chat settings panel.                                              |
+| `/status`             | Hecate Chat is open                     | Opens the chat settings/status details panel.                               |
+| `/task`               | Hecate Chat is open                     | Opens the active task when one exists; otherwise opens the Tasks workspace. |
+| `/project`            | Hecate Chat is linked to a project      | Opens the linked project in Projects.                                       |
+| `/connections`        | Hecate Chat is open with app navigation | Opens Connections for provider/model and External Agent setup.              |
+
+Submitting a project command without text after the command returns a composer
+notice and does not draft a proposal. Unknown slash commands in Hecate Chat are
+submitted as ordinary chat text, matching the normal composer path.
 
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -23,10 +23,12 @@ the Projects workspace. Project-linked Hecate Chat also exposes a compact
 composer action that deterministically drafts a Project Assistant proposal from
 the current message and hands it to the Projects review surface. The same path
 is available as the Hecate-owned `/proposal <request>` chat command for
-operators who prefer a slash-command flow; selecting `/proposal` only inserts
-the command scaffold, and submitting it drafts from the text after the command.
-That handoff is proposal data only; it does not send a chat message, create
-project records, call the model-backed draft path, or apply the proposal.
+operators who prefer a slash-command flow. Project-shaping commands such as
+`/plan`, `/work`, `/handoff`, and `/review` use the same proposal boundary:
+selecting one only inserts the command scaffold, and submitting it drafts from
+the text after the command. That handoff is proposal data only; it does not send
+a chat message, create project records, call the model-backed draft path, or
+apply the proposal.
 Deleting a project also deletes its project-scoped chat transcripts.
 Unprojected chats and chats in other projects stay untouched. The Projects
 review card preserves the originating request and chat session id for operator
@@ -115,8 +117,12 @@ session snapshot. These are agent-native slash command hints, not Hecate
 project commands; selecting one still sends ordinary prompt text to the
 external agent. The operator UI may show these hints while the composer starts
 with `/`; choosing a hint only inserts the slash command text. Hecate-owned
-chat commands, such as `/proposal`, are separate local shortcuts and must still
-route through Hecate's proposal, validation, and operator-apply boundaries.
+chat commands are separate local shortcuts and must still route through
+Hecate's proposal, validation, and operator-apply boundaries. Current
+Hecate-owned commands are `/proposal`, `/plan`, `/work`, `/handoff`, `/review`,
+`/diff`, `/model`, `/settings`, `/status`, `/task`, `/project`, and
+`/connections`. The project commands draft Project Assistant proposals; the
+navigation commands open Hecate UI surfaces without sending a chat message.
 
 Hecate Chat settings also own the **Tools** toggle and the optional **Compact
 command output** toggle. Tools decides whether future turns stay as direct

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -113,8 +113,10 @@ a separate execute-command RPC. The operator UI can surface the advertised list
 when the composer starts with `/`, but choosing an item only inserts the command
 text. These are external-agent-native commands, not Hecate-owned project
 mutations. Hecate Chat shortcuts such as `/proposal` are separate local UI
-commands, not ACP commands; they should remain intent hints that go through the
-usual proposal, validation, and operator-apply boundaries.
+commands, not ACP commands. Project-shaping shortcuts such as `/plan`, `/work`,
+`/handoff`, and `/review` should remain intent hints that go through the usual
+proposal, validation, and operator-apply boundaries instead of directly
+mutating project records.
 
 Check discovery:
 

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -317,6 +317,7 @@ export function ChatComposer(props: ChatComposerProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const messageHistoryCursorRef = useRef<number | null>(null);
   const messageHistoryPendingTextRef = useRef("");
+  const commandOptionRefs = useRef<Array<HTMLDivElement | null>>([]);
   const commandListboxID = useId();
   const [commandPickerDismissed, setCommandPickerDismissed] = useState(false);
   const [activeCommandIndex, setActiveCommandIndex] = useState(0);
@@ -397,6 +398,15 @@ export function ChatComposer(props: ChatComposerProps) {
       commandSuggestions.length === 0 ? 0 : Math.min(current, commandSuggestions.length - 1),
     );
   }, [commandSuggestions.length]);
+
+  useEffect(() => {
+    commandOptionRefs.current = commandOptionRefs.current.slice(0, commandSuggestions.length);
+  }, [commandSuggestions.length]);
+
+  useEffect(() => {
+    if (!commandPickerVisible) return;
+    commandOptionRefs.current[activeCommandIndex]?.scrollIntoView({ block: "nearest" });
+  }, [activeCommandIndex, commandPickerVisible]);
 
   // Reset history navigation on session change. Scroll-side reset
   // lives in ChatView since it concerns the transcript surface.
@@ -865,6 +875,9 @@ export function ChatComposer(props: ChatComposerProps) {
                   return (
                     <div
                       key={`${command.kind}:${command.name}:${index}`}
+                      ref={(node) => {
+                        commandOptionRefs.current[index] = node;
+                      }}
                       id={`${commandListboxID}-option-${index}`}
                       role="option"
                       aria-label={`Insert ${commandText} command`}

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -41,7 +41,6 @@ import { mergeAgentConfigOptions } from "./agentConfigOptions";
 
 const COMPOSER_TEXTAREA_MAX_LINES = 10;
 const COMPOSER_TEXTAREA_MIN_HEIGHT = 42;
-const COMMAND_SUGGESTION_LIMIT = 6;
 const PROJECT_PROPOSAL_COMMAND = {
   name: "proposal",
   description: "Draft a Project Assistant proposal",
@@ -273,7 +272,7 @@ export function ChatComposer(props: ChatComposerProps) {
       );
     }
 
-    return suggestions.slice(0, COMMAND_SUGGESTION_LIMIT);
+    return suggestions;
   }, [
     activeChatSession?.available_commands,
     commandQuery,
@@ -679,6 +678,9 @@ export function ChatComposer(props: ChatComposerProps) {
                   borderRadius: "var(--radius-sm)",
                   background: "var(--bg2)",
                   boxShadow: "0 10px 28px rgba(0, 0, 0, 0.28)",
+                  maxHeight: "min(40vh, 320px)",
+                  overflowY: "auto",
+                  overscrollBehavior: "contain",
                   padding: 4,
                   display: "grid",
                   gap: 2,

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -46,6 +46,70 @@ const PROJECT_PROPOSAL_COMMAND = {
   description: "Draft a Project Assistant proposal",
   inputHint: "request",
 };
+const HECATE_MESSAGE_COMMANDS: Record<
+  HecateMessageCommandName,
+  { description: string; inputHint?: string }
+> = {
+  proposal: PROJECT_PROPOSAL_COMMAND,
+  plan: {
+    description: "Draft a Project Assistant plan",
+    inputHint: "request",
+  },
+  work: {
+    description: "Draft project work from this chat",
+    inputHint: "title or request",
+  },
+  handoff: {
+    description: "Draft a project handoff proposal",
+    inputHint: "role and request",
+  },
+  review: {
+    description: "Draft a project review proposal",
+    inputHint: "target",
+  },
+  diff: {
+    description: "Open workspace changes",
+  },
+  model: {
+    description: "Open chat model controls",
+  },
+  settings: {
+    description: "Open chat settings",
+  },
+  status: {
+    description: "Open chat status details",
+  },
+  task: {
+    description: "Open the active task or Tasks",
+  },
+  project: {
+    description: "Open the linked project",
+  },
+  connections: {
+    description: "Open Connections",
+  },
+};
+const HECATE_PROJECT_COMMAND_NAMES = new Set<string>([
+  "proposal",
+  "plan",
+  "work",
+  "handoff",
+  "review",
+]);
+
+type HecateMessageCommandName =
+  | "proposal"
+  | "plan"
+  | "work"
+  | "handoff"
+  | "review"
+  | "diff"
+  | "model"
+  | "settings"
+  | "status"
+  | "task"
+  | "project"
+  | "connections";
 type ComposerTextareaNumericStyle =
   | "paddingTop"
   | "paddingBottom"
@@ -62,10 +126,11 @@ type HecateProviderOption = {
 };
 
 type MessageCommandSuggestion = {
-  kind: "external_agent" | "project_proposal";
+  kind: "external_agent" | "hecate";
   name: string;
   description?: string;
   inputHint?: string;
+  sourceLabel?: string;
 };
 
 export type ChatComposerProps = {
@@ -112,6 +177,7 @@ export type ChatComposerProps = {
   activeQueuedChatMessages: QueuedChatMessage[];
   projectProposalAvailable?: boolean;
   projectProposalDrafting?: boolean;
+  workspaceChangesAvailable?: boolean;
 
   // User-message history feeds the arrow-key recall, derived in
   // ChatView from visibleMessages.
@@ -122,6 +188,9 @@ export type ChatComposerProps = {
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
   onDraftProjectProposal?: (request?: string) => void;
+  onOpenWorkspaceChanges?: () => void;
+  onOpenChatSettings?: () => void;
+  onOpenLinkedProject?: () => void;
 };
 
 export function ChatComposer(props: ChatComposerProps) {
@@ -189,11 +258,15 @@ export function ChatComposer(props: ChatComposerProps) {
     activeQueuedChatMessages,
     projectProposalAvailable = false,
     projectProposalDrafting = false,
+    workspaceChangesAvailable = false,
     messageHistory,
     onNavigate,
     onOpenTask,
     onOpenTrace,
     onDraftProjectProposal,
+    onOpenWorkspaceChanges,
+    onOpenChatSettings,
+    onOpenLinkedProject,
   } = props;
   const activeExternalAgentID =
     activeChatSession?.agent_id && activeChatSession.agent_id !== "hecate"
@@ -253,8 +326,25 @@ export function ChatComposer(props: ChatComposerProps) {
     const query = commandQuery.toLowerCase();
     const suggestions: MessageCommandSuggestion[] = [];
 
-    if (projectProposalAvailable && PROJECT_PROPOSAL_COMMAND.name.startsWith(query)) {
-      suggestions.push({ ...PROJECT_PROPOSAL_COMMAND, kind: "project_proposal" });
+    if (isHecateChat) {
+      for (const command of availableHecateMessageCommands({
+        projectProposalAvailable:
+          projectProposalAvailable && !projectProposalDrafting && Boolean(onDraftProjectProposal),
+        workspaceChangesAvailable: workspaceChangesAvailable && Boolean(onOpenWorkspaceChanges),
+        chatSettingsAvailable: Boolean(onOpenChatSettings),
+        taskAvailable: Boolean(onOpenTask && activeHecateTaskID) || Boolean(onNavigate),
+        projectAvailable: Boolean(onOpenLinkedProject),
+        connectionsAvailable: Boolean(onNavigate),
+      })) {
+        if (!command.name.startsWith(query)) continue;
+        suggestions.push({
+          kind: "hecate",
+          name: command.name,
+          description: command.description,
+          inputHint: command.inputHint,
+          sourceLabel: "Hecate",
+        });
+      }
     }
 
     if (isExternalAgentChat) {
@@ -266,6 +356,7 @@ export function ChatComposer(props: ChatComposerProps) {
             name: externalAgentCommandName(command),
             description: command.description,
             inputHint: command.input_hint,
+            sourceLabel: selectedActiveAgent?.name || "Agent",
           }))
           .filter((command) => command.name !== "")
           .filter((command) => command.name.toLowerCase().startsWith(query)),
@@ -275,9 +366,20 @@ export function ChatComposer(props: ChatComposerProps) {
     return suggestions;
   }, [
     activeChatSession?.available_commands,
+    activeHecateTaskID,
     commandQuery,
     isExternalAgentChat,
+    isHecateChat,
+    onDraftProjectProposal,
+    onNavigate,
+    onOpenChatSettings,
+    onOpenLinkedProject,
+    onOpenTask,
+    onOpenWorkspaceChanges,
     projectProposalAvailable,
+    projectProposalDrafting,
+    selectedActiveAgent?.name,
+    workspaceChangesAvailable,
   ]);
   const commandPickerVisible =
     composerVisible && !commandPickerDismissed && commandSuggestions.length > 0;
@@ -430,14 +532,10 @@ export function ChatComposer(props: ChatComposerProps) {
   }
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    const proposalRequest = projectProposalCommandRequest(message);
-    if (proposalRequest !== null && projectProposalAvailable && onDraftProjectProposal) {
+    const hecateCommand = parseHecateMessageCommand(message);
+    if (hecateCommand && isHecateChat && hecateCommandDefinition(hecateCommand.name)) {
       e.preventDefault();
-      if (!proposalRequest) {
-        settingsActions.setNoticeMessage("error", "Add a request after /proposal.");
-        return;
-      }
-      onDraftProjectProposal(proposalRequest);
+      handleHecateMessageCommand(hecateCommand);
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
@@ -446,6 +544,81 @@ export function ChatComposer(props: ChatComposerProps) {
     void chatActions.submitChat(e);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
+    }
+  }
+
+  function clearLocalCommandMessage() {
+    messageHistoryCursorRef.current = null;
+    messageHistoryPendingTextRef.current = "";
+    runtime.actions.setMessage("");
+  }
+
+  function handleHecateMessageCommand(command: ParsedHecateMessageCommand) {
+    const name = command.name;
+    if (HECATE_PROJECT_COMMAND_NAMES.has(name)) {
+      if (!projectProposalAvailable || projectProposalDrafting || !onDraftProjectProposal) {
+        settingsActions.setNoticeMessage(
+          "error",
+          "This command needs an idle Hecate chat linked to a project.",
+        );
+        return;
+      }
+      if (!command.args) {
+        settingsActions.setNoticeMessage("error", `Add a request after /${name}.`);
+        return;
+      }
+      onDraftProjectProposal(projectAssistantRequestForHecateCommand(name, command.args));
+      return;
+    }
+
+    switch (name) {
+      case "diff":
+        if (!workspaceChangesAvailable || !onOpenWorkspaceChanges) {
+          settingsActions.setNoticeMessage("error", "Choose a workspace before using /diff.");
+          return;
+        }
+        onOpenWorkspaceChanges();
+        clearLocalCommandMessage();
+        return;
+      case "model":
+      case "settings":
+      case "status":
+        if (!onOpenChatSettings) {
+          settingsActions.setNoticeMessage("error", "Chat settings are not available here.");
+          return;
+        }
+        onOpenChatSettings();
+        clearLocalCommandMessage();
+        return;
+      case "task":
+        if (activeHecateTaskID && onOpenTask) {
+          onOpenTask(activeHecateTaskID, activeHecateRunID);
+          clearLocalCommandMessage();
+          return;
+        }
+        if (onNavigate) {
+          onNavigate("runs");
+          clearLocalCommandMessage();
+          return;
+        }
+        settingsActions.setNoticeMessage("error", "Tasks are not available here.");
+        return;
+      case "project":
+        if (!onOpenLinkedProject) {
+          settingsActions.setNoticeMessage("error", "This command needs a linked project chat.");
+          return;
+        }
+        onOpenLinkedProject();
+        clearLocalCommandMessage();
+        return;
+      case "connections":
+        if (!onNavigate) {
+          settingsActions.setNoticeMessage("error", "Connections are not available here.");
+          return;
+        }
+        onNavigate("connections");
+        clearLocalCommandMessage();
+        return;
     }
   }
 
@@ -707,7 +880,7 @@ export function ChatComposer(props: ChatComposerProps) {
                         color: "var(--t0)",
                         cursor: "pointer",
                         display: "grid",
-                        gridTemplateColumns: "minmax(84px, auto) minmax(0, 1fr)",
+                        gridTemplateColumns: "minmax(84px, auto) minmax(0, 1fr) auto",
                         alignItems: "center",
                         gap: 10,
                         padding: "7px 8px",
@@ -739,6 +912,23 @@ export function ChatComposer(props: ChatComposerProps) {
                       >
                         {messageCommandDetail(command)}
                       </span>
+                      {command.sourceLabel && (
+                        <span
+                          style={{
+                            color: "var(--t3)",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 10,
+                            textTransform: "uppercase",
+                            letterSpacing: "0.06em",
+                            minWidth: 0,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {command.sourceLabel}
+                        </span>
+                      )}
                     </div>
                   );
                 })}
@@ -1030,6 +1220,41 @@ function externalAgentCommandName(command: ChatAvailableCommandRecord) {
   return command.name.trim().replace(/^\/+/, "");
 }
 
+type HecateMessageCommandAvailability = {
+  projectProposalAvailable: boolean;
+  workspaceChangesAvailable: boolean;
+  chatSettingsAvailable: boolean;
+  taskAvailable: boolean;
+  projectAvailable: boolean;
+  connectionsAvailable: boolean;
+};
+
+function availableHecateMessageCommands(availability: HecateMessageCommandAvailability) {
+  const out: Array<{ name: HecateMessageCommandName; description: string; inputHint?: string }> =
+    [];
+  const push = (name: HecateMessageCommandName) =>
+    out.push({ name, ...HECATE_MESSAGE_COMMANDS[name] });
+
+  if (availability.projectProposalAvailable) {
+    push("proposal");
+    push("plan");
+    push("work");
+    push("handoff");
+    push("review");
+  }
+  if (availability.workspaceChangesAvailable) push("diff");
+  if (availability.chatSettingsAvailable) {
+    push("model");
+    push("settings");
+    push("status");
+  }
+  if (availability.taskAvailable) push("task");
+  if (availability.projectAvailable) push("project");
+  if (availability.connectionsAvailable) push("connections");
+
+  return out;
+}
+
 function messageCommandInsertion(command: MessageCommandSuggestion) {
   const name = command.name;
   return name ? `/${name} ` : "";
@@ -1041,11 +1266,36 @@ function messageCommandDetail(command: MessageCommandSuggestion) {
   return command.inputHint?.trim() ?? "";
 }
 
-function projectProposalCommandRequest(message: string): string | null {
+type ParsedHecateMessageCommand = {
+  name: string;
+  args: string;
+};
+
+function parseHecateMessageCommand(message: string): ParsedHecateMessageCommand | null {
   if (!message.startsWith("/")) return null;
-  const match = message.match(/^\/proposal(?:\s+([\s\S]*))?$/i);
+  const match = message.match(/^\/([A-Za-z][\w-]*)(?:\s+([\s\S]*))?$/);
   if (!match) return null;
-  return (match[1] ?? "").trim();
+  return {
+    name: match[1].toLowerCase(),
+    args: (match[2] ?? "").trim(),
+  };
+}
+
+function hecateCommandDefinition(name: string) {
+  return HECATE_MESSAGE_COMMANDS[name as HecateMessageCommandName];
+}
+
+function projectAssistantRequestForHecateCommand(name: string, request: string) {
+  switch (name) {
+    case "work":
+      return `Create project work from this chat request:\n\n${request}`;
+    case "handoff":
+      return `Draft a project handoff from this chat request:\n\n${request}`;
+    case "review":
+      return `Draft a project review request from this chat request:\n\n${request}`;
+    default:
+      return request;
+  }
 }
 
 export function ChatErrorPanel({

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3041,6 +3041,36 @@ describe("ChatView input", () => {
     expect(within(commands).queryByRole("option", { name: "Insert /plan command" })).toBeNull();
   });
 
+  it("renders every matching external-agent slash command in a scrollable picker", () => {
+    const availableCommands = Array.from({ length: 9 }, (_, index) => ({
+      name: `cmd${index + 1}`,
+      description: `Command ${index + 1}`,
+    }));
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      message: "/",
+      activeChatSession: {
+        id: "chat_commands",
+        title: "Agent commands",
+        agent_id: "claude_code",
+        driver_kind: "acp",
+        execution_mode: "external_agent",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: availableCommands,
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
+    expect(within(commands).getAllByRole("option")).toHaveLength(availableCommands.length);
+    expect(within(commands).getByRole("option", { name: "Insert /cmd9 command" })).toBeTruthy();
+    expect(commands).toHaveStyle({ overflowY: "auto" });
+    expect(commands.getAttribute("style")).toContain("max-height:");
+  });
+
   it("dismisses external-agent slash command suggestions with Escape", () => {
     const { state, actions } = setup({
       chatTarget: "external_agent",

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3147,7 +3147,7 @@ describe("ChatView input", () => {
     expect(submitChat).not.toHaveBeenCalled();
   });
 
-  it("does not show slash command suggestions for Hecate Chat", () => {
+  it("suggests Hecate utility slash commands for Hecate Chat", () => {
     const { state, actions } = setup({
       chatTarget: "agent",
       defaultChatToolsEnabled: false,
@@ -3163,9 +3163,18 @@ describe("ChatView input", () => {
         messages: [],
       },
     });
-    render(withRuntimeConsole(<ChatView />, { state, actions }));
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
 
-    expect(screen.queryByRole("listbox", { name: "Message commands" })).toBeNull();
+    const commands = screen.getByRole("listbox", { name: "Message commands" });
+    expect(within(commands).getByRole("option", { name: "Insert /diff command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /model command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /settings command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /status command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /task command" })).toBeTruthy();
+    expect(
+      within(commands).getByRole("option", { name: "Insert /connections command" }),
+    ).toBeTruthy();
+    expect(within(commands).queryByRole("option", { name: "Insert /proposal command" })).toBeNull();
   });
 
   it("suggests the project proposal slash command for project-linked Hecate chats", async () => {
@@ -3272,6 +3281,217 @@ describe("ChatView input", () => {
       source_session_id: "s1",
       proposal: { id: "pa_chat" },
     });
+  });
+
+  it("drafts a Project Assistant proposal with /plan without sending chat", async () => {
+    const selectProject = vi.fn(async () => undefined);
+    const submitChat = vi.fn(async () => undefined);
+    const onNavigate = vi.fn();
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/plan Split the project assistant work",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          project_id: "proj_1",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { selectProject, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(draftChatProjectAssistant).toHaveBeenCalledWith("s1", {
+        request: "Split the project assistant work",
+      });
+    });
+    expect(submitChat).not.toHaveBeenCalled();
+    expect(selectProject).toHaveBeenCalledWith("proj_1");
+    expect(onNavigate).toHaveBeenCalledWith("projects");
+  });
+
+  it("routes /work through the Project Assistant proposal boundary", async () => {
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/work Add a nightly maintenance check",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          project_id: "proj_1",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(draftChatProjectAssistant).toHaveBeenCalledWith("s1", {
+        request: "Create project work from this chat request:\n\nAdd a nightly maintenance check",
+      });
+    });
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("opens workspace changes with /diff without sending chat", () => {
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/diff",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(screen.getByLabelText("Workspace changes panel")).toBeTruthy();
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("opens chat settings with /model without sending chat", () => {
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/model",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(screen.getByLabelText("Chat settings panel")).toBeTruthy();
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("opens the active Hecate task with /task", () => {
+    const onOpenTask = vi.fn();
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: true,
+        message: "/task",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "running",
+          workspace: "/tmp/hecate",
+          segments: [
+            {
+              id: "task:task_1",
+              turn_kind: "hecate_task",
+              execution_mode: "hecate_task",
+              task_id: "task_1",
+              latest_run_id: "run_1",
+              status: "running",
+              message_count: 1,
+            },
+          ],
+          messages: [],
+        },
+      },
+      { setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(onOpenTask).toHaveBeenCalledWith("task_1", "run_1");
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("submits external-agent slash commands as ordinary prompt text", () => {
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        agentAdapterID: "claude_code",
+        message: "/plan keep this in Claude",
+        activeChatSession: {
+          id: "chat_commands",
+          title: "Agent commands",
+          agent_id: "claude_code",
+          driver_kind: "acp",
+          execution_mode: "external_agent",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          available_commands: [{ name: "plan", description: "Create a plan" }],
+          messages: [],
+        },
+      },
+      { submitChat },
+    );
+    render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(submitChat).toHaveBeenCalled();
+    expect(draftChatProjectAssistant).not.toHaveBeenCalled();
   });
 
   it("requires text after the /proposal command", () => {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3071,6 +3071,63 @@ describe("ChatView input", () => {
     expect(commands.getAttribute("style")).toContain("max-height:");
   });
 
+  it("scrolls the active slash command into view during keyboard navigation", () => {
+    const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollIntoView",
+    );
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    try {
+      const availableCommands = Array.from({ length: 9 }, (_, index) => ({
+        name: `cmd${index + 1}`,
+        description: `Command ${index + 1}`,
+      }));
+      const { state, actions } = setup({
+        chatTarget: "external_agent",
+        agentAdapterID: "claude_code",
+        message: "/",
+        activeChatSession: {
+          id: "chat_commands",
+          title: "Agent commands",
+          agent_id: "claude_code",
+          driver_kind: "acp",
+          execution_mode: "external_agent",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          available_commands: availableCommands,
+          messages: [],
+        },
+      });
+      render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+      const textarea = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+      const commands = screen.getByRole("listbox", { name: "Message commands" });
+      scrollIntoView.mockClear();
+
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+
+      expect(within(commands).getByRole("option", { selected: true })).toHaveAttribute(
+        "aria-label",
+        "Insert /cmd2 command",
+      );
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    } finally {
+      if (originalScrollIntoViewDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollIntoView",
+          originalScrollIntoViewDescriptor,
+        );
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollIntoView;
+      }
+    }
+  });
+
   it("dismisses external-agent slash command suggestions with Escape", () => {
     const { state, actions } = setup({
       chatTarget: "external_agent",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -537,6 +537,8 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     Boolean(activeSessionProjectID) &&
     Boolean(onNavigate) &&
     Boolean(state.message.trim());
+  const composerWorkspaceChangesAvailable =
+    selectedChatReady && isAgentChat && Boolean(activeWorkspacePath.trim());
 
   function openAgentSetup(adapterID = activeAgentAdapterID) {
     try {
@@ -1032,11 +1034,23 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                 activeQueuedChatMessages={activeQueuedChatMessages}
                 projectProposalAvailable={projectProposalAvailable}
                 projectProposalDrafting={projectProposalDrafting}
+                workspaceChangesAvailable={composerWorkspaceChangesAvailable}
                 messageHistory={messageHistory}
                 onDraftProjectProposal={(request) => void draftProjectProposalFromChat(request)}
                 onNavigate={onNavigate}
                 onOpenTask={onOpenTask}
                 onOpenTrace={onOpenTrace}
+                onOpenWorkspaceChanges={() => {
+                  setChatSettingsOpen(false);
+                  setWorkspaceChangesOpen(true);
+                }}
+                onOpenChatSettings={() => {
+                  setWorkspaceChangesOpen(false);
+                  setChatSettingsOpen(true);
+                }}
+                onOpenLinkedProject={
+                  activeSessionProjectID && onNavigate ? () => openLinkedProject() : undefined
+                }
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- Remove the six-item cap from the chat slash-command picker and keep the menu scrollable.
- Add Hecate-owned chat commands for Project Assistant proposals and local navigation: /proposal, /plan, /work, /handoff, /review, /diff, /model, /settings, /status, /task, /project, and /connections.
- Keep External Agent slash commands agent-owned: selecting them inserts prompt text, and submitting them still goes through the agent instead of Hecate local command dispatch.
- Update runtime docs and UI agent guidance for the Hecate-owned command boundary.

## Tests
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx
- cd ui && bun run test
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- just docs-format-check
- git diff --check