### PR TITLE
Clarify project context inspection in chat

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -118,6 +118,10 @@ an operator-facing transcript count, not a provider token count or a guarantee
 that every counted message was packed into the provider or agent prompt. Context
 packets are snapshots on assistant messages; changing project context sources,
 skills, or work records later does not rewrite old message packets.
+For project-linked Hecate Chat packets, the inspector also calls out the
+bounded project prelude explicitly so operators can distinguish project
+guidance from ordinary transcript/runtime metadata and see the metadata-only
+root / skill-body boundary.
 
 Long Hecate-owned model chats compact older transcript context before a direct
 model turn once the compactable transcript reaches the automatic threshold.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3454,6 +3454,9 @@ accepts only one active task-backed turn per Hecate Chat session.
 ### `GET /hecate/v1/chat/sessions/{id}/messages/{message_id}/context`
 
 Returns the persisted context packet snapshot for an assistant message:
+operator UIs render project-linked Hecate Chat packets with an explicit
+project-prelude note, while the wire packet remains the same itemized
+`context_packet` shape.
 
 ```json
 GET /hecate/v1/chat/sessions/chat_.../messages/msg_.../context

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -247,6 +247,7 @@ export function ContextInspectorPanel({
       }}
     >
       <ContextSummary packet={packet} />
+      <ProjectLinkedHecateContextNotice packet={packet} />
       {!compact && refs.length > 0 && (
         <section style={{ display: "grid", gap: 8 }}>
           <div className="kicker">Linked refs</div>
@@ -293,6 +294,7 @@ function ContextSummary({ packet }: { packet: ContextPacketRecord }) {
   const modeValue = packet.execution_mode ? humanExecutionMode(packet.execution_mode) : "—";
   const profileValue = packet.execution_profile || "—";
   const workspaceValue = packet.workspace || "—";
+  const projectPreludeValue = projectLinkedHecateChatPacket(packet) ? "Included" : "—";
   const systemPromptValue =
     typeof packet.system_prompt_included === "boolean"
       ? packet.system_prompt_included
@@ -319,6 +321,9 @@ function ContextSummary({ packet }: { packet: ContextPacketRecord }) {
         <ContextMetaCell label="Execution profile" value={profileValue} />
         <ContextMetaCell label="Workspace" value={workspaceValue} />
         <ContextMetaCell label="System prompt" value={systemPromptValue} />
+        {projectLinkedHecateChatPacket(packet) && (
+          <ContextMetaCell label="Project prelude" value={projectPreludeValue} />
+        )}
         <ContextMetaCell label="Transcript count" value={messageCountValue} />
       </div>
     </section>
@@ -377,6 +382,26 @@ function ContextSectionGroup({ group }: { group: ContextSectionGroupRecord }) {
         ))}
       </div>
     </section>
+  );
+}
+
+function ProjectLinkedHecateContextNotice({ packet }: { packet: ContextPacketRecord }) {
+  if (!projectLinkedHecateChatPacket(packet)) return null;
+  const includedSections = projectPreludeSections(packet.items ?? []);
+  const sectionText =
+    includedSections.length > 0 ? ` Itemized sections here: ${includedSections.join(", ")}.` : "";
+  return (
+    <ContextInspectorNotice
+      title="Project-linked Hecate context"
+      detail={
+        "This turn used Hecate's bounded project prelude for the linked project. " +
+        "Project roots, roles, skills, active work, and accepted memory may guide the turn; " +
+        "root files and SKILL.md bodies are metadata-only unless a tool reads them explicitly. " +
+        "Durable project changes still go through Project Assistant proposal review/apply." +
+        sectionText
+      }
+      tone="muted"
+    />
   );
 }
 
@@ -522,6 +547,32 @@ function visibleRefs(refs?: ContextPacketRefsRecord): Array<[string, string]> {
 
 function hasRefs(refs?: ContextPacketRefsRecord): boolean {
   return visibleRefs(refs).length > 0;
+}
+
+function projectLinkedHecateChatPacket(packet: ContextPacketRecord): boolean {
+  return (
+    packet.execution_mode === "hecate_task" &&
+    Boolean(packet.refs?.project_id?.trim()) &&
+    Boolean(packet.refs?.session_id?.trim())
+  );
+}
+
+function projectPreludeSections(items: ContextPacketItemRecord[]): string[] {
+  const labels = new Map<string, string>([
+    ["project", "project"],
+    ["skills", "skills"],
+    ["project_work", "active work"],
+    ["memory", "memory"],
+    ["sources", "sources"],
+    ["instructions", "instructions"],
+  ]);
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (!item.included) continue;
+    const label = labels.get(item.section ?? "");
+    if (label) seen.add(label);
+  }
+  return Array.from(labels.values()).filter((label) => seen.has(label));
 }
 
 function humanExecutionMode(mode: string): string {

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -592,6 +592,75 @@ describe("TranscriptMessageRow", () => {
     ).toBeInTheDocument();
   });
 
+  it("calls out project-linked Hecate context packets", async () => {
+    const user = userEvent.setup();
+    const contextPacket: ChatContextPacketRecord = {
+      execution_mode: "hecate_task",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      workspace: "/tmp/hecate",
+      system_prompt_included: true,
+      message_count: 2,
+      refs: {
+        project_id: "proj_1",
+        session_id: "chat_1",
+        message_id: "msg_1",
+      },
+      items: [
+        {
+          section: "project",
+          kind: "project",
+          trust_level: "project",
+          origin: "proj_1",
+          title: "Hecate",
+          included: true,
+          inclusion_reason: "Project linked to this chat session",
+        },
+        {
+          section: "skills",
+          kind: "project_skills",
+          trust_level: "workspace_guidance",
+          origin: "project.skills",
+          title: "Project skills",
+          body: "Backend Skill (backend): Backend changes. Path: .hecate/skills/backend/SKILL.md",
+          included: true,
+        },
+        {
+          section: "project_work",
+          kind: "project_work",
+          trust_level: "project",
+          origin: "project.work",
+          title: "Project work",
+          body: "Work item Plan chat context (work_1): status=ready",
+          included: true,
+        },
+        {
+          section: "memory",
+          kind: "memory",
+          trust_level: "operator_memory",
+          origin: "mem_1",
+          title: "Project boundary",
+          body: "Use Project Assistant proposals for durable changes.",
+          included: true,
+        },
+      ],
+    };
+
+    render(<TranscriptMessageRow {...baseProps} contextPacket={contextPacket} />);
+    await user.click(screen.getByText(/what the agent saw · 2 messages · openai · gpt-4o-mini/));
+
+    expect(screen.getByText("Project prelude")).toBeInTheDocument();
+    expect(screen.getAllByText("Included").length).toBeGreaterThan(0);
+    expect(screen.getByText("Project-linked Hecate context")).toBeInTheDocument();
+    expect(
+      screen.getByText(/root files and SKILL\.md bodies are metadata-only/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Project Assistant proposal review\/apply/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Itemized sections here: project, skills, active work, memory\./),
+    ).toBeInTheDocument();
+  });
+
   it("links failed tools to related stdout and stderr artifacts", async () => {
     const onOpenTask = vi.fn();
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

- Add a project-linked Hecate context notice to the shared context inspector.
- Surface a Project prelude summary cell for project-linked Hecate Chat context packets.
- Update chat/runtime docs for the explicit project-prelude inspection cue.

## Validation

- `cd ui && bun run test -- src/features/transcript/TranscriptMessageRow.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-format-check`

Note: the full UI test run still emits the existing jsdom `HTMLCanvasElement.getContext()` warning, but all tests pass.
