### PR TITLE
Expose local provider policy in whoami

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3819,6 +3819,11 @@ Hosted runtimes require runtime identity middleware. When
 `HECATE_EMBEDDED_TERMINAL=false`, this route returns `404` and `/whoami` omits
 the `embedded_terminal` capability.
 
+`GET /hecate/v1/whoami` also reports
+`capabilities.local_providers_allowed`. Local mode reports `true`; cloud
+runtime mode reports `false` by default and `true` only when
+`HECATE_CLOUD_ALLOW_LOCAL_PROVIDERS=1` is explicitly set.
+
 ```http
 POST /hecate/v1/terminal/sessions
 Content-Type: application/json

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -601,7 +601,8 @@ func (h *Handler) HandleSession(w http.ResponseWriter, r *http.Request) {
 	item := SessionResponseItem{
 		Role: "operator",
 		Capabilities: SessionCapabilitiesItem{
-			EmbeddedTerminal: h.config.EmbeddedTerminalEnabled(),
+			EmbeddedTerminal:      h.config.EmbeddedTerminalEnabled(),
+			LocalProvidersAllowed: h.config.LocalProvidersAllowed(),
 		},
 	}
 	if identity, ok := cloudruntime.FromContext(r.Context()); ok {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -717,6 +717,9 @@ func TestSessionAdvertisesEmbeddedTerminalCapability(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `"embedded_terminal":true`) {
 		t.Fatalf("local whoami body = %s, want embedded terminal capability", rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), `"local_providers_allowed":true`) {
+		t.Fatalf("local whoami body = %s, want local providers allowed capability", rec.Body.String())
+	}
 
 	handler = NewServer(logger, NewHandler(config.Config{
 		Server: config.ServerConfig{
@@ -737,6 +740,39 @@ func TestSessionAdvertisesEmbeddedTerminalCapability(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"embedded_terminal":true`) {
 		t.Fatalf("cloud whoami body = %s, want embedded terminal capability", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"local_providers_allowed":false`) {
+		t.Fatalf("cloud whoami body = %s, want local providers disabled capability", rec.Body.String())
+	}
+}
+
+func TestSessionAdvertisesLocalProvidersAllowedWhenCloudOptIn(t *testing.T) {
+	t.Parallel()
+
+	const secret = "cloud-runtime-secret-123456"
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{
+		Server: config.ServerConfig{
+			CloudRuntimeMode:         true,
+			CloudRuntimeSecret:       secret,
+			CloudAllowLocalProviders: true,
+		},
+	}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	req.Header.Set(cloudruntime.HeaderRuntimeSecret, secret)
+	req.Header.Set(cloudruntime.HeaderActorID, "actor_1")
+	req.Header.Set(cloudruntime.HeaderOrgID, "org_1")
+	req.Header.Set(cloudruntime.HeaderProjectID, "proj_1")
+	req.Header.Set(cloudruntime.HeaderRuntimeID, "rt_1")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cloud status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"local_providers_allowed":true`) {
+		t.Fatalf("cloud whoami body = %s, want local providers opt-in capability", rec.Body.String())
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -247,7 +247,8 @@ type SessionResponseItem struct {
 }
 
 type SessionCapabilitiesItem struct {
-	EmbeddedTerminal bool `json:"embedded_terminal,omitempty"`
+	EmbeddedTerminal      bool `json:"embedded_terminal,omitempty"`
+	LocalProvidersAllowed bool `json:"local_providers_allowed"`
 }
 
 type CloudIdentityResponseItem struct {


### PR DESCRIPTION
## Summary
- add explicit `capabilities.local_providers_allowed` to `/hecate/v1/whoami`
- report `true` in local mode, `false` by default in cloud runtime mode, and `true` when cloud local providers are explicitly enabled
- document the field in the runtime API docs

## Tests
- `go test ./internal/api`
- `go vet ./internal/api`