### PR TITLE
Add built-in agent profile catalog

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -29,6 +29,9 @@ project skills registry exposes local `SKILL.md` metadata for roles/profiles
 without granting tools, injecting bodies, or executing skill scripts. The
 operator UI can manage agent profiles and pick registered project skills for
 roles/profiles; those selections remain metadata until launch-time resolution.
+Agent profile responses include immutable built-in profiles such as
+`implementation`, `planning`, and `review_qa`; those built-ins are selectable
+defaults, not persisted rows or operator-editable project memory.
 Project roots are concrete checkouts, not project identity: one project can span
 the main checkout and linked Git worktrees, while newly discovered worktree roots
 stay inactive until the operator enables them. Context discovery must not treat

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -391,11 +391,13 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
    task-backed turns.
 5. Thread project identity into chat context packets. Done for itemized project context-source metadata.
 6. Add project-scoped memory. Done.
-7. Add agent-profile memory-source selection.
+7. Add agent-profile memory-source selection. Done for profile memory/source
+   policy snapshots and bounded native-assignment prompt inclusion.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.
    Partial: provider, model, workspace mode, and agent profile defaults are
    project defaults; assignment starts resolve role/project/fallback profiles,
-   but profile-driven memory/source activation remains future.
+   including immutable built-in profile defaults. Host-specific source-document
+   prompt policy remains future work.
 9. Add project activity aggregation. Done for the read-only V1 inbox.
 10. Add structured handoffs. Done for memory + SQLite store parity, API, UI
     actions, and activity projection signals.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1998,16 +1998,16 @@ Role list responses merge built-in roles with project custom roles. Built-ins
 are listable but immutable and are not seeded as duplicate project rows. The
 built-in role ids and default profile mappings are:
 
-| Role id              | Default driver | Default profile             |
-| -------------------- | -------------- | --------------------------- |
-| `product_manager`    | `hecate_task`  | `planning`                  |
-| `architect`          | `hecate_task`  | `architecture`              |
-| `software_developer` | `hecate_task`  | `implementation`            |
-| `frontend_engineer`  | `hecate_task`  | `frontend_implementation`   |
-| `designer`           | `hecate_task`  | `design_review`             |
-| `sre`                | `hecate_task`  | `reliability_ops`           |
-| `tech_writer`        | `hecate_task`  | `documentation`             |
-| `reviewer_qa`        | `hecate_task`  | `review_qa`                 |
+| Role id              | Default driver | Default profile           |
+| -------------------- | -------------- | ------------------------- |
+| `product_manager`    | `hecate_task`  | `planning`                |
+| `architect`          | `hecate_task`  | `architecture`            |
+| `software_developer` | `hecate_task`  | `implementation`          |
+| `frontend_engineer`  | `hecate_task`  | `frontend_implementation` |
+| `designer`           | `hecate_task`  | `design_review`           |
+| `sre`                | `hecate_task`  | `reliability_ops`         |
+| `tech_writer`        | `hecate_task`  | `documentation`           |
+| `reviewer_qa`        | `hecate_task`  | `review_qa`               |
 
 Supported work-item statuses are `backlog`, `ready`, `running`, `review`,
 `blocked`, `done`, and `cancelled`. Supported assignment statuses are `queued`,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1360,6 +1360,27 @@ resolved/skipped skill metadata and warnings into the context packet, but it
 does not install skills, execute scripts, grant tools, or inject `SKILL.md`
 bodies from an agent profile.
 
+Hecate also exposes an immutable built-in profile catalog. Built-ins are
+returned by list/get requests with `built_in: true`, can be selected by project
+or role defaults, and are resolved at assignment launch without being persisted
+as `agent_profiles` rows. `POST`, `PATCH`, and `DELETE` against built-in ids
+return `409 conflict`.
+
+Built-in profile ids:
+
+```text
+project_assignment
+planning
+architecture
+implementation
+frontend_implementation
+design_review
+reliability_ops
+documentation
+review_qa
+safe_external_review
+```
+
 Profile responses use the normal Hecate envelope:
 
 ```json
@@ -1376,7 +1397,7 @@ GET /hecate/v1/agent-profiles
       "surface": "hecate_task",
       "provider_hint": "anthropic",
       "model_hint": "claude-sonnet-4",
-      "execution_profile": "implementation",
+      "execution_profile": "coding_agent",
       "tools_enabled": true,
       "writes_allowed": true,
       "network_allowed": false,
@@ -1386,6 +1407,7 @@ GET /hecate/v1/agent-profiles
       "skill_ids": ["backend", "providers"],
       "external_agent_kind": "codex",
       "external_agent_options": { "effort": "high" },
+      "built_in": false,
       "created_at": "2026-06-08T12:00:00Z",
       "updated_at": "2026-06-08T12:00:00Z"
     }
@@ -1967,18 +1989,18 @@ instead of overwriting the existing record.
 
 Role list responses merge built-in roles with project custom roles. Built-ins
 are listable but immutable and are not seeded as duplicate project rows. The
-built-in IDs are:
+built-in role ids and default profile mappings are:
 
-```text
-product_manager
-architect
-software_developer
-frontend_engineer
-designer
-sre
-tech_writer
-reviewer_qa
-```
+| Role id              | Default driver | Default profile             |
+| -------------------- | -------------- | --------------------------- |
+| `product_manager`    | `hecate_task`  | `planning`                  |
+| `architect`          | `hecate_task`  | `architecture`              |
+| `software_developer` | `hecate_task`  | `implementation`            |
+| `frontend_engineer`  | `hecate_task`  | `frontend_implementation`   |
+| `designer`           | `hecate_task`  | `design_review`             |
+| `sre`                | `hecate_task`  | `reliability_ops`           |
+| `tech_writer`        | `hecate_task`  | `documentation`             |
+| `reviewer_qa`        | `hecate_task`  | `review_qa`                 |
 
 Supported work-item statuses are `backlog`, `ready`, `running`, `review`,
 `blocked`, `done`, and `cancelled`. Supported assignment statuses are `queued`,
@@ -2325,6 +2347,8 @@ Lists built-in roles plus custom roles for the project.
       "project_id": "proj_...",
       "name": "Architect",
       "description": "Owns technical direction, boundaries, and system trade-offs.",
+      "default_driver_kind": "hecate_task",
+      "default_agent_profile": "architecture",
       "built_in": true
     },
     {

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1365,6 +1365,8 @@ returned by list/get requests with `built_in: true`, can be selected by project
 or role defaults, and are resolved at assignment launch without being persisted
 as `agent_profiles` rows. `POST`, `PATCH`, and `DELETE` against built-in ids
 return `409 conflict`.
+If an older persisted row uses a now-reserved built-in id, list/get responses
+prefer the immutable built-in and suppress the stored duplicate.
 
 Built-in profile ids:
 
@@ -1380,6 +1382,11 @@ documentation
 review_qa
 safe_external_review
 ```
+
+Built-in profiles are portable runtime postures and intentionally avoid
+project-specific `skill_ids`. Bind discovered project skills through roles or
+custom profiles so missing project-local skills do not create warnings in every
+project.
 
 Profile responses use the normal Hecate envelope:
 

--- a/internal/agentprofiles/builtin.go
+++ b/internal/agentprofiles/builtin.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-func BuiltInProfiles() []Profile {
-	profiles := []Profile{
+var (
+	builtInProfiles = normalizeBuiltInProfiles([]Profile{
 		{
 			ID:                  "project_assignment",
 			Name:                "Project Assignment",
@@ -147,7 +147,28 @@ func BuiltInProfiles() []Profile {
 			ProjectMemoryPolicy: MemoryVisibleOnly,
 			ContextSourcePolicy: ContextVisibleOnly,
 		},
+	})
+	builtInProfilesByID = indexBuiltInProfiles(builtInProfiles)
+)
+
+func BuiltInProfiles() []Profile {
+	return cloneProfiles(builtInProfiles)
+}
+
+func BuiltInProfile(id string) (Profile, bool) {
+	profile, ok := builtInProfilesByID[strings.TrimSpace(id)]
+	if !ok {
+		return Profile{}, false
 	}
+	return cloneProfile(profile), true
+}
+
+func IsBuiltInProfileID(id string) bool {
+	_, ok := builtInProfilesByID[strings.TrimSpace(id)]
+	return ok
+}
+
+func normalizeBuiltInProfiles(profiles []Profile) []Profile {
 	for idx := range profiles {
 		profiles[idx] = normalizeProfile(profiles[idx], profiles[idx].UpdatedAt)
 		profiles[idx].BuiltIn = true
@@ -158,17 +179,10 @@ func BuiltInProfiles() []Profile {
 	return profiles
 }
 
-func BuiltInProfile(id string) (Profile, bool) {
-	id = strings.TrimSpace(id)
-	for _, profile := range BuiltInProfiles() {
-		if profile.ID == id {
-			return cloneProfile(profile), true
-		}
+func indexBuiltInProfiles(profiles []Profile) map[string]Profile {
+	index := make(map[string]Profile, len(profiles))
+	for _, profile := range profiles {
+		index[profile.ID] = cloneProfile(profile)
 	}
-	return Profile{}, false
-}
-
-func IsBuiltInProfileID(id string) bool {
-	_, ok := BuiltInProfile(id)
-	return ok
+	return index
 }

--- a/internal/agentprofiles/builtin.go
+++ b/internal/agentprofiles/builtin.go
@@ -1,0 +1,174 @@
+package agentprofiles
+
+import (
+	"strings"
+	"time"
+)
+
+func BuiltInProfiles() []Profile {
+	profiles := []Profile{
+		{
+			ID:                  "project_assignment",
+			Name:                "Project Assignment",
+			Description:         "General project work with tool access, write access, and visible-only project context until a role or project chooses a sharper profile.",
+			Instructions:        "Use the project, work item, assignment, and available context to complete the scoped task. Keep changes reviewable and preserve operator control over risky actions.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "coding_agent",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalInherit,
+			ProjectMemoryPolicy: MemoryVisibleOnly,
+			ContextSourcePolicy: ContextVisibleOnly,
+		},
+		{
+			ID:                  "planning",
+			Name:                "Planning",
+			Description:         "Turns ambiguous project intent into scoped work items, sequencing, and acceptance criteria.",
+			Instructions:        "Clarify the outcome, split work into reviewable slices, call out dependencies and risks, and avoid starting execution without operator approval.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "repo_local",
+			ToolsEnabled:        true,
+			WritesAllowed:       false,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "architecture",
+			Name:                "Architecture",
+			Description:         "Investigates system shape, boundaries, trade-offs, and rollout risk before implementation.",
+			Instructions:        "Read existing design and code paths first, preserve established boundaries, identify migration and observability impact, and produce concrete recommendations.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "repo_local",
+			ToolsEnabled:        true,
+			WritesAllowed:       false,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "implementation",
+			Name:                "Implementation",
+			Description:         "Implements scoped code changes with tests, docs, and evidence for review.",
+			Instructions:        "Read the surrounding code before editing, keep the patch narrow, add or update focused tests, update docs when behavior changes, and leave clear verification notes.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "coding_agent",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "frontend_implementation",
+			Name:                "Frontend Implementation",
+			Description:         "Builds user-facing surfaces with ergonomic interaction, responsive layout, and focused UI tests.",
+			Instructions:        "Respect the existing design system, make the first screen directly usable, prevent text and control overlap, cover important states, and verify the changed workflow.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "coding_agent",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "design_review",
+			Name:                "Design Review",
+			Description:         "Reviews interaction flow, information hierarchy, visual quality, and product fit.",
+			Instructions:        "Evaluate the workflow from the operator's perspective, identify confusing states, suggest simpler flows, and separate must-fix usability issues from polish.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "repo_local",
+			ToolsEnabled:        true,
+			WritesAllowed:       false,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "reliability_ops",
+			Name:                "Reliability Ops",
+			Description:         "Checks deployment, runtime safety, observability, failure modes, and operational readiness.",
+			Instructions:        "Trace the runtime path, look for unsafe defaults, missing telemetry, retry or cleanup gaps, and document the verification needed before shipping.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "coding_agent",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "documentation",
+			Name:                "Documentation",
+			Description:         "Turns implementation details and decisions into clear operator and contributor documentation.",
+			Instructions:        "Update the docs closest to the changed behavior, keep wording practical, distinguish facts from future intent, and avoid stale process labels.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "coding_agent",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "review_qa",
+			Name:                "Review QA",
+			Description:         "Reviews diffs, product behavior, regressions, verification gaps, and release risk.",
+			Instructions:        "Lead with actionable findings, ground each issue in evidence, check tests and docs, and avoid speculative feedback when the patch is sound.",
+			Surface:             SurfaceHecateTask,
+			ExecutionProfile:    "repo_local",
+			ToolsEnabled:        true,
+			WritesAllowed:       false,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryInclude,
+			ContextSourcePolicy: ContextIncludeEnabled,
+		},
+		{
+			ID:                  "safe_external_review",
+			Name:                "Safe External Review",
+			Description:         "Prepares an external-agent review posture without granting writes, network, or automatic context body injection.",
+			Instructions:        "Review the supplied assignment context and evidence. Do not assume extra workspace access; ask the operator for missing context instead of taking actions outside the assignment.",
+			Surface:             SurfaceExternalAgent,
+			ExecutionProfile:    "repo_local",
+			ToolsEnabled:        false,
+			WritesAllowed:       false,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      ApprovalRequire,
+			ProjectMemoryPolicy: MemoryVisibleOnly,
+			ContextSourcePolicy: ContextVisibleOnly,
+		},
+	}
+	for idx := range profiles {
+		profiles[idx] = normalizeProfile(profiles[idx], profiles[idx].UpdatedAt)
+		profiles[idx].BuiltIn = true
+		profiles[idx].CreatedAt = time.Time{}
+		profiles[idx].UpdatedAt = time.Time{}
+	}
+	sortProfiles(profiles)
+	return profiles
+}
+
+func BuiltInProfile(id string) (Profile, bool) {
+	id = strings.TrimSpace(id)
+	for _, profile := range BuiltInProfiles() {
+		if profile.ID == id {
+			return cloneProfile(profile), true
+		}
+	}
+	return Profile{}, false
+}
+
+func IsBuiltInProfileID(id string) bool {
+	_, ok := BuiltInProfile(id)
+	return ok
+}

--- a/internal/agentprofiles/sqlite.go
+++ b/internal/agentprofiles/sqlite.go
@@ -111,6 +111,9 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Profile, error) {
 		if err != nil {
 			return nil, err
 		}
+		if IsBuiltInProfileID(item.ID) {
+			continue
+		}
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/agentprofiles/sqlite.go
+++ b/internal/agentprofiles/sqlite.go
@@ -71,6 +71,9 @@ CREATE TABLE IF NOT EXISTS `+s.table+` (
 
 func (s *SQLiteStore) Create(ctx context.Context, profile Profile) (Profile, error) {
 	profile = normalizeProfile(profile, time.Now().UTC())
+	if IsBuiltInProfileID(profile.ID) || profile.BuiltIn {
+		return Profile{}, ErrBuiltIn
+	}
 	if err := validateProfile(profile); err != nil {
 		return Profile{}, err
 	}
@@ -81,7 +84,11 @@ func (s *SQLiteStore) Create(ctx context.Context, profile Profile) (Profile, err
 }
 
 func (s *SQLiteStore) Get(ctx context.Context, id string) (Profile, bool, error) {
-	row := s.client.DB().QueryRowContext(ctx, selectAgentProfileSQL(s.table)+" WHERE id = ?", strings.TrimSpace(id))
+	id = strings.TrimSpace(id)
+	if profile, ok := BuiltInProfile(id); ok {
+		return profile, true, nil
+	}
+	row := s.client.DB().QueryRowContext(ctx, selectAgentProfileSQL(s.table)+" WHERE id = ?", id)
 	profile, err := scanAgentProfile(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Profile{}, false, nil
@@ -98,7 +105,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Profile, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Profile
+	items := BuiltInProfiles()
 	for rows.Next() {
 		item, err := scanAgentProfile(rows)
 		if err != nil {
@@ -109,10 +116,14 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Profile, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	sortProfiles(items)
 	return items, nil
 }
 
 func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Profile)) (Profile, error) {
+	if IsBuiltInProfileID(id) {
+		return Profile{}, ErrBuiltIn
+	}
 	profile, ok, err := s.Get(ctx, id)
 	if err != nil {
 		return Profile{}, err
@@ -139,7 +150,11 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, update func(*Profil
 }
 
 func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
-	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.table+` WHERE id = ?`, strings.TrimSpace(id))
+	id = strings.TrimSpace(id)
+	if IsBuiltInProfileID(id) {
+		return ErrBuiltIn
+	}
+	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.table+` WHERE id = ?`, id)
 	if err != nil {
 		return err
 	}

--- a/internal/agentprofiles/sqlite_test.go
+++ b/internal/agentprofiles/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/storage"
 )
@@ -108,5 +109,26 @@ func TestSQLiteStore_BuiltInProfiles(t *testing.T) {
 	}
 	if err := store.Delete(ctx, "safe_external_review"); !errors.Is(err, ErrBuiltIn) {
 		t.Fatalf("Delete built-in error = %v, want ErrBuiltIn", err)
+	}
+	legacy := normalizeProfile(Profile{
+		ID:   "safe_external_review",
+		Name: "Legacy Collision",
+	}, time.Now().UTC())
+	if err := store.upsert(ctx, legacy); err != nil {
+		t.Fatalf("seed legacy built-in collision: %v", err)
+	}
+	items, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List with legacy built-in collision: %v", err)
+	}
+	if countProfileID(items, "safe_external_review") != 1 {
+		t.Fatalf("items = %+v, want exactly one safe_external_review built-in", items)
+	}
+	profile, ok, err = store.Get(ctx, "safe_external_review")
+	if err != nil || !ok {
+		t.Fatalf("Get colliding built-in ok=%v err=%v, want safe external review profile", ok, err)
+	}
+	if !profile.BuiltIn || profile.Name == "Legacy Collision" {
+		t.Fatalf("colliding profile = %+v, want built-in to shadow stored row", profile)
 	}
 }

--- a/internal/agentprofiles/sqlite_test.go
+++ b/internal/agentprofiles/sqlite_test.go
@@ -2,6 +2,7 @@ package agentprofiles
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -80,7 +81,32 @@ func TestSQLiteStore_ProfileRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(items) != 1 || items[0].ID != "prof_reviewer" {
-		t.Fatalf("items = %+v, want one profile", items)
+	if !profileIDExists(items, "review_qa") || !profileIDExists(items, "prof_reviewer") {
+		t.Fatalf("items = %+v, want built-ins plus persisted profile", items)
+	}
+}
+
+func TestSQLiteStore_BuiltInProfiles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newSQLiteProfileTestStore(t)
+
+	profile, ok, err := store.Get(ctx, "safe_external_review")
+	if err != nil || !ok {
+		t.Fatalf("Get built-in ok=%v err=%v, want safe external review profile", ok, err)
+	}
+	if !profile.BuiltIn || profile.Surface != SurfaceExternalAgent || profile.WritesAllowed {
+		t.Fatalf("built-in profile = %+v, want safe external review posture", profile)
+	}
+	if _, err := store.Create(ctx, Profile{ID: "safe_external_review", Name: "Override"}); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Create built-in error = %v, want ErrBuiltIn", err)
+	}
+	if _, err := store.Update(ctx, "safe_external_review", func(profile *Profile) {
+		profile.Name = "Override"
+	}); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Update built-in error = %v, want ErrBuiltIn", err)
+	}
+	if err := store.Delete(ctx, "safe_external_review"); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Delete built-in error = %v, want ErrBuiltIn", err)
 	}
 }

--- a/internal/agentprofiles/store.go
+++ b/internal/agentprofiles/store.go
@@ -113,6 +113,9 @@ func (s *MemoryStore) List(_ context.Context) ([]Profile, error) {
 	defer s.mu.Unlock()
 	items := BuiltInProfiles()
 	for _, profile := range s.profiles {
+		if IsBuiltInProfileID(profile.ID) {
+			continue
+		}
 		items = append(items, cloneProfile(profile))
 	}
 	sortProfiles(items)
@@ -226,6 +229,14 @@ func cloneProfile(profile Profile) Profile {
 	profile.SkillIDs = append([]string(nil), profile.SkillIDs...)
 	profile.ExternalAgentOptions = cloneStringMap(profile.ExternalAgentOptions)
 	return profile
+}
+
+func cloneProfiles(profiles []Profile) []Profile {
+	out := make([]Profile, 0, len(profiles))
+	for _, profile := range profiles {
+		out = append(out, cloneProfile(profile))
+	}
+	return out
 }
 
 func sortProfiles(items []Profile) {

--- a/internal/agentprofiles/store.go
+++ b/internal/agentprofiles/store.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrNotFound = errors.New("agent profile not found")
 	ErrInvalid  = errors.New("invalid agent profile")
+	ErrBuiltIn  = errors.New("built-in agent profile cannot be mutated")
 )
 
 const (
@@ -54,6 +55,7 @@ type Profile struct {
 	SkillIDs             []string
 	ExternalAgentKind    string
 	ExternalAgentOptions map[string]string
+	BuiltIn              bool
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 }
@@ -82,6 +84,9 @@ func (s *MemoryStore) Create(_ context.Context, profile Profile) (Profile, error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	profile = normalizeProfile(profile, time.Now().UTC())
+	if IsBuiltInProfileID(profile.ID) || profile.BuiltIn {
+		return Profile{}, ErrBuiltIn
+	}
 	if err := validateProfile(profile); err != nil {
 		return Profile{}, err
 	}
@@ -92,7 +97,11 @@ func (s *MemoryStore) Create(_ context.Context, profile Profile) (Profile, error
 func (s *MemoryStore) Get(_ context.Context, id string) (Profile, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	profile, ok := s.profiles[strings.TrimSpace(id)]
+	id = strings.TrimSpace(id)
+	if profile, ok := BuiltInProfile(id); ok {
+		return profile, true, nil
+	}
+	profile, ok := s.profiles[id]
 	if !ok {
 		return Profile{}, false, nil
 	}
@@ -102,7 +111,7 @@ func (s *MemoryStore) Get(_ context.Context, id string) (Profile, bool, error) {
 func (s *MemoryStore) List(_ context.Context) ([]Profile, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	items := make([]Profile, 0, len(s.profiles))
+	items := BuiltInProfiles()
 	for _, profile := range s.profiles {
 		items = append(items, cloneProfile(profile))
 	}
@@ -114,6 +123,9 @@ func (s *MemoryStore) Update(_ context.Context, id string, update func(*Profile)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id = strings.TrimSpace(id)
+	if IsBuiltInProfileID(id) {
+		return Profile{}, ErrBuiltIn
+	}
 	profile, ok := s.profiles[id]
 	if !ok {
 		return Profile{}, ErrNotFound
@@ -139,6 +151,9 @@ func (s *MemoryStore) Delete(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id = strings.TrimSpace(id)
+	if IsBuiltInProfileID(id) {
+		return ErrBuiltIn
+	}
 	if _, ok := s.profiles[id]; !ok {
 		return ErrNotFound
 	}
@@ -215,6 +230,9 @@ func cloneProfile(profile Profile) Profile {
 
 func sortProfiles(items []Profile) {
 	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].BuiltIn != items[j].BuiltIn {
+			return items[i].BuiltIn
+		}
 		if items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
 			return items[i].Name < items[j].Name
 		}

--- a/internal/agentprofiles/store_test.go
+++ b/internal/agentprofiles/store_test.go
@@ -66,8 +66,8 @@ func TestMemoryStore_ProfileRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(items) != 1 || items[0].ID != "prof_backend" {
-		t.Fatalf("items = %+v, want created profile", items)
+	if !profileIDExists(items, "implementation") || !profileIDExists(items, "prof_backend") {
+		t.Fatalf("items = %+v, want built-ins plus created profile", items)
 	}
 
 	if err := store.Delete(ctx, "prof_backend"); err != nil {
@@ -75,6 +75,31 @@ func TestMemoryStore_ProfileRoundTrip(t *testing.T) {
 	}
 	if err := store.Delete(ctx, "prof_backend"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Delete missing error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemoryStore_BuiltInProfiles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	profile, ok, err := store.Get(ctx, "implementation")
+	if err != nil || !ok {
+		t.Fatalf("Get built-in ok=%v err=%v, want implementation profile", ok, err)
+	}
+	if !profile.BuiltIn || profile.ExecutionProfile != "coding_agent" || !profile.WritesAllowed {
+		t.Fatalf("built-in profile = %+v, want coding implementation posture", profile)
+	}
+	if _, err := store.Create(ctx, Profile{ID: "implementation", Name: "Override"}); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Create built-in error = %v, want ErrBuiltIn", err)
+	}
+	if _, err := store.Update(ctx, "implementation", func(profile *Profile) {
+		profile.Name = "Override"
+	}); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Update built-in error = %v, want ErrBuiltIn", err)
+	}
+	if err := store.Delete(ctx, "implementation"); !errors.Is(err, ErrBuiltIn) {
+		t.Fatalf("Delete built-in error = %v, want ErrBuiltIn", err)
 	}
 }
 
@@ -92,4 +117,13 @@ func TestMemoryStore_Validation(t *testing.T) {
 	if _, err := store.Create(ctx, Profile{ID: "prof_bad_policy", Name: "Bad", ApprovalPolicy: "sometimes"}); !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Create bad policy error = %v, want ErrInvalid", err)
 	}
+}
+
+func profileIDExists(items []Profile, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/agentprofiles/store_test.go
+++ b/internal/agentprofiles/store_test.go
@@ -101,6 +101,23 @@ func TestMemoryStore_BuiltInProfiles(t *testing.T) {
 	if err := store.Delete(ctx, "implementation"); !errors.Is(err, ErrBuiltIn) {
 		t.Fatalf("Delete built-in error = %v, want ErrBuiltIn", err)
 	}
+	store.mu.Lock()
+	store.profiles["implementation"] = Profile{ID: "implementation", Name: "Legacy Collision"}
+	store.mu.Unlock()
+	items, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List with legacy built-in collision: %v", err)
+	}
+	if countProfileID(items, "implementation") != 1 {
+		t.Fatalf("items = %+v, want exactly one implementation built-in", items)
+	}
+	profile, ok, err = store.Get(ctx, "implementation")
+	if err != nil || !ok {
+		t.Fatalf("Get colliding built-in ok=%v err=%v, want implementation profile", ok, err)
+	}
+	if !profile.BuiltIn || profile.Name == "Legacy Collision" {
+		t.Fatalf("colliding profile = %+v, want built-in to shadow stored row", profile)
+	}
 }
 
 func TestMemoryStore_Validation(t *testing.T) {
@@ -120,10 +137,15 @@ func TestMemoryStore_Validation(t *testing.T) {
 }
 
 func profileIDExists(items []Profile, id string) bool {
+	return countProfileID(items, id) > 0
+}
+
+func countProfileID(items []Profile, id string) int {
+	count := 0
 	for _, item := range items {
 		if item.ID == id {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }

--- a/internal/api/handler_agent_profiles.go
+++ b/internal/api/handler_agent_profiles.go
@@ -34,6 +34,10 @@ func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
 		return
 	}
+	if errors.Is(err, agentprofiles.ErrBuiltIn) {
+		WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be created")
+		return
+	}
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -66,6 +70,10 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
 		return
 	}
+	if errors.Is(err, agentprofiles.ErrBuiltIn) {
+		WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be updated")
+		return
+	}
 	if errors.Is(err, agentprofiles.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
 		return
@@ -80,6 +88,9 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Request) {
 	if err := h.agentProfiles.Delete(r.Context(), r.PathValue("id")); errors.Is(err, agentprofiles.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+		return
+	} else if errors.Is(err, agentprofiles.ErrBuiltIn) {
+		WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be deleted")
 		return
 	} else if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -180,6 +191,7 @@ func renderAgentProfile(profile agentprofiles.Profile) AgentProfileResponseItem 
 		SkillIDs:             append([]string(nil), profile.SkillIDs...),
 		ExternalAgentKind:    profile.ExternalAgentKind,
 		ExternalAgentOptions: cloneAgentProfileOptions(profile.ExternalAgentOptions),
+		BuiltIn:              profile.BuiltIn,
 		CreatedAt:            formatOptionalTime(profile.CreatedAt),
 		UpdatedAt:            formatOptionalTime(profile.UpdatedAt),
 	}

--- a/internal/api/handler_agent_profiles_test.go
+++ b/internal/api/handler_agent_profiles_test.go
@@ -50,6 +50,9 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	if created.Object != "agent_profile" || created.Data.ID != "prof_backend" || created.Data.ExecutionProfile != "implementation" {
 		t.Fatalf("created = %+v, want profile envelope", created)
 	}
+	if created.Data.BuiltIn {
+		t.Fatalf("created profile is marked built-in")
+	}
 	if !created.Data.ToolsEnabled || !created.Data.WritesAllowed || created.Data.NetworkAllowed {
 		t.Fatalf("posture = tools=%v writes=%v network=%v, want true/true/false", created.Data.ToolsEnabled, created.Data.WritesAllowed, created.Data.NetworkAllowed)
 	}
@@ -80,14 +83,48 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode list response: %v", err)
 	}
-	if listed.Object != "agent_profiles" || len(listed.Data) != 1 || listed.Data[0].ID != "prof_backend" {
-		t.Fatalf("listed = %+v, want created profile", listed)
+	if listed.Object != "agent_profiles" || !agentProfileResponseIDExists(listed.Data, "implementation") || !agentProfileResponseIDExists(listed.Data, "prof_backend") {
+		t.Fatalf("listed = %+v, want built-ins plus created profile", listed)
 	}
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_backend", nil))
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentProfilesAPI_BuiltInProfilesAreReadOnly(t *testing.T) {
+	t.Parallel()
+	server := newAgentProfilesTestServer()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/agent-profiles/implementation", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get built-in status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var got AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if !got.Data.BuiltIn || got.Data.ExecutionProfile != "coding_agent" || !got.Data.WritesAllowed {
+		t.Fatalf("built-in profile = %+v, want implementation posture", got.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{"id":"implementation","name":"Override"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("create built-in status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/agent-profiles/implementation", bytes.NewReader([]byte(`{"name":"Override"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("patch built-in status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/implementation", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("delete built-in status = %d body=%s, want 409", rec.Code, rec.Body.String())
 	}
 }
 
@@ -104,6 +141,15 @@ func TestAgentProfilesAPI_RejectsInvalidEnums(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("create bad enum status = %d body=%s, want 400", rec.Code, rec.Body.String())
 	}
+}
+
+func agentProfileResponseIDExists(items []AgentProfileResponseItem, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAgentProfilesAPI_GeneratesIDsAndReturnsNotFound(t *testing.T) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -682,7 +682,7 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	if runResp.Data.ProjectID != "proj_start" || runResp.Data.WorkItemID != "work_start" || runResp.Data.AssignmentID != "asgn_start" {
 		t.Fatalf("run response linkage = project %q work %q assignment %q, want proj_start/work_start/asgn_start", runResp.Data.ProjectID, runResp.Data.WorkItemID, runResp.Data.AssignmentID)
 	}
-	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "implementation" {
+	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.ExecutionProfile != "coding_agent" {
 		t.Fatalf("task provider/model/profile = %q/%q/%q, want role defaults", task.RequestedProvider, task.RequestedModel, task.ExecutionProfile)
 	}
 	if task.WorkingDirectory != workspace || task.SandboxAllowedRoot != workspace || task.WorkspaceMode != "in_place" {
@@ -733,8 +733,8 @@ func TestProjectWorkAPI_PreflightAssignmentReturnsLaunchContextWithoutSideEffect
 	if packetResp.Data.ExecutionMode != chat.ExecutionModeHecateTask || packetResp.Data.Provider != "anthropic" || packetResp.Data.Model != "claude-sonnet-4" {
 		t.Fatalf("preflight mode/provider/model = %q/%q/%q, want native task launch hints", packetResp.Data.ExecutionMode, packetResp.Data.Provider, packetResp.Data.Model)
 	}
-	if packetResp.Data.ExecutionProfile != "implementation" || packetResp.Data.Workspace != workspace {
-		t.Fatalf("preflight profile/workspace = %q/%q, want implementation/%q", packetResp.Data.ExecutionProfile, packetResp.Data.Workspace, workspace)
+	if packetResp.Data.ExecutionProfile != "coding_agent" || packetResp.Data.Workspace != workspace {
+		t.Fatalf("preflight profile/workspace = %q/%q, want coding_agent/%q", packetResp.Data.ExecutionProfile, packetResp.Data.Workspace, workspace)
 	}
 	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != "proj_start" || packetResp.Data.Refs.WorkItemID != "work_start" || packetResp.Data.Refs.AssignmentID != "asgn_start" || packetResp.Data.Refs.RoleID != "role_backend" {
 		t.Fatalf("preflight refs = %+v, want project/work/assignment/role refs", packetResp.Data.Refs)
@@ -976,9 +976,20 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	handler.SetMemoryStore(memory.NewMemoryStore())
 	workspace := t.TempDir()
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
-		Workspace: workspace,
-		Driver:    projectwork.AssignmentDriverHecateTask,
+		Workspace:        workspace,
+		Driver:           projectwork.AssignmentDriverHecateTask,
+		RoleAgentProfile: "prof_packet_visible",
 	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "prof_packet_visible",
+		Name:                "Packet visible-only",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ExecutionProfile:    "repo_local",
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}); err != nil {
+		t.Fatalf("Create profile: %v", err)
+	}
 	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
 		project.ContextSources = []projects.ContextSource{{
 			ID:      "ctx_readme",
@@ -1054,8 +1065,8 @@ func TestProjectWorkAPI_StartAssignmentPersistsInspectableContextPacket(t *testi
 	if packetResp.Data.ID != ref.ContextSnapshotID {
 		t.Fatalf("task run context id = %q, want %q", packetResp.Data.ID, ref.ContextSnapshotID)
 	}
-	if packetResp.Data.ExecutionProfile != "implementation" {
-		t.Fatalf("execution_profile = %q, want implementation", packetResp.Data.ExecutionProfile)
+	if packetResp.Data.ExecutionProfile != "repo_local" {
+		t.Fatalf("execution_profile = %q, want repo_local", packetResp.Data.ExecutionProfile)
 	}
 	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != "proj_start" || packetResp.Data.Refs.WorkItemID != "work_start" || packetResp.Data.Refs.AssignmentID != "asgn_start" || packetResp.Data.Refs.RoleID != "role_backend" {
 		t.Fatalf("packet refs = %+v, want project/work/assignment/role refs", packetResp.Data.Refs)
@@ -1137,15 +1148,17 @@ func TestProjectWorkAPI_StartAssignmentAppliesProfileContextPolicies(t *testing.
 			handler, server := newProjectWorkTestServer()
 			handler.SetMemoryStore(memory.NewMemoryStore())
 			workspace := t.TempDir()
+			profileID := "prof_policy_" + strings.ReplaceAll(tc.name, " ", "_")
 			seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
-				Workspace: workspace,
-				Driver:    projectwork.AssignmentDriverHecateTask,
+				Workspace:        workspace,
+				Driver:           projectwork.AssignmentDriverHecateTask,
+				RoleAgentProfile: profileID,
 			})
 			if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
-				ID:                  "implementation",
+				ID:                  profileID,
 				Name:                "Implementation",
 				Surface:             agentprofiles.SurfaceHecateTask,
-				ExecutionProfile:    "implementation",
+				ExecutionProfile:    "repo_local",
 				ToolsEnabled:        true,
 				WritesAllowed:       true,
 				ProjectMemoryPolicy: tc.memoryPolicy,
@@ -1222,14 +1235,15 @@ func TestProjectWorkAPI_StartAssignmentIncludesExplicitPromptContext(t *testing.
 		t.Fatalf("Write CLAUDE.md: %v", err)
 	}
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
-		Workspace: workspace,
-		Driver:    projectwork.AssignmentDriverHecateTask,
+		Workspace:        workspace,
+		Driver:           projectwork.AssignmentDriverHecateTask,
+		RoleAgentProfile: "prof_prompt_context",
 	})
 	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
-		ID:                  "implementation",
+		ID:                  "prof_prompt_context",
 		Name:                "Implementation",
 		Surface:             agentprofiles.SurfaceHecateTask,
-		ExecutionProfile:    "implementation",
+		ExecutionProfile:    "repo_local",
 		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
 		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
 	}); err != nil {
@@ -1328,14 +1342,15 @@ func TestProjectWorkAPI_StartAssignmentKeepsVisibleOnlyPromptContextOutOfSystemP
 		t.Fatalf("Write AGENTS.md: %v", err)
 	}
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
-		Workspace: workspace,
-		Driver:    projectwork.AssignmentDriverHecateTask,
+		Workspace:        workspace,
+		Driver:           projectwork.AssignmentDriverHecateTask,
+		RoleAgentProfile: "prof_visible_context",
 	})
 	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
-		ID:                  "implementation",
+		ID:                  "prof_visible_context",
 		Name:                "Implementation",
 		Surface:             agentprofiles.SurfaceHecateTask,
-		ExecutionProfile:    "implementation",
+		ExecutionProfile:    "repo_local",
 		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
 		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
 	}); err != nil {
@@ -1402,14 +1417,15 @@ func TestProjectWorkAPI_StartAssignmentTruncatesPromptContext(t *testing.T) {
 	handler.SetMemoryStore(memory.NewMemoryStore())
 	workspace := t.TempDir()
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
-		Workspace: workspace,
-		Driver:    projectwork.AssignmentDriverHecateTask,
+		Workspace:        workspace,
+		Driver:           projectwork.AssignmentDriverHecateTask,
+		RoleAgentProfile: "prof_truncate_context",
 	})
 	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
-		ID:                  "implementation",
+		ID:                  "prof_truncate_context",
 		Name:                "Implementation",
 		Surface:             agentprofiles.SurfaceHecateTask,
-		ExecutionProfile:    "implementation",
+		ExecutionProfile:    "repo_local",
 		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
 		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
 	}); err != nil {
@@ -2937,6 +2953,7 @@ type projectWorkAssignmentStartSeed struct {
 	TaskID              string
 	RunID               string
 	ProjectAgentProfile string
+	RoleAgentProfile    string
 	WithoutRoleDefaults bool
 }
 
@@ -2969,7 +2986,10 @@ func seedProjectWorkAssignmentStartTest(t *testing.T, handler *Handler, seed pro
 	if !seed.WithoutRoleDefaults {
 		role.DefaultProvider = "anthropic"
 		role.DefaultModel = "claude-sonnet-4"
-		role.DefaultAgentProfile = "implementation"
+		role.DefaultAgentProfile = strings.TrimSpace(seed.RoleAgentProfile)
+		if role.DefaultAgentProfile == "" {
+			role.DefaultAgentProfile = "implementation"
+		}
 	}
 	if _, err := handler.projectWork.CreateRole(t.Context(), role); err != nil {
 		t.Fatalf("CreateRole: %v", err)

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -184,6 +184,9 @@ func (h *Handler) resetAgentProfiles(ctx context.Context) (int, error) {
 	}
 	deleted := 0
 	for _, item := range items {
+		if item.BuiltIn {
+			continue
+		}
 		if err := h.agentProfiles.Delete(ctx, item.ID); err != nil {
 			return deleted, err
 		}

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -163,8 +163,8 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if err != nil {
 		t.Fatalf("list agent profiles: %v", err)
 	}
-	if len(profiles) != 0 {
-		t.Fatalf("agent profiles after reset = %#v, want none", profiles)
+	if !agentProfileListIsBuiltInOnly(profiles) {
+		t.Fatalf("agent profiles after reset = %#v, want only built-ins", profiles)
 	}
 	workItems, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID)
 	if err != nil {
@@ -380,4 +380,16 @@ func assertSQLiteTableCount(t *testing.T, client *storage.SQLiteClient, table st
 	if got != want {
 		t.Fatalf("count %s = %d, want %d", table, got, want)
 	}
+}
+
+func agentProfileListIsBuiltInOnly(items []agentprofiles.Profile) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if !item.BuiltIn {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -303,6 +303,7 @@ type AgentProfileResponseItem struct {
 	SkillIDs             []string          `json:"skill_ids,omitempty"`
 	ExternalAgentKind    string            `json:"external_agent_kind,omitempty"`
 	ExternalAgentOptions map[string]string `json:"external_agent_options,omitempty"`
+	BuiltIn              bool              `json:"built_in"`
 	CreatedAt            string            `json:"created_at,omitempty"`
 	UpdatedAt            string            `json:"updated_at,omitempty"`
 }

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -247,14 +247,14 @@ func (s *MemoryStore) Backend() string {
 func BuiltInRoleProfiles(projectID string) []AgentRoleProfile {
 	projectID = strings.TrimSpace(projectID)
 	roles := []AgentRoleProfile{
-		{ID: "product_manager", Name: "Product Manager", Description: "Shapes product intent, scope, and acceptance criteria."},
-		{ID: "architect", Name: "Architect", Description: "Owns technical direction, boundaries, and system trade-offs."},
-		{ID: "software_developer", Name: "Software Developer", Description: "Implements backend and shared application behavior."},
-		{ID: "frontend_engineer", Name: "Frontend Engineer", Description: "Implements user-facing application surfaces."},
-		{ID: "designer", Name: "Designer", Description: "Owns interaction, information architecture, and visual quality."},
-		{ID: "sre", Name: "SRE", Description: "Owns deployability, reliability, observability, and operations."},
-		{ID: "tech_writer", Name: "Technical Writer", Description: "Turns implementation and decisions into clear operator-facing docs."},
-		{ID: "reviewer_qa", Name: "Reviewer QA", Description: "Reviews behavior, risks, regressions, and verification gaps."},
+		{ID: "product_manager", Name: "Product Manager", Description: "Shapes product intent, scope, and acceptance criteria.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "planning"},
+		{ID: "architect", Name: "Architect", Description: "Owns technical direction, boundaries, and system trade-offs.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "architecture"},
+		{ID: "software_developer", Name: "Software Developer", Description: "Implements backend and shared application behavior.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "implementation"},
+		{ID: "frontend_engineer", Name: "Frontend Engineer", Description: "Implements user-facing application surfaces.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "frontend_implementation"},
+		{ID: "designer", Name: "Designer", Description: "Owns interaction, information architecture, and visual quality.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "design_review"},
+		{ID: "sre", Name: "SRE", Description: "Owns deployability, reliability, observability, and operations.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "reliability_ops"},
+		{ID: "tech_writer", Name: "Technical Writer", Description: "Turns implementation and decisions into clear operator-facing docs.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "documentation"},
+		{ID: "reviewer_qa", Name: "Reviewer QA", Description: "Reviews behavior, risks, regressions, and verification gaps.", DefaultDriverKind: AssignmentDriverHecateTask, DefaultAgentProfile: "review_qa"},
 	}
 	for idx := range roles {
 		roles[idx].ProjectID = projectID

--- a/internal/projectwork/store_test.go
+++ b/internal/projectwork/store_test.go
@@ -31,6 +31,12 @@ func TestStoreConformance_ProjectWorkLifecycle(t *testing.T) {
 			if len(roles) < 8 || !roleIDExists(roles, "product_manager") || !roleIDExists(roles, "reviewer_qa") {
 				t.Fatalf("built-in roles = %+v, want default project team roles", roles)
 			}
+			if role := roleByID(roles, "software_developer"); role.DefaultDriverKind != AssignmentDriverHecateTask || role.DefaultAgentProfile != "implementation" {
+				t.Fatalf("software developer role = %+v, want hecate_task implementation default", role)
+			}
+			if role := roleByID(roles, "reviewer_qa"); role.DefaultDriverKind != AssignmentDriverHecateTask || role.DefaultAgentProfile != "review_qa" {
+				t.Fatalf("reviewer role = %+v, want hecate_task review_qa default", role)
+			}
 
 			custom, err := store.CreateRole(ctx, AgentRoleProfile{
 				ID:                  "role_release_captain",
@@ -762,6 +768,15 @@ func roleIDExists(roles []AgentRoleProfile, id string) bool {
 		}
 	}
 	return false
+}
+
+func roleByID(roles []AgentRoleProfile, id string) AgentRoleProfile {
+	for _, role := range roles {
+		if role.ID == id {
+			return role
+		}
+	}
+	return AgentRoleProfile{}
 }
 
 func workItemIDExists(items []WorkItem, id string) bool {

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -301,18 +301,10 @@ func (app *Application) ResolveAssignmentProfile(ctx context.Context, role proje
 			Warnings:            []string{fmt.Sprintf("Referenced agent profile %q was not found; using stored profile id as execution_profile hint.", candidate.id)},
 		}, nil
 	}
-	return ResolvedAgentProfile{
-		ID:                  "project_assignment",
-		Name:                "Project Assignment",
-		Source:              "built_in_fallback",
-		Surface:             agentprofiles.SurfaceHecateTask,
-		ExecutionProfile:    "project_assignment",
-		ToolsEnabled:        true,
-		WritesAllowed:       true,
-		ApprovalPolicy:      agentprofiles.ApprovalInherit,
-		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
-		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
-	}, nil
+	if profile, ok := agentprofiles.BuiltInProfile("project_assignment"); ok {
+		return resolvedProfileFromStore(profile, "built_in_fallback"), nil
+	}
+	return ResolvedAgentProfile{}, fmt.Errorf("%w: project_assignment built-in profile is unavailable", agentprofiles.ErrNotFound)
 }
 
 func resolvedProfileFromStore(profile agentprofiles.Profile, source string) ResolvedAgentProfile {

--- a/ui/src/features/projects/ProfilesModal.test.tsx
+++ b/ui/src/features/projects/ProfilesModal.test.tsx
@@ -131,6 +131,37 @@ describe("ProfilesModal", () => {
     );
   });
 
+  it("shows built-in profiles as read-only", () => {
+    render(
+      <ProfilesModal
+        error=""
+        pending={false}
+        profiles={[
+          profile({
+            id: "implementation",
+            name: "Implementation",
+            built_in: true,
+            writes_allowed: true,
+          }),
+        ]}
+        project={project()}
+        projectSkills={[skill()]}
+        roles={[]}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        onDelete={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("built-in").length).toBeGreaterThan(0);
+    expect(screen.getByText("Built-in profile")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save profile" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete profile" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toBeDisabled();
+    expect(screen.getByLabelText("Use skill Backend")).toBeDisabled();
+  });
+
   it("confirms deletion with project and role references", async () => {
     const onDelete = vi.fn(async () => true);
 

--- a/ui/src/features/projects/ProfilesModal.tsx
+++ b/ui/src/features/projects/ProfilesModal.tsx
@@ -55,6 +55,7 @@ export function ProfilesModal({
   const [selectedProfileID, setSelectedProfileID] = useState(profiles[0]?.id ?? "new");
   const selectedProfile = profiles.find((profile) => profile.id === selectedProfileID) ?? null;
   const editingNew = selectedProfileID === "new";
+  const editingBuiltIn = Boolean(selectedProfile?.built_in);
   const [deleteProfile, setDeleteProfile] = useState<AgentProfileRecord | null>(null);
   const [form, setForm] = useState<AgentProfileForm>(() =>
     selectedProfile ? profileFormFromRecord(selectedProfile) : emptyAgentProfileForm(),
@@ -71,7 +72,7 @@ export function ProfilesModal({
     setForm(profileFormFromRecord(profile));
   }
 
-  const canSave = form.name.trim().length > 0;
+  const canSave = !editingBuiltIn && form.name.trim().length > 0;
   const submit = async () => {
     if (!canSave) return;
     if (editingNew) {
@@ -104,7 +105,12 @@ export function ProfilesModal({
         width={840}
         footer={
           <div style={{ display: "flex", gap: 8, width: "100%" }}>
-            {selectedProfile && !editingNew && (
+            {editingBuiltIn && (
+              <span className="badge badge-muted" style={{ alignSelf: "center" }}>
+                Built-in profile
+              </span>
+            )}
+            {selectedProfile && !editingNew && !editingBuiltIn && (
               <button
                 className="btn btn-ghost"
                 type="button"
@@ -115,15 +121,17 @@ export function ProfilesModal({
                 Delete profile
               </button>
             )}
-            <button
-              className="btn btn-primary"
-              type="button"
-              disabled={pending || !canSave}
-              onClick={() => void submit()}
-              style={{ marginLeft: "auto" }}
-            >
-              {pending ? "Saving..." : editingNew ? "Create profile" : "Save profile"}
-            </button>
+            {!editingBuiltIn && (
+              <button
+                className="btn btn-primary"
+                type="button"
+                disabled={pending || !canSave}
+                onClick={() => void submit()}
+                style={{ marginLeft: "auto" }}
+              >
+                {pending ? "Saving..." : editingNew ? "Create profile" : "Save profile"}
+              </button>
+            )}
           </div>
         }
       >
@@ -163,6 +171,7 @@ export function ProfilesModal({
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
                   {profile.name || profile.id}
                 </span>
+                {profile.built_in && <span className="badge badge-muted">built-in</span>}
               </button>
             ))}
           </div>
@@ -193,6 +202,7 @@ export function ProfilesModal({
                   className="input"
                   value={form.name}
                   autoFocus={editingNew}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, name: event.target.value }))
                   }
@@ -204,6 +214,7 @@ export function ProfilesModal({
               <textarea
                 className="input"
                 value={form.description}
+                disabled={editingBuiltIn}
                 rows={2}
                 onChange={(event) =>
                   setForm((current) => ({ ...current, description: event.target.value }))
@@ -215,6 +226,7 @@ export function ProfilesModal({
               <textarea
                 className="input"
                 value={form.instructions}
+                disabled={editingBuiltIn}
                 rows={5}
                 onChange={(event) =>
                   setForm((current) => ({ ...current, instructions: event.target.value }))
@@ -227,6 +239,7 @@ export function ProfilesModal({
                 <select
                   className="input"
                   value={form.surface}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, surface: event.target.value }))
                   }
@@ -243,6 +256,7 @@ export function ProfilesModal({
                 <input
                   className="input"
                   value={form.executionProfile}
+                  disabled={editingBuiltIn}
                   placeholder="implementation"
                   onChange={(event) =>
                     setForm((current) => ({ ...current, executionProfile: event.target.value }))
@@ -254,6 +268,7 @@ export function ProfilesModal({
                 <input
                   className="input"
                   value={form.providerHint}
+                  disabled={editingBuiltIn}
                   placeholder="ollama"
                   onChange={(event) =>
                     setForm((current) => ({ ...current, providerHint: event.target.value }))
@@ -265,6 +280,7 @@ export function ProfilesModal({
                 <input
                   className="input"
                   value={form.modelHint}
+                  disabled={editingBuiltIn}
                   placeholder="qwen2.5-coder"
                   onChange={(event) =>
                     setForm((current) => ({ ...current, modelHint: event.target.value }))
@@ -277,6 +293,7 @@ export function ProfilesModal({
                 <input
                   type="checkbox"
                   checked={form.toolsEnabled}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, toolsEnabled: event.target.checked }))
                   }
@@ -287,6 +304,7 @@ export function ProfilesModal({
                 <input
                   type="checkbox"
                   checked={form.writesAllowed}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
                   }
@@ -297,6 +315,7 @@ export function ProfilesModal({
                 <input
                   type="checkbox"
                   checked={form.networkAllowed}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
                   }
@@ -310,6 +329,7 @@ export function ProfilesModal({
                 <select
                   className="input"
                   value={form.approvalPolicy}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
                   }
@@ -326,6 +346,7 @@ export function ProfilesModal({
                 <select
                   className="input"
                   value={form.projectMemoryPolicy}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
                   }
@@ -342,6 +363,7 @@ export function ProfilesModal({
                 <select
                   className="input"
                   value={form.contextSourcePolicy}
+                  disabled={editingBuiltIn}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
                   }
@@ -358,6 +380,7 @@ export function ProfilesModal({
                 <input
                   className="input"
                   value={form.externalAgentKind}
+                  disabled={editingBuiltIn}
                   placeholder="claude_code"
                   onChange={(event) =>
                     setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
@@ -366,6 +389,7 @@ export function ProfilesModal({
               </label>
             </div>
             <ProjectSkillPicker
+              disabled={editingBuiltIn}
               onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
               skills={projectSkills}
               value={form.skillIDs}

--- a/ui/src/types/agent-profile.ts
+++ b/ui/src/types/agent-profile.ts
@@ -18,6 +18,7 @@ export type AgentProfileRecord = {
   skill_ids?: string[];
   external_agent_kind?: string;
   external_agent_options?: Record<string, string>;
+  built_in?: boolean;
   created_at?: string;
   updated_at?: string;
 };


### PR DESCRIPTION
## Summary
- add immutable built-in agent profiles for planning, architecture, implementation, frontend, design review, reliability, documentation, QA review, safe external review, and the project assignment fallback
- expose built-in profiles through the agent profile API with built_in markers and reject create/update/delete mutations for built-in ids
- map built-in project roles to realistic default profiles and make built-in profiles read-only in the Profiles UI
- update runtime and agent guidance docs

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-real-profiles/.gocache" go test ./internal/agentprofiles ./internal/projectwork ./internal/projectworkapp ./internal/api
- bun run test -- src/features/projects/ProfilesModal.test.tsx src/features/projects/ProjectSettingsPanel.test.tsx src/features/projects/RolesModal.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test
- just agent-docs-check
- go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-real-profiles/.gocache" go test -race -timeout 10m ./...