### PR TITLE
Use semantic chat context compaction

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -118,6 +118,18 @@ that every counted message was packed into the provider or agent prompt. Context
 packets are snapshots on assistant messages; changing project context sources,
 skills, or work records later does not rewrite old message packets.
 
+Long Hecate-owned model chats compact older transcript context before a direct
+model turn once the compactable transcript reaches the automatic threshold.
+`/compact` runs the same compaction path manually. When the session has a
+routable provider/model, Hecate asks that model to produce a structured semantic
+summary of the older transcript window and stores it as `context_summary` with
+`strategy: "semantic_transcript_summary"`. If that model call is unavailable,
+empty, or fails, Hecate falls back to the deterministic transcript summary:
+one bounded line per compacted message, capped from the oldest side, with
+`strategy: "deterministic_transcript_summary"`. Original chat messages remain
+stored; future Hecate-owned model turns inject the summary as background and
+send newer transcript messages in full.
+
 External Agent sessions may expose ACP-advertised `available_commands` on the
 session snapshot. These are agent-native slash command hints, not Hecate
 project commands; selecting one still sends ordinary prompt text to the
@@ -154,6 +166,8 @@ packing remains agent-owned and does not receive this Hecate prelude.
 | `/task`               | Hecate Chat is open                     | Opens the active task when one exists; otherwise opens the Tasks workspace. |
 | `/project`            | Hecate Chat is linked to a project      | Opens the linked project in Projects.                                       |
 | `/connections`        | Hecate Chat is open with app navigation | Opens Connections for provider/model and External Agent setup.              |
+| `/context`            | Hecate Chat is open                     | Opens the chat context/settings panel without sending a chat message.       |
+| `/compact`            | Hecate Chat is open                     | Compacts older Hecate-owned transcript context without sending a message.   |
 
 Submitting a project command without text after the command returns a composer
 notice and does not draft a proposal. Unknown slash commands in Hecate Chat are

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3095,6 +3095,16 @@ contains its derived `turn_kind`, `execution_mode`, provider/model snapshot,
 optional `task_id`, latest run id, status, message count, and first/last
 timestamps.
 
+Hecate-owned sessions may include `context_summary` after automatic or manual
+context compaction. The summary is operator-visible metadata for older
+transcript context and includes `content`, `message_count`,
+`through_message_id`, `compacted_at`, and `strategy`. `strategy` is
+`semantic_transcript_summary` when Hecate used the session provider/model to
+summarize the older transcript window, and `deterministic_transcript_summary`
+when it used the bounded transcript-line fallback. Original messages remain in
+`messages`; future direct model turns inject the summary as background context
+and send newer messages in full.
+
 External Agent sessions may also include `config_options`, a normalized
 projection of ACP session configuration options reported by the agent during
 `session/new`, `session/load`, or `session/set_config_option`, merged with any

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -240,10 +240,8 @@ func (h *Handler) HandleUpdateChatSession(w http.ResponseWriter, r *http.Request
 }
 
 func (h *Handler) HandleCompactChatSession(w http.ResponseWriter, r *http.Request) {
-	result, err := h.chatApplication().CompactSession(r.Context(), chatapp.CompactSessionCommand{
-		ID:               r.PathValue("id"),
+	session, err := h.compactChatSession(r.Context(), r.PathValue("id"), compactChatSessionOptions{
 		RetainMessages:   agentChatManualCompactRetainMessages,
-		HecateOnly:       true,
 		RequireCompacted: true,
 		Now:              time.Now().UTC(),
 	})
@@ -254,8 +252,8 @@ func (h *Handler) HandleCompactChatSession(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	h.agentChatLive.publishSession(result.Session)
-	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
+	h.agentChatLive.publishSession(session)
+	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(session, h.agentChatSnapshotConfig())})
 }
 
 func (h *Handler) HandleChatSessionStream(w http.ResponseWriter, r *http.Request) {
@@ -955,7 +953,7 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	content := strings.TrimSpace(req.Content)
-	if compacted, err := h.compactChatSessionForModelTurn(r.Context(), session); err != nil {
+	if compacted, err := h.compactChatSessionForModelTurn(r.Context(), session, provider, model); err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	} else if compacted.ID != "" {
@@ -1097,18 +1095,14 @@ func (h *Handler) handleDirectModelTurn(w http.ResponseWriter, r *http.Request, 
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(updated, h.agentChatSnapshotConfig())})
 }
 
-func (h *Handler) compactChatSessionForModelTurn(ctx context.Context, session chat.Session) (chat.Session, error) {
-	result, err := h.chatApplication().CompactSession(ctx, chatapp.CompactSessionCommand{
-		ID:             session.ID,
+func (h *Handler) compactChatSessionForModelTurn(ctx context.Context, session chat.Session, provider, model string) (chat.Session, error) {
+	return h.compactChatSession(ctx, session.ID, compactChatSessionOptions{
 		RetainMessages: agentChatAutoCompactRetainMessages,
 		MinMessages:    agentChatAutoCompactMinMessages,
-		HecateOnly:     true,
+		Provider:       provider,
+		Model:          model,
 		Now:            time.Now().UTC(),
 	})
-	if err != nil {
-		return chat.Session{}, err
-	}
-	return result.Session, nil
 }
 
 func agentChatModelHistory(session chat.Session, systemPrompt, content string) []types.Message {

--- a/internal/api/handler_chat_compaction.go
+++ b/internal/api/handler_chat_compaction.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/chatapp"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	agentChatSemanticCompactMaxOutputTokens    = 2048
+	agentChatSemanticCompactTranscriptMaxRunes = 24000
+	agentChatSemanticCompactMessageMaxRunes    = 2400
+	agentChatSemanticCompactSummaryMaxRunes    = 8000
+)
+
+type compactChatSessionOptions struct {
+	RetainMessages   int
+	MinMessages      int
+	RequireCompacted bool
+	Provider         string
+	Model            string
+	Now              time.Time
+}
+
+func (h *Handler) compactChatSession(ctx context.Context, id string, opts compactChatSessionOptions) (chat.Session, error) {
+	app := h.chatApplication()
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	result, err := app.CompactSessionWithSummary(ctx, chatapp.CompactSessionCommand{
+		ID:               id,
+		RetainMessages:   opts.RetainMessages,
+		MinMessages:      opts.MinMessages,
+		HecateOnly:       true,
+		RequireCompacted: opts.RequireCompacted,
+		Now:              now,
+	}, func(ctx context.Context, session chat.Session, selection chat.CompactTranscriptResult) (chat.ContextSummary, error) {
+		summary, err := h.semanticCompactTranscript(ctx, session, selection, opts)
+		if err == nil {
+			return summary, nil
+		}
+		if h != nil && h.logger != nil {
+			h.logger.DebugContext(ctx, "chat.compaction.semantic_fallback", "session_id", session.ID, "error", err)
+		}
+		return selection.Summary, nil
+	})
+	if err != nil {
+		return chat.Session{}, err
+	}
+	return result.Session, nil
+}
+
+func (h *Handler) semanticCompactTranscript(ctx context.Context, session chat.Session, selection chat.CompactTranscriptResult, opts compactChatSessionOptions) (chat.ContextSummary, error) {
+	provider := strings.TrimSpace(opts.Provider)
+	if provider == "" {
+		provider = strings.TrimSpace(session.Provider)
+	}
+	model := strings.TrimSpace(opts.Model)
+	if model == "" {
+		model = strings.TrimSpace(session.Model)
+	}
+	if h == nil || h.service == nil {
+		return chat.ContextSummary{}, fmt.Errorf("chat service is not configured")
+	}
+	if model == "" {
+		return chat.ContextSummary{}, fmt.Errorf("chat model is not configured")
+	}
+	prompt := semanticCompactTranscriptPrompt(session.ContextSummary, selection.Messages)
+	resp, err := (gatewayAgentLLMClient{service: h.service}).Chat(ctx, types.ChatRequest{
+		RequestID:   newChatID("compact"),
+		Model:       model,
+		MaxTokens:   agentChatSemanticCompactMaxOutputTokens,
+		Temperature: 0,
+		Scope:       types.RequestScope{ProviderHint: provider},
+		Messages: []types.Message{
+			{
+				Role:    "system",
+				Content: "You compact Hecate Chat transcripts for future turns. Return only the requested Markdown summary.",
+			},
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+	})
+	if err != nil {
+		return chat.ContextSummary{}, err
+	}
+	content := strings.TrimSpace(chatResponseText(resp))
+	if content == "" {
+		return chat.ContextSummary{}, fmt.Errorf("semantic compaction returned an empty summary")
+	}
+	summary := selection.Summary
+	summary.Content = trimRunesFromEnd(content, agentChatSemanticCompactSummaryMaxRunes)
+	summary.Strategy = chat.ContextSummaryStrategySemantic
+	return summary, nil
+}
+
+func semanticCompactTranscriptPrompt(previous chat.ContextSummary, messages []chat.Message) string {
+	transcript := trimRunesFromStart(serializeSemanticCompactTranscript(messages), agentChatSemanticCompactTranscriptMaxRunes)
+	var b strings.Builder
+	if content := strings.TrimSpace(previous.Content); content != "" {
+		b.WriteString("Update the previous summary with the new transcript. Preserve still-true details, remove stale details, and merge new facts.\n\n")
+		b.WriteString("<previous-summary>\n")
+		b.WriteString(content)
+		b.WriteString("\n</previous-summary>\n\n")
+	} else {
+		b.WriteString("Create a compact anchored summary from this transcript.\n\n")
+	}
+	b.WriteString("Return exactly these Markdown sections, in this order:\n")
+	b.WriteString("## Goal\n- [single-sentence task summary]\n\n")
+	b.WriteString("## Constraints & Preferences\n- [user constraints, preferences, specs, or \"(none)\"]\n\n")
+	b.WriteString("## Progress\n### Done\n- [completed work or \"(none)\"]\n\n")
+	b.WriteString("### In Progress\n- [current work or \"(none)\"]\n\n")
+	b.WriteString("### Blocked\n- [blockers or \"(none)\"]\n\n")
+	b.WriteString("## Key Decisions\n- [decision and why, or \"(none)\"]\n\n")
+	b.WriteString("## Next Steps\n- [ordered next actions or \"(none)\"]\n\n")
+	b.WriteString("## Critical Context\n- [important technical facts, exact errors, open questions, commands, ids, or \"(none)\"]\n\n")
+	b.WriteString("## Relevant Files\n- [file or directory path: why it matters, or \"(none)\"]\n\n")
+	b.WriteString("Rules:\n")
+	b.WriteString("- Keep every section, even when empty.\n")
+	b.WriteString("- Use terse bullets, not prose paragraphs.\n")
+	b.WriteString("- Preserve exact file paths, commands, error strings, ids, providers, models, and decisions when known.\n")
+	b.WriteString("- Do not mention that a summary or compaction happened.\n\n")
+	b.WriteString("<transcript>\n")
+	b.WriteString(transcript)
+	b.WriteString("\n</transcript>")
+	return b.String()
+}
+
+func serializeSemanticCompactTranscript(messages []chat.Message) string {
+	var lines []string
+	for _, message := range messages {
+		role := "User"
+		if message.Role == "assistant" {
+			role = "Assistant"
+		}
+		status := strings.TrimSpace(message.Status)
+		if status != "" && status != "completed" {
+			role += " (" + status + ")"
+		}
+		content := strings.TrimSpace(message.Content)
+		if content == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("[%s]\n%s", role, trimRunesFromEnd(content, agentChatSemanticCompactMessageMaxRunes)))
+	}
+	return strings.Join(lines, "\n\n")
+}
+
+func chatResponseText(resp *types.ChatResponse) string {
+	if resp == nil {
+		return ""
+	}
+	for _, choice := range resp.Choices {
+		if text := strings.TrimSpace(choice.Message.Content); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func trimRunesFromEnd(value string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}
+
+func trimRunesFromStart(value string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	if maxRunes <= 3 {
+		return string(runes[len(runes)-maxRunes:])
+	}
+	return "..." + string(runes[len(runes)-maxRunes+3:])
+}

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -992,6 +992,10 @@ func appendTranscriptContext(packet *chat.ContextPacket, summary chat.ContextSum
 	if summary.MessageCount > 0 {
 		detail = fmt.Sprintf("%d older messages summarized", summary.MessageCount)
 	}
+	strategy := strings.TrimSpace(summary.Strategy)
+	if strategy == "" {
+		strategy = chat.ContextSummaryStrategyDeterministic
+	}
 	appendContextPacketSourceWithSection(packet, contextSectionRuntime, chat.ContextSource{
 		Kind:   "transcript_summary",
 		Label:  "Compacted transcript",
@@ -1008,7 +1012,7 @@ func appendTranscriptContext(packet *chat.ContextPacket, summary chat.ContextSum
 		Metadata: map[string]string{
 			"message_count":       fmt.Sprintf("%d", summary.MessageCount),
 			"through_message_id":  strings.TrimSpace(summary.ThroughMessageID),
-			"compaction_strategy": "deterministic_transcript_summary",
+			"compaction_strategy": strategy,
 		},
 	})
 }

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -532,6 +532,9 @@ func TestDirectHecateChatAutoCompactsLongTranscript(t *testing.T) {
 	if updated.Data.ContextSummary.MessageCount != 10 {
 		t.Fatalf("context_summary message_count = %d, want 10", updated.Data.ContextSummary.MessageCount)
 	}
+	if updated.Data.ContextSummary.Strategy != chat.ContextSummaryStrategySemantic {
+		t.Fatalf("context_summary strategy = %q, want semantic", updated.Data.ContextSummary.Strategy)
+	}
 	request := provider.LastRequest()
 	if len(request.Messages) != 10 {
 		t.Fatalf("provider message count = %d, want compact summary + 8 retained + current", len(request.Messages))
@@ -584,8 +587,54 @@ func TestHecateChatCompactEndpointCompactsTranscript(t *testing.T) {
 	if compacted.Data.ContextSummary.MessageCount != 2 {
 		t.Fatalf("context_summary message_count = %d, want 2", compacted.Data.ContextSummary.MessageCount)
 	}
-	if !strings.Contains(compacted.Data.ContextSummary.Content, "manual 01") {
-		t.Fatalf("context_summary content = %q, want first turn", compacted.Data.ContextSummary.Content)
+	if compacted.Data.ContextSummary.Strategy != chat.ContextSummaryStrategySemantic {
+		t.Fatalf("context_summary strategy = %q, want semantic", compacted.Data.ContextSummary.Strategy)
+	}
+	if compacted.Data.ContextSummary.Content != "ack" {
+		t.Fatalf("context_summary content = %q, want provider semantic summary", compacted.Data.ContextSummary.Content)
+	}
+	request := provider.LastRequest()
+	if len(request.Messages) != 2 || !strings.Contains(request.Messages[1].Content, "manual 01") {
+		t.Fatalf("semantic compaction request = %+v, want transcript in compaction prompt", request.Messages)
+	}
+}
+
+func TestHecateChatCompactEndpointFallsBackToDeterministicSummary(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{
+		name: "openai",
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-hecate-compact-fallback",
+			Model:     "gpt-4o-mini",
+			CreatedAt: time.Now().UTC(),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "ack"},
+				FinishReason: "stop",
+			}},
+		},
+		errSequence: []error{nil, nil, nil, nil, nil, fmt.Errorf("semantic compaction unavailable")},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	handler := NewServer(logger, apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","provider":"openai","model":"gpt-4o-mini"}`)
+	for i := 1; i <= 5; i++ {
+		_ = mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+			fmt.Sprintf(`{"execution_mode":"hecate_task","tools_enabled":false,"content":"fallback %02d"}`, i))
+	}
+
+	compacted := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+session.Data.ID+"/compact", `{}`)
+	if compacted.Data.ContextSummary == nil {
+		t.Fatal("context_summary is nil, want fallback compaction metadata")
+	}
+	if compacted.Data.ContextSummary.Strategy != chat.ContextSummaryStrategyDeterministic {
+		t.Fatalf("context_summary strategy = %q, want deterministic fallback", compacted.Data.ContextSummary.Strategy)
+	}
+	if !strings.Contains(compacted.Data.ContextSummary.Content, "fallback 01") {
+		t.Fatalf("context_summary content = %q, want deterministic transcript line", compacted.Data.ContextSummary.Content)
 	}
 }
 

--- a/internal/api/handler_chat_render.go
+++ b/internal/api/handler_chat_render.go
@@ -133,6 +133,7 @@ func renderChatContextSummary(summary chat.ContextSummary) *ChatContextSummaryIt
 		Content:          summary.Content,
 		MessageCount:     summary.MessageCount,
 		ThroughMessageID: summary.ThroughMessageID,
+		Strategy:         summary.Strategy,
 		CompactedAt:      formatOptionalTime(summary.CompactedAt),
 	}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -870,6 +870,7 @@ type ChatContextSummaryItem struct {
 	Content          string `json:"content,omitempty"`
 	MessageCount     int    `json:"message_count,omitempty"`
 	ThroughMessageID string `json:"through_message_id,omitempty"`
+	Strategy         string `json:"strategy,omitempty"`
 	CompactedAt      string `json:"compacted_at,omitempty"`
 }
 

--- a/internal/chat/compaction.go
+++ b/internal/chat/compaction.go
@@ -15,6 +15,11 @@ const (
 	compactLineMaxRunes    = 600
 )
 
+const (
+	ContextSummaryStrategyDeterministic = "deterministic_transcript_summary"
+	ContextSummaryStrategySemantic      = "semantic_transcript_summary"
+)
+
 type CompactTranscriptOptions struct {
 	Now            time.Time
 	RetainMessages int
@@ -23,6 +28,7 @@ type CompactTranscriptOptions struct {
 
 type CompactTranscriptResult struct {
 	Summary   ContextSummary
+	Messages  []Message
 	Compacted bool
 }
 
@@ -72,15 +78,14 @@ func CompactTranscriptSummary(session Session, opts CompactTranscriptOptions) Co
 		Content:          buildCompactTranscriptSummary(current.Content, nextMessages),
 		MessageCount:     current.MessageCount + len(nextMessages),
 		ThroughMessageID: nextMessages[len(nextMessages)-1].ID,
+		Strategy:         ContextSummaryStrategyDeterministic,
 		CompactedAt:      now.UTC(),
 	}
-	return CompactTranscriptResult{Summary: nextSummary, Compacted: true}
+	return CompactTranscriptResult{Summary: nextSummary, Messages: append([]Message(nil), nextMessages...), Compacted: true}
 }
 
-// Transcript compaction is deterministic and intentionally not model-backed
-// semantic summarization. Each older message contributes one bounded line, and
-// the combined text is capped from the oldest side to keep the prompt budget
-// predictable.
+// Transcript summaries are injected ahead of retained full messages so direct
+// model turns keep older context without resending the whole transcript.
 func TranscriptSummaryPrompt(summary ContextSummary) string {
 	content := strings.TrimSpace(summary.Content)
 	if content == "" {

--- a/internal/chat/compaction_test.go
+++ b/internal/chat/compaction_test.go
@@ -35,6 +35,12 @@ func TestCompactTranscriptSummary_SummarizesOlderVisibleMessages(t *testing.T) {
 	if !result.Summary.CompactedAt.Equal(now) {
 		t.Fatalf("CompactedAt = %s, want %s", result.Summary.CompactedAt, now)
 	}
+	if result.Summary.Strategy != ContextSummaryStrategyDeterministic {
+		t.Fatalf("Strategy = %q, want %q", result.Summary.Strategy, ContextSummaryStrategyDeterministic)
+	}
+	if len(result.Messages) != 3 || result.Messages[0].ID != "m1" || result.Messages[2].ID != "m4" {
+		t.Fatalf("Messages = %+v, want compacted transcript selection m1..m4 without running assistant", result.Messages)
+	}
 	if strings.Contains(result.Summary.Content, "still running") {
 		t.Fatalf("summary includes running assistant message: %q", result.Summary.Content)
 	}

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -183,6 +183,7 @@ type ContextSummary struct {
 	Content          string    `json:"content,omitempty"`
 	MessageCount     int       `json:"message_count,omitempty"`
 	ThroughMessageID string    `json:"through_message_id,omitempty"`
+	Strategy         string    `json:"strategy,omitempty"`
 	CompactedAt      time.Time `json:"compacted_at,omitempty"`
 }
 
@@ -190,6 +191,7 @@ func (summary ContextSummary) Empty() bool {
 	return strings.TrimSpace(summary.Content) == "" &&
 		summary.MessageCount == 0 &&
 		strings.TrimSpace(summary.ThroughMessageID) == "" &&
+		strings.TrimSpace(summary.Strategy) == "" &&
 		summary.CompactedAt.IsZero()
 }
 

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -445,6 +445,7 @@ func runStoreContextSummaryRoundTrip(t *testing.T, store Store) {
 			Content:          "- User: first request",
 			MessageCount:     1,
 			ThroughMessageID: "msg_user_1",
+			Strategy:         ContextSummaryStrategySemantic,
 			CompactedAt:      createdAt,
 		},
 	}); err != nil {
@@ -458,6 +459,7 @@ func runStoreContextSummaryRoundTrip(t *testing.T, store Store) {
 	if got.ContextSummary.Content != "- User: first request" ||
 		got.ContextSummary.MessageCount != 1 ||
 		got.ContextSummary.ThroughMessageID != "msg_user_1" ||
+		got.ContextSummary.Strategy != ContextSummaryStrategySemantic ||
 		!got.ContextSummary.CompactedAt.Equal(createdAt) {
 		t.Fatalf("stored context summary = %+v", got.ContextSummary)
 	}
@@ -475,6 +477,7 @@ func runStoreContextSummaryRoundTrip(t *testing.T, store Store) {
 			Content:          "- Assistant: answer",
 			MessageCount:     2,
 			ThroughMessageID: "msg_assistant_1",
+			Strategy:         ContextSummaryStrategyDeterministic,
 			CompactedAt:      createdAt.Add(time.Minute),
 		}
 	})
@@ -482,7 +485,8 @@ func runStoreContextSummaryRoundTrip(t *testing.T, store Store) {
 		t.Fatalf("UpdateSession: %v", err)
 	}
 	if updated.ContextSummary.MessageCount != 2 ||
-		updated.ContextSummary.ThroughMessageID != "msg_assistant_1" {
+		updated.ContextSummary.ThroughMessageID != "msg_assistant_1" ||
+		updated.ContextSummary.Strategy != ContextSummaryStrategyDeterministic {
 		t.Fatalf("updated context summary = %+v", updated.ContextSummary)
 	}
 }

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -131,6 +131,8 @@ type CompactSessionCommand struct {
 	Now              time.Time
 }
 
+type CompactSessionSummaryFunc func(context.Context, chat.Session, chat.CompactTranscriptResult) (chat.ContextSummary, error)
+
 type SessionResult struct {
 	Session chat.Session
 }
@@ -273,6 +275,10 @@ func (app *Application) RenameSession(ctx context.Context, cmd RenameSessionComm
 }
 
 func (app *Application) CompactSession(ctx context.Context, cmd CompactSessionCommand) (*SessionResult, error) {
+	return app.CompactSessionWithSummary(ctx, cmd, nil)
+}
+
+func (app *Application) CompactSessionWithSummary(ctx context.Context, cmd CompactSessionCommand, summarize CompactSessionSummaryFunc) (*SessionResult, error) {
 	if app == nil || app.store == nil {
 		return nil, ErrStoreNotConfigured
 	}
@@ -301,8 +307,16 @@ func (app *Application) CompactSession(ctx context.Context, cmd CompactSessionCo
 		}
 		return &SessionResult{Session: session}, nil
 	}
+	summary := result.Summary
+	if summarize != nil {
+		customSummary, err := summarize(ctx, session, result)
+		if err != nil {
+			return nil, err
+		}
+		summary = customSummary
+	}
 	updated, err := app.store.UpdateSession(ctx, id, func(item *chat.Session) {
-		item.ContextSummary = result.Summary
+		item.ContextSummary = summary
 	})
 	if err != nil {
 		return nil, err

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -167,6 +167,69 @@ func TestApplication_RenameSessionValidation(t *testing.T) {
 	}
 }
 
+func TestApplication_CompactSessionWithSummaryPersistsCustomSummary(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := chat.NewMemoryStore()
+	app := New(Options{Store: store})
+	now := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	if _, err := store.Create(ctx, chat.Session{
+		ID:      "chat_hecate",
+		AgentID: chat.DefaultAgentID,
+		Messages: []chat.Message{
+			{ID: "msg_1", Role: "user", Content: "first", Status: "completed"},
+			{ID: "msg_2", Role: "assistant", Content: "second", Status: "completed"},
+			{ID: "msg_3", Role: "user", Content: "third", Status: "completed"},
+			{ID: "msg_4", Role: "assistant", Content: "fourth", Status: "completed"},
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	called := false
+	result, err := app.CompactSessionWithSummary(ctx, CompactSessionCommand{
+		ID:               " chat_hecate ",
+		RetainMessages:   2,
+		MinMessages:      3,
+		HecateOnly:       true,
+		RequireCompacted: true,
+		Now:              now,
+	}, func(_ context.Context, session chat.Session, selection chat.CompactTranscriptResult) (chat.ContextSummary, error) {
+		called = true
+		if session.ID != "chat_hecate" {
+			t.Fatalf("callback session id = %q, want chat_hecate", session.ID)
+		}
+		if len(selection.Messages) != 2 || selection.Messages[0].ID != "msg_1" || selection.Messages[1].ID != "msg_2" {
+			t.Fatalf("callback compacted messages = %+v, want msg_1/msg_2", selection.Messages)
+		}
+		summary := selection.Summary
+		summary.Content = "semantic summary"
+		summary.Strategy = chat.ContextSummaryStrategySemantic
+		return summary, nil
+	})
+	if err != nil {
+		t.Fatalf("CompactSessionWithSummary() error = %v", err)
+	}
+	if !called {
+		t.Fatal("summary callback was not called")
+	}
+	if result.Session.ContextSummary.Content != "semantic summary" ||
+		result.Session.ContextSummary.MessageCount != 2 ||
+		result.Session.ContextSummary.ThroughMessageID != "msg_2" ||
+		result.Session.ContextSummary.Strategy != chat.ContextSummaryStrategySemantic ||
+		!result.Session.ContextSummary.CompactedAt.Equal(now) {
+		t.Fatalf("context summary = %+v, want custom semantic summary", result.Session.ContextSummary)
+	}
+	stored, ok, err := store.Get(ctx, "chat_hecate")
+	if err != nil || !ok {
+		t.Fatalf("Get(chat_hecate) ok=%v err=%v", ok, err)
+	}
+	if stored.ContextSummary.Content != "semantic summary" {
+		t.Fatalf("stored context summary = %+v, want custom semantic summary", stored.ContextSummary)
+	}
+}
+
 func TestApplication_CreateSessionPreparesExternalSession(t *testing.T) {
 	t.Parallel()
 

--- a/ui/src/features/chats/ChatSettingsPanel.tsx
+++ b/ui/src/features/chats/ChatSettingsPanel.tsx
@@ -198,7 +198,7 @@ export function ChatSettingsPanel({
             {contextSummary?.message_count ? (
               <ChatSettingsField
                 label="Compacted"
-                value={`${formatInteger(contextSummary.message_count)} messages`}
+                value={`${formatInteger(contextSummary.message_count)} messages (${contextSummaryStrategyLabel(contextSummary.strategy)})`}
                 title={contextSummary.through_message_id}
                 mono
               />
@@ -534,6 +534,17 @@ function CopyCommandRow({
 
 function shortID(id: string): string {
   return compactID(id, ["task_", "run_", "chat_"], 8);
+}
+
+function contextSummaryStrategyLabel(strategy?: string): string {
+  switch (strategy) {
+    case "semantic_transcript_summary":
+      return "semantic";
+    case "deterministic_transcript_summary":
+      return "deterministic";
+    default:
+      return "summary";
+  }
 }
 
 function formatAgentContextUsage(usage: ChatUsageRecord): string {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3661,6 +3661,7 @@ describe("ChatView input", () => {
           context_summary: {
             message_count: 12,
             through_message_id: "msg_12",
+            strategy: "semantic_transcript_summary",
             content: "- User: old request",
           },
           messages: [],
@@ -3674,7 +3675,7 @@ describe("ChatView input", () => {
 
     expect(screen.getByLabelText("Chat settings panel")).toBeTruthy();
     expect(screen.getByText("Compacted")).toBeTruthy();
-    expect(screen.getByText("12 messages")).toBeTruthy();
+    expect(screen.getByText("12 messages (semantic)")).toBeTruthy();
     expect(setMessage).toHaveBeenCalledWith("");
     expect(submitChat).not.toHaveBeenCalled();
   });

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -117,6 +117,7 @@ export type ChatContextSummaryRecord = {
   content?: string;
   message_count?: number;
   through_message_id?: string;
+  strategy?: string;
   compacted_at?: string;
 };
 


### PR DESCRIPTION
## Summary
- add semantic chat transcript compaction that asks the session provider/model for a structured summary
- preserve deterministic transcript-line compaction as the fallback when semantic summarization fails or is unavailable
- persist and expose context summary strategy metadata
- show semantic/deterministic compaction strategy in the chat settings panel

## Verification
- go test ./internal/chat ./internal/chatapp ./internal/api
- go vet ./internal/chat ./internal/chatapp ./internal/api
- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx
- just docs-format-check
- just check-links
- cd ui && bun run test
- go test -race -timeout 10m ./...

## Notes
Rebased onto current master after #426. The branch now contains one semantic-compaction commit on top of the merged deterministic compaction/model-default base.