### PR TITLE
Avoid local workspace controls in remote runtime

### DIFF
--- a/ui/src/features/chats/ChatHeader.test.tsx
+++ b/ui/src/features/chats/ChatHeader.test.tsx
@@ -14,6 +14,7 @@ function renderChatHeader(overrides: Partial<Parameters<typeof ChatHeader>[0]> =
     sublineHoverTitle: "Tools on",
     isAgentChat: true,
     isExternalAgentChat: false,
+    isRemoteRuntime: false,
     showWorkspaceButton: true,
     workspacePath: "/Users/alice/dev/hecate",
     workspaceDialogOpen: false,
@@ -42,5 +43,13 @@ describe("ChatHeader", () => {
 
     expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Workspace changes" })).toBeNull();
+  });
+
+  it("hides local workspace opener controls in remote runtime", () => {
+    renderChatHeader({ isRemoteRuntime: true });
+
+    expect(screen.getByRole("button", { name: "Workspace changes" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Open workspace in/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Choose workspace opener" })).toBeNull();
   });
 });

--- a/ui/src/features/chats/ChatHeader.tsx
+++ b/ui/src/features/chats/ChatHeader.tsx
@@ -18,6 +18,7 @@ type Props = {
   // Right-side actions.
   isAgentChat: boolean;
   isExternalAgentChat: boolean;
+  isRemoteRuntime: boolean;
   linkedProjectName?: string;
   onOpenProject?: () => void;
   showWorkspaceButton: boolean;
@@ -45,6 +46,7 @@ export function ChatHeader(props: Props) {
     sublineHoverTitle,
     isAgentChat,
     isExternalAgentChat,
+    isRemoteRuntime,
     linkedProjectName,
     onOpenProject,
     showWorkspaceButton,
@@ -189,9 +191,17 @@ export function ChatHeader(props: Props) {
                   ? "Workspace folder dialog is already open"
                   : workspacePath
                     ? `Workspace: ${workspacePath}`
+                    : isRemoteRuntime
+                      ? "Set workspace path"
+                      : "Choose workspace folder"
+              }
+              aria-label={
+                workspacePath
+                  ? `Workspace: ${workspacePath}`
+                  : isRemoteRuntime
+                    ? "Set workspace path"
                     : "Choose workspace folder"
               }
-              aria-label={workspacePath ? `Workspace: ${workspacePath}` : "Choose workspace folder"}
               type="button"
               style={{
                 width: 30,
@@ -205,7 +215,7 @@ export function ChatHeader(props: Props) {
               <Icon d={Icons.folder} size={13} />
             </button>
           )}
-          <WorkspaceOpenMenu workspacePath={workspacePath} />
+          {!isRemoteRuntime && <WorkspaceOpenMenu workspacePath={workspacePath} />}
           {workspacePath.trim() && (
             <button
               className="btn btn-ghost btn-sm chat-header-action"

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -5828,6 +5828,51 @@ describe("ChatView external-agent target", () => {
     expect(setAgentWorkspace).toHaveBeenCalledWith("/workspaces/hecate");
   });
 
+  it("uses typed workspace entry instead of the local picker in remote runtime", async () => {
+    const chooseAgentWorkspace = vi.fn(async () => true);
+    const setAgentWorkspace = vi.fn();
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        agentWorkspace: "",
+        sessionInfo: {
+          role: "operator",
+          remote_identity: {
+            actor_id: "actor_1",
+            org_id: "org_1",
+            project_id: "proj_1",
+            runtime_id: "rt_1",
+          },
+        },
+        agentAdapters: [
+          {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+          },
+        ],
+      },
+      { chooseAgentWorkspace, setAgentWorkspace },
+    );
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle("Set workspace path"));
+    expect(chooseAgentWorkspace).not.toHaveBeenCalled();
+
+    const input = screen.getByPlaceholderText("/workspace") as HTMLInputElement;
+    expect(input.value).toBe("/workspace");
+    await user.clear(input);
+    await user.type(input, "/workspace/project");
+    await user.click(screen.getByRole("button", { name: "Use" }));
+
+    expect(setAgentWorkspace).toHaveBeenCalledWith("/workspace/project");
+  });
+
   it("keeps the workspace changes button enabled for current git diff checks", () => {
     const { state, actions } = setup({
       chatTarget: "external_agent",

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -662,6 +662,11 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
 
   async function chooseWorkspace() {
     if (workspaceDialogOpenRef.current) return;
+    if (isRemoteRuntime) {
+      setWorkspacePathValue(state.agentWorkspace || "/workspace");
+      setWorkspaceEntryOpen(true);
+      return;
+    }
     workspaceDialogOpenRef.current = true;
     setWorkspaceDialogOpen(true);
     setWorkspacePathValue(state.agentWorkspace);
@@ -853,6 +858,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
             }
             isAgentChat={isAgentChat}
             isExternalAgentChat={isExternalAgentChat}
+            isRemoteRuntime={isRemoteRuntime}
             linkedProjectName={linkedProjectName}
             onOpenProject={
               activeSessionProjectID && onNavigate ? () => openLinkedProject() : undefined
@@ -916,7 +922,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
                       useTypedWorkspace();
                     }
                   }}
-                  placeholder="/Users/alice/dev/project"
+                  placeholder={isRemoteRuntime ? "/workspace" : "/Users/alice/dev/project"}
                   style={{ height: 30, minWidth: 0 }}
                   value={workspacePathValue}
                 />


### PR DESCRIPTION
## Summary
- make remote runtime workspace selection use typed path entry instead of the local folder picker
- default remote workspace entry to /workspace
- hide local editor/opener controls while keeping workspace changes available

## Tests
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx src/features/chats/ChatHeader.test.tsx src/features/chats/WorkspaceOpenMenu.test.tsx
- cd ui && bun run test