### PR TITLE
test(security): pin removed terminal routes

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -190,6 +190,8 @@ func TestServerRejectsLegacyNativePathsButKeepsProviderCompatibleV1(t *testing.T
 		{method: http.MethodGet, path: "/v1/agent-chat/sessions"},
 		{method: http.MethodGet, path: "/admin/control-plane"},
 		{method: http.MethodPost, path: "/admin/control-plane/providers"},
+		{method: http.MethodPost, path: "/hecate/v1/terminal/sessions"},
+		{method: http.MethodGet, path: "/hecate/v1/terminal?workspace=/tmp&token=legacy"},
 	} {
 		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
 			client.mustRequestStatus(http.StatusNotFound, tc.method, tc.path, "")


### PR DESCRIPTION
## Summary
- extend the legacy-route rejection test to cover the removed embedded terminal ticket and WebSocket paths
- assert the old routes return API 404s while provider-compatible `/v1/models` still routes normally

## Validation
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/remove-embedded-terminal/.gocache go test ./internal/api -run TestServerRejectsLegacyNativePathsButKeepsProviderCompatibleV1
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/remove-embedded-terminal/.gocache go test ./internal/api