### PR TITLE
Align chat memory inclusion with prompt budget

### DIFF
--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -221,8 +221,12 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 	packet.MessageCount = chatTranscriptMessageCount(session.Messages) + 1
 	populateProjectRefs(&packet, session.ProjectID)
 	project := h.projectSummary(ctx, session.ProjectID)
+	var promptPlan projectChatWorkflowPromptPlan
 	appendProjectSummary(&packet, project, true, "Project linked to this chat session")
 	projectPromptIncluded := project != nil
+	if projectPromptIncluded {
+		promptPlan = h.projectChatWorkflowPromptPlan(ctx, session)
+	}
 	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "direct model turn"))
 	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "direct model turn"))
 	if project != nil {
@@ -245,7 +249,7 @@ func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Ses
 		})
 	}
 	if projectPromptIncluded {
-		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session), promptPlan.IncludedMemoryIDs)
 	} else {
 		appendProjectMemoryWithInclusion(&packet, h.projectMemoryEntries(ctx, session), false, "Project memory is inspectable only; no linked project prompt prelude was assembled")
 	}
@@ -277,8 +281,12 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 	packet.ExecutionProfile = "chat_agent"
 	populateProjectRefs(&packet, session.ProjectID)
 	project := h.projectSummary(ctx, session.ProjectID)
+	var promptPlan projectChatWorkflowPromptPlan
 	appendProjectSummary(&packet, project, true, "Project linked to this chat session")
 	projectPromptIncluded := project != nil
+	if projectPromptIncluded {
+		promptPlan = h.projectChatWorkflowPromptPlan(ctx, session)
+	}
 	appendProjectChatSkills(&packet, h.projectChatEnabledSkills(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "task-backed turn"))
 	appendProjectChatWork(&packet, h.projectChatWorkSnapshot(ctx, session.ProjectID), projectPromptIncluded, hecateChatProjectMetadataReason(projectPromptIncluded, "task-backed turn"))
 	if project != nil {
@@ -301,7 +309,7 @@ func (h *Handler) hecateTaskContextPacket(ctx context.Context, session chat.Sess
 		})
 	}
 	if projectPromptIncluded {
-		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session))
+		appendProjectMemory(&packet, h.projectMemoryEntries(ctx, session), promptPlan.IncludedMemoryIDs)
 	} else {
 		appendProjectMemoryWithInclusion(&packet, h.projectMemoryEntries(ctx, session), false, "Project memory is inspectable only; no linked project prompt prelude was assembled")
 	}
@@ -677,14 +685,13 @@ func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment pro
 	return filtered
 }
 
-func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry) {
+func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry, includedMemoryIDs map[string]bool) {
 	if len(entries) == 0 {
 		return
 	}
-	included := projectChatPromptIncludedMemoryIDs(entries)
 	for _, entry := range entries {
 		reason := "Project memory body is inspectable but omitted from the bounded Hecate-owned chat prompt"
-		isIncluded := included[strings.TrimSpace(entry.ID)]
+		isIncluded := includedMemoryIDs[strings.TrimSpace(entry.ID)]
 		if isIncluded {
 			reason = "Bounded project memory body included in the Hecate-owned project chat system prompt"
 		}
@@ -782,27 +789,6 @@ func appendProjectMemoryEntry(packet *chat.ContextPacket, entry memory.Entry, in
 		Included:        included,
 		InclusionReason: reason,
 	})
-}
-
-func projectChatPromptIncludedMemoryIDs(entries []memory.Entry) map[string]bool {
-	included := make(map[string]bool, min(len(entries), projectChatPromptMemoryMaxItems))
-	remaining := projectChatPromptMaxBytes
-	count := 0
-	for _, entry := range entries {
-		if count >= projectChatPromptMemoryMaxItems {
-			break
-		}
-		id := strings.TrimSpace(entry.ID)
-		if id == "" {
-			continue
-		}
-		if _, ok := projectChatMemorySection(entry, &remaining); !ok {
-			continue
-		}
-		included[id] = true
-		count++
-	}
-	return included
 }
 
 func appendProjectContextSources(packet *chat.ContextPacket, sources []chat.ContextSource) {

--- a/internal/api/handler_chat_context_test.go
+++ b/internal/api/handler_chat_context_test.go
@@ -237,6 +237,58 @@ func TestChatContextPacketsIncludeEnabledProjectMemory(t *testing.T) {
 	}
 }
 
+func TestChatContextPacketsMarkOverflowProjectMemoryVisibleOnly(t *testing.T) {
+	ctx := context.Background()
+	memoryStore := memory.NewMemoryStore()
+	base := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	for idx := 0; idx < projectChatPromptMemoryMaxItems+1; idx++ {
+		id := fmt.Sprintf("mem_%02d", idx)
+		if _, err := memoryStore.Create(ctx, memory.Entry{
+			ID:         id,
+			ProjectID:  "proj_1",
+			Title:      fmt.Sprintf("Memory %02d", idx),
+			Body:       fmt.Sprintf("Memory body %02d.", idx),
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+			Enabled:    true,
+			CreatedAt:  base.Add(-time.Duration(idx) * time.Minute),
+			UpdatedAt:  base.Add(-time.Duration(idx) * time.Minute),
+		}); err != nil {
+			t.Fatalf("Create memory %s: %v", id, err)
+		}
+	}
+	projectStore := projects.NewMemoryStore()
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_1", Name: "Hecate"}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	handler := &Handler{memory: memoryStore, projects: projectStore}
+	packet := handler.directModelContextPacket(ctx, chat.Session{
+		ID:        "chat_1",
+		ProjectID: "proj_1",
+		Messages:  []chat.Message{{ID: "u1", Role: "user", Content: "first"}},
+	}, "ollama", "llama3.1:8b", "")
+
+	included := 0
+	for _, item := range packet.Items {
+		if item.Kind == "memory" && item.Included {
+			included++
+		}
+	}
+	if included != projectChatPromptMemoryMaxItems {
+		t.Fatalf("included memory count = %d, want %d", included, projectChatPromptMemoryMaxItems)
+	}
+	overflow := findContextItemByOrigin(packet, "mem_04")
+	if overflow == nil {
+		t.Fatalf("overflow memory item not found: %+v", packet.Items)
+	}
+	if overflow.Included {
+		t.Fatalf("overflow memory Included = true, want visible-only")
+	}
+	if !strings.Contains(overflow.InclusionReason, "omitted from the bounded Hecate-owned chat prompt") {
+		t.Fatalf("overflow memory reason = %q, want bounded prompt omission", overflow.InclusionReason)
+	}
+}
+
 func TestChatContextPacketsIncludeProjectSkillAndWorkMetadata(t *testing.T) {
 	ctx := context.Background()
 	skillStore := projectskills.NewMemoryStore()

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -41,6 +41,16 @@ var (
 	}
 )
 
+type projectChatWorkflowPromptPlan struct {
+	Text              string
+	IncludedMemoryIDs map[string]bool
+}
+
+type projectChatPromptBuilder struct {
+	sections  []string
+	remaining int
+}
+
 func (h *Handler) hecateChatEffectiveSystemPrompt(ctx context.Context, session chat.Session, operatorPrompt string) string {
 	operatorPrompt = strings.TrimSpace(operatorPrompt)
 	projectPrompt := h.projectChatWorkflowSystemPrompt(ctx, session)
@@ -67,33 +77,120 @@ func (h *Handler) hecateChatTaskSystemPrompt(ctx context.Context, session chat.S
 }
 
 func (h *Handler) projectChatWorkflowSystemPrompt(ctx context.Context, session chat.Session) string {
+	return h.projectChatWorkflowPromptPlan(ctx, session).Text
+}
+
+func (h *Handler) projectChatWorkflowPromptPlan(ctx context.Context, session chat.Session) projectChatWorkflowPromptPlan {
+	plan := projectChatWorkflowPromptPlan{IncludedMemoryIDs: make(map[string]bool)}
 	if !isHecateChatSession(session) {
-		return ""
+		return plan
 	}
 	project := h.projectSummary(ctx, session.ProjectID)
 	if project == nil {
-		return ""
+		return plan
 	}
 
-	sections := []string{projectChatWorkflowBoundary(*project)}
+	builder := projectChatPromptBuilder{remaining: projectChatPromptMaxBytes}
+	builder.append(projectChatWorkflowBoundary(*project))
 	if roots := projectChatRootHints(*project); roots != "" {
-		sections = append(sections, roots)
+		builder.append(roots)
 	}
 	if roles := h.projectChatRoleHints(ctx, project.ID); roles != "" {
-		sections = append(sections, roles)
+		builder.append(roles)
 	}
 	if skills := h.projectChatSkillHints(ctx, project.ID); skills != "" {
-		sections = append(sections, skills)
+		builder.append(skills)
 	}
 	if work := h.projectChatWorkHints(ctx, project.ID); work != "" {
-		sections = append(sections, work)
+		builder.append(work)
 	}
-	if memoryText := h.projectChatMemoryPrompt(ctx, project.ID); memoryText != "" {
-		sections = append(sections, memoryText)
+	builder.appendMemory(h.enabledProjectMemoryEntries(ctx, project.ID), plan.IncludedMemoryIDs)
+	plan.Text = builder.text()
+	return plan
+}
+
+func (b *projectChatPromptBuilder) append(section string) bool {
+	section = strings.TrimSpace(section)
+	if b == nil || section == "" {
+		return false
 	}
-	text := strings.Join(sections, "\n\n")
-	text, _ = truncatePromptContextText(text, projectChatPromptMaxBytes)
-	return text
+	separatorBytes := 0
+	if len(b.sections) > 0 {
+		separatorBytes = len("\n\n")
+	}
+	if b.remaining <= separatorBytes {
+		return false
+	}
+	text, _ := truncatePromptContextText(section, b.remaining-separatorBytes)
+	if text == "" {
+		return false
+	}
+	b.sections = append(b.sections, text)
+	b.remaining -= separatorBytes + len(text)
+	return true
+}
+
+func (b *projectChatPromptBuilder) appendMemory(entries []memory.Entry, includedIDs map[string]bool) {
+	if b == nil || len(entries) == 0 {
+		return
+	}
+	separatorBytes := 0
+	if len(b.sections) > 0 {
+		separatorBytes = len("\n\n")
+	}
+	if b.remaining <= separatorBytes {
+		return
+	}
+	remaining := b.remaining - separatorBytes
+	header := "Accepted project memory:"
+	if remaining <= len(header) {
+		return
+	}
+	parts := []string{header}
+	remaining -= len(header)
+	included := 0
+	for _, entry := range entries {
+		if included >= projectChatPromptMemoryMaxItems {
+			appendProjectChatMemoryLine(&parts, &remaining, fmt.Sprintf("- %d additional memory entries omitted.", len(entries)-included))
+			break
+		}
+		if remaining <= len("\n") {
+			break
+		}
+		entryRemaining := remaining - len("\n")
+		section, ok := projectChatMemorySection(entry, &entryRemaining)
+		if !ok {
+			continue
+		}
+		parts = append(parts, section)
+		remaining = entryRemaining
+		if id := strings.TrimSpace(entry.ID); id != "" && includedIDs != nil {
+			includedIDs[id] = true
+		}
+		included++
+	}
+	if included == 0 {
+		return
+	}
+	text := strings.Join(parts, "\n")
+	b.sections = append(b.sections, text)
+	b.remaining -= separatorBytes + len(text)
+}
+
+func appendProjectChatMemoryLine(parts *[]string, remaining *int, line string) {
+	if parts == nil || remaining == nil || *remaining <= len("\n") {
+		return
+	}
+	text, _ := truncatePromptContextText(line, *remaining-len("\n"))
+	if text == "" {
+		return
+	}
+	*parts = append(*parts, text)
+	*remaining -= len("\n") + len(text)
+}
+
+func (b projectChatPromptBuilder) text() string {
+	return strings.Join(b.sections, "\n\n")
 }
 
 func projectChatWorkflowBoundary(project projects.Project) string {
@@ -205,25 +302,9 @@ func (h *Handler) projectChatMemoryPrompt(ctx context.Context, projectID string)
 	if len(entries) == 0 {
 		return ""
 	}
-	remaining := projectChatPromptMaxBytes
-	sections := []string{"Accepted project memory:"}
-	included := 0
-	for _, entry := range entries {
-		if included >= projectChatPromptMemoryMaxItems {
-			sections = append(sections, fmt.Sprintf("- %d additional memory entries omitted.", len(entries)-included))
-			break
-		}
-		section, ok := projectChatMemorySection(entry, &remaining)
-		if !ok {
-			continue
-		}
-		sections = append(sections, section)
-		included++
-	}
-	if included == 0 {
-		return ""
-	}
-	return strings.Join(sections, "\n")
+	builder := projectChatPromptBuilder{remaining: projectChatPromptMaxBytes}
+	builder.appendMemory(entries, nil)
+	return builder.text()
 }
 
 func projectChatMemorySection(entry memory.Entry, remaining *int) (string, bool) {


### PR DESCRIPTION
## Summary
- build the Hecate-owned project chat prompt with one shared byte budget across prelude sections
- use that assembled prompt plan to mark project memory as included vs visible-only in context packets
- add overflow coverage so memory beyond the prompt cap is reported as visible-only

## Validation
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestChatContextPackets|TestExternalAgentContextPacket|TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession|TestProjectChatWorkflowSystemPrompt'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- just agent-docs-check\n- go vet ./...\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n- go build ./...\n\nFollow-up to the prompt source-policy review note: memory inclusion is now derived from the same bounded prompt assembly used for the Hecate-owned chat prompt.