### PR TITLE
Add plugin MCP server capability metadata

### DIFF
--- a/docs/design/proposals/plugin-architecture.md
+++ b/docs/design/proposals/plugin-architecture.md
@@ -215,6 +215,12 @@ ways:
 - Expose as a connector-backed resource/tool surface in Hecate UI after an
   operator enables it.
 
+The registry slice validates MCP server declarations and projects them as
+mount candidates. Installing a plugin still does not start the declared server,
+mount it into a task/chat/profile, or grant credentials. Env/header values in
+manifests are `$VAR_NAME` references only; secret binding and literal secret
+storage stay Hecate-owned.
+
 MCP tool descriptions and metadata must be treated as external input. Hecate
 should preserve MCP annotations, but approval policy remains Hecate-owned:
 read-only hints can improve UX, while writes/destructive operations still need
@@ -519,8 +525,8 @@ wait until the registry and permission model are in place.
    Add memory/sqlite/postgres stores, API, and a read-only UI list. No network
    calls, no execution.
 3. **MCP-backed plugin capability**
-   Let a plugin declare MCP server configs that can be mounted into profiles or
-   task/chat starts.
+   Landed as validated mount-candidate metadata in the plugin registry. Follow-up
+   work should add explicit operator pickers for profiles and task/chat starts.
 4. **GitHub plugin v0**
    Start with read/search/link external refs and evidence links.
 5. **Linear plugin v0**

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -82,11 +82,12 @@ shipping `v0.1.0-alpha.N` releases from reviewed PRs merged into `master`.
   per-tool `agent_loop` gating (`read_file`, `all_tools`). Unknown policy names
   are rejected at startup. The per-MCP-server `approval_policy` axis
   (`auto` / `require_approval` / `block`) is separate.
-- Hecate has a registry-only plugin metadata slice for native manifests, but it
-  does not execute plugin code, start plugin-declared MCP servers, mount plugin
-  tools, grant plugin secrets, or call connector APIs yet. Browser automation,
-  WASM plugins, arbitrary plugin hooks, and broad tool marketplaces remain out
-  of scope for the current alpha. Design notes live in
+- Hecate has a registry-only plugin metadata slice for native manifests. It can
+  validate and show plugin-declared MCP server mount candidates, but it does not
+  execute plugin code, start plugin-declared MCP servers, mount plugin tools,
+  grant plugin secrets, or call connector APIs yet. Browser automation, WASM
+  plugins, arbitrary plugin hooks, and broad tool marketplaces remain out of
+  scope for the current alpha. Design notes live in
   `docs/design/proposals/plugin-architecture.md`.
 
 ## Hecate Chat

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -23,7 +23,11 @@ Hecate assumes the operator trusts their own machine, local user account, and se
   and keeps the runtime home/XDG directories on its persistent volume.
   The runtime secret is not public auth; keep the runtime network-private.
 - Do not put local-only endpoints such as workspace folder selection, "open in editor", local provider discovery, MCP registry discovery, MCP probe, reset-data, or shutdown behind a forwarding proxy. Those endpoints reject non-loopback sockets and `X-Forwarded-For` / `X-Real-IP` headers because they can inspect host-local state, open local OS UI, spawn diagnostic subprocesses, or mutate local operator state.
-- Plugin registry APIs are also blocked in remote-runtime mode. In the first registry-only slice, plugin rows are metadata for operator review: installing a manifest records requested capabilities, permissions, and auth bindings, but does not execute plugin code, start plugin-declared MCP servers, mount tools, grant secrets, or make connector network calls.
+- Plugin registry APIs are also blocked in remote-runtime mode. Plugin rows are
+  metadata for operator review: installing a manifest records requested
+  capabilities, permissions, auth bindings, and validated MCP-server mount
+  candidates, but does not execute plugin code, start plugin-declared MCP
+  servers, mount tools, grant secrets, or make connector network calls.
 - Do not run Hecate on a shared host where untrusted local users can access the gateway port or data directory.
 
 ## Runtime boundaries

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1244,8 +1244,9 @@ Status codes:
 
 The plugin registry is a local catalog and policy-review surface. Registry rows
 store a raw Hecate-native manifest plus normalized capabilities, requested
-permissions, and auth-binding requests. They do not run plugin code, start MCP
-servers, mount tools, call external providers, or grant secrets.
+permissions, auth-binding requests, and validated MCP-server mount candidates.
+They do not run plugin code, start MCP servers, mount tools, call external
+providers, or grant secrets.
 `manifest_digest` is a SHA-256 digest of Hecate's canonicalized manifest JSON,
 so semantically equivalent manifests share the same digest even when caller
 formatting differs.
@@ -1281,11 +1282,31 @@ POST /hecate/v1/plugins/install-local
           "auth": [{ "name": "github_token", "kind": "token" }]
         }
       ],
+      "mcp_servers": [
+        {
+          "id": "github-mcp",
+          "name": "github",
+          "display_name": "GitHub MCP",
+          "transport": "stdio",
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-github"],
+          "env": { "GITHUB_TOKEN": "$GITHUB_TOKEN" },
+          "approval_policy": "require_approval"
+        }
+      ],
       "slash_commands": [{ "name": "github" }]
     }
   }
 }
 ```
+
+MCP server capabilities may use the inline shape above or place the same fields
+inside `config`. The registry normalizes either shape into an `mcp_server`
+response object. Exactly one of `command` or `url` must be set; `transport`, if
+present, must match (`stdio` for `command`, `http` for `url`). `env` and
+`headers` values must be whole `$VAR_NAME` references. Literal values and
+manifest-provided encrypted blobs are rejected so plugin registry records do
+not become a credential store.
 
 ```json
 → 200
@@ -1311,6 +1332,20 @@ POST /hecate/v1/plugins/install-local
         "kind": "connector",
         "display_name": "Issues",
         "enabled": true
+      },
+      {
+        "id": "github-mcp",
+        "kind": "mcp_server",
+        "display_name": "GitHub MCP",
+        "enabled": true,
+        "mcp_server": {
+          "name": "github",
+          "transport": "stdio",
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-github"],
+          "env": { "GITHUB_TOKEN": "$GITHUB_TOKEN" },
+          "approval_policy": "require_approval"
+        }
       },
       {
         "id": "github",

--- a/internal/api/handler_plugins.go
+++ b/internal/api/handler_plugins.go
@@ -176,10 +176,31 @@ func renderPluginCapabilities(items []pluginregistry.Capability) []PluginCapabil
 			DisplayName:          item.DisplayName,
 			RequestedPermissions: renderPluginPermissions(item.RequestedPermissions),
 			Enabled:              item.Enabled,
+			MCPServer:            renderPluginMCPServer(item),
 			Warnings:             item.Warnings,
 		})
 	}
 	return out
+}
+
+func renderPluginMCPServer(item pluginregistry.Capability) *PluginMCPServerRecord {
+	if item.Kind != pluginregistry.CapabilityMCPServer {
+		return nil
+	}
+	cfg, err := pluginregistry.ParseMCPServerConfig(item.ID, item.ConfigJSON)
+	if err != nil {
+		return nil
+	}
+	return &PluginMCPServerRecord{
+		Name:           cfg.Name,
+		Transport:      cfg.Transport,
+		Command:        cfg.Command,
+		Args:           append([]string(nil), cfg.Args...),
+		Env:            cloneStringMap(cfg.Env),
+		URL:            cfg.URL,
+		Headers:        cloneStringMap(cfg.Headers),
+		ApprovalPolicy: cfg.ApprovalPolicy,
+	}
 }
 
 func renderPluginPermissions(items []pluginregistry.Permission) []PluginPermissionRecord {

--- a/internal/api/handler_plugins_test.go
+++ b/internal/api/handler_plugins_test.go
@@ -32,6 +32,14 @@ func TestPluginRegistryAPI_InstallListPatchAndHealth(t *testing.T) {
 					"permissions":  []string{"secret:github_token"},
 					"auth":         []map[string]any{{"name": "github_token", "kind": "token"}},
 				}},
+				"mcp_servers": []map[string]any{{
+					"id":              "github",
+					"transport":       "stdio",
+					"command":         "npx",
+					"args":            []string{"-y", "@modelcontextprotocol/server-github"},
+					"env":             map[string]string{"GITHUB_TOKEN": "$GITHUB_TOKEN"},
+					"approval_policy": "require_approval",
+				}},
 			},
 		},
 	})))
@@ -45,8 +53,15 @@ func TestPluginRegistryAPI_InstallListPatchAndHealth(t *testing.T) {
 	if installed.Object != "plugin" || installed.Data.ID != "github" || installed.Data.Enabled {
 		t.Fatalf("installed = %+v, want disabled github plugin", installed)
 	}
-	if len(installed.Data.Capabilities) != 1 || len(installed.Data.Auth) != 1 {
+	if len(installed.Data.Capabilities) != 2 || len(installed.Data.Auth) != 1 {
 		t.Fatalf("installed data = %+v, want projected capabilities and auth", installed.Data)
+	}
+	mcpCapability := findPluginCapabilityForTest(installed.Data.Capabilities, "github")
+	if mcpCapability.MCPServer == nil || mcpCapability.MCPServer.Transport != "stdio" || mcpCapability.MCPServer.Command != "npx" {
+		t.Fatalf("mcp capability = %+v, want projected stdio server config", mcpCapability)
+	}
+	if mcpCapability.MCPServer.Env["GITHUB_TOKEN"] != "$GITHUB_TOKEN" || mcpCapability.MCPServer.ApprovalPolicy != "require_approval" {
+		t.Fatalf("mcp capability = %+v, want env refs and approval policy", mcpCapability)
 	}
 
 	patchRec := httptest.NewRecorder()
@@ -148,6 +163,32 @@ func TestPluginRegistryAPI_RejectsDuplicateCapabilityIDsAsInvalidRequest(t *test
 	}
 }
 
+func TestPluginRegistryAPI_RejectsUnsafeMCPServerConfig(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/plugins/install-local", pluginAPITestJSONBody(t, map[string]any{
+		"manifest": map[string]any{
+			"schema_version": "hecate.plugin.v0",
+			"id":             "github",
+			"name":           "GitHub",
+			"version":        "0.1.0",
+			"capabilities": map[string]any{
+				"mcp_servers": []map[string]any{{
+					"id":      "github",
+					"command": "npx",
+					"env":     map[string]string{"GITHUB_TOKEN": "literal-token"},
+				}},
+			},
+		},
+	})))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400 for unsafe MCP server config", rec.Code, rec.Body.String())
+	}
+}
+
 func pluginAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {
 	t.Helper()
 	raw, err := json.Marshal(payload)
@@ -155,4 +196,13 @@ func pluginAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {
 		t.Fatalf("marshal payload: %v", err)
 	}
 	return bytes.NewReader(raw)
+}
+
+func findPluginCapabilityForTest(items []PluginCapabilityRecord, id string) PluginCapabilityRecord {
+	for _, item := range items {
+		if item.ID == id {
+			return item
+		}
+	}
+	return PluginCapabilityRecord{}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -454,7 +454,19 @@ type PluginCapabilityRecord struct {
 	DisplayName          string                   `json:"display_name"`
 	RequestedPermissions []PluginPermissionRecord `json:"requested_permissions,omitempty"`
 	Enabled              bool                     `json:"enabled"`
+	MCPServer            *PluginMCPServerRecord   `json:"mcp_server,omitempty"`
 	Warnings             []string                 `json:"warnings,omitempty"`
+}
+
+type PluginMCPServerRecord struct {
+	Name           string            `json:"name"`
+	Transport      string            `json:"transport"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	ApprovalPolicy string            `json:"approval_policy,omitempty"`
 }
 
 type PluginPermissionRecord struct {

--- a/internal/pluginregistry/manifest.go
+++ b/internal/pluginregistry/manifest.go
@@ -18,14 +18,21 @@ type Manifest struct {
 }
 
 type manifestCapability struct {
-	ID          string          `json:"id"`
-	Name        string          `json:"name"`
-	Kind        string          `json:"kind"`
-	DisplayName string          `json:"display_name"`
-	Permissions []string        `json:"permissions"`
-	Enabled     *bool           `json:"enabled"`
-	Auth        []manifestAuth  `json:"auth"`
-	Config      json.RawMessage `json:"config"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Kind           string            `json:"kind"`
+	DisplayName    string            `json:"display_name"`
+	Permissions    []string          `json:"permissions"`
+	Enabled        *bool             `json:"enabled"`
+	Auth           []manifestAuth    `json:"auth"`
+	Config         json.RawMessage   `json:"config"`
+	Transport      string            `json:"transport"`
+	Command        string            `json:"command"`
+	Args           []string          `json:"args"`
+	Env            map[string]string `json:"env"`
+	URL            string            `json:"url"`
+	Headers        map[string]string `json:"headers"`
+	ApprovalPolicy string            `json:"approval_policy"`
 }
 
 type manifestAuth struct {
@@ -151,6 +158,13 @@ func capabilitiesFromManifest(items []manifestCapability, forcedKind string) ([]
 			Enabled:              enabled,
 			ConfigJSON:           item.Config,
 		}
+		if kind == CapabilityMCPServer {
+			configJSON, err := mcpServerConfigJSONFromManifest(id, item)
+			if err != nil {
+				return nil, nil, err
+			}
+			capability.ConfigJSON = configJSON
+		}
 		capability = NormalizeCapability("", capability)
 		if capability.ID == "" || capability.Kind == "" {
 			return nil, nil, ErrInvalid
@@ -161,6 +175,53 @@ func capabilitiesFromManifest(items []manifestCapability, forcedKind string) ([]
 		}
 	}
 	return capabilities, auth, nil
+}
+
+func mcpServerConfigJSONFromManifest(capabilityID string, item manifestCapability) (json.RawMessage, error) {
+	hasConfig := len(compactJSON(item.Config)) > 0
+	hasInline := hasInlineMCPServerConfig(item)
+	if hasConfig && hasInline {
+		return nil, ErrInvalid
+	}
+	if hasConfig {
+		return normalizeMCPServerConfigJSON(capabilityID, item.Config)
+	}
+	cfg := MCPServerConfig{
+		Name:           item.Name,
+		Transport:      item.Transport,
+		Command:        item.Command,
+		Args:           append([]string(nil), item.Args...),
+		Env:            cloneStringMap(item.Env),
+		URL:            item.URL,
+		Headers:        cloneStringMap(item.Headers),
+		ApprovalPolicy: item.ApprovalPolicy,
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, ErrInvalid
+	}
+	return normalizeMCPServerConfigJSON(capabilityID, raw)
+}
+
+func hasInlineMCPServerConfig(item manifestCapability) bool {
+	return strings.TrimSpace(item.Transport) != "" ||
+		strings.TrimSpace(item.Command) != "" ||
+		len(item.Args) > 0 ||
+		len(item.Env) > 0 ||
+		strings.TrimSpace(item.URL) != "" ||
+		len(item.Headers) > 0 ||
+		strings.TrimSpace(item.ApprovalPolicy) != ""
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for key, value := range items {
+		out[key] = value
+	}
+	return out
 }
 
 func authBindingFromManifest(capabilityID string, item manifestAuth) AuthBinding {

--- a/internal/pluginregistry/mcp.go
+++ b/internal/pluginregistry/mcp.go
@@ -1,0 +1,132 @@
+package pluginregistry
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	MCPServerTransportStdio = "stdio"
+	MCPServerTransportHTTP  = "http"
+)
+
+type MCPServerConfig struct {
+	Name           string            `json:"name"`
+	Transport      string            `json:"transport"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	ApprovalPolicy string            `json:"approval_policy,omitempty"`
+}
+
+func ParseMCPServerConfig(capabilityID string, raw json.RawMessage) (MCPServerConfig, error) {
+	return normalizeMCPServerConfig(capabilityID, raw)
+}
+
+func normalizeMCPServerConfigJSON(capabilityID string, raw json.RawMessage) (json.RawMessage, error) {
+	cfg, err := normalizeMCPServerConfig(capabilityID, raw)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, ErrInvalid
+	}
+	return out, nil
+}
+
+func normalizeMCPServerConfig(capabilityID string, raw json.RawMessage) (MCPServerConfig, error) {
+	raw = compactJSON(raw)
+	if len(raw) == 0 {
+		return MCPServerConfig{}, ErrInvalid
+	}
+	var cfg MCPServerConfig
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return MCPServerConfig{}, ErrInvalid
+	}
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	if cfg.Name == "" {
+		cfg.Name = normalizeID(capabilityID)
+	}
+	cfg.Transport = strings.TrimSpace(cfg.Transport)
+	cfg.Command = strings.TrimSpace(cfg.Command)
+	cfg.URL = strings.TrimSpace(cfg.URL)
+	cfg.ApprovalPolicy = strings.TrimSpace(cfg.ApprovalPolicy)
+	cfg.Args = append([]string(nil), cfg.Args...)
+	var err error
+	if cfg.Env, err = normalizeMCPRefMap(cfg.Env); err != nil {
+		return MCPServerConfig{}, err
+	}
+	if cfg.Headers, err = normalizeMCPRefMap(cfg.Headers); err != nil {
+		return MCPServerConfig{}, err
+	}
+	if cfg.Name == "" {
+		return MCPServerConfig{}, ErrInvalid
+	}
+	if cfg.Command != "" && cfg.URL != "" {
+		return MCPServerConfig{}, ErrInvalid
+	}
+	switch {
+	case cfg.Command != "":
+		if cfg.Transport == "" {
+			cfg.Transport = MCPServerTransportStdio
+		}
+		if cfg.Transport != MCPServerTransportStdio {
+			return MCPServerConfig{}, ErrInvalid
+		}
+	case cfg.URL != "":
+		if cfg.Transport == "" {
+			cfg.Transport = MCPServerTransportHTTP
+		}
+		if cfg.Transport != MCPServerTransportHTTP {
+			return MCPServerConfig{}, ErrInvalid
+		}
+	default:
+		return MCPServerConfig{}, ErrInvalid
+	}
+	if !types.IsValidMCPApprovalPolicy(cfg.ApprovalPolicy) {
+		return MCPServerConfig{}, ErrInvalid
+	}
+	return cfg, nil
+}
+
+func normalizeMCPRefMap(values map[string]string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || !isMCPEnvRef(value) {
+			return nil, ErrInvalid
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func isMCPEnvRef(value string) bool {
+	if len(value) < 2 || value[0] != '$' {
+		return false
+	}
+	for i, c := range value[1:] {
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c == '_':
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pluginregistry/store.go
+++ b/internal/pluginregistry/store.go
@@ -349,6 +349,11 @@ func ValidatePlugin(plugin Plugin) error {
 		if !oneOf(capability.Kind, CapabilityConnector, CapabilityMCPServer, CapabilitySkill, CapabilitySlashCommand, CapabilityProjectMapper, CapabilityEvidenceProvider, CapabilityUISurface) {
 			return ErrInvalid
 		}
+		if capability.Kind == CapabilityMCPServer {
+			if _, err := ParseMCPServerConfig(capability.ID, capability.ConfigJSON); err != nil {
+				return err
+			}
+		}
 		if !validPermissionClassifications(capability.RequestedPermissions) {
 			return ErrInvalid
 		}

--- a/internal/pluginregistry/store_test.go
+++ b/internal/pluginregistry/store_test.go
@@ -41,6 +41,14 @@ func TestStoreConformance_PluginRegistryLifecycle(t *testing.T) {
 							"secret_ref": "secret:from-manifest",
 						}},
 					}},
+					"mcp_servers": []map[string]any{{
+						"id":              "github-mcp",
+						"transport":       "stdio",
+						"command":         "npx",
+						"args":            []string{"-y", "@modelcontextprotocol/server-github"},
+						"env":             map[string]string{"GITHUB_TOKEN": "$GITHUB_TOKEN"},
+						"approval_policy": "require_approval",
+					}},
 					"slash_commands": []map[string]any{{
 						"name":         "github",
 						"display_name": "/github",
@@ -55,8 +63,15 @@ func TestStoreConformance_PluginRegistryLifecycle(t *testing.T) {
 			if stored.ID != "github" || stored.Enabled {
 				t.Fatalf("stored plugin = %+v, want normalized disabled plugin", stored)
 			}
-			if len(stored.Capabilities) != 2 || len(stored.Auth) != 1 {
+			if len(stored.Capabilities) != 3 || len(stored.Auth) != 1 {
 				t.Fatalf("stored plugin = %+v, want capabilities and auth projection", stored)
+			}
+			mcpConfig, err := ParseMCPServerConfig("github-mcp", findCapabilityForTest(stored.Capabilities, "github-mcp").ConfigJSON)
+			if err != nil {
+				t.Fatalf("ParseMCPServerConfig: %v", err)
+			}
+			if mcpConfig.Transport != MCPServerTransportStdio || mcpConfig.Command != "npx" || mcpConfig.Env["GITHUB_TOKEN"] != "$GITHUB_TOKEN" {
+				t.Fatalf("mcp config = %+v, want normalized stdio github server", mcpConfig)
 			}
 			if stored.Auth[0].SecretRef != "" || stored.Auth[0].Status != AuthStatusUnknown {
 				t.Fatalf("stored auth = %+v, want manifest secret_ref ignored", stored.Auth[0])
@@ -124,6 +139,110 @@ func TestPluginFromManifestRequiresSchemaVersion(t *testing.T) {
 	}
 	if _, err := PluginFromManifest(raw, SourceLocalPath, ""); !errors.Is(err, ErrInvalid) {
 		t.Fatalf("PluginFromManifest err = %v, want ErrInvalid", err)
+	}
+}
+
+func TestPluginFromManifest_MCPServerConfigObjectNormalizes(t *testing.T) {
+	t.Parallel()
+	plugin := testPluginFromManifest(t, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"id":             "linear",
+		"name":           "Linear",
+		"version":        "0.1.0",
+		"capabilities": map[string]any{
+			"mcp_servers": []map[string]any{{
+				"id": "linear-mcp",
+				"config": map[string]any{
+					"name":            "linear",
+					"url":             "https://linear.example/mcp",
+					"headers":         map[string]string{"Authorization": "$LINEAR_AUTHORIZATION"},
+					"approval_policy": "block",
+				},
+			}},
+		},
+	})
+	capability := findCapabilityForTest(plugin.Capabilities, "linear-mcp")
+	cfg, err := ParseMCPServerConfig(capability.ID, capability.ConfigJSON)
+	if err != nil {
+		t.Fatalf("ParseMCPServerConfig: %v", err)
+	}
+	if cfg.Name != "linear" || cfg.Transport != MCPServerTransportHTTP || cfg.URL != "https://linear.example/mcp" {
+		t.Fatalf("mcp config = %+v, want normalized http config object", cfg)
+	}
+	if cfg.Headers["Authorization"] != "$LINEAR_AUTHORIZATION" || cfg.ApprovalPolicy != "block" {
+		t.Fatalf("mcp config = %+v, want header ref and block policy", cfg)
+	}
+}
+
+func TestPluginFromManifest_MCPServerConfigValidation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		server map[string]any
+	}{
+		{
+			name:   "missing transport target",
+			server: map[string]any{"id": "github"},
+		},
+		{
+			name: "command and url",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"url":     "https://example.test/mcp",
+			},
+		},
+		{
+			name: "literal env value",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"env":     map[string]string{"GITHUB_TOKEN": "literal-token"},
+			},
+		},
+		{
+			name: "encrypted env value",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"env":     map[string]string{"GITHUB_TOKEN": "enc:token"},
+			},
+		},
+		{
+			name: "invalid approval",
+			server: map[string]any{
+				"id":              "github",
+				"command":         "npx",
+				"approval_policy": "trust_me",
+			},
+		},
+		{
+			name: "mixed inline and config shapes",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"config":  map[string]any{"command": "npx"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			raw, err := json.Marshal(map[string]any{
+				"schema_version": ManifestSchemaVersion,
+				"id":             "github",
+				"name":           "GitHub",
+				"version":        "0.1.0",
+				"capabilities": map[string]any{
+					"mcp_servers": []map[string]any{tc.server},
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal manifest: %v", err)
+			}
+			if _, err := PluginFromManifest(raw, SourceLocalPath, ""); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("PluginFromManifest err = %v, want ErrInvalid", err)
+			}
+		})
 	}
 }
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -91,6 +91,20 @@ describe("SettingsView", () => {
               requested_permissions: [{ value: "secret:github_token", classification: "advisory" }],
               enabled: true,
             },
+            {
+              id: "github",
+              kind: "mcp_server",
+              display_name: "GitHub MCP",
+              enabled: true,
+              mcp_server: {
+                name: "github",
+                transport: "stdio",
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-github"],
+                env: { GITHUB_TOKEN: "$GITHUB_TOKEN" },
+                approval_policy: "require_approval",
+              },
+            },
           ],
           auth: [
             {
@@ -110,7 +124,10 @@ describe("SettingsView", () => {
 
     expect(await screen.findByText("GitHub")).toBeTruthy();
     expect(screen.getByText("github@0.1.0")).toBeTruthy();
-    expect(screen.getByText(/1 capabilities/i)).toBeTruthy();
+    expect(screen.getByText(/2 capabilities/i)).toBeTruthy();
+    expect(
+      screen.getByText(/MCP github · stdio: npx -y @modelcontextprotocol\/server-github/i),
+    ).toBeTruthy();
     expect(screen.getByText(/Unresolved auth: github_token/i)).toBeTruthy();
   });
 });

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -341,18 +341,35 @@ function PluginRegistryRow({ plugin }: { plugin: PluginRecord }) {
         </div>
       </div>
       {capabilities.length > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 12 }}>
-          {capabilities.map((capability) => (
-            <span
-              key={capability.id}
-              className="badge badge-muted"
-              title={capability.id}
-              style={{ textTransform: "none" }}
-            >
-              {pluginCapabilityKindLabel(capability.kind)} ·{" "}
-              {capability.display_name || capability.id}
-            </span>
-          ))}
+        <div style={{ display: "grid", gap: 6, marginTop: 12 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {capabilities.map((capability) => (
+              <span
+                key={capability.id}
+                className="badge badge-muted"
+                title={capability.id}
+                style={{ textTransform: "none" }}
+              >
+                {pluginCapabilityKindLabel(capability.kind)} ·{" "}
+                {capability.display_name || capability.id}
+              </span>
+            ))}
+          </div>
+          {capabilities
+            .filter((capability) => capability.mcp_server)
+            .map((capability) => (
+              <div
+                key={`${capability.id}-mcp`}
+                style={{
+                  color: "var(--t3)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  lineHeight: 1.45,
+                }}
+              >
+                {pluginMCPServerSummary(capability.mcp_server!)}
+              </div>
+            ))}
         </div>
       )}
       {(unsupported.length > 0 ||
@@ -387,6 +404,23 @@ function sourceLabel(plugin: PluginRecord) {
 
 function pluginCapabilityKindLabel(kind: string) {
   return kind.replaceAll("_", " ");
+}
+
+function pluginMCPServerSummary(
+  server: NonNullable<PluginRecord["capabilities"]>[number]["mcp_server"],
+) {
+  if (!server) return "";
+  const route =
+    server.transport === "http"
+      ? server.url || "http"
+      : [server.command, ...(server.args ?? [])].filter(Boolean).join(" ");
+  const auth = [
+    ...Object.keys(server.env ?? {}).map((key) => `env:${key}`),
+    ...Object.keys(server.headers ?? {}).map((key) => `header:${key}`),
+  ];
+  const policy = server.approval_policy ? ` · approval ${server.approval_policy}` : "";
+  const refs = auth.length > 0 ? ` · refs ${auth.join(", ")}` : "";
+  return `MCP ${server.name} · ${server.transport}: ${route}${policy}${refs}`;
 }
 
 type RetentionSubsystemID = (typeof RETENTION_SUBSYSTEMS)[number]["id"];

--- a/ui/src/types/plugin.ts
+++ b/ui/src/types/plugin.ts
@@ -9,7 +9,19 @@ export type PluginCapabilityRecord = {
   display_name: string;
   requested_permissions?: PluginPermissionRecord[];
   enabled: boolean;
+  mcp_server?: PluginMCPServerRecord;
   warnings?: string[];
+};
+
+export type PluginMCPServerRecord = {
+  name: string;
+  transport: "stdio" | "http" | string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  approval_policy?: "auto" | "require_approval" | "block" | string;
 };
 
 export type PluginAuthBindingRecord = {


### PR DESCRIPTION
## Summary
- add typed validation/normalization for plugin-declared MCP server capabilities
- expose safe mount-candidate metadata on plugin capability API responses and Settings inspection
- document that plugin MCP declarations remain metadata only: no startup, mounting, connector calls, or secret grants

## Tests
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test ./internal/pluginregistry ./internal/api -run 'TestPlugin'
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test ./internal/pluginregistry ./internal/api
- go vet ./internal/pluginregistry ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test -race -timeout 10m ./...
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run test
- cd ui && bun run format:check
- cd ui && bun run lint
- git diff --check