### PR TITLE
Clarify project prompt source policy

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -45,6 +45,14 @@ mark project memory and source metadata active, visible-only, or omitted. Native
 project assignments can include bounded project memory and portable `AGENTS.md`
 workspace-instruction bodies only when the resolved profile explicitly includes
 them; host-specific guidance files and skill bodies remain metadata-only.
+Project-linked Hecate Chat uses a bounded project prelude in the chat system
+prompt and records that policy in the context packet; project context-source
+file bodies, host-specific guidance file bodies, and `SKILL.md` bodies are not
+loaded into chat prompts in V1. External Agent chat and External Agent
+project-assignment starts record project metadata for inspection, but Hecate
+does not inject project memory bodies, source bodies, or skill bodies into
+adapter prompts; the adapter owns private prompt packing inside its native
+session.
 Model-backed assistant turns should carry a small context-inspector packet:
 execution mode, route/workspace metadata, source provenance, and visible
 transcript counts. Do not store full prompt bodies, raw transcript text, file

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -414,8 +414,10 @@ The next project-orchestration slices are:
    assignments. Profile-management UI, role/project default profile selection,
    project-skill pickers, profile-driven context-packet activation, and bounded
    native-assignment prompt inclusion for project memory plus portable
-   `AGENTS.md` guidance exist. Chat, external-agent, host-specific guidance, and
-   arbitrary source-document prompt policy remain follow-up work.
+   `AGENTS.md` guidance exist. Project-linked Hecate Chat now records its
+   bounded project prelude explicitly, and External Agent chat/assignment
+   packets keep project memory/source bodies metadata-only. Host-specific
+   guidance and arbitrary source-document prompt policy remain follow-up work.
 2. Broaden focused project journeys beyond the current API-level create
    project -> discover guidance/skills -> add memory -> create/start assignment
    -> inspect context -> follow handoff regression. Remaining hardening should

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -9,10 +9,10 @@
 > [Agent memory](agent-memory.md), [Projects](../accepted/projects.md), and
 > [Runtime API](../../runtime/runtime-api.md) for today's context-packet,
 > memory, project, and task behavior.
-> **Next action:** extend profile-driven prompt/source content policy to chats
-> and external-agent starts, then add compatibility warnings for host-specific
-> guidance. Remote skill install and skill execution remain separate later
-> slices.
+> **Next action:** add compatibility warnings for host-specific guidance and
+> decide whether arbitrary source-document body inclusion needs an explicit
+> operator approval flow. Remote skill install and skill execution remain
+> separate later slices.
 
 Hecate needs a clean vocabulary for several things that are easy to blur:
 workspace `AGENTS.md` files, other Markdown instruction files, reusable

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -358,7 +358,9 @@ Deployment-specific notes:
   inspection, and context packets snapshot project-scoped memory/source
   decisions. Native project assignments can include bounded project memory and
   portable `AGENTS.md` prompt context when the resolved profile asks for it;
-  broader chat/external-agent source-content policy remains follow-up work.
+  Hecate-owned project chat has an explicit bounded project prelude, while
+  External Agent paths keep project memory/source bodies metadata-only unless a
+  future adapter-specific prompt policy is added.
 - When `HECATE_BACKEND=sqlite` or `postgres`, Hecate runs a startup reconcile
   pass that flips any pending external-agent approvals from a prior process to
   `status=timed_out`, `path=startup_reconcile` before serving requests, so an

--- a/docs/runtime/agent-runtime.md
+++ b/docs/runtime/agent-runtime.md
@@ -276,6 +276,16 @@ remain metadata-only for this path. If the selected route is a cloud provider,
 included project memory and workspace-instruction bodies are sent to that
 provider as normal task prompt content.
 
+Project-linked Hecate Chat uses a separate bounded project prelude in the chat
+system prompt. It may include project identity, root metadata, role hints,
+enabled skill metadata, active work metadata, and accepted project memory
+bodies. Project context-source file bodies, host-specific guidance file bodies,
+and `SKILL.md` bodies are not loaded into chat prompts in V1. External Agent
+chat and External Agent project-assignment starts record project metadata for
+inspection, but Hecate does not inject project memory bodies, source bodies, or
+skill bodies into adapter prompts; the adapter owns any private prompt packing
+inside its native session.
+
 ## Approval gating
 
 Two distinct approval flows:

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -104,16 +104,19 @@ Hecate owns routing, workspace path, whether a system prompt was included, the
 visible transcript message count for that turn, the legacy high-level
 `sources`, and itemized `items` with `kind`, `trust_level`, `origin`, `title`,
 optional `body` / `body_ref`, `included`, and `inclusion_reason`. Current items
-cover visible metadata only: system prompt presence, transcript count, enabled
+cover system prompt presence, prompt-policy notes, transcript count, enabled
 project source metadata (workspace guidance, URLs, notes, local paths, or
 external references), enabled project skill metadata, current active project
 work metadata, accepted project memory, workspace path metadata, Hecate
-task-runtime state, and external-agent session metadata. It deliberately does
-not persist full system prompts, raw transcript text, file contents, source
-bodies, `SKILL.md` bodies, or agent-private prompt packing. External Agent
-packets explicitly note
-that Hecate can show adapter metadata and transcript rows it receives but cannot
-inspect the agent's private prompt or packed model context. The message count is
+task-runtime state, and external-agent session metadata. Hecate-owned project
+chat packets mark bounded project prelude content as included, but mark project
+context-source file bodies as visible-only because those bodies are not loaded
+into chat prompts. External Agent packets mark project memory and source records
+as visible-only and explicitly note that Hecate can show adapter metadata and
+transcript rows it receives but cannot inspect or control the agent's private
+prompt packing. Context packets deliberately do not persist full system prompts,
+raw transcript text, file contents, source bodies, `SKILL.md` bodies, or
+agent-private prompt packing. The message count is
 an operator-facing transcript count, not a provider token count or a guarantee
 that every counted message was packed into the provider or agent prompt. Context
 packets are snapshots on assistant messages; changing project context sources,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3550,9 +3550,15 @@ Section values currently used by the runtime are:
 
 `included=true` means the item was part of the prepared context for that
 message or run. `included=false` means the item is related inspectable metadata
-that V1 did not inject into the runtime context. Native project-assignment
-packets currently use `included=false` for project memory, project sources,
-handoffs, and artifact refs.
+that V1 did not inject into the runtime context. Hecate-owned project chat
+packets use explicit `prompt_context` items to distinguish bounded project
+prelude content from visible-only project source metadata. External Agent chat
+and External Agent project-assignment packets mark project memory/source
+records as visible-only because Hecate records metadata for inspection but does
+not inject those bodies into adapter prompts. Native project-assignment packets
+can mark project memory and eligible source metadata included only when the
+resolved profile policy activated bounded prompt inclusion; handoffs and
+artifact refs remain metadata-only.
 
 Legacy packets can omit `id`, `execution_profile`, `refs`, or `section`. The
 server backfills obvious request-scoped refs and default sections where it can,

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -220,9 +220,14 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 	packet.SystemPromptIncluded = strings.TrimSpace(systemPrompt) != ""
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	populateProjectRefs(&packet, session.ProjectID)
-	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
-	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), true, "Enabled project skill metadata for this direct model turn; skill bodies are not injected")
-	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), true, "Current project work metadata for this direct model turn")
+	project := h.projectSummary(ctx, session.ProjectID)
+	appendProjectSummary(&packet, project, true, "Project linked to this chat session")
+	projectPromptIncluded := project != nil
+	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "direct model turn"))
+	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "direct model turn"))
+	if project != nil {
+		appendHecateChatPromptPolicy(&packet)
+	}
 	if packet.SystemPromptIncluded {
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
@@ -239,7 +244,11 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 			InclusionReason: "Configured for this direct model turn",
 		})
 	}
-	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+	if projectPromptIncluded {
+		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+	} else {
+		appendProjectMemoryWithInclusion(&packet, h.projectMemoryEntries(ctx, session), false, "Project memory is inspectable only; no linked project prompt prelude was assembled")
+	}
 	if strings.TrimSpace(session.Workspace) != "" {
 		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
@@ -267,9 +276,14 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	packet.ExecutionProfile = "chat_agent"
 	populateProjectRefs(&packet, session.ProjectID)
-	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
-	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), true, "Enabled project skill metadata for this task-backed turn; skill bodies are not injected")
-	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), true, "Current project work metadata for this task-backed turn")
+	project := h.projectSummary(ctx, session.ProjectID)
+	appendProjectSummary(&packet, project, true, "Project linked to this chat session")
+	projectPromptIncluded := project != nil
+	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "task-backed turn"))
+	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "task-backed turn"))
+	if project != nil {
+		appendHecateChatPromptPolicy(&packet)
+	}
 	if packet.SystemPromptIncluded {
 		appendContextPacketSourceWithSection(&packet, contextSectionInstructions, chat.ContextSource{
 			Kind:   "system_prompt",
@@ -286,7 +300,11 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 			InclusionReason: "Stored on the backing task for this task segment",
 		})
 	}
-	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+	if projectPromptIncluded {
+		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+	} else {
+		appendProjectMemoryWithInclusion(&packet, h.projectMemoryEntries(ctx, session), false, "Project memory is inspectable only; no linked project prompt prelude was assembled")
+	}
 	if strings.TrimSpace(session.Workspace) != "" {
 		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
@@ -330,8 +348,9 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 	packet := baseChatContextPacket(chat.ExecutionModeExternalAgent, "", "", session.Workspace)
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	populateProjectRefs(&packet, session.ProjectID)
-	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), true, "Project linked to this chat session")
-	appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+	appendProjectSummary(&packet, h.projectSummary(ctx, session.ProjectID), false, "Project linked to this external-agent chat session; not injected into the adapter prompt")
+	appendExternalAgentChatPromptPolicy(&packet)
+	appendProjectMemoryWithInclusion(&packet, h.projectMemoryEntries(ctx, session), false, "Project memory is inspectable only; Hecate does not inject memory bodies into External Agent chat prompts in V1")
 	if strings.TrimSpace(session.Workspace) != "" {
 		appendContextPacketSourceWithSection(&packet, contextSectionWorkspace, chat.ContextSource{
 			Kind:   "workspace",
@@ -348,7 +367,7 @@ func (h *Handler) externalAgentContextPacket(ctx context.Context, session chat.S
 			InclusionReason: "Workspace path selected for this external-agent session",
 		})
 	}
-	appendProjectContextSources(&packet, h.projectContextSources(ctx, session))
+	appendProjectContextSourcesWithInclusion(&packet, h.projectContextSources(ctx, session), false, "Project source metadata is inspectable only; Hecate does not inject source bodies into External Agent chat prompts in V1")
 	if strings.TrimSpace(adapterName) == "" {
 		adapterName = "External agent"
 	}
@@ -505,6 +524,9 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 	appendResolvedAgentProfile(&packet, profile)
 	appendResolvedProjectSkills(&packet, skills)
 	appendProjectAssignmentPromptContext(&packet, promptContext)
+	if driverKind == projectwork.AssignmentDriverExternalAgent {
+		appendExternalAgentAssignmentPromptPolicy(&packet, profile)
+	}
 	if packet.SystemPromptIncluded {
 		promptOrigin := "task.system_prompt"
 		promptBodyRef := "task_system_prompt"
@@ -545,8 +567,13 @@ func (h *Handler) projectAssignmentContextPacket(ctx context.Context, project pr
 			InclusionReason: "Selected as the project assignment workspace",
 		})
 	}
-	appendProjectMemoryForProfilePolicy(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), profile)
-	appendProjectContextSourcesForProfilePolicy(&packet, projectContextSourcesFromProject(project), profile)
+	if driverKind == projectwork.AssignmentDriverExternalAgent {
+		appendProjectMemoryWithInclusion(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), false, "External-agent assignment launch records memory metadata only; Hecate does not inject memory bodies into adapter prompts in V1")
+		appendProjectContextSourcesWithInclusion(&packet, projectContextSourcesFromProject(project), false, "External-agent assignment launch records source metadata only; Hecate does not inject source bodies into adapter prompts in V1")
+	} else {
+		appendProjectMemoryForProfilePolicy(&packet, h.enabledProjectMemoryEntries(ctx, project.ID), profile)
+		appendProjectContextSourcesForProfilePolicy(&packet, projectContextSourcesFromProject(project), profile)
+	}
 	appendProjectAssignmentHandoffs(&packet, h.assignmentRelevantHandoffs(ctx, assignment, role.ID), false, "Handoff references are inspectable metadata only in project assignment launch context v1")
 	appendProjectAssignmentArtifacts(&packet, h.assignmentRelevantArtifacts(ctx, assignment), false, "Artifact references are inspectable metadata only in project assignment launch context v1")
 	return packet
@@ -651,7 +678,18 @@ func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment pro
 }
 
 func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
-	appendProjectMemoryWithInclusion(packet, entries, true, "Enabled project memory entry")
+	if len(entries) == 0 {
+		return
+	}
+	included := projectChatPromptIncludedMemoryIDs(entries)
+	for _, entry := range entries {
+		reason := "Project memory body is inspectable but omitted from the bounded Hecate-owned chat prompt"
+		isIncluded := included[strings.TrimSpace(entry.ID)]
+		if isIncluded {
+			reason = "Bounded project memory body included in the Hecate-owned project chat system prompt"
+		}
+		appendProjectMemoryEntry(packet, entry, isIncluded, reason)
+	}
 }
 
 func appendProjectChatSkills(packet *chat.ContextPacket, skills []projectskills.Skill, included bool, reason string) {
@@ -673,6 +711,13 @@ func appendProjectChatSkills(packet *chat.ContextPacket, skills []projectskills.
 		Included:        included,
 		InclusionReason: reason,
 	})
+}
+
+func hecateChatProjectMetadataReason(included bool, turn string) string {
+	if included {
+		return "Included in the Hecate-owned project chat system prompt for this " + turn + "; bodies remain metadata-only unless explicitly noted"
+	}
+	return "Inspectable project metadata only; no linked project prompt prelude was assembled for this " + turn
 }
 
 func appendProjectChatWork(packet *chat.ContextPacket, snapshot projectChatWorkSnapshot, included bool, reason string) {
@@ -710,33 +755,58 @@ func appendProjectMemoryForProfilePolicy(packet *chat.ContextPacket, entries []m
 
 func appendProjectMemoryWithInclusion(packet *chat.ContextPacket, entries []memory.Entry, included bool, reason string) {
 	for _, entry := range entries {
-		trust := strings.TrimSpace(entry.TrustLabel)
-		if trust == "" {
-			trust = contextTrustOperatorMemory
-		}
-		sourceDetail := strings.TrimSpace(entry.SourceKind)
-		if sourceID := strings.TrimSpace(entry.SourceID); sourceID != "" {
-			sourceDetail = firstNonEmptyString(sourceDetail, "operator") + ":" + sourceID
-		}
-		appendContextPacketSourceWithSection(packet, contextSectionMemory, chat.ContextSource{
-			Kind:   "memory",
-			Label:  entry.Title,
-			Detail: sourceDetail,
-			Trust:  trust,
-		}, chat.ContextItem{
-			Kind:            "memory",
-			TrustLevel:      trust,
-			Origin:          entry.ID,
-			Title:           entry.Title,
-			Body:            entry.Body,
-			Included:        included,
-			InclusionReason: reason,
-		})
+		appendProjectMemoryEntry(packet, entry, included, reason)
 	}
 }
 
+func appendProjectMemoryEntry(packet *chat.ContextPacket, entry memory.Entry, included bool, reason string) {
+	trust := strings.TrimSpace(entry.TrustLabel)
+	if trust == "" {
+		trust = contextTrustOperatorMemory
+	}
+	sourceDetail := strings.TrimSpace(entry.SourceKind)
+	if sourceID := strings.TrimSpace(entry.SourceID); sourceID != "" {
+		sourceDetail = firstNonEmptyString(sourceDetail, "operator") + ":" + sourceID
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionMemory, chat.ContextSource{
+		Kind:   "memory",
+		Label:  entry.Title,
+		Detail: sourceDetail,
+		Trust:  trust,
+	}, chat.ContextItem{
+		Kind:            "memory",
+		TrustLevel:      trust,
+		Origin:          entry.ID,
+		Title:           entry.Title,
+		Body:            entry.Body,
+		Included:        included,
+		InclusionReason: reason,
+	})
+}
+
+func projectChatPromptIncludedMemoryIDs(entries []memory.Entry) map[string]bool {
+	included := make(map[string]bool, min(len(entries), projectChatPromptMemoryMaxItems))
+	remaining := projectChatPromptMaxBytes
+	count := 0
+	for _, entry := range entries {
+		if count >= projectChatPromptMemoryMaxItems {
+			break
+		}
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := projectChatMemorySection(entry, &remaining); !ok {
+			continue
+		}
+		included[id] = true
+		count++
+	}
+	return included
+}
+
 func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.ContextSource) {
-	appendProjectContextSourcesWithInclusion(packet, sources, true, "Enabled project context source metadata")
+	appendProjectContextSourcesWithInclusion(packet, sources, false, "Project context-source metadata is inspectable for Hecate-owned chat; source file bodies are not loaded into chat prompts in V1")
 }
 
 func appendProjectContextSourcesForProfilePolicy(packet *chat.ContextPacket, sources []chat.ContextSource, profile projectworkapp.ResolvedAgentProfile) {
@@ -922,6 +992,70 @@ func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptCont
 		Body:            strings.Join(body, "\n"),
 		Included:        len(promptContext.Sections) > 0,
 		InclusionReason: "Profile memory/source policies applied to the native assignment prompt",
+	})
+}
+
+func appendHecateChatPromptPolicy(packet *chat.ContextPacket) {
+	appendContextPacketSourceWithSection(packet, contextSectionInstructions, chat.ContextSource{
+		Kind:   "prompt_context",
+		Label:  "Project prompt policy",
+		Detail: "Hecate-owned chat",
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:       "prompt_context",
+		TrustLevel: contextTrustRuntimeState,
+		Origin:     "chat.project_prompt_context",
+		Title:      "Project prompt policy",
+		Body: strings.Join([]string{
+			"Hecate-owned project chat turns include a bounded project workflow prelude in the system prompt.",
+			"The prelude may include project identity, root metadata, role hints, enabled skill metadata, active work metadata, and bounded accepted project memory bodies.",
+			"Project context-source file bodies, host-specific guidance file bodies, and SKILL.md bodies are not loaded into Hecate-owned chat prompts in V1.",
+		}, "\n"),
+		Included:        true,
+		InclusionReason: "Hecate-owned project chat system prompt policy",
+	})
+}
+
+func appendExternalAgentChatPromptPolicy(packet *chat.ContextPacket) {
+	appendContextPacketSourceWithSection(packet, contextSectionInstructions, chat.ContextSource{
+		Kind:   "prompt_context",
+		Label:  "External Agent prompt policy",
+		Detail: "adapter-owned prompt packing",
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:       "prompt_context",
+		TrustLevel: contextTrustRuntimeState,
+		Origin:     "external_agent.prompt_context",
+		Title:      "External Agent prompt policy",
+		Body: strings.Join([]string{
+			"Hecate sends the operator message to the External Agent adapter. When a project is linked, Hecate records project metadata for inspection.",
+			"Hecate does not inject project memory bodies, project source bodies, host-specific guidance file bodies, or SKILL.md bodies into External Agent chat prompts in V1.",
+			"The adapter owns any private prompt packing inside its native session.",
+		}, "\n"),
+		Included:        false,
+		InclusionReason: "Inspectable boundary note only; External Agent prompt packing is adapter-owned",
+	})
+}
+
+func appendExternalAgentAssignmentPromptPolicy(packet *chat.ContextPacket, profile projectworkapp.ResolvedAgentProfile) {
+	appendContextPacketSourceWithSection(packet, contextSectionInstructions, chat.ContextSource{
+		Kind:   "prompt_context",
+		Label:  "External Agent assignment prompt policy",
+		Detail: "adapter-owned prompt packing",
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:       "prompt_context",
+		TrustLevel: contextTrustRuntimeState,
+		Origin:     "external_agent_assignment.prompt_context",
+		Title:      "External Agent assignment prompt policy",
+		Body: strings.Join([]string{
+			"External Agent assignment start prepares a supervised chat session; it does not dispatch an adapter prompt.",
+			"Hecate records project launch metadata for inspection, but does not inject project memory bodies, project source bodies, host-specific guidance file bodies, or SKILL.md bodies into adapter prompts in V1.",
+			"Profile project_memory_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ProjectMemoryPolicy), agentprofiles.MemoryInherit),
+			"Profile context_source_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ContextSourcePolicy), agentprofiles.ContextInherit),
+		}, "\n"),
+		Included:        false,
+		InclusionReason: "Inspectable boundary note only; External Agent prompt packing is adapter-owned",
 	})
 }
 

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -102,6 +102,13 @@ func TestChatContextPacketsIncludeEnabledProjectSources(t *testing.T) {
 				Trust:  "project",
 			})
 			assertContextItem(t, tc.packet, "workspace_doc", contextTrustWorkspaceGuidance, "README.md")
+			readme := findContextItemByOrigin(tc.packet, "README.md")
+			if readme == nil || readme.Included {
+				t.Fatalf("README source item = %+v, want visible-only source metadata for chat packets", readme)
+			}
+			if !strings.Contains(readme.InclusionReason, "source") || !(strings.Contains(readme.InclusionReason, "not loaded") || strings.Contains(readme.InclusionReason, "not inject")) {
+				t.Fatalf("README source reason = %q, want source-body boundary", readme.InclusionReason)
+			}
 			assertContextSource(t, tc.packet, chat.ContextSource{
 				Kind:   "project_notes",
 				Label:  "docs/notes.md",
@@ -158,7 +165,11 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create disabled memory: %v", err)
 	}
-	handler := &Handler{memory: memoryStore}
+	projectStore := projects.NewMemoryStore()
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Hecate"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	handler := &Handler{memory: memoryStore, projects: projectStore}
 	session := chat.Session{
 		ID:        "chat_1",
 		ProjectID: "proj_1",
@@ -167,20 +178,24 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 	}
 
 	packets := []struct {
-		name   string
-		packet chat.ContextPacket
+		name           string
+		packet         chat.ContextPacket
+		memoryIncluded bool
 	}{
 		{
-			name:   "direct model",
-			packet: handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", ""),
+			name:           "direct model",
+			packet:         handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", ""),
+			memoryIncluded: true,
 		},
 		{
-			name:   "hecate task",
-			packet: handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "", false),
+			name:           "hecate task",
+			packet:         handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "", false),
+			memoryIncluded: true,
 		},
 		{
-			name:   "external agent",
-			packet: handler.externalAgentContextPacket(ctx, session, "Cursor Agent"),
+			name:           "external agent",
+			packet:         handler.externalAgentContextPacket(ctx, session, "Cursor Agent"),
+			memoryIncluded: false,
 		},
 	}
 
@@ -193,6 +208,9 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 			if operator.TrustLevel != contextTrustOperatorMemory || operator.Body != "Use conventional commits." {
 				t.Fatalf("operator memory item = %+v, want operator_memory body snapshot", *operator)
 			}
+			if operator.Included != tc.memoryIncluded {
+				t.Fatalf("operator memory Included = %v, want %v for %s", operator.Included, tc.memoryIncluded, tc.name)
+			}
 			generated := findContextItemByOrigin(tc.packet, "mem_generated")
 			if generated == nil {
 				t.Fatalf("generated memory item not found: %+v", tc.packet.Items)
@@ -200,8 +218,20 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 			if generated.TrustLevel != "generated_summary" || generated.Body != "Generated summary content." {
 				t.Fatalf("generated memory item = %+v, want generated_summary body snapshot", *generated)
 			}
+			if generated.Included != tc.memoryIncluded {
+				t.Fatalf("generated memory Included = %v, want %v for %s", generated.Included, tc.memoryIncluded, tc.name)
+			}
 			if findContextItemByOrigin(tc.packet, "mem_disabled") != nil {
 				t.Fatalf("disabled memory was included: %+v", tc.packet.Items)
+			}
+			if tc.memoryIncluded {
+				policy := findContextItemByOrigin(tc.packet, "chat.project_prompt_context")
+				if policy == nil || !policy.Included {
+					t.Fatalf("chat project prompt policy item = %+v, want included Hecate-owned chat policy", policy)
+				}
+				if !strings.Contains(policy.Body, "bounded accepted project memory bodies") || !strings.Contains(policy.Body, "source file bodies") {
+					t.Fatalf("chat project prompt policy body = %q, want content boundary", policy.Body)
+				}
 			}
 		})
 	}
@@ -271,7 +301,11 @@ func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create completed assignment: %v", err)
 	}
-	handler := &Handler{projectSkills: skillStore, projectWork: workStore}
+	projectStore := projects.NewMemoryStore()
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Hecate"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	handler := &Handler{projects: projectStore, projectSkills: skillStore, projectWork: workStore}
 	session := chat.Session{
 		ID:        "chat_1",
 		ProjectID: "proj_1",
@@ -436,6 +470,16 @@ func TestExternalAgentContextPacketNotesPrivatePromptBoundary(t *testing.T) {
 	}
 	if !strings.Contains(item.Body, "cannot inspect the external agent's private prompt") {
 		t.Fatalf("external agent item body = %q, want private prompt boundary note", item.Body)
+	}
+	policy := findContextItemByOrigin(packet, "external_agent.prompt_context")
+	if policy == nil {
+		t.Fatalf("external-agent prompt policy item not found: %+v", packet.Items)
+	}
+	if policy.Included {
+		t.Fatalf("external-agent prompt policy Included = true, want inspect-only boundary note")
+	}
+	if !strings.Contains(policy.Body, "does not inject project memory bodies") || !strings.Contains(policy.Body, "adapter owns any private prompt packing") {
+		t.Fatalf("external-agent prompt policy body = %q, want project content boundary", policy.Body)
 	}
 }
 
@@ -813,17 +857,17 @@ func TestChatContextPacketSourceOrdering(t *testing.T) {
 		{
 			name: "direct model",
 			got:  sourceKinds(handler.directModelContextPacket(ctx, session, "ollama", "llama3.1:8b", "system")),
-			want: []string{"project", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript"},
+			want: []string{"project", "prompt_context", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript"},
 		},
 		{
 			name: "hecate task",
 			got:  sourceKinds(handler.hecateTaskContextPacket(ctx, session, "ollama", "llama3.1:8b", "system", false)),
-			want: []string{"project", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript", "task_runtime"},
+			want: []string{"project", "prompt_context", "system_prompt", "workspace", "workspace_doc", "project_notes", "transcript", "task_runtime"},
 		},
 		{
 			name: "external agent",
 			got:  sourceKinds(handler.externalAgentContextPacket(ctx, session, "Cursor Agent")),
-			want: []string{"project", "workspace", "workspace_doc", "project_notes", "transcript", "adapter_session"},
+			want: []string{"project", "prompt_context", "workspace", "workspace_doc", "project_notes", "transcript", "adapter_session"},
 		},
 	}
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1599,6 +1599,29 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 		Driver:              projectwork.AssignmentDriverExternalAgent,
 		WithoutRoleDefaults: true,
 	})
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_external",
+		ProjectID:  "proj_start",
+		Title:      "External boundary",
+		Body:       "Do not inject this into external-agent prompts.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create external assignment memory: %v", err)
+	}
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.ContextSources = []projects.ContextSource{{
+			ID:         "ctx_external",
+			Kind:       "workspace_instruction",
+			Title:      "AGENTS.md",
+			Path:       "AGENTS.md",
+			Enabled:    true,
+			TrustLabel: "workspace_guidance",
+		}}
+	}); err != nil {
+		t.Fatalf("Update project context source: %v", err)
+	}
 	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
 		ID:                  "prof_external",
 		Name:                "External implementer",
@@ -1607,8 +1630,8 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 		ExecutionProfile:    "external_implementation",
 		ExternalAgentKind:   "codex",
 		ApprovalPolicy:      agentprofiles.ApprovalRequire,
-		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
-		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
 		SkillIDs:            []string{"project-handoff"},
 	}); err != nil {
 		t.Fatalf("Create external profile: %v", err)
@@ -1670,6 +1693,29 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	profileItem := findRenderedContextItemByOrigin(packetResp.Data, "prof_external")
 	if profileItem == nil || profileItem.Section != contextSectionProfile || !strings.Contains(profileItem.Body, "External agent: codex") {
 		t.Fatalf("profile item = %+v, want external profile metadata", profileItem)
+	}
+	memoryItem := findRenderedContextItemByOrigin(packetResp.Data, "mem_external")
+	if memoryItem == nil || memoryItem.Included {
+		t.Fatalf("external assignment memory item = %+v, want visible-only memory despite include policy", memoryItem)
+	}
+	if !strings.Contains(memoryItem.InclusionReason, "does not inject memory bodies into adapter prompts") {
+		t.Fatalf("external assignment memory reason = %q, want adapter prompt boundary", memoryItem.InclusionReason)
+	}
+	sourceItem := findRenderedContextItemByOrigin(packetResp.Data, "AGENTS.md")
+	if sourceItem == nil || sourceItem.Included {
+		t.Fatalf("external assignment source item = %+v, want visible-only source despite include policy", sourceItem)
+	}
+	if !strings.Contains(sourceItem.InclusionReason, "does not inject source bodies into adapter prompts") {
+		t.Fatalf("external assignment source reason = %q, want adapter prompt boundary", sourceItem.InclusionReason)
+	}
+	policyItem := findRenderedContextItemByOrigin(packetResp.Data, "external_agent_assignment.prompt_context")
+	if policyItem == nil || policyItem.Included {
+		t.Fatalf("external assignment prompt policy item = %+v, want inspect-only policy note", policyItem)
+	}
+	for _, want := range []string{"does not dispatch an adapter prompt", "Profile project_memory_policy: include", "Profile context_source_policy: include_enabled"} {
+		if !strings.Contains(policyItem.Body, want) {
+			t.Fatalf("external assignment prompt policy body = %q, want %q", policyItem.Body, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add explicit prompt-policy rows to project-linked Hecate Chat and External Agent context packets
- mark chat project source records as visible-only unless their bodies are actually loaded into the prompt path
- keep External Agent chat and assignment project memory/source bodies metadata-only, even when profiles request include policies
- update runtime/operator/design/agent docs for the prompt-source boundary

## Why

Operators need context packets to distinguish metadata that Hecate can inspect from content that was actually prepared for a model or adapter prompt. This keeps Hecate-owned chat, native project assignments, and External Agent sessions honest about their different prompt boundaries.

## Validation

- `go build ./...`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`
- `just agent-docs-check`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`