### PR TITLE
Improve project setup follow-through

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -258,6 +258,11 @@ Projects with no work items use setup as their primary onboarding action before
 showing the full work cockpit.
 The resulting proposal is still review/apply gated and does not attach to the
 currently selected work item.
+After a successful setup apply, the Projects UI keeps the apply result visible
+with explicit follow-up actions such as reviewing memory candidates, reviewing
+roles, opening the work queue, or creating the first work item. These actions
+only navigate or open the normal operator-controlled editors; they do not
+auto-promote memory, auto-start assignments, or bypass proposal review.
 
 `draft_mode: "model"` asks the configured gateway model to author the proposal
 from the same context packet. The request may provide `model` and `provider`;
@@ -523,7 +528,8 @@ deterministic Project Assistant draft path only; durable mutations must still
 stop at the explicit Projects review/apply card.
 Applying a proposal always calls `/project-assistant/apply` with `confirm: true`
 after the operator reviews the action rows. A successful apply refreshes the
-project list, project work, selected work-item detail, and project memory.
+project list, project work, selected work-item detail, and project memory, then
+the UI can offer next-step navigation into the refreshed project state.
 `404 not_found` and `409 conflict` apply responses are treated as stale review
 state: refresh the current work view and draft a fresh proposal instead of
 retrying blindly.

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectRecord } from "../../types/project";
+import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
+
+function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    id: "proj_1",
+    name: "Hecate",
+    roots: [],
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderAssistantPanel(
+  overrides: Partial<Parameters<typeof ProjectAssistantPanel>[0]> = {},
+) {
+  const handlers = {
+    onApply: vi.fn(),
+    onBootstrap: vi.fn(),
+    onCreateWork: vi.fn(),
+    onDismiss: vi.fn(),
+    onInspectContext: vi.fn(),
+    onManageRoles: vi.fn(),
+    onOpenWork: vi.fn(),
+    onPropose: vi.fn(),
+    onReviewMemory: vi.fn(),
+  };
+
+  render(
+    <ProjectAssistantPanel
+      applyResult={null}
+      bootstrapPending={false}
+      context={null}
+      contextError=""
+      contextStatus="idle"
+      error=""
+      project={project()}
+      proposal={null}
+      roles={[]}
+      status="idle"
+      workItem={null}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+
+  return handlers;
+}
+
+describe("ProjectAssistantPanel", () => {
+  it("turns applied setup proposals into follow-up actions", async () => {
+    const user = userEvent.setup();
+    const handlers = renderAssistantPanel({
+      applyResult: {
+        proposal_id: "pa_setup",
+        applied: true,
+        actions: [{ kind: "create_memory_candidate" }, { kind: "create_role" }],
+      },
+      memoryCandidateCount: 1,
+      roleCount: 2,
+      setupFirst: true,
+      setupStarted: true,
+      status: "applied",
+      workItemCount: 0,
+    });
+
+    const assistant = screen.getByRole("region", { name: "Project Assistant" });
+    const result = within(assistant).getByRole("status", {
+      name: "Project Assistant apply result",
+    });
+    expect(within(result).getByText("Applied 2 actions")).toBeTruthy();
+    expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
+
+    await user.click(within(result).getByRole("button", { name: "Review memory" }));
+    await user.click(within(result).getByRole("button", { name: "Review roles" }));
+    await user.click(within(result).getByRole("button", { name: "Create first work" }));
+
+    expect(handlers.onReviewMemory).toHaveBeenCalledTimes(1);
+    expect(handlers.onManageRoles).toHaveBeenCalledTimes(1);
+    expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes applied work proposals back to the work queue", async () => {
+    const user = userEvent.setup();
+    const handlers = renderAssistantPanel({
+      applyResult: {
+        proposal_id: "pa_assignment",
+        applied: true,
+        actions: [{ kind: "create_assignment" }],
+      },
+      status: "applied",
+      workItemCount: 1,
+    });
+
+    const result = screen.getByRole("status", { name: "Project Assistant apply result" });
+    expect(within(result).queryByRole("button", { name: "Create first work" })).toBeNull();
+
+    await user.click(within(result).getByRole("button", { name: "Open work queue" }));
+
+    expect(handlers.onOpenWork).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -32,18 +32,25 @@ type Props = {
   error: string;
   onApply: () => void;
   onBootstrap: () => void;
+  onCreateWork?: () => void;
   onDismiss: () => void;
   onInspectContext: (form: ProjectAssistantDraftForm) => void;
+  onManageRoles?: () => void;
+  onOpenWork?: () => void;
   onOpenSourceChat?: () => void;
   onPropose: (form: ProjectAssistantDraftForm) => void;
+  onReviewMemory?: () => void;
   project: ProjectRecord | null;
   proposal: ProjectAssistantProposal | null;
   roles: ProjectWorkRoleRecord[];
   bootstrapPending: boolean;
+  memoryCandidateCount?: number;
+  roleCount?: number;
   setupStarted?: boolean;
   setupFirst?: boolean;
   status: ProjectAssistantStatus;
   workItem: ProjectWorkItemRecord | null;
+  workItemCount?: number;
 };
 
 export type ProjectAssistantChatDraftSource = {
@@ -61,18 +68,25 @@ export function ProjectAssistantPanel({
   error,
   onApply,
   onBootstrap,
+  onCreateWork,
   onDismiss,
   onInspectContext,
+  onManageRoles,
+  onOpenWork,
   onOpenSourceChat,
   onPropose,
+  onReviewMemory,
   project,
   proposal,
   roles,
   bootstrapPending,
+  memoryCandidateCount = 0,
+  roleCount = roles.length,
   setupStarted = false,
   setupFirst = false,
   status,
   workItem,
+  workItemCount = workItem ? 1 : 0,
 }: Props) {
   const [form, setForm] = useState<ProjectAssistantDraftForm>(() =>
     projectAssistantDraftForm(project, workItem, roles),
@@ -336,15 +350,78 @@ export function ProjectAssistantPanel({
         </div>
       )}
       {applyResult && (
-        <div style={assistantResultStyle} role="status">
-          <span className="badge badge-green">applied</span>
-          <span>
-            Applied {applyResult.actions.length} action
-            {applyResult.actions.length === 1 ? "" : "s"} from {applyResult.proposal_id}.
-          </span>
-        </div>
+        <ProjectAssistantApplyResultPanel
+          result={applyResult}
+          memoryCandidateCount={memoryCandidateCount}
+          onCreateWork={onCreateWork}
+          onManageRoles={onManageRoles}
+          onOpenWork={onOpenWork}
+          onReviewMemory={onReviewMemory}
+          roleCount={roleCount}
+          workItemCount={workItemCount}
+        />
       )}
     </section>
+  );
+}
+
+function ProjectAssistantApplyResultPanel({
+  memoryCandidateCount,
+  onCreateWork,
+  onManageRoles,
+  onOpenWork,
+  onReviewMemory,
+  result,
+  roleCount,
+  workItemCount,
+}: {
+  memoryCandidateCount: number;
+  onCreateWork?: () => void;
+  onManageRoles?: () => void;
+  onOpenWork?: () => void;
+  onReviewMemory?: () => void;
+  result: ProjectAssistantApplyResult;
+  roleCount: number;
+  workItemCount: number;
+}) {
+  const resultActions = projectAssistantFollowUpActions({
+    memoryCandidateCount,
+    onCreateWork,
+    onManageRoles,
+    onOpenWork,
+    onReviewMemory,
+    result,
+    roleCount,
+    workItemCount,
+  });
+
+  return (
+    <div style={assistantResultStyle} role="status" aria-label="Project Assistant apply result">
+      <div style={assistantResultSummaryStyle}>
+        <span className="badge badge-green">applied</span>
+        <div style={assistantResultCopyStyle}>
+          <strong style={{ color: "var(--t1)" }}>
+            Applied {result.actions.length} action{result.actions.length === 1 ? "" : "s"}
+          </strong>
+          <span style={subtleTextStyle}>Proposal {result.proposal_id} is applied.</span>
+        </div>
+      </div>
+      {resultActions.length > 0 && (
+        <div style={assistantResultActionsStyle} aria-label="Project Assistant next steps">
+          {resultActions.map((action) => (
+            <button
+              key={action.key}
+              className={`btn ${action.primary ? "btn-primary" : "btn-ghost"} btn-sm`}
+              type="button"
+              onClick={action.onClick}
+            >
+              <Icon d={action.icon} size={13} />
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -583,6 +660,77 @@ function projectAssistantActionLabel(kind: string): string {
     default:
       return kind.replace(/_/g, " ");
   }
+}
+
+function projectAssistantFollowUpActions({
+  memoryCandidateCount,
+  onCreateWork,
+  onManageRoles,
+  onOpenWork,
+  onReviewMemory,
+  result,
+  roleCount,
+  workItemCount,
+}: {
+  memoryCandidateCount: number;
+  onCreateWork?: () => void;
+  onManageRoles?: () => void;
+  onOpenWork?: () => void;
+  onReviewMemory?: () => void;
+  result: ProjectAssistantApplyResult;
+  roleCount: number;
+  workItemCount: number;
+}): Array<{
+  icon: string | string[];
+  key: string;
+  label: string;
+  onClick: () => void;
+  primary?: boolean;
+}> {
+  const appliedKinds = new Set(result.actions.map((action) => action.kind));
+  const actions: Array<{
+    icon: string | string[];
+    key: string;
+    label: string;
+    onClick: () => void;
+    primary?: boolean;
+  }> = [];
+
+  if ((memoryCandidateCount > 0 || appliedKinds.has("create_memory_candidate")) && onReviewMemory) {
+    actions.push({
+      icon: Icons.observe,
+      key: "review-memory",
+      label: "Review memory",
+      onClick: onReviewMemory,
+    });
+  }
+  if ((roleCount > 0 || appliedKinds.has("create_role")) && onManageRoles) {
+    actions.push({
+      icon: Icons.user,
+      key: "review-roles",
+      label: "Review roles",
+      onClick: onManageRoles,
+    });
+  }
+  if (workItemCount === 0 && !appliedKinds.has("create_work_item") && onCreateWork) {
+    actions.push({
+      icon: Icons.plus,
+      key: "create-work",
+      label: "Create first work",
+      onClick: onCreateWork,
+      primary: true,
+    });
+  } else if (onOpenWork) {
+    actions.push({
+      icon: Icons.tasks,
+      key: "open-work",
+      label: "Open work queue",
+      onClick: onOpenWork,
+      primary: actions.length === 0,
+    });
+  }
+
+  return actions;
 }
 
 function formatAssistantValue(value: unknown): string {
@@ -905,16 +1053,37 @@ const assistantProposalActionsStyle: CSSProperties = {
 };
 
 const assistantResultStyle: CSSProperties = {
-  alignItems: "center",
   background: "var(--green-bg)",
   border: "1px solid var(--green-border)",
   borderRadius: "var(--radius-sm)",
-  color: "var(--green)",
+  display: "grid",
+  gap: 9,
+  minWidth: 0,
+  padding: "9px 10px",
+};
+
+const assistantResultSummaryStyle: CSSProperties = {
+  alignItems: "center",
   display: "flex",
   flexWrap: "wrap",
-  fontSize: 12,
   gap: 8,
-  padding: "8px 9px",
+  minWidth: 0,
+};
+
+const assistantResultCopyStyle: CSSProperties = {
+  display: "grid",
+  flex: "1 1 220px",
+  fontSize: 12,
+  gap: 2,
+  minWidth: 0,
+};
+
+const assistantResultActionsStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "flex-start",
+  minWidth: 0,
 };
 
 const domainHeaderStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -268,8 +268,11 @@ export function ProjectWorkspaceView({
                   error={assistant.error}
                   onApply={() => void assistant.apply()}
                   onBootstrap={() => void assistant.bootstrap()}
+                  onCreateWork={onCreateWork}
                   onInspectContext={(form) => void assistant.inspectContext(form)}
                   onDismiss={assistant.dismiss}
+                  onManageRoles={onManageRoles}
+                  onOpenWork={() => onWorkspaceTabChange("work")}
                   onOpenSourceChat={
                     assistant.chatDraftSource?.sourceSessionID && onOpenChat
                       ? () =>
@@ -280,13 +283,17 @@ export function ProjectWorkspaceView({
                       : undefined
                   }
                   onPropose={(form) => void assistant.propose(form)}
+                  onReviewMemory={() => onWorkspaceTabChange("memory")}
                   project={project}
                   proposal={assistant.proposal}
                   roles={roles}
+                  memoryCandidateCount={memoryCandidates.length}
+                  roleCount={roles.length}
                   setupFirst={projectSetupFirst}
                   setupStarted={projectSetupStarted}
                   status={assistant.status}
                   workItem={selectedWorkItem}
+                  workItemCount={workItems.length}
                 />
                 <ProjectWorkspaceTabs
                   activeTab={workspaceTab}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1420,7 +1420,8 @@ describe("ProjectsView cockpit", () => {
         confirm: true,
       });
     });
-    expect(await within(assistant).findByText("Applied 1 action from pa_test.")).toBeTruthy();
+    expect(await within(assistant).findByText("Applied 1 action")).toBeTruthy();
+    expect(within(assistant).getByText("Proposal pa_test is applied.")).toBeTruthy();
     expect(getProjectWorkItems).toHaveBeenLastCalledWith(project.id);
     expect(getProjectAssignments).toHaveBeenLastCalledWith(project.id, workItem.id);
   });


### PR DESCRIPTION
## Summary

- Replace the Project Assistant post-apply dead-end with explicit next-step actions for memory review, role review, work queue navigation, and first-work creation.
- Thread the workspace navigation callbacks into the assistant panel without changing the Project Assistant API or store model.
- Document the post-apply follow-through contract and add focused UI coverage.

## Validation

- bun run typecheck
- bun run lint
- bun run format:check
- bun run test
- just agent-docs-check