### PR TITLE
Add Hecate chat context compaction

### DIFF
--- a/internal/api/chat_application_http.go
+++ b/internal/api/chat_application_http.go
@@ -11,6 +11,7 @@ var chatAppErrorMappings = []appErrorMapping{
 	validationAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest),
 	sentinelAppErrorMapping(http.StatusNotFound, errCodeNotFound, chatapp.ErrSessionNotFound),
 	sentinelAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest, chatapp.ErrNoSettingsProvided),
+	sentinelAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest, chatapp.ErrNothingToCompact),
 	sentinelAppErrorMapping(http.StatusConflict, errCodeRuntimeMismatch,
 		chatapp.ErrExternalSessionOnly,
 		chatapp.ErrHecateSessionOnly,

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -30,6 +30,12 @@ const (
 	agentChatMaxOutputBytes      = 4 * 1024 * 1024
 )
 
+const (
+	agentChatManualCompactRetainMessages = chat.DefaultCompactRetainMessages
+	agentChatAutoCompactRetainMessages   = chat.DefaultCompactRetainMessages
+	agentChatAutoCompactMinMessages      = chat.DefaultCompactMinMessages
+)
+
 func (h *Handler) HandleChatSessions(w http.ResponseWriter, r *http.Request) {
 	result, err := h.chatApplication().ListSessions(r.Context())
 	if err != nil {
@@ -221,6 +227,25 @@ func (h *Handler) HandleUpdateChatSession(w http.ResponseWriter, r *http.Request
 	result, err := h.chatApplication().RenameSession(r.Context(), chatapp.RenameSessionCommand{
 		ID:    r.PathValue("id"),
 		Title: req.Title,
+	})
+	if err != nil {
+		if writeChatAppError(w, err) {
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	h.agentChatLive.publishSession(result.Session)
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
+}
+
+func (h *Handler) HandleCompactChatSession(w http.ResponseWriter, r *http.Request) {
+	result, err := h.chatApplication().CompactSession(r.Context(), chatapp.CompactSessionCommand{
+		ID:               r.PathValue("id"),
+		RetainMessages:   agentChatManualCompactRetainMessages,
+		HecateOnly:       true,
+		RequireCompacted: true,
+		Now:              time.Now().UTC(),
 	})
 	if err != nil {
 		if writeChatAppError(w, err) {
@@ -930,6 +955,15 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	content := strings.TrimSpace(req.Content)
+	if compacted, err := h.compactChatSessionForModelTurn(r.Context(), session); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	} else if compacted.ID != "" {
+		if compacted.ContextSummary.ThroughMessageID != session.ContextSummary.ThroughMessageID || compacted.ContextSummary.Content != session.ContextSummary.Content {
+			h.agentChatLive.publishSession(compacted)
+		}
+		session = compacted
+	}
 	assistantID := newChatID("msg")
 	runID := newChatID("model_run")
 	startedAt := time.Now().UTC()
@@ -1063,12 +1097,33 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
 }
 
+func (h *Handler) compactChatSessionForModelTurn(ctx context.Context, session chat.Session) (chat.Session, error) {
+	result, err := h.chatApplication().CompactSession(ctx, chatapp.CompactSessionCommand{
+		ID:             session.ID,
+		RetainMessages: agentChatAutoCompactRetainMessages,
+		MinMessages:    agentChatAutoCompactMinMessages,
+		HecateOnly:     true,
+		Now:            time.Now().UTC(),
+	})
+	if err != nil {
+		return chat.Session{}, err
+	}
+	return result.Session, nil
+}
+
 func agentChatModelHistory(session chat.Session, systemPrompt, content string) []types.Message {
 	messages := make([]types.Message, 0, len(session.Messages))
 	if systemPrompt = strings.TrimSpace(systemPrompt); systemPrompt != "" {
 		messages = append(messages, types.Message{Role: "system", Content: systemPrompt})
 	}
-	for _, message := range session.Messages {
+	skipThroughIndex := compactedTranscriptMessageIndex(session.Messages, session.ContextSummary.ThroughMessageID)
+	if compacted := chat.TranscriptSummaryPrompt(session.ContextSummary); compacted != "" && skipThroughIndex >= 0 {
+		messages = append(messages, types.Message{Role: "system", Content: compacted})
+	}
+	for i, message := range session.Messages {
+		if skipThroughIndex >= 0 && i <= skipThroughIndex {
+			continue
+		}
 		if message.Role != "user" && message.Role != "assistant" {
 			continue
 		}
@@ -1083,6 +1138,19 @@ func agentChatModelHistory(session chat.Session, systemPrompt, content string) [
 	}
 	messages = append(messages, types.Message{Role: "user", Content: content})
 	return messages
+}
+
+func compactedTranscriptMessageIndex(messages []chat.Message, throughMessageID string) int {
+	throughMessageID = strings.TrimSpace(throughMessageID)
+	if throughMessageID == "" {
+		return -1
+	}
+	for i, message := range messages {
+		if message.ID == throughMessageID {
+			return i
+		}
+	}
+	return -1
 }
 
 func modelSegmentID(session chat.Session, provider, model string) string {

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -257,7 +257,7 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 		})
 	}
 	appendProjectContextSources(&packet, h.projectContextSources(ctx, session))
-	appendTranscriptContext(&packet)
+	appendTranscriptContext(&packet, session.ContextSummary)
 	return packet
 }
 
@@ -308,7 +308,7 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	if forceNewTask || strings.TrimSpace(session.TaskID) == "" {
 		taskDetail = "Starting a new task-backed agent loop"
 	}
-	appendTranscriptContext(&packet)
+	appendTranscriptContext(&packet, session.ContextSummary)
 	appendContextPacketSourceWithSection(&packet, contextSectionRuntime, chat.ContextSource{
 		Kind:   "task_runtime",
 		Label:  "Hecate task runtime",
@@ -352,7 +352,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	if strings.TrimSpace(adapterName) == "" {
 		adapterName = "External agent"
 	}
-	appendTranscriptContext(&packet)
+	appendTranscriptContext(&packet, session.ContextSummary)
 	appendContextPacketSourceWithSection(&packet, contextSectionRuntime, chat.ContextSource{
 		Kind:   "adapter_session",
 		Label:  adapterName + " ACP session",
@@ -974,7 +974,7 @@ func appendProjectAssignmentArtifacts(packet *chat.ContextPacket, items []projec
 	}
 }
 
-func appendTranscriptContext(packet *chat.ContextPacket) {
+func appendTranscriptContext(packet *chat.ContextPacket, summary chat.ContextSummary) {
 	source := transcriptContextSource(packet.MessageCount)
 	appendContextPacketSourceWithSection(packet, contextSectionRuntime, source, chat.ContextItem{
 		Kind:            "transcript",
@@ -984,6 +984,32 @@ func appendTranscriptContext(packet *chat.ContextPacket) {
 		Body:            source.Detail,
 		Included:        true,
 		InclusionReason: "Visible terminal transcript count for this turn",
+	})
+	if summary.Empty() {
+		return
+	}
+	detail := "Older transcript messages are summarized before newer messages"
+	if summary.MessageCount > 0 {
+		detail = fmt.Sprintf("%d older messages summarized", summary.MessageCount)
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionRuntime, chat.ContextSource{
+		Kind:   "transcript_summary",
+		Label:  "Compacted transcript",
+		Detail: detail,
+		Trust:  "runtime",
+	}, chat.ContextItem{
+		Kind:            "transcript_summary",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          "chat.transcript.compacted",
+		Title:           "Compacted transcript",
+		Body:            detail,
+		Included:        true,
+		InclusionReason: "Hecate summarized older chat messages to keep long sessions usable",
+		Metadata: map[string]string{
+			"message_count":       fmt.Sprintf("%d", summary.MessageCount),
+			"through_message_id":  strings.TrimSpace(summary.ThroughMessageID),
+			"compaction_strategy": "deterministic_transcript_summary",
+		},
 	})
 }
 

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -499,6 +499,105 @@ func TestDirectHecateChatProjectSessionInjectsProposalGuidance(t *testing.T) {
 	}
 }
 
+func TestDirectHecateChatAutoCompactsLongTranscript(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-hecate-direct-compact",
+			Model:     "gpt-4o-mini",
+			CreatedAt: time.Now().UTC(),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "ack"},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	handler := NewServer(logger, apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini"}`)
+	var updated ChatSessionResponse
+	for i := 1; i <= 10; i++ {
+		updated = mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+			fmt.Sprintf(`{"execution_mode":"hecate_task","tools_enabled":false,"content":"question %02d"}`, i))
+	}
+
+	if updated.Data.ContextSummary == nil {
+		t.Fatal("context_summary is nil, want automatic compaction metadata")
+	}
+	if updated.Data.ContextSummary.MessageCount != 10 {
+		t.Fatalf("context_summary message_count = %d, want 10", updated.Data.ContextSummary.MessageCount)
+	}
+	request := provider.LastRequest()
+	if len(request.Messages) != 10 {
+		t.Fatalf("provider message count = %d, want compact summary + 8 retained + current", len(request.Messages))
+	}
+	if request.Messages[0].Role != "system" || !strings.Contains(request.Messages[0].Content, "Earlier chat transcript compacted by Hecate") {
+		t.Fatalf("first provider message = %+v, want compacted transcript system summary", request.Messages[0])
+	}
+	if request.Messages[1].Role != "user" || request.Messages[1].Content != "question 06" {
+		t.Fatalf("first retained provider message = %+v, want question 06", request.Messages[1])
+	}
+	if request.Messages[len(request.Messages)-1].Content != "question 10" {
+		t.Fatalf("last provider message = %+v, want current prompt", request.Messages[len(request.Messages)-1])
+	}
+	lastAssistant := updated.Data.Messages[len(updated.Data.Messages)-1]
+	if lastAssistant.ContextPacket == nil || !chatContextPacketHasKind(*lastAssistant.ContextPacket, "transcript_summary") {
+		t.Fatalf("assistant context packet missing transcript_summary: %+v", lastAssistant.ContextPacket)
+	}
+}
+
+func TestHecateChatCompactEndpointCompactsTranscript(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-hecate-manual-compact",
+			Model:     "gpt-4o-mini",
+			CreatedAt: time.Now().UTC(),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "ack"},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	handler := NewServer(logger, apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini"}`)
+	for i := 1; i <= 5; i++ {
+		_ = mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+			fmt.Sprintf(`{"execution_mode":"hecate_task","tools_enabled":false,"content":"manual %02d"}`, i))
+	}
+
+	compacted := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/compact", `{}`)
+	if compacted.Data.ContextSummary == nil {
+		t.Fatal("context_summary is nil, want manual compaction metadata")
+	}
+	if compacted.Data.ContextSummary.MessageCount != 2 {
+		t.Fatalf("context_summary message_count = %d, want 2", compacted.Data.ContextSummary.MessageCount)
+	}
+	if !strings.Contains(compacted.Data.ContextSummary.Content, "manual 01") {
+		t.Fatalf("context_summary content = %q, want first turn", compacted.Data.ContextSummary.Content)
+	}
+}
+
+func chatContextPacketHasKind(packet ChatContextPacketItem, kind string) bool {
+	for _, item := range packet.Items {
+		if item.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 func TestProjectChatPromptHelpersBoundUTF8Text(t *testing.T) {
 	remaining := 64
 	section, truncated := boundedPromptContextSection("Header", strings.Repeat("é", 80), 48, &remaining)

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -117,10 +117,23 @@ func renderChatSession(session chat.Session, limits agentChatSnapshotConfig) Cha
 		IdleTimeoutMS:        limits.IdleTimeout.Milliseconds(),
 		ConfigOptions:        session.ConfigOptions,
 		AvailableCommands:    session.AvailableCommands,
+		ContextSummary:       renderChatContextSummary(session.ContextSummary),
 		CreatedAt:            formatOptionalTime(session.CreatedAt),
 		UpdatedAt:            formatOptionalTime(session.UpdatedAt),
 		Segments:             renderChatSegments(session),
 		Messages:             messages,
+	}
+}
+
+func renderChatContextSummary(summary chat.ContextSummary) *ChatContextSummaryItem {
+	if summary.Empty() {
+		return nil
+	}
+	return &ChatContextSummaryItem{
+		Content:          summary.Content,
+		MessageCount:     summary.MessageCount,
+		ThroughMessageID: summary.ThroughMessageID,
+		CompactedAt:      formatOptionalTime(summary.CompactedAt),
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -859,10 +859,18 @@ type ChatSessionItem struct {
 	IdleTimeoutMS        int64                        `json:"idle_timeout_ms,omitempty"`
 	ConfigOptions        []agentcontrols.ConfigOption `json:"config_options,omitempty"`
 	AvailableCommands    []agentcontrols.Command      `json:"available_commands,omitempty"`
+	ContextSummary       *ChatContextSummaryItem      `json:"context_summary,omitempty"`
 	CreatedAt            string                       `json:"created_at,omitempty"`
 	UpdatedAt            string                       `json:"updated_at,omitempty"`
 	Segments             []ChatSegmentItem            `json:"segments,omitempty"`
 	Messages             []ChatMessageItem            `json:"messages"`
+}
+
+type ChatContextSummaryItem struct {
+	Content          string `json:"content,omitempty"`
+	MessageCount     int    `json:"message_count,omitempty"`
+	ThroughMessageID string `json:"through_message_id,omitempty"`
+	CompactedAt      string `json:"compacted_at,omitempty"`
 }
 
 type ChatSegmentItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -94,6 +94,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/chat/sessions/{id}/stream"},
 	{method: http.MethodPost, path: "/hecate/v1/chat/sessions/{id}/cancel"},
 	{method: http.MethodPost, path: "/hecate/v1/chat/sessions/{id}/close"},
+	{method: http.MethodPost, path: "/hecate/v1/chat/sessions/{id}/compact"},
 	{method: http.MethodPatch, path: "/hecate/v1/chat/sessions/{id}/settings"},
 	{method: http.MethodPost, path: "/hecate/v1/chat/sessions/{id}/config-options/{config_id}"},
 	{method: http.MethodPost, path: "/hecate/v1/chat/sessions/{id}/messages"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -140,6 +140,7 @@ func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/chat/sessions/{id}/stream", handler.HandleChatSessionStream)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/cancel", handler.HandleCancelChatSession)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/close", handler.HandleCloseChatSession)
+	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/compact", handler.HandleCompactChatSession)
 	mux.HandleFunc("PATCH /hecate/v1/chat/sessions/{id}/settings", handler.HandleSetAgentChatSettings)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/config-options/{config_id}", handler.HandleSetAgentChatConfigOption)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions/{id}/messages", handler.HandleCreateChatMessage)

--- a/internal/chat/compaction.go
+++ b/internal/chat/compaction.go
@@ -77,6 +77,10 @@ func CompactTranscriptSummary(session Session, opts CompactTranscriptOptions) Co
 	return CompactTranscriptResult{Summary: nextSummary, Compacted: true}
 }
 
+// Transcript compaction is deterministic and intentionally not model-backed
+// semantic summarization. Each older message contributes one bounded line, and
+// the combined text is capped from the oldest side to keep the prompt budget
+// predictable.
 func TranscriptSummaryPrompt(summary ContextSummary) string {
 	content := strings.TrimSpace(summary.Content)
 	if content == "" {

--- a/internal/chat/compaction.go
+++ b/internal/chat/compaction.go
@@ -1,0 +1,175 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	DefaultCompactRetainMessages = 8
+	DefaultCompactMinMessages    = 18
+
+	compactSummaryMaxRunes = 8000
+	compactLineMaxRunes    = 600
+)
+
+type CompactTranscriptOptions struct {
+	Now            time.Time
+	RetainMessages int
+	MinMessages    int
+}
+
+type CompactTranscriptResult struct {
+	Summary   ContextSummary
+	Compacted bool
+}
+
+func CompactTranscriptSummary(session Session, opts CompactTranscriptOptions) CompactTranscriptResult {
+	retain := opts.RetainMessages
+	if retain <= 0 {
+		retain = DefaultCompactRetainMessages
+	}
+	minMessages := opts.MinMessages
+	if minMessages <= 0 {
+		minMessages = retain + 1
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	visible := compactableTranscriptMessages(session.Messages)
+	current := cloneContextSummary(session.ContextSummary)
+	if len(visible) < minMessages || len(visible) <= retain {
+		return CompactTranscriptResult{Summary: current}
+	}
+
+	start := 0
+	if current.ThroughMessageID != "" {
+		found := false
+		for i, message := range visible {
+			if message.ID != current.ThroughMessageID {
+				continue
+			}
+			start = i + 1
+			found = true
+			break
+		}
+		if !found {
+			return CompactTranscriptResult{Summary: current}
+		}
+	}
+
+	end := len(visible) - retain
+	if end <= start {
+		return CompactTranscriptResult{Summary: current}
+	}
+
+	nextMessages := visible[start:end]
+	nextSummary := ContextSummary{
+		Content:          buildCompactTranscriptSummary(current.Content, nextMessages),
+		MessageCount:     current.MessageCount + len(nextMessages),
+		ThroughMessageID: nextMessages[len(nextMessages)-1].ID,
+		CompactedAt:      now.UTC(),
+	}
+	return CompactTranscriptResult{Summary: nextSummary, Compacted: true}
+}
+
+func TranscriptSummaryPrompt(summary ContextSummary) string {
+	content := strings.TrimSpace(summary.Content)
+	if content == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Earlier chat transcript compacted by Hecate")
+	if summary.MessageCount > 0 {
+		b.WriteString(fmt.Sprintf(" (%d messages", summary.MessageCount))
+		if summary.ThroughMessageID != "" {
+			b.WriteString(" through ")
+			b.WriteString(summary.ThroughMessageID)
+		}
+		b.WriteString(")")
+	}
+	b.WriteString(":\n")
+	b.WriteString(content)
+	b.WriteString("\n\nUse this as background. Newer transcript messages follow in full.")
+	return b.String()
+}
+
+func compactableTranscriptMessages(messages []Message) []Message {
+	out := make([]Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Role != "user" && message.Role != "assistant" {
+			continue
+		}
+		if message.Role == "assistant" && !terminalTranscriptStatus(message.Status) {
+			continue
+		}
+		if strings.TrimSpace(message.Content) == "" {
+			continue
+		}
+		out = append(out, message)
+	}
+	return out
+}
+
+func terminalTranscriptStatus(status string) bool {
+	switch status {
+	case "completed", "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func buildCompactTranscriptSummary(previous string, messages []Message) string {
+	var lines []string
+	if previous = strings.TrimSpace(previous); previous != "" {
+		lines = append(lines, previous)
+	}
+	for _, message := range messages {
+		lines = append(lines, compactTranscriptLine(message))
+	}
+	return trimRunesFromStart(strings.Join(lines, "\n"), compactSummaryMaxRunes)
+}
+
+func compactTranscriptLine(message Message) string {
+	role := "User"
+	if message.Role == "assistant" {
+		role = "Assistant"
+	}
+	text := compactSingleLine(message.Content)
+	if message.Role == "assistant" && message.Status != "" && message.Status != "completed" {
+		return fmt.Sprintf("- %s (%s): %s", role, message.Status, text)
+	}
+	return fmt.Sprintf("- %s: %s", role, text)
+}
+
+func compactSingleLine(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	return trimRunesFromEnd(value, compactLineMaxRunes)
+}
+
+func trimRunesFromEnd(value string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}
+
+func trimRunesFromStart(value string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	if maxRunes <= 3 {
+		return string(runes[len(runes)-maxRunes:])
+	}
+	return "..." + string(runes[len(runes)-maxRunes+3:])
+}

--- a/internal/chat/compaction_test.go
+++ b/internal/chat/compaction_test.go
@@ -1,0 +1,95 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCompactTranscriptSummary_SummarizesOlderVisibleMessages(t *testing.T) {
+	session := Session{Messages: []Message{
+		{ID: "m1", Role: "user", Content: "first request"},
+		{ID: "m2", Role: "assistant", Status: "completed", Content: "first answer"},
+		{ID: "m3", Role: "assistant", Status: "running", Content: "still running"},
+		{ID: "m4", Role: "user", Content: "second request"},
+		{ID: "m5", Role: "assistant", Status: "completed", Content: "second answer"},
+		{ID: "m6", Role: "user", Content: "latest request"},
+	}}
+	now := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+
+	result := CompactTranscriptSummary(session, CompactTranscriptOptions{
+		Now:            now,
+		RetainMessages: 2,
+		MinMessages:    3,
+	})
+
+	if !result.Compacted {
+		t.Fatal("Compacted = false, want true")
+	}
+	if result.Summary.MessageCount != 3 {
+		t.Fatalf("MessageCount = %d, want 3", result.Summary.MessageCount)
+	}
+	if result.Summary.ThroughMessageID != "m4" {
+		t.Fatalf("ThroughMessageID = %q, want m4", result.Summary.ThroughMessageID)
+	}
+	if !result.Summary.CompactedAt.Equal(now) {
+		t.Fatalf("CompactedAt = %s, want %s", result.Summary.CompactedAt, now)
+	}
+	if strings.Contains(result.Summary.Content, "still running") {
+		t.Fatalf("summary includes running assistant message: %q", result.Summary.Content)
+	}
+	for _, want := range []string{"- User: first request", "- Assistant: first answer", "- User: second request"} {
+		if !strings.Contains(result.Summary.Content, want) {
+			t.Fatalf("summary missing %q: %q", want, result.Summary.Content)
+		}
+	}
+}
+
+func TestCompactTranscriptSummary_ExtendsExistingSummaryOnce(t *testing.T) {
+	session := Session{
+		ContextSummary: ContextSummary{
+			Content:          "- User: first request",
+			MessageCount:     1,
+			ThroughMessageID: "m1",
+			CompactedAt:      time.Date(2026, 6, 16, 9, 0, 0, 0, time.UTC),
+		},
+		Messages: []Message{
+			{ID: "m1", Role: "user", Content: "first request"},
+			{ID: "m2", Role: "assistant", Status: "completed", Content: "first answer"},
+			{ID: "m3", Role: "user", Content: "second request"},
+			{ID: "m4", Role: "assistant", Status: "completed", Content: "second answer"},
+		},
+	}
+
+	result := CompactTranscriptSummary(session, CompactTranscriptOptions{
+		RetainMessages: 1,
+		MinMessages:    2,
+	})
+
+	if !result.Compacted {
+		t.Fatal("Compacted = false, want true")
+	}
+	if result.Summary.MessageCount != 3 {
+		t.Fatalf("MessageCount = %d, want 3", result.Summary.MessageCount)
+	}
+	if got := strings.Count(result.Summary.Content, "first request"); got != 1 {
+		t.Fatalf("first request appears %d times, want once: %q", got, result.Summary.Content)
+	}
+	if !strings.Contains(result.Summary.Content, "- Assistant: first answer") ||
+		!strings.Contains(result.Summary.Content, "- User: second request") {
+		t.Fatalf("summary did not append new compacted messages: %q", result.Summary.Content)
+	}
+}
+
+func TestTranscriptSummaryPrompt(t *testing.T) {
+	prompt := TranscriptSummaryPrompt(ContextSummary{
+		Content:          "- User: first request",
+		MessageCount:     1,
+		ThroughMessageID: "m1",
+	})
+
+	if !strings.Contains(prompt, "Earlier chat transcript compacted by Hecate") ||
+		!strings.Contains(prompt, "Use this as background") {
+		t.Fatalf("prompt missing guidance: %q", prompt)
+	}
+}

--- a/internal/chat/conformance_test.go
+++ b/internal/chat/conformance_test.go
@@ -41,6 +41,10 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreAvailableCommandsRoundTrip(t, factory(t))
 	})
+	t.Run(name+"/ContextSummaryRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		runStoreContextSummaryRoundTrip(t, factory(t))
+	})
 	t.Run(name+"/DeleteByProjectID", func(t *testing.T) {
 		t.Parallel()
 		runStoreDeleteByProjectID(t, factory(t))

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -67,9 +67,9 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		fmt.Sprintf(
 			`INSERT INTO %s (
 				id, title, project_id, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
-				status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, created_at, updated_at
+				status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, context_summary, created_at, updated_at
 			 )
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 			   title = excluded.title,
 			   project_id = excluded.project_id,
@@ -87,6 +87,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 			   config_options = excluded.config_options,
 			   available_commands = excluded.available_commands,
 			   rtk_enabled = excluded.rtk_enabled,
+			   context_summary = excluded.context_summary,
 			   updated_at = excluded.updated_at`,
 			s.sessionsTable,
 		),
@@ -108,6 +109,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		marshalCommands(session.AvailableCommands),
 		boolToSQLiteInt(session.RTKEnabled),
 		session.TurnsUsed,
+		marshalContextSummary(session.ContextSummary),
 		session.CreatedAt.UTC(),
 		session.UpdatedAt.UTC(),
 	)
@@ -133,12 +135,12 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		ctx,
 		fmt.Sprintf(
 			`SELECT s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
-			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at,
+			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at,
 			        COUNT(m.id) AS message_count
 			 FROM %s AS s
 			 LEFT JOIN %s AS m ON m.session_id = s.id
 			 GROUP BY s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.workspace, s.workspace_branch,
-			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.created_at, s.updated_at
+			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at
 			 ORDER BY s.updated_at DESC, s.created_at DESC`,
 			s.sessionsTable,
 			s.messagesTable,
@@ -156,6 +158,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		var capabilities string
 		var configOptions string
 		var availableCommands string
+		var contextSummary string
 		var rtkEnabled int
 		if err := rows.Scan(
 			&session.ID,
@@ -176,6 +179,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 			&availableCommands,
 			&rtkEnabled,
 			&session.TurnsUsed,
+			&contextSummary,
 			&session.CreatedAt,
 			&session.UpdatedAt,
 			&messageCount,
@@ -185,6 +189,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		session.Capabilities = unmarshalModelCapabilities(capabilities)
 		session.ConfigOptions = unmarshalConfigOptions(configOptions)
 		session.AvailableCommands = unmarshalCommands(availableCommands)
+		session.ContextSummary = unmarshalContextSummary(contextSummary)
 		session.RTKEnabled = rtkEnabled != 0
 		if session.AgentID == "" {
 			session.AgentID = DefaultAgentID
@@ -253,7 +258,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, update func(
 		fmt.Sprintf(
 			`UPDATE %s SET
 			   title = ?, project_id = ?, agent_id = ?, driver_kind = ?, native_session_id = ?, workspace = ?, workspace_branch = ?,
-			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, available_commands = ?, rtk_enabled = ?, turns_used = ?, updated_at = ?
+			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, available_commands = ?, rtk_enabled = ?, turns_used = ?, context_summary = ?, updated_at = ?
 			 WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -274,6 +279,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, update func(
 		marshalCommands(session.AvailableCommands),
 		boolToSQLiteInt(session.RTKEnabled),
 		session.TurnsUsed,
+		marshalContextSummary(session.ContextSummary),
 		session.UpdatedAt.UTC(),
 		id,
 	); err != nil {
@@ -459,6 +465,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 				model TEXT NOT NULL DEFAULT '',
 				capabilities TEXT NOT NULL DEFAULT '{}',
 				config_options TEXT NOT NULL DEFAULT '[]',
+				context_summary TEXT NOT NULL DEFAULT '{}',
 				rtk_enabled INTEGER NOT NULL DEFAULT 0,
 				turns_used INTEGER NOT NULL DEFAULT 0,
 				created_at TIMESTAMP NOT NULL,
@@ -542,6 +549,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		{name: "capabilities", definition: "TEXT NOT NULL DEFAULT '{}'"},
 		{name: "config_options", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "available_commands", definition: "TEXT NOT NULL DEFAULT '[]'"},
+		{name: "context_summary", definition: "TEXT NOT NULL DEFAULT '{}'"},
 		{name: "rtk_enabled", definition: "INTEGER NOT NULL DEFAULT 0"},
 	} {
 		if err := s.ensureSessionColumn(ctx, column.name, column.definition); err != nil {
@@ -605,12 +613,13 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	var capabilities string
 	var configOptions string
 	var availableCommands string
+	var contextSummary string
 	var rtkEnabled int
 	err := s.client.DB().QueryRowContext(
 		ctx,
 		fmt.Sprintf(
 			`SELECT id, title, project_id, agent_id, driver_kind, native_session_id, workspace, workspace_branch,
-			        status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, created_at, updated_at
+			        status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, rtk_enabled, turns_used, context_summary, created_at, updated_at
 			 FROM %s WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -634,6 +643,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 		&availableCommands,
 		&rtkEnabled,
 		&session.TurnsUsed,
+		&contextSummary,
 		&session.CreatedAt,
 		&session.UpdatedAt,
 	)
@@ -649,6 +659,7 @@ func (s *SQLiteStore) loadSession(ctx context.Context, id string) (Session, erro
 	session.Capabilities = unmarshalModelCapabilities(capabilities)
 	session.ConfigOptions = unmarshalConfigOptions(configOptions)
 	session.AvailableCommands = unmarshalCommands(availableCommands)
+	session.ContextSummary = unmarshalContextSummary(contextSummary)
 	session.RTKEnabled = rtkEnabled != 0
 	messages, err := s.loadMessages(ctx, id)
 	if err != nil {
@@ -967,6 +978,29 @@ func unmarshalContextPacket(raw string) ContextPacket {
 		return ContextPacket{}
 	}
 	return packet
+}
+
+func marshalContextSummary(summary ContextSummary) string {
+	if summary.Empty() {
+		return "{}"
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
+func unmarshalContextSummary(raw string) ContextSummary {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ContextSummary{}
+	}
+	var summary ContextSummary
+	if err := json.Unmarshal([]byte(raw), &summary); err != nil {
+		return ContextSummary{}
+	}
+	return cloneContextSummary(summary)
 }
 
 func normalizeAgentID(session Session) string {

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -36,10 +36,11 @@ type Session struct {
 	// TurnsUsed counts how many user→assistant round-trips have completed
 	// (successfully or with failure) in this session. Used to enforce the
 	// HECATE_CHAT_MAX_TURNS_PER_SESSION ceiling.
-	TurnsUsed int
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	Messages  []Message
+	TurnsUsed      int
+	ContextSummary ContextSummary
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Messages       []Message
 }
 
 type Message struct {
@@ -176,6 +177,20 @@ func (packet ContextPacket) Empty() bool {
 		packet.MessageCount == 0 &&
 		len(packet.Sources) == 0 &&
 		len(packet.Items) == 0
+}
+
+type ContextSummary struct {
+	Content          string    `json:"content,omitempty"`
+	MessageCount     int       `json:"message_count,omitempty"`
+	ThroughMessageID string    `json:"through_message_id,omitempty"`
+	CompactedAt      time.Time `json:"compacted_at,omitempty"`
+}
+
+func (summary ContextSummary) Empty() bool {
+	return strings.TrimSpace(summary.Content) == "" &&
+		summary.MessageCount == 0 &&
+		strings.TrimSpace(summary.ThroughMessageID) == "" &&
+		summary.CompactedAt.IsZero()
 }
 
 type Usage struct {
@@ -433,6 +448,7 @@ func (s *MemoryStore) UpdateMessage(_ context.Context, sessionID string, message
 func cloneSession(session Session) Session {
 	session.ConfigOptions = cloneConfigOptions(session.ConfigOptions)
 	session.AvailableCommands = cloneCommands(session.AvailableCommands)
+	session.ContextSummary = cloneContextSummary(session.ContextSummary)
 	session.Messages = append([]Message(nil), session.Messages...)
 	for i := range session.Messages {
 		session.Messages[i].Activities = append([]Activity(nil), session.Messages[i].Activities...)
@@ -446,6 +462,12 @@ func cloneSession(session Session) Session {
 		}
 	}
 	return session
+}
+
+func cloneContextSummary(summary ContextSummary) ContextSummary {
+	summary.Content = strings.TrimSpace(summary.Content)
+	summary.ThroughMessageID = strings.TrimSpace(summary.ThroughMessageID)
+	return summary
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -433,6 +433,60 @@ func runStoreAvailableCommandsRoundTrip(t *testing.T, store Store) {
 	}
 }
 
+func runStoreContextSummaryRoundTrip(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	createdAt := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	if _, err := store.Create(ctx, Session{
+		ID:      "chat_context_summary",
+		Title:   "Context summary",
+		AgentID: DefaultAgentID,
+		ContextSummary: ContextSummary{
+			Content:          "- User: first request",
+			MessageCount:     1,
+			ThroughMessageID: "msg_user_1",
+			CompactedAt:      createdAt,
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, ok, err := store.Get(ctx, "chat_context_summary")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.ContextSummary.Content != "- User: first request" ||
+		got.ContextSummary.MessageCount != 1 ||
+		got.ContextSummary.ThroughMessageID != "msg_user_1" ||
+		!got.ContextSummary.CompactedAt.Equal(createdAt) {
+		t.Fatalf("stored context summary = %+v", got.ContextSummary)
+	}
+	got.ContextSummary.Content = "mutated"
+	again, _, err := store.Get(ctx, "chat_context_summary")
+	if err != nil {
+		t.Fatalf("Get again: %v", err)
+	}
+	if again.ContextSummary.Content != "- User: first request" {
+		t.Fatalf("context summary mutated through get snapshot: %+v", again.ContextSummary)
+	}
+
+	updated, err := store.UpdateSession(ctx, "chat_context_summary", func(item *Session) {
+		item.ContextSummary = ContextSummary{
+			Content:          "- Assistant: answer",
+			MessageCount:     2,
+			ThroughMessageID: "msg_assistant_1",
+			CompactedAt:      createdAt.Add(time.Minute),
+		}
+	})
+	if err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+	if updated.ContextSummary.MessageCount != 2 ||
+		updated.ContextSummary.ThroughMessageID != "msg_assistant_1" {
+		t.Fatalf("updated context summary = %+v", updated.ContextSummary)
+	}
+}
+
 func runStoreDeleteByProjectID(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -28,6 +28,7 @@ var (
 	ErrSessionIDRequired       = errors.New("session id is required")
 	ErrTitleRequired           = errors.New("request must include title")
 	ErrTitleEmpty              = errors.New("title cannot be set to an empty string")
+	ErrNothingToCompact        = errors.New("chat transcript has no older context to compact")
 )
 
 type ValidationError = apperrors.ValidationError
@@ -119,6 +120,15 @@ type SetHecateSettingsResult struct {
 type RenameSessionCommand struct {
 	ID    string
 	Title *string
+}
+
+type CompactSessionCommand struct {
+	ID               string
+	RetainMessages   int
+	MinMessages      int
+	HecateOnly       bool
+	RequireCompacted bool
+	Now              time.Time
 }
 
 type SessionResult struct {
@@ -255,6 +265,44 @@ func (app *Application) RenameSession(ctx context.Context, cmd RenameSessionComm
 	}
 	updated, err := app.store.UpdateSession(ctx, id, func(item *chat.Session) {
 		item.Title = title
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &SessionResult{Session: updated}, nil
+}
+
+func (app *Application) CompactSession(ctx context.Context, cmd CompactSessionCommand) (*SessionResult, error) {
+	if app == nil || app.store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	id := strings.TrimSpace(cmd.ID)
+	if id == "" {
+		return nil, Validation(ErrSessionIDRequired)
+	}
+	session, ok, err := app.store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	if cmd.HecateOnly && isExternalSession(session) {
+		return nil, ErrHecateSessionOnly
+	}
+	result := chat.CompactTranscriptSummary(session, chat.CompactTranscriptOptions{
+		Now:            cmd.Now,
+		RetainMessages: cmd.RetainMessages,
+		MinMessages:    cmd.MinMessages,
+	})
+	if !result.Compacted {
+		if cmd.RequireCompacted {
+			return nil, ErrNothingToCompact
+		}
+		return &SessionResult{Session: session}, nil
+	}
+	updated, err := app.store.UpdateSession(ctx, id, func(item *chat.Session) {
+		item.ContextSummary = result.Summary
 	})
 	if err != nil {
 		return nil, err

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -3427,7 +3427,11 @@ test("Claude Code setup appears when the adapter is not installed", async ({ pag
   await openClaudeExternalAgent(page, { available: false, healthStatus: "not_installed" });
 
   await expect(page.getByText("Claude Code is unavailable")).toBeVisible();
-  await expect(page.getByText(/Install Claude Code, then sign in with Claude Code/)).toBeVisible();
+  await expect(
+    page.getByText(
+      /Install Claude Code plus the Claude ACP adapter, then sign in with Claude Code/,
+    ),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: "Install" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Auth" })).toBeVisible();
   await page.locator("textarea").fill("hello from Claude Code");

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -21,6 +21,7 @@ import {
   cancelChatSession as cancelChatSessionRequest,
   chatCompletionsStream,
   chooseWorkspaceDirectory as chooseWorkspaceDirectoryRequest,
+  compactChatSession as compactChatSessionRequest,
   createChatMessage as createChatMessageRequest,
   createChatSession as createChatSessionRequest,
   deleteChatSession as deleteChatSessionRequest,
@@ -247,6 +248,7 @@ type ChatActionsReturn = {
   submitAgentChat: (queued?: QueuedChatMessage) => Promise<void>;
   submitChat: (event: SyntheticEvent<HTMLFormElement>) => Promise<void>;
   cancelAgentChat: () => Promise<void>;
+  compactChatSession: (sessionID?: string) => Promise<boolean>;
   updateToolResult: (index: number, result: string) => void;
   submitToolResults: () => Promise<void>;
   createChatSession: (options?: CreateChatSessionOptions) => Promise<void>;
@@ -786,6 +788,30 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     } catch (error) {
       setChatCancelling(false);
       setChatErrorState(error, "failed to cancel agent chat");
+    }
+  }
+
+  async function compactChatSession(sessionID = activeChatSessionID): Promise<boolean> {
+    if (!sessionID) {
+      params.setNoticeMessage("error", "Open a Hecate chat before using /compact.");
+      return false;
+    }
+    setChatLoading(true);
+    clearChatErrorState();
+    try {
+      const payload = await compactChatSessionRequest(sessionID);
+      applyChatSession(payload.data);
+      const count = payload.data.context_summary?.message_count ?? 0;
+      params.setNoticeMessage(
+        "success",
+        count > 0 ? `Compacted ${count} transcript messages.` : "Compacted chat context.",
+      );
+      return true;
+    } catch (error) {
+      setChatErrorState(error, "failed to compact chat context");
+      return false;
+    } finally {
+      setChatLoading(false);
     }
   }
 
@@ -1477,6 +1503,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     // The wide public surface that lands in the viewmodel actions bag
     submitChat,
     cancelAgentChat,
+    compactChatSession,
     updateToolResult,
     submitToolResults,
     createChatSession,

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -79,6 +79,12 @@ const HECATE_MESSAGE_COMMANDS: Record<
   status: {
     description: "Open chat status details",
   },
+  context: {
+    description: "Open chat context details",
+  },
+  compact: {
+    description: "Compact older chat context",
+  },
   task: {
     description: "Open the active task or Tasks",
   },
@@ -107,6 +113,8 @@ type HecateMessageCommandName =
   | "model"
   | "settings"
   | "status"
+  | "context"
+  | "compact"
   | "task"
   | "project"
   | "connections";
@@ -333,6 +341,7 @@ export function ChatComposer(props: ChatComposerProps) {
           projectProposalAvailable && !projectProposalDrafting && Boolean(onDraftProjectProposal),
         workspaceChangesAvailable: workspaceChangesAvailable && Boolean(onOpenWorkspaceChanges),
         chatSettingsAvailable: Boolean(onOpenChatSettings),
+        compactAvailable: Boolean(activeSessionID),
         taskAvailable: Boolean(onOpenTask && activeHecateTaskID) || Boolean(onNavigate),
         projectAvailable: Boolean(onOpenLinkedProject),
         connectionsAvailable: Boolean(onNavigate),
@@ -368,6 +377,7 @@ export function ChatComposer(props: ChatComposerProps) {
   }, [
     activeChatSession?.available_commands,
     activeHecateTaskID,
+    activeSessionID,
     commandQuery,
     isExternalAgentChat,
     isHecateChat,
@@ -545,7 +555,7 @@ export function ChatComposer(props: ChatComposerProps) {
     const hecateCommand = parseHecateMessageCommand(message);
     if (hecateCommand && isHecateChat && hecateCommandDefinition(hecateCommand.name)) {
       e.preventDefault();
-      handleHecateMessageCommand(hecateCommand);
+      void handleHecateMessageCommand(hecateCommand);
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
@@ -563,7 +573,7 @@ export function ChatComposer(props: ChatComposerProps) {
     runtime.actions.setMessage("");
   }
 
-  function handleHecateMessageCommand(command: ParsedHecateMessageCommand) {
+  async function handleHecateMessageCommand(command: ParsedHecateMessageCommand) {
     const name = command.name;
     if (HECATE_PROJECT_COMMAND_NAMES.has(name)) {
       if (!projectProposalAvailable || projectProposalDrafting || !onDraftProjectProposal) {
@@ -593,12 +603,22 @@ export function ChatComposer(props: ChatComposerProps) {
       case "model":
       case "settings":
       case "status":
+      case "context":
         if (!onOpenChatSettings) {
           settingsActions.setNoticeMessage("error", "Chat settings are not available here.");
           return;
         }
         onOpenChatSettings();
         clearLocalCommandMessage();
+        return;
+      case "compact":
+        if (!activeSessionID) {
+          settingsActions.setNoticeMessage("error", "Open a Hecate chat before using /compact.");
+          return;
+        }
+        if (await chatActions.compactChatSession(activeSessionID)) {
+          clearLocalCommandMessage();
+        }
         return;
       case "task":
         if (activeHecateTaskID && onOpenTask) {
@@ -1240,6 +1260,7 @@ type HecateMessageCommandAvailability = {
   projectProposalAvailable: boolean;
   workspaceChangesAvailable: boolean;
   chatSettingsAvailable: boolean;
+  compactAvailable: boolean;
   taskAvailable: boolean;
   projectAvailable: boolean;
   connectionsAvailable: boolean;
@@ -1263,7 +1284,9 @@ function availableHecateMessageCommands(availability: HecateMessageCommandAvaila
     push("model");
     push("settings");
     push("status");
+    push("context");
   }
+  if (availability.compactAvailable) push("compact");
   if (availability.taskAvailable) push("task");
   if (availability.projectAvailable) push("project");
   if (availability.connectionsAvailable) push("connections");

--- a/ui/src/features/chats/ChatSettingsPanel.tsx
+++ b/ui/src/features/chats/ChatSettingsPanel.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 import { formatInteger } from "../../lib/format";
-import type { ChatSessionRecord, ChatUsageRecord } from "../../types/chat";
+import type {
+  ChatContextSummaryRecord,
+  ChatSessionRecord,
+  ChatUsageRecord,
+} from "../../types/chat";
 import { Icon, Icons } from "../shared/ui";
 import { ExternalAgentSettingsControls } from "./ChatAgentControls";
 import { compactID } from "./ChatComposer";
@@ -21,6 +25,7 @@ export function ChatSettingsPanel({
   workspace,
   status,
   messageCount,
+  contextSummary,
   agentUsage,
   usageSource,
   externalSession,
@@ -48,6 +53,7 @@ export function ChatSettingsPanel({
   workspace?: string;
   status?: string;
   messageCount: number;
+  contextSummary?: ChatContextSummaryRecord;
   agentUsage: ChatUsageRecord | null;
   usageSource: "hecate" | "adapter";
   externalSession: ChatSessionRecord | null;
@@ -189,6 +195,14 @@ export function ChatSettingsPanel({
             />
             <ChatSettingsField label="Status" value={status || "new chat"} />
             <ChatSettingsField label="Messages" value={String(messageCount)} mono />
+            {contextSummary?.message_count ? (
+              <ChatSettingsField
+                label="Compacted"
+                value={`${formatInteger(contextSummary.message_count)} messages`}
+                title={contextSummary.through_message_id}
+                mono
+              />
+            ) : null}
             {taskID && <ChatSettingsField label="Task" value={shortID(taskID)} mono />}
           </div>
         </ChatSettingsSection>

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3387,6 +3387,8 @@ describe("ChatView input", () => {
     expect(within(commands).getByRole("option", { name: "Insert /model command" })).toBeTruthy();
     expect(within(commands).getByRole("option", { name: "Insert /settings command" })).toBeTruthy();
     expect(within(commands).getByRole("option", { name: "Insert /status command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /context command" })).toBeTruthy();
+    expect(within(commands).getByRole("option", { name: "Insert /compact command" })).toBeTruthy();
     expect(within(commands).getByRole("option", { name: "Insert /task command" })).toBeTruthy();
     expect(
       within(commands).getByRole("option", { name: "Insert /connections command" }),
@@ -3634,6 +3636,78 @@ describe("ChatView input", () => {
     fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
 
     expect(screen.getByLabelText("Chat settings panel")).toBeTruthy();
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("opens chat context with /context without sending chat", () => {
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/context",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          context_summary: {
+            message_count: 12,
+            through_message_id: "msg_12",
+            content: "- User: old request",
+          },
+          messages: [],
+        },
+      },
+      { setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    expect(screen.getByLabelText("Chat settings panel")).toBeTruthy();
+    expect(screen.getByText("Compacted")).toBeTruthy();
+    expect(screen.getByText("12 messages")).toBeTruthy();
+    expect(setMessage).toHaveBeenCalledWith("");
+    expect(submitChat).not.toHaveBeenCalled();
+  });
+
+  it("compacts chat context with /compact without sending chat", async () => {
+    const compactChatSession = vi.fn(async () => true);
+    const setMessage = vi.fn();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup(
+      {
+        chatTarget: "agent",
+        defaultChatToolsEnabled: false,
+        message: "/compact",
+        activeChatSessionID: "s1",
+        activeChatSession: {
+          id: "s1",
+          agent_id: "hecate",
+          title: "Project chat",
+          execution_mode: "hecate_task",
+          provider: "openai",
+          model: "gpt-4o-mini",
+          status: "idle",
+          workspace: "/tmp/hecate",
+          messages: [],
+        },
+      },
+      { compactChatSession, setMessage, submitChat },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    fireEvent.submit(screen.getByRole("textbox", { name: "Message" }).closest("form")!);
+
+    await waitFor(() => expect(compactChatSession).toHaveBeenCalledWith("s1"));
     expect(setMessage).toHaveBeenCalledWith("");
     expect(submitChat).not.toHaveBeenCalled();
   });

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1086,6 +1086,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                   workspace={state.activeChatSession?.workspace || state.agentWorkspace}
                   status={state.activeChatSession?.status || ""}
                   messageCount={state.activeChatSession?.messages?.length ?? 0}
+                  contextSummary={state.activeChatSession?.context_summary}
                   agentUsage={latestChatUsage}
                   usageSource={isHecateChat ? "hecate" : "adapter"}
                   externalSession={isExternalAgentChat ? state.activeChatSession : null}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -862,6 +862,13 @@ export async function cancelChatSession(id: string): Promise<ChatSessionResponse
   );
 }
 
+export async function compactChatSession(id: string): Promise<ChatSessionResponse> {
+  return fetchJSON<ChatSessionResponse>(
+    `${HECATE_API}/chat/sessions/${encodeURIComponent(id)}/compact`,
+    { method: "POST", body: {} },
+  );
+}
+
 export async function createChatMessage(
   id: string,
   payload: string | CreateChatMessagePayload,

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -201,6 +201,7 @@ export function createRuntimeConsoleFixture(
 export type RuntimeConsoleFixtureActions = {
   copyCommand: (command: string) => Promise<void>;
   cancelAgentChat: () => Promise<void>;
+  compactChatSession: (sessionID?: string) => Promise<boolean>;
   chooseAgentWorkspace: () => Promise<boolean>;
   createChatSession: (options?: {
     agentID?: string;
@@ -283,6 +284,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
   return {
     copyCommand: async () => undefined,
     cancelAgentChat: async () => undefined,
+    compactChatSession: async () => true,
     chooseAgentWorkspace: async () => true,
     createChatSession: async () => undefined,
     deleteChatSession: async () => undefined,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -201,6 +201,7 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
       submitChat: actions.submitChat,
       submitToolResults: actions.submitToolResults,
       cancelAgentChat: actions.cancelAgentChat,
+      compactChatSession: actions.compactChatSession,
       chooseAgentWorkspace: actions.chooseAgentWorkspace,
       createChatSession: actions.createChatSession,
       deleteChatSession: actions.deleteChatSession,

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -506,6 +506,7 @@ export function useRuntimeConsole() {
     actions: {
       copyCommand,
       cancelAgentChat: chatActions.cancelAgentChat,
+      compactChatSession: chatActions.compactChatSession,
       deletePolicyRule: policyActions.deletePolicyRule,
       chooseAgentWorkspace: chatActions.chooseAgentWorkspace,
       createChatSession: chatActions.createChatSession,

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -113,6 +113,13 @@ export type ChatUsageRecord = {
   reported_cost_currency?: string;
 };
 
+export type ChatContextSummaryRecord = {
+  content?: string;
+  message_count?: number;
+  through_message_id?: string;
+  compacted_at?: string;
+};
+
 export type ChatTimingRecord = {
   total_ms?: number;
   queue_ms?: number;
@@ -208,6 +215,7 @@ export type ChatSessionRecord = {
   updated_at?: string;
   config_options?: ChatConfigOptionRecord[];
   available_commands?: ChatAvailableCommandRecord[];
+  context_summary?: ChatContextSummaryRecord;
   segments?: ChatSegmentRecord[];
   messages?: ChatMessageRecord[];
 };


### PR DESCRIPTION
## Summary
- Add persisted context summaries for Hecate chat sessions with manual `/compact` and automatic long-transcript compaction.
- Inject compacted summaries into model history, rendered chat payloads, and transcript context packets.
- Surface `/compact` and `/context` utility commands in Hecate chat plus a compacted-summary row in chat settings.

## Tests
- `go test ./...`
- `go test -race -timeout 10m ./internal/api ./internal/chat ./internal/chatapp`
- `go vet ./internal/api ./internal/chat ./internal/chatapp`
- `bun run typecheck`
- `bun run test -- src/features/chats/ChatView.test.tsx src/app/state/coordinators/chat.test.ts src/app/state/reconcileChatSession.test.ts`
- `bun run lint`
- `bun run format:check`
- `git diff --check`