### PR TITLE
Snapshot project linkage on task runs

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -359,8 +359,9 @@ work, missing provider/model defaults, and context readiness without adding a
 separate persisted health model. Assignment rows now render compact execution
 evidence from canonical assignment/activity refs, while the Context Inspector
 renders the full persisted launch packet with Profile, Instructions, Skills,
-Memory, Project sources, Work context, and Runtime evidence groups. Broader task
-`project_id` scoping, profiles, and presets are not linked to `project_id` yet.
+Memory, Project sources, Work context, and Runtime evidence groups. Task and run
+records now carry direct project/work/assignment linkage when created from
+project-scoped surfaces; profiles and presets are not linked to `project_id` yet.
 
 Persist `project_id` on:
 
@@ -385,9 +386,9 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 1. Add project store and API basics. Done for memory + SQLite CRUD.
 2. Add UI list/create/rename/delete basics. Done.
 3. Add `project_id` to chat sessions.
-4. Add `project_id` to tasks. Partial: project work assignments can start
-   linked native tasks via origin metadata; broader task/run scoping remains
-   future.
+4. Add `project_id` to tasks and runs. Done for task records, run records, task
+   lists, run responses, project assignments, and project-linked Hecate Chat
+   task-backed turns.
 5. Thread project identity into chat context packets. Done for itemized project context-source metadata.
 6. Add project-scoped memory. Done.
 7. Add agent-profile memory-source selection.
@@ -409,20 +410,18 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 
 The next project-orchestration slices are:
 
-1. Finish durable task/run project linkage so native tasks, project assignments,
-   and chat-origin work all expose the same `project_id` boundary.
-2. Extend explicit prompt/source-content policy beyond native project
+1. Extend explicit prompt/source-content policy beyond native project
    assignments. Profile-management UI, role/project default profile selection,
    project-skill pickers, profile-driven context-packet activation, and bounded
    native-assignment prompt inclusion for project memory plus portable
    `AGENTS.md` guidance exist. Chat, external-agent, host-specific guidance, and
    arbitrary source-document prompt policy remain follow-up work.
-3. Broaden focused project journeys beyond the current API-level create
+2. Broaden focused project journeys beyond the current API-level create
    project -> discover guidance/skills -> add memory -> create/start assignment
    -> inspect context -> follow handoff regression. Remaining hardening should
    cover approval/failure paths, activity-health triage, and UI end-to-end
    flows.
-4. Keep tightening the Projects cockpit UI around operator decisions: no hidden
+3. Keep tightening the Projects cockpit UI around operator decisions: no hidden
    recommendations, no separate health persistence, and no automatic memory
    promotion.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -193,9 +193,10 @@ and do not replace the task's generic `origin_kind` / `origin_id` fields.
 
 `task_run` carries the cost figures the operator UI surfaces:
 
-- `project_id` / `work_item_id` / `assignment_id` — project-work inspection
-  links when Hecate can derive them from the parent task or the run context
-  packet refs.
+- `project_id` / `work_item_id` / `assignment_id` — project inspection links
+  snapped onto new runs from the parent task. Older alpha rows may still derive
+  these links from the parent task or run context-packet refs when the run
+  payload predates direct run linkage.
 - `total_cost_micros_usd` — this run's LLM spend (after routing).
 - `prior_cost_micros_usd` — cumulative spend of every prior run in this run's resume chain. Cumulative-across-task = `prior + total`.
 - `model` / `provider` / `provider_kind` — what was actually used (after routing). May differ from the task's `requested_*` when the operator picked auto. Agent-loop runs preserve these fields for both streaming and non-streaming model turns.
@@ -2470,8 +2471,8 @@ assignment, and role exist, then
 creates a normal Task with `execution_kind="agent_loop"`,
 `origin_kind="project_work_item"`, and `origin_id` set to the work item ID. The
 task response also exposes `work_item_id` and `assignment_id` for direct
-inspection, and the created run response exposes `project_id`, `work_item_id`,
-and `assignment_id` from the parent task and stored context packet refs. The
+inspection, and the created run snapshots `project_id`, `work_item_id`, and
+`assignment_id` directly on the run payload. The
 task title, prompt, and system prompt are composed from a visible launch-context
 block covering project, work item, assignment, role, execution hints, role
 defaults, project defaults, and any profile-activated prompt context. Project

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -743,6 +743,9 @@ func renderTaskRun(run types.TaskRun, parentTasks ...types.Task) TaskRunItem {
 	item := TaskRunItem{
 		ID:                 run.ID,
 		TaskID:             run.TaskID,
+		ProjectID:          run.ProjectID,
+		WorkItemID:         run.WorkItemID,
+		AssignmentID:       run.AssignmentID,
 		Number:             run.Number,
 		Status:             run.Status,
 		Orchestrator:       run.Orchestrator,
@@ -765,15 +768,15 @@ func renderTaskRun(run types.TaskRun, parentTasks ...types.Task) TaskRunItem {
 	}
 	if len(parentTasks) > 0 {
 		task := parentTasks[0]
-		item.ProjectID = task.ProjectID
-		item.WorkItemID = task.WorkItemID
-		item.AssignmentID = task.AssignmentID
+		item.ProjectID = firstNonEmptyString(item.ProjectID, task.ProjectID)
+		item.WorkItemID = firstNonEmptyString(item.WorkItemID, task.WorkItemID)
+		item.AssignmentID = firstNonEmptyString(item.AssignmentID, task.AssignmentID)
 	}
 	if packet, ok, err := chatcontext.FromTaskRun(run); err == nil && ok && packet.Refs != nil {
 		refs := chatcontext.Refs(*packet.Refs)
-		item.ProjectID = firstNonEmptyString(refs.ProjectID, item.ProjectID)
-		item.WorkItemID = firstNonEmptyString(refs.WorkItemID, item.WorkItemID)
-		item.AssignmentID = firstNonEmptyString(refs.AssignmentID, item.AssignmentID)
+		item.ProjectID = firstNonEmptyString(item.ProjectID, refs.ProjectID)
+		item.WorkItemID = firstNonEmptyString(item.WorkItemID, refs.WorkItemID)
+		item.AssignmentID = firstNonEmptyString(item.AssignmentID, refs.AssignmentID)
 	}
 	if !run.StartedAt.IsZero() {
 		item.StartedAt = run.StartedAt.UTC().Format(time.RFC3339Nano)

--- a/internal/api/handler_tasks_render_test.go
+++ b/internal/api/handler_tasks_render_test.go
@@ -1,10 +1,33 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+func TestRenderTaskRunUsesDirectRunProjectLinkage(t *testing.T) {
+	t.Parallel()
+
+	item := renderTaskRun(types.TaskRun{
+		ID:           "run_1",
+		TaskID:       "task_1",
+		ProjectID:    "proj_run",
+		WorkItemID:   "work_run",
+		AssignmentID: "asgn_run",
+		Status:       "running",
+	}, types.Task{
+		ID:           "task_1",
+		ProjectID:    "proj_task",
+		WorkItemID:   "work_task",
+		AssignmentID: "asgn_task",
+	})
+	if item.ProjectID != "proj_run" || item.WorkItemID != "work_run" || item.AssignmentID != "asgn_run" {
+		t.Fatalf("run linkage = project %q work %q assignment %q, want direct run linkage", item.ProjectID, item.WorkItemID, item.AssignmentID)
+	}
+}
 
 func TestRenderTaskRunUsesParentTaskProjectLinkage(t *testing.T) {
 	t.Parallel()
@@ -21,5 +44,31 @@ func TestRenderTaskRunUsesParentTaskProjectLinkage(t *testing.T) {
 	})
 	if item.ProjectID != "proj_1" || item.WorkItemID != "work_1" || item.AssignmentID != "asgn_1" {
 		t.Fatalf("run linkage = project %q work %q assignment %q, want proj_1/work_1/asgn_1", item.ProjectID, item.WorkItemID, item.AssignmentID)
+	}
+}
+
+func TestRenderTaskRunUsesContextPacketProjectLinkageFallback(t *testing.T) {
+	t.Parallel()
+
+	packet, err := json.Marshal(chat.ContextPacket{
+		Version: "chat.context.v1",
+		Refs: &chat.ContextRefs{
+			ProjectID:    "proj_context",
+			WorkItemID:   "work_context",
+			AssignmentID: "asgn_context",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal context packet: %v", err)
+	}
+
+	item := renderTaskRun(types.TaskRun{
+		ID:            "run_1",
+		TaskID:        "task_1",
+		Status:        "running",
+		ContextPacket: packet,
+	})
+	if item.ProjectID != "proj_context" || item.WorkItemID != "work_context" || item.AssignmentID != "asgn_context" {
+		t.Fatalf("run linkage = project %q work %q assignment %q, want context fallback linkage", item.ProjectID, item.WorkItemID, item.AssignmentID)
 	}
 }

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -608,6 +608,9 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 	run := types.TaskRun{
 		ID:           idgen("run"),
 		TaskID:       task.ID,
+		ProjectID:    strings.TrimSpace(task.ProjectID),
+		WorkItemID:   strings.TrimSpace(task.WorkItemID),
+		AssignmentID: strings.TrimSpace(task.AssignmentID),
 		Number:       len(runs) + 1,
 		Status:       "queued",
 		Orchestrator: "builtin",
@@ -624,6 +627,9 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 	}
 	if options.ResumeFromRun != nil {
 		prior := *options.ResumeFromRun
+		run.ProjectID = firstNonEmpty(run.ProjectID, strings.TrimSpace(prior.ProjectID))
+		run.WorkItemID = firstNonEmpty(run.WorkItemID, strings.TrimSpace(prior.WorkItemID))
+		run.AssignmentID = firstNonEmpty(run.AssignmentID, strings.TrimSpace(prior.AssignmentID))
 		if strings.TrimSpace(prior.WorkspacePath) != "" {
 			run.WorkspacePath = prior.WorkspacePath
 			run.WorkspaceID = firstNonEmpty(prior.WorkspaceID, run.WorkspaceID)

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -105,6 +105,55 @@ func TestStartReconcileLoop_RequeuesStaleRunningRun(t *testing.T) {
 	}
 }
 
+func TestRunnerStartTaskSnapshotsProjectLinkageOnRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{ApprovalPolicies: []string{"shell_exec"}},
+	)
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = runner.Shutdown(shutdownCtx)
+	}()
+
+	idgen := func(prefix string) string {
+		return prefix + "_linkage"
+	}
+	task := types.Task{
+		ID:            "task_project",
+		ProjectID:     "proj_1",
+		WorkItemID:    "work_1",
+		AssignmentID:  "asgn_1",
+		ExecutionKind: "shell",
+		ShellCommand:  "echo ready",
+		Status:        "queued",
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	result, err := runner.StartTask(ctx, task, idgen)
+	if err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if result.Run.ProjectID != "proj_1" || result.Run.WorkItemID != "work_1" || result.Run.AssignmentID != "asgn_1" {
+		t.Fatalf("result run linkage = project %q work %q assignment %q, want proj_1/work_1/asgn_1", result.Run.ProjectID, result.Run.WorkItemID, result.Run.AssignmentID)
+	}
+	storedRun, ok, err := store.GetRun(ctx, task.ID, result.Run.ID)
+	if err != nil || !ok {
+		t.Fatalf("GetRun: ok=%v err=%v", ok, err)
+	}
+	if storedRun.ProjectID != "proj_1" || storedRun.WorkItemID != "work_1" || storedRun.AssignmentID != "asgn_1" {
+		t.Fatalf("stored run linkage = project %q work %q assignment %q, want proj_1/work_1/asgn_1", storedRun.ProjectID, storedRun.WorkItemID, storedRun.AssignmentID)
+	}
+}
+
 // TestStartReconcileLoop_SkipsFreshRunningRun verifies that the loop does NOT
 // re-enqueue a run that only recently entered "running" state — i.e. an
 // active worker is still within its lease window.

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -174,9 +174,12 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 	ctx := context.Background()
 
 	task := types.Task{
-		ID:     "task-1",
-		Title:  "demo",
-		Status: "queued",
+		ID:           "task-1",
+		Title:        "demo",
+		ProjectID:    "proj-1",
+		WorkItemID:   "work-1",
+		AssignmentID: "asgn-1",
+		Status:       "queued",
 	}
 	saved, err := store.CreateTask(ctx, task)
 	if err != nil {
@@ -195,11 +198,14 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 	}
 
 	run := types.TaskRun{
-		ID:        "run-1",
-		TaskID:    "task-1",
-		Number:    1,
-		Status:    "running",
-		StartedAt: time.Now().UTC(),
+		ID:           "run-1",
+		TaskID:       "task-1",
+		ProjectID:    "proj-1",
+		WorkItemID:   "work-1",
+		AssignmentID: "asgn-1",
+		Number:       1,
+		Status:       "running",
+		StartedAt:    time.Now().UTC(),
 	}
 	if _, err := store.CreateRun(ctx, run); err != nil {
 		t.Fatalf("CreateRun: %v", err)
@@ -210,6 +216,9 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 	}
 	if gotRun.Status != "running" || gotRun.Number != 1 {
 		t.Fatalf("GetRun round-trip mismatch: %+v", gotRun)
+	}
+	if gotRun.ProjectID != "proj-1" || gotRun.WorkItemID != "work-1" || gotRun.AssignmentID != "asgn-1" {
+		t.Fatalf("GetRun linkage = project %q work %q assignment %q, want proj-1/work-1/asgn-1", gotRun.ProjectID, gotRun.WorkItemID, gotRun.AssignmentID)
 	}
 
 	for i, status := range []string{"running", "completed"} {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -161,8 +161,15 @@ type MCPServerConfig struct {
 }
 
 type TaskRun struct {
-	ID                 string
-	TaskID             string
+	ID     string
+	TaskID string
+	// ProjectID, WorkItemID, and AssignmentID snapshot the project
+	// boundary from the parent task at run creation time. They let
+	// run streams, traces, and retained run records remain project-aware
+	// even when the parent task is not loaded by the caller.
+	ProjectID          string
+	WorkItemID         string
+	AssignmentID       string
 	Number             int
 	Status             string
 	Orchestrator       string


### PR DESCRIPTION
## Summary

- snapshot `project_id`, `work_item_id`, and `assignment_id` directly onto new task runs from the parent task
- prefer direct run linkage in task-run API rendering, with fallback to parent task and legacy context-packet refs
- update taskstate/API/orchestrator tests plus runtime and Projects docs

## Why

Project work, Hecate Chat task-backed turns, run streams, and traces should expose the same durable project boundary without requiring callers to load the parent task first.

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/taskstate ./internal/api ./internal/orchestrator`
- `just agent-docs-check`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`