### PR TITLE
Label slash command provenance in chat

### DIFF
--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -142,6 +142,9 @@ external agent. The operator UI may show these hints while the composer starts
 with `/`; choosing a hint only inserts the slash command text. Hecate-owned
 chat commands are separate local shortcuts and must still route through
 Hecate's proposal, validation, and operator-apply boundaries.
+The composer picker labels command provenance as **External Agent** for
+ACP-advertised external commands, **Project** for Hecate-owned project proposal
+shortcuts, and **Hecate** for local navigation/runtime shortcuts.
 
 ### Hecate-owned chat commands
 

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -142,6 +142,9 @@ commands, not ACP commands. Project-shaping shortcuts such as `/plan`, `/work`,
 `/handoff`, and `/review` should remain intent hints that go through the usual
 proposal, validation, and operator-apply boundaries instead of directly
 mutating project records.
+The composer picker labels ACP-advertised commands as **External Agent**.
+Hecate-owned local shortcuts use **Project** for proposal-oriented project
+commands and **Hecate** for local navigation/runtime commands.
 
 Check discovery:
 

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -95,6 +95,8 @@ const HECATE_MESSAGE_COMMANDS: Record<
     description: "Open Connections",
   },
 };
+// Keep proposal-oriented project commands here so the picker labels them as
+// Project, not as generic Hecate navigation/runtime shortcuts.
 const HECATE_PROJECT_COMMAND_NAMES = new Set<string>([
   "proposal",
   "plan",
@@ -352,7 +354,7 @@ export function ChatComposer(props: ChatComposerProps) {
           name: command.name,
           description: command.description,
           inputHint: command.inputHint,
-          sourceLabel: "Hecate",
+          sourceLabel: hecateMessageCommandSourceLabel(command.name),
         });
       }
     }
@@ -366,7 +368,7 @@ export function ChatComposer(props: ChatComposerProps) {
             name: externalAgentCommandName(command),
             description: command.description,
             inputHint: command.input_hint,
-            sourceLabel: selectedActiveAgent?.name || "Agent",
+            sourceLabel: "External Agent",
           }))
           .filter((command) => command.name !== "")
           .filter((command) => command.name.toLowerCase().startsWith(query)),
@@ -389,7 +391,6 @@ export function ChatComposer(props: ChatComposerProps) {
     onOpenWorkspaceChanges,
     projectProposalAvailable,
     projectProposalDrafting,
-    selectedActiveAgent?.name,
     workspaceChangesAvailable,
   ]);
   const commandPickerVisible =
@@ -955,7 +956,7 @@ export function ChatComposer(props: ChatComposerProps) {
                             fontFamily: "var(--font-mono)",
                             fontSize: 10,
                             textTransform: "uppercase",
-                            letterSpacing: "0.06em",
+                            letterSpacing: 0,
                             minWidth: 0,
                             overflow: "hidden",
                             textOverflow: "ellipsis",
@@ -1254,6 +1255,10 @@ function messageCommandQuery(message: string): string | null {
 
 function externalAgentCommandName(command: ChatAvailableCommandRecord) {
   return command.name.trim().replace(/^\/+/, "");
+}
+
+function hecateMessageCommandSourceLabel(name: HecateMessageCommandName) {
+  return HECATE_PROJECT_COMMAND_NAMES.has(name) ? "Project" : "Hecate";
 }
 
 type HecateMessageCommandAvailability = {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3123,6 +3123,9 @@ describe("ChatView input", () => {
     expect(within(commands).getByRole("option", { name: "Insert /web command" })).toHaveTextContent(
       "/web",
     );
+    expect(within(commands).getByRole("option", { name: "Insert /web command" })).toHaveTextContent(
+      "External Agent",
+    );
     expect(within(commands).getByRole("option", { selected: true })).toHaveAttribute(
       "aria-label",
       "Insert /web command",
@@ -3383,7 +3386,9 @@ describe("ChatView input", () => {
     render(withRuntimeConsole(<ChatView onNavigate={() => undefined} />, { state, actions }));
 
     const commands = screen.getByRole("listbox", { name: "Message commands" });
-    expect(within(commands).getByRole("option", { name: "Insert /diff command" })).toBeTruthy();
+    expect(
+      within(commands).getByRole("option", { name: "Insert /diff command" }),
+    ).toHaveTextContent("Hecate");
     expect(within(commands).getByRole("option", { name: "Insert /model command" })).toBeTruthy();
     expect(within(commands).getByRole("option", { name: "Insert /settings command" })).toBeTruthy();
     expect(within(commands).getByRole("option", { name: "Insert /status command" })).toBeTruthy();
@@ -3422,6 +3427,9 @@ describe("ChatView input", () => {
     expect(
       within(commands).getByRole("option", { name: "Insert /proposal command" }),
     ).toHaveTextContent("/proposal");
+    expect(
+      within(commands).getByRole("option", { name: "Insert /proposal command" }),
+    ).toHaveTextContent("Project");
     expect(within(commands).getByText("Draft a Project Assistant proposal")).toBeTruthy();
 
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

- Label slash command picker provenance as Agent, Project, or Hecate.
- Keep ACP-advertised commands visually distinct from Hecate-owned local shortcuts.
- Update chat and external-agent docs for the command provenance labels.

## Validation

- `cd ui && bun run test -- src/features/chats/ChatView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-format-check`

Note: the full UI test run still emits the existing jsdom `HTMLCanvasElement.getContext()` warning, but all tests pass.
