### PR TITLE
Focus first work start actions

### DIFF
--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -349,9 +349,11 @@ describe("ProjectWorkItemDetail", () => {
     expect(screen.queryByText("No assignments recorded yet.")).toBeNull();
 
     await userEvent.click(screen.getByRole("button", { name: "Draft first assignment" }));
-    await userEvent.click(screen.getByRole("button", { name: "Manual assignment" }));
-    await userEvent.click(screen.getByRole("button", { name: "Evidence" }));
-    await userEvent.click(screen.getByRole("button", { name: "Handoff" }));
+    const manualActions = screen.getByRole("group", { name: "Manual work item actions" });
+    expect(within(manualActions).getByText("Manual options")).toBeTruthy();
+    await userEvent.click(within(manualActions).getByRole("button", { name: "Assignment" }));
+    await userEvent.click(within(manualActions).getByRole("button", { name: "Evidence" }));
+    await userEvent.click(within(manualActions).getByRole("button", { name: "Handoff" }));
 
     expect(handlers.onDraftDefaultAssignment).toHaveBeenCalledWith(item);
     expect(handlers.onAddAssignment).toHaveBeenCalledTimes(1);

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -597,18 +597,21 @@ function WorkItemStartPanel({
             Manage roles
           </button>
         )}
-        <button className="btn btn-ghost btn-sm" type="button" onClick={onAddAssignment}>
-          <Icon d={Icons.plus} size={12} />
-          Manual assignment
-        </button>
-        <button className="btn btn-ghost btn-sm" type="button" onClick={onAddEvidenceLink}>
-          <Icon d={Icons.plus} size={12} />
-          Evidence
-        </button>
-        <button className="btn btn-ghost btn-sm" type="button" onClick={onAddHandoff}>
-          <Icon d={Icons.plus} size={12} />
-          Handoff
-        </button>
+        <div aria-label="Manual work item actions" role="group" style={startPanelSecondaryStyle}>
+          <span style={startPanelSecondaryLabelStyle}>Manual options</span>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddAssignment}>
+            <Icon d={Icons.plus} size={12} />
+            Assignment
+          </button>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddEvidenceLink}>
+            <Icon d={Icons.plus} size={12} />
+            Evidence
+          </button>
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddHandoff}>
+            <Icon d={Icons.plus} size={12} />
+            Handoff
+          </button>
+        </div>
       </div>
     </section>
   );
@@ -1815,10 +1818,26 @@ const startPanelCopyStyle: CSSProperties = {
 
 const startPanelActionsStyle: CSSProperties = {
   alignItems: "center",
+  display: "grid",
+  gap: 8,
+  justifyItems: "end",
+  minWidth: 0,
+};
+
+const startPanelSecondaryStyle: CSSProperties = {
+  alignItems: "center",
   display: "flex",
   flexWrap: "wrap",
-  gap: 8,
+  gap: 6,
   justifyContent: "flex-end",
+  minWidth: 0,
+};
+
+const startPanelSecondaryLabelStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  textTransform: "uppercase",
 };
 
 const closeoutListStyle: CSSProperties = {


### PR DESCRIPTION
## Summary

- Make the empty work-item start panel emphasize the guided `Draft first assignment` path.
- Group manual escape hatches under a quieter `Manual options` row.
- Update the focused component test to assert the grouped manual actions.

## Dogfood

- Started a local Hecate runtime with memory storage.
- Created a throwaway project, role, work item, and queued assignment through `/hecate/v1/*`.
- Confirmed the API path works for the project/work loop used by this UI slice.

## Tests

- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- src/features/projects/ProjectWorkItemDetail.test.tsx`
- `cd ui && bun run test`

## Docs

No docs changed. `docs/operator/projects.md` already describes drafting the first assignment as the first work-item step.