### PR TITLE
Include project roots in Hecate Chat prelude

### DIFF
--- a/docs/runtime/agent-runtime.md
+++ b/docs/runtime/agent-runtime.md
@@ -20,13 +20,15 @@ Providers without streaming fall back to the normal non-streaming chat call.
 
 When a Hecate Chat session is linked to a project, Hecate keeps the Chat UI
 simple and injects project workflow guidance into the effective system prompt
-for project-linked turns. The prompt uses the same project, role, skill,
-active-work, and accepted-memory vocabulary as project assignment launch
-context, and tells the model to treat planning/assignment/handoff/memory
-requests as proposal-only Project Assistant intent. Skill entries are metadata
-only; `SKILL.md` bodies are not injected by the simple chat path. The guidance
-does not grant Chat or the agent loop direct authority to create/start project
-records, tasks, runs, chats, external-agent sessions, or promoted memory.
+for project-linked Hecate-owned turns. The prompt includes bounded project-root
+metadata plus role, skill, active-work, and accepted-memory vocabulary, and
+tells the model to treat planning/assignment/handoff/memory requests as
+proposal-only Project Assistant intent. Project roots and skill entries are
+metadata only; root files and `SKILL.md` bodies are not injected by the simple
+chat path. The guidance does not grant Chat or the agent loop direct authority
+to create/start project records, tasks, runs, chats, external-agent sessions,
+or promoted memory. External Agent sessions linked to a project keep their
+agent-owned prompt and receive no Hecate project workflow prompt layer.
 
 **Invariant: one chat, many segments, one active task-backed loop.** A single
 Hecate Chat session can carry an arbitrary history of segments — alternating

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -127,6 +127,13 @@ commands and they do not run when submitted to an External Agent chat. Project
 commands draft Project Assistant proposals; navigation commands open Hecate UI
 surfaces without sending a chat message.
 
+Project-linked Hecate Chat also receives a bounded Hecate-owned prompt prelude
+with project-root metadata, role hints, enabled skill metadata, active work,
+and accepted project memory excerpts. Roots and skills are metadata only: the
+chat path does not read root files or inject `SKILL.md` bodies. External Agent
+sessions may share the same project filter and sidebar scope, but their prompt
+packing remains agent-owned and does not receive this Hecate prelude.
+
 | Command               | Available when                          | Behavior                                                                    |
 | --------------------- | --------------------------------------- | --------------------------------------------------------------------------- |
 | `/proposal <request>` | Hecate Chat is linked to a project      | Drafts a Project Assistant proposal from the request.                       |

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -175,9 +176,26 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	workspace := t.TempDir()
 
 	project, err := apiHandler.projects.Create(context.Background(), projects.Project{
-		ID:          "proj_hecate",
-		Name:        "Hecate",
-		Description: "Local AI operations console.",
+		ID:            "proj_hecate",
+		Name:          "Hecate",
+		Description:   "Local AI operations console.",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{
+			{
+				ID:        "root_main",
+				Path:      workspace,
+				Kind:      "git",
+				GitRemote: "git@github.com:hecatehq/hecate.git",
+				GitBranch: "main",
+				Active:    true,
+			},
+			{
+				ID:     "root_archive",
+				Path:   filepath.Join(workspace, "archive"),
+				Kind:   "local",
+				Active: false,
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Create project: %v", err)
@@ -276,6 +294,9 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 		"Project Assistant is a proposal author only.",
 		"Do not create or start chats, tasks, runs, external-agent sessions, promoted memory, or durable project records through generic tools or direct API calls.",
 		"Assignments proposed from chat must stay queued and unstarted.",
+		"Project roots (metadata only; files are not read):",
+		"- Root " + workspace + " (root_main): active=true, default=true, kind=git, branch=main, remote=git@github.com:hecatehq/hecate.git",
+		"- Root " + filepath.Join(workspace, "archive") + " (root_archive): active=false, kind=local",
 		"Role hints:",
 		"A Project Planner (role_planner): Shapes reviewable project work.",
 		"Project skills (metadata only; skill bodies are not loaded):",
@@ -300,6 +321,28 @@ func TestHecateAgentChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 		if strings.Contains(backingTask.SystemPrompt, excluded) {
 			t.Fatalf("task system_prompt included inactive work %q:\n%s", excluded, backingTask.SystemPrompt)
 		}
+	}
+}
+
+func TestProjectChatWorkflowSystemPromptSkipsExternalAgentSessions(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{name: "openai"}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+
+	project, err := apiHandler.projects.Create(context.Background(), projects.Project{
+		ID:   "proj_external",
+		Name: "External Project",
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	prompt := apiHandler.projectChatWorkflowSystemPrompt(context.Background(), chat.Session{
+		AgentID:   "codex",
+		ProjectID: project.ID,
+	})
+	if prompt != "" {
+		t.Fatalf("external-agent project prompt = %q, want empty", prompt)
 	}
 }
 
@@ -370,6 +413,37 @@ func TestProjectChatPromptHelpersBoundUTF8Text(t *testing.T) {
 	}
 	if remaining != 64-len(section) {
 		t.Fatalf("remaining = %d, want %d", remaining, 64-len(section))
+	}
+}
+
+func TestProjectChatRootHintsBoundsAndOrdersMetadata(t *testing.T) {
+	text := projectChatRootHints(projects.Project{
+		DefaultRootID: "root_default",
+		Roots: []projects.Root{
+			{ID: "root_zeta", Path: "/tmp/zeta", Kind: "local", Active: true},
+			{ID: "root_inactive", Path: "/tmp/inactive", Kind: "local"},
+			{ID: "root_alpha", Path: "/tmp/alpha", Kind: "git", Active: true},
+			{ID: "root_default", Path: "/tmp/default", Kind: "git_worktree", Active: false, GitBranch: "feature/chat"},
+			{ID: "root_omitted", Path: "/tmp/omitted", Kind: "local"},
+		},
+	})
+
+	for _, want := range []string{
+		"Project roots (metadata only; files are not read):",
+		"- Root /tmp/default (root_default): active=false, default=true, kind=git_worktree, branch=feature/chat",
+		"- 1 additional roots omitted.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("root hints missing %q:\n%s", want, text)
+		}
+	}
+	defaultIndex := strings.Index(text, "root_default")
+	activeIndex := strings.Index(text, "root_zeta")
+	if defaultIndex < 0 || activeIndex < 0 || defaultIndex > activeIndex {
+		t.Fatalf("root hints order = %q, want default root before active roots", text)
+	}
+	if strings.Contains(text, "root_omitted") {
+		t.Fatalf("root hints included omitted root:\n%s", text)
 	}
 }
 

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	projectChatPromptMaxBytes           = 6 * 1024
+	projectChatPromptRootMaxItems       = 4
 	projectChatPromptMemoryMaxItems     = 4
 	projectChatPromptMemoryMaxBytes     = 1024
 	projectChatPromptRoleMaxItems       = 8
@@ -66,12 +67,18 @@ func (h *Handler) hecateChatTaskSystemPrompt(ctx context.Context, session chat.S
 }
 
 func (h *Handler) projectChatWorkflowSystemPrompt(ctx context.Context, session chat.Session) string {
+	if !isHecateChatSession(session) {
+		return ""
+	}
 	project := h.projectSummary(ctx, session.ProjectID)
 	if project == nil {
 		return ""
 	}
 
 	sections := []string{projectChatWorkflowBoundary(*project)}
+	if roots := projectChatRootHints(*project); roots != "" {
+		sections = append(sections, roots)
+	}
 	if roles := h.projectChatRoleHints(ctx, project.ID); roles != "" {
 		sections = append(sections, roles)
 	}
@@ -102,6 +109,51 @@ func projectChatWorkflowBoundary(project projects.Project) string {
 			"- Assignments proposed from chat must stay queued and unstarted. Memory from model or document output should become memory candidates for operator promotion, not promoted memory.",
 		}, "\n"),
 	}, "\n")
+}
+
+func projectChatRootHints(project projects.Project) string {
+	if len(project.Roots) == 0 {
+		return ""
+	}
+	roots := append([]projects.Root(nil), project.Roots...)
+	defaultRootID := strings.TrimSpace(project.DefaultRootID)
+	sort.SliceStable(roots, func(i, j int) bool {
+		leftDefault := defaultRootID != "" && strings.TrimSpace(roots[i].ID) == defaultRootID
+		rightDefault := defaultRootID != "" && strings.TrimSpace(roots[j].ID) == defaultRootID
+		if leftDefault != rightDefault {
+			return leftDefault
+		}
+		if roots[i].Active != roots[j].Active {
+			return roots[i].Active
+		}
+		return false
+	})
+
+	lines := []string{"Project roots (metadata only; files are not read):"}
+	for i, root := range roots {
+		if i >= projectChatPromptRootMaxItems {
+			lines = append(lines, fmt.Sprintf("- %d additional roots omitted.", len(roots)-i))
+			break
+		}
+		label := compactProjectChatField(firstNonEmptyString(strings.TrimSpace(root.Path), "root"))
+		line := "- Root " + labelWithID(label, root.ID)
+		details := []string{"active=" + fmt.Sprint(root.Active)}
+		if defaultRootID != "" && strings.TrimSpace(root.ID) == defaultRootID {
+			details = append(details, "default=true")
+		}
+		if kind := strings.TrimSpace(root.Kind); kind != "" {
+			details = append(details, "kind="+kind)
+		}
+		if branch := compactProjectChatField(root.GitBranch); branch != "" {
+			details = append(details, "branch="+branch)
+		}
+		if remote := compactProjectChatField(root.GitRemote); remote != "" {
+			details = append(details, "remote="+remote)
+		}
+		line += ": " + strings.Join(details, ", ")
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (h *Handler) projectChatRoleHints(ctx context.Context, projectID string) string {
@@ -376,6 +428,15 @@ func projectChatWorkStatusCounts(items []projectwork.WorkItem) string {
 
 func compactProjectChatInline(value string) string {
 	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	return truncateProjectChatInlineValue(value)
+}
+
+func compactProjectChatField(value string) string {
+	value = strings.TrimSpace(value)
+	return truncateProjectChatInlineValue(value)
+}
+
+func truncateProjectChatInlineValue(value string) string {
 	if value == "" {
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Add bounded project-root metadata to the project-linked Hecate Chat prompt prelude.
- Keep the project workflow prompt explicitly scoped to Hecate-owned chat sessions so External Agent sessions keep their agent-owned prompt packing.
- Update runtime/chat docs to describe the metadata-only root/skill boundary and external-agent exclusion.

## Tests

- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestHecateAgentChatProjectSessionInjectsProposalGuidance|TestProjectChatWorkflowSystemPromptSkipsExternalAgentSessions|TestDirectHecateChatProjectSessionInjectsProposalGuidance|TestProjectChatPromptHelpersBoundUTF8Text|TestProjectChatRootHintsBoundsAndOrdersMetadata'
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api
- go vet ./internal/api
- just docs-format-check
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...
- git diff --check
