### PR TITLE
Polish project proposal activity in chat

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -32,9 +32,10 @@ apply the proposal.
 When tools are on, project-linked Hecate Chat can also let the model call the
 Hecate-owned `draft_project_proposal` tool from ordinary natural-language
 planning intent. That produces a `project_assistant_proposal` task artifact on
-the backing run and shows a compact transcript activity that opens the proposal
-in Projects. It is still proposal data only: no mirrored Project Assistant chat
-is created, and apply remains an explicit Projects action.
+the backing run and shows a compact transcript activity with the proposal title,
+action count, and a **Review in Projects** action. It is still proposal data
+only: no mirrored Project Assistant chat is created, and apply remains an
+explicit Projects action.
 Deleting a project also deletes its project-scoped chat transcripts.
 Unprojected chats and chats in other projects stay untouched. The Projects
 review card preserves the originating request and chat session id for operator
@@ -215,9 +216,10 @@ instead of split across two execution-mode values:
   the captured app iframe directly in the assistant message body and keeps the
   compact tool activity row collapsed below it as audit metadata.
   If the project-linked agent loop drafts a Project Assistant proposal, the
-  transcript shows a `Project Assistant proposal` activity with an **Open in
-  Projects** action. The linked artifact is the handoff; Chats does not create a
-  second Project Assistant chat thread.
+  transcript shows a `Project Assistant proposal` activity with proposal
+  title/action-count metadata and a **Review in Projects** action. The linked
+  artifact is the handoff; Chats does not create a second Project Assistant chat
+  thread.
   Deleting a Hecate Chat cancels any non-terminal backing task run before the
   transcript is removed; the backing Task record remains in Tasks for audit and
   artifact history.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -53,9 +53,10 @@ Project-linked Hecate Chat task-backed runs also expose a Hecate-owned
 `draft_project_proposal` agent-loop tool. The model can call it from ordinary
 chat intent, but it uses the same deterministic Project Assistant draft path and
 stores the result as a `project_assistant_proposal` task artifact. The transcript
-can open that artifact in Projects via the same transient handoff shape; no
-Project Assistant chat is mirrored into Chats, and apply still sends only the
-typed proposal through the normal confirmation path.
+shows the proposal title/action count and can open that artifact in Projects via
+the same transient handoff shape; no Project Assistant chat is mirrored into
+Chats, and apply still sends only the typed proposal through the normal
+confirmation path.
 
 When Projects consumes a chat-drafted proposal handoff, the review card shows
 the source as `drafted from chat`, preserves the originating request text and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2816,8 +2816,10 @@ Task-backed project-linked Hecate Chat may also produce
 `project_assistant_proposal` artifacts when the model calls the
 `draft_project_proposal` agent-loop tool. The artifact content is JSON with the
 linked `project_id`, optional `source_chat_session_id`, original request, and
-embedded Project Assistant `proposal`. It is a review handoff only; clients open
-it in Projects and still apply through `/hecate/v1/project-assistant/apply`.
+embedded Project Assistant `proposal`. The normalized chat activity may carry
+proposal title/action-count detail so clients can render a compact review row.
+It is a review handoff only; clients open it in Projects and still apply through
+`/hecate/v1/project-assistant/apply`.
 
 ## Chat session endpoints
 

--- a/internal/api/handler_chat_activities.go
+++ b/internal/api/handler_chat_activities.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/telemetry"
 )
 
@@ -247,6 +249,9 @@ func agentChatTaskArtifactPreview(item TaskActivityItem) string {
 }
 
 func agentChatTaskActivityDetail(item TaskActivityItem) string {
+	if item.Type == orchestrator.ProjectAssistantProposalArtifactKind || item.Kind == orchestrator.ProjectAssistantProposalArtifactKind {
+		return agentChatProjectAssistantProposalDetail(item)
+	}
 	parts := make([]string, 0, 3)
 	if item.Path != "" && item.Path != item.Title {
 		parts = append(parts, item.Path)
@@ -274,6 +279,41 @@ func agentChatTaskActivityDetail(item TaskActivityItem) string {
 		parts = append(parts, item.Status)
 	}
 	return strings.Join(parts, " - ")
+}
+
+func agentChatProjectAssistantProposalDetail(item TaskActivityItem) string {
+	parts := make([]string, 0, 3)
+	if title, _ := item.Summary["proposal_title"].(string); strings.TrimSpace(title) != "" && title != item.Title {
+		parts = append(parts, strings.TrimSpace(title))
+	}
+	if actionCount := intFromActivitySummary(item.Summary["proposal_action_count"]); actionCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d action%s", actionCount, activityPluralSuffix(actionCount)))
+	}
+	parts = append(parts, "ready for review")
+	return strings.Join(parts, " - ")
+}
+
+func intFromActivitySummary(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		n, _ := typed.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func activityPluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func compactActivityArgv(value any) string {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -1207,6 +1207,34 @@ func TestChatActivityFromTaskActivityCarriesArtifactMetadata(t *testing.T) {
 	}
 }
 
+func TestChatActivityFromTaskActivityFormatsProjectAssistantProposalDetail(t *testing.T) {
+	item := TaskActivityItem{
+		ID:         "artifact:proposal_1",
+		Type:       orchestrator.ProjectAssistantProposalArtifactKind,
+		Status:     "ready",
+		Title:      "Project Assistant proposal",
+		ArtifactID: "artifact_project_proposal",
+		Kind:       orchestrator.ProjectAssistantProposalArtifactKind,
+		Summary: map[string]any{
+			"proposal_title":        "Plan next project work",
+			"proposal_action_count": float64(2),
+		},
+		OccurredAt: "2026-05-03T10:00:00Z",
+	}
+
+	activity := agentChatActivityFromTaskActivity(item)
+	rendered := renderAgentChatActivities([]chat.Activity{activity})
+	if len(rendered) != 1 {
+		t.Fatalf("rendered activities = %d, want 1", len(rendered))
+	}
+	if rendered[0].Detail != "Plan next project work - 2 actions - ready for review" {
+		t.Fatalf("proposal detail = %q", rendered[0].Detail)
+	}
+	if rendered[0].ArtifactID != "artifact_project_proposal" {
+		t.Fatalf("artifact_id = %q", rendered[0].ArtifactID)
+	}
+}
+
 func TestChatActivityFromTaskActivityCarriesMCPApp(t *testing.T) {
 	item := TaskActivityItem{
 		ID:       "step:step_weather",
@@ -1355,6 +1383,38 @@ func TestTaskActivityItemsIncludeOutputArtifactPreview(t *testing.T) {
 	preview, _ := item.Summary["content_preview"].(string)
 	if !strings.Contains(preview, "+hello") {
 		t.Fatalf("content_preview = %q, want stdout preview", preview)
+	}
+}
+
+func TestTaskActivityItemsIncludeProjectAssistantProposalMetadata(t *testing.T) {
+	items := buildTaskActivityItems(nil, []TaskArtifactItem{{
+		ID:          "artifact_project_proposal",
+		TaskID:      "task_1",
+		RunID:       "run_1",
+		Kind:        orchestrator.ProjectAssistantProposalArtifactKind,
+		Name:        "Project Assistant proposal",
+		MimeType:    "application/json",
+		StorageKind: "inline",
+		Status:      "ready",
+		ContentText: `{
+			"object":"project_assistant.chat_proposal",
+			"project_id":"proj_1",
+			"proposal_id":"pa_1",
+			"title":"Plan next project work",
+			"action_count":2,
+			"proposal":{"id":"pa_1","title":"Plan next project work","actions":[]}
+		}`,
+	}}, nil, types.TaskRun{})
+
+	item := taskActivityByID(items, "artifact:artifact_project_proposal")
+	if item.Type != orchestrator.ProjectAssistantProposalArtifactKind {
+		t.Fatalf("activity type = %q, want proposal activity", item.Type)
+	}
+	if item.Summary["proposal_title"] != "Plan next project work" || item.Summary["proposal_action_count"] != 2 {
+		t.Fatalf("proposal summary = %#v, want title/action count", item.Summary)
+	}
+	if item.Summary["proposal_id"] != "pa_1" {
+		t.Fatalf("proposal_id = %#v", item.Summary["proposal_id"])
 	}
 }
 

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -463,6 +464,9 @@ func buildTaskActivityItems(steps []TaskStepItem, artifacts []TaskArtifactItem, 
 		if preview := taskActivityArtifactContentPreview(artifact); preview != "" {
 			summary["content_preview"] = preview
 		}
+		if artifact.Kind == orchestrator.ProjectAssistantProposalArtifactKind {
+			addProjectAssistantProposalActivitySummary(summary, artifact)
+		}
 		items = append(items, TaskActivityItem{
 			ID:         "artifact:" + artifact.ID,
 			Type:       itemType,
@@ -514,6 +518,22 @@ func cloneActivitySummary(summary map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
+}
+
+func addProjectAssistantProposalActivitySummary(summary map[string]any, artifact TaskArtifactItem) {
+	var payload orchestrator.ProjectAssistantDraftResult
+	if err := json.Unmarshal([]byte(artifact.ContentText), &payload); err != nil {
+		return
+	}
+	if title := strings.TrimSpace(payload.Title); title != "" {
+		summary["proposal_title"] = title
+	}
+	if payload.ActionCount > 0 {
+		summary["proposal_action_count"] = payload.ActionCount
+	}
+	if proposalID := strings.TrimSpace(payload.ProposalID); proposalID != "" {
+		summary["proposal_id"] = proposalID
+	}
 }
 
 func addShellDebugSummary(summary map[string]any, input map[string]any) {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -6394,6 +6394,7 @@ describe("ChatView session title", () => {
                   kind: "project_assistant_proposal",
                   status: "ready",
                   title: "Project Assistant proposal",
+                  detail: "Plan next project work - 1 action - ready for review",
                   artifact_id: "artifact_project_proposal",
                 },
               ],
@@ -6407,8 +6408,9 @@ describe("ChatView session title", () => {
     render(withRuntimeConsole(<ChatView onNavigate={onNavigate} />, { state, actions }));
 
     const user = userEvent.setup();
+    await user.click(screen.getByText(/1 proposal ready/));
     await user.click(screen.getByText("Proposal"));
-    await user.click(screen.getByRole("button", { name: "Open in Projects" }));
+    await user.click(screen.getByRole("button", { name: "Review in Projects" }));
 
     await waitFor(() => {
       expect(getTaskRunArtifact).toHaveBeenCalledWith(

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -559,6 +559,26 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.queryByText(/Output/)).toBeNull();
   });
 
+  it("summarizes project proposal activities as ready proposals", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        type: "project_assistant_proposal",
+        kind: "project_assistant_proposal",
+        title: "Project Assistant proposal",
+        detail: "Plan next project work - 1 action - ready for review",
+        status: "ready",
+      },
+    ];
+
+    render(<TranscriptActivityTimeline activities={activities} />);
+
+    expect(screen.getByText(/1 proposal ready/)).toBeInTheDocument();
+    expect(screen.getByText("Project Assistant proposal")).toBeInTheDocument();
+    expect(
+      screen.getByText("Plan next project work - 1 action - ready for review"),
+    ).toBeInTheDocument();
+  });
+
   it("hides output artifacts without captured previews", () => {
     const activities: ChatActivityRecord[] = [
       { type: "artifact", title: "ACP output", status: "ready", detail: "stdout · 1 line" },

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -130,6 +130,7 @@ export function TranscriptActivityTimeline({
 
   const plan = primaryRaw.filter((activity) => activity.type === "plan");
   const tools = primaryRaw.filter((activity) => activity.type === "tool_call");
+  const proposals = primaryRaw.filter(isProjectAssistantProposalActivity);
   const failedTools = tools.filter(
     (activity) => activityEffectiveStatus(activity) === "failed",
   ).length;
@@ -144,6 +145,9 @@ export function TranscriptActivityTimeline({
         : failedTools > 0
           ? `${failedTools} failed tool${failedTools === 1 ? "" : "s"}`
           : `${tools.length} tool${tools.length === 1 ? "" : "s"}`
+      : "",
+    proposals.length > 0
+      ? `${proposals.length} proposal${proposals.length === 1 ? "" : "s"} ready`
       : "",
     diffStat ? "workspace diff snapshot" : "",
   ]
@@ -366,6 +370,12 @@ function advancedSummaryLabel(activity: ChatActivityRecord): string {
   )
     return "Output";
   return "Advanced";
+}
+
+function isProjectAssistantProposalActivity(activity: ChatActivityRecord): boolean {
+  return (
+    activity.type === "project_assistant_proposal" || activity.kind === "project_assistant_proposal"
+  );
 }
 
 function PlanActivityLine({ activity }: { activity: ChatActivityRecord }) {

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -749,6 +749,7 @@ describe("TranscriptMessageRow", () => {
       type: "project_assistant_proposal",
       kind: "project_assistant_proposal",
       title: "Project Assistant proposal",
+      detail: "Plan next project work - 1 action - ready for review",
       status: "ready",
       artifact_id: "artifact_project_proposal",
     };
@@ -762,7 +763,10 @@ describe("TranscriptMessageRow", () => {
     );
 
     await user.click(screen.getByText("Proposal"));
-    await user.click(screen.getByRole("button", { name: "Open in Projects" }));
+    expect(
+      screen.getAllByText("Plan next project work - 1 action - ready for review").length,
+    ).toBeGreaterThanOrEqual(1);
+    await user.click(screen.getByRole("button", { name: "Review in Projects" }));
 
     expect(onOpenProjectProposal).toHaveBeenCalledWith(activity);
   });

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -409,11 +409,11 @@ function ProjectAssistantProposalActivity({
           type="button"
           className="btn btn-ghost btn-sm"
           onClick={onOpen}
-          title="Open Project Assistant proposal in Projects"
+          title="Review Project Assistant proposal in Projects"
           style={{ fontSize: 10, padding: "2px 7px", gap: 5 }}
         >
           <Icon d={Icons.projects} size={12} />
-          Open in Projects
+          Review in Projects
         </button>
       </div>
     </div>

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -443,6 +443,22 @@ describe("activityDisplay", () => {
     });
   });
 
+  it("renders project proposal rows with review-ready metadata", () => {
+    expect(
+      activityDisplay(
+        activity({
+          type: "project_assistant_proposal",
+          kind: "project_assistant_proposal",
+          title: "Project Assistant proposal",
+          detail: "Plan next project work - 2 actions - ready for review",
+        }),
+      ),
+    ).toEqual({
+      title: "Project Assistant proposal",
+      detail: "Plan next project work - 2 actions - ready for review",
+    });
+  });
+
   it("renders 'Starting agent' for the canonical start-row title", () => {
     expect(
       activityDisplay(activity({ type: "started", title: "Starting Hecate Chat tools" })).title,


### PR DESCRIPTION
## Summary

- Add proposal title/action-count metadata to Project Assistant proposal task activities.
- Surface project proposal transcript rows as ready proposals with a Review in Projects action.
- Update runtime docs for the proposal activity review handoff wording.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestChatActivityFromTaskActivityFormatsProjectAssistantProposalDetail|TestTaskActivityItemsIncludeProjectAssistantProposalMetadata'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `go vet ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx src/features/transcript/TranscriptActivityTimeline.test.tsx src/features/transcript/transcriptActivityHelpers.test.ts src/features/chats/ChatView.test.tsx`
- `cd ui && bun run test`
- `just docs-format-check`

Note: the UI test run still emits the existing jsdom `HTMLCanvasElement.getContext()` warning, but all tests pass.
