### PR TITLE
Harden plugin MCP metadata validation

### DIFF
--- a/docs/design/proposals/plugin-architecture.md
+++ b/docs/design/proposals/plugin-architecture.md
@@ -219,7 +219,9 @@ The registry slice validates MCP server declarations and projects them as
 mount candidates. Installing a plugin still does not start the declared server,
 mount it into a task/chat/profile, or grant credentials. Env/header values in
 manifests are `$VAR_NAME` references only; secret binding and literal secret
-storage stay Hecate-owned.
+storage stay Hecate-owned. The declared `approval_policy` is a requested mount
+default, not authority: Hecate's policy gates remain the final source of truth,
+and plugin metadata cannot downgrade an operator-required approval.
 
 MCP tool descriptions and metadata must be treated as external input. Hecate
 should preserve MCP annotations, but approval policy remains Hecate-owned:

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1304,9 +1304,18 @@ MCP server capabilities may use the inline shape above or place the same fields
 inside `config`. The registry normalizes either shape into an `mcp_server`
 response object. Exactly one of `command` or `url` must be set; `transport`, if
 present, must match (`stdio` for `command`, `http` for `url`). `env` and
-`headers` values must be whole `$VAR_NAME` references. Literal values and
-manifest-provided encrypted blobs are rejected so plugin registry records do
-not become a credential store.
+`headers` values must be whole `$VAR_NAME` references; `env` keys must be valid
+process environment names and `headers` keys must be valid HTTP header names.
+Literal values and manifest-provided encrypted blobs are rejected so plugin
+registry records do not become a credential store. Unknown MCP server
+capability fields are rejected in this native v0 schema; compatibility
+importers should translate or drop host-specific fields such as `cwd` or
+`timeout` before installing a Hecate manifest.
+
+`approval_policy` is recorded as requested mount metadata only. When explicit
+mounting into profiles or task/chat starts lands, Hecate's own approval policy
+remains authoritative; a plugin-declared `auto` value must not downgrade a
+Hecate-owned requirement for approval.
 
 ```json
 → 200

--- a/internal/pluginregistry/manifest.go
+++ b/internal/pluginregistry/manifest.go
@@ -33,6 +33,18 @@ type manifestCapability struct {
 	URL            string            `json:"url"`
 	Headers        map[string]string `json:"headers"`
 	ApprovalPolicy string            `json:"approval_policy"`
+	raw            json.RawMessage
+}
+
+func (item *manifestCapability) UnmarshalJSON(raw []byte) error {
+	type manifestCapabilityAlias manifestCapability
+	var decoded manifestCapabilityAlias
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return err
+	}
+	*item = manifestCapability(decoded)
+	item.raw = compactJSON(raw)
+	return nil
 }
 
 type manifestAuth struct {
@@ -178,6 +190,9 @@ func capabilitiesFromManifest(items []manifestCapability, forcedKind string) ([]
 }
 
 func mcpServerConfigJSONFromManifest(capabilityID string, item manifestCapability) (json.RawMessage, error) {
+	if err := validateMCPServerCapabilityFields(item.raw); err != nil {
+		return nil, err
+	}
 	hasConfig := len(compactJSON(item.Config)) > 0
 	hasInline := hasInlineMCPServerConfig(item)
 	if hasConfig && hasInline {
@@ -201,6 +216,25 @@ func mcpServerConfigJSONFromManifest(capabilityID string, item manifestCapabilit
 		return nil, ErrInvalid
 	}
 	return normalizeMCPServerConfigJSON(capabilityID, raw)
+}
+
+func validateMCPServerCapabilityFields(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return ErrInvalid
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return ErrInvalid
+	}
+	for field := range fields {
+		switch field {
+		case "id", "name", "kind", "display_name", "permissions", "enabled", "auth",
+			"config", "transport", "command", "args", "env", "url", "headers", "approval_policy":
+		default:
+			return ErrInvalid
+		}
+	}
+	return nil
 }
 
 func hasInlineMCPServerConfig(item manifestCapability) bool {

--- a/internal/pluginregistry/mcp.go
+++ b/internal/pluginregistry/mcp.go
@@ -61,10 +61,10 @@ func normalizeMCPServerConfig(capabilityID string, raw json.RawMessage) (MCPServ
 	cfg.ApprovalPolicy = strings.TrimSpace(cfg.ApprovalPolicy)
 	cfg.Args = append([]string(nil), cfg.Args...)
 	var err error
-	if cfg.Env, err = normalizeMCPRefMap(cfg.Env); err != nil {
+	if cfg.Env, err = normalizeMCPRefMap(cfg.Env, isMCPEnvName); err != nil {
 		return MCPServerConfig{}, err
 	}
-	if cfg.Headers, err = normalizeMCPRefMap(cfg.Headers); err != nil {
+	if cfg.Headers, err = normalizeMCPRefMap(cfg.Headers, isHTTPHeaderName); err != nil {
 		return MCPServerConfig{}, err
 	}
 	if cfg.Name == "" {
@@ -97,7 +97,7 @@ func normalizeMCPServerConfig(capabilityID string, raw json.RawMessage) (MCPServ
 	return cfg, nil
 }
 
-func normalizeMCPRefMap(values map[string]string) (map[string]string, error) {
+func normalizeMCPRefMap(values map[string]string, validKey func(string) bool) (map[string]string, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -105,7 +105,7 @@ func normalizeMCPRefMap(values map[string]string) (map[string]string, error) {
 	for key, value := range values {
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
-		if key == "" || !isMCPEnvRef(value) {
+		if key == "" || !validKey(key) || !isMCPEnvRef(value) {
 			return nil, ErrInvalid
 		}
 		out[key] = value
@@ -113,17 +113,43 @@ func normalizeMCPRefMap(values map[string]string) (map[string]string, error) {
 	return out, nil
 }
 
-func isMCPEnvRef(value string) bool {
-	if len(value) < 2 || value[0] != '$' {
+func isMCPEnvName(value string) bool {
+	if value == "" {
 		return false
 	}
-	for i, c := range value[1:] {
+	for i, c := range value {
 		switch {
 		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c == '_':
 		case c >= '0' && c <= '9':
 			if i == 0 {
 				return false
 			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isMCPEnvRef(value string) bool {
+	if len(value) < 2 || value[0] != '$' {
+		return false
+	}
+	return isMCPEnvName(value[1:])
+}
+
+func isHTTPHeaderName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, c := range value {
+		switch {
+		case c >= 'A' && c <= 'Z',
+			c >= 'a' && c <= 'z',
+			c >= '0' && c <= '9',
+			c == '!', c == '#', c == '$', c == '%', c == '&', c == '\'',
+			c == '*', c == '+', c == '-', c == '.', c == '^', c == '_',
+			c == '`', c == '|', c == '~':
 		default:
 			return false
 		}

--- a/internal/pluginregistry/store_test.go
+++ b/internal/pluginregistry/store_test.go
@@ -155,7 +155,7 @@ func TestPluginFromManifest_MCPServerConfigObjectNormalizes(t *testing.T) {
 				"config": map[string]any{
 					"name":            "linear",
 					"url":             "https://linear.example/mcp",
-					"headers":         map[string]string{"Authorization": "$LINEAR_AUTHORIZATION"},
+					"headers":         map[string]string{"X-API-Key": "$LINEAR_API_KEY"},
 					"approval_policy": "block",
 				},
 			}},
@@ -169,7 +169,7 @@ func TestPluginFromManifest_MCPServerConfigObjectNormalizes(t *testing.T) {
 	if cfg.Name != "linear" || cfg.Transport != MCPServerTransportHTTP || cfg.URL != "https://linear.example/mcp" {
 		t.Fatalf("mcp config = %+v, want normalized http config object", cfg)
 	}
-	if cfg.Headers["Authorization"] != "$LINEAR_AUTHORIZATION" || cfg.ApprovalPolicy != "block" {
+	if cfg.Headers["X-API-Key"] != "$LINEAR_API_KEY" || cfg.ApprovalPolicy != "block" {
 		t.Fatalf("mcp config = %+v, want header ref and block policy", cfg)
 	}
 }
@@ -209,6 +209,22 @@ func TestPluginFromManifest_MCPServerConfigValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid env key",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"env":     map[string]string{"GITHUB TOKEN": "$GITHUB_TOKEN"},
+			},
+		},
+		{
+			name: "invalid header key",
+			server: map[string]any{
+				"id":      "github",
+				"url":     "https://example.test/mcp",
+				"headers": map[string]string{"Bad Header": "$GITHUB_TOKEN"},
+			},
+		},
+		{
 			name: "invalid approval",
 			server: map[string]any{
 				"id":              "github",
@@ -222,6 +238,24 @@ func TestPluginFromManifest_MCPServerConfigValidation(t *testing.T) {
 				"id":      "github",
 				"command": "npx",
 				"config":  map[string]any{"command": "npx"},
+			},
+		},
+		{
+			name: "unknown inline field",
+			server: map[string]any{
+				"id":      "github",
+				"command": "npx",
+				"cwd":     ".",
+			},
+		},
+		{
+			name: "unknown nested config field",
+			server: map[string]any{
+				"id": "github",
+				"config": map[string]any{
+					"command": "npx",
+					"cwd":     ".",
+				},
 			},
 		},
 	} {


### PR DESCRIPTION
## Summary
- validate plugin MCP env keys as process env names and header keys as HTTP header names
- reject unknown MCP server capability fields in both inline and nested config forms
- document that plugin-declared approval_policy is mount metadata only and cannot downgrade Hecate-owned approval gates

## Tests
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test ./internal/pluginregistry ./internal/api -run 'TestPlugin'
- go vet ./internal/pluginregistry ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test ./internal/pluginregistry ./internal/api
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/plugin-mcp-capabilities/.gocache go test -race -timeout 10m ./...
- git diff --check