### PR TITLE
Fix terminal and slash command handling

### DIFF
--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -20,17 +20,20 @@ import (
 const (
 	acpShutdownCancelTimeout = 2 * time.Second
 	acpShutdownCloseTimeout  = 2 * time.Second
+	acpInitialCommandTimeout = 500 * time.Millisecond
 )
 
 type acpSession struct {
-	adapter    Adapter
-	workspace  string
-	cmd        *exec.Cmd
-	conn       *acp.ClientSideConnection
-	client     *acpChatClient
-	nativeID   string
-	logger     *slog.Logger
-	envCleanup func()
+	sessionID           string
+	adapter             Adapter
+	workspace           string
+	cmd                 *exec.Cmd
+	conn                *acp.ClientSideConnection
+	client              *acpChatClient
+	nativeID            string
+	logger              *slog.Logger
+	envCleanup          func()
+	onAvailableCommands func(AvailableCommandsUpdate)
 
 	configMu      sync.Mutex
 	configOptions []agentcontrols.ConfigOption
@@ -39,6 +42,7 @@ type acpSession struct {
 	commandMu              sync.Mutex
 	availableCommands      []agentcontrols.Command
 	availableCommandsKnown bool
+	commandUpdate          chan struct{}
 
 	turnMu sync.Mutex
 
@@ -47,7 +51,7 @@ type acpSession struct {
 	activeDone   chan struct{}
 }
 
-func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, selectedOptions []agentcontrols.ConfigOption, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics) (*acpSession, bool, string, error) {
+func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, selectedOptions []agentcontrols.ConfigOption, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics, onAvailableCommands func(AvailableCommandsUpdate)) (*acpSession, bool, string, error) {
 	command, err := resolveExecutable(adapter, exec.LookPath)
 	if err != nil {
 		return nil, false, "", err
@@ -109,17 +113,20 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		coordinator: coordinator,
 		metrics:     metrics,
 	}
-	conn := acp.NewClientSideConnection(client, stdin, stdout)
 	session := &acpSession{
-		adapter:    adapter,
-		workspace:  workspace,
-		cmd:        cmd,
-		conn:       conn,
-		client:     client,
-		logger:     sessionLogger,
-		envCleanup: processEnv.cleanup,
+		sessionID:           sessionID,
+		adapter:             adapter,
+		workspace:           workspace,
+		cmd:                 cmd,
+		client:              client,
+		logger:              sessionLogger,
+		envCleanup:          processEnv.cleanup,
+		onAvailableCommands: onAvailableCommands,
+		commandUpdate:       make(chan struct{}),
 	}
 	client.onAvailableCommands = session.setAvailableCommands
+	conn := acp.NewClientSideConnection(client, stdin, stdout)
+	session.conn = conn
 	if logger != nil {
 		conn.SetLogger(logger.With(
 			slog.String("component", "agent_adapters.acp"),
@@ -251,6 +258,7 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	session.nativeID = nativeID
 	session.configOptions = configOptions
 	session.managedConfig = managedConfig
+	session.waitForInitialAvailableCommands(ctx)
 	cleanupEnvOnError = false
 	return session, resumed, recovery, nil
 }
@@ -521,10 +529,23 @@ func (s *acpSession) configOptionsSnapshot() []agentcontrols.ConfigOption {
 }
 
 func (s *acpSession) setAvailableCommands(commands []agentcontrols.Command) {
+	commands = cloneCommands(commands)
 	s.commandMu.Lock()
-	defer s.commandMu.Unlock()
-	s.availableCommands = cloneCommands(commands)
+	s.availableCommands = commands
 	s.availableCommandsKnown = true
+	if s.commandUpdate != nil {
+		close(s.commandUpdate)
+	}
+	s.commandUpdate = make(chan struct{})
+	s.commandMu.Unlock()
+
+	if s.onAvailableCommands != nil {
+		s.onAvailableCommands(AvailableCommandsUpdate{
+			SessionID: s.sessionID,
+			AdapterID: s.adapter.ID,
+			Commands:  cloneCommands(commands),
+		})
+	}
 }
 
 func (s *acpSession) availableCommandsSnapshot() ([]agentcontrols.Command, bool) {
@@ -534,6 +555,26 @@ func (s *acpSession) availableCommandsSnapshot() ([]agentcontrols.Command, bool)
 		return nil, false
 	}
 	return cloneCommands(s.availableCommands), true
+}
+
+func (s *acpSession) waitForInitialAvailableCommands(ctx context.Context) {
+	s.commandMu.Lock()
+	if s.availableCommandsKnown {
+		s.commandMu.Unlock()
+		return
+	}
+	update := s.commandUpdate
+	s.commandMu.Unlock()
+	if update == nil {
+		return
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, acpInitialCommandTimeout)
+	defer cancel()
+	select {
+	case <-waitCtx.Done():
+	case <-update:
+	}
 }
 
 func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.ConfigOption {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -163,6 +163,27 @@ func TestACPChatClientCapturesAvailableCommandsWithoutActiveTurn(t *testing.T) {
 	}
 }
 
+func TestSessionManagerPrepareWaitsForInitialAvailableCommands(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_COMMANDS_DELAY", "50ms")
+	installFakeACPExecutable(t, "codex-acp")
+
+	manager := NewSessionManager()
+	result, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_commands",
+		AdapterID: "codex",
+		Workspace: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+	if !result.AvailableCommandsKnown {
+		t.Fatal("AvailableCommandsKnown = false, want true")
+	}
+	if got := result.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[1].Name != "plan" {
+		t.Fatalf("available commands = %#v, want web and plan", got)
+	}
+}
+
 func TestSessionManagerUsesACPModelStateForBuiltInACPAdapters(t *testing.T) {
 	t.Setenv("HECATE_FAKE_ACP_MODELS", "1")
 
@@ -1627,9 +1648,10 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
+		os.Getenv("HECATE_FAKE_ACP_COMMANDS_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_MODELS"),
 		os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS"),
 		os.Getenv("HECATE_FAKE_ACP_SET_MODEL_ERROR"),
@@ -1685,6 +1707,7 @@ func (a *fakeACPAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.N
 	a.mu.Lock()
 	a.sessions[id] = &fakeACPSession{model: "model-a", mode: "ask"}
 	a.mu.Unlock()
+	a.publishAvailableCommandsAfterDelay(acp.SessionId(id))
 	return acp.NewSessionResponse{
 		SessionId:     acp.SessionId(id),
 		ConfigOptions: fakeACPConfigOptions("ask", "model-a"),
@@ -1698,9 +1721,32 @@ func (a *fakeACPAgent) LoadSession(_ context.Context, params acp.LoadSessionRequ
 	a.mu.Lock()
 	a.sessions[string(params.SessionId)] = &fakeACPSession{model: "model-a", mode: "ask"}
 	a.mu.Unlock()
+	a.publishAvailableCommandsAfterDelay(params.SessionId)
 	return acp.LoadSessionResponse{
 		ConfigOptions: fakeACPConfigOptions("ask", "model-a"),
 	}, nil
+}
+
+func (a *fakeACPAgent) publishAvailableCommandsAfterDelay(sessionID acp.SessionId) {
+	delay, err := time.ParseDuration(os.Getenv("HECATE_FAKE_ACP_COMMANDS_DELAY"))
+	if err != nil || delay <= 0 {
+		return
+	}
+	go func() {
+		time.Sleep(delay)
+		_ = a.conn.SessionUpdate(context.Background(), acp.SessionNotification{
+			SessionId: sessionID,
+			Update: acp.SessionUpdate{
+				AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
+					SessionUpdate: "available_commands_update",
+					AvailableCommands: []acp.AvailableCommand{
+						{Name: "web", Description: "Search the web"},
+						{Name: "plan", Description: "Create a plan"},
+					},
+				},
+			},
+		})
+	}()
 }
 
 func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -192,6 +192,12 @@ type PrepareSessionResult struct {
 	AvailableCommandsKnown bool
 }
 
+type AvailableCommandsUpdate struct {
+	SessionID string
+	AdapterID string
+	Commands  []agentcontrols.Command
+}
+
 type SetSessionConfigOptionRequest struct {
 	SessionID string
 	ConfigID  string

--- a/internal/agentadapters/session_manager.go
+++ b/internal/agentadapters/session_manager.go
@@ -22,8 +22,9 @@ type SessionManager struct {
 	// acpChatClient created from this manager. Optional — nil is
 	// safe (every Record* method is nil-tolerant) and matches the
 	// pre-existing constructor surface that older tests rely on.
-	metrics *telemetry.AgentAdapterMetrics
-	closed  bool
+	metrics             *telemetry.AgentAdapterMetrics
+	onAvailableCommands func(AvailableCommandsUpdate)
+	closed              bool
 }
 
 func NewSessionManager() *SessionManager {
@@ -61,6 +62,12 @@ func (m *SessionManager) SetAdapterMetrics(metrics *telemetry.AgentAdapterMetric
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.metrics = metrics
+}
+
+func (m *SessionManager) SetAvailableCommandsUpdateHook(hook func(AvailableCommandsUpdate)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onAvailableCommands = hook
 }
 
 // shutdownCancelHook is invoked once per adapter id torn down via
@@ -219,9 +226,10 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		logger := m.logger
 		coordinator := m.coordinator
 		metrics := m.metrics
+		onAvailableCommands := m.onAvailableCommands
 		m.mu.Unlock()
 
-		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, req.ConfigOptions, logger, coordinator, metrics)
+		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, req.ConfigOptions, logger, coordinator, metrics, onAvailableCommands)
 		startCancel()
 
 		var previous *acpSession

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -339,6 +339,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		terminalLauncher:    terminal.NewPTYLauncher(logger),
 		terminalTickets:     make(map[string]terminalTicket),
 	}
+	h.wireAgentChatRunnerHooks(agentChatRunner)
 	runner.SetProjectAssistantDraftTool(h)
 	h.startAgentChatIdleSweeper()
 	return h
@@ -473,6 +474,15 @@ func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {
 		return
 	}
 	h.agentChatRunner = runner
+	h.wireAgentChatRunnerHooks(runner)
+}
+
+func (h *Handler) wireAgentChatRunnerHooks(runner agentadapters.Runner) {
+	mgr, ok := runner.(*agentadapters.SessionManager)
+	if !ok {
+		return
+	}
+	mgr.SetAvailableCommandsUpdateHook(h.handleAgentChatAvailableCommandsUpdate)
 }
 
 func (h *Handler) SetStateCleaner(cleaner StateCleaner) {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -160,6 +162,43 @@ func (h *Handler) isValidChatAgentID(agentID string) bool {
 	}
 	_, ok := agentadapters.BuiltInByID(agentID)
 	return ok
+}
+
+func (h *Handler) handleAgentChatAvailableCommandsUpdate(update agentadapters.AvailableCommandsUpdate) {
+	if h == nil || h.agentChat == nil {
+		return
+	}
+	sessionID := strings.TrimSpace(update.SessionID)
+	if sessionID == "" {
+		return
+	}
+	commands := slices.Clone(update.Commands)
+	ctx, cancel := context.WithTimeout(context.Background(), agentChatConfigOptionTimeout)
+	defer cancel()
+	session, ok, err := h.agentChat.Get(ctx, sessionID)
+	if err != nil {
+		telemetry.Warn(h.logger, ctx, "agent chat available commands load failed", slog.String("session_id", sessionID), slog.Any("error", err))
+		return
+	}
+	if !ok {
+		return
+	}
+	if update.AdapterID != "" && session.AgentID != update.AdapterID {
+		return
+	}
+	if slices.Equal(session.AvailableCommands, commands) {
+		return
+	}
+	updated, err := h.agentChat.UpdateSession(ctx, sessionID, func(item *chat.Session) {
+		item.AvailableCommands = commands
+	})
+	if err != nil {
+		telemetry.Warn(h.logger, ctx, "agent chat available commands update failed", slog.String("session_id", sessionID), slog.Any("error", err))
+		return
+	}
+	if h.agentChatLive != nil {
+		h.agentChatLive.publishSession(updated)
+	}
 }
 
 func (h *Handler) HandleChatSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_terminal.go
+++ b/internal/api/handler_terminal.go
@@ -134,7 +134,7 @@ func (h *Handler) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		_ = wsjson.Write(ctx, conn, terminalServerMessage{
 			Type:    "error",
-			Message: fmt.Sprintf("failed to start terminal: %v", err),
+			Message: terminalStartErrorMessage(err),
 		})
 		return
 	}
@@ -346,4 +346,13 @@ func terminalExitCode(err error) int {
 		return exitErr.ExitCode()
 	}
 	return -1
+}
+
+func terminalStartErrorMessage(err error) string {
+	if terminal.DeviceNotConfigured(err) {
+		return "failed to start terminal: macOS could not allocate a pseudo-terminal " +
+			"(device not configured). Restart Hecate and try again; if this persists in a " +
+			"packaged build, use a build that allows PTY access."
+	}
+	return fmt.Sprintf("failed to start terminal: %v", err)
 }

--- a/internal/api/handler_terminal_test.go
+++ b/internal/api/handler_terminal_test.go
@@ -92,6 +92,18 @@ func TestTerminalDisabledReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestTerminalStartErrorMessageExplainsDeviceNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	got := terminalStartErrorMessage(errors.New("device not configured"))
+	if !strings.Contains(got, "could not allocate a pseudo-terminal") {
+		t.Fatalf("message = %q, want PTY allocation guidance", got)
+	}
+	if !strings.Contains(got, "device not configured") {
+		t.Fatalf("message = %q, want original device error", got)
+	}
+}
+
 func TestCreateTerminalSessionDisabledReturnsNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2889,6 +2889,54 @@ func (r *fakeAgentChatRunner) CloseSession(_ context.Context, sessionID string) 
 
 func (r *fakeAgentChatRunner) Shutdown(context.Context) error { return nil }
 
+func TestAgentChatAvailableCommandsUpdateHookPersistsAndPublishes(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	session, err := apiHandler.agentChat.Create(context.Background(), chat.Session{
+		ID:         "chat_commands",
+		Title:      "Codex chat",
+		AgentID:    "codex",
+		DriverKind: agentadapters.DriverKindACP,
+		Workspace:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	updates, unsubscribe := apiHandler.agentChatLive.subscribe(session.ID)
+	defer unsubscribe()
+
+	apiHandler.handleAgentChatAvailableCommandsUpdate(agentadapters.AvailableCommandsUpdate{
+		SessionID: session.ID,
+		AdapterID: "codex",
+		Commands: []agentcontrols.Command{
+			{Name: "web", Description: "Search the web"},
+			{Name: "plan", Description: "Create a plan"},
+		},
+	})
+
+	got, ok, err := apiHandler.agentChat.Get(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if got := got.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[1].Name != "plan" {
+		t.Fatalf("stored commands = %#v, want web and plan", got)
+	}
+	select {
+	case event := <-updates:
+		if event.Type != AgentChatLiveEventSessionUpdate || event.SessionUpdate == nil {
+			t.Fatalf("event = %#v, want session update", event)
+		}
+		if got := event.SessionUpdate.Data.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[1].Name != "plan" {
+			t.Fatalf("event commands = %#v, want web and plan", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session update")
+	}
+}
+
 func TestAgentChatExternalConfigOptionsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	gopty "github.com/aymanbagabas/go-pty"
 )
@@ -35,6 +36,32 @@ func NewPTYLauncher(logger *slog.Logger) *PTYLauncher {
 }
 
 func (l *PTYLauncher) Start(ctx context.Context, req StartRequest) (Session, error) {
+	const attempts = 3
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		session, err := l.startOnce(ctx, req)
+		if err == nil {
+			return session, nil
+		}
+		lastErr = err
+		if !DeviceNotConfigured(err) || attempt == attempts {
+			return nil, err
+		}
+		if l.logger != nil {
+			l.logger.Debug("terminal pty allocation failed; retrying", "attempt", attempt, "error", err)
+		}
+		timer := time.NewTimer(time.Duration(attempt*25) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, lastErr
+}
+
+func (l *PTYLauncher) startOnce(ctx context.Context, req StartRequest) (Session, error) {
 	cols, rows := normalizedSize(req.Cols, req.Rows)
 	pt, err := gopty.New()
 	if err != nil {
@@ -56,6 +83,13 @@ func (l *PTYLauncher) Start(ctx context.Context, req StartRequest) (Session, err
 		return nil, err
 	}
 	return &ptySession{pty: pt, cmd: cmd}, nil
+}
+
+func DeviceNotConfigured(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "device not configured")
 }
 
 func normalizedSize(cols, rows int) (int, int) {

--- a/internal/terminal/session_test.go
+++ b/internal/terminal/session_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"errors"
 	"slices"
 	"testing"
 )
@@ -32,5 +33,14 @@ func TestTerminalEnvStripsSecrets(t *testing.T) {
 		if !slices.Contains(env, required) {
 			t.Fatalf("terminalEnv missing %q in %v", required, env)
 		}
+	}
+}
+
+func TestDeviceNotConfiguredDetectsMacOSErrnoText(t *testing.T) {
+	if !DeviceNotConfigured(errors.New("device not configured")) {
+		t.Fatal("DeviceNotConfigured returned false for macOS ENXIO text")
+	}
+	if DeviceNotConfigured(errors.New("permission denied")) {
+		t.Fatal("DeviceNotConfigured returned true for an unrelated error")
 	}
 }

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -861,13 +861,16 @@ export function ChatComposer(props: ChatComposerProps) {
                   borderRadius: "var(--radius-sm)",
                   background: "var(--bg2)",
                   boxShadow: "0 10px 28px rgba(0, 0, 0, 0.28)",
-                  maxHeight: "min(40vh, 320px)",
+                  maxHeight: "min(60vh, 520px)",
                   overflowY: "auto",
                   overscrollBehavior: "contain",
+                  scrollbarGutter: "stable",
+                  touchAction: "pan-y",
                   padding: 4,
                   display: "grid",
                   gap: 2,
                 }}
+                onWheel={(event) => event.stopPropagation()}
               >
                 {commandSuggestions.map((command, index) => {
                   const commandText = messageCommandInsertion(command).trim();

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -465,12 +465,16 @@ function agentSetupHint(adapter: AgentAdapterRecord): {
     case "claude_code":
       return {
         label: "Claude Code",
-        action: "Install Claude Code, then sign in with Claude Code.",
+        action: "Install Claude Code plus the Claude ACP adapter, then sign in with Claude Code.",
         commands: [
-          { label: "Install", command: "npm install -g @anthropic-ai/claude-code" },
+          {
+            label: "Install",
+            command:
+              "npm install -g @anthropic-ai/claude-code @agentclientprotocol/claude-agent-acp",
+          },
           { label: "Auth", command: "claude /login" },
         ],
-        note: "Hecate uses Claude Code's local auth; it does not store Claude tokens.",
+        note: "Hecate launches claude-agent-acp. If Node/npm/npx is visible to Hecate, Connections can manage that adapter package for you. Hecate uses Claude Code's local auth and does not store Claude tokens.",
       };
     case "cursor_agent":
       return {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3194,6 +3194,41 @@ describe("ChatView input", () => {
     expect(within(commands).getByRole("option", { name: "Insert /cmd9 command" })).toBeTruthy();
     expect(commands).toHaveStyle({ overflowY: "auto" });
     expect(commands.getAttribute("style")).toContain("max-height:");
+    expect(commands.getAttribute("style")).toContain("scrollbar-gutter: stable");
+  });
+
+  it("keeps slash command wheel scrolling inside the picker", () => {
+    const availableCommands = Array.from({ length: 9 }, (_, index) => ({
+      name: `cmd${index + 1}`,
+      description: `Command ${index + 1}`,
+    }));
+    const { state, actions } = setup({
+      chatTarget: "external_agent",
+      agentAdapterID: "claude_code",
+      message: "/",
+      activeChatSession: {
+        id: "chat_commands",
+        title: "Agent commands",
+        agent_id: "claude_code",
+        driver_kind: "acp",
+        execution_mode: "external_agent",
+        status: "idle",
+        workspace: "/tmp/hecate",
+        available_commands: availableCommands,
+        messages: [],
+      },
+    });
+    const bubbled = vi.fn();
+    document.body.addEventListener("wheel", bubbled);
+    try {
+      render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+      fireEvent.wheel(screen.getByRole("listbox", { name: "Message commands" }));
+
+      expect(bubbled).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeEventListener("wheel", bubbled);
+    }
   });
 
   it("scrolls the active slash command into view during keyboard navigation", () => {

--- a/ui/src/lib/external-agent-readiness.test.ts
+++ b/ui/src/lib/external-agent-readiness.test.ts
@@ -89,6 +89,27 @@ describe("resolveExternalAgentReadiness", () => {
     });
   });
 
+  it("names the Claude ACP adapter in setup guidance", () => {
+    const readiness = resolveExternalAgentReadiness(
+      adapter({
+        id: "claude_code",
+        name: "Claude Code",
+        command: "claude-agent-acp",
+        available: false,
+        status: "missing",
+        managed_package: "@agentclientprotocol/claude-agent-acp",
+      }),
+      null,
+    );
+
+    expect(readiness).toMatchObject({
+      kind: "setup",
+      needsRepair: true,
+    });
+    expect(readiness.setupHint).toContain("@agentclientprotocol/claude-agent-acp");
+    expect(readiness.setupHint).toContain("claude /login");
+  });
+
   it("keeps unprobed available agents muted until a probe verifies readiness", () => {
     const readiness = resolveExternalAgentReadiness(adapter({ auth_status: "unknown" }), null);
 

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -179,6 +179,9 @@ export function externalAgentSignInHint(adapter: AgentAdapterRecord): string {
 }
 
 export function externalAgentSetupHint(adapter: AgentAdapterRecord): string {
+  if (adapter.id === "claude_code") {
+    return 'Install Claude Code and the Claude ACP adapter. Hecate can manage "@agentclientprotocol/claude-agent-acp" when Node/npm/npx is visible to the app, or install claude-agent-acp directly; then run claude /login.';
+  }
   if (adapter.id === "cursor_agent") {
     return "Install Cursor's command-line agent, confirm cursor-agent is on PATH, then run cursor-agent login.";
   }


### PR DESCRIPTION
## Summary

This fixes the terminal and external-agent slash-command issues reported from the desktop UI.

- Move the terminal toggle into the activity rail so it aligns with the other navigation controls instead of floating over Settings.
- Retry transient macOS PTY allocation failures and surface a clearer device not configured terminal startup message.
- Persist and publish ACP available_commands_update notifications so fresh Codex/ACP chats can show slash commands without sending a first prompt.
- Improve slash-command picker scrolling and wheel containment.
- Clarify Claude Code setup guidance so users install both Claude Code and the Claude ACP adapter.

## Root Cause

The terminal button was positioned separately from the activity rail, which allowed it to overlap nearby controls. Terminal launch also treated a transient PTY allocation failure as a single hard failure.

For slash commands, Hecate only snapshotted ACP command metadata at prepare/run boundaries. If the adapter published commands asynchronously after session creation, the UI would not see them until a later interaction refreshed the session.

## Validation

- go test ./internal/agentadapters
- go test ./internal/api
- go test ./internal/terminal ./internal/api
- bun run test -- src/features/chats/ChatView.test.tsx
- bun run test -- src/app/AppShell.test.tsx src/lib/external-agent-readiness.test.ts
- bun run typecheck
- git diff --check
- Browser smoke test confirmed the terminal button is in the nav rail and opens without the old PTY error.