### PR TITLE
Stamp dev image builds with runtime version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@
 ARG GO_VERSION=1.26.2
 ARG BUN_VERSION=1.3.13
 ARG NODE_IMAGE=node:24-trixie-slim
+ARG HECATE_VERSION=dev
 
 # ── 1. UI build ─────────────────────────────────────────────────────────────
 
@@ -30,6 +31,7 @@ RUN bun run build
 # ── 2. Go build ─────────────────────────────────────────────────────────────
 
 FROM golang:${GO_VERSION}-alpine AS go-builder
+ARG HECATE_VERSION=dev
 WORKDIR /src
 
 RUN apk add --no-cache git
@@ -43,7 +45,7 @@ COPY --from=ui-builder /app/ui/dist ./ui/dist
 
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
-    -ldflags='-s -w' \
+    -ldflags="-s -w -X github.com/hecatehq/hecate/internal/version.Version=${HECATE_VERSION}" \
     -o /out/hecate \
     ./cmd/hecate
 

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -1174,6 +1174,15 @@ describe("status bar version chip", () => {
     expect(statusbar!.textContent).toContain(sampleVersion);
   });
 
+  it("labels raw dev builds clearly", () => {
+    renderWorkspace({ status: "ok", time: "2026-04-25T00:00:00Z", version: "dev" });
+
+    const statusbar = document.querySelector(".hecate-statusbar");
+    expect(statusbar).not.toBeNull();
+    expect(statusbar!.textContent).toContain("source build");
+    expect(statusbar!.textContent).not.toContain("|dev|");
+  });
+
   it("hides the version chip when /healthz did not include one", () => {
     renderWorkspace({ status: "ok", time: "2026-04-25T00:00:00Z" });
 

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -217,6 +217,13 @@ export function getAvailableWorkspaces(): WorkspaceDefinition[] {
   return [WS.chats, WS.projects, WS.runs, WS.connections, WS.overview, WS.usage, WS.settings];
 }
 
+function runtimeVersionLabel(version: string | undefined): string {
+  const trimmed = version?.trim() ?? "";
+  if (!trimmed) return "";
+  if (trimmed === "dev") return "source build";
+  return trimmed;
+}
+
 export function ConsoleShell({
   activeWorkspace,
   onSelectWorkspace,
@@ -296,6 +303,7 @@ function AuthenticatedShell({
     setNoticeMessage: settingsActions.setNoticeMessage,
   });
   const session = deriveSessionState(runtime.state.sessionInfo);
+  const runtimeVersion = runtimeVersionLabel(runtime.state.health?.version);
   const workspaces = getAvailableWorkspaces();
   const [taskFocusRequest, setTaskFocusRequest] = useState<TaskFocusRequest | null>(null);
   const [traceFocusRequest, setTraceFocusRequest] = useState<TraceFocusRequest | null>(null);
@@ -453,10 +461,10 @@ function AuthenticatedShell({
       {/* Status bar */}
       <div className="hecate-statusbar">
         <span className="hecate-statusbar__brand">hecate</span>
-        {runtime.state.health?.version && (
+        {runtimeVersion && (
           <>
             <span className="hecate-statusbar__sep">|</span>
-            <span style={{ fontFamily: "var(--font-mono)" }}>{runtime.state.health.version}</span>
+            <span style={{ fontFamily: "var(--font-mono)" }}>{runtimeVersion}</span>
           </>
         )}
         <span className="hecate-statusbar__sep">|</span>

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -1,7 +1,8 @@
 export type HealthResponse = {
   status: string;
   time: string;
-  // Build identifier of the gateway. "dev" for local builds; release
+  // Build identifier of the gateway. Local source builds default to
+  // "dev"; container/dev builds may stamp a commit label; release
   // builds (via goreleaser) inject the git tag.
   version?: string;
 };


### PR DESCRIPTION
## Summary
- stamp source-built Docker images with HECATE_VERSION via ldflags
- show raw dev builds as source build in the status bar
- update the runtime health version type note and AppShell coverage

## Tests
- cd ui && bun run typecheck
- cd ui && bun run test -- src/app/AppShell.test.tsx