### PR TITLE
Add registry-only plugin records

### DIFF
--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hecatehq/hecate/internal/governor"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
@@ -212,6 +213,7 @@ func runServe() {
 	memoryStore := buildMemoryStore(cfg, logger, sqliteClient, postgresClient)
 	projectWorkStore := buildProjectWorkStore(cfg, logger, sqliteClient, postgresClient)
 	projectSkillStore := buildProjectSkillStore(cfg, logger, sqliteClient, postgresClient)
+	pluginRegistryStore := buildPluginRegistryStore(cfg, logger, sqliteClient, postgresClient)
 	agentProfileStore := buildAgentProfileStore(cfg, logger, sqliteClient, postgresClient)
 	// Approval state follows HECATE_BACKEND so chat transcripts, grants,
 	// and pending approval rows move together across memory/sqlite/postgres modes.
@@ -284,6 +286,7 @@ func runServe() {
 	handler.SetMemoryStore(memoryStore)
 	handler.SetProjectWorkStore(projectWorkStore)
 	handler.SetProjectSkillStore(projectSkillStore)
+	handler.SetPluginRegistryStore(pluginRegistryStore)
 	handler.SetAgentProfileStore(agentProfileStore)
 	handler.SetAgentApprovalStore(approvalStore)
 	if postgresClient != nil {
@@ -890,6 +893,27 @@ func buildProjectSkillStore(cfg config.Config, logger *slog.Logger, sqliteClient
 		return store
 	default:
 		return projectskills.NewMemoryStore()
+	}
+}
+
+func buildPluginRegistryStore(cfg config.Config, logger *slog.Logger, sqliteClient *storage.SQLiteClient, postgresClient *storage.PostgresClient) pluginregistry.Store {
+	switch cfg.Projects.Backend {
+	case "sqlite":
+		store, err := pluginregistry.NewSQLiteStore(context.Background(), sqliteClient)
+		if err != nil {
+			logger.Error("plugin registry store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	case "postgres":
+		store, err := pluginregistry.NewPostgresStore(context.Background(), postgresClient)
+		if err != nil {
+			logger.Error("plugin registry store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	default:
+		return pluginregistry.NewMemoryStore()
 	}
 }
 

--- a/docs/design/proposals/plugin-architecture.md
+++ b/docs/design/proposals/plugin-architecture.md
@@ -462,14 +462,25 @@ GET  /hecate/v1/plugins/{id}/health
 
 API behavior for the registry slice:
 
-- `POST /install-local` validates and stores a manifest projection. It does not
-  execute package code or fetch provider state.
+- `POST /install-local` validates and stores a manifest projection. In the
+  first implementation it records manifest JSON supplied by the operator/client
+  plus an optional `source_ref`; it does not read arbitrary paths, execute
+  package code, or fetch provider state.
 - `PATCH /{id}` can enable/disable the plugin or individual capabilities as
   metadata. It does not grant secrets, network, tools, or UI execution by
   itself.
 - `GET /{id}/health` reports registry health: manifest validity, unsupported
   permissions, unresolved secret bindings, disabled capabilities, and command
   collisions. It does not call external providers.
+
+The first shipped registry slice uses `schema_version: "hecate.plugin.v0"`,
+stores the raw manifest, projects capabilities from either a capability array
+or grouped `connectors`, `mcp_servers`, `skills`, `slash_commands`,
+`project_mappers`, `evidence_providers`, and `ui_surfaces`, and classifies
+permission strings as review metadata (`advisory` or `unsupported`). No
+permission string is treated as an executable grant in this slice.
+`manifest_digest` is computed from Hecate's canonicalized manifest JSON rather
+than caller/file bytes, so formatting-only differences produce the same digest.
 
 The first UI can be a read-only/plugin-settings list: plugin name, version,
 source, enabled state, capabilities, requested permissions, auth-binding status,

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -82,10 +82,12 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   per-tool `agent_loop` gating (`read_file`, `all_tools`). Unknown policy names
   are rejected at startup. The per-MCP-server `approval_policy` axis
   (`auto` / `require_approval` / `block`) is separate.
-- A Hecate plugin architecture is proposed in
-  `docs/design/proposals/plugin-architecture.md`, but browser automation, WASM
-  plugins, arbitrary plugin hooks, and broad tool marketplaces remain out of
-  scope for the current alpha.
+- Hecate has a registry-only plugin metadata slice for native manifests, but it
+  does not execute plugin code, start plugin-declared MCP servers, mount plugin
+  tools, grant plugin secrets, or call connector APIs yet. Browser automation,
+  WASM plugins, arbitrary plugin hooks, and broad tool marketplaces remain out
+  of scope for the current alpha. Design notes live in
+  `docs/design/proposals/plugin-architecture.md`.
 
 ## Hecate Chat
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -23,6 +23,7 @@ Hecate assumes the operator trusts their own machine, local user account, and se
   and keeps the runtime home/XDG directories on its persistent volume.
   The runtime secret is not public auth; keep the runtime network-private.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", local provider discovery, MCP registry discovery, MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can inspect host-local state, open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.
+- Plugin registry APIs are also blocked in remote-runtime mode. In the first registry-only slice, plugin rows are metadata for operator review: installing a manifest records requested capabilities, permissions, and auth bindings, but does not execute plugin code, start plugin-declared MCP servers, mount tools, grant secrets, or make connector network calls.
 - Do not run Hecate on a shared host where untrusted local users can access the gateway port or data directory.
 
 ## Runtime boundaries

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,8 +47,8 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, and local provider
-and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
+workspace picker/open, reset-data, shutdown, MCP probe, plugin-registry
+management, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
 
@@ -139,6 +139,7 @@ object when available.
 - [Runtime backend and queue configuration](#runtime-backend-and-queue-configuration)
 - [Usage endpoints](#usage-endpoints)
 - [Health and discovery endpoints](#health-and-discovery-endpoints)
+- [Plugin registry endpoints](#plugin-registry-endpoints)
 - [Agent profile endpoints](#agent-profile-endpoints)
 - [Project endpoints](#project-endpoints)
 - [Project Assistant endpoints](#project-assistant-endpoints)
@@ -618,7 +619,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. MCP Apps metadata is preserved when present: `_meta` is the raw upstream object, `ui_resource_uri` and `ui_visibility` are derived convenience fields, and `model_visible: false` means the tool is app-only and will not be shown to the agent-loop model. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, plugin registry records, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -627,6 +628,7 @@ Tool names come back un-namespaced — the operator wants to see what the upstre
   "data": {
     "projects_deleted": 1,
     "project_work_rows_deleted": 3,
+    "plugins_deleted": 1,
     "agent_profiles_deleted": 1,
     "chat_sessions_deleted": 2,
     "tasks_deleted": 1,
@@ -1237,6 +1239,114 @@ Status codes:
 - `404 not_found` when the adapter id is not registered.
 - `409 conflict` when the adapter is not managed or the launcher cannot be
   recreated.
+
+## Plugin registry endpoints
+
+The plugin registry is a local catalog and policy-review surface. Registry rows
+store a raw Hecate-native manifest plus normalized capabilities, requested
+permissions, and auth-binding requests. They do not run plugin code, start MCP
+servers, mount tools, call external providers, or grant secrets.
+`manifest_digest` is a SHA-256 digest of Hecate's canonicalized manifest JSON,
+so semantically equivalent manifests share the same digest even when caller
+formatting differs.
+
+The initial routes are local-only in remote-runtime mode:
+
+- `GET /hecate/v1/plugins`
+- `GET /hecate/v1/plugins/{id}`
+- `POST /hecate/v1/plugins/install-local`
+- `PATCH /hecate/v1/plugins/{id}`
+- `GET /hecate/v1/plugins/{id}/health`
+
+`POST /hecate/v1/plugins/install-local` accepts either a manifest directly or
+an object with `manifest` and optional `source_ref`. The current slice records
+the manifest JSON sent by the operator/client; it does not read arbitrary local
+paths or execute package lifecycle hooks.
+
+```json
+POST /hecate/v1/plugins/install-local
+{
+  "source_ref": "/plugins/github/plugin.json",
+  "manifest": {
+    "schema_version": "hecate.plugin.v0",
+    "id": "github",
+    "name": "GitHub",
+    "version": "0.1.0",
+    "permissions": ["network:github.com", "secret:github_token"],
+    "capabilities": {
+      "connectors": [
+        {
+          "id": "issues",
+          "display_name": "Issues",
+          "auth": [{ "name": "github_token", "kind": "token" }]
+        }
+      ],
+      "slash_commands": [{ "name": "github" }]
+    }
+  }
+}
+```
+
+```json
+→ 200
+{
+  "object": "plugin",
+  "data": {
+    "id": "github",
+    "name": "GitHub",
+    "version": "0.1.0",
+    "source_kind": "local_path",
+    "source_ref": "/plugins/github/plugin.json",
+    "manifest_schema_version": "hecate.plugin.v0",
+    "manifest_digest": "sha256:...",
+    "requested_permissions": [
+      { "value": "network:github.com", "classification": "advisory" },
+      { "value": "secret:github_token", "classification": "advisory" }
+    ],
+    "registry_state": "valid",
+    "enabled": false,
+    "capabilities": [
+      {
+        "id": "issues",
+        "kind": "connector",
+        "display_name": "Issues",
+        "enabled": true
+      },
+      {
+        "id": "github",
+        "kind": "slash_command",
+        "display_name": "/github",
+        "enabled": true
+      }
+    ],
+    "auth": [
+      {
+        "capability_id": "issues",
+        "requested_name": "github_token",
+        "kind": "token",
+        "status": "unknown"
+      }
+    ],
+    "installed_at": "2026-06-18T10:00:00Z",
+    "updated_at": "2026-06-18T10:00:00Z"
+  }
+}
+```
+
+`PATCH /hecate/v1/plugins/{id}` currently toggles only registry metadata:
+
+```json
+{
+  "enabled": true,
+  "capabilities": {
+    "issues": { "enabled": false }
+  }
+}
+```
+
+`GET /hecate/v1/plugins/{id}/health` reports manifest review status:
+unsupported permissions, unresolved secret-binding requests, disabled
+capabilities, and slash-command collisions. It does not call external services.
 
 ## Agent profile endpoints
 

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/hecatehq/hecate/internal/chatapp"
 	"github.com/hecatehq/hecate/internal/modelapp"
+	"github.com/hecatehq/hecate/internal/pluginregistryapp"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/internal/providerapp"
@@ -89,6 +90,13 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 		})
 	}
 	return h.projectAssistant
+}
+
+func (h *Handler) pluginRegistryApplication() *pluginregistryapp.Application {
+	if h == nil {
+		return pluginregistryapp.New(pluginregistryapp.Options{})
+	}
+	return pluginregistryapp.New(pluginregistryapp.Options{Store: h.pluginRegistry})
 }
 
 func (h *Handler) modelApplication() *modelapp.Application {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -53,6 +54,7 @@ type Handler struct {
 	memoryCandidates         memory.CandidateStore
 	projectWork              projectwork.Store
 	projectSkills            projectskills.Store
+	pluginRegistry           pluginregistry.Store
 	projectAssistantMu       sync.Mutex
 	projectAssistant         *projectassistantapp.Application
 	agentProfiles            agentprofiles.Store
@@ -330,6 +332,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		memoryCandidates:    memoryStore,
 		projectWork:         projectwork.NewMemoryStore(),
 		projectSkills:       projectskills.NewMemoryStore(),
+		pluginRegistry:      pluginregistry.NewMemoryStore(),
 		agentProfiles:       agentprofiles.NewMemoryStore(),
 		agentChatRunner:     agentChatRunner,
 		agentChatLive:       agentChatLive,
@@ -460,6 +463,13 @@ func (h *Handler) SetProjectSkillStore(store projectskills.Store) {
 	h.projectAssistantMu.Lock()
 	h.projectAssistant = nil
 	h.projectAssistantMu.Unlock()
+}
+
+func (h *Handler) SetPluginRegistryStore(store pluginregistry.Store) {
+	if store == nil {
+		return
+	}
+	h.pluginRegistry = store
 }
 
 func (h *Handler) SetAgentProfileStore(store agentprofiles.Store) {

--- a/internal/api/handler_plugins.go
+++ b/internal/api/handler_plugins.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/pluginregistry"
+	"github.com/hecatehq/hecate/internal/pluginregistryapp"
+)
+
+type installLocalPluginRequest struct {
+	Manifest  json.RawMessage `json:"manifest"`
+	SourceRef string          `json:"source_ref"`
+}
+
+type updatePluginRequest struct {
+	Enabled      *bool                                    `json:"enabled"`
+	Capabilities map[string]updatePluginCapabilityRequest `json:"capabilities"`
+}
+
+type updatePluginCapabilityRequest struct {
+	Enabled *bool `json:"enabled"`
+}
+
+func (h *Handler) HandlePlugins(w http.ResponseWriter, r *http.Request) {
+	app := h.pluginRegistryApplication()
+	items, err := app.List(r.Context())
+	if err != nil {
+		writePluginRegistryError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, PluginsResponse{Object: "plugins", Data: renderPlugins(items)})
+}
+
+func (h *Handler) HandlePlugin(w http.ResponseWriter, r *http.Request) {
+	app := h.pluginRegistryApplication()
+	plugin, ok, err := app.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writePluginRegistryError(w, err)
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "plugin not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, PluginResponse{Object: "plugin", Data: renderPlugin(plugin)})
+}
+
+func (h *Handler) HandleInstallLocalPlugin(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be valid JSON")
+		return
+	}
+	cmd, ok := parseInstallLocalPluginRequest(w, body)
+	if !ok {
+		return
+	}
+	plugin, err := h.pluginRegistryApplication().InstallLocal(r.Context(), cmd)
+	if err != nil {
+		writePluginRegistryError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, PluginResponse{Object: "plugin", Data: renderPlugin(plugin)})
+}
+
+func (h *Handler) HandleUpdatePlugin(w http.ResponseWriter, r *http.Request) {
+	var req updatePluginRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	plugin, err := h.pluginRegistryApplication().Update(r.Context(), r.PathValue("id"), pluginRegistryUpdateCommand(req))
+	if err != nil {
+		writePluginRegistryError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, PluginResponse{Object: "plugin", Data: renderPlugin(plugin)})
+}
+
+func (h *Handler) HandlePluginHealth(w http.ResponseWriter, r *http.Request) {
+	health, ok, err := h.pluginRegistryApplication().Health(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writePluginRegistryError(w, err)
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "plugin not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, PluginHealthResponse{Object: "plugin_health", Data: renderPluginHealth(health)})
+}
+
+func parseInstallLocalPluginRequest(w http.ResponseWriter, body []byte) (pluginregistryapp.InstallLocalCommand, bool) {
+	var req installLocalPluginRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be valid JSON")
+		return pluginregistryapp.InstallLocalCommand{}, false
+	}
+	if len(req.Manifest) == 0 {
+		var manifest pluginregistry.Manifest
+		if err := json.Unmarshal(body, &manifest); err != nil || strings.TrimSpace(manifest.SchemaVersion) == "" {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "manifest is required")
+			return pluginregistryapp.InstallLocalCommand{}, false
+		}
+		req.Manifest = append(json.RawMessage(nil), body...)
+	}
+	return pluginregistryapp.InstallLocalCommand{
+		Manifest:  req.Manifest,
+		SourceRef: req.SourceRef,
+	}, true
+}
+
+func pluginRegistryUpdateCommand(req updatePluginRequest) pluginregistryapp.UpdateCommand {
+	cmd := pluginregistryapp.UpdateCommand{Enabled: req.Enabled}
+	if len(req.Capabilities) > 0 {
+		cmd.Capabilities = make(map[string]pluginregistryapp.CapabilityUpdate, len(req.Capabilities))
+		for id, patch := range req.Capabilities {
+			cmd.Capabilities[id] = pluginregistryapp.CapabilityUpdate{Enabled: patch.Enabled}
+		}
+	}
+	return cmd
+}
+
+func writePluginRegistryError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, pluginregistry.ErrNotFound):
+		WriteError(w, http.StatusNotFound, errCodeNotFound, err.Error())
+	case errors.Is(err, pluginregistry.ErrInvalid):
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+	case errors.Is(err, pluginregistry.ErrConflict):
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+	default:
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	}
+}
+
+func renderPlugins(items []pluginregistry.Plugin) []PluginResponseItem {
+	out := make([]PluginResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderPlugin(item))
+	}
+	return out
+}
+
+func renderPlugin(item pluginregistry.Plugin) PluginResponseItem {
+	return PluginResponseItem{
+		ID:                    item.ID,
+		Name:                  item.Name,
+		Description:           item.Description,
+		Version:               item.Version,
+		SourceKind:            item.SourceKind,
+		SourceRef:             item.SourceRef,
+		ManifestSchemaVersion: item.ManifestSchemaVersion,
+		ManifestDigest:        item.ManifestDigest,
+		RequestedPermissions:  renderPluginPermissions(item.RequestedPermissions),
+		RegistryState:         item.RegistryState,
+		Enabled:               item.Enabled,
+		Warnings:              item.Warnings,
+		Capabilities:          renderPluginCapabilities(item.Capabilities),
+		Auth:                  renderPluginAuth(item.Auth),
+		InstalledAt:           formatPluginTime(item.InstalledAt),
+		UpdatedAt:             formatPluginTime(item.UpdatedAt),
+	}
+}
+
+func renderPluginCapabilities(items []pluginregistry.Capability) []PluginCapabilityRecord {
+	out := make([]PluginCapabilityRecord, 0, len(items))
+	for _, item := range items {
+		out = append(out, PluginCapabilityRecord{
+			ID:                   item.ID,
+			Kind:                 item.Kind,
+			DisplayName:          item.DisplayName,
+			RequestedPermissions: renderPluginPermissions(item.RequestedPermissions),
+			Enabled:              item.Enabled,
+			Warnings:             item.Warnings,
+		})
+	}
+	return out
+}
+
+func renderPluginPermissions(items []pluginregistry.Permission) []PluginPermissionRecord {
+	out := make([]PluginPermissionRecord, 0, len(items))
+	for _, item := range items {
+		out = append(out, PluginPermissionRecord{Value: item.Value, Classification: item.Classification})
+	}
+	return out
+}
+
+func renderPluginAuth(items []pluginregistry.AuthBinding) []PluginAuthBindingRecord {
+	out := make([]PluginAuthBindingRecord, 0, len(items))
+	for _, item := range items {
+		out = append(out, PluginAuthBindingRecord{
+			CapabilityID:  item.CapabilityID,
+			RequestedName: item.RequestedName,
+			Kind:          item.Kind,
+			Status:        item.Status,
+			SecretRef:     item.SecretRef,
+			Warnings:      item.Warnings,
+		})
+	}
+	return out
+}
+
+func renderPluginHealth(item pluginregistry.Health) PluginHealthRecord {
+	return PluginHealthRecord{
+		PluginID:                 item.PluginID,
+		RegistryState:            item.RegistryState,
+		Warnings:                 item.Warnings,
+		UnsupportedPermissions:   item.UnsupportedPermissions,
+		UnresolvedSecretBindings: item.UnresolvedSecretBindings,
+		DisabledCapabilities:     item.DisabledCapabilities,
+		CommandCollisions:        renderPluginCommandCollisions(item.CommandCollisions),
+	}
+}
+
+func renderPluginCommandCollisions(items []pluginregistry.CommandCollision) []PluginCommandCollisionRecord {
+	out := make([]PluginCommandCollisionRecord, 0, len(items))
+	for _, item := range items {
+		out = append(out, PluginCommandCollisionRecord{Command: item.Command, PluginIDs: item.PluginIDs})
+	}
+	return out
+}
+
+func formatPluginTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/api/handler_plugins_test.go
+++ b/internal/api/handler_plugins_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+)
+
+func TestPluginRegistryAPI_InstallListPatchAndHealth(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+
+	installRec := httptest.NewRecorder()
+	server.ServeHTTP(installRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/plugins/install-local", pluginAPITestJSONBody(t, map[string]any{
+		"source_ref": "/plugins/github/plugin.json",
+		"manifest": map[string]any{
+			"schema_version": "hecate.plugin.v0",
+			"id":             "github",
+			"name":           "GitHub",
+			"description":    "Read and link GitHub work.",
+			"version":        "0.1.0",
+			"permissions":    []string{"network:github.com", "unsupported:host-hook"},
+			"capabilities": map[string]any{
+				"connectors": []map[string]any{{
+					"id":           "issues",
+					"display_name": "Issues",
+					"permissions":  []string{"secret:github_token"},
+					"auth":         []map[string]any{{"name": "github_token", "kind": "token"}},
+				}},
+			},
+		},
+	})))
+	if installRec.Code != http.StatusOK {
+		t.Fatalf("install status = %d body=%s, want 200", installRec.Code, installRec.Body.String())
+	}
+	var installed PluginResponse
+	if err := json.Unmarshal(installRec.Body.Bytes(), &installed); err != nil {
+		t.Fatalf("decode install response: %v", err)
+	}
+	if installed.Object != "plugin" || installed.Data.ID != "github" || installed.Data.Enabled {
+		t.Fatalf("installed = %+v, want disabled github plugin", installed)
+	}
+	if len(installed.Data.Capabilities) != 1 || len(installed.Data.Auth) != 1 {
+		t.Fatalf("installed data = %+v, want projected capabilities and auth", installed.Data)
+	}
+
+	patchRec := httptest.NewRecorder()
+	server.ServeHTTP(patchRec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/plugins/github", pluginAPITestJSONBody(t, map[string]any{
+		"enabled":      true,
+		"capabilities": map[string]any{"issues": map[string]any{"enabled": false}},
+	})))
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", patchRec.Code, patchRec.Body.String())
+	}
+	var patched PluginResponse
+	if err := json.Unmarshal(patchRec.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if !patched.Data.Enabled || patched.Data.Capabilities[0].Enabled {
+		t.Fatalf("patched = %+v, want plugin enabled and capability disabled", patched.Data)
+	}
+
+	badPatchRec := httptest.NewRecorder()
+	server.ServeHTTP(badPatchRec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/plugins/github", pluginAPITestJSONBody(t, map[string]any{
+		"capabilities": map[string]any{"missing": map[string]any{"enabled": false}},
+	})))
+	if badPatchRec.Code != http.StatusBadRequest {
+		t.Fatalf("bad patch status = %d body=%s, want 400", badPatchRec.Code, badPatchRec.Body.String())
+	}
+
+	listRec := httptest.NewRecorder()
+	server.ServeHTTP(listRec, httptest.NewRequest(http.MethodGet, "/hecate/v1/plugins", nil))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", listRec.Code, listRec.Body.String())
+	}
+	var listed PluginsResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Data) != 1 || listed.Data[0].ID != "github" {
+		t.Fatalf("listed = %+v, want github plugin", listed)
+	}
+
+	healthRec := httptest.NewRecorder()
+	server.ServeHTTP(healthRec, httptest.NewRequest(http.MethodGet, "/hecate/v1/plugins/github/health", nil))
+	if healthRec.Code != http.StatusOK {
+		t.Fatalf("health status = %d body=%s, want 200", healthRec.Code, healthRec.Body.String())
+	}
+	var health PluginHealthResponse
+	if err := json.Unmarshal(healthRec.Body.Bytes(), &health); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if len(health.Data.UnsupportedPermissions) != 1 || health.Data.UnsupportedPermissions[0] != "unsupported:host-hook" {
+		t.Fatalf("health = %+v, want unsupported permission", health.Data)
+	}
+	if len(health.Data.UnresolvedSecretBindings) != 1 || health.Data.UnresolvedSecretBindings[0] != "github_token" {
+		t.Fatalf("health = %+v, want unresolved secret", health.Data)
+	}
+	if len(health.Data.DisabledCapabilities) != 1 || health.Data.DisabledCapabilities[0] != "issues" {
+		t.Fatalf("health = %+v, want disabled capability", health.Data)
+	}
+}
+
+func TestPluginRegistryAPI_RejectsInvalidManifest(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/plugins/install-local", pluginAPITestJSONBody(t, map[string]any{
+		"manifest": map[string]any{
+			"schema_version": "other",
+			"id":             "bad",
+			"name":           "Bad",
+			"version":        "0.1.0",
+		},
+	})))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPluginRegistryAPI_RejectsDuplicateCapabilityIDsAsInvalidRequest(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/plugins/install-local", pluginAPITestJSONBody(t, map[string]any{
+		"manifest": map[string]any{
+			"schema_version": "hecate.plugin.v0",
+			"id":             "github",
+			"name":           "GitHub",
+			"version":        "0.1.0",
+			"capabilities": []map[string]any{
+				{"id": "issues", "kind": "connector"},
+				{"id": "issues", "kind": "slash_command"},
+			},
+		},
+	})))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400 for duplicate capability id", rec.Code, rec.Body.String())
+	}
+}
+
+func pluginAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return bytes.NewReader(raw)
+}

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -60,6 +60,12 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 	}
 	stats.ProjectSkillsDeleted = projectSkillsDeleted
 
+	pluginsDeleted, err := h.resetPlugins(ctx)
+	if err != nil {
+		return stats, err
+	}
+	stats.PluginsDeleted = pluginsDeleted
+
 	agentProfilesDeleted, err := h.resetAgentProfiles(ctx)
 	if err != nil {
 		return stats, err
@@ -159,6 +165,13 @@ func (h *Handler) resetProjectSkills(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return h.projectSkills.Clear(ctx)
+}
+
+func (h *Handler) resetPlugins(ctx context.Context) (int, error) {
+	if h.pluginRegistry == nil {
+		return 0, nil
+	}
+	return h.pluginRegistry.Clear(ctx)
 }
 
 func (h *Handler) resetAgentProfiles(ctx context.Context) (int, error) {

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/storage"
@@ -27,6 +28,7 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	runtime := &fakeProviderRuntime{store: cpStore}
 	handler := NewHandler(config.Config{}, logger, nil, cpStore, taskstate.NewMemoryStore(), nil, runtime)
 	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetPluginRegistryStore(pluginregistry.NewMemoryStore())
 	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
 	chatStore := chat.NewMemoryStore()
 	handler.SetAgentChatStore(chatStore)
@@ -96,6 +98,16 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if _, err := handler.agentProfiles.Create(ctx, agentprofiles.Profile{ID: "prof_reset", Name: "Reset profile"}); err != nil {
 		t.Fatalf("create agent profile: %v", err)
 	}
+	if _, err := handler.pluginRegistry.Upsert(ctx, pluginregistry.Plugin{
+		ID:                    "github",
+		Name:                  "GitHub",
+		Version:               "0.1.0",
+		SourceKind:            pluginregistry.SourceLocalPath,
+		ManifestSchemaVersion: pluginregistry.ManifestSchemaVersion,
+		ManifestJSON:          []byte(`{"schema_version":"hecate.plugin.v0","id":"github","name":"GitHub","version":"0.1.0"}`),
+	}); err != nil {
+		t.Fatalf("create plugin record: %v", err)
+	}
 	if _, err := cpStore.UpsertProvider(ctx, controlplane.Provider{
 		ID:       "openai",
 		Name:     "OpenAI",
@@ -126,8 +138,8 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &reset); err != nil {
 		t.Fatalf("decode reset response: %v", err)
 	}
-	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.AgentProfilesDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
-		t.Fatalf("reset stats = %+v, want one project, one profile, two project-work rows, one task, provider, rule and two chats", reset.Data)
+	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.PluginsDeleted != 1 || reset.Data.AgentProfilesDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
+		t.Fatalf("reset stats = %+v, want one project, one plugin, one profile, two project-work rows, one task, provider, rule and two chats", reset.Data)
 	}
 	if len(runner.closedSessions) != 2 {
 		t.Fatalf("closed sessions = %#v, want two external chats closed", runner.closedSessions)
@@ -239,6 +251,10 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(agentprofiles): %v", err)
 	}
+	pluginStore, err := pluginregistry.NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore(pluginregistry): %v", err)
+	}
 	taskStore, err := taskstate.NewSQLiteStore(ctx, client)
 	if err != nil {
 		t.Fatalf("NewSQLiteStore(taskstate): %v", err)
@@ -257,6 +273,7 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	handler.SetProjectStore(projectStore)
 	handler.SetMemoryStore(memoryStore)
 	handler.SetProjectWorkStore(projectWorkStore)
+	handler.SetPluginRegistryStore(pluginStore)
 	handler.SetAgentProfileStore(agentProfileStore)
 	handler.SetStateCleaner(client)
 	runner := &fakeAgentChatRunner{}
@@ -301,6 +318,16 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if _, err := agentProfileStore.Create(ctx, agentprofiles.Profile{ID: "prof_sqlite_reset", Name: "SQLite profile"}); err != nil {
 		t.Fatalf("create agent profile: %v", err)
 	}
+	if _, err := pluginStore.Upsert(ctx, pluginregistry.Plugin{
+		ID:                    "linear",
+		Name:                  "Linear",
+		Version:               "0.1.0",
+		SourceKind:            pluginregistry.SourceLocalPath,
+		ManifestSchemaVersion: pluginregistry.ManifestSchemaVersion,
+		ManifestJSON:          []byte(`{"schema_version":"hecate.plugin.v0","id":"linear","name":"Linear","version":"0.1.0"}`),
+	}); err != nil {
+		t.Fatalf("create plugin record: %v", err)
+	}
 	if _, err := cpStore.UpsertProvider(ctx, controlplane.Provider{
 		ID:       "openai",
 		Name:     "OpenAI",
@@ -332,11 +359,15 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if reset.Data.AgentProfilesDeleted != 1 {
 		t.Fatalf("agent profiles deleted = %d, want 1", reset.Data.AgentProfilesDeleted)
 	}
+	if reset.Data.PluginsDeleted != 1 {
+		t.Fatalf("plugins deleted = %d, want 1", reset.Data.PluginsDeleted)
+	}
 	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_sqlite_external" {
 		t.Fatalf("closed sessions = %#v, want sqlite external chat closed", runner.closedSessions)
 	}
 	assertSQLiteTableCount(t, client, client.QualifiedTable("memory_entries"), 0)
 	assertSQLiteTableCount(t, client, client.QualifiedTable("agent_profiles"), 0)
+	assertSQLiteTableCount(t, client, client.QualifiedTable("plugins"), 0)
 	assertSQLiteTableCount(t, client, client.QualifiedTable("reset_scratch"), 0)
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -419,6 +419,78 @@ type ProjectSkillResponseItem struct {
 	UpdatedAt              string   `json:"updated_at"`
 }
 
+type PluginsResponse struct {
+	Object string               `json:"object"`
+	Data   []PluginResponseItem `json:"data"`
+}
+
+type PluginResponse struct {
+	Object string             `json:"object"`
+	Data   PluginResponseItem `json:"data"`
+}
+
+type PluginResponseItem struct {
+	ID                    string                    `json:"id"`
+	Name                  string                    `json:"name"`
+	Description           string                    `json:"description,omitempty"`
+	Version               string                    `json:"version"`
+	SourceKind            string                    `json:"source_kind"`
+	SourceRef             string                    `json:"source_ref,omitempty"`
+	ManifestSchemaVersion string                    `json:"manifest_schema_version"`
+	ManifestDigest        string                    `json:"manifest_digest"`
+	RequestedPermissions  []PluginPermissionRecord  `json:"requested_permissions,omitempty"`
+	RegistryState         string                    `json:"registry_state"`
+	Enabled               bool                      `json:"enabled"`
+	Warnings              []string                  `json:"warnings,omitempty"`
+	Capabilities          []PluginCapabilityRecord  `json:"capabilities,omitempty"`
+	Auth                  []PluginAuthBindingRecord `json:"auth,omitempty"`
+	InstalledAt           string                    `json:"installed_at"`
+	UpdatedAt             string                    `json:"updated_at"`
+}
+
+type PluginCapabilityRecord struct {
+	ID                   string                   `json:"id"`
+	Kind                 string                   `json:"kind"`
+	DisplayName          string                   `json:"display_name"`
+	RequestedPermissions []PluginPermissionRecord `json:"requested_permissions,omitempty"`
+	Enabled              bool                     `json:"enabled"`
+	Warnings             []string                 `json:"warnings,omitempty"`
+}
+
+type PluginPermissionRecord struct {
+	Value          string `json:"value"`
+	Classification string `json:"classification"`
+}
+
+type PluginAuthBindingRecord struct {
+	CapabilityID  string   `json:"capability_id,omitempty"`
+	RequestedName string   `json:"requested_name"`
+	Kind          string   `json:"kind"`
+	Status        string   `json:"status"`
+	SecretRef     string   `json:"secret_ref,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
+}
+
+type PluginHealthResponse struct {
+	Object string             `json:"object"`
+	Data   PluginHealthRecord `json:"data"`
+}
+
+type PluginHealthRecord struct {
+	PluginID                 string                         `json:"plugin_id"`
+	RegistryState            string                         `json:"registry_state"`
+	Warnings                 []string                       `json:"warnings,omitempty"`
+	UnsupportedPermissions   []string                       `json:"unsupported_permissions,omitempty"`
+	UnresolvedSecretBindings []string                       `json:"unresolved_secret_bindings,omitempty"`
+	DisabledCapabilities     []string                       `json:"disabled_capabilities,omitempty"`
+	CommandCollisions        []PluginCommandCollisionRecord `json:"command_collisions,omitempty"`
+}
+
+type PluginCommandCollisionRecord struct {
+	Command   string   `json:"command"`
+	PluginIDs []string `json:"plugin_ids"`
+}
+
 type ProjectMemoryResponse struct {
 	Object string                    `json:"object"`
 	Data   ProjectMemoryResponseItem `json:"data"`
@@ -1257,6 +1329,7 @@ type SystemResetDataResponseItem struct {
 	ProjectsDeleted            int `json:"projects_deleted"`
 	ProjectSkillsDeleted       int `json:"project_skills_deleted"`
 	ProjectWorkRowsDeleted     int `json:"project_work_rows_deleted"`
+	PluginsDeleted             int `json:"plugins_deleted"`
 	AgentProfilesDeleted       int `json:"agent_profiles_deleted"`
 	ChatSessionsDeleted        int `json:"chat_sessions_deleted"`
 	TasksDeleted               int `json:"tasks_deleted"`

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -18,6 +18,11 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},
 	{method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers"},
 	{method: http.MethodGet, path: "/hecate/v1/settings/providers/local-discovery"},
+	{method: http.MethodGet, path: "/hecate/v1/plugins"},
+	{method: http.MethodPost, path: "/hecate/v1/plugins/install-local"},
+	{method: http.MethodGet, path: "/hecate/v1/plugins/{id}"},
+	{method: http.MethodPatch, path: "/hecate/v1/plugins/{id}"},
+	{method: http.MethodGet, path: "/hecate/v1/plugins/{id}/health"},
 }
 
 // Keep this table in lockstep with server.go. The coverage test is part of the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ func NewServer(logger *slog.Logger, handler *Handler) http.Handler {
 	registerHecateAgentRoutes(mux, handler)
 	registerHecateTaskRoutes(mux, handler)
 	registerHecateOperationsRoutes(mux, handler)
+	registerHecatePluginRoutes(mux, handler)
 	registerHecateSettingsRoutes(mux, handler)
 	registerAPINotFound(mux)
 
@@ -216,6 +217,17 @@ func registerHecateOperationsRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/mcp/probe", handler.HandleMCPProbe)
 	mux.HandleFunc("GET /hecate/v1/usage/events", handler.HandleUsageEvents)
 	mux.HandleFunc("GET /hecate/v1/usage/summary", handler.HandleUsageSummary)
+}
+
+func registerHecatePluginRoutes(mux *http.ServeMux, handler *Handler) {
+	// Plugin records are registry-only metadata in this slice. The routes are
+	// local-only in remote-runtime mode until package trust, auth binding, and
+	// capability execution policies exist.
+	mux.HandleFunc("GET /hecate/v1/plugins", handler.HandlePlugins)
+	mux.HandleFunc("POST /hecate/v1/plugins/install-local", handler.HandleInstallLocalPlugin)
+	mux.HandleFunc("GET /hecate/v1/plugins/{id}", handler.HandlePlugin)
+	mux.HandleFunc("PATCH /hecate/v1/plugins/{id}", handler.HandleUpdatePlugin)
+	mux.HandleFunc("GET /hecate/v1/plugins/{id}/health", handler.HandlePluginHealth)
 }
 
 func registerHecateSettingsRoutes(mux *http.ServeMux, handler *Handler) {

--- a/internal/pluginregistry/manifest.go
+++ b/internal/pluginregistry/manifest.go
@@ -1,0 +1,192 @@
+package pluginregistry
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+type Manifest struct {
+	SchemaVersion string          `json:"schema_version"`
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description"`
+	Version       string          `json:"version"`
+	Permissions   []string        `json:"permissions"`
+	Auth          []manifestAuth  `json:"auth"`
+	Capabilities  json.RawMessage `json:"capabilities"`
+}
+
+type manifestCapability struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Kind        string          `json:"kind"`
+	DisplayName string          `json:"display_name"`
+	Permissions []string        `json:"permissions"`
+	Enabled     *bool           `json:"enabled"`
+	Auth        []manifestAuth  `json:"auth"`
+	Config      json.RawMessage `json:"config"`
+}
+
+type manifestAuth struct {
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	CapabilityID string   `json:"capability_id"`
+	SecretRef    string   `json:"secret_ref"`
+	Warnings     []string `json:"warnings"`
+}
+
+type capabilityGroups struct {
+	Connectors        []manifestCapability `json:"connectors"`
+	MCPServers        []manifestCapability `json:"mcp_servers"`
+	Skills            []manifestCapability `json:"skills"`
+	SlashCommands     []manifestCapability `json:"slash_commands"`
+	ProjectMappers    []manifestCapability `json:"project_mappers"`
+	EvidenceProviders []manifestCapability `json:"evidence_providers"`
+	UISurfaces        []manifestCapability `json:"ui_surfaces"`
+}
+
+func PluginFromManifest(raw json.RawMessage, sourceKind, sourceRef string) (Plugin, error) {
+	raw = compactJSON(raw)
+	if len(raw) == 0 {
+		return Plugin{}, ErrInvalid
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return Plugin{}, ErrInvalid
+	}
+	if strings.TrimSpace(manifest.SchemaVersion) != ManifestSchemaVersion {
+		return Plugin{}, ErrInvalid
+	}
+	plugin := Plugin{
+		ID:                    manifest.ID,
+		Name:                  manifest.Name,
+		Description:           manifest.Description,
+		Version:               manifest.Version,
+		SourceKind:            sourceKind,
+		SourceRef:             sourceRef,
+		ManifestSchemaVersion: strings.TrimSpace(manifest.SchemaVersion),
+		ManifestJSON:          raw,
+		RequestedPermissions:  permissionsFromStrings(manifest.Permissions),
+		RegistryState:         StateValid,
+		Enabled:               false,
+	}
+	capabilities, auth, err := parseManifestCapabilities(manifest.Capabilities)
+	if err != nil {
+		return Plugin{}, err
+	}
+	plugin.Capabilities = capabilities
+	for _, binding := range manifest.Auth {
+		auth = append(auth, authBindingFromManifest("", binding))
+	}
+	plugin.Auth = auth
+	plugin = NormalizePlugin(plugin, time.Now().UTC())
+	if err := ValidatePlugin(plugin); err != nil {
+		return Plugin{}, err
+	}
+	return plugin, nil
+}
+
+func parseManifestCapabilities(raw json.RawMessage) ([]Capability, []AuthBinding, error) {
+	if len(raw) == 0 {
+		return nil, nil, nil
+	}
+	var list []manifestCapability
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return capabilitiesFromManifest(list, "")
+	}
+	var groups capabilityGroups
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		return nil, nil, ErrInvalid
+	}
+	var all []Capability
+	var auth []AuthBinding
+	for _, group := range []struct {
+		kind  string
+		items []manifestCapability
+	}{
+		{kind: CapabilityConnector, items: groups.Connectors},
+		{kind: CapabilityMCPServer, items: groups.MCPServers},
+		{kind: CapabilitySkill, items: groups.Skills},
+		{kind: CapabilitySlashCommand, items: groups.SlashCommands},
+		{kind: CapabilityProjectMapper, items: groups.ProjectMappers},
+		{kind: CapabilityEvidenceProvider, items: groups.EvidenceProviders},
+		{kind: CapabilityUISurface, items: groups.UISurfaces},
+	} {
+		capabilities, bindings, err := capabilitiesFromManifest(group.items, group.kind)
+		if err != nil {
+			return nil, nil, err
+		}
+		all = append(all, capabilities...)
+		auth = append(auth, bindings...)
+	}
+	return all, auth, nil
+}
+
+func capabilitiesFromManifest(items []manifestCapability, forcedKind string) ([]Capability, []AuthBinding, error) {
+	var capabilities []Capability
+	var auth []AuthBinding
+	for _, item := range items {
+		kind := strings.TrimSpace(item.Kind)
+		if forcedKind != "" {
+			kind = forcedKind
+		}
+		id := item.ID
+		if id == "" && kind == CapabilitySlashCommand {
+			id = strings.TrimPrefix(item.Name, "/")
+		}
+		displayName := item.DisplayName
+		if displayName == "" && kind == CapabilitySlashCommand && item.Name != "" {
+			displayName = "/" + strings.TrimPrefix(item.Name, "/")
+		}
+		enabled := true
+		if item.Enabled != nil {
+			enabled = *item.Enabled
+		}
+		capability := Capability{
+			ID:                   id,
+			Kind:                 kind,
+			DisplayName:          displayName,
+			RequestedPermissions: permissionsFromStrings(item.Permissions),
+			Enabled:              enabled,
+			ConfigJSON:           item.Config,
+		}
+		capability = NormalizeCapability("", capability)
+		if capability.ID == "" || capability.Kind == "" {
+			return nil, nil, ErrInvalid
+		}
+		capabilities = append(capabilities, capability)
+		for _, binding := range item.Auth {
+			auth = append(auth, authBindingFromManifest(capability.ID, binding))
+		}
+	}
+	return capabilities, auth, nil
+}
+
+func authBindingFromManifest(capabilityID string, item manifestAuth) AuthBinding {
+	if capabilityID == "" {
+		capabilityID = item.CapabilityID
+	}
+	return AuthBinding{
+		CapabilityID:  capabilityID,
+		RequestedName: item.Name,
+		Kind:          item.Kind,
+		Status:        AuthStatusUnknown,
+		Warnings:      item.Warnings,
+	}
+}
+
+func permissionsFromStrings(values []string) []Permission {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]Permission, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, Permission{Value: value, Classification: ClassifyPermission(value)})
+	}
+	return NormalizePermissions(out)
+}

--- a/internal/pluginregistry/sqlite.go
+++ b/internal/pluginregistry/sqlite.go
@@ -1,0 +1,520 @@
+package pluginregistry
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+type SQLiteStore struct {
+	client       storage.SQLClient
+	backend      string
+	plugins      string
+	capabilities string
+	auth         string
+}
+
+func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
+	return newSQLStore(ctx, client)
+}
+
+func NewPostgresStore(ctx context.Context, client *storage.PostgresClient) (*SQLiteStore, error) {
+	return newSQLStore(ctx, client)
+}
+
+func newSQLStore(ctx context.Context, client storage.SQLClient) (*SQLiteStore, error) {
+	if client == nil {
+		return nil, errors.New("sql client is required")
+	}
+	store := &SQLiteStore{
+		client:       client,
+		backend:      client.Backend(),
+		plugins:      client.QualifiedTable("plugins"),
+		capabilities: client.QualifiedTable("plugin_capabilities"),
+		auth:         client.QualifiedTable("plugin_auth"),
+	}
+	if err := store.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLiteStore) Backend() string { return s.backend }
+
+func (s *SQLiteStore) migrate(ctx context.Context) error {
+	timestampColumn := storage.TimestampColumnDefaultZero(s.client)
+	for _, stmt := range []string{
+		`
+CREATE TABLE IF NOT EXISTS ` + s.plugins + ` (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL DEFAULT '',
+	description TEXT NOT NULL DEFAULT '',
+	version TEXT NOT NULL DEFAULT '',
+	source_kind TEXT NOT NULL DEFAULT 'local_path',
+	source_ref TEXT NOT NULL DEFAULT '',
+	manifest_schema_version TEXT NOT NULL DEFAULT 'hecate.plugin.v0',
+	manifest_digest TEXT NOT NULL DEFAULT '',
+	manifest_json TEXT NOT NULL DEFAULT '{}',
+	requested_permissions_json TEXT NOT NULL DEFAULT '[]',
+	registry_state TEXT NOT NULL DEFAULT 'valid',
+	enabled INTEGER NOT NULL DEFAULT 0,
+	warnings TEXT NOT NULL DEFAULT '[]',
+	installed_at ` + timestampColumn + `,
+	updated_at ` + timestampColumn + `
+)`,
+		`
+CREATE TABLE IF NOT EXISTS ` + s.capabilities + ` (
+	plugin_id TEXT NOT NULL,
+	capability_id TEXT NOT NULL,
+	capability_kind TEXT NOT NULL,
+	display_name TEXT NOT NULL DEFAULT '',
+	requested_permissions_json TEXT NOT NULL DEFAULT '[]',
+	enabled INTEGER NOT NULL DEFAULT 1,
+	config_json TEXT NOT NULL DEFAULT '{}',
+	warnings TEXT NOT NULL DEFAULT '[]',
+	PRIMARY KEY(plugin_id, capability_id)
+)`,
+		`
+CREATE TABLE IF NOT EXISTS ` + s.auth + ` (
+	plugin_id TEXT NOT NULL,
+	capability_id TEXT NOT NULL DEFAULT '',
+	requested_name TEXT NOT NULL,
+	auth_kind TEXT NOT NULL DEFAULT 'unknown',
+	status TEXT NOT NULL DEFAULT 'unknown',
+	secret_ref TEXT NOT NULL DEFAULT '',
+	warnings TEXT NOT NULL DEFAULT '[]',
+	PRIMARY KEY(plugin_id, capability_id, requested_name)
+)`,
+	} {
+		if _, err := s.client.DB().ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) List(ctx context.Context) ([]Plugin, error) {
+	rows, err := s.client.DB().QueryContext(ctx, selectPluginSQL(s.plugins)+`
+ORDER BY name ASC, id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Plugin
+	for rows.Next() {
+		item, err := scanPlugin(rows)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.loadChildren(ctx, &item); err != nil {
+			return nil, err
+		}
+		items = append(items, NormalizePlugin(item, item.UpdatedAt))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (s *SQLiteStore) Get(ctx context.Context, id string) (Plugin, bool, error) {
+	row := s.client.DB().QueryRowContext(ctx, selectPluginSQL(s.plugins)+"WHERE id = ?", normalizeID(id))
+	item, err := scanPlugin(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Plugin{}, false, nil
+	}
+	if err != nil {
+		return Plugin{}, false, err
+	}
+	if err := s.loadChildren(ctx, &item); err != nil {
+		return Plugin{}, false, err
+	}
+	return NormalizePlugin(item, item.UpdatedAt), true, nil
+}
+
+func (s *SQLiteStore) Upsert(ctx context.Context, plugin Plugin) (Plugin, error) {
+	now := time.Now().UTC()
+	if existing, ok, err := s.Get(ctx, plugin.ID); err != nil {
+		return Plugin{}, err
+	} else if ok && !existing.InstalledAt.IsZero() {
+		plugin.InstalledAt = existing.InstalledAt
+	}
+	plugin = NormalizePlugin(plugin, now)
+	if err := ValidatePlugin(plugin); err != nil {
+		return Plugin{}, err
+	}
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return Plugin{}, err
+	}
+	if err := s.upsertWith(ctx, tx, plugin); err != nil {
+		_ = tx.Rollback()
+		return Plugin{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Plugin{}, err
+	}
+	return clonePlugin(plugin), nil
+}
+
+func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Plugin)) (Plugin, error) {
+	item, ok, err := s.Get(ctx, id)
+	if err != nil {
+		return Plugin{}, err
+	}
+	if !ok {
+		return Plugin{}, ErrNotFound
+	}
+	originalID := item.ID
+	installedAt := item.InstalledAt
+	if update != nil {
+		update(&item)
+	}
+	item.ID = originalID
+	item.InstalledAt = installedAt
+	item.UpdatedAt = time.Now().UTC()
+	item = NormalizePlugin(item, item.UpdatedAt)
+	if err := ValidatePlugin(item); err != nil {
+		return Plugin{}, err
+	}
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return Plugin{}, err
+	}
+	if err := s.upsertWith(ctx, tx, item); err != nil {
+		_ = tx.Rollback()
+		return Plugin{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Plugin{}, err
+	}
+	return clonePlugin(item), nil
+}
+
+func (s *SQLiteStore) Clear(ctx context.Context) (int, error) {
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, table := range []string{s.auth, s.capabilities, s.plugins} {
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, table))
+		if err != nil {
+			_ = tx.Rollback()
+			return deleted, err
+		}
+		if affected, err := res.RowsAffected(); err == nil && table == s.plugins {
+			deleted = int(affected)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+func (s *SQLiteStore) loadChildren(ctx context.Context, plugin *Plugin) error {
+	capabilities, err := s.listCapabilities(ctx, plugin.ID)
+	if err != nil {
+		return err
+	}
+	auth, err := s.listAuth(ctx, plugin.ID)
+	if err != nil {
+		return err
+	}
+	plugin.Capabilities = capabilities
+	plugin.Auth = auth
+	return nil
+}
+
+func (s *SQLiteStore) listCapabilities(ctx context.Context, pluginID string) ([]Capability, error) {
+	rows, err := s.client.DB().QueryContext(ctx, selectCapabilitySQL(s.capabilities)+`
+WHERE plugin_id = ?
+ORDER BY capability_kind ASC, capability_id ASC`, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Capability
+	for rows.Next() {
+		item, err := scanCapability(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) listAuth(ctx context.Context, pluginID string) ([]AuthBinding, error) {
+	rows, err := s.client.DB().QueryContext(ctx, selectAuthSQL(s.auth)+`
+WHERE plugin_id = ?
+ORDER BY capability_id ASC, requested_name ASC`, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AuthBinding
+	for rows.Next() {
+		item, err := scanAuthBinding(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *SQLiteStore) upsertWith(ctx context.Context, tx storage.Tx, plugin Plugin) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, name, description, version, source_kind, source_ref, manifest_schema_version,
+	manifest_digest, manifest_json, requested_permissions_json, registry_state,
+	enabled, warnings, installed_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	name = excluded.name,
+	description = excluded.description,
+	version = excluded.version,
+	source_kind = excluded.source_kind,
+	source_ref = excluded.source_ref,
+	manifest_schema_version = excluded.manifest_schema_version,
+	manifest_digest = excluded.manifest_digest,
+	manifest_json = excluded.manifest_json,
+	requested_permissions_json = excluded.requested_permissions_json,
+	registry_state = excluded.registry_state,
+	enabled = excluded.enabled,
+	warnings = excluded.warnings,
+	updated_at = excluded.updated_at`, s.plugins),
+		plugin.ID,
+		plugin.Name,
+		plugin.Description,
+		plugin.Version,
+		plugin.SourceKind,
+		plugin.SourceRef,
+		plugin.ManifestSchemaVersion,
+		plugin.ManifestDigest,
+		string(plugin.ManifestJSON),
+		encodePermissions(plugin.RequestedPermissions),
+		plugin.RegistryState,
+		boolToDB(plugin.Enabled),
+		encodeStringSlice(plugin.Warnings),
+		formatTime(plugin.InstalledAt),
+		formatTime(plugin.UpdatedAt),
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE plugin_id = ?`, s.capabilities), plugin.ID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE plugin_id = ?`, s.auth), plugin.ID); err != nil {
+		return err
+	}
+	for _, capability := range plugin.Capabilities {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	plugin_id, capability_id, capability_kind, display_name,
+	requested_permissions_json, enabled, config_json, warnings
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.capabilities),
+			plugin.ID,
+			capability.ID,
+			capability.Kind,
+			capability.DisplayName,
+			encodePermissions(capability.RequestedPermissions),
+			boolToDB(capability.Enabled),
+			string(capability.ConfigJSON),
+			encodeStringSlice(capability.Warnings),
+		); err != nil {
+			return err
+		}
+	}
+	for _, binding := range plugin.Auth {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	plugin_id, capability_id, requested_name, auth_kind, status, secret_ref, warnings
+) VALUES (?, ?, ?, ?, ?, ?, ?)`, s.auth),
+			plugin.ID,
+			binding.CapabilityID,
+			binding.RequestedName,
+			binding.Kind,
+			binding.Status,
+			binding.SecretRef,
+			encodeStringSlice(binding.Warnings),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func selectPluginSQL(table string) string {
+	return fmt.Sprintf(`
+SELECT id, name, description, version, source_kind, source_ref,
+	manifest_schema_version, manifest_digest, manifest_json,
+	requested_permissions_json, registry_state, enabled, warnings,
+	installed_at, updated_at
+FROM %s
+`, table)
+}
+
+func selectCapabilitySQL(table string) string {
+	return fmt.Sprintf(`
+SELECT plugin_id, capability_id, capability_kind, display_name,
+	requested_permissions_json, enabled, config_json, warnings
+FROM %s
+`, table)
+}
+
+func selectAuthSQL(table string) string {
+	return fmt.Sprintf(`
+SELECT plugin_id, capability_id, requested_name, auth_kind, status, secret_ref, warnings
+FROM %s
+`, table)
+}
+
+func scanPlugin(row rowScanner) (Plugin, error) {
+	var plugin Plugin
+	var enabled int
+	var manifestJSON, permissionsJSON, warningsJSON string
+	var installedAt, updatedAt string
+	if err := row.Scan(
+		&plugin.ID,
+		&plugin.Name,
+		&plugin.Description,
+		&plugin.Version,
+		&plugin.SourceKind,
+		&plugin.SourceRef,
+		&plugin.ManifestSchemaVersion,
+		&plugin.ManifestDigest,
+		&manifestJSON,
+		&permissionsJSON,
+		&plugin.RegistryState,
+		&enabled,
+		&warningsJSON,
+		&installedAt,
+		&updatedAt,
+	); err != nil {
+		return Plugin{}, err
+	}
+	var err error
+	plugin.ManifestJSON = json.RawMessage(strings.TrimSpace(manifestJSON))
+	plugin.RequestedPermissions = decodePermissions(permissionsJSON)
+	plugin.Enabled = enabled != 0
+	plugin.Warnings = decodeStringSlice(warningsJSON)
+	if plugin.InstalledAt, err = parseTime(installedAt); err != nil {
+		return Plugin{}, err
+	}
+	if plugin.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return Plugin{}, err
+	}
+	return plugin, nil
+}
+
+func scanCapability(row rowScanner) (Capability, error) {
+	var capability Capability
+	var permissionsJSON, configJSON, warningsJSON string
+	var enabled int
+	if err := row.Scan(
+		&capability.PluginID,
+		&capability.ID,
+		&capability.Kind,
+		&capability.DisplayName,
+		&permissionsJSON,
+		&enabled,
+		&configJSON,
+		&warningsJSON,
+	); err != nil {
+		return Capability{}, err
+	}
+	capability.RequestedPermissions = decodePermissions(permissionsJSON)
+	capability.Enabled = enabled != 0
+	capability.ConfigJSON = json.RawMessage(strings.TrimSpace(configJSON))
+	capability.Warnings = decodeStringSlice(warningsJSON)
+	return NormalizeCapability(capability.PluginID, capability), nil
+}
+
+func scanAuthBinding(row rowScanner) (AuthBinding, error) {
+	var binding AuthBinding
+	var warningsJSON string
+	if err := row.Scan(
+		&binding.PluginID,
+		&binding.CapabilityID,
+		&binding.RequestedName,
+		&binding.Kind,
+		&binding.Status,
+		&binding.SecretRef,
+		&warningsJSON,
+	); err != nil {
+		return AuthBinding{}, err
+	}
+	binding.Warnings = decodeStringSlice(warningsJSON)
+	return NormalizeAuthBinding(binding.PluginID, binding), nil
+}
+
+func boolToDB(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func encodePermissions(items []Permission) string {
+	raw, err := json.Marshal(NormalizePermissions(items))
+	if err != nil {
+		return "[]"
+	}
+	return string(raw)
+}
+
+func decodePermissions(raw string) []Permission {
+	var items []Permission
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &items); err != nil {
+		return nil
+	}
+	return NormalizePermissions(items)
+}
+
+func encodeStringSlice(items []string) string {
+	raw, err := json.Marshal(normalizeStringSlice(items))
+	if err != nil {
+		return "[]"
+	}
+	return string(raw)
+}
+
+func decodeStringSlice(raw string) []string {
+	var items []string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &items); err != nil {
+		return nil
+	}
+	return normalizeStringSlice(items)
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed.UTC(), nil
+}

--- a/internal/pluginregistry/store.go
+++ b/internal/pluginregistry/store.go
@@ -1,0 +1,614 @@
+package pluginregistry
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+)
+
+const (
+	ManifestSchemaVersion = "hecate.plugin.v0"
+
+	SourceBuiltin        = "builtin"
+	SourceLocalPath      = "local_path"
+	SourceImported       = "imported"
+	SourceRemoteRegistry = "remote_registry"
+
+	StateValid       = "valid"
+	StateInvalid     = "invalid"
+	StateUnsupported = "unsupported"
+
+	CapabilityConnector        = "connector"
+	CapabilityMCPServer        = "mcp_server"
+	CapabilitySkill            = "skill"
+	CapabilitySlashCommand     = "slash_command"
+	CapabilityProjectMapper    = "project_mapper"
+	CapabilityEvidenceProvider = "evidence_provider"
+	CapabilityUISurface        = "ui_surface"
+
+	PermissionAdvisory    = "advisory"
+	PermissionEnforced    = "enforced"
+	PermissionUnsupported = "unsupported"
+
+	AuthToken   = "token"
+	AuthOAuth   = "oauth"
+	AuthEnv     = "env"
+	AuthNone    = "none"
+	AuthUnknown = "unknown"
+
+	AuthStatusUnknown    = "unknown"
+	AuthStatusConfigured = "configured"
+	AuthStatusExpired    = "expired"
+	AuthStatusError      = "error"
+)
+
+var (
+	ErrNotFound = errors.New("plugin not found")
+	ErrInvalid  = errors.New("invalid plugin")
+	ErrConflict = errors.New("plugin conflict")
+)
+
+type Plugin struct {
+	ID                    string
+	Name                  string
+	Description           string
+	Version               string
+	SourceKind            string
+	SourceRef             string
+	ManifestSchemaVersion string
+	ManifestDigest        string
+	ManifestJSON          json.RawMessage
+	RequestedPermissions  []Permission
+	RegistryState         string
+	Enabled               bool
+	Warnings              []string
+	Capabilities          []Capability
+	Auth                  []AuthBinding
+	InstalledAt           time.Time
+	UpdatedAt             time.Time
+}
+
+type Capability struct {
+	ID                   string
+	PluginID             string
+	Kind                 string
+	DisplayName          string
+	RequestedPermissions []Permission
+	Enabled              bool
+	ConfigJSON           json.RawMessage
+	Warnings             []string
+}
+
+type Permission struct {
+	Value          string
+	Classification string
+}
+
+type AuthBinding struct {
+	PluginID      string
+	CapabilityID  string
+	RequestedName string
+	Kind          string
+	Status        string
+	SecretRef     string
+	Warnings      []string
+}
+
+type Health struct {
+	PluginID                 string
+	RegistryState            string
+	Warnings                 []string
+	UnsupportedPermissions   []string
+	UnresolvedSecretBindings []string
+	DisabledCapabilities     []string
+	CommandCollisions        []CommandCollision
+}
+
+type CommandCollision struct {
+	Command   string
+	PluginIDs []string
+}
+
+type Store interface {
+	Backend() string
+	List(ctx context.Context) ([]Plugin, error)
+	Get(ctx context.Context, id string) (Plugin, bool, error)
+	Upsert(ctx context.Context, plugin Plugin) (Plugin, error)
+	Update(ctx context.Context, id string, update func(*Plugin)) (Plugin, error)
+	Clear(ctx context.Context) (int, error)
+}
+
+type MemoryStore struct {
+	mu      sync.Mutex
+	plugins map[string]Plugin
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{plugins: make(map[string]Plugin)}
+}
+
+func (s *MemoryStore) Backend() string { return "memory" }
+
+func (s *MemoryStore) List(_ context.Context) ([]Plugin, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneSortedPlugins(s.plugins), nil
+}
+
+func (s *MemoryStore) Get(_ context.Context, id string) (Plugin, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	plugin, ok := s.plugins[normalizeID(id)]
+	if !ok {
+		return Plugin{}, false, nil
+	}
+	return clonePlugin(plugin), true, nil
+}
+
+func (s *MemoryStore) Upsert(_ context.Context, plugin Plugin) (Plugin, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	if existing, ok := s.plugins[normalizeID(plugin.ID)]; ok && !existing.InstalledAt.IsZero() {
+		plugin.InstalledAt = existing.InstalledAt
+	}
+	plugin = NormalizePlugin(plugin, now)
+	if err := ValidatePlugin(plugin); err != nil {
+		return Plugin{}, err
+	}
+	s.plugins[plugin.ID] = clonePlugin(plugin)
+	return clonePlugin(plugin), nil
+}
+
+func (s *MemoryStore) Update(_ context.Context, id string, update func(*Plugin)) (Plugin, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id = normalizeID(id)
+	plugin, ok := s.plugins[id]
+	if !ok {
+		return Plugin{}, ErrNotFound
+	}
+	plugin = clonePlugin(plugin)
+	originalID := plugin.ID
+	installedAt := plugin.InstalledAt
+	if update != nil {
+		update(&plugin)
+	}
+	plugin.ID = originalID
+	plugin.InstalledAt = installedAt
+	plugin.UpdatedAt = time.Now().UTC()
+	plugin = NormalizePlugin(plugin, plugin.UpdatedAt)
+	if err := ValidatePlugin(plugin); err != nil {
+		return Plugin{}, err
+	}
+	s.plugins[id] = clonePlugin(plugin)
+	return clonePlugin(plugin), nil
+}
+
+func (s *MemoryStore) Clear(_ context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := len(s.plugins)
+	s.plugins = make(map[string]Plugin)
+	return count, nil
+}
+
+func NormalizePlugin(plugin Plugin, now time.Time) Plugin {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	plugin.ID = normalizeID(plugin.ID)
+	plugin.Name = strings.TrimSpace(plugin.Name)
+	plugin.Description = strings.TrimSpace(plugin.Description)
+	plugin.Version = strings.TrimSpace(plugin.Version)
+	plugin.SourceKind = strings.TrimSpace(plugin.SourceKind)
+	plugin.SourceRef = strings.TrimSpace(plugin.SourceRef)
+	plugin.ManifestSchemaVersion = strings.TrimSpace(plugin.ManifestSchemaVersion)
+	plugin.ManifestDigest = strings.TrimSpace(plugin.ManifestDigest)
+	plugin.RegistryState = strings.TrimSpace(plugin.RegistryState)
+	if plugin.Name == "" {
+		plugin.Name = titleFromID(plugin.ID)
+	}
+	if plugin.SourceKind == "" {
+		plugin.SourceKind = SourceLocalPath
+	}
+	if plugin.ManifestSchemaVersion == "" {
+		plugin.ManifestSchemaVersion = ManifestSchemaVersion
+	}
+	if plugin.RegistryState == "" {
+		plugin.RegistryState = StateValid
+	}
+	if plugin.InstalledAt.IsZero() {
+		plugin.InstalledAt = now
+	}
+	if plugin.UpdatedAt.IsZero() {
+		plugin.UpdatedAt = plugin.InstalledAt
+	}
+	plugin.ManifestJSON = compactJSON(plugin.ManifestJSON)
+	if len(plugin.ManifestJSON) > 0 && plugin.ManifestDigest == "" {
+		plugin.ManifestDigest = digestJSON(plugin.ManifestJSON)
+	}
+	plugin.RequestedPermissions = NormalizePermissions(plugin.RequestedPermissions)
+	plugin.Warnings = normalizeStringSlice(plugin.Warnings)
+	for idx := range plugin.Capabilities {
+		plugin.Capabilities[idx] = NormalizeCapability(plugin.ID, plugin.Capabilities[idx])
+	}
+	sortCapabilities(plugin.Capabilities)
+	for idx := range plugin.Auth {
+		plugin.Auth[idx] = NormalizeAuthBinding(plugin.ID, plugin.Auth[idx])
+	}
+	sortAuthBindings(plugin.Auth)
+	return plugin
+}
+
+func NormalizeCapability(pluginID string, capability Capability) Capability {
+	capability.PluginID = normalizeID(pluginID)
+	capability.ID = normalizeID(capability.ID)
+	capability.Kind = strings.TrimSpace(capability.Kind)
+	capability.DisplayName = strings.TrimSpace(capability.DisplayName)
+	if capability.DisplayName == "" {
+		capability.DisplayName = titleFromID(capability.ID)
+	}
+	capability.RequestedPermissions = NormalizePermissions(capability.RequestedPermissions)
+	capability.ConfigJSON = compactJSON(capability.ConfigJSON)
+	capability.Warnings = normalizeStringSlice(capability.Warnings)
+	return capability
+}
+
+func NormalizeAuthBinding(pluginID string, binding AuthBinding) AuthBinding {
+	binding.PluginID = normalizeID(pluginID)
+	binding.CapabilityID = normalizeID(binding.CapabilityID)
+	binding.RequestedName = normalizeID(binding.RequestedName)
+	binding.Kind = strings.TrimSpace(binding.Kind)
+	binding.Status = strings.TrimSpace(binding.Status)
+	binding.SecretRef = strings.TrimSpace(binding.SecretRef)
+	if binding.Kind == "" {
+		binding.Kind = AuthUnknown
+	}
+	if binding.Status == "" {
+		binding.Status = AuthStatusUnknown
+	}
+	binding.Warnings = normalizeStringSlice(binding.Warnings)
+	return binding
+}
+
+func NormalizePermissions(items []Permission) []Permission {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(items))
+	out := make([]Permission, 0, len(items))
+	for _, item := range items {
+		value := strings.TrimSpace(item.Value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		classification := strings.TrimSpace(item.Classification)
+		if classification == "" {
+			classification = ClassifyPermission(value)
+		}
+		out = append(out, Permission{Value: value, Classification: classification})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Value < out[j].Value })
+	return out
+}
+
+func ClassifyPermission(value string) string {
+	value = strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(value, "network:"):
+		return PermissionAdvisory
+	case strings.HasPrefix(value, "secret:"):
+		return PermissionAdvisory
+	case strings.HasPrefix(value, "mcp:"):
+		return PermissionAdvisory
+	case strings.HasPrefix(value, "project:"):
+		return PermissionAdvisory
+	case strings.HasPrefix(value, "workspace:"):
+		return PermissionAdvisory
+	case strings.HasPrefix(value, "external-ref:"):
+		return PermissionAdvisory
+	default:
+		return PermissionUnsupported
+	}
+}
+
+func ValidatePlugin(plugin Plugin) error {
+	if plugin.ID == "" || plugin.Name == "" || plugin.Version == "" {
+		return ErrInvalid
+	}
+	if !oneOf(plugin.SourceKind, SourceBuiltin, SourceLocalPath, SourceImported, SourceRemoteRegistry) {
+		return ErrInvalid
+	}
+	if plugin.ManifestSchemaVersion != ManifestSchemaVersion {
+		return ErrInvalid
+	}
+	if !oneOf(plugin.RegistryState, StateValid, StateInvalid, StateUnsupported) {
+		return ErrInvalid
+	}
+	if !validPermissionClassifications(plugin.RequestedPermissions) {
+		return ErrInvalid
+	}
+	seenCapabilities := make(map[string]bool, len(plugin.Capabilities))
+	for _, capability := range plugin.Capabilities {
+		if capability.PluginID != plugin.ID || capability.ID == "" {
+			return ErrInvalid
+		}
+		if seenCapabilities[capability.ID] {
+			return ErrInvalid
+		}
+		seenCapabilities[capability.ID] = true
+		if !oneOf(capability.Kind, CapabilityConnector, CapabilityMCPServer, CapabilitySkill, CapabilitySlashCommand, CapabilityProjectMapper, CapabilityEvidenceProvider, CapabilityUISurface) {
+			return ErrInvalid
+		}
+		if !validPermissionClassifications(capability.RequestedPermissions) {
+			return ErrInvalid
+		}
+	}
+	for _, binding := range plugin.Auth {
+		if binding.PluginID != plugin.ID || binding.RequestedName == "" {
+			return ErrInvalid
+		}
+		if binding.CapabilityID != "" && !seenCapabilities[binding.CapabilityID] {
+			return ErrInvalid
+		}
+		if !oneOf(binding.Kind, AuthToken, AuthOAuth, AuthEnv, AuthNone, AuthUnknown) {
+			return ErrInvalid
+		}
+		if !oneOf(binding.Status, AuthStatusUnknown, AuthStatusConfigured, AuthStatusExpired, AuthStatusError) {
+			return ErrInvalid
+		}
+	}
+	return nil
+}
+
+func HealthFor(plugin Plugin, all []Plugin) Health {
+	plugin = NormalizePlugin(plugin, time.Now().UTC())
+	health := Health{
+		PluginID:      plugin.ID,
+		RegistryState: plugin.RegistryState,
+		Warnings:      append([]string(nil), plugin.Warnings...),
+	}
+	for _, perm := range plugin.RequestedPermissions {
+		if perm.Classification == PermissionUnsupported {
+			health.UnsupportedPermissions = appendUniqueString(health.UnsupportedPermissions, perm.Value)
+		}
+	}
+	for _, capability := range plugin.Capabilities {
+		if !capability.Enabled {
+			health.DisabledCapabilities = appendUniqueString(health.DisabledCapabilities, capability.ID)
+		}
+		for _, perm := range capability.RequestedPermissions {
+			if perm.Classification == PermissionUnsupported {
+				health.UnsupportedPermissions = appendUniqueString(health.UnsupportedPermissions, perm.Value)
+			}
+		}
+		health.Warnings = appendUniqueStrings(health.Warnings, capability.Warnings...)
+	}
+	for _, binding := range plugin.Auth {
+		if binding.Kind != AuthNone && binding.SecretRef == "" && binding.Status != AuthStatusConfigured {
+			health.UnresolvedSecretBindings = appendUniqueString(health.UnresolvedSecretBindings, binding.RequestedName)
+		}
+		health.Warnings = appendUniqueStrings(health.Warnings, binding.Warnings...)
+	}
+	health.CommandCollisions = commandCollisions(plugin, all)
+	sort.Strings(health.UnsupportedPermissions)
+	sort.Strings(health.UnresolvedSecretBindings)
+	sort.Strings(health.DisabledCapabilities)
+	sort.Strings(health.Warnings)
+	return health
+}
+
+func cloneSortedPlugins(items map[string]Plugin) []Plugin {
+	out := make([]Plugin, 0, len(items))
+	for _, item := range items {
+		out = append(out, clonePlugin(item))
+	}
+	sortPlugins(out)
+	return out
+}
+
+func clonePlugin(plugin Plugin) Plugin {
+	plugin.ManifestJSON = cloneRaw(plugin.ManifestJSON)
+	plugin.RequestedPermissions = append([]Permission(nil), plugin.RequestedPermissions...)
+	plugin.Warnings = append([]string(nil), plugin.Warnings...)
+	plugin.Capabilities = append([]Capability(nil), plugin.Capabilities...)
+	for idx := range plugin.Capabilities {
+		plugin.Capabilities[idx].RequestedPermissions = append([]Permission(nil), plugin.Capabilities[idx].RequestedPermissions...)
+		plugin.Capabilities[idx].ConfigJSON = cloneRaw(plugin.Capabilities[idx].ConfigJSON)
+		plugin.Capabilities[idx].Warnings = append([]string(nil), plugin.Capabilities[idx].Warnings...)
+	}
+	plugin.Auth = append([]AuthBinding(nil), plugin.Auth...)
+	for idx := range plugin.Auth {
+		plugin.Auth[idx].Warnings = append([]string(nil), plugin.Auth[idx].Warnings...)
+	}
+	return plugin
+}
+
+func sortPlugins(items []Plugin) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortCapabilities(items []Capability) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortAuthBindings(items []AuthBinding) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CapabilityID != items[j].CapabilityID {
+			return items[i].CapabilityID < items[j].CapabilityID
+		}
+		return items[i].RequestedName < items[j].RequestedName
+	})
+}
+
+func commandCollisions(plugin Plugin, all []Plugin) []CommandCollision {
+	byCommand := make(map[string][]string)
+	for _, item := range all {
+		for _, capability := range item.Capabilities {
+			if capability.Kind != CapabilitySlashCommand {
+				continue
+			}
+			command := strings.TrimPrefix(capability.ID, "/")
+			command = strings.TrimSpace(command)
+			if command == "" {
+				continue
+			}
+			byCommand[command] = appendUniqueString(byCommand[command], item.ID)
+		}
+	}
+	var out []CommandCollision
+	for command, pluginIDs := range byCommand {
+		if len(pluginIDs) < 2 || !containsString(pluginIDs, plugin.ID) {
+			continue
+		}
+		sort.Strings(pluginIDs)
+		out = append(out, CommandCollision{Command: command, PluginIDs: pluginIDs})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Command < out[j].Command })
+	return out
+}
+
+func validPermissionClassifications(items []Permission) bool {
+	for _, item := range items {
+		if !oneOf(item.Classification, PermissionAdvisory, PermissionEnforced, PermissionUnsupported) {
+			return false
+		}
+	}
+	return true
+}
+
+func compactJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return cloneRaw(raw)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return cloneRaw(raw)
+	}
+	return encoded
+}
+
+func digestJSON(raw json.RawMessage) string {
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizeID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		case r == '_' || r == '.' || r == '-':
+			b.WriteRune(r)
+			lastDash = r == '-'
+		case unicode.IsSpace(r), r == '/', r == ':':
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
+}
+
+func titleFromID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "Untitled Plugin"
+	}
+	parts := strings.FieldsFunc(id, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.'
+	})
+	for idx, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[idx] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func normalizeStringSlice(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func appendUniqueString(items []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" || containsString(items, value) {
+		return items
+	}
+	return append(items, value)
+}
+
+func appendUniqueStrings(items []string, values ...string) []string {
+	for _, value := range values {
+		items = appendUniqueString(items, value)
+	}
+	return items
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, item := range allowed {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pluginregistry/store_test.go
+++ b/internal/pluginregistry/store_test.go
@@ -1,0 +1,207 @@
+package pluginregistry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+func TestStoreConformance_PluginRegistryLifecycle(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: func(t *testing.T) Store { return newSQLitePluginTestStore(t) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tc.new(t)
+			plugin := testPluginFromManifest(t, map[string]any{
+				"schema_version": ManifestSchemaVersion,
+				"id":             "GitHub",
+				"name":           "GitHub",
+				"description":    "Read and link GitHub work.",
+				"version":        "0.1.0",
+				"permissions":    []string{"network:github.com", "unsupported:host-hook"},
+				"capabilities": map[string]any{
+					"connectors": []map[string]any{{
+						"id":           "issues",
+						"display_name": "Issues",
+						"permissions":  []string{"secret:github_token"},
+						"auth": []map[string]any{{
+							"name":       "github_token",
+							"kind":       "token",
+							"secret_ref": "secret:from-manifest",
+						}},
+					}},
+					"slash_commands": []map[string]any{{
+						"name":         "github",
+						"display_name": "/github",
+					}},
+				},
+			})
+
+			stored, err := store.Upsert(ctx, plugin)
+			if err != nil {
+				t.Fatalf("Upsert: %v", err)
+			}
+			if stored.ID != "github" || stored.Enabled {
+				t.Fatalf("stored plugin = %+v, want normalized disabled plugin", stored)
+			}
+			if len(stored.Capabilities) != 2 || len(stored.Auth) != 1 {
+				t.Fatalf("stored plugin = %+v, want capabilities and auth projection", stored)
+			}
+			if stored.Auth[0].SecretRef != "" || stored.Auth[0].Status != AuthStatusUnknown {
+				t.Fatalf("stored auth = %+v, want manifest secret_ref ignored", stored.Auth[0])
+			}
+			if stored.RequestedPermissions[1].Classification != PermissionUnsupported {
+				t.Fatalf("requested permissions = %+v, want unsupported classification", stored.RequestedPermissions)
+			}
+
+			updated, err := store.Update(ctx, "github", func(plugin *Plugin) {
+				plugin.Enabled = true
+				for idx := range plugin.Capabilities {
+					if plugin.Capabilities[idx].ID == "issues" {
+						plugin.Capabilities[idx].Enabled = false
+					}
+				}
+			})
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if !updated.Enabled || findCapabilityForTest(updated.Capabilities, "issues").Enabled {
+				t.Fatalf("updated plugin = %+v, want plugin enabled and issues disabled", updated)
+			}
+
+			health := HealthFor(updated, []Plugin{updated})
+			if !containsStringForTest(health.UnsupportedPermissions, "unsupported:host-hook") {
+				t.Fatalf("health = %+v, want unsupported permission", health)
+			}
+			if !containsStringForTest(health.UnresolvedSecretBindings, "github_token") {
+				t.Fatalf("health = %+v, want unresolved secret binding", health)
+			}
+			if !containsStringForTest(health.DisabledCapabilities, "issues") {
+				t.Fatalf("health = %+v, want disabled capability", health)
+			}
+
+			if _, err := store.Update(ctx, "missing", func(*Plugin) {}); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("Update missing err = %v, want ErrNotFound", err)
+			}
+			cleared, err := store.Clear(ctx)
+			if err != nil {
+				t.Fatalf("Clear: %v", err)
+			}
+			if cleared != 1 {
+				t.Fatalf("Clear deleted = %d, want 1", cleared)
+			}
+			items, err := store.List(ctx)
+			if err != nil {
+				t.Fatalf("List after clear: %v", err)
+			}
+			if len(items) != 0 {
+				t.Fatalf("items after clear = %+v, want none", items)
+			}
+		})
+	}
+}
+
+func TestPluginFromManifestRequiresSchemaVersion(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal(map[string]any{
+		"id":      "github",
+		"name":    "GitHub",
+		"version": "0.1.0",
+	})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if _, err := PluginFromManifest(raw, SourceLocalPath, ""); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("PluginFromManifest err = %v, want ErrInvalid", err)
+	}
+}
+
+func TestPluginRegistry_CommandCollisionHealth(t *testing.T) {
+	t.Parallel()
+	first := testPluginFromManifest(t, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"id":             "github",
+		"name":           "GitHub",
+		"version":        "0.1.0",
+		"capabilities": map[string]any{
+			"slash_commands": []map[string]any{{"name": "issue"}},
+		},
+	})
+	second := testPluginFromManifest(t, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"id":             "linear",
+		"name":           "Linear",
+		"version":        "0.1.0",
+		"capabilities": map[string]any{
+			"slash_commands": []map[string]any{{"name": "issue"}},
+		},
+	})
+	health := HealthFor(first, []Plugin{first, second})
+	if len(health.CommandCollisions) != 1 || health.CommandCollisions[0].Command != "issue" {
+		t.Fatalf("health = %+v, want issue collision", health)
+	}
+}
+
+func newSQLitePluginTestStore(t *testing.T) Store {
+	t.Helper()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "hecate.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("new sqlite client: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("close sqlite client: %v", err)
+		}
+	})
+	store, err := NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new sqlite plugin store: %v", err)
+	}
+	return store
+}
+
+func testPluginFromManifest(t *testing.T, manifest map[string]any) Plugin {
+	t.Helper()
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	plugin, err := PluginFromManifest(raw, SourceLocalPath, "/plugins/"+manifest["id"].(string)+"/plugin.json")
+	if err != nil {
+		t.Fatalf("PluginFromManifest: %v", err)
+	}
+	return plugin
+}
+
+func findCapabilityForTest(items []Capability, id string) Capability {
+	for _, item := range items {
+		if item.ID == id {
+			return item
+		}
+	}
+	return Capability{}
+}
+
+func containsStringForTest(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pluginregistryapp/application.go
+++ b/internal/pluginregistryapp/application.go
@@ -1,0 +1,120 @@
+package pluginregistryapp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/pluginregistry"
+)
+
+type Store interface {
+	Backend() string
+	List(ctx context.Context) ([]pluginregistry.Plugin, error)
+	Get(ctx context.Context, id string) (pluginregistry.Plugin, bool, error)
+	Upsert(ctx context.Context, plugin pluginregistry.Plugin) (pluginregistry.Plugin, error)
+	Update(ctx context.Context, id string, update func(*pluginregistry.Plugin)) (pluginregistry.Plugin, error)
+	Clear(ctx context.Context) (int, error)
+}
+
+type Options struct {
+	Store Store
+}
+
+type Application struct {
+	store Store
+}
+
+func New(options Options) *Application {
+	return &Application{store: options.Store}
+}
+
+type InstallLocalCommand struct {
+	Manifest  json.RawMessage
+	SourceRef string
+}
+
+type UpdateCommand struct {
+	Enabled      *bool
+	Capabilities map[string]CapabilityUpdate
+}
+
+type CapabilityUpdate struct {
+	Enabled *bool
+}
+
+func (app *Application) List(ctx context.Context) ([]pluginregistry.Plugin, error) {
+	if app == nil || app.store == nil {
+		return nil, nil
+	}
+	return app.store.List(ctx)
+}
+
+func (app *Application) Get(ctx context.Context, id string) (pluginregistry.Plugin, bool, error) {
+	if app == nil || app.store == nil {
+		return pluginregistry.Plugin{}, false, nil
+	}
+	return app.store.Get(ctx, id)
+}
+
+func (app *Application) InstallLocal(ctx context.Context, cmd InstallLocalCommand) (pluginregistry.Plugin, error) {
+	if app == nil || app.store == nil {
+		return pluginregistry.Plugin{}, pluginregistry.ErrInvalid
+	}
+	plugin, err := pluginregistry.PluginFromManifest(cmd.Manifest, pluginregistry.SourceLocalPath, strings.TrimSpace(cmd.SourceRef))
+	if err != nil {
+		return pluginregistry.Plugin{}, err
+	}
+	return app.store.Upsert(ctx, plugin)
+}
+
+func (app *Application) Update(ctx context.Context, id string, cmd UpdateCommand) (pluginregistry.Plugin, error) {
+	if app == nil || app.store == nil {
+		return pluginregistry.Plugin{}, pluginregistry.ErrInvalid
+	}
+	if len(cmd.Capabilities) > 0 {
+		plugin, ok, err := app.store.Get(ctx, id)
+		if err != nil {
+			return pluginregistry.Plugin{}, err
+		}
+		if !ok {
+			return pluginregistry.Plugin{}, pluginregistry.ErrNotFound
+		}
+		known := make(map[string]bool, len(plugin.Capabilities))
+		for _, capability := range plugin.Capabilities {
+			known[capability.ID] = true
+		}
+		for capabilityID := range cmd.Capabilities {
+			if !known[capabilityID] {
+				return pluginregistry.Plugin{}, pluginregistry.ErrInvalid
+			}
+		}
+	}
+	return app.store.Update(ctx, id, func(plugin *pluginregistry.Plugin) {
+		if cmd.Enabled != nil {
+			plugin.Enabled = *cmd.Enabled
+		}
+		if len(cmd.Capabilities) > 0 {
+			for idx := range plugin.Capabilities {
+				if patch, ok := cmd.Capabilities[plugin.Capabilities[idx].ID]; ok && patch.Enabled != nil {
+					plugin.Capabilities[idx].Enabled = *patch.Enabled
+				}
+			}
+		}
+	})
+}
+
+func (app *Application) Health(ctx context.Context, id string) (pluginregistry.Health, bool, error) {
+	if app == nil || app.store == nil {
+		return pluginregistry.Health{}, false, nil
+	}
+	plugin, ok, err := app.store.Get(ctx, id)
+	if err != nil || !ok {
+		return pluginregistry.Health{}, ok, err
+	}
+	all, err := app.store.List(ctx)
+	if err != nil {
+		return pluginregistry.Health{}, false, err
+	}
+	return pluginregistry.HealthFor(plugin, all), true, nil
+}

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resetSystemData } from "../../lib/api";
+import { getPlugins, resetSystemData } from "../../lib/api";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { SettingsView } from "./SettingsView";
 import {
@@ -13,6 +13,7 @@ import { withRuntimeConsole } from "../../test/runtime-console-render";
 
 vi.mock("../../lib/api", async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
+  getPlugins: vi.fn(),
   resetSystemData: vi.fn(),
 }));
 
@@ -24,6 +25,8 @@ function setup(stateOverrides = {}, actionOverrides = {}) {
 }
 
 beforeEach(() => {
+  vi.mocked(getPlugins).mockReset();
+  vi.mocked(getPlugins).mockResolvedValue({ object: "plugins", data: [] });
   vi.mocked(resetSystemData).mockReset();
   sessionStorage.removeItem("hecate.settingsFocus");
   sessionStorage.removeItem("hecate.connectionsFocus");
@@ -61,6 +64,54 @@ describe("SettingsView", () => {
     const { state, actions } = setup({}, { loadRetentionRuns });
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
     expect(loadRetentionRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders plugin registry records for operator inspection", async () => {
+    vi.mocked(getPlugins).mockResolvedValue({
+      object: "plugins",
+      data: [
+        {
+          id: "github",
+          name: "GitHub",
+          description: "Read and link GitHub work.",
+          version: "0.1.0",
+          source_kind: "local_path",
+          source_ref: "/plugins/github/plugin.json",
+          manifest_schema_version: "hecate.plugin.v0",
+          manifest_digest: "sha256:abc",
+          requested_permissions: [{ value: "network:github.com", classification: "advisory" }],
+          registry_state: "valid",
+          enabled: false,
+          warnings: [],
+          capabilities: [
+            {
+              id: "issues",
+              kind: "connector",
+              display_name: "Issues",
+              requested_permissions: [{ value: "secret:github_token", classification: "advisory" }],
+              enabled: true,
+            },
+          ],
+          auth: [
+            {
+              capability_id: "issues",
+              requested_name: "github_token",
+              kind: "token",
+              status: "unknown",
+            },
+          ],
+          installed_at: "2026-06-18T10:00:00Z",
+          updated_at: "2026-06-18T10:00:00Z",
+        },
+      ],
+    });
+    const { state, actions } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(await screen.findByText("GitHub")).toBeTruthy();
+    expect(screen.getByText("github@0.1.0")).toBeTruthy();
+    expect(screen.getByText(/1 capabilities/i)).toBeTruthy();
+    expect(screen.getByText(/Unresolved auth: github_token/i)).toBeTruthy();
   });
 });
 
@@ -131,6 +182,7 @@ describe("SettingsView maintenance cleanup", () => {
       object: "system_reset",
       data: {
         projects_deleted: 1,
+        plugins_deleted: 1,
         chat_sessions_deleted: 2,
         tasks_deleted: 1,
         providers_deleted: 1,

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -3,7 +3,8 @@ import { useRetention, type RetentionState } from "../../app/state/retention";
 import { useRetentionActions } from "../../app/state/coordinators/retention";
 import { useWiredDashboardActions } from "../../app/state/coordinators/wired";
 import { useSettings } from "../../app/state/settings";
-import { resetSystemData } from "../../lib/api";
+import { getPlugins, resetSystemData } from "../../lib/api";
+import type { PluginRecord } from "../../types/plugin";
 import { Badge, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
 
 export function SettingsView() {
@@ -20,6 +21,9 @@ export function SettingsView() {
   const [resetConfirmation, setResetConfirmation] = useState("");
   const [resetPending, setResetPending] = useState(false);
   const [resetError, setResetError] = useState("");
+  const [plugins, setPlugins] = useState<PluginRecord[]>([]);
+  const [pluginsLoading, setPluginsLoading] = useState(false);
+  const [pluginsError, setPluginsError] = useState("");
   // Retention runs aren't in the boot-time dashboard snapshot —
   // fetch on first SettingsView mount so the user doesn't see a
   // permanently empty list. `loadRuns` is a stable useCallback, so
@@ -31,6 +35,24 @@ export function SettingsView() {
     didFetchRetentionRunsRef.current = true;
     void loadRetentionRuns();
   }, [loadRetentionRuns]);
+
+  useEffect(() => {
+    void loadPlugins();
+  }, []);
+
+  async function loadPlugins() {
+    setPluginsLoading(true);
+    setPluginsError("");
+    try {
+      const response = await getPlugins();
+      setPlugins(response.data ?? []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load plugins.";
+      setPluginsError(message);
+    } finally {
+      setPluginsLoading(false);
+    }
+  }
 
   async function handleResetData() {
     if (resetConfirmation !== "RESET") return;
@@ -58,6 +80,12 @@ export function SettingsView() {
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <div style={{ flex: 1, overflowY: "auto", padding: 16 }}>
+        <PluginRegistrySettings
+          error={pluginsError}
+          loading={pluginsLoading}
+          plugins={plugins}
+          onRefresh={() => void loadPlugins()}
+        />
         <RetentionSettings
           storageBackend={storageBackend}
           state={retention.state}
@@ -117,6 +145,7 @@ export function SettingsView() {
 
 function resetSummary(data: {
   projects_deleted: number;
+  plugins_deleted?: number;
   chat_sessions_deleted: number;
   tasks_deleted: number;
   providers_deleted: number;
@@ -126,6 +155,7 @@ function resetSummary(data: {
 }): string {
   const total =
     data.projects_deleted +
+    (data.plugins_deleted ?? 0) +
     data.chat_sessions_deleted +
     data.tasks_deleted +
     data.providers_deleted +
@@ -217,6 +247,147 @@ const RETENTION_SUBSYSTEMS = [
     description: "Resolved approval prompts. Durable grants are kept.",
   },
 ] as const;
+
+function PluginRegistrySettings({
+  error,
+  loading,
+  onRefresh,
+  plugins,
+}: {
+  error: string;
+  loading: boolean;
+  onRefresh: () => void;
+  plugins: PluginRecord[];
+}) {
+  const capabilityCount = plugins.reduce(
+    (sum, plugin) => sum + (plugin.capabilities?.length ?? 0),
+    0,
+  );
+  return (
+    <section style={{ marginBottom: 20 }}>
+      <SectionHeader
+        title="Plugins"
+        description="Installed plugin manifests and requested capabilities. Registry entries do not run code or mount tools yet."
+        meta={`${plugins.length} plugin${plugins.length === 1 ? "" : "s"} · ${capabilityCount} cap${capabilityCount === 1 ? "" : "s"}`}
+        actions={
+          <button className="btn btn-ghost btn-sm" disabled={loading} onClick={onRefresh}>
+            <Icon d={Icons.refresh} size={13} /> {loading ? "Loading…" : "Refresh"}
+          </button>
+        }
+      />
+      {error && <InlineError message={error} />}
+      {!error && plugins.length === 0 && !loading && (
+        <div className="card" style={{ padding: "14px 16px", color: "var(--t3)", fontSize: 12 }}>
+          No plugins installed.
+        </div>
+      )}
+      {plugins.length > 0 && (
+        <div style={{ display: "grid", gap: 10 }}>
+          {plugins.map((plugin) => (
+            <PluginRegistryRow key={plugin.id} plugin={plugin} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PluginRegistryRow({ plugin }: { plugin: PluginRecord }) {
+  const capabilities = plugin.capabilities ?? [];
+  const permissions = [
+    ...(plugin.requested_permissions ?? []),
+    ...capabilities.flatMap((capability) => capability.requested_permissions ?? []),
+  ];
+  const unsupported = permissions.filter(
+    (permission) => permission.classification === "unsupported",
+  );
+  const auth = plugin.auth ?? [];
+  const unresolvedAuth = auth.filter((binding) => binding.status !== "configured");
+  return (
+    <article className="card" style={{ padding: "14px 16px" }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: "var(--t0)" }}>{plugin.name}</div>
+            <span style={{ fontSize: 11, color: "var(--t3)", fontFamily: "var(--font-mono)" }}>
+              {plugin.id}@{plugin.version}
+            </span>
+            <Badge status={plugin.enabled ? "enabled" : "disabled"} />
+            <Badge
+              status={plugin.registry_state === "valid" ? "ok" : "warn"}
+              label={plugin.registry_state}
+            />
+          </div>
+          {plugin.description && (
+            <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.45, marginTop: 6 }}>
+              {plugin.description}
+            </div>
+          )}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 8,
+              marginTop: 10,
+              fontSize: 11,
+              color: "var(--t3)",
+            }}
+          >
+            <span>{sourceLabel(plugin)}</span>
+            <span>{capabilities.length} capabilities</span>
+            <span>{permissions.length} permissions</span>
+            <span>{auth.length} auth requests</span>
+          </div>
+        </div>
+      </div>
+      {capabilities.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 12 }}>
+          {capabilities.map((capability) => (
+            <span
+              key={capability.id}
+              className="badge badge-muted"
+              title={capability.id}
+              style={{ textTransform: "none" }}
+            >
+              {pluginCapabilityKindLabel(capability.kind)} ·{" "}
+              {capability.display_name || capability.id}
+            </span>
+          ))}
+        </div>
+      )}
+      {(unsupported.length > 0 ||
+        unresolvedAuth.length > 0 ||
+        (plugin.warnings?.length ?? 0) > 0) && (
+        <div style={{ display: "grid", gap: 4, marginTop: 12, fontSize: 11, color: "var(--t3)" }}>
+          {unsupported.length > 0 && (
+            <div>
+              Unsupported permissions:{" "}
+              {unsupported.map((permission) => permission.value).join(", ")}
+            </div>
+          )}
+          {unresolvedAuth.length > 0 && (
+            <div>
+              Unresolved auth: {unresolvedAuth.map((binding) => binding.requested_name).join(", ")}
+            </div>
+          )}
+          {plugin.warnings?.map((warning) => (
+            <div key={warning}>{warning}</div>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function sourceLabel(plugin: PluginRecord) {
+  const kind = plugin.source_kind.replaceAll("_", " ");
+  if (!plugin.source_ref) return kind;
+  return `${kind}: ${plugin.source_ref}`;
+}
+
+function pluginCapabilityKindLabel(kind: string) {
+  return kind.replaceAll("_", " ");
+}
 
 type RetentionSubsystemID = (typeof RETENTION_SUBSYSTEMS)[number]["id"];
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -57,6 +57,13 @@ import type { TraceListResponse, TraceResponse } from "../types/trace";
 import type { UsageEventsResponse, UsageSummaryResponse } from "../types/usage";
 import type { RetentionRunResponse, RetentionRunsResponse } from "../types/retention";
 import type {
+  InstallLocalPluginPayload,
+  PluginHealthResponse,
+  PluginResponse,
+  PluginsResponse,
+  UpdatePluginPayload,
+} from "../types/plugin";
+import type {
   CreateProjectPayload,
   CreateProjectCollaborationArtifactPayload,
   CreateProjectWorktreeRootPayload,
@@ -302,6 +309,39 @@ export async function resetSystemData(): Promise<SystemResetDataResponse> {
   return fetchJSON<SystemResetDataResponse>(`${HECATE_API}/system/reset-data`, {
     method: "POST",
   });
+}
+
+export async function getPlugins(): Promise<PluginsResponse> {
+  return fetchJSON<PluginsResponse>(`${HECATE_API}/plugins`);
+}
+
+export async function getPlugin(pluginID: string): Promise<PluginResponse> {
+  return fetchJSON<PluginResponse>(`${HECATE_API}/plugins/${encodeURIComponent(pluginID)}`);
+}
+
+export async function installLocalPlugin(
+  payload: InstallLocalPluginPayload,
+): Promise<PluginResponse> {
+  return fetchJSON<PluginResponse>(`${HECATE_API}/plugins/install-local`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function updatePlugin(
+  pluginID: string,
+  payload: UpdatePluginPayload,
+): Promise<PluginResponse> {
+  return fetchJSON<PluginResponse>(`${HECATE_API}/plugins/${encodeURIComponent(pluginID)}`, {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export async function getPluginHealth(pluginID: string): Promise<PluginHealthResponse> {
+  return fetchJSON<PluginHealthResponse>(
+    `${HECATE_API}/plugins/${encodeURIComponent(pluginID)}/health`,
+  );
 }
 
 export async function getProviderPresets(): Promise<ProviderPresetResponse> {

--- a/ui/src/types/plugin.ts
+++ b/ui/src/types/plugin.ts
@@ -1,0 +1,76 @@
+export type PluginPermissionRecord = {
+  value: string;
+  classification: "advisory" | "enforced" | "unsupported" | string;
+};
+
+export type PluginCapabilityRecord = {
+  id: string;
+  kind: string;
+  display_name: string;
+  requested_permissions?: PluginPermissionRecord[];
+  enabled: boolean;
+  warnings?: string[];
+};
+
+export type PluginAuthBindingRecord = {
+  capability_id?: string;
+  requested_name: string;
+  kind: string;
+  status: "unknown" | "configured" | "expired" | "error" | string;
+  secret_ref?: string;
+  warnings?: string[];
+};
+
+export type PluginRecord = {
+  id: string;
+  name: string;
+  description?: string;
+  version: string;
+  source_kind: string;
+  source_ref?: string;
+  manifest_schema_version: string;
+  manifest_digest: string;
+  requested_permissions?: PluginPermissionRecord[];
+  registry_state: "valid" | "invalid" | "unsupported" | string;
+  enabled: boolean;
+  warnings?: string[];
+  capabilities?: PluginCapabilityRecord[];
+  auth?: PluginAuthBindingRecord[];
+  installed_at: string;
+  updated_at: string;
+};
+
+export type PluginsResponse = {
+  object: string;
+  data: PluginRecord[];
+};
+
+export type PluginResponse = {
+  object: string;
+  data: PluginRecord;
+};
+
+export type InstallLocalPluginPayload = {
+  manifest: unknown;
+  source_ref?: string;
+};
+
+export type UpdatePluginPayload = {
+  enabled?: boolean;
+  capabilities?: Record<string, { enabled?: boolean }>;
+};
+
+export type PluginHealthRecord = {
+  plugin_id: string;
+  registry_state: string;
+  warnings?: string[];
+  unsupported_permissions?: string[];
+  unresolved_secret_bindings?: string[];
+  disabled_capabilities?: string[];
+  command_collisions?: Array<{ command: string; plugin_ids: string[] }>;
+};
+
+export type PluginHealthResponse = {
+  object: string;
+  data: PluginHealthRecord;
+};

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -116,6 +116,10 @@ export type SystemResetDataResponse = {
   object: string;
   data: {
     projects_deleted: number;
+    project_skills_deleted?: number;
+    project_work_rows_deleted?: number;
+    plugins_deleted?: number;
+    agent_profiles_deleted?: number;
     chat_sessions_deleted: number;
     tasks_deleted: number;
     providers_deleted: number;


### PR DESCRIPTION
## Summary
- add a registry-only plugin domain with memory/SQLite/Postgres-backed storage for raw manifests, normalized capabilities, requested permissions, and auth-binding metadata
- add local-only plugin registry APIs plus system reset cleanup and Settings UI inspection
- document the registry-only boundary: no plugin code execution, no path install reads, no MCP server launch, no tool mounting, no secret grants, and no connector network calls

## Tests
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-registry/.gocache go test ./internal/pluginregistry ./internal/pluginregistryapp ./internal/api -run 'TestPluginRegistry|TestSystemResetData|TestRemoteRuntime|TestRegisteredHecateRoutes'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-registry/.gocache go vet ./...`
- `/bin/zsh -lc "GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-registry/.gocache go test -race -timeout 10m ./..."`
- `cd ui && bun run test`
- `cd ui && bun run test -- src/features/settings/SettingsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run format:check`

## Self-review
- Confirmed plugin routes are remote-runtime local-only and covered by route classification tests.
- Confirmed manifest install records JSON supplied by the caller and does not read arbitrary paths or execute lifecycle hooks.
- Confirmed manifest-provided `secret_ref` values are ignored so auth bindings stay unresolved until a future explicit operator binding step.
- Confirmed registry enablement is metadata only; it does not grant network, secrets, tools, UI execution, MCP processes, or connector calls.

## Docs
- Updated runtime API, security, known limitations, and plugin architecture proposal docs for the shipped registry-only slice.
