### PR TITLE
Fix Hecate chat start and terminal action placement

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -357,20 +357,72 @@ test("New chat creates an external-agent session with controls before the first 
   );
 });
 
-test("New Hecate chat asks for workspace before creating a tools-on session", async ({ page }) => {
+test("New Hecate chat can start without workspace and shows tools workspace guidance", async ({
+  page,
+}) => {
   let createBody: any = null;
+  let messageBody: any = null;
   await page.route("/hecate/v1/chat/sessions", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "chat_sessions", data: [] }),
+      });
+      return;
+    }
     if (route.request().method() === "POST") {
       createBody = JSON.parse(route.request().postData() ?? "{}");
       await route.fulfill({
-        status: 500,
+        status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ error: { type: "unexpected", message: "unexpected create" } }),
+        body: JSON.stringify({
+          object: "chat_session",
+          data: {
+            id: "chat-no-workspace-tools-e2e",
+            title: "Hecate chat",
+            agent_id: "hecate",
+            provider: createBody.provider || "anthropic",
+            model: createBody.model || "claude-sonnet-4-6",
+            capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
+            rtk_enabled: Boolean(createBody.rtk_enabled),
+            tools_enabled: true,
+            status: "idle",
+            messages: [],
+          },
+        }),
       });
       return;
     }
     await route.fallback();
   });
+  await page.route(
+    "/hecate/v1/chat/sessions/chat-no-workspace-tools-e2e/messages",
+    async (route) => {
+      messageBody = await route.request().postDataJSON();
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { type: "unexpected", message: "unexpected message" } }),
+      });
+    },
+  );
+  await page.route("/v1/models*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "list",
+        data: MOCK_MODELS.map((entry) => ({
+          ...entry,
+          metadata: {
+            ...entry.metadata,
+            capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
+          },
+        })),
+      }),
+    }),
+  );
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.removeItem("hecate.project");
@@ -378,12 +430,21 @@ test("New Hecate chat asks for workspace before creating a tools-on session", as
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
 
-  await expect(page.getByRole("button", { name: "New Hecate chat", exact: true })).toBeDisabled();
+  await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
 
+  await expect.poll(() => createBody?.agent_id).toBe("hecate");
+  expect(createBody).not.toHaveProperty("workspace");
+  await expect(page.getByText("Tools on", { exact: true })).toBeVisible();
   await expect(page.getByText("Choose a workspace", { exact: true })).toBeVisible();
-  await expect(page.locator("textarea")).toHaveCount(0);
+  await expect(
+    page.getByText("Hecate uses the workspace as the working directory for this chat."),
+  ).toBeVisible();
+  await expect(page.locator("textarea")).toHaveCount(1);
+  await page.getByRole("textbox", { name: "Message" }).fill("inspect the workspace");
+  await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled();
+  await page.keyboard.press("Enter");
   await expect(page.getByText("Model required")).toHaveCount(0);
-  await expect.poll(() => createBody).toBeNull();
+  await expect.poll(() => messageBody).toBeNull();
 });
 
 test("New external-agent chat asks for workspace without flashing an inline error", async ({

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -66,41 +66,6 @@ html[data-tauri-os="macos"] .hecate-shell {
   flex: 1;
 }
 
-.hecate-shell-terminal {
-  position: absolute;
-  top: 10px;
-  right: 12px;
-  z-index: 1100;
-  width: 34px;
-  height: 34px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  border-radius: 11px;
-  background: color-mix(in srgb, var(--bg1) 92%, transparent);
-  color: var(--t2);
-  box-shadow:
-    0 10px 30px color-mix(in srgb, black 24%, transparent),
-    0 1px 0 color-mix(in srgb, var(--t0) 7%, transparent) inset;
-  cursor: pointer;
-}
-
-.hecate-shell-terminal:hover {
-  color: var(--t0);
-  background: var(--bg2);
-}
-
-.hecate-shell-terminal--active {
-  color: var(--teal);
-  background: var(--teal-bg);
-  border-color: var(--teal-border);
-}
-
-html[data-tauri-os="macos"] .hecate-shell-terminal {
-  top: 34px;
-}
-
 /* Activity bar */
 .hecate-activitybar {
   background: var(--bg1);

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConsoleShell, getAvailableWorkspaces } from "./AppShell";
@@ -253,7 +253,10 @@ describe("ConsoleShell terminal", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open terminal" }));
+    const navigation = screen.getByRole("navigation", { name: "Workspace navigation" });
+    const terminalButton = within(navigation).getByRole("button", { name: "Open terminal" });
+
+    fireEvent.click(terminalButton);
 
     const terminal = screen.getByRole("region", { name: "Embedded terminal" });
     expect(terminal).toHaveAttribute("data-workspace", "/Users/alice/project");

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -384,18 +384,6 @@ function AuthenticatedShell({
           <UpdateBanner />
         </div>
       )}
-      {terminalAvailable && (
-        <button
-          aria-expanded={terminalOpen}
-          aria-label={terminalOpen ? "Close terminal" : "Open terminal"}
-          className={`hecate-shell-terminal${terminalOpen ? " hecate-shell-terminal--active" : ""}`}
-          onClick={() => setTerminalOpen((open) => !open)}
-          title={terminalOpen ? "Close terminal" : "Open terminal"}
-          type="button"
-        >
-          <SvgIcon d={IC.terminal} size={17} />
-        </button>
-      )}
       <div className="hecate-workarea">
         {/* Activity bar */}
         <nav className="hecate-activitybar" aria-label="Workspace navigation">
@@ -412,6 +400,18 @@ function AuthenticatedShell({
               {ws.icon}
             </button>
           ))}
+          {terminalAvailable && (
+            <button
+              aria-expanded={terminalOpen}
+              aria-label={terminalOpen ? "Close terminal" : "Open terminal"}
+              className={`hecate-activitybtn${terminalOpen ? " hecate-activitybtn--active" : ""}`}
+              onClick={() => setTerminalOpen((open) => !open)}
+              title={terminalOpen ? "Close terminal" : "Open terminal"}
+              type="button"
+            >
+              <SvgIcon d={IC.terminal} size={17} />
+            </button>
+          )}
           {/* Pin theme toggle to the bottom of the rail. The flex spacer
               keeps it visually separated from workspace icons regardless
               of how many workspaces are registered. */}

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -937,12 +937,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ? ""
         : requestedSelectionModel;
     const workspace = workspaceForNewChat(createProjectID);
-    if (toolsEnabled && !workspace) {
-      setChatErrorState(chatWorkspaceRequiredError());
-      setActiveChatSessionID("");
-      setActiveChatSession(null);
-      return;
-    }
     const createProvider = requestedProviderFilter === "auto" ? "" : requestedProviderFilter;
     if (requestedReuseEmptyDraft) {
       const reusable = findReusableEmptyDraftSession(chat.state.chatSessions, {

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -4,7 +4,7 @@ import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useProjects } from "../../app/state/projects";
 import { useChatActions } from "../../app/state/coordinators/chat";
-import { useNewChatAgentID, useChatTarget, useChatToolsEnabled } from "../../app/state/derived";
+import { useNewChatAgentID, useChatTarget } from "../../app/state/derived";
 import { useWiredSettingsActions } from "../../app/state/coordinators/wired";
 import { formatAbsoluteTime } from "../../lib/format";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
@@ -53,7 +53,6 @@ export function ChatSidebar({
   const providersAndModels = useProvidersAndModels();
   const projects = useProjects();
   const chatTarget = useChatTarget();
-  const chatToolsEnabled = useChatToolsEnabled();
   const { actions: settingsActions } = useWiredSettingsActions();
   const chatActions = useChatActions({
     chatTarget,
@@ -98,8 +97,7 @@ export function ChatSidebar({
   const workspaceForNewChat = projects.activeProjectID
     ? selectedProjectWorkspace
     : chat.state.agentWorkspace.trim();
-  const selectedNewChatUsesWorkspace =
-    newChatAgentID !== "hecate" || (chatTarget === "agent" && chatToolsEnabled);
+  const selectedNewChatUsesWorkspace = newChatAgentID !== "hecate";
   const workspaceRequiredForNewChat =
     isAgentChat && selectedNewChatUsesWorkspace && !workspaceForNewChat;
 

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -357,7 +357,7 @@ describe("ChatView input", () => {
     expect(selectChatSession).toHaveBeenCalledWith("");
   });
 
-  it("disables new agent chat creation without a workspace and keeps setup on the canvas", async () => {
+  it("keeps external-agent chat creation blocked until a workspace is selected", async () => {
     const createChatSession = vi.fn(async () => undefined);
     const chooseAgentWorkspace = vi.fn(async () => true);
     const { state, actions } = setup(
@@ -460,6 +460,32 @@ describe("ChatView input", () => {
       {
         chatTarget: "agent",
         defaultChatToolsEnabled: false,
+        agentWorkspace: "",
+        activeChatSessionID: "",
+        activeChatSession: null,
+      },
+      { createChatSession },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const user = userEvent.setup();
+    const newChatButton = screen.getByRole("button", { name: "New Hecate chat" });
+    expect(newChatButton).not.toBeDisabled();
+    expect(
+      screen.queryByText("Choose a workspace in the chat view before starting agent chats."),
+    ).toBeNull();
+
+    await user.click(newChatButton);
+
+    expect(createChatSession).toHaveBeenCalledWith({ agentID: "hecate", projectID: "" });
+  });
+
+  it("allows Hecate chat creation without a workspace even when tools are enabled", async () => {
+    const createChatSession = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: true,
         agentWorkspace: "",
         activeChatSessionID: "",
         activeChatSession: null,

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -1177,7 +1177,7 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatError).toBe("");
   });
 
-  it("keeps Hecate tools-on setup local when no workspace is selected", async () => {
+  it("creates a tools-on Hecate chat shell when no workspace is selected", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.model", "llama3.1:8b");
     let createBody: any = null;
@@ -1207,8 +1207,9 @@ describe("useRuntimeConsole", () => {
                 id: "chat_no_workspace",
                 title: "Hecate Chat",
                 agent_id: "hecate",
-                provider: "",
+                provider: createBody.provider,
                 model: "llama3.1:8b",
+                capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
                 status: "idle",
                 messages: [],
               },
@@ -1226,14 +1227,19 @@ describe("useRuntimeConsole", () => {
       await result.current.actions.createChatSession();
     });
 
-    expect(createBody).toBeNull();
-    expect(result.current.state.activeChatSessionID).toBe("");
-    expect(result.current.state.activeChatSession).toBeNull();
-    expect(result.current.state.chatError).toBe(
-      "Choose a workspace before using Hecate Chat tools or External Agent.",
-    );
-    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
-    expect(result.current.state.chatErrorStatus).toBe(400);
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      provider: "ollama",
+      model: "llama3.1:8b",
+      rtk_enabled: false,
+    });
+    expect(createBody).not.toHaveProperty("workspace");
+    expect(result.current.state.activeChatSessionID).toBe("chat_no_workspace");
+    expect(result.current.state.activeChatSession?.workspace ?? "").toBe("");
+    expect(result.current.state.chatToolsEnabledBySessionID.get("chat_no_workspace")).toBe(true);
+    expect(result.current.state.chatError).toBe("");
+    expect(result.current.state.chatErrorCode).toBe("");
+    expect(result.current.state.chatErrorStatus).toBeNull();
   });
 
   it("starts a direct Hecate chat when the selected model explicitly has no tools", async () => {
@@ -1337,11 +1343,11 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatErrorStatus).toBe(400);
   });
 
-  it("shows workspace guidance when creating a tools-on Hecate chat without a workspace", async () => {
+  it("creates the selected tools-on Hecate chat without a workspace", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.model", "gpt-4o-mini");
     window.localStorage.removeItem("hecate.agentWorkspace");
-    let createCalled = false;
+    let createBody: any = null;
     fetchMock.mockImplementation(
       defaultBackendMock({
         "/v1/models": () =>
@@ -1361,7 +1367,20 @@ describe("useRuntimeConsole", () => {
           }),
         "/hecate/v1/chat/sessions": (init) => {
           if (init?.method === "POST") {
-            createCalled = true;
+            createBody = JSON.parse(String(init.body ?? "{}"));
+            return jsonResponse({
+              object: "chat_session",
+              data: {
+                id: "chat_no_workspace_selected",
+                title: "Hecate Chat",
+                agent_id: "hecate",
+                provider: createBody.provider,
+                model: "gpt-4o-mini",
+                capabilities: { tool_calling: "basic", streaming: true, source: "provider" },
+                status: "idle",
+                messages: [],
+              },
+            });
           }
           return jsonResponse({ object: "chat_sessions", data: [] });
         },
@@ -1375,13 +1394,20 @@ describe("useRuntimeConsole", () => {
       await result.current.actions.createChatSession({ agentID: "hecate" });
     });
 
-    expect(createCalled).toBe(false);
-    expect(result.current.state.activeChatSessionID).toBe("");
-    expect(result.current.state.chatError).toBe(
-      "Choose a workspace before using Hecate Chat tools or External Agent.",
+    expect(createBody).toMatchObject({
+      agent_id: "hecate",
+      model: "gpt-4o-mini",
+      rtk_enabled: false,
+    });
+    expect(createBody).not.toHaveProperty("workspace");
+    expect(result.current.state.activeChatSessionID).toBe("chat_no_workspace_selected");
+    expect(result.current.state.activeChatSession?.workspace ?? "").toBe("");
+    expect(result.current.state.chatToolsEnabledBySessionID.get("chat_no_workspace_selected")).toBe(
+      true,
     );
-    expect(result.current.state.chatErrorCode).toBe("chat.workspace_required");
-    expect(result.current.state.chatErrorStatus).toBe(400);
+    expect(result.current.state.chatError).toBe("");
+    expect(result.current.state.chatErrorCode).toBe("");
+    expect(result.current.state.chatErrorStatus).toBeNull();
   });
 
   it("does not create or select a chat when eager external-agent prepare fails", async () => {


### PR DESCRIPTION
## Summary
- allow starting a plain Hecate chat before a workspace is selected, even when chat tools are enabled
- keep the workspace requirement for external-agent chats
- move the embedded terminal action into the workspace navigation rail so it does not overlap the workspace header

## Verification
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx src/app/AppShell.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check