### PR TITLE
Polish Projects V1 closure

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -29,6 +29,9 @@ project skills registry exposes local `SKILL.md` metadata for roles/profiles
 without granting tools, injecting bodies, or executing skill scripts. The
 operator UI can manage agent profiles and pick registered project skills for
 roles/profiles; those selections remain metadata until launch-time resolution.
+Projects V1 is a usable local cockpit substrate, not a Planner/Manager agent:
+new project work should improve setup, inspection, evidence, and deliberate
+operator actions unless a separate proposal changes that boundary.
 Agent profile responses include immutable built-in profiles such as
 `implementation`, `planning`, and `review_qa`; those built-ins are selectable
 defaults, not persisted rows or operator-editable project memory.

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -472,7 +472,10 @@ When the Go side adds a required prop (e.g. `streamTurnCosts`), update the `setu
   Settings, Roles, and Agent Profiles. Work with Project Assistant Bootstrap
   through one reviewable proposal path: UI helpers may refresh guidance/skills
   first, but they should still call the normal draft/apply flow rather than
-  mutating setup directly. Work Coordination uses one Work Queue with All /
+  mutating setup directly. New-project onboarding should make setup the primary
+  path, expose row-level actions for missing purpose/defaults/guidance/roles,
+  and move first-work creation after setup instead of leading with an open-ended
+  request box. Work Coordination uses one Work Queue with All /
   activity filters plus one selected work-item card; don't split the same work
   state across a separate Activity Inbox, Work Items list, and detail card.
   Keep the Projects index as a fixed left panel; don't add or restore a

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,14 +15,14 @@ Docs are organized by audience and stability:
 
 ## Start Here
 
-| You are...                                  | Read in this order                                                                                                                                                                                         |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Running Hecate locally                      | [Desktop app](operator/desktop-app.md), [Deployment](operator/deployment.md), [Security](operator/security.md), [Providers](operator/providers.md), [Known limitations](operator/known-limitations.md)     |
-| Calling Hecate from a client                | [Runtime API](runtime/runtime-api.md), [Chat sessions](runtime/chat-sessions.md), [Agent runtime](runtime/agent-runtime.md), [Events](runtime/events.md)                                                   |
-| Building or using coding-agent integrations | [External Agents](runtime/external-agents.md), [Runtime API](runtime/runtime-api.md), [Events](runtime/events.md), [MCP integration](runtime/mcp.md)                                                       |
-| Changing the codebase                       | [Architecture](contributor/architecture.md), [Development](contributor/development.md), [Beta roadmap](contributor/beta-roadmap.md), [`docs-ai/`](../docs-ai/README.md), [Release](contributor/release.md) |
-| Planning future behavior                    | [Design records](design/), especially the relevant lifecycle bucket before implementation starts.                                                                                                          |
-| Working as an AI agent                      | [`AGENTS.md`](../AGENTS.md), [`docs-ai/README.md`](../docs-ai/README.md), then the relevant `docs-ai/skills/*/SKILL.md`.                                                                                   |
+| You are...                                  | Read in this order                                                                                                                                                                                                                       |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Running Hecate locally                      | [Desktop app](operator/desktop-app.md), [Projects](operator/projects.md), [Deployment](operator/deployment.md), [Security](operator/security.md), [Providers](operator/providers.md), [Known limitations](operator/known-limitations.md) |
+| Calling Hecate from a client                | [Runtime API](runtime/runtime-api.md), [Chat sessions](runtime/chat-sessions.md), [Agent runtime](runtime/agent-runtime.md), [Events](runtime/events.md)                                                                                 |
+| Building or using coding-agent integrations | [External Agents](runtime/external-agents.md), [Runtime API](runtime/runtime-api.md), [Events](runtime/events.md), [MCP integration](runtime/mcp.md)                                                                                     |
+| Changing the codebase                       | [Architecture](contributor/architecture.md), [Development](contributor/development.md), [Beta roadmap](contributor/beta-roadmap.md), [`docs-ai/`](../docs-ai/README.md), [Release](contributor/release.md)                               |
+| Planning future behavior                    | [Design records](design/), especially the relevant lifecycle bucket before implementation starts.                                                                                                                                        |
+| Working as an AI agent                      | [`AGENTS.md`](../AGENTS.md), [`docs-ai/README.md`](../docs-ai/README.md), then the relevant `docs-ai/skills/*/SKILL.md`.                                                                                                                 |
 
 ## Operator Guides
 
@@ -30,6 +30,7 @@ Docs are organized by audience and stability:
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | [Deployment](operator/deployment.md)                           | Docker, binary install, image pinning, storage backends, rate limits, lost-token recovery.                     |
 | [Desktop app](operator/desktop-app.md)                         | Native bundles, tested-platform status, first-launch warnings, platform data dirs, sidecar lifecycle, roadmap. |
+| [Projects](operator/projects.md)                               | Project setup, roots/worktrees, assignments, reviews, handoffs, evidence, and V1 boundaries.                   |
 | [Security](operator/security.md)                               | Local-first threat model, runtime boundaries, workspace safety, approvals, secrets, and advisory handling.     |
 | [Providers](operator/providers.md)                             | Built-in provider presets, custom endpoints, credentials, model discovery, health, circuit breaking.           |
 | [Desktop updater signing](operator/desktop-updater-signing.md) | Tauri updater signing key custody and release integration.                                                     |

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -1,19 +1,22 @@
 # Projects
 
-> **Status:** accepted; orchestration foundation in progress.
+> **Status:** accepted; Projects V1 local cockpit substrate implemented.
 
 Current source of truth: [Agent runtime](../../runtime/agent-runtime.md), [Chat sessions](../../runtime/chat-sessions.md), [Architecture](../../contributor/architecture.md)
 
-Next action: make Projects the operational cockpit for project-scoped agent
-teams: add profile-management UI, finish profile-driven memory/source
-selection, and harden the activity/health/timeline UI with end-to-end project
-journeys.
+Projects V1 is the durable local cockpit for project-scoped work: roots,
+defaults, memory/context, skills metadata, roles, work items, assignments,
+handoffs, reviews, evidence, activity, and context inspection. Remaining
+near-term work should be beta hardening and dogfood-driven UX polish. Planner /
+Manager agents, runbooks, browser QA, automatic memory promotion, skill-body
+injection, and team project management should be handled as separate proposals
+instead of expanding this foundation document.
 
 ## Summary
 
 Hecate should distinguish **Projects** from **Workspaces**.
 
-A project is the durable Hecate identity for a codebase or work area. It owns memory scopes, chat/task grouping, default runtime choices, trusted context sources, and future agent-profile defaults. A workspace is a concrete filesystem root used by one chat, task, run, or external-agent session.
+A project is the durable Hecate identity for a codebase or work area. It owns memory scopes, chat/task grouping, default runtime choices, trusted context sources, and agent-profile defaults. A workspace is a concrete filesystem root used by one chat, task, run, or external-agent session.
 
 Today Hecate often uses a raw workspace path as both identity and runtime location. That works for early local flows, but it becomes confusing once we add durable memory, imported contexts, multiple checkouts of the same repo, temporary task workspaces, editor-owned workspaces, and future assistant layers.
 
@@ -396,12 +399,12 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
 5. Thread project identity into chat context packets. Done for itemized project context-source metadata.
 6. Add project-scoped memory. Done.
 7. Add agent-profile memory-source selection. Done for profile memory/source
-   policy snapshots and bounded native-assignment prompt inclusion.
+   policy snapshots, bounded native-assignment prompt inclusion, and
+   project-linked Hecate Chat prelude inspection.
 8. Move relevant defaults from ad hoc chat/task state into project defaults.
    Partial: provider, model, workspace mode, and agent profile defaults are
    project defaults; assignment starts resolve role/project/fallback profiles,
-   including immutable built-in profile defaults. Host-specific source-document
-   prompt policy remains future work.
+   including immutable built-in profile defaults.
 9. Add project activity aggregation. Done for the read-only V1 inbox.
 10. Add structured handoffs. Done for memory + SQLite store parity, API, UI
     actions, and activity projection signals.
@@ -412,26 +415,41 @@ Because Hecate has no stable users yet, later cleanup can remove legacy path-der
     tests, and an API-level project journey regression are updated; broad UI
     end-to-end project journeys remain beta-hardening work.
 
-## Near-Term Plan
+## V1 Closure Boundary
 
-The next project-orchestration slices are:
+Projects V1 is considered structurally complete when an operator can:
 
-1. Extend explicit prompt/source-content policy beyond native project
-   assignments. Profile-management UI, role/project default profile selection,
-   project-skill pickers, profile-driven context-packet activation, and bounded
-   native-assignment prompt inclusion for project memory plus portable
-   `AGENTS.md` guidance exist. Project-linked Hecate Chat now records its
-   bounded project prelude explicitly, and External Agent chat/assignment
-   packets keep project memory/source bodies metadata-only. Host-specific
-   guidance and arbitrary source-document prompt policy remain follow-up work.
-2. Broaden focused project journeys beyond the current API-level create
-   project -> discover guidance/skills -> add memory -> create/start assignment
-   -> inspect context -> follow handoff regression. Remaining hardening should
-   cover approval/failure paths, activity-health triage, and UI end-to-end
-   flows.
-3. Keep tightening the Projects cockpit UI around operator decisions: no hidden
-   recommendations, no separate health persistence, and no automatic memory
-   promotion.
+- Create a rootless or workspace-backed project without treating every project
+  as a GitHub/code project.
+- Run project setup to discover guidance and skills metadata, then review the
+  proposed memory/role changes before applying them.
+- Configure project defaults, roles, profiles, skills, provider/model posture,
+  memory/source policies, roots, and worktrees explicitly.
+- Create a work item, draft or manually create assignments, start Hecate Task
+  or External Agent execution, inspect launch context, record evidence/reviews,
+  hand off to another role, and close the work item deliberately.
+- See actionable project activity and health without a separate persisted
+  health model.
+
+Remaining Projects V1 hardening:
+
+- Add at least one browser-level operator journey test for create project ->
+  setup -> create work -> draft/start assignment -> review/closeout.
+- Keep polishing onboarding and first-work UI so setup is the obvious path and
+  manual forms remain available but secondary.
+- Continue dogfooding Hecate development through a Hecate project and capture
+  only concrete gaps as follow-up issues.
+
+Out of scope for this document and Projects V1:
+
+- Planner / Manager agents that autonomously propose sequencing across many
+  work items.
+- Workflow runbooks, browser QA capture, design-review automation, or
+  production-risk review modes.
+- Automatic memory writes, automatic handoff dispatch, remote skill install,
+  skill-body prompt injection, or host-specific guidance-body injection.
+- Multi-operator/team project-management semantics, GitHub issue sync, or
+  non-local permission models.
 
 ## Test Plan
 
@@ -444,13 +462,19 @@ The next project-orchestration slices are:
 - Memory tests that project memory appears only for matching `project_id`.
 - Profile tests proving Hecate Chat and external-agent profiles can opt into the
   same project memory without sharing private adapter memory.
-- E2E: create project from workspace, start chat, create task-backed turn, refresh, verify chat/task grouping.
+- API journey: create project, discover guidance/skills, add memory, create and
+  start assignment, inspect context, create handoff/follow-up assignment.
+- UI journeys: create rootless and workspace-backed projects, run setup, create
+  work, draft/start assignment, inspect context, record review/evidence,
+  complete closeout, and verify no-project/new-project onboarding states.
 
 ## Open Questions
 
-- Should a single filesystem root be allowed in multiple projects?
-- Should project identity be inferred from Git remote by default, or only from explicit user selection?
+- Should project identity ever be inferred from Git remote, or only from
+  explicit operator selection?
 - How should project defaults interact with per-chat overrides?
 - Should imported Claude/Codex contexts create projects automatically?
 - Should a project have one preferred workspace mode or separate defaults for Hecate Chat, Tasks, and External Agents?
 - Which agent profiles should opt into project memory by default?
+- What structured fields are needed for review/evidence querying once the V1
+  markdown-body artifact model is not enough?

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -433,8 +433,8 @@ Projects V1 is considered structurally complete when an operator can:
 
 Remaining Projects V1 hardening:
 
-- Add at least one browser-level operator journey test for create project ->
-  setup -> create work -> draft/start assignment -> review/closeout.
+- Keep the browser-level project journey test representative as setup,
+  assignment, evidence, and closeout flows evolve.
 - Keep polishing onboarding and first-work UI so setup is the obvious path and
   manual forms remain available but secondary.
 - Continue dogfooding Hecate development through a Hecate project and capture
@@ -466,7 +466,9 @@ Out of scope for this document and Projects V1:
   start assignment, inspect context, create handoff/follow-up assignment.
 - UI journeys: create rootless and workspace-backed projects, run setup, create
   work, draft/start assignment, inspect context, record review/evidence,
-  complete closeout, and verify no-project/new-project onboarding states.
+  complete closeout, and verify no-project/new-project onboarding states. A
+  browser-level Projects journey now covers create project -> setup proposal ->
+  first work -> assignment draft/start -> evidence -> closeout.
 
 ## Open Questions
 

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -1,0 +1,60 @@
+# Projects
+
+Projects are durable coordination spaces inside Hecate. Use them when you want
+history, memory, roles, assignments, evidence, handoffs, and context inspection
+to stay attached to one body of work over time.
+
+A project does not have to be a GitHub project, a code repository, or even a
+folder on disk. Rootless projects work for planning, research, writing, ops, and
+design. Add a local folder only when Hecate should discover workspace guidance,
+register local skills, or launch work against files.
+
+## First Setup
+
+1. Create a project with a clear name and optional purpose.
+2. Attach a local folder only if the project starts from files.
+3. Set provider, model, profile, memory, and source defaults when the project
+   should launch Hecate Chat, Hecate Tasks, or External Agents.
+4. Run **Set up project** to discover portable workspace guidance and local
+   skill metadata, then review the proposed memory candidates and role changes
+   before applying them.
+5. Create the first work item once the setup checklist looks right.
+
+Setup is reviewable. Hecate may propose roles or memory candidates, but the
+operator applies or dismisses them. Setup does not launch agents, write project
+memory automatically, install skills, or inject skill bodies into prompts.
+
+## Work Flow
+
+For each work item:
+
+1. Draft the first assignment from the owner role, or create one manually.
+2. Inspect the launch context before starting work when defaults, roots, or
+   provider/model posture are uncertain.
+3. Start a Hecate Task or External Agent assignment.
+4. Record evidence, reviews, and handoffs as the work moves between roles.
+5. Close the work item only after assignments and review follow-up are clear.
+
+Assignments keep their own execution records. Projects coordinate the work, but
+Tasks, Chats, and External Agents remain the execution surfaces.
+
+## Roots And Worktrees
+
+Project roots are concrete workspace paths, not project identity. A single
+project can include a main checkout and linked Git worktrees. Work items and
+assignments may select a root; launch resolution uses assignment root, then
+work-item root, then project default root, then the first active root.
+
+Worktree creation is an explicit operator action. In V1, Hecate creates
+worktrees under the selected root's `.worktrees/` directory and does not create
+sibling workspaces outside the registered project root.
+
+## What Projects V1 Does Not Do
+
+- It does not replace issue trackers or team project-management systems.
+- It does not infer every project from Git remotes automatically.
+- It does not auto-promote memory, auto-dispatch handoffs, or launch work from
+  setup without operator review.
+- It does not treat local skill metadata as permission to run tools or load
+  `SKILL.md` bodies into prompts.
+- It does not make External Agent private memory part of Hecate project memory.

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -1,0 +1,624 @@
+import type { Page, Route } from "@playwright/test";
+import { expect, mockGatewayAPIs, MOCK_SETTINGS_CONFIG_WITH_PROVIDERS, test } from "./fixtures";
+import type {
+  ProjectActivityData,
+  ProjectAssignmentRecord,
+  ProjectCollaborationArtifactRecord,
+  ProjectContextSourceRecord,
+  ProjectMemoryCandidateRecord,
+  ProjectRecord,
+  ProjectSkillRecord,
+  ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
+} from "../src/types/project";
+
+const NOW = "2026-06-14T10:10:57Z";
+
+test("Projects journey: setup, first work, assignment, evidence, closeout", async ({ page }) => {
+  const state = await mockProjectJourneyAPIs(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.workspace", "projects");
+  });
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await expect(page.getByText("Add a project to begin")).toBeVisible();
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByLabel("Name").fill("Launch operations");
+  await page
+    .getByLabel("Purpose")
+    .fill("Coordinate launch readiness, evidence, and review follow-up.");
+  await page.getByRole("button", { name: "Create project" }).click();
+
+  await expect(page.getByText("Set up Launch operations")).toBeVisible();
+  await page.getByRole("button", { name: "Set up project" }).click();
+  await expect(page.getByText("Bootstrap Launch operations guidance")).toBeVisible();
+  await page.getByRole("button", { name: "Apply proposal" }).click();
+
+  await expect(page.getByText("Applied 3 actions")).toBeVisible();
+  await page.getByRole("button", { name: "Dismiss" }).click();
+  await expect(page.getByText("Setup ready")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create first work" })).toBeVisible();
+  await page.getByRole("button", { name: "Create first work" }).click();
+  await page.getByLabel("Title").fill("Verify launch checklist");
+  await page
+    .getByLabel("Brief")
+    .fill("Confirm evidence is captured and the first assignment can be closed.");
+  await page.getByRole("button", { name: "Create work item" }).click();
+
+  await expect(page.getByRole("heading", { name: "Verify launch checklist" })).toBeVisible();
+  await page.getByRole("button", { name: "Draft first assignment" }).click();
+  await expect(
+    page.getByText("Queue the implementation role for the selected work item."),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Apply proposal" }).click();
+
+  await expect(page.getByRole("button", { name: "Start" })).toBeVisible();
+  await page.getByRole("button", { name: "Start" }).click();
+  await expect(page.getByRole("dialog", { name: /launch preflight/i })).toBeVisible();
+  await expect(page.getByText("Launch readiness")).toBeVisible();
+  await page.getByRole("button", { name: "Start assignment" }).click();
+
+  await expect(page.getByText("completed", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Evidence" }).click();
+  await page
+    .getByRole("dialog", { name: "Record evidence" })
+    .getByLabel("Title")
+    .fill("Launch checklist");
+  await page.getByLabel("URL").fill("https://example.test/checklist");
+  await page.getByLabel("Summary").fill("Operator confirmed the launch checklist evidence.");
+  await page.getByRole("button", { name: "Record evidence" }).click();
+
+  await expect(page.getByText("Launch checklist", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Mark done" }).click();
+  await expect(page.getByRole("article", { name: /Verify launch checklist/ })).toContainText(
+    "done",
+  );
+
+  expect(state.projects).toHaveLength(1);
+  expect(state.roles).toHaveLength(1);
+  expect(state.workItems[0]?.status).toBe("done");
+  expect(state.assignments[0]?.status).toBe("completed");
+  expect(state.artifacts).toHaveLength(1);
+});
+
+async function mockProjectJourneyAPIs(page: Page) {
+  const state = {
+    projects: [] as ProjectRecord[],
+    sources: [] as ProjectContextSourceRecord[],
+    skills: [] as ProjectSkillRecord[],
+    roles: [] as ProjectWorkRoleRecord[],
+    memoryCandidates: [] as ProjectMemoryCandidateRecord[],
+    workItems: [] as ProjectWorkItemRecord[],
+    assignments: [] as ProjectAssignmentRecord[],
+    artifacts: [] as ProjectCollaborationArtifactRecord[],
+  };
+  const ok = (body: unknown, status = 200) => ({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.authToken", "e2e-test-token");
+  });
+  await mockGatewayAPIs(page, {
+    projects: [],
+    settingsConfig: MOCK_SETTINGS_CONFIG_WITH_PROVIDERS,
+  });
+
+  await page.route(/\/hecate\/v1\/agent-profiles(?:\?.*)?$/, (route) =>
+    route.fulfill(ok({ object: "agent_profiles", data: [] })),
+  );
+
+  await page.route(/\/hecate\/v1\/project-assistant\/(?:draft|context|apply)$/, async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/context")) {
+      await route.fulfill(
+        ok({
+          object: "project_assistant_context",
+          data: projectAssistantContext(state),
+        }),
+      );
+      return;
+    }
+    if (path.endsWith("/draft")) {
+      const body = JSON.parse(request.postData() || "{}") as {
+        draft_mode?: string;
+        project_id?: string;
+        work_item_id?: string;
+      };
+      const proposal =
+        body.draft_mode === "bootstrap"
+          ? bootstrapProposal(state.projects[0])
+          : assignmentProposal(state.projects[0], body.work_item_id || state.workItems[0]?.id);
+      await route.fulfill(ok({ object: "project_assistant_proposal", data: proposal }));
+      return;
+    }
+    if (path.endsWith("/apply")) {
+      const body = JSON.parse(request.postData() || "{}") as { proposal?: { id?: string } };
+      if (body.proposal?.id === "pa_setup") {
+        applySetup(state);
+        await route.fulfill(
+          ok({
+            object: "project_assistant_apply_result",
+            data: {
+              proposal_id: "pa_setup",
+              applied: true,
+              actions: [
+                { kind: "set_project_defaults" },
+                {
+                  kind: "create_memory_candidate",
+                  data: { memory_candidate_id: "memcand_launch" },
+                },
+                { kind: "create_role", data: { role_id: "implementation" } },
+              ],
+            },
+          }),
+        );
+        return;
+      }
+      const assignment = applyAssignment(state);
+      await route.fulfill(
+        ok({
+          object: "project_assistant_apply_result",
+          data: {
+            proposal_id: "pa_assignment",
+            applied: true,
+            actions: [{ kind: "create_assignment", data: { assignment_id: assignment.id } }],
+          },
+        }),
+      );
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route(/\/hecate\/v1\/projects(?:\/.*)?(?:\?.*)?$/, async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = new URL(request.url());
+    const parts = url.pathname
+      .replace(/^\/hecate\/v1\/projects\/?/, "")
+      .split("/")
+      .filter(Boolean)
+      .map(decodeURIComponent);
+
+    if (parts.length === 0) {
+      if (method === "GET") {
+        await route.fulfill(ok({ object: "projects", data: state.projects }));
+        return;
+      }
+      if (method === "POST") {
+        const body = JSON.parse(request.postData() || "{}") as {
+          name?: string;
+          description?: string;
+        };
+        const project: ProjectRecord = {
+          id: "proj_launch",
+          name: body.name || "Launch operations",
+          description: body.description || "",
+          roots: [],
+          context_sources: [],
+          created_at: NOW,
+          updated_at: NOW,
+        };
+        state.projects = [project];
+        await route.fulfill(ok({ object: "project", data: project }, 201));
+        return;
+      }
+    }
+
+    const projectID = parts[0] || "";
+    if (!projectID || projectID !== state.projects[0]?.id) {
+      await route.fulfill(ok({ object: "projects", data: state.projects }));
+      return;
+    }
+
+    const resource = parts[1];
+    if (resource === "context-sources" && parts[2] === "discover" && method === "POST") {
+      state.sources = [
+        {
+          id: "ctx_agents",
+          kind: "workspace_instruction",
+          title: "AGENTS.md",
+          path: "AGENTS.md",
+          enabled: true,
+          format: "agents_md",
+          scope: "workspace",
+          trust_label: "workspace_guidance",
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      state.projects[0] = { ...state.projects[0], context_sources: state.sources, updated_at: NOW };
+      await route.fulfill(ok({ object: "project", data: state.projects[0] }));
+      return;
+    }
+    if (resource === "skills") {
+      if (parts[2] === "discover" && method === "POST") {
+        state.skills = [
+          {
+            id: "implementation",
+            project_id: projectID,
+            title: "Implementation",
+            description: "Build and verify changes.",
+            path: "docs-ai/skills/backend/SKILL.md",
+            format: "skill_md",
+            enabled: true,
+            status: "available",
+            trust_label: "workspace_skill",
+            source_context_source_ids: ["ctx_agents"],
+            discovered_at: NOW,
+            created_at: NOW,
+            updated_at: NOW,
+          },
+        ];
+      }
+      await route.fulfill(ok({ object: "project_skills", data: state.skills }));
+      return;
+    }
+    if (resource === "memory") {
+      if (parts[2] === "candidates") {
+        await route.fulfill(
+          ok({ object: "project_memory_candidates", data: state.memoryCandidates }),
+        );
+        return;
+      }
+      await route.fulfill(ok({ object: "project_memory", data: [] }));
+      return;
+    }
+    if (resource === "roles") {
+      await route.fulfill(ok({ object: "project_roles", data: state.roles }));
+      return;
+    }
+    if (resource === "activity") {
+      await route.fulfill(ok({ object: "project_activity", data: projectActivity(state) }));
+      return;
+    }
+    if (resource === "work-items") {
+      await handleWorkItemRoute(route, state, parts, method, projectID, ok);
+      return;
+    }
+
+    await route.fulfill(ok({ object: "project", data: state.projects[0] }));
+  });
+
+  return state;
+}
+
+async function handleWorkItemRoute(
+  route: Route,
+  state: ProjectJourneyState,
+  parts: string[],
+  method: string,
+  projectID: string,
+  ok: (body: unknown, status?: number) => { status: number; contentType: string; body: string },
+) {
+  const request = route.request();
+  const workItemID = parts[2] || "";
+  const subresource = parts[3];
+
+  if (!workItemID) {
+    if (method === "GET") {
+      await route.fulfill(ok({ object: "project_work_items", data: state.workItems }));
+      return;
+    }
+    if (method === "POST") {
+      const body = JSON.parse(request.postData() || "{}") as {
+        title?: string;
+        brief?: string;
+        priority?: string;
+        owner_role_id?: string;
+      };
+      const item: ProjectWorkItemRecord = {
+        id: "work_launch",
+        project_id: projectID,
+        title: body.title || "Verify launch checklist",
+        brief: body.brief || "",
+        status: "ready",
+        priority: body.priority || "normal",
+        owner_role_id: body.owner_role_id || state.roles[0]?.id || "",
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      state.workItems = [item];
+      await route.fulfill(ok({ object: "project_work_item", data: item }, 201));
+      return;
+    }
+  }
+
+  const item = state.workItems.find((candidate) => candidate.id === workItemID);
+  if (!item) {
+    await route.fulfill(ok({ object: "project_work_item", data: null }, 404));
+    return;
+  }
+
+  if (!subresource) {
+    if (method === "GET") {
+      await route.fulfill(ok({ object: "project_work_item", data: item }));
+      return;
+    }
+    if (method === "PATCH") {
+      const patch = JSON.parse(request.postData() || "{}") as Partial<ProjectWorkItemRecord>;
+      Object.assign(item, patch, { updated_at: NOW });
+      await route.fulfill(ok({ object: "project_work_item", data: item }));
+      return;
+    }
+  }
+
+  if (subresource === "assignments") {
+    const assignmentID = parts[4] || "";
+    if (!assignmentID) {
+      await route.fulfill(ok({ object: "project_assignments", data: state.assignments }));
+      return;
+    }
+    const assignment = state.assignments.find((candidate) => candidate.id === assignmentID);
+    if (parts[5] === "preflight") {
+      await route.fulfill(
+        ok({
+          object: "context_packet",
+          data: assignmentPreflight(projectID, workItemID, assignmentID),
+        }),
+      );
+      return;
+    }
+    if (parts[5] === "start" && method === "POST" && assignment) {
+      Object.assign(assignment, {
+        status: "completed",
+        started_at: NOW,
+        completed_at: NOW,
+        updated_at: NOW,
+        execution_ref: {
+          kind: "task_run",
+          task_id: "task_launch",
+          run_id: "run_launch",
+          status: "completed",
+          trace_id: "trace_launch",
+        },
+        execution: {
+          task_id: "task_launch",
+          run_id: "run_launch",
+          status: "completed",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          trace_id: "trace_launch",
+        },
+      });
+      await route.fulfill(ok({ object: "project_assignment", data: assignment }));
+      return;
+    }
+    await route.fulfill(ok({ object: "project_assignment", data: assignment ?? null }));
+    return;
+  }
+
+  if (subresource === "artifacts") {
+    if (method === "GET") {
+      await route.fulfill(ok({ object: "project_collaboration_artifacts", data: state.artifacts }));
+      return;
+    }
+    if (method === "POST") {
+      const body = JSON.parse(
+        request.postData() || "{}",
+      ) as Partial<ProjectCollaborationArtifactRecord>;
+      const artifact: ProjectCollaborationArtifactRecord = {
+        id: "artifact_launch",
+        project_id: projectID,
+        work_item_id: workItemID,
+        assignment_id: body.assignment_id,
+        kind: body.kind || "evidence_link",
+        title: body.title || "Launch checklist",
+        body: body.body || "Operator confirmed the launch checklist evidence.",
+        evidence_source_kind: body.evidence_source_kind,
+        evidence_url: body.evidence_url,
+        evidence_provider: body.evidence_provider,
+        evidence_trust_label: body.evidence_trust_label,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      state.artifacts = [artifact];
+      await route.fulfill(ok({ object: "project_collaboration_artifact", data: artifact }, 201));
+      return;
+    }
+  }
+
+  if (subresource === "handoffs") {
+    await route.fulfill(ok({ object: "project_handoffs", data: [] }));
+    return;
+  }
+
+  await route.fallback();
+}
+
+type ProjectJourneyState = Awaited<ReturnType<typeof mockProjectJourneyAPIs>>;
+
+function applySetup(state: ProjectJourneyState) {
+  state.projects[0] = {
+    ...state.projects[0],
+    default_provider: "anthropic",
+    default_model: "claude-sonnet-4-6",
+    default_agent_profile: "implementation",
+    default_workspace_mode: "in_place",
+    updated_at: NOW,
+  };
+  state.roles = [
+    {
+      id: "implementation",
+      project_id: state.projects[0].id,
+      name: "Implementation",
+      description: "Build and verify the next project change.",
+      default_driver_kind: "hecate_task",
+      default_provider: "anthropic",
+      default_model: "claude-sonnet-4-6",
+      default_agent_profile: "implementation",
+      skill_ids: ["implementation"],
+      built_in: false,
+      created_at: NOW,
+      updated_at: NOW,
+    },
+  ];
+  state.memoryCandidates = [
+    {
+      id: "memcand_launch",
+      project_id: state.projects[0].id,
+      title: "Guidance source: AGENTS.md",
+      body: "Review project guidance before promoting durable memory.",
+      suggested_trust_label: "workspace_guidance",
+      suggested_source_kind: "context_source",
+      suggested_source_id: "ctx_agents",
+      status: "pending",
+      created_at: NOW,
+      updated_at: NOW,
+    },
+  ];
+}
+
+function applyAssignment(state: ProjectJourneyState): ProjectAssignmentRecord {
+  const assignment: ProjectAssignmentRecord = {
+    id: "assign_launch",
+    project_id: state.projects[0].id,
+    work_item_id: state.workItems[0].id,
+    role_id: state.roles[0].id,
+    driver_kind: "hecate_task",
+    status: "queued",
+    created_at: NOW,
+    updated_at: NOW,
+  };
+  state.assignments = [assignment];
+  return assignment;
+}
+
+function bootstrapProposal(project?: ProjectRecord) {
+  return {
+    id: "pa_setup",
+    title: `Bootstrap ${project?.name || "project"} guidance`,
+    summary: "Prepare setup defaults, memory candidates, and roles for review.",
+    requires_confirmation: true,
+    actions: [
+      { kind: "set_project_defaults", patch: { default_provider: "anthropic" } },
+      { kind: "create_memory_candidate", target: { project_id: project?.id || "" } },
+      { kind: "create_role", patch: { id: "implementation", name: "Implementation" } },
+    ],
+  };
+}
+
+function assignmentProposal(project?: ProjectRecord, workItemID?: string) {
+  return {
+    id: "pa_assignment",
+    title: "Create assignment",
+    summary: "Queue the implementation role for the selected work item.",
+    requires_confirmation: true,
+    actions: [
+      {
+        kind: "create_assignment",
+        target: { project_id: project?.id || "", work_item_id: workItemID || "" },
+        patch: { role_id: "implementation", driver_kind: "hecate_task" },
+      },
+    ],
+  };
+}
+
+function projectAssistantContext(state: ProjectJourneyState) {
+  return {
+    project: state.projects[0],
+    request: "Set up project guidance",
+    roles: state.roles,
+    skills: state.skills,
+    memory: [],
+    memory_candidates: state.memoryCandidates,
+    recent_activity: [],
+    budget: {
+      memory_body_max_bytes: 12288,
+      memory_candidate_body_max_bytes: 12288,
+      body_original_bytes: 0,
+      body_returned_bytes: 0,
+      body_tokens_estimate: 0,
+      body_truncated_count: 0,
+    },
+    selection: {
+      driver_kind: "hecate_task",
+      driver_source: "fallback",
+      reason: "E2E setup context.",
+    },
+  };
+}
+
+function assignmentPreflight(projectID: string, workItemID: string, assignmentID: string) {
+  return {
+    id: "ctx_launch",
+    version: "project_assignment_launch.v1",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    refs: { project_id: projectID, work_item_id: workItemID, assignment_id: assignmentID },
+    items: [
+      {
+        section: "runtime_evidence",
+        kind: "launch_readiness",
+        trust_level: "system",
+        origin: "hecate",
+        title: "Launch readiness",
+        body: "Provider: anthropic\nModel: claude-sonnet-4-6\nReady: true",
+        included: true,
+      },
+    ],
+  };
+}
+
+function projectActivity(state: ProjectJourneyState): ProjectActivityData {
+  const assignment = state.assignments[0];
+  const role = state.roles[0];
+  const workItem = state.workItems[0];
+  const completed = assignment?.status === "completed";
+  const item =
+    assignment && role && workItem
+      ? [
+          {
+            id: assignment.id,
+            project_id: state.projects[0].id,
+            work_item: {
+              id: workItem.id,
+              title: workItem.title,
+              status: workItem.status,
+              priority: workItem.priority,
+            },
+            assignment,
+            role,
+            status: assignment.status,
+            blocking_signal: completed ? "completed" : "not_started",
+            status_summary: completed ? "completed" : "queued",
+            linked_task_id: assignment.execution_ref?.task_id,
+            linked_run_id: assignment.execution_ref?.run_id,
+            artifact_summary: {
+              count: state.artifacts.length,
+              latest_kind: state.artifacts[0]?.kind,
+              latest_title: state.artifacts[0]?.title,
+              latest_at: state.artifacts[0]?.updated_at,
+            },
+            handoff_summary: { count: 0 },
+            recent_artifacts: state.artifacts,
+            updated_at: assignment.updated_at,
+          },
+        ]
+      : [];
+  return {
+    project_id: state.projects[0]?.id || "proj_launch",
+    summary: {
+      work_item_count: state.workItems.length,
+      assignment_count: state.assignments.length,
+      active_count: completed || !assignment ? 0 : 1,
+      blocked_count: 0,
+      completed_count: completed ? 1 : 0,
+      recent_count: item.length,
+    },
+    buckets: {
+      active: completed ? [] : item,
+      blocked: [],
+      completed: completed ? item : [],
+      recent: item,
+    },
+    recent: item,
+  };
+}

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -53,6 +53,34 @@ function renderAssistantPanel(
 }
 
 describe("ProjectAssistantPanel", () => {
+  it("shows setup-ready actions after project setup has begun", async () => {
+    const user = userEvent.setup();
+    const handlers = renderAssistantPanel({
+      memoryCandidateCount: 1,
+      roleCount: 2,
+      setupFirst: true,
+      setupStarted: true,
+      workItemCount: 0,
+    });
+
+    const assistant = screen.getByRole("region", { name: "Project Assistant" });
+    expect(within(assistant).getByText("Setup ready")).toBeTruthy();
+    expect(
+      within(assistant).getByText(/Project setup has 2 roles · 1 memory candidate/),
+    ).toBeTruthy();
+    expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
+
+    await user.click(within(assistant).getByRole("button", { name: "Review memory" }));
+    await user.click(within(assistant).getByRole("button", { name: "Review roles" }));
+    await user.click(within(assistant).getByRole("button", { name: "Create first work" }));
+    await user.click(within(assistant).getByRole("button", { name: "Refresh setup" }));
+
+    expect(handlers.onReviewMemory).toHaveBeenCalledTimes(1);
+    expect(handlers.onManageRoles).toHaveBeenCalledTimes(1);
+    expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
+    expect(handlers.onBootstrap).toHaveBeenCalledTimes(1);
+  });
+
   it("turns applied setup proposals into follow-up actions", async () => {
     const user = userEvent.setup();
     const handlers = renderAssistantPanel({

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -115,6 +115,12 @@ export function ProjectAssistantPanel({
   const bootstrapForm = projectAssistantBootstrapForm();
   const showSetupRow = setupFirst && !proposal && !applyResult;
   const showBootstrapAction = setupFirst && !setupStarted && !proposal && !applyResult;
+  const showSetupRefreshAction = setupFirst && setupStarted && !proposal && !applyResult;
+  const setupSummary = projectAssistantSetupSummary({
+    memoryCandidateCount,
+    roleCount,
+    workItemCount,
+  });
 
   return (
     <section style={assistantPanelStyle} aria-label="Project Assistant">
@@ -135,11 +141,11 @@ export function ProjectAssistantPanel({
           <div style={assistantOnboardingCopyStyle}>
             <div style={sectionLabelStyle}>Project setup</div>
             <div style={setupPromptTitleStyle}>
-              {setupStarted ? "Create the first work item" : "Set up project context"}
+              {setupStarted ? "Setup ready" : "Set up project context"}
             </div>
             <div style={{ ...subtleTextStyle, marginTop: 4 }}>
               {setupStarted
-                ? "Project guidance or roles already exist. Inspect context or add the first reviewable work item."
+                ? `${setupSummary}. Create the first reviewable work item, review setup output, or refresh setup when guidance changes.`
                 : bootstrapPending
                   ? "Discovering guidance and skills, then preparing a reviewable setup proposal."
                   : "Discover guidance and skills, suggest roles, and prepare setup actions for review."}
@@ -157,6 +163,39 @@ export function ProjectAssistantPanel({
                 {contextBusy ? "Inspecting..." : "Inspect context"}
               </button>
             )}
+            {setupStarted && memoryCandidateCount > 0 && onReviewMemory && (
+              <button
+                className="btn btn-ghost btn-sm"
+                type="button"
+                disabled={bootstrapBusy || contextBusy}
+                onClick={onReviewMemory}
+              >
+                <Icon d={Icons.observe} size={13} />
+                Review memory
+              </button>
+            )}
+            {setupStarted && roleCount > 0 && onManageRoles && (
+              <button
+                className="btn btn-ghost btn-sm"
+                type="button"
+                disabled={bootstrapBusy || contextBusy}
+                onClick={onManageRoles}
+              >
+                <Icon d={Icons.user} size={13} />
+                Review roles
+              </button>
+            )}
+            {setupStarted && workItemCount === 0 && onCreateWork && (
+              <button
+                className="btn btn-primary btn-sm"
+                type="button"
+                disabled={bootstrapBusy || contextBusy}
+                onClick={onCreateWork}
+              >
+                <Icon d={Icons.plus} size={13} />
+                Create first work
+              </button>
+            )}
             {showBootstrapAction && (
               <button
                 className="btn btn-primary btn-sm"
@@ -166,6 +205,17 @@ export function ProjectAssistantPanel({
               >
                 <Icon d={Icons.refresh} size={14} />
                 {bootstrapPending ? "Setting up..." : "Set up project"}
+              </button>
+            )}
+            {showSetupRefreshAction && (
+              <button
+                className="btn btn-ghost btn-sm"
+                type="button"
+                disabled={bootstrapBusy || contextBusy}
+                onClick={onBootstrap}
+              >
+                <Icon d={Icons.refresh} size={13} />
+                {bootstrapPending ? "Refreshing..." : "Refresh setup"}
               </button>
             )}
           </div>
@@ -731,6 +781,25 @@ function projectAssistantFollowUpActions({
   }
 
   return actions;
+}
+
+function projectAssistantSetupSummary({
+  memoryCandidateCount,
+  roleCount,
+  workItemCount,
+}: {
+  memoryCandidateCount: number;
+  roleCount: number;
+  workItemCount: number;
+}): string {
+  const parts = [
+    roleCount > 0 ? `${roleCount} role${roleCount === 1 ? "" : "s"}` : "",
+    memoryCandidateCount > 0
+      ? `${memoryCandidateCount} memory candidate${memoryCandidateCount === 1 ? "" : "s"}`
+      : "",
+    workItemCount > 0 ? `${workItemCount} work item${workItemCount === 1 ? "" : "s"}` : "",
+  ].filter(Boolean);
+  return parts.length > 0 ? `Project setup has ${parts.join(" · ")}` : "Project setup has begun";
 }
 
 function formatAssistantValue(value: unknown): string {

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -348,7 +348,7 @@ describe("ProjectWorkItemDetail", () => {
     expect(screen.queryByRole("button", { name: "Mark done" })).toBeNull();
     expect(screen.queryByText("No assignments recorded yet.")).toBeNull();
 
-    await userEvent.click(screen.getByRole("button", { name: "Draft assignment" }));
+    await userEvent.click(screen.getByRole("button", { name: "Draft first assignment" }));
     await userEvent.click(screen.getByRole("button", { name: "Manual assignment" }));
     await userEvent.click(screen.getByRole("button", { name: "Evidence" }));
     await userEvent.click(screen.getByRole("button", { name: "Handoff" }));

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -576,7 +576,7 @@ function WorkItemStartPanel({
         </div>
         <div style={{ ...subtleTextStyle, marginTop: 5 }}>
           {role
-            ? `Hecate can draft a queued ${role.name || role.id} assignment proposal from this work item. You will review and apply it before anything is created.`
+            ? `Hecate can draft a reviewable ${role.name || role.id} assignment proposal from this work item. You will review and apply it before anything is created.`
             : "Create or select a project role so Hecate can prepare this work from defaults."}
         </div>
       </div>
@@ -589,7 +589,7 @@ function WorkItemStartPanel({
             disabled={drafting}
           >
             <Icon d={Icons.tasks} size={13} />
-            {drafting ? "Drafting..." : "Draft assignment"}
+            {drafting ? "Drafting..." : "Draft first assignment"}
           </button>
         ) : (
           <button className="btn btn-primary btn-sm" type="button" onClick={onManageRoles}>

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -195,7 +195,8 @@ describe("ProjectWorkspaceView", () => {
     await userEvent.click(screen.getByRole("button", { name: "Set defaults" }));
     await userEvent.click(screen.getByRole("button", { name: "Review setup" }));
     await userEvent.click(screen.getByRole("button", { name: "Set up" }));
-    await userEvent.click(screen.getAllByRole("button", { name: "Create work" })[1]);
+    const firstWorkCheck = screen.getByRole("group", { name: "First work item" });
+    await userEvent.click(within(firstWorkCheck).getByRole("button", { name: "Create work" }));
     await userEvent.click(screen.getByRole("button", { name: "Set up project" }));
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -191,13 +191,17 @@ describe("ProjectWorkspaceView", () => {
     expect(screen.getByText("Optional; attach files when this project needs them.")).toBeTruthy();
     expect(screen.getByText("optional")).toBeTruthy();
 
+    await userEvent.click(screen.getByRole("button", { name: "Add purpose" }));
+    await userEvent.click(screen.getByRole("button", { name: "Set defaults" }));
+    await userEvent.click(screen.getByRole("button", { name: "Review setup" }));
+    await userEvent.click(screen.getByRole("button", { name: "Set up" }));
+    await userEvent.click(screen.getAllByRole("button", { name: "Create work" })[1]);
     await userEvent.click(screen.getByRole("button", { name: "Set up project" }));
-    await userEvent.click(screen.getByRole("button", { name: "Create work" }));
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 
-    expect(assistantState.bootstrap).toHaveBeenCalledTimes(1);
+    expect(assistantState.bootstrap).toHaveBeenCalledTimes(2);
     expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
-    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(4);
   });
 
   it("renders workspace tabs and delegates tab changes", async () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -541,6 +541,16 @@ function SectionHeader({
   );
 }
 
+type ProjectOnboardingCheck = {
+  action?: () => void;
+  actionDisabled?: boolean;
+  actionLabel?: string;
+  detail: string;
+  done: boolean;
+  label: string;
+  optional?: boolean;
+};
+
 function ProjectOnboardingPanel({
   bootstrapPending,
   contextSourceCount,
@@ -565,11 +575,14 @@ function ProjectOnboardingPanel({
   const hasPurpose = Boolean(project.description?.trim());
   const hasDefaults = Boolean(project.default_provider && project.default_model);
   const hasGuidance = contextSourceCount > 0 || skillCount > 0;
-  const checks = [
+  const bootstrapActionLabel = bootstrapPending ? "Setting up..." : "Set up";
+  const checks: ProjectOnboardingCheck[] = [
     {
       label: "Project purpose",
       detail: hasPurpose ? project.description?.trim() || "Ready" : "Add a short purpose.",
       done: hasPurpose,
+      actionLabel: "Add purpose",
+      action: onOpenSettings,
     },
     {
       label: "Workspace source",
@@ -583,6 +596,8 @@ function ProjectOnboardingPanel({
       label: "Provider and model",
       detail: hasDefaults ? `${project.default_provider} / ${project.default_model}` : "Not set",
       done: hasDefaults,
+      actionLabel: "Set defaults",
+      action: onOpenSettings,
     },
     {
       label: "Sources and memory",
@@ -592,16 +607,24 @@ function ProjectOnboardingPanel({
           ? "Setup can discover workspace guidance and local skills."
           : "Add sources manually, or attach a workspace when files matter.",
       done: hasGuidance,
+      actionLabel: hasRoot ? "Discover" : "Review setup",
+      action: hasRoot ? onBootstrap : onOpenSettings,
+      actionDisabled: bootstrapPending,
     },
     {
       label: "Roles",
       detail: roleCount > 0 ? `${roleCount} roles` : "Setup can suggest roles from skills.",
       done: roleCount > 0,
+      actionLabel: bootstrapActionLabel,
+      action: onBootstrap,
+      actionDisabled: bootstrapPending,
     },
     {
       label: "First work item",
       detail: "Create the first reviewable task after setup.",
       done: false,
+      actionLabel: "Create work",
+      action: onCreateWork,
     },
   ];
   return (
@@ -648,6 +671,17 @@ function ProjectOnboardingPanel({
               <div style={titleStyle}>{check.label}</div>
               <div style={subtleTextStyle}>{check.detail}</div>
             </div>
+            {!check.done && check.action && (
+              <button
+                className="btn btn-ghost btn-sm"
+                disabled={check.actionDisabled}
+                onClick={check.action}
+                style={projectOnboardingCheckActionStyle}
+                type="button"
+              >
+                {check.actionLabel}
+              </button>
+            )}
           </div>
         ))}
       </div>
@@ -1004,7 +1038,7 @@ const projectOnboardingCheckStyle: CSSProperties = {
   borderRadius: "var(--radius-sm)",
   display: "grid",
   gap: 10,
-  gridTemplateColumns: "auto minmax(0, 1fr)",
+  gridTemplateColumns: "auto minmax(0, 1fr) auto",
   minWidth: 0,
   padding: 10,
 };
@@ -1012,6 +1046,11 @@ const projectOnboardingCheckStyle: CSSProperties = {
 const projectOnboardingCheckBadgeStyle: CSSProperties = {
   justifySelf: "start",
   textTransform: "uppercase",
+};
+
+const projectOnboardingCheckActionStyle: CSSProperties = {
+  justifySelf: "end",
+  whiteSpace: "nowrap",
 };
 
 const projectWorkspaceTabsStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -660,7 +660,12 @@ function ProjectOnboardingPanel({
       </div>
       <div style={projectOnboardingChecklistStyle}>
         {checks.map((check) => (
-          <div key={check.label} style={projectOnboardingCheckStyle}>
+          <div
+            aria-label={check.label}
+            key={check.label}
+            role="group"
+            style={projectOnboardingCheckStyle}
+          >
             <span
               className={check.done ? "badge badge-green" : "badge badge-muted"}
               style={projectOnboardingCheckBadgeStyle}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4728,7 +4728,7 @@ describe("ProjectsView cockpit", () => {
 
     const detail = await screen.findByRole("region", { name: "Selected work item" });
     await within(detail).findByText("Ready to queue the first assignment");
-    await userEvent.click(within(detail).getByRole("button", { name: "Draft assignment" }));
+    await userEvent.click(within(detail).getByRole("button", { name: "Draft first assignment" }));
 
     await waitFor(() =>
       expect(draftProjectAssistant).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- Make the new-project onboarding checklist actionable so setup remains the primary path and first-work creation is clearly secondary.
- Clarify first-work assignment drafting copy and button labels.
- Add an operator Projects guide and update the Projects design record/docs-ai guidance to mark the V1 substrate boundary and remaining hardening work.

## Tests
- cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check
- just docs-format-check