### PR TITLE
Fix Hecate chat model defaults and Fireworks discovery

### DIFF
--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -139,6 +139,12 @@ provider-specific endpoint layout: Hecate sends chat traffic to
 fields such as `citations` and `search_results` are not forwarded yet; the
 normalized assistant text, model, and token usage are.
 
+Fireworks AI is also OpenAI Chat Completions-compatible, but its public model
+catalog is account-scoped. Hecate sends chat traffic to
+`https://api.fireworks.ai/inference/v1` and discovers the public Fireworks model
+list through `https://api.fireworks.ai/v1/accounts/fireworks/models`, which
+returns model metadata such as context length and tool support.
+
 ## Anthropic prompt caching
 
 Hecate automatically attaches `cache_control: {"type":"ephemeral"}`

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3111,6 +3111,13 @@ optional `description`, and optional `input_hint`. The `name` is agent-owned;
 clients should render it as a slash command hint but submit the chosen command
 as normal prompt text.
 
+Hecate-owned sessions may include `context_summary` when older direct-model
+chat transcript turns have been compacted. The original messages remain in the
+durable transcript; `context_summary` tells clients and later model calls how
+many older messages were summarized, the last summarized message id, and when
+the summary was produced. Hecate injects that summary as system context before
+the retained recent transcript on later direct-model turns.
+
 ### `PATCH /hecate/v1/chat/sessions/{id}`
 
 Renames a chat session. This is shared by Hecate Chat
@@ -3180,6 +3187,36 @@ PATCH /hecate/v1/chat/sessions/chat_.../settings
     "id": "chat_...",
     "agent_id": "hecate",
     "rtk_enabled": true
+  }
+}
+```
+
+### `POST /hecate/v1/chat/sessions/{id}/compact`
+
+Compacts older transcript context for a Hecate-owned chat session and returns
+the updated session. This endpoint is deterministic and local to Hecate; it
+does not call a model. It summarizes older user/assistant turns into
+`context_summary` while retaining the newest messages in full for later turns.
+
+External Agent sessions reject this endpoint with `409 chat.runtime_mismatch`
+because their native runtimes own their own context windows. If there are not
+enough older messages to compact, Hecate returns `400 invalid_request`.
+
+```json
+POST /hecate/v1/chat/sessions/chat_.../compact
+
+→ 200
+{
+  "object": "chat_session",
+  "data": {
+    "id": "chat_...",
+    "agent_id": "hecate",
+    "context_summary": {
+      "content": "- User: previous request\n- Assistant: previous answer",
+      "message_count": 2,
+      "through_message_id": "msg_...",
+      "compacted_at": "2026-06-16T10:00:00Z"
+    }
   }
 }
 ```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -796,6 +796,9 @@ func TestBuiltInProviderCatalogMetadata(t *testing.T) {
 	if fireworks.BaseURL != "https://api.fireworks.ai/inference/v1" {
 		t.Fatalf("fireworks base url = %q, want https://api.fireworks.ai/inference/v1", fireworks.BaseURL)
 	}
+	if fireworks.ModelsPath != "https://api.fireworks.ai/v1/accounts/fireworks/models" {
+		t.Fatalf("fireworks models path = %q, want Fireworks account models endpoint", fireworks.ModelsPath)
+	}
 
 	huggingface, ok := BuiltInProviderByID("huggingface")
 	if !ok {

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -91,6 +91,7 @@ var builtInProviders = []BuiltInProvider{
 		Protocol:    "openai",
 		BaseURL:     "https://api.fireworks.ai/inference/v1",
 		APIKeyEnv:   "PROVIDER_FIREWORKS_API_KEY",
+		ModelsPath:  "https://api.fireworks.ai/v1/accounts/fireworks/models",
 		DocsURL:     "https://docs.fireworks.ai/getting-started/introduction",
 		Description: "Fireworks.ai serverless inference. Hosts an evolving catalog of open-weight models; model IDs are namespaced (`accounts/fireworks/models/<slug>`).",
 	},

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -212,6 +212,20 @@ type openAIModel struct {
 	ID string `json:"id"`
 }
 
+type fireworksModelsResponse struct {
+	Models []fireworksModel `json:"models"`
+	Data   []fireworksModel `json:"data"`
+}
+
+type fireworksModel struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	DisplayName        string `json:"displayName"`
+	SupportsTools      bool   `json:"supportsTools"`
+	SupportsImageInput bool   `json:"supportsImageInput"`
+	ContextLength      int    `json:"contextLength"`
+}
+
 type ollamaShowRequest struct {
 	Model string `json:"model"`
 }
@@ -400,6 +414,10 @@ func (p *OpenAICompatibleProvider) staticCapabilities(source string) Capabilitie
 
 func (p *OpenAICompatibleProvider) discoverCapabilities(ctx context.Context) (Capabilities, error) {
 	endpoint := buildModelsURL(p.config.BaseURL, p.config.ModelsPath)
+	if p.isFireworksProvider() {
+		return p.discoverFireworksCapabilities(ctx, endpoint)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return Capabilities{}, fmt.Errorf("build models request: %w", err)
@@ -444,6 +462,83 @@ func (p *OpenAICompatibleProvider) discoverCapabilities(ctx context.Context) (Ca
 		ModelCapabilities: p.discoverProviderModelCapabilities(ctx, models),
 		Discoverable:      true,
 		DiscoverySource:   "upstream_v1_models",
+		RefreshedAt:       time.Now().UTC(),
+	}, nil
+}
+
+func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Context, endpoint string) (Capabilities, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("build Fireworks models request: %w", err)
+	}
+	if p.config.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.config.APIKey)
+	}
+	injectTraceContext(req)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("send Fireworks models request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return Capabilities{}, decodeUpstreamError(resp)
+	}
+
+	var payload fireworksModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return Capabilities{}, fmt.Errorf("decode Fireworks models response: %w", err)
+	}
+
+	items := payload.Models
+	if len(items) == 0 {
+		items = payload.Data
+	}
+	models := make([]string, 0, len(items))
+	modelCapabilities := make(map[string]types.ModelCapabilities, len(items))
+	for _, item := range items {
+		id := strings.TrimSpace(item.Name)
+		if id == "" {
+			id = strings.TrimSpace(item.ID)
+		}
+		if id == "" || contains(models, id) {
+			continue
+		}
+		models = append(models, id)
+
+		cap := types.ModelCapabilities{
+			Streaming:      true,
+			StreamingKnown: true,
+			Source:         "provider",
+		}
+		if item.SupportsTools {
+			cap.ToolCalling = "basic"
+		}
+		if item.ContextLength > 0 {
+			cap.MaxContextTokens = item.ContextLength
+		}
+		if cap.ToolCalling != "" || cap.MaxContextTokens > 0 {
+			modelCapabilities[id] = cap
+		}
+	}
+	if len(modelCapabilities) == 0 {
+		modelCapabilities = nil
+	}
+
+	defaultModel := p.config.DefaultModel
+	if defaultModel == "" && len(models) > 0 {
+		defaultModel = models[0]
+	}
+
+	return Capabilities{
+		Name:              p.Name(),
+		Kind:              p.Kind(),
+		DefaultModel:      defaultModel,
+		Models:            models,
+		ModelCapabilities: modelCapabilities,
+		Discoverable:      true,
+		DiscoverySource:   "fireworks_models",
 		RefreshedAt:       time.Now().UTC(),
 	}, nil
 }
@@ -511,6 +606,10 @@ func (p *OpenAICompatibleProvider) ollamaCapabilityDiscoveryTimeout() time.Durat
 
 func (p *OpenAICompatibleProvider) isOllamaProvider() bool {
 	return strings.EqualFold(strings.TrimSpace(p.config.Name), "ollama")
+}
+
+func (p *OpenAICompatibleProvider) isFireworksProvider() bool {
+	return strings.EqualFold(strings.TrimSpace(p.config.Name), "fireworks")
 }
 
 func ollamaNativeBaseURL(base string) (string, error) {
@@ -907,7 +1006,11 @@ func buildModelsURL(baseURL, path string) string {
 }
 
 func buildProviderURL(baseURL, path string) string {
-	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(strings.TrimSpace(path), "/")
+	trimmedPath := strings.TrimSpace(path)
+	if u, err := url.Parse(trimmedPath); err == nil && u.IsAbs() {
+		return trimmedPath
+	}
+	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(trimmedPath, "/")
 }
 
 func decodeUpstreamError(resp *http.Response) error {

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -365,6 +365,61 @@ func TestOpenAIProviderCapabilitiesDiscovery(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderFireworksDiscoveryUsesModelsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	transport := testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if r.Method != http.MethodGet {
+			return nil, fmt.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.String(); got != "https://api.fireworks.ai/v1/accounts/fireworks/models" {
+			return nil, fmt.Errorf("url = %s, want Fireworks models endpoint", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fireworks-key" {
+			return nil, fmt.Errorf("Authorization = %q, want Bearer fireworks-key", got)
+		}
+		return jsonHTTPResponse(fireworksModelsResponse{Models: []fireworksModel{
+			{
+				Name:          "accounts/fireworks/models/deepseek-v3p1",
+				SupportsTools: true,
+				ContextLength: 131072,
+			},
+			{ID: "accounts/fireworks/models/llama-v3p1"},
+		}})
+	})
+
+	provider := NewOpenAICompatibleProvider(config.OpenAICompatibleProviderConfig{
+		Name:         "fireworks",
+		Kind:         "cloud",
+		BaseURL:      "https://api.fireworks.ai/inference/v1",
+		ModelsPath:   "https://api.fireworks.ai/v1/accounts/fireworks/models",
+		APIKey:       "fireworks-key",
+		Timeout:      time.Second,
+		DefaultModel: "accounts/fireworks/models/deepseek-v3p1",
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	provider.httpClient.Transport = transport
+
+	caps, err := provider.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("discovery call count = %d, want 1", calls)
+	}
+	if len(caps.Models) != 2 || caps.Models[0] != "accounts/fireworks/models/deepseek-v3p1" {
+		t.Fatalf("models = %#v, want Fireworks model names", caps.Models)
+	}
+	if caps.DiscoverySource != "fireworks_models" {
+		t.Fatalf("discovery source = %q, want fireworks_models", caps.DiscoverySource)
+	}
+	capability := caps.ModelCapabilities["accounts/fireworks/models/deepseek-v3p1"]
+	if capability.ToolCalling != "basic" || capability.MaxContextTokens != 131072 {
+		t.Fatalf("model capability = %+v, want tools and context length", capability)
+	}
+}
+
 func TestOpenAIProviderOllamaDiscoveryReadsNativeToolCapabilities(t *testing.T) {
 	t.Parallel()
 

--- a/ui/src/app/runtimeConsoleChatHelpers.test.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.test.ts
@@ -15,6 +15,7 @@ import {
   isModelValidForProvider,
   providerHasChatRouteEvidence,
   renderChatSessionSummary,
+  withConfiguredDefaultModels,
 } from "./runtimeConsoleChatHelpers";
 
 function emptyRuntimeHeaders(overrides: Partial<RuntimeHeaders> = {}): RuntimeHeaders {
@@ -187,6 +188,24 @@ describe("defaultModelForProvider", () => {
     const providers = [provider({ name: "ollama", models: ["llama3.1:8b"] })];
     expect(defaultModelForProvider("ollama", [], providers)).toBe("llama3.1:8b");
   });
+
+  it("falls back to configured provider defaults before discovery reports models", () => {
+    const configured = [
+      {
+        id: "fireworks",
+        name: "fireworks",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "",
+        default_model: "accounts/fireworks/models/deepseek-v3p1",
+        credential_configured: true,
+      },
+    ];
+
+    expect(defaultModelForProvider("fireworks", [], [], configured, [])).toBe(
+      "accounts/fireworks/models/deepseek-v3p1",
+    );
+  });
 });
 
 describe("defaultProviderForChat", () => {
@@ -286,6 +305,89 @@ describe("isModelValidForProvider", () => {
   it("rejects models not listed by a provider record", () => {
     const providers = [provider({ name: "openai", default_model: "gpt-4o", models: ["gpt-4o"] })];
     expect(isModelValidForProvider("gpt-3.5", "openai", [], providers)).toBe(false);
+  });
+
+  it("accepts configured provider defaults before discovery reports models", () => {
+    const configured = [
+      {
+        id: "fireworks",
+        name: "fireworks",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "",
+        default_model: "accounts/fireworks/models/deepseek-v3p1",
+        credential_configured: true,
+      },
+    ];
+
+    expect(
+      isModelValidForProvider(
+        "accounts/fireworks/models/deepseek-v3p1",
+        "fireworks",
+        [],
+        [],
+        configured,
+        [],
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("withConfiguredDefaultModels", () => {
+  it("adds configured default models when discovery has not reported them yet", () => {
+    const configured = [
+      {
+        id: "fireworks",
+        name: "fireworks",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "",
+        default_model: "accounts/fireworks/models/deepseek-v3p1",
+        credential_configured: true,
+      },
+    ];
+
+    expect(withConfiguredDefaultModels([], "fireworks", configured, [])).toEqual([
+      {
+        id: "accounts/fireworks/models/deepseek-v3p1",
+        owned_by: "fireworks",
+        metadata: {
+          provider: "fireworks",
+          provider_kind: "cloud",
+          default: true,
+          discovery_source: "configured_default",
+        },
+      },
+    ]);
+  });
+
+  it("uses preset defaults when configured providers inherit the preset model", () => {
+    const configured = [
+      {
+        id: "fireworks",
+        name: "fireworks",
+        preset_id: "fireworks",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "",
+        credential_configured: true,
+      },
+    ];
+    const presets = [
+      {
+        id: "fireworks",
+        name: "Fireworks AI",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "https://api.fireworks.ai/inference/v1",
+        default_model: "accounts/fireworks/models/deepseek-v3p1",
+      },
+    ];
+
+    expect(withConfiguredDefaultModels([], "fireworks", configured, presets)).toHaveLength(1);
+    expect(withConfiguredDefaultModels([], "fireworks", configured, presets)[0].id).toBe(
+      "accounts/fireworks/models/deepseek-v3p1",
+    );
   });
 });
 

--- a/ui/src/app/runtimeConsoleChatHelpers.ts
+++ b/ui/src/app/runtimeConsoleChatHelpers.ts
@@ -1,9 +1,10 @@
 import type { ChatMessage } from "../lib/api";
 import type { RuntimeHeaders } from "../types/runtime";
-import type { ModelResponse } from "../types/model";
+import type { ModelRecord, ModelResponse } from "../types/model";
 import type {
   ConfiguredStateResponse,
   ProviderFilter,
+  ProviderPresetRecord,
   ProviderStatusResponse,
 } from "../types/provider";
 import type {
@@ -111,6 +112,8 @@ export function defaultModelForProvider(
   provider: ProviderFilter,
   models: ModelResponse["data"],
   providers: ProviderStatusResponse["data"],
+  configuredProviders: ConfiguredStateResponse["data"]["providers"] = [],
+  providerPresets: ProviderPresetRecord[] = [],
 ): string {
   if (provider === "auto") {
     return "";
@@ -118,6 +121,11 @@ export function defaultModelForProvider(
 
   const providerRecord = providers.find((entry) => entry.name === provider);
   const scopedModels = models.filter((entry) => entry.metadata?.provider === provider);
+  const configuredDefault = configuredDefaultModelForProvider(
+    provider,
+    configuredProviders,
+    providerPresets,
+  );
   if (providerRecord?.default_model) {
     return providerRecord.default_model;
   }
@@ -127,11 +135,65 @@ export function defaultModelForProvider(
       scopedModels.find((entry) => entry.metadata?.default)?.id ??
       scopedModels[0]?.id ??
       providerRecord.models?.[0] ??
+      configuredDefault ??
       ""
     );
   }
 
-  return scopedModels.find((entry) => entry.metadata?.default)?.id ?? scopedModels[0]?.id ?? "";
+  return (
+    scopedModels.find((entry) => entry.metadata?.default)?.id ??
+    scopedModels[0]?.id ??
+    configuredDefault
+  );
+}
+
+function configuredDefaultModelForProvider(
+  provider: ProviderFilter,
+  configuredProviders: ConfiguredStateResponse["data"]["providers"] = [],
+  providerPresets: ProviderPresetRecord[] = [],
+): string {
+  if (provider === "auto") return "";
+  const configured = configuredProviders.find((entry) => entry.id === provider);
+  const presetID = configured?.preset_id || provider;
+  const preset = providerPresets.find((entry) => entry.id === presetID);
+  return configured?.default_model || preset?.default_model || "";
+}
+
+export function withConfiguredDefaultModels(
+  models: ModelRecord[],
+  provider: ProviderFilter,
+  configuredProviders: ConfiguredStateResponse["data"]["providers"] = [],
+  providerPresets: ProviderPresetRecord[] = [],
+): ModelRecord[] {
+  if (configuredProviders.length === 0) return models;
+  const out = [...models];
+  const seen = new Set(out.map((entry) => `${entry.metadata?.provider ?? ""}\0${entry.id}`));
+  const includeProvider = (id: string) => provider === "auto" || provider === id;
+
+  for (const configured of configuredProviders) {
+    if (!includeProvider(configured.id)) continue;
+    const modelID = configuredDefaultModelForProvider(
+      configured.id,
+      configuredProviders,
+      providerPresets,
+    );
+    if (!modelID) continue;
+    const key = `${configured.id}\0${modelID}`;
+    if (seen.has(key)) continue;
+    out.push({
+      id: modelID,
+      owned_by: configured.id,
+      metadata: {
+        provider: configured.id,
+        provider_kind: configured.kind,
+        default: true,
+        discovery_source: "configured_default",
+      },
+    });
+    seen.add(key);
+  }
+
+  return out;
 }
 
 export function defaultProviderForChat(
@@ -172,6 +234,8 @@ export function isModelValidForProvider(
   provider: ProviderFilter,
   models: ModelResponse["data"],
   providers: ProviderStatusResponse["data"],
+  configuredProviders: ConfiguredStateResponse["data"]["providers"] = [],
+  providerPresets: ProviderPresetRecord[] = [],
 ): boolean {
   if (!model || provider === "auto") {
     return true;
@@ -183,6 +247,9 @@ export function isModelValidForProvider(
 
   const providerRecord = providers.find((entry) => entry.name === provider);
   if (providerRecord?.default_model === model || providerRecord?.models?.includes(model)) {
+    return true;
+  }
+  if (configuredDefaultModelForProvider(provider, configuredProviders, providerPresets) === model) {
     return true;
   }
   if (providerRecord) {

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -186,6 +186,32 @@ function modelAvailableForProviderFilter(
   model: string,
 ): boolean {
   if (!model.trim()) return false;
+  if (providerFilter === "auto") {
+    const knownProviders = new Set<string>();
+    for (const entry of models) {
+      if (entry.id === model && typeof entry.metadata?.provider === "string") {
+        knownProviders.add(entry.metadata.provider);
+      }
+    }
+    for (const provider of providers) {
+      if (provider.default_model === model || provider.models?.includes(model)) {
+        knownProviders.add(provider.name);
+      }
+    }
+    for (const configured of configuredProviders) {
+      knownProviders.add(configured.id);
+    }
+    return Array.from(knownProviders).some((provider) =>
+      isModelValidForProvider(
+        model,
+        provider,
+        models,
+        providers,
+        configuredProviders,
+        providerPresets,
+      ),
+    );
+  }
   return isModelValidForProvider(
     model,
     providerFilter,

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -48,6 +48,7 @@ import {
   buildSyntheticChatResult,
   defaultModelForProvider,
   deriveChatSessionTitle,
+  isModelValidForProvider,
   renderChatSessionSummary,
 } from "../../runtimeConsoleChatHelpers";
 import { modelSelectionHasNoToolCalling } from "../../../lib/chat-setup-readiness";
@@ -68,9 +69,15 @@ import { reconcileChatSession } from "../reconcileChatSession";
 import { useProjects } from "../projects";
 import { useProvidersAndModels } from "../providersAndModels";
 import { useRuntime } from "../runtime";
+import { useSettings } from "../settings";
 import { useUsage } from "../usage";
 import type { RuntimeHeaders } from "../../../types/runtime";
-import type { ProviderFilter } from "../../../types/provider";
+import type {
+  ConfiguredStateResponse,
+  ProviderFilter,
+  ProviderPresetRecord,
+  ProviderStatusResponse,
+} from "../../../types/provider";
 import type { ModelRecord } from "../../../types/model";
 import type {
   ChatActivityRecord,
@@ -172,15 +179,21 @@ function effectiveHecateToolsEnabled({
 
 function modelAvailableForProviderFilter(
   models: ModelRecord[],
+  providers: ProviderStatusResponse["data"],
+  configuredProviders: ConfiguredStateResponse["data"]["providers"],
+  providerPresets: ProviderPresetRecord[],
   providerFilter: ProviderFilter,
   model: string,
 ): boolean {
   if (!model.trim()) return false;
-  return models.some((entry) => {
-    if (entry.id !== model) return false;
-    if (!providerFilter || providerFilter === "auto") return true;
-    return entry.metadata?.provider === providerFilter;
-  });
+  return isModelValidForProvider(
+    model,
+    providerFilter,
+    models,
+    providers,
+    configuredProviders,
+    providerPresets,
+  );
 }
 
 export { chatSessionIsExternal, chatSessionIsBusy };
@@ -318,6 +331,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
   const chat = useChat();
   const projects = useProjects();
   const approvals = useApprovals();
+  const settings = useSettings();
 
   const { message, hecateRTKEnabled } = runtime.state;
   const {
@@ -326,7 +340,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     setHecateRTKEnabled: setHecateRTKEnabledState,
   } = runtime.actions;
   const { setSummary: setUsageSummary, setEvents: setUsageEvents } = usage.actions;
-  const { agentAdapters, models, providers } = providersAndModels.state;
+  const { agentAdapters, models, providers, providerPresets } = providersAndModels.state;
+  const configuredProviders = settings.state.config?.providers ?? [];
   const activeProjectID = projects.activeProjectID.trim();
   const {
     defaultChatTarget,
@@ -414,7 +429,15 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
   function selectProviderRoute(nextProvider: ProviderFilter) {
     setProviderFilter(nextProvider);
-    setModel(defaultModelForProvider(nextProvider, models, providers));
+    setModel(
+      defaultModelForProvider(
+        nextProvider,
+        models,
+        providers,
+        configuredProviders,
+        providerPresets,
+      ),
+    );
   }
 
   function updateAgentWorkspace(nextWorkspace: string) {
@@ -959,7 +982,14 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     const requestedModel =
       toolsEnabled &&
       requestedSelectionModel &&
-      !modelAvailableForProviderFilter(models, requestedProviderFilter, requestedSelectionModel)
+      !modelAvailableForProviderFilter(
+        models,
+        providers,
+        configuredProviders,
+        providerPresets,
+        requestedProviderFilter,
+        requestedSelectionModel,
+      )
         ? ""
         : requestedSelectionModel;
     const workspace = workspaceForNewChat(createProjectID);

--- a/ui/src/app/state/coordinators/providers.ts
+++ b/ui/src/app/state/coordinators/providers.ts
@@ -45,7 +45,7 @@ export type UseProviderActionsParams = {
 export function useProviderActions(params: UseProviderActionsParams) {
   const providersAndModels = useProvidersAndModels();
   const chat = useChat();
-  const { providers, models } = providersAndModels.state;
+  const { providers, models, providerPresets } = providersAndModels.state;
   const { setProviders } = providersAndModels.actions;
   const { providerFilter, model } = chat.state;
   const { setProviderFilter, setModel } = chat.actions;
@@ -108,7 +108,15 @@ export function useProviderActions(params: UseProviderActionsParams) {
         params.settingsConfig?.providers.filter((provider) => provider.id !== id) ?? [];
       const nextProvider = defaultProviderForChat(models, remainingConfigured, remainingProviders);
       setProviderFilter(nextProvider);
-      setModel(defaultModelForProvider(nextProvider, models, remainingProviders));
+      setModel(
+        defaultModelForProvider(
+          nextProvider,
+          models,
+          remainingProviders,
+          remainingConfigured,
+          providerPresets,
+        ),
+      );
     }
 
     try {

--- a/ui/src/app/state/rootEffects.ts
+++ b/ui/src/app/state/rootEffects.ts
@@ -130,7 +130,7 @@ export function RootEffects() {
   } = chat.state;
   const { setChatCancelling, setModel, setProviderFilter, setQueuedChatMessages } = chat.actions;
   const { setHecateRTKEnabled: setHecateRTKEnabledState } = runtime.actions;
-  const { models, providers } = providersAndModels.state;
+  const { models, providers, providerPresets } = providersAndModels.state;
   const { notice } = settings.state;
   const { dismissNoticeIfMatching } = settings.actions;
   const settingsConfig = settings.state.config;
@@ -190,11 +190,34 @@ export function RootEffects() {
     if (nextProvider === providerFilter) return;
     setProviderFilter(nextProvider);
     const nextModel =
-      model && isModelValidForProvider(model, nextProvider, models, providers)
+      model &&
+      isModelValidForProvider(
+        model,
+        nextProvider,
+        models,
+        providers,
+        configuredProviders,
+        providerPresets,
+      )
         ? model
-        : defaultModelForProvider(nextProvider, models, providers);
+        : defaultModelForProvider(
+            nextProvider,
+            models,
+            providers,
+            configuredProviders,
+            providerPresets,
+          );
     setModel(nextModel);
-  }, [model, models, providerFilter, providers, settingsConfig, setProviderFilter, setModel]);
+  }, [
+    model,
+    models,
+    providerFilter,
+    providerPresets,
+    providers,
+    settingsConfig,
+    setProviderFilter,
+    setModel,
+  ]);
 
   useEffect(() => {
     if (!settingsConfig) return;
@@ -212,18 +235,40 @@ export function RootEffects() {
       if (activeHecateSessionUsesProvider) return;
       const nextProvider = defaultProviderForChat(models, configuredProviders, providers);
       setProviderFilter(nextProvider);
-      setModel(defaultModelForProvider(nextProvider, models, providers));
+      setModel(
+        defaultModelForProvider(
+          nextProvider,
+          models,
+          providers,
+          configuredProviders,
+          providerPresets,
+        ),
+      );
       return;
     }
-    const stillValid = isModelValidForProvider(model, providerFilter, models, providers);
+    const stillValid = isModelValidForProvider(
+      model,
+      providerFilter,
+      models,
+      providers,
+      configuredProviders,
+      providerPresets,
+    );
     if (stillValid) return;
-    const nextModel = defaultModelForProvider(providerFilter, models, providers);
+    const nextModel = defaultModelForProvider(
+      providerFilter,
+      models,
+      providers,
+      configuredProviders,
+      providerPresets,
+    );
     setModel(nextModel);
   }, [
     activeChatSession,
     model,
     models,
     providerFilter,
+    providerPresets,
     providers,
     settingsConfig,
     setModel,

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../app/state/coordinators/wired";
 import { discoverLocalProviders, draftChatProjectAssistant } from "../../lib/api";
 import { writeProjectAssistantChatHandoff } from "../../lib/project-assistant-chat-handoff";
+import { withConfiguredDefaultModels } from "../../app/runtimeConsoleChatHelpers";
 import {
   modelSelectionHasNoToolCalling,
   resolveChatSetupRepairState,
@@ -288,10 +289,16 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     if (!providerConfigLoaded) return state.providerScopedModels;
     if (configuredProviders.length === 0) return [];
     const ids = new Set(configuredProviders.map((c) => c.id));
-    return state.providerScopedModels.filter((m) => {
+    const filteredModels = state.providerScopedModels.filter((m) => {
       const provider = m.metadata?.provider;
       return typeof provider === "string" ? ids.has(provider) : true;
     });
+    return withConfiguredDefaultModels(
+      filteredModels,
+      state.providerFilter,
+      configuredProviders,
+      state.providerPresets,
+    );
   })();
   const modelRouteUnavailable = providerConfigLoaded && selectableModels.length === 0;
   const hasConfiguredProviders = configuredProviders.length > 0;

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -12,7 +12,7 @@ import {
   providerReadinessMeaning,
   providerRepairActionLabel,
 } from "../../lib/provider-readiness";
-import { resolvedBaseURL } from "../../lib/provider-utils";
+import { providerDisplayName, resolvedBaseURL } from "../../lib/provider-utils";
 import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
 import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
 import { Badge, BrandAvatar, ConfirmModal, Icon, Icons, Modal } from "../shared/ui";
@@ -196,16 +196,15 @@ export function ProvidersView() {
 
   const selectedConfig = selectedID ? (configuredByID.get(selectedID) ?? null) : null;
   const selectedStatus = selectedID ? statusByName.get(selectedID) : null;
-  const selectedPreset = selectedID ? providerPresets.find((p) => p.id === selectedID) : null;
+  const selectedDisplayName = selectedID
+    ? providerDisplayName(selectedID, configuredProviders, providerPresets, providers)
+    : "";
+  const deleteConfirmName = deleteConfirmID
+    ? providerDisplayName(deleteConfirmID, configuredProviders, providerPresets, providers)
+    : "provider";
   const deleteConfirmConfig = deleteConfirmID
     ? (configuredByID.get(deleteConfirmID) ?? null)
     : null;
-  const deleteConfirmPreset = deleteConfirmID
-    ? providerPresets.find((p) => p.id === deleteConfirmID)
-    : null;
-  const deleteConfirmName = deleteConfirmConfig
-    ? deleteConfirmPreset?.name || deleteConfirmConfig.name || deleteConfirmID || "provider"
-    : "provider";
 
   const selectedHealthCounters = [
     selectedStatus?.consecutive_failures
@@ -224,7 +223,7 @@ export function ProvidersView() {
     const cp = configuredByID.get(id);
     const rt = statusByName.get(id);
     const preset = providerPresets.find((p) => p.id === id);
-    const displayName = preset?.name || cp?.name || id;
+    const displayName = providerDisplayName(id, configuredProviders, providerPresets, providers);
     const baseURL = rt?.base_url || resolvedBaseURL(id, cp ?? undefined, providerPresets);
     const modelCount = rt?.model_count ?? rt?.models?.length ?? 0;
     const modelBadge =
@@ -579,7 +578,7 @@ export function ProvidersView() {
       {/* Edit provider modal — opens on row click */}
       {selectedID && selectedConfig && (
         <Modal
-          title={`${selectedPreset?.name || selectedConfig.name || selectedID} · ${selectedConfig.kind || "cloud"}`}
+          title={`${selectedDisplayName} · ${selectedConfig.kind || "cloud"}`}
           onClose={() => setSelectedID(null)}
           footer={null}
           width={560}
@@ -587,11 +586,7 @@ export function ProvidersView() {
           <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
             {/* Header strip: brand initial + base URL */}
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-              <BrandAvatar
-                brand={selectedID}
-                fallback={selectedPreset?.name || selectedConfig.name || selectedID}
-                size={32}
-              />
+              <BrandAvatar brand={selectedID} fallback={selectedDisplayName} size={32} />
               {selectedConfig.base_url && (
                 <span
                   style={{

--- a/ui/src/lib/provider-utils.test.ts
+++ b/ui/src/lib/provider-utils.test.ts
@@ -92,6 +92,7 @@ describe("providerDisplayName", () => {
   it("falls back to canonical names before lower-case configured names", () => {
     expect(providerDisplayName("ollama", [makeCP("ollama")], [])).toBe("Ollama");
     expect(providerDisplayName("lmstudio", [makeCP("lmstudio")], [])).toBe("LM Studio");
+    expect(providerDisplayName("fireworks", [makeCP("fireworks")], [])).toBe("Fireworks AI");
     expect(providerDisplayName("openrouter", [makeCP("openrouter")], [])).toBe("OpenRouter");
     expect(providerDisplayName("vercel_ai_gateway", [makeCP("vercel_ai_gateway")], [])).toBe(
       "Vercel AI Gateway",

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -347,11 +347,25 @@ export function useRuntimeConsole() {
     }
     setProviderFilter(nextProvider);
     const nextModel =
-      model && isModelValidForProvider(model, nextProvider, models, providers)
+      model &&
+      isModelValidForProvider(
+        model,
+        nextProvider,
+        models,
+        providers,
+        configuredProviders,
+        providerPresets,
+      )
         ? model
-        : defaultModelForProvider(nextProvider, models, providers);
+        : defaultModelForProvider(
+            nextProvider,
+            models,
+            providers,
+            configuredProviders,
+            providerPresets,
+          );
     setModel(nextModel);
-  }, [model, models, providerFilter, providers, settingsConfig]);
+  }, [model, models, providerFilter, providerPresets, providers, settingsConfig]);
 
   useEffect(() => {
     if (providerFilter === "auto") {
@@ -375,16 +389,45 @@ export function useRuntimeConsole() {
       }
       const nextProvider = defaultProviderForChat(models, configuredProviders, providers);
       setProviderFilter(nextProvider);
-      setModel(defaultModelForProvider(nextProvider, models, providers));
+      setModel(
+        defaultModelForProvider(
+          nextProvider,
+          models,
+          providers,
+          configuredProviders,
+          providerPresets,
+        ),
+      );
       return;
     }
-    const stillValid = isModelValidForProvider(model, providerFilter, models, providers);
+    const stillValid = isModelValidForProvider(
+      model,
+      providerFilter,
+      models,
+      providers,
+      configuredProviders,
+      providerPresets,
+    );
     if (stillValid) {
       return;
     }
-    const nextModel = defaultModelForProvider(providerFilter, models, providers);
+    const nextModel = defaultModelForProvider(
+      providerFilter,
+      models,
+      providers,
+      configuredProviders,
+      providerPresets,
+    );
     setModel(nextModel);
-  }, [activeChatSession, model, models, providerFilter, providers, settingsConfig]);
+  }, [
+    activeChatSession,
+    model,
+    models,
+    providerFilter,
+    providerPresets,
+    providers,
+    settingsConfig,
+  ]);
 
   // When models load, validate the selected model. If it's not in the list
   // (e.g. stale localStorage), clear it and let the operator pick.


### PR DESCRIPTION
## Summary
- keep configured/preset default models available before provider model discovery finishes
- add Fireworks account-scoped model discovery and document the endpoint
- tighten Hecate chat create-time model validation so stale local selections are dropped
- document the deterministic chat compaction endpoint still missing from runtime API docs

## Verification
- go test ./internal/providers ./internal/config ./internal/chat ./internal/chatapp ./internal/api
- go vet ./internal/providers ./internal/config ./internal/chat ./internal/chatapp ./internal/api
- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run test -- src/test/runtime-console-composition.test.tsx src/app/runtimeConsoleChatHelpers.test.ts src/lib/provider-utils.test.ts
- cd ui && bun run test
- just docs-format-check
- just check-links
- go test -race -timeout 10m ./...

## PR triage
The core deterministic compaction commits are already on master. This PR now carries the remaining provider/model-default fixes and missing docs. PR #427 is the semantic compaction follow-up and should stay unmerged until this base is settled.