### PR TITLE
Add project resume summary

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -38,6 +38,10 @@ For each work item:
 Assignments keep their own execution records. Projects coordinate the work, but
 Tasks, Chats, and External Agents remain the execution surfaces.
 
+The Work Coordination tab starts with a compact resume summary. Use it to jump
+back to blocked, active, recent, or memory-review work before drilling into the
+full work queue.
+
 ## Roots And Worktrees
 
 Project roots are concrete workspace paths, not project identity. A single

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -3,9 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
+  ProjectActivityData,
+  ProjectActivityItemRecord,
   ProjectAssignmentRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
+  ProjectWorkRoleRecord,
 } from "../../types/project";
 import {
   ProjectWorkspaceView,
@@ -56,6 +59,89 @@ function assignment(overrides: Partial<ProjectAssignmentRecord> = {}): ProjectAs
     },
     created_at: "2026-06-12T00:00:00Z",
     updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function role(overrides: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRecord {
+  return {
+    id: "developer",
+    project_id: "proj_1",
+    name: "Developer",
+    built_in: false,
+    created_at: "2026-06-12T00:00:00Z",
+    updated_at: "2026-06-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<ProjectActivityData> = {}): ProjectActivityData {
+  const item = workItem({ id: "work_blocked", title: "Fix blocked launch" });
+  const blocked = activityItem({
+    assignment: assignment({
+      id: "assign_blocked",
+      work_item_id: item.id,
+      status: "queued",
+      execution_ref: { kind: "none" },
+    }),
+    blocking_signal: "not_started",
+    id: "assign_blocked",
+    status: "queued",
+    status_summary: "not started",
+    updated_at: "2026-06-13T00:00:00Z",
+    work_item: {
+      id: item.id,
+      title: item.title,
+      status: item.status,
+      priority: item.priority,
+    },
+  });
+  return {
+    project_id: "proj_1",
+    summary: {
+      work_item_count: 1,
+      assignment_count: 1,
+      active_count: 0,
+      blocked_count: 1,
+      completed_count: 0,
+      recent_count: 1,
+    },
+    buckets: {
+      active: [],
+      blocked: [blocked],
+      completed: [],
+      recent: [blocked],
+    },
+    recent: [blocked],
+    ...overrides,
+  };
+}
+
+function activityItem(
+  overrides: Partial<ProjectActivityItemRecord> = {},
+): ProjectActivityItemRecord {
+  const assign = assignment({
+    id: "assign_blocked",
+    work_item_id: "work_blocked",
+    status: "queued",
+    execution_ref: { kind: "none" },
+  });
+  return {
+    id: assign.id,
+    project_id: "proj_1",
+    work_item: {
+      id: "work_blocked",
+      title: "Fix blocked launch",
+      status: "ready",
+      priority: "normal",
+    },
+    assignment: assign,
+    role: role(),
+    status: "queued",
+    blocking_signal: "not_started",
+    status_summary: "not started",
+    artifact_summary: { count: 0 },
+    updated_at: "2026-06-13T00:00:00Z",
     ...overrides,
   };
 }
@@ -173,8 +259,8 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     ...overrides,
   };
 
-  render(<ProjectWorkspaceView {...props} />);
-  return { handlers, props };
+  const result = render(<ProjectWorkspaceView {...props} />);
+  return { handlers, props, ...result };
 }
 
 describe("ProjectWorkspaceView", () => {
@@ -222,6 +308,149 @@ describe("ProjectWorkspaceView", () => {
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(1, "timeline");
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(2, "memory");
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(3, "skills");
+  });
+
+  it("renders a resume summary and delegates resume actions", async () => {
+    const item = workItem({ id: "work_blocked", title: "Fix blocked launch" });
+    const { handlers } = renderWorkspace({
+      activity: activity(),
+      memoryCandidates: [
+        {
+          id: "memcand_1",
+          project_id: "proj_1",
+          title: "Project lesson",
+          body: "Remember the launch flow.",
+          status: "pending",
+          suggested_kind: "note",
+          suggested_trust_label: "operator_review",
+          suggested_source_kind: "dogfood",
+          created_at: "2026-06-13T00:00:00Z",
+          updated_at: "2026-06-13T00:00:00Z",
+        },
+      ],
+      workItems: [item],
+    });
+
+    const resume = screen.getByRole("region", { name: "Project resume" });
+    expect(within(resume).getByText("1 assignment needs attention")).toBeTruthy();
+    expect(within(resume).getByText("Queued assignment is ready to start.")).toBeTruthy();
+
+    await userEvent.click(within(resume).getByRole("button", { name: /Blocked/ }));
+    await userEvent.click(within(resume).getByRole("button", { name: /Recent/ }));
+    await userEvent.click(within(resume).getByRole("button", { name: /Memory/ }));
+    await userEvent.click(within(resume).getByRole("button", { name: "Continue here" }));
+
+    expect(handlers.onActivityBucketChange).toHaveBeenNthCalledWith(1, "blocked");
+    expect(handlers.onActivityBucketChange).toHaveBeenNthCalledWith(2, "recent");
+    expect(handlers.onWorkspaceTabChange).toHaveBeenCalledWith("memory");
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_blocked");
+  });
+
+  it("prioritizes active, memory, latest work, and empty resume states", async () => {
+    const activeItem = activityItem({
+      assignment: assignment({
+        id: "assign_active",
+        work_item_id: "work_active",
+        status: "running",
+      }),
+      blocking_signal: "running",
+      id: "assign_active",
+      status: "running",
+      work_item: {
+        id: "work_active",
+        title: "Continue execution",
+        status: "ready",
+        priority: "normal",
+      },
+    });
+    const memoryCandidate: ProjectWorkspaceViewProps["memoryCandidates"][number] = {
+      id: "memcand_1",
+      project_id: "proj_1",
+      title: "Project lesson",
+      body: "Remember the launch flow.",
+      status: "pending",
+      suggested_kind: "note",
+      suggested_trust_label: "operator_review",
+      suggested_source_kind: "dogfood",
+      created_at: "2026-06-13T00:00:00Z",
+      updated_at: "2026-06-13T00:00:00Z",
+    };
+    const latest = workItem({
+      id: "work_latest",
+      title: "Polish project onboarding",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-14T00:00:00Z",
+    });
+
+    const { handlers, props, rerender } = renderWorkspace({
+      activity: activity({
+        summary: {
+          work_item_count: 1,
+          assignment_count: 1,
+          active_count: 1,
+          blocked_count: 0,
+          completed_count: 0,
+          recent_count: 1,
+        },
+        buckets: {
+          active: [activeItem],
+          blocked: [],
+          completed: [],
+          recent: [activeItem],
+        },
+        recent: [activeItem],
+      }),
+    });
+
+    let resume = screen.getByRole("region", { name: "Project resume" });
+    expect(within(resume).getByText("1 assignment in progress")).toBeTruthy();
+    expect(
+      within(resume).getByText("An assignment is in progress; inspect or continue it."),
+    ).toBeTruthy();
+
+    await userEvent.click(within(resume).getByRole("button", { name: "Continue here" }));
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_active");
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={null}
+        memoryCandidates={[memoryCandidate]}
+        workItems={[]}
+      />,
+    );
+    resume = screen.getByRole("region", { name: "Project resume" });
+    expect(within(resume).getByText("1 memory candidate to review")).toBeTruthy();
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={null}
+        memoryCandidates={[]}
+        workItems={[latest]}
+      />,
+    );
+    resume = screen.getByRole("region", { name: "Project resume" });
+    expect(within(resume).getByText("Resume Polish project onboarding")).toBeTruthy();
+    await userEvent.click(within(resume).getByRole("button", { name: "Continue here" }));
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_latest");
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={null}
+        memoryCandidates={[]}
+        workItems={[]}
+      />,
+    );
+    resume = screen.getByRole("region", { name: "Project resume" });
+    expect(within(resume).getByText("No project work in motion")).toBeTruthy();
+    expect(
+      within(resume).getByText("Create a work item when there is something to coordinate."),
+    ).toBeTruthy();
   });
 
   it("renders project empty state when nothing is selected", () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -26,7 +26,7 @@ import {
   type ProjectAssignmentChatLaunchRequest,
 } from "./ProjectWorkItemDetail";
 import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
-import { workStatusLabel } from "./projectDisplay";
+import { formatProjectRowRelativeTime, workStatusLabel } from "./projectDisplay";
 import {
   projectActivityWorkItemToWorkItem,
   type ProjectActivityBucketKey,
@@ -307,6 +307,14 @@ export function ProjectWorkspaceView({
             )}
             {!projectNeedsOnboarding && workspaceTab === "work" && (
               <section style={projectTabPanelStyle} aria-label="Work coordination">
+                <ProjectResumeSummary
+                  activity={activity}
+                  memoryCandidateCount={memoryCandidates.length}
+                  onBucketChange={onActivityBucketChange}
+                  onReviewMemory={() => onWorkspaceTabChange("memory")}
+                  onSelectWorkItem={onSelectWorkItem}
+                  workItems={workItems}
+                />
                 <section aria-label="Work activity" style={workActivityPanelStyle}>
                   <SectionHeader
                     title="Work Queue"
@@ -694,6 +702,104 @@ function ProjectOnboardingPanel({
   );
 }
 
+function ProjectResumeSummary({
+  activity,
+  memoryCandidateCount,
+  onBucketChange,
+  onReviewMemory,
+  onSelectWorkItem,
+  workItems,
+}: {
+  activity: ProjectActivityData | null;
+  memoryCandidateCount: number;
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
+  onReviewMemory: () => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  workItems: ProjectWorkItemRecord[];
+}) {
+  const blocked = activity?.summary.blocked_count ?? 0;
+  const active = activity?.summary.active_count ?? 0;
+  const recent = activity?.summary.recent_count ?? 0;
+  const notStartedItem =
+    activity?.buckets.blocked.find((item) => item.blocking_signal === "not_started") ?? null;
+  const attentionItem = activity?.buckets.blocked[0] ?? activity?.buckets.active[0] ?? null;
+  const latestWorkItem = latestProjectWorkItem(workItems);
+  const continueWorkItemID =
+    attentionItem?.work_item.id ?? notStartedItem?.work_item.id ?? latestWorkItem?.id ?? "";
+  const attentionDetail =
+    attentionItem?.blocking_signal === "not_started"
+      ? "Queued assignment is ready to start."
+      : blocked > 0
+        ? "Open the blocked assignment and resolve the next action."
+        : active > 0
+          ? "An assignment is in progress; inspect or continue it."
+          : "";
+  const title =
+    blocked > 0
+      ? blocked === 1
+        ? "1 assignment needs attention"
+        : `${blocked} assignments need attention`
+      : active > 0
+        ? `${active} assignment${active === 1 ? "" : "s"} in progress`
+        : memoryCandidateCount > 0
+          ? `${memoryCandidateCount} memory candidate${memoryCandidateCount === 1 ? "" : "s"} to review`
+          : latestWorkItem
+            ? `Resume ${latestWorkItem.title}`
+            : "No project work in motion";
+  const detail =
+    attentionDetail ||
+    (latestWorkItem
+      ? `Last updated ${formatProjectRowRelativeTime(latestWorkItem.updated_at)}.`
+      : "Create a work item when there is something to coordinate.");
+
+  return (
+    <section aria-label="Project resume" style={projectResumeSummaryStyle}>
+      <div style={projectResumeCopyStyle}>
+        <div style={sectionLabelStyle}>Resume</div>
+        <div style={titleStyle}>{title}</div>
+        <div style={subtleTextStyle}>{detail}</div>
+      </div>
+      <div style={projectResumeStatsStyle}>
+        <button
+          className={blocked > 0 ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"}
+          type="button"
+          onClick={() => onBucketChange("blocked")}
+        >
+          Blocked <span className="badge badge-muted">{blocked}</span>
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={() => onBucketChange("active")}
+        >
+          Active <span className="badge badge-muted">{active}</span>
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={() => onBucketChange("recent")}
+        >
+          Recent <span className="badge badge-muted">{recent}</span>
+        </button>
+        {memoryCandidateCount > 0 && (
+          <button className="btn btn-ghost btn-sm" type="button" onClick={onReviewMemory}>
+            Memory <span className="badge badge-muted">{memoryCandidateCount}</span>
+          </button>
+        )}
+        {continueWorkItemID && (
+          <button
+            className="btn btn-ghost btn-sm"
+            type="button"
+            onClick={() => onSelectWorkItem(continueWorkItemID)}
+          >
+            Continue here
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function ProjectWorkspaceTabs({
   activeTab,
   memoryCandidateCount,
@@ -873,6 +979,17 @@ function uniqueActivityWorkItems(
     );
   }
   return out;
+}
+
+function latestProjectWorkItem(items: ProjectWorkItemRecord[]): ProjectWorkItemRecord | null {
+  if (items.length === 0) return null;
+  return [...items].sort((left, right) => {
+    const leftTime = Date.parse(left.updated_at || left.created_at || "");
+    const rightTime = Date.parse(right.updated_at || right.created_at || "");
+    return (
+      (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
+    );
+  })[0];
 }
 
 export function ProjectEmptyBlock({ title, detail }: { title: string; detail: string }) {
@@ -1093,6 +1210,29 @@ const workActivityPanelStyle: CSSProperties = {
   ...panelStyle,
   display: "grid",
   gap: 10,
+};
+
+const projectResumeSummaryStyle: CSSProperties = {
+  ...panelStyle,
+  alignItems: "center",
+  display: "grid",
+  gap: 12,
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const projectResumeCopyStyle: CSSProperties = {
+  display: "grid",
+  gap: 5,
+  minWidth: 0,
+};
+
+const projectResumeStatsStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  justifyContent: "flex-end",
+  minWidth: 0,
 };
 
 const workCoordinationGridStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- add a compact Projects resume summary above Work Coordination
- surface blocked, active, recent, and memory-review jumps
- document the resume summary in the operator Projects guide

## Tests
- bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run test
- bun run typecheck
- bun run lint
- bun run format:check
- just docs-format-check
- just agent-docs-check
- git diff --check