### PR TITLE
fix(security): warn on exposed tokenless deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,16 @@ HECATE_ALLOW_NON_LOOPBACK_BIND=0
 # APIs. Provider-compatible `/v1/*` inference endpoints and `/healthz` stay
 # unchanged. Hecate-aware clients send it as `X-Hecate-Runtime-Token`; the
 # operator UI reads `hecate.runtimeToken` from sessionStorage/localStorage when
-# you enable this.
+# you enable this. Strongly recommended when binding beyond loopback with
+# configured provider credentials.
 # HECATE_RUNTIME_TOKEN=
 # Optional shared token for provider-compatible inference ingress:
 # GET /v1/models, POST /v1/chat/completions, and POST /v1/messages. Clients
 # may send it as `Authorization: Bearer ...` or `x-api-key: ...`. It does not
 # protect `/hecate/v1/*`, `/healthz`, or OTLP `/v1/traces|metrics|logs`.
 # The operator UI reads `hecate.inferenceToken` from sessionStorage/localStorage
-# when you enable this.
+# when you enable this. Strongly recommended when exposing `/v1/*` beyond
+# loopback with configured provider credentials.
 # HECATE_INFERENCE_TOKEN=
 
 # Optional client-facing URL written to `hecate.runtime.json` for helper

--- a/cmd/hecate/exposure_warnings.go
+++ b/cmd/hecate/exposure_warnings.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/providers"
+)
+
+type exposureProtectionWarning struct {
+	envName string
+	routes  string
+	message string
+}
+
+func logNetworkExposureProtectionWarnings(logger *slog.Logger, cfg config.Config, registry providers.Registry) {
+	riskProviderCount, warnings := networkExposureProtectionWarnings(cfg, registry)
+	for _, warning := range warnings {
+		logger.Warn(warning.message,
+			slog.String("event.name", "runtime.exposed_without_token"),
+			slog.String("listen_addr", cfg.Server.Address),
+			slog.String("missing_env", warning.envName),
+			slog.String("routes", warning.routes),
+			slog.Int("credential_risk_provider_count", riskProviderCount),
+		)
+	}
+}
+
+func networkExposureProtectionWarnings(cfg config.Config, registry providers.Registry) (int, []exposureProtectionWarning) {
+	if config.ListenAddressIsLoopback(cfg.Server.Address) || cfg.Server.RemoteRuntimeMode {
+		return 0, nil
+	}
+
+	riskProviderCount := credentialRiskProviderCount(registry)
+	if riskProviderCount == 0 {
+		return 0, nil
+	}
+
+	var warnings []exposureProtectionWarning
+	if strings.TrimSpace(cfg.Server.InferenceToken) == "" {
+		warnings = append(warnings, exposureProtectionWarning{
+			envName: "HECATE_INFERENCE_TOKEN",
+			routes:  "/v1/models, /v1/chat/completions, /v1/messages",
+			message: "provider-compatible inference routes are exposed without an inference token",
+		})
+	}
+	if strings.TrimSpace(cfg.Server.RuntimeToken) == "" {
+		warnings = append(warnings, exposureProtectionWarning{
+			envName: "HECATE_RUNTIME_TOKEN",
+			routes:  "/hecate/v1/*",
+			message: "Hecate-native routes are exposed without a runtime token",
+		})
+	}
+	return riskProviderCount, warnings
+}
+
+func credentialRiskProviderCount(registry providers.Registry) int {
+	if registry == nil {
+		return 0
+	}
+
+	var count int
+	for _, provider := range registry.All() {
+		if enabler, ok := provider.(providers.Enabler); ok && !enabler.Enabled() {
+			continue
+		}
+		if providerCredentialMayBeConfigured(provider) {
+			count++
+		}
+	}
+	return count
+}
+
+func providerCredentialMayBeConfigured(provider providers.Provider) bool {
+	reporter, ok := provider.(providers.CredentialReporter)
+	if !ok {
+		return provider.Kind() == providers.KindCloud
+	}
+	switch reporter.CredentialState() {
+	case providers.CredentialStateConfigured, providers.CredentialStateUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/hecate/exposure_warnings_test.go
+++ b/cmd/hecate/exposure_warnings_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestNetworkExposureProtectionWarnings(t *testing.T) {
+	t.Parallel()
+
+	configuredProvider := exposureTestProvider{
+		name:            "openai",
+		credentialState: providers.CredentialStateConfigured,
+		enabled:         true,
+	}
+	missingCredentialProvider := exposureTestProvider{
+		name:            "openai",
+		credentialState: providers.CredentialStateMissing,
+		enabled:         true,
+	}
+	unknownCredentialProvider := exposureTestProvider{
+		name:            "openai",
+		credentialState: providers.CredentialStateUnknown,
+		enabled:         true,
+	}
+	disabledConfiguredProvider := exposureTestProvider{
+		name:            "openai",
+		credentialState: providers.CredentialStateConfigured,
+		enabled:         false,
+	}
+	nonReportingCloudProvider := exposureBareProvider{
+		name:    "future_cloud",
+		kind:    providers.KindCloud,
+		enabled: true,
+	}
+	nonReportingLocalProvider := exposureBareProvider{
+		name:    "future_local",
+		kind:    providers.KindLocal,
+		enabled: true,
+	}
+
+	cases := []struct {
+		name      string
+		cfg       config.Config
+		registry  providers.Registry
+		wantCount int
+		wantEnv   []string
+	}{
+		{
+			name: "loopback stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "127.0.0.1:8765",
+			}},
+			registry: providers.NewRegistry(configuredProvider),
+		},
+		{
+			name: "remote runtime identity mode stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address:           "0.0.0.0:8765",
+				RemoteRuntimeMode: true,
+			}},
+			registry: providers.NewRegistry(configuredProvider),
+		},
+		{
+			name: "no configured provider credentials stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry: providers.NewRegistry(missingCredentialProvider),
+		},
+		{
+			name: "disabled configured provider stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry: providers.NewRegistry(disabledConfiguredProvider),
+		},
+		{
+			name: "unknown credential state warns conservatively",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry:  providers.NewRegistry(unknownCredentialProvider),
+			wantCount: 1,
+			wantEnv:   []string{"HECATE_INFERENCE_TOKEN", "HECATE_RUNTIME_TOKEN"},
+		},
+		{
+			name: "cloud provider without credential reporter warns conservatively",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry:  providers.NewRegistry(nonReportingCloudProvider),
+			wantCount: 1,
+			wantEnv:   []string{"HECATE_INFERENCE_TOKEN", "HECATE_RUNTIME_TOKEN"},
+		},
+		{
+			name: "local provider without credential reporter stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry: providers.NewRegistry(nonReportingLocalProvider),
+		},
+		{
+			name: "non-loopback with configured credentials warns for both missing tokens",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address: "0.0.0.0:8765",
+			}},
+			registry:  providers.NewRegistry(configuredProvider),
+			wantCount: 1,
+			wantEnv:   []string{"HECATE_INFERENCE_TOKEN", "HECATE_RUNTIME_TOKEN"},
+		},
+		{
+			name: "inference token leaves runtime token warning",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address:        "0.0.0.0:8765",
+				InferenceToken: "inference-token-present",
+			}},
+			registry:  providers.NewRegistry(configuredProvider),
+			wantCount: 1,
+			wantEnv:   []string{"HECATE_RUNTIME_TOKEN"},
+		},
+		{
+			name: "runtime token leaves inference token warning",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address:      "0.0.0.0:8765",
+				RuntimeToken: "runtime-token-present",
+			}},
+			registry:  providers.NewRegistry(configuredProvider),
+			wantCount: 1,
+			wantEnv:   []string{"HECATE_INFERENCE_TOKEN"},
+		},
+		{
+			name: "both tokens configured stays quiet",
+			cfg: config.Config{Server: config.ServerConfig{
+				Address:        "0.0.0.0:8765",
+				InferenceToken: "inference-token-present",
+				RuntimeToken:   "runtime-token-present",
+			}},
+			registry:  providers.NewRegistry(configuredProvider),
+			wantCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotCount, gotWarnings := networkExposureProtectionWarnings(tc.cfg, tc.registry)
+			if gotCount != tc.wantCount {
+				t.Fatalf("credential risk provider count = %d, want %d", gotCount, tc.wantCount)
+			}
+			gotEnv := make([]string, 0, len(gotWarnings))
+			for _, warning := range gotWarnings {
+				gotEnv = append(gotEnv, warning.envName)
+			}
+			if !slices.Equal(gotEnv, tc.wantEnv) {
+				t.Fatalf("warning envs = %v, want %v", gotEnv, tc.wantEnv)
+			}
+		})
+	}
+}
+
+type exposureTestProvider struct {
+	name            string
+	credentialState providers.CredentialState
+	enabled         bool
+}
+
+func (p exposureTestProvider) Name() string {
+	return p.name
+}
+
+func (p exposureTestProvider) Kind() providers.Kind {
+	return providers.KindCloud
+}
+
+func (p exposureTestProvider) DefaultModel() string {
+	return ""
+}
+
+func (p exposureTestProvider) Capabilities(context.Context) (providers.Capabilities, error) {
+	return providers.Capabilities{
+		Name: p.name,
+		Kind: providers.KindCloud,
+	}, nil
+}
+
+func (p exposureTestProvider) Chat(context.Context, types.ChatRequest) (*types.ChatResponse, error) {
+	return nil, errors.New("not used")
+}
+
+func (p exposureTestProvider) Supports(string) bool {
+	return true
+}
+
+func (p exposureTestProvider) CredentialState() providers.CredentialState {
+	return p.credentialState
+}
+
+func (p exposureTestProvider) Enabled() bool {
+	return p.enabled
+}
+
+type exposureBareProvider struct {
+	name    string
+	kind    providers.Kind
+	enabled bool
+}
+
+func (p exposureBareProvider) Name() string {
+	return p.name
+}
+
+func (p exposureBareProvider) Kind() providers.Kind {
+	return p.kind
+}
+
+func (p exposureBareProvider) DefaultModel() string {
+	return ""
+}
+
+func (p exposureBareProvider) Capabilities(context.Context) (providers.Capabilities, error) {
+	return providers.Capabilities{
+		Name: p.name,
+		Kind: p.kind,
+	}, nil
+}
+
+func (p exposureBareProvider) Chat(context.Context, types.ChatRequest) (*types.ChatResponse, error) {
+	return nil, errors.New("not used")
+}
+
+func (p exposureBareProvider) Supports(string) bool {
+	return true
+}
+
+func (p exposureBareProvider) Enabled() bool {
+	return p.enabled
+}

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -177,6 +177,7 @@ func runServe() {
 		logger.Warn("auto-import of env-preconfigured providers failed", slog.Any("error", err))
 	}
 	providerRegistry := providerRuntime.Registry()
+	logNetworkExposureProtectionWarnings(logger, cfg, providerRegistry)
 	providerHistoryStore := buildProviderHistoryStore(cfg, logger, sqliteClient, postgresClient)
 	healthTracker := providers.NewMemoryHealthTrackerWithHistory(
 		cfg.Provider.HealthThreshold,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -26,6 +26,15 @@ MCP tools, and chat/task control-plane calls. Use `HECATE_INFERENCE_TOKEN` for
 OpenAI- or Anthropic-shaped SDK clients pointed at `/v1/*`. Keep `/healthz`
 private to the host, load balancer, or orchestrator health check.
 
+When a self-hosted runtime binds beyond loopback and has configured provider
+credentials, startup logs a warning for each missing token so exposed
+deployments do not silently leave credential-spending routes unguarded. Remote
+runtime mode is different: valid `X-Hecate-Remote-*` identity from the trusted
+control-plane proxy is the auth boundary there, and the shared local tokens are
+bypassed after that identity check succeeds. The self-hosted warning is
+advisory and intentionally conservative; it can still appear when an
+authenticating reverse proxy is your access-control boundary.
+
 ## Contents
 
 - [Image pinning](#image-pinning)
@@ -155,6 +164,13 @@ reach through `-p 8765:8765` or `docker compose`. The image also sets
 `0.0.0.0` for the published port to work. Treat the host-side published port as
 the exposed surface and protect it with host firewall rules or a reverse proxy
 when it is reachable beyond your own machine.
+
+For container deployments reachable by other machines, use the same baseline as
+the top-level guardrail set: private `/data` volume, `HECATE_BACKEND=sqlite` or
+Postgres, platform-managed secrets for provider keys and bootstrap overrides,
+`HECATE_RUNTIME_TOKEN` for Hecate-native UI/API clients, and
+`HECATE_INFERENCE_TOKEN` for provider-compatible SDK clients. Do not put tokens
+or provider keys in image layers.
 
 The runtime stage defaults to `node:24-trixie-slim` through the `NODE_IMAGE`
 build arg so the image has a maintained Debian userspace for shell, npm, and

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -89,6 +89,11 @@ Hecate stores local configuration and operational state on disk.
 - External agent credentials belong to the underlying CLI account. Hecate can probe and surface auth failures, but it does not own, proxy, or pool those accounts. See [External Agents](../runtime/external-agents.md#credential-and-account-boundaries) for credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok Build.
 - Stdio MCP servers inherit only runtime-essential environment variables from the gateway. Server credentials must be configured explicitly on that MCP server entry.
 - If you expose Hecate beyond loopback while provider credentials are configured, anyone who can reach an unprotected inference path may be able to spend those credentials. Use your own network access control; set `HECATE_INFERENCE_TOKEN` for provider-compatible `/v1/*` clients and `HECATE_RUNTIME_TOKEN` for Hecate-native chat, task, and control-plane clients.
+- On self-hosted non-loopback starts, Hecate logs warnings when configured
+  provider credentials exist and either shared token is missing. Remote runtime
+  mode uses trusted proxy identity instead, so those local token warnings do not
+  apply there. The self-hosted warning is conservative advisory output and can
+  still appear behind an authenticating reverse proxy.
 
 ### Bootstrap key today
 


### PR DESCRIPTION
## Summary
- warn at startup when a self-hosted non-loopback runtime has configured provider credentials and is missing Hecate runtime or inference token protection
- skip the warning for loopback, remote-runtime identity mode, missing credentials, and disabled providers
- document the exposed-instance/container baseline and token split in operator docs and .env.example

## Validation
- go test ./cmd/hecate ./internal/config
- go vet ./cmd/hecate ./internal/config
- /Users/chicoxyzzy/dev/hecate/hecate/ui/node_modules/.bin/oxfmt --check docs/operator/deployment.md docs/operator/security.md