### PR TITLE
Validate assistant assignment roots

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -491,7 +491,7 @@ Every action has the same envelope:
 | `create_role`             | `internal/projectwork` | Creates a custom project role; built-in role ids remain immutable.                                                                      |
 | `create_work_item`        | `internal/projectwork` | Creates a project-scoped work item; does not start a task.                                                                              |
 | `update_work_item`        | `internal/projectwork` | Updates one existing work item.                                                                                                         |
-| `create_assignment`       | `internal/projectwork` | Creates an assignment for existing project work.                                                                                        |
+| `create_assignment`       | `internal/projectwork` | Creates an assignment for existing project work; supplied `root_id` must match one of the project's roots.                              |
 | `create_handoff`          | `internal/projectwork` | Creates a handoff record; does not launch follow-up work.                                                                               |
 | `create_memory_candidate` | `internal/memory`      | Creates a candidate with provenance; never a durable memory entry.                                                                      |
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -540,6 +540,16 @@ func TestProjectWorkAPI_WorkAndAssignmentRootIDs(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_rooted/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_missing_root",
+		"role_id":"software_developer",
+		"root_id":"root_missing"
+	}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create assignment invalid root status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_rooted/assignments", bytes.NewReader([]byte(`{
 		"id":"asgn_rooted",
 		"role_id":"software_developer",
 		"root_id":"root_feature"

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -338,8 +338,20 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 	if projectID == "" {
 		projectID = targetValue(action, "project_id")
 	}
-	if _, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID); err != nil {
+	item, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID)
+	if err != nil {
 		return ActionResult{}, err
+	}
+	projectID = item.ProjectID
+	rootID := strings.TrimSpace(patch.RootID)
+	if rootID != "" {
+		project, err := s.requireProject(ctx, projectID)
+		if err != nil {
+			return ActionResult{}, err
+		}
+		if !projectHasRoot(project, rootID) {
+			return ActionResult{}, fmt.Errorf("%w: root %q", ErrNotFound, rootID)
+		}
 	}
 	id := strings.TrimSpace(patch.ID)
 	if id == "" {
@@ -348,9 +360,9 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 	assignment, err := s.work.CreateAssignment(ctx, projectwork.Assignment{
 		ID:         id,
 		ProjectID:  projectID,
-		WorkItemID: patch.WorkItemID,
+		WorkItemID: item.ID,
 		RoleID:     patch.RoleID,
-		RootID:     patch.RootID,
+		RootID:     rootID,
 		DriverKind: patch.DriverKind,
 		Status:     patch.Status,
 	})

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1320,6 +1320,14 @@ func TestService_ApplyRevalidatesStaleTargets(t *testing.T) {
 			ctx := context.Background()
 			fixture := builder.build(t)
 			project := createTestProject(t, ctx, fixture.projects)
+			if _, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+				ID:        "work_stale_root",
+				ProjectID: project.ID,
+				Title:     "Stale root check",
+				Status:    projectwork.WorkItemStatusReady,
+			}); err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
 
 			cases := []struct {
 				name   string
@@ -1349,6 +1357,19 @@ func TestService_ApplyRevalidatesStaleTargets(t *testing.T) {
 					},
 				},
 				{
+					name: "missing assignment root",
+					action: Action{
+						Kind: ActionCreateAssignment,
+						Patch: rawPatch(t, map[string]any{
+							"project_id":   project.ID,
+							"work_item_id": "work_stale_root",
+							"role_id":      "software_developer",
+							"root_id":      "root_missing",
+							"driver_kind":  projectwork.AssignmentDriverHecateTask,
+						}),
+					},
+				},
+				{
 					name: "missing chat",
 					action: Action{
 						Kind:   ActionMoveChatSession,
@@ -1367,6 +1388,13 @@ func TestService_ApplyRevalidatesStaleTargets(t *testing.T) {
 					}, true)
 					if !errors.Is(err, ErrNotFound) {
 						t.Fatalf("Apply err = %v, want ErrNotFound", err)
+					}
+					assignments, err := fixture.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: project.ID})
+					if err != nil {
+						t.Fatalf("ListAssignments: %v", err)
+					}
+					if len(assignments) != 0 {
+						t.Fatalf("assignments = %+v, want none after stale-target rejection", assignments)
 					}
 				})
 			}
@@ -1445,7 +1473,7 @@ func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
 							"project_id":   project.ID,
 							"work_item_id": "work_a",
 							"role_id":      "software_developer",
-							"root_id":      "root_worktree",
+							"root_id":      project.Roots[0].ID,
 							"driver_kind":  projectwork.AssignmentDriverHecateTask,
 						}),
 					},
@@ -1477,7 +1505,7 @@ func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
 			if err != nil {
 				t.Fatalf("list assignments: %v", err)
 			}
-			if len(assignments) != 1 || assignments[0].ID != "asgn_a" || assignments[0].Status != projectwork.AssignmentStatusQueued || assignments[0].RootID != "root_worktree" {
+			if len(assignments) != 1 || assignments[0].ID != "asgn_a" || assignments[0].Status != projectwork.AssignmentStatusQueued || assignments[0].RootID != project.Roots[0].ID {
 				t.Fatalf("assignments = %+v, want queued assignment with root", assignments)
 			}
 			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: "work_a"})

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -98,10 +98,13 @@ type WorkItem struct {
 }
 
 type Assignment struct {
-	ID            string
-	ProjectID     string
-	WorkItemID    string
-	RoleID        string
+	ID         string
+	ProjectID  string
+	WorkItemID string
+	RoleID     string
+	// RootID references a projects.Root. The projectwork store treats it as an
+	// opaque project-scoped ref; caller boundaries validate membership because
+	// project roots live in the projects store.
 	RootID        string
 	DriverKind    string
 	Status        string


### PR DESCRIPTION
## Summary
- validate Project Assistant create_assignment root_id against the project roots before creating assignments
- normalize applied assignment project/work item refs from the loaded work item
- document the root ownership rule for assistant assignment actions

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-guided-assignment/.gocache" go test ./internal/projectassistant -run 'TestService_Apply(RevalidatesStaleTargets|CreatesProjectWorkRecords)'
- go vet ./...
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-guided-assignment/.gocache" go test -race -timeout 10m ./...
