### PR TITLE
refactor(agent-adapters): drop managed launchers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 
 ARG GO_VERSION=1.26.2
 ARG BUN_VERSION=1.3.13
+ARG ALPINE_VERSION=3.22
 ARG NODE_IMAGE=node:24-trixie-slim
 ARG HECATE_VERSION=dev
 
@@ -28,18 +29,54 @@ RUN bun install --frozen-lockfile
 COPY ui/ ./
 RUN bun run build
 
-# ── 2. Go build ─────────────────────────────────────────────────────────────
+# ── 2. ACP adapter release downloads ────────────────────────────────────────
+
+FROM alpine:${ALPINE_VERSION} AS adapter-downloader
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
+
+RUN apk add --no-cache ca-certificates curl tar \
+    && set -eux; \
+    os="${TARGETOS:-linux}"; \
+    arch="${TARGETARCH:-amd64}"; \
+    if [ "$os" != "linux" ]; then \
+      echo "unsupported adapter target OS: ${os}" >&2; \
+      exit 1; \
+    fi; \
+    case "$arch" in \
+      amd64|arm64) ;; \
+      *) echo "unsupported adapter target arch: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /adapter-bin; \
+    download_adapter() { \
+      repo="$1"; \
+      binary="$2"; \
+      version="$3"; \
+      release_version="${version#v}"; \
+      archive="${binary}_${release_version}_${os}_${arch}.tar.gz"; \
+      release_url="https://github.com/hecatehq/${repo}/releases/download/${version}"; \
+      workdir="/tmp/${binary}"; \
+      mkdir -p "$workdir"; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "$release_url/checksums.txt" -o "$workdir/checksums.txt"; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "$release_url/$archive" -o "$workdir/$archive"; \
+      grep "  ${archive}$" "$workdir/checksums.txt" > "$workdir/${archive}.sha256"; \
+      (cd "$workdir" && sha256sum -c "${archive}.sha256"); \
+      tar -xzf "$workdir/$archive" -C /adapter-bin "$binary"; \
+      chmod 0755 "/adapter-bin/$binary"; \
+      rm -rf "$workdir"; \
+    }; \
+    download_adapter codex-acp-adapter codex-acp-adapter "$CODEX_ACP_ADAPTER_VERSION"; \
+    download_adapter claude-code-acp-adapter claude-code-acp-adapter "$CLAUDE_CODE_ACP_ADAPTER_VERSION"
+
+# ── 3. Go build ─────────────────────────────────────────────────────────────
 
 FROM golang:${GO_VERSION}-alpine AS go-builder
 ARG HECATE_VERSION=dev
-ARG CODEX_ACP_ADAPTER_REF=latest
-ARG CLAUDE_CODE_ACP_ADAPTER_REF=latest
 WORKDIR /src
 
 RUN apk add --no-cache git
-RUN mkdir -p /adapter-bin \
-    && GOBIN=/adapter-bin go install github.com/hecatehq/codex-acp-adapter/cmd/codex-acp-adapter@${CODEX_ACP_ADAPTER_REF} \
-    && GOBIN=/adapter-bin go install github.com/hecatehq/claude-code-acp-adapter/cmd/claude-code-acp-adapter@${CLAUDE_CODE_ACP_ADAPTER_REF}
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -54,7 +91,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o /out/hecate \
     ./cmd/hecate
 
-# ── 3. Runtime ──────────────────────────────────────────────────────────────
+# ── 4. Runtime ──────────────────────────────────────────────────────────────
 
 FROM ${NODE_IMAGE} AS runtime
 
@@ -91,8 +128,8 @@ RUN npm install -g \
       @xai-official/grok@${GROK_VERSION} \
     && npm cache clean --force
 
-COPY --from=go-builder /adapter-bin/codex-acp-adapter /usr/local/bin/codex-acp-adapter
-COPY --from=go-builder /adapter-bin/claude-code-acp-adapter /usr/local/bin/claude-code-acp-adapter
+COPY --from=adapter-downloader /adapter-bin/codex-acp-adapter /usr/local/bin/codex-acp-adapter
+COPY --from=adapter-downloader /adapter-bin/claude-code-acp-adapter /usr/local/bin/claude-code-acp-adapter
 
 RUN mkdir -p /opt/cursor-agent \
     && curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${CURSOR_INSTALL_URL}" -o /tmp/cursor-install.sh \
@@ -120,7 +157,6 @@ ENV HECATE_ADDRESS=0.0.0.0:8765 \
     HECATE_DATA_DIR=/data \
     HECATE_SQLITE_PATH=/data/hecate.db \
     HECATE_BACKEND=sqlite \
-    HECATE_AGENT_ADAPTERS_DIR=/data/agent-adapters \
     NPM_CONFIG_CACHE=/data/npm-cache \
     TINI_SUBREAPER=1 \
     # Local inference: from inside a container 127.0.0.1 is the container's

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.3
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.3
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -8,17 +8,47 @@
 # embedded UI, git/ssh, supported External Agent CLIs/ACP adapters, /data
 # persistence, and /workspace as the default work root.
 
-ARG GO_VERSION=1.26.2
+ARG ALPINE_VERSION=3.22
 ARG NODE_IMAGE=node:24-trixie-slim
 
-FROM golang:${GO_VERSION}-alpine AS adapter-builder
-ARG CODEX_ACP_ADAPTER_REF=latest
-ARG CLAUDE_CODE_ACP_ADAPTER_REF=latest
+FROM alpine:${ALPINE_VERSION} AS adapter-downloader
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
 
-RUN apk add --no-cache git \
-    && mkdir -p /adapter-bin \
-    && GOBIN=/adapter-bin go install github.com/hecatehq/codex-acp-adapter/cmd/codex-acp-adapter@${CODEX_ACP_ADAPTER_REF} \
-    && GOBIN=/adapter-bin go install github.com/hecatehq/claude-code-acp-adapter/cmd/claude-code-acp-adapter@${CLAUDE_CODE_ACP_ADAPTER_REF}
+RUN apk add --no-cache ca-certificates curl tar \
+    && set -eux; \
+    os="${TARGETOS:-linux}"; \
+    arch="${TARGETARCH:-amd64}"; \
+    if [ "$os" != "linux" ]; then \
+      echo "unsupported adapter target OS: ${os}" >&2; \
+      exit 1; \
+    fi; \
+    case "$arch" in \
+      amd64|arm64) ;; \
+      *) echo "unsupported adapter target arch: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /adapter-bin; \
+    download_adapter() { \
+      repo="$1"; \
+      binary="$2"; \
+      version="$3"; \
+      release_version="${version#v}"; \
+      archive="${binary}_${release_version}_${os}_${arch}.tar.gz"; \
+      release_url="https://github.com/hecatehq/${repo}/releases/download/${version}"; \
+      workdir="/tmp/${binary}"; \
+      mkdir -p "$workdir"; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "$release_url/checksums.txt" -o "$workdir/checksums.txt"; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "$release_url/$archive" -o "$workdir/$archive"; \
+      grep "  ${archive}$" "$workdir/checksums.txt" > "$workdir/${archive}.sha256"; \
+      (cd "$workdir" && sha256sum -c "${archive}.sha256"); \
+      tar -xzf "$workdir/$archive" -C /adapter-bin "$binary"; \
+      chmod 0755 "/adapter-bin/$binary"; \
+      rm -rf "$workdir"; \
+    }; \
+    download_adapter codex-acp-adapter codex-acp-adapter "$CODEX_ACP_ADAPTER_VERSION"; \
+    download_adapter claude-code-acp-adapter claude-code-acp-adapter "$CLAUDE_CODE_ACP_ADAPTER_VERSION"
 
 FROM ${NODE_IMAGE}
 
@@ -57,8 +87,8 @@ RUN npm install -g \
       @xai-official/grok@${GROK_VERSION} \
     && npm cache clean --force
 
-COPY --from=adapter-builder /adapter-bin/codex-acp-adapter /usr/local/bin/codex-acp-adapter
-COPY --from=adapter-builder /adapter-bin/claude-code-acp-adapter /usr/local/bin/claude-code-acp-adapter
+COPY --from=adapter-downloader /adapter-bin/codex-acp-adapter /usr/local/bin/codex-acp-adapter
+COPY --from=adapter-downloader /adapter-bin/claude-code-acp-adapter /usr/local/bin/claude-code-acp-adapter
 
 RUN mkdir -p /opt/cursor-agent \
     && curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${CURSOR_INSTALL_URL}" -o /tmp/cursor-install.sh \
@@ -86,7 +116,6 @@ ENV HECATE_ADDRESS=0.0.0.0:8765 \
     HECATE_DATA_DIR=/data \
     HECATE_SQLITE_PATH=/data/hecate.db \
     HECATE_BACKEND=sqlite \
-    HECATE_AGENT_ADAPTERS_DIR=/data/agent-adapters \
     NPM_CONFIG_CACHE=/data/npm-cache \
     TINI_SUBREAPER=1 \
     PROVIDER_OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.2
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.3
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.3
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/design/accepted/external-agent-integrations.md
+++ b/docs/design/accepted/external-agent-integrations.md
@@ -126,8 +126,8 @@ internal/agentadapters/
 
 The current runtime shape is ACP-first:
 
-- `registry.go` declares built-in adapters, direct commands, managed launcher
-  metadata, tested version ranges, and lightweight auth hints.
+- `registry.go` declares built-in adapters, direct commands, tested version
+  ranges, and lightweight auth hints.
 - `probe.go` performs the explicit "can this adapter really start?" check by
   spawning the adapter, completing ACP `initialize`, opening a no-op session,
   and classifying the result.
@@ -157,7 +157,6 @@ Implemented MVP endpoints:
 GET  /hecate/v1/agent-adapters
 POST /hecate/v1/agent-adapters/{id}/probe
 GET  /hecate/v1/agent-adapters/{id}/health
-POST /hecate/v1/agent-adapters/{id}/refresh-launcher
 GET  /hecate/v1/chat/sessions
 POST /hecate/v1/chat/sessions
 GET  /hecate/v1/chat/sessions/{id}
@@ -215,11 +214,6 @@ storage is enabled, Hecate keeps the transcript and saved native session id. On
 the next prompt it asks the adapter to load that native session when the adapter
 advertises load-session support; otherwise it starts a fresh native ACP session
 and keeps the Hecate-side transcript intact.
-
-Managed launchers are intentionally local and operator-controlled. Hecate writes
-small wrapper scripts into the user cache directory or `HECATE_AGENT_ADAPTERS_DIR`,
-refreshes one adapter on demand, and removes stale launcher scripts at startup
-when the built-in adapter list changes.
 
 ## Relationship To ACP
 

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -86,10 +86,13 @@ Remote deployments using the published image must supply container- or
 VM-level isolation around each instance. The image intentionally includes a
 POSIX shell, git/ssh, common project-dependency tools (`build-essential`,
 Python/pip/venv, `pkg-config`, `ripgrep`, `jq`, and archive/process helpers),
-and External Agent CLIs. It does not install `bwrap` by default; Hecate still
-applies its process policy, env sanitisation, and approval gates, but
-filesystem/network isolation inside the container is normally reported as
-`none`.
+and External Agent CLIs. The Codex and Claude Code ACP bridges are bundled as
+release-built Go binaries verified against their release checksums. The
+container build args `CODEX_ACP_ADAPTER_VERSION` and
+`CLAUDE_CODE_ACP_ADAPTER_VERSION` select those adapter releases. The image does
+not install `bwrap` by default; Hecate still applies its process policy, env
+sanitisation, and approval gates, but filesystem/network isolation inside the
+container is normally reported as `none`.
 
 Remote mode also disables local model providers by default. Local presets are
 hidden, `kind=local` provider creates/updates are rejected, env-preconfigured
@@ -276,19 +279,15 @@ chat sessions and External Agent integrations. The native app spawns the bundled
 process; Docker reads them from `.env` / compose; bare binaries read the shell
 environment.
 
-| Env var                             | Default             | Applies to                                           |
-| ----------------------------------- | ------------------- | ---------------------------------------------------- |
-| `HECATE_AGENT_ADAPTERS_DIR`         | platform user cache | Legacy/custom managed ACP launcher scripts           |
-| `HECATE_CHAT_MAX_TURNS_PER_SESSION` | `0`                 | Per-session user→assistant turn ceiling              |
-| `HECATE_CHAT_MAX_SESSION_DURATION`  | `0s`                | Wall-clock age ceiling before new turns are rejected |
-| `HECATE_CHAT_IDLE_TIMEOUT`          | `0s`                | Background idle auto-close sweeper                   |
+| Env var                             | Default | Applies to                                           |
+| ----------------------------------- | ------- | ---------------------------------------------------- |
+| `HECATE_CHAT_MAX_TURNS_PER_SESSION` | `0`     | Per-session user→assistant turn ceiling              |
+| `HECATE_CHAT_MAX_SESSION_DURATION`  | `0s`    | Wall-clock age ceiling before new turns are rejected |
+| `HECATE_CHAT_IDLE_TIMEOUT`          | `0s`    | Background idle auto-close sweeper                   |
 
-Managed launchers are legacy/custom wrapper scripts around a local package
-runner such as `npx`; Hecate garbage-collects stale launcher names at startup.
-Codex and Claude Code now use standalone Go adapter binaries instead of managed
-npm launchers. If you still run a managed custom adapter and move Node/npm
-managers, restart Hecate and use `POST
-/hecate/v1/agent-adapters/{id}/refresh-launcher` to recreate the affected wrapper.
+External Agent integrations now use direct ACP binaries only. Codex and Claude
+Code use standalone Go adapter binaries, while Cursor Agent and Grok Build use
+ACP modes built into their vendor CLIs.
 Connections probes External Agent integrations when the workspace opens; the probe calls
 `POST /hecate/v1/agent-adapters/{id}/probe`, which re-runs discovery and
 performs the ACP handshake so login/billing problems are visible before a chat

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -97,7 +97,8 @@ agent bridge, while authentication and billing stay with the provider.
 6. If the agent row is amber/red, open **Connections**. The probe performs
    a real spawn + ACP handshake + temporary
    no-op session, so it catches missing auth, billing/subscription issues,
-   unsupported versions, and broken managed launchers before a prompt fails.
+   unsupported versions, and missing or unsupported binaries before a prompt
+   fails.
 7. Send a small smoke prompt:
 
    ```text
@@ -156,10 +157,7 @@ Discovery reports command availability, tested version range, and lightweight
 auth hints (`auth_status`: `ok`, `unauthenticated`, `billing`, or `unknown`).
 When an ACP adapter binary is separate from the coding-agent CLI, Hecate reports
 both versions: `adapter_version` for the bridge and `agent_version` for the
-underlying agent (`codex`, `claude`, `cursor-agent`, `grok`). Legacy/custom
-managed package adapters avoid package-manager execution during passive
-discovery; their `adapter_version` is populated only after an explicit agent
-readiness test.
+underlying agent (`codex`, `claude`, `cursor-agent`, `grok`).
 
 Manual setup stays in the upstream CLIs:
 
@@ -193,27 +191,11 @@ installed and visible on `PATH`. Hecate does not pin an external-agent model by
 default. When an ACP agent reports model state, the agent-provided model list and
 current model become the chat model control.
 
-By default the managed launcher directory is the user cache location:
-
-```text
-<user-cache>/hecate/agent-adapters
-```
-
-Set `HECATE_AGENT_ADAPTERS_DIR` only if you still use a managed custom adapter
-and want to override that location for development, Docker volume mapping, or a
-packaged desktop build. Hecate removes stale managed-launcher scripts at startup
-when their adapter no longer exists. To force-refresh one managed launcher after
-changing Node/npm managers:
-
-```sh
-curl -X POST http://127.0.0.1:8765/hecate/v1/agent-adapters/managed_adapter_id/refresh-launcher | jq
-```
-
 ## Setup checks
 
 External Agent chat does not use Hecate model providers. It needs the selected
-coding-agent to be authenticated, and either a direct ACP command or a managed
-package runner to be visible to Hecate.
+coding-agent to be authenticated, and the direct ACP command to be visible to
+Hecate.
 
 Use this order when troubleshooting:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1068,13 +1068,14 @@ GET /hecate/v1/agent-adapters
 
 `adapter_version` is the ACP bridge version when Hecate uses a separate binary
 to speak ACP. The standalone Go Codex and Claude Code adapters report
-`0.0.0-dev` when installed directly with `go install`; release-built binaries
-report their stamped tag. `agent_version` is the underlying coding-agent CLI
-version, such as `codex`, `claude`, `cursor-agent`, or `grok`. Both fields are
-extracted from `--version` output and omitted when the command is missing or
-does not print a recognisable semver string. `version_outside_range` is `true`
-when the version subject to `supported_range` does not satisfy the constraint —
-the Connections UI shows an amber "outside tested range" chip in that case.
+`0.0.0-dev` when installed directly with `go install`; Hecate container images
+bundle release-built adapter binaries so they report their stamped tag.
+`agent_version` is the underlying coding-agent CLI version, such as `codex`,
+`claude`, `cursor-agent`, or `grok`. Both fields are extracted from `--version`
+output and omitted when the command is missing or does not print a recognisable
+semver string. `version_outside_range` is `true` when the version subject to
+`supported_range` does not satisfy the constraint — the Connections UI shows an
+amber "outside tested range" chip in that case.
 
 `auth_status` is a lightweight dashboard hint, not a full login check. Values:
 `ok`, `unauthenticated`, `billing`, or `unknown`. It is derived from known env
@@ -1176,7 +1177,7 @@ GET /hecate/v1/agent-adapters/codex/health
 `status` is one of:
 
 - `ready` — spawn + Initialize + NewSession all succeeded.
-- `not_installed` — binary not on PATH and managed launcher unavailable.
+- `not_installed` — binary not on PATH.
 - `auth_required` — process started but Initialize or NewSession failed with
   an auth-shaped error (`Authentication required`, `Please log in`, `API key`,
   `Credit balance is too low`, `401`, `403`, …).
@@ -1198,32 +1199,6 @@ Status codes:
 The probe creates and immediately abandons a fresh ACP session, so agents that
 bill on session creation will see one no-op session per call. Agents that bill
 on prompt completion see no charge.
-
-### `POST /hecate/v1/agent-adapters/{id}/refresh-launcher`
-
-Deletes and recreates the Hecate-managed launcher script for a managed adapter,
-then returns a one-item `agent_adapters` response with the refreshed status.
-Codex and Claude Code now use standalone Go adapter binaries and normally return
-`409 conflict` from this endpoint.
-
-```json
-POST /hecate/v1/agent-adapters/codex/refresh-launcher
-→ 409
-{
-  "error": {
-    "type": "conflict",
-    "message": "adapter codex does not use a managed launcher"
-  }
-}
-```
-
-Status codes:
-
-- `200 OK` for managed adapters when a local package runner such as `npx` is
-  available.
-- `404 not_found` when the adapter id is not registered.
-- `409 conflict` when the adapter is not managed or the launcher cannot be
-  recreated.
 
 ## Plugin registry endpoints
 

--- a/internal/agentadapters/claude_setup_test.go
+++ b/internal/agentadapters/claude_setup_test.go
@@ -28,7 +28,7 @@ func TestDetectClaudeCodeCLI(t *testing.T) {
 		}
 	})
 	if !status.Available || status.Command != "/tmp/bin/npx -y @anthropic-ai/claude-code" || status.ExecutablePath != "/tmp/bin/npx" {
-		t.Fatalf("DetectClaudeCodeCLI() = %+v, want npx-managed path", status)
+		t.Fatalf("DetectClaudeCodeCLI() = %+v, want npx setup path", status)
 	}
 
 	status = DetectClaudeCodeCLI(func(string) (string, error) {

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -334,12 +334,8 @@ func matchesAny(haystack string, needles ...string) bool {
 }
 
 // lookupHint is the human-friendly suggestion attached to a "binary
-// not on PATH" failure. We prefer the adapter's docs URL when one is
-// declared; otherwise we point at the managed-launcher fallback.
+// not on PATH" failure.
 func lookupHint(adapter Adapter) string {
-	if adapter.Managed.Package != "" {
-		return fmt.Sprintf("Install Node/npm so Hecate can manage %q automatically, or install the binary directly. Setup docs: %s", adapter.Managed.Package, adapter.DocsURL)
-	}
 	if adapter.DocsURL != "" {
 		return fmt.Sprintf("Install %s and ensure it's on PATH. Setup docs: %s", adapter.Name, adapter.DocsURL)
 	}

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -291,10 +291,10 @@ func TestLookupHint(t *testing.T) {
 		if hint == "" {
 			t.Fatalf("lookupHint(%s) = empty — every adapter must surface a suggestion", a.ID)
 		}
-		// Hint should reference the adapter by name or by managed
-		// package — never just "install something".
-		if !strings.Contains(hint, a.Name) && !strings.Contains(hint, a.Managed.Package) {
-			t.Errorf("lookupHint(%s) = %q, want it to reference the adapter or its managed package", a.ID, hint)
+		// Hint should reference the adapter by name — never just
+		// "install something".
+		if !strings.Contains(hint, a.Name) {
+			t.Errorf("lookupHint(%s) = %q, want it to reference the adapter", a.ID, hint)
 		}
 	}
 }

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +69,6 @@ type Adapter struct {
 	Args             []string
 	CandidatePaths   []string
 	AgentVersion     VersionProbe
-	Managed          ManagedLauncher
 	LaunchSuffixArgs []string
 	LaunchModel      LaunchModelConfig
 	LaunchOptions    []LaunchSelectConfig
@@ -127,17 +125,6 @@ type LaunchSelectOption struct {
 	ID          string
 	Name        string
 	Description string
-}
-
-type ManagedLauncher struct {
-	Package string
-	Runners []ManagedRunner
-}
-
-type ManagedRunner struct {
-	Command        string
-	Args           []string
-	CandidatePaths []string
 }
 
 type Status struct {
@@ -537,24 +524,20 @@ func ListWithLookup(ctx context.Context, lookup LookupFunc) []Status {
 	items := BuiltIns()
 	out := make([]Status, 0, len(items))
 	for _, item := range items {
-		out = append(out, statusForAdapter(ctx, item, lookup, statusProbeOptions{}))
+		out = append(out, statusForAdapter(ctx, item, lookup))
 	}
 	return out
 }
 
 func StatusForAdapter(ctx context.Context, id string, lookup LookupFunc) (Status, bool) {
-	return statusForAdapterByID(ctx, id, lookup, statusProbeOptions{})
+	return statusForAdapterByID(ctx, id, lookup)
 }
 
 func StatusForAdapterAfterExplicitProbe(ctx context.Context, id string, lookup LookupFunc) (Status, bool) {
-	return statusForAdapterByID(ctx, id, lookup, statusProbeOptions{allowManagedAdapterVersion: true})
+	return statusForAdapterByID(ctx, id, lookup)
 }
 
-type statusProbeOptions struct {
-	allowManagedAdapterVersion bool
-}
-
-func statusForAdapterByID(ctx context.Context, id string, lookup LookupFunc, opts statusProbeOptions) (Status, bool) {
+func statusForAdapterByID(ctx context.Context, id string, lookup LookupFunc) (Status, bool) {
 	if lookup == nil {
 		lookup = exec.LookPath
 	}
@@ -562,12 +545,12 @@ func statusForAdapterByID(ctx context.Context, id string, lookup LookupFunc, opt
 		if item.ID != strings.TrimSpace(id) {
 			continue
 		}
-		return statusForAdapter(ctx, item, lookup, opts), true
+		return statusForAdapter(ctx, item, lookup), true
 	}
 	return Status{}, false
 }
 
-func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc, opts statusProbeOptions) Status {
+func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Status {
 	status := Status{
 		Adapter:    item,
 		Status:     StatusMissing,
@@ -607,41 +590,24 @@ func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc, opts
 	status.Available = true
 	status.Status = StatusAvailable
 	status.Path = path
-	if item.Managed.Package != "" && shouldProbeAdapterVersionForStatus(item, path, lookup, opts.allowManagedAdapterVersion) {
-		v := DetectVersion(ctx, path)
-		status.AdapterVersion = v
-	}
-	status.AgentVersion = detectAgentVersionForStatus(ctx, item, path, lookup)
+	status.AdapterVersion, status.AgentVersion = detectAdapterAndAgentVersionsForStatus(ctx, item, path, lookup)
 	status.VersionOutsideRange = !satisfiesRange(firstNonEmptyVersion(status.AdapterVersion, status.AgentVersion), item.SupportedRange)
 	status.AuthStatus, status.AuthError = DetectAuthStatus(item)
 	return status
 }
 
-func shouldProbeAdapterVersionForStatus(adapter Adapter, path string, lookup LookupFunc, allowManaged bool) bool {
-	if !shouldProbeVersion(path) {
-		return false
-	}
-	if adapter.Managed.Package == "" {
-		return true
-	}
-	if allowManaged {
-		return true
-	}
-	planned, err := plannedManagedLauncher(adapter, lookup)
-	if err != nil {
-		return true
-	}
-	return filepath.Clean(planned) != filepath.Clean(path)
-}
-
-func detectAgentVersionForStatus(ctx context.Context, adapter Adapter, path string, lookup LookupFunc) string {
+func detectAdapterAndAgentVersionsForStatus(ctx context.Context, adapter Adapter, path string, lookup LookupFunc) (string, string) {
 	if adapter.AgentVersion.Command != "" {
-		return DetectVersionProbe(ctx, adapter.AgentVersion, lookup)
+		adapterVersion := ""
+		if shouldProbeVersion(path) {
+			adapterVersion = DetectVersion(ctx, path)
+		}
+		return adapterVersion, DetectVersionProbe(ctx, adapter.AgentVersion, lookup)
 	}
-	if adapter.Managed.Package != "" {
-		return ""
+	if shouldProbeVersion(path) {
+		return "", DetectVersion(ctx, path)
 	}
-	return DetectVersion(ctx, path)
+	return "", ""
 }
 
 func firstNonEmptyVersion(values ...string) string {
@@ -817,14 +783,6 @@ func applyAdapterDiscoveryOverride(status Status, override string) Status {
 }
 
 func resolveExecutable(adapter Adapter, lookup LookupFunc) (string, error) {
-	return resolveExecutableWithManaged(adapter, lookup, true)
-}
-
-func resolveExecutableForStatus(adapter Adapter, lookup LookupFunc) (string, error) {
-	return resolveExecutableWithManaged(adapter, lookup, false)
-}
-
-func resolveExecutableWithManaged(adapter Adapter, lookup LookupFunc, createManaged bool) (string, error) {
 	if lookup == nil {
 		lookup = exec.LookPath
 	}
@@ -850,202 +808,11 @@ func resolveExecutableWithManaged(adapter Adapter, lookup LookupFunc, createMana
 		}
 		return path, nil
 	}
-	if adapter.Managed.Package != "" {
-		var path string
-		var err error
-		if createManaged {
-			path, err = ensureManagedLauncher(adapter, lookup)
-		} else {
-			path, err = plannedManagedLauncher(adapter, lookup)
-		}
-		if err == nil {
-			return path, nil
-		}
-		return "", fmt.Errorf("%w; managed launcher unavailable: %v", firstErr, err)
-	}
 	return "", firstErr
 }
 
-func plannedManagedLauncher(adapter Adapter, lookup LookupFunc) (string, error) {
-	if adapter.Managed.Package == "" {
-		return "", errors.New("adapter has no managed launcher")
-	}
-	if _, _, err := resolveManagedRunner(adapter.Managed, lookup); err != nil {
-		return "", err
-	}
-	dir, err := managedLauncherDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, managedLauncherName(adapter.Command)), nil
-}
-
-func ensureManagedLauncher(adapter Adapter, lookup LookupFunc) (string, error) {
-	if adapter.Managed.Package == "" {
-		return "", errors.New("adapter has no managed launcher")
-	}
-	runner, runnerPath, err := resolveManagedRunner(adapter.Managed, lookup)
-	if err != nil {
-		return "", err
-	}
-	dir, err := managedLauncherDir()
-	if err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("create managed adapter directory: %w", err)
-	}
-	path := filepath.Join(dir, managedLauncherName(adapter.Command))
-	content := managedLauncherContent(runnerPath, runner.Args)
-	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
-		return path, nil
-	}
-	mode := os.FileMode(0o755)
-	if runtime.GOOS == "windows" {
-		mode = 0o644
-	}
-	if err := os.WriteFile(path, []byte(content), mode); err != nil {
-		return "", fmt.Errorf("write managed adapter launcher: %w", err)
-	}
-	return path, nil
-}
-
-func RefreshManagedLauncher(ctx context.Context, id string, lookup LookupFunc) (Status, error) {
-	adapter, ok := FindAdapter(id)
-	if !ok {
-		return Status{}, fmt.Errorf("unknown adapter %q", id)
-	}
-	if adapter.Managed.Package == "" {
-		return Status{}, fmt.Errorf("adapter %q does not use a managed launcher", id)
-	}
-	dir, err := managedLauncherDir()
-	if err != nil {
-		return Status{}, err
-	}
-	_ = os.Remove(filepath.Join(dir, managedLauncherName(adapter.Command)))
-	if _, err := ensureManagedLauncher(adapter, lookup); err != nil {
-		return Status{}, err
-	}
-	return statusForAdapter(ctx, adapter, lookup, statusProbeOptions{}), nil
-}
-
-func GCManagedLaunchers() (int, error) {
-	dir, err := managedLauncherDir()
-	if err != nil {
-		return 0, err
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	keep := make(map[string]struct{})
-	for _, adapter := range BuiltIns() {
-		if adapter.Managed.Package != "" {
-			keep[managedLauncherName(adapter.Command)] = struct{}{}
-		}
-	}
-	removed := 0
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if _, ok := keep[entry.Name()]; ok {
-			continue
-		}
-		if err := os.Remove(filepath.Join(dir, entry.Name())); err == nil {
-			removed++
-		}
-	}
-	return removed, nil
-}
-
-func resolveManagedRunner(managed ManagedLauncher, lookup LookupFunc) (ManagedRunner, string, error) {
-	if lookup == nil {
-		lookup = exec.LookPath
-	}
-	var errorsText []string
-	for _, runner := range managed.Runners {
-		if strings.TrimSpace(runner.Command) == "" {
-			continue
-		}
-		path, err := lookup(runner.Command)
-		if err == nil {
-			return runner, path, nil
-		}
-		for _, candidate := range runner.CandidatePaths {
-			path := expandPath(candidate)
-			if path == "" {
-				continue
-			}
-			info, statErr := os.Stat(path)
-			if statErr != nil || info.IsDir() || info.Mode()&0o111 == 0 {
-				continue
-			}
-			return runner, path, nil
-		}
-		errorsText = append(errorsText, fmt.Sprintf("%s: %v", runner.Command, err))
-	}
-	if len(errorsText) == 0 {
-		return ManagedRunner{}, "", fmt.Errorf("no runner configured for managed adapter package %s", managed.Package)
-	}
-	return ManagedRunner{}, "", fmt.Errorf("no local package runner found for %s (%s)", managed.Package, strings.Join(errorsText, "; "))
-}
-
-func managedLauncherDir() (string, error) {
-	if dir := strings.TrimSpace(os.Getenv("HECATE_AGENT_ADAPTERS_DIR")); dir != "" {
-		return filepath.Abs(filepath.Clean(dir))
-	}
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve user cache directory: %w", err)
-	}
-	return filepath.Join(dir, "hecate", "agent-adapters"), nil
-}
-
-func managedNPXCandidates() []string {
-	return []string{
-		"${HOME}/.volta/bin/npx",
-		"${HOME}/.local/share/mise/shims/npx",
-		"${HOME}/.asdf/shims/npx",
-		"/opt/homebrew/bin/npx",
-		"/usr/local/bin/npx",
-		"/usr/bin/npx",
-	}
-}
-
-func managedLauncherName(command string) string {
-	if runtime.GOOS == "windows" {
-		return command + ".cmd"
-	}
-	return command
-}
-
-func managedLauncherContent(runnerPath string, args []string) string {
-	if runtime.GOOS == "windows" {
-		parts := []string{windowsQuote(runnerPath)}
-		for _, arg := range args {
-			parts = append(parts, windowsQuote(arg))
-		}
-		parts = append(parts, "%*")
-		return "@echo off\r\n" + strings.Join(parts, " ") + "\r\n"
-	}
-	parts := []string{"exec", shellQuote(runnerPath)}
-	for _, arg := range args {
-		parts = append(parts, shellQuote(arg))
-	}
-	parts = append(parts, "\"$@\"")
-	return "#!/bin/sh\n" + strings.Join(parts, " ") + "\n"
-}
-
-func shellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
-}
-
-func windowsQuote(value string) string {
-	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+func resolveExecutableForStatus(adapter Adapter, lookup LookupFunc) (string, error) {
+	return resolveExecutable(adapter, lookup)
 }
 
 func Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -3,7 +3,6 @@ package agentadapters
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,13 +26,13 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 		found[item.ID] = item
 	}
 
-	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.Managed.Package != "" || got.CostMode != "external" {
+	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
 	if got := found["codex"]; got.SupportedRange != ">=0.0.0-dev" {
 		t.Fatalf("codex supported range = %q, want alpha dev-compatible range", got.SupportedRange)
 	}
-	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.Managed.Package != "" || got.CostMode != "external" {
+	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
 	if got := found["claude_code"]; got.SupportedRange != ">=0.0.0-dev" {
@@ -370,7 +369,7 @@ func TestStatusForAdapterIgnoresInvalidDiscoveryOverride(t *testing.T) {
 		Command: "fake-adapter",
 	}, func(file string) (string, error) {
 		return "", errors.New("not found on PATH")
-	}, statusProbeOptions{})
+	})
 	if status.Available || status.Status != StatusMissing || !strings.Contains(status.Error, "not found") {
 		t.Fatalf("status = %#v, want normal missing lookup", status)
 	}
@@ -417,7 +416,7 @@ func TestResolveExecutableExpandsHomeCandidate(t *testing.T) {
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatalf("mkdir bin: %v", err)
 	}
-	exe := filepath.Join(bin, "managed-test-acp")
+	exe := filepath.Join(bin, "direct-test-acp")
 	if err := os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write executable: %v", err)
 	}
@@ -425,7 +424,7 @@ func TestResolveExecutableExpandsHomeCandidate(t *testing.T) {
 	path, err := resolveExecutable(Adapter{
 		ID:             "codex",
 		Command:        "codex-missing",
-		CandidatePaths: []string{"${HOME}/.local/bin/managed-test-acp"},
+		CandidatePaths: []string{"${HOME}/.local/bin/direct-test-acp"},
 	}, func(file string) (string, error) {
 		return "", errors.New("not found on PATH")
 	})
@@ -437,333 +436,38 @@ func TestResolveExecutableExpandsHomeCandidate(t *testing.T) {
 	}
 }
 
-func TestResolveExecutableForStatusReportsManagedLauncherWithoutWriting(t *testing.T) {
+func TestStatusForAdapterReportsAdapterAndAgentVersionsForBridgeBinary(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	adapter := Adapter{
-		ID:      "codex",
-		Command: "managed-test-acp",
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-	}
-	path, err := resolveExecutableForStatus(adapter, func(file string) (string, error) {
-		if file == "npx" {
-			return "/usr/local/bin/npx", nil
-		}
-		return "", errors.New("not found on PATH")
-	})
-	if err != nil {
-		t.Fatalf("resolve executable for status: %v", err)
-	}
-	want := filepath.Join(dir, managedLauncherName("managed-test-acp"))
-	if path != want {
-		t.Fatalf("path = %q, want %q", path, want)
-	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("managed status lookup wrote launcher, stat error = %v", err)
-	}
-}
-
-func TestShouldProbeVersionForStatusSkipsPlannedManagedLauncher(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	adapter := Adapter{
-		ID:      "codex",
-		Command: "managed-test-acp",
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-	}
-	path := filepath.Join(dir, managedLauncherName("managed-test-acp"))
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
-		t.Fatalf("write planned launcher: %v", err)
-	}
-
-	lookup := func(file string) (string, error) {
-		if file == "npx" {
-			return "/usr/local/bin/npx", nil
-		}
-		return "", errors.New("not found on PATH")
-	}
-	if shouldProbeAdapterVersionForStatus(adapter, path, lookup, false) {
-		t.Fatalf("shouldProbeAdapterVersionForStatus returned true for planned managed launcher")
-	}
-}
-
-func TestStatusForAdapterDoesNotRunManagedPackageForVersion(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-	marker := filepath.Join(dir, "runner-called")
-
-	runnerPath := writeGoHelperBinary(t, dir, "fake-npx", fmt.Sprintf(`package main
-
-import "os"
-
-func main() {
-	if err := os.WriteFile(%q, []byte("called"), 0o644); err != nil {
-		panic(err)
-	}
-}
-`, marker))
-	adapter := Adapter{
-		ID:      "managed_test",
-		Name:    "Managed Test",
-		Command: "managed-test-acp",
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-		SupportedRange: ">=4.0.0",
-	}
-	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
-		if file == "npx" {
-			return runnerPath, nil
-		}
-		return "", errors.New("not found on PATH")
-	}, statusProbeOptions{})
-	if !status.Available {
-		t.Fatalf("status = %#v, want managed adapter available", status)
-	}
-	if status.AdapterVersion != "" {
-		t.Fatalf("status.AdapterVersion = %q, want passive status to avoid package-manager execution", status.AdapterVersion)
-	}
-	if status.VersionOutsideRange {
-		t.Fatalf("status.VersionOutsideRange = true, want false when version is unknown")
-	}
-	if _, err := os.Stat(status.Path); !os.IsNotExist(err) {
-		t.Fatalf("managed status lookup wrote launcher at %q, stat error = %v", status.Path, err)
-	}
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("passive managed status probe executed package runner, marker stat error = %v", err)
-	}
-}
-
-func TestStatusForAdapterReportsManagedAgentVersionWithoutRunningPackage(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-	marker := filepath.Join(dir, "runner-called")
+	adapterBinary := writeFakeBinary(t, dir, "codex-acp-adapter", "codex-acp-adapter 0.1.0-alpha.2")
 	agent := writeFakeBinary(t, dir, "codex", "codex 9.8.7")
-	runnerPath := writeGoHelperBinary(t, dir, "fake-npx", fmt.Sprintf(`package main
-
-import "os"
-
-func main() {
-	if err := os.WriteFile(%q, []byte("called"), 0o644); err != nil {
-		panic(err)
-	}
-}
-`, marker))
 	adapter := Adapter{
-		ID:      "managed_test",
-		Name:    "Managed Test",
-		Command: "managed-test-acp",
+		ID:      "codex",
+		Name:    "Codex",
+		Command: "codex-acp-adapter",
 		AgentVersion: VersionProbe{
 			Command: "codex",
 			Args:    []string{"--version"},
 		},
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-		SupportedRange: ">=4.0.0",
+		SupportedRange: ">=0.0.0-dev",
 	}
 	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
 		switch file {
+		case "codex-acp-adapter":
+			return adapterBinary, nil
 		case "codex":
 			return agent, nil
-		case "npx":
-			return runnerPath, nil
 		default:
 			return "", errors.New("not found on PATH")
 		}
-	}, statusProbeOptions{})
+	})
+	if status.AdapterVersion != "0.1.0-alpha.2" {
+		t.Fatalf("status.AdapterVersion = %q, want 0.1.0-alpha.2", status.AdapterVersion)
+	}
 	if status.AgentVersion != "9.8.7" {
 		t.Fatalf("status.AgentVersion = %q, want 9.8.7", status.AgentVersion)
 	}
-	if status.AdapterVersion != "" {
-		t.Fatalf("status.AdapterVersion = %q, want passive status to avoid package-manager execution", status.AdapterVersion)
-	}
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("passive managed status probe executed package runner, marker stat error = %v", err)
-	}
-}
-
-func TestStatusForAdapterExplicitProbeAllowsManagedAdapterVersion(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	adapter := Adapter{
-		ID:      "managed_test",
-		Name:    "Managed Test",
-		Command: "managed-test-acp",
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-		SupportedRange: ">=4.0.0",
-	}
-	path := filepath.Join(dir, managedLauncherName(adapter.Command))
-	if err := os.WriteFile(path, []byte("#!/bin/sh\necho managed-test-acp 4.5.6\n"), 0o755); err != nil {
-		t.Fatalf("write planned launcher: %v", err)
-	}
-	status := statusForAdapter(context.Background(), adapter, func(file string) (string, error) {
-		if file == "npx" {
-			return "/usr/local/bin/npx", nil
-		}
-		return "", errors.New("not found on PATH")
-	}, statusProbeOptions{allowManagedAdapterVersion: true})
-	if status.AdapterVersion != "4.5.6" {
-		t.Fatalf("status.AdapterVersion = %q, want 4.5.6", status.AdapterVersion)
-	}
 	if status.VersionOutsideRange {
 		t.Fatalf("status.VersionOutsideRange = true, want version in supported range")
-	}
-}
-
-func TestShouldProbeVersionForStatusAllowsDirectBinary(t *testing.T) {
-	exe := filepath.Join(t.TempDir(), "managed-test-acp")
-	if err := os.WriteFile(exe, []byte("#!/bin/sh\necho 1.2.3\n"), 0o755); err != nil {
-		t.Fatalf("write executable: %v", err)
-	}
-
-	if !shouldProbeAdapterVersionForStatus(Adapter{Command: "managed-test-acp"}, exe, func(file string) (string, error) {
-		return "", errors.New("not found on PATH")
-	}, false) {
-		t.Fatalf("shouldProbeAdapterVersionForStatus returned false for direct binary")
-	}
-}
-
-func TestResolveExecutableCreatesManagedLauncher(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	adapter := Adapter{
-		ID:      "codex",
-		Command: "managed-test-acp",
-		Managed: ManagedLauncher{
-			Package: "@example/managed-test-acp",
-			Runners: []ManagedRunner{{Command: "npx", Args: []string{"-y", "@example/managed-test-acp"}}},
-		},
-	}
-	path, err := resolveExecutable(adapter, func(file string) (string, error) {
-		if file == "npx" {
-			return "/usr/local/bin/npx", nil
-		}
-		return "", errors.New("not found on PATH")
-	})
-	if err != nil {
-		t.Fatalf("resolve executable: %v", err)
-	}
-	want := filepath.Join(dir, managedLauncherName("managed-test-acp"))
-	if path != want {
-		t.Fatalf("path = %q, want %q", path, want)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat launcher: %v", err)
-	}
-	if info.Mode()&0o111 == 0 {
-		t.Fatalf("launcher mode = %v, want executable", info.Mode())
-	}
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read launcher: %v", err)
-	}
-	text := string(content)
-	if !strings.Contains(text, "/usr/local/bin/npx") || !strings.Contains(text, "@example/managed-test-acp") {
-		t.Fatalf("launcher content = %q", text)
-	}
-}
-
-func TestRefreshManagedLauncherRejectsUnmanagedBuiltIn(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	stale := filepath.Join(dir, managedLauncherName("codex-acp-adapter"))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir launcher dir: %v", err)
-	}
-	if err := os.WriteFile(stale, []byte("#!/bin/sh\nexit 99\n"), 0o755); err != nil {
-		t.Fatalf("write stale launcher: %v", err)
-	}
-
-	_, err := RefreshManagedLauncher(context.Background(), "codex", func(file string) (string, error) {
-		if file == "npx" {
-			return "/usr/local/bin/npx", nil
-		}
-		return "", errors.New("not found on PATH")
-	})
-	if err == nil || !strings.Contains(err.Error(), `adapter "codex" does not use a managed launcher`) {
-		t.Fatalf("RefreshManagedLauncher error = %v, want unmanaged adapter conflict", err)
-	}
-	content, err := os.ReadFile(stale)
-	if err != nil {
-		t.Fatalf("read preserved launcher: %v", err)
-	}
-	if text := string(content); !strings.Contains(text, "exit 99") {
-		t.Fatalf("launcher content = %q, want unchanged stale content", text)
-	}
-}
-
-func TestGCManagedLaunchersRemovesOldManagedBuiltInFiles(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HECATE_AGENT_ADAPTERS_DIR", dir)
-
-	oldManaged := filepath.Join(dir, managedLauncherName("managed-test-acp"))
-	stale := filepath.Join(dir, "old-adapter-acp")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir launcher dir: %v", err)
-	}
-	if err := os.WriteFile(oldManaged, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write old managed launcher: %v", err)
-	}
-	if err := os.WriteFile(stale, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write stale launcher: %v", err)
-	}
-
-	removed, err := GCManagedLaunchers()
-	if err != nil {
-		t.Fatalf("GCManagedLaunchers: %v", err)
-	}
-	if removed != 2 {
-		t.Fatalf("removed = %d, want 2", removed)
-	}
-	if _, err := os.Stat(oldManaged); !os.IsNotExist(err) {
-		t.Fatalf("old managed launcher stat error = %v, want not exist", err)
-	}
-	if _, err := os.Stat(stale); !os.IsNotExist(err) {
-		t.Fatalf("stale launcher stat error = %v, want not exist", err)
-	}
-}
-
-func TestResolveManagedRunnerUsesCandidatePath(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	bin := filepath.Join(home, ".volta", "bin")
-	if err := os.MkdirAll(bin, 0o755); err != nil {
-		t.Fatalf("mkdir volta bin: %v", err)
-	}
-	npx := filepath.Join(bin, "npx")
-	if err := os.WriteFile(npx, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write npx: %v", err)
-	}
-
-	_, path, err := resolveManagedRunner(ManagedLauncher{
-		Package: "@example/managed-test-acp",
-		Runners: []ManagedRunner{{Command: "npx", CandidatePaths: []string{"${HOME}/.volta/bin/npx"}}},
-	}, func(file string) (string, error) {
-		return "", errors.New("not found on PATH")
-	})
-	if err != nil {
-		t.Fatalf("resolve managed runner: %v", err)
-	}
-	if path != npx {
-		t.Fatalf("path = %q, want %q", path, npx)
 	}
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -236,11 +236,6 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 			Reason:    "shutdown",
 		})
 	})
-	if removed, err := agentadapters.GCManagedLaunchers(); err != nil {
-		logger.Warn("agent adapter launcher GC failed", "error", err)
-	} else if removed > 0 {
-		logger.Info("agent adapter launcher GC removed stale entries", "removed", removed)
-	}
 	// Wire the four-layer agent_loop system-prompt composer. Layers
 	// are concatenated broadest-first:
 	//   1. global default — operator's HECATE_TASK_AGENT_SYSTEM_PROMPT

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -47,27 +47,6 @@ func (h *Handler) HandleAgentAdapterProbe(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func (h *Handler) HandleAgentAdapterRefreshLauncher(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimSpace(r.PathValue("id"))
-	if id == "" {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "adapter id is required")
-		return
-	}
-	status, err := agentadapters.RefreshManagedLauncher(r.Context(), id, nil)
-	if err != nil {
-		if _, ok := agentadapters.FindAdapter(id); !ok {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "adapter not found")
-			return
-		}
-		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
-		return
-	}
-	WriteJSON(w, http.StatusOK, AgentAdapterResponse{
-		Object: "agent_adapters",
-		Data:   []AgentAdapterResponseItem{renderAgentAdapterItem(r.Context(), status)},
-	})
-}
-
 type AgentAdapterProbeResponse struct {
 	Object string                `json:"object"`
 	Data   AgentAdapterProbeData `json:"data"`
@@ -85,8 +64,6 @@ func renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) Agen
 		Kind:                 item.Kind,
 		Command:              item.Command,
 		Args:                 item.Args,
-		Managed:              item.Managed.Package != "",
-		ManagedPackage:       item.Managed.Package,
 		Available:            item.Available,
 		Status:               item.Status,
 		Path:                 item.Path,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -819,8 +819,6 @@ type AgentAdapterResponseItem struct {
 	Kind                 string                              `json:"kind"`
 	Command              string                              `json:"command"`
 	Args                 []string                            `json:"args,omitempty"`
-	Managed              bool                                `json:"managed,omitempty"`
-	ManagedPackage       string                              `json:"managed_package,omitempty"`
 	Available            bool                                `json:"available"`
 	Status               string                              `json:"status"`
 	Path                 string                              `json:"path,omitempty"`

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -89,7 +89,6 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodDelete, path: "/hecate/v1/agent-profiles/{id}"},
 	{method: http.MethodGet, path: "/hecate/v1/agent-adapters"},
 	{method: http.MethodPost, path: "/hecate/v1/agent-adapters/{id}/probe"},
-	{method: http.MethodPost, path: "/hecate/v1/agent-adapters/{id}/refresh-launcher"},
 	{method: http.MethodGet, path: "/hecate/v1/agent-adapters/{id}/health"},
 	{method: http.MethodGet, path: "/hecate/v1/chat/sessions"},
 	{method: http.MethodPost, path: "/hecate/v1/chat/sessions"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -123,7 +123,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 
 func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	// External-agent adapters and agent-chat sessions are Hecate-native state:
-	// approvals, grants, launcher refresh, diffs, and session streams.
+	// approvals, grants, diffs, and session streams.
 	mux.HandleFunc("GET /hecate/v1/agent-profiles", handler.HandleAgentProfiles)
 	mux.HandleFunc("POST /hecate/v1/agent-profiles", handler.HandleCreateAgentProfile)
 	mux.HandleFunc("GET /hecate/v1/agent-profiles/{id}", handler.HandleAgentProfile)
@@ -131,7 +131,6 @@ func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("DELETE /hecate/v1/agent-profiles/{id}", handler.HandleDeleteAgentProfile)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters", handler.HandleAgentAdapters)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/probe", handler.HandleAgentAdapterProbe)
-	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/refresh-launcher", handler.HandleAgentAdapterRefreshLauncher)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters/{id}/health", handler.HandleAgentAdapterHealth)
 	mux.HandleFunc("GET /hecate/v1/chat/sessions", handler.HandleChatSessions)
 	mux.HandleFunc("POST /hecate/v1/chat/sessions", handler.HandleCreateChatSession)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1107,10 +1107,10 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 	foundCursor := false
 	foundGrok := false
 	for _, item := range response.Data {
-		if item.ID == "codex" && item.Kind == "acp" && item.Command == "codex-acp-adapter" && !item.Managed && item.ManagedPackage == "" && item.CostMode == "external" {
+		if item.ID == "codex" && item.Kind == "acp" && item.Command == "codex-acp-adapter" && item.CostMode == "external" {
 			foundCodex = true
 		}
-		if item.ID == "claude_code" && item.Kind == "acp" && item.Command == "claude-code-acp-adapter" && !item.Managed && item.ManagedPackage == "" && item.CostMode == "external" {
+		if item.ID == "claude_code" && item.Kind == "acp" && item.Command == "claude-code-acp-adapter" && item.CostMode == "external" {
 			foundClaude = true
 		}
 		if item.ID == "cursor_agent" && item.Kind == "acp" && item.Command == "cursor-agent" && item.CostMode == "external" {

--- a/ui/src/app/state/rootEffects.test.tsx
+++ b/ui/src/app/state/rootEffects.test.tsx
@@ -27,8 +27,8 @@ describe("RootEffects", () => {
     const probeAgentAdapter = vi.fn(async () => null);
     const state = createRuntimeConsoleFixture({
       agentAdapters: [
-        adapter("codex", { managed: true }),
-        adapter("claude_code", { managed: true }),
+        adapter("codex"),
+        adapter("claude_code"),
         adapter("cursor_agent"),
         adapter("grok_build"),
       ],

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -108,7 +108,7 @@ export function ChatEmptyState({
     isAgentChat && selectedAgentUnavailable
       ? `Hecate could not start ${selectedAgent?.name || "the selected agent"} because its CLI is not ready in this environment.`
       : isExternalAgentChat && agentRouteUnavailable
-        ? "Hecate did not find any supported coding-agent CLI or managed local runner in the known operator locations."
+        ? "Hecate did not find any supported coding-agent CLI or ACP adapter binary in the known operator locations."
         : nothingRunnable
           ? "Add a model provider or install a supported coding-agent CLI before sending a message."
           : selectedModelIssue

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -34,7 +34,7 @@ import type {
   ConfiguredStateResponse,
   ProviderRecord,
 } from "../../types/provider";
-import { BrandAvatar, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
+import { BrandAvatar, Icon, Icons, InlineError } from "../shared/ui";
 
 type Props = {
   onNavigate?: (
@@ -626,10 +626,8 @@ function AnthropicProviderKeyCard({
 }
 
 // AdapterStatusSection lists the configured external agents.
-// Quiet startup probes only touch direct binaries. Managed launchers may
-// invoke a package-manager launcher, so manual checks ask first before
-// spawning the agent bridge, completing the ACP handshake, and returning a
-// typed health classification. That handshake is also the auth check:
+// Manual checks spawn the adapter bridge, complete the ACP handshake, and
+// return a typed health classification. That handshake is also the auth check:
 // auth failures surface as `auth_required`.
 //
 // The section is read-only otherwise: agent discovery and
@@ -651,22 +649,9 @@ function AdapterStatusSection({
   copyCommand: (command: string) => Promise<void>;
   onProbeAdapter: (adapterID: string) => void;
 }) {
-  const [managedProbeConfirm, setManagedProbeConfirm] = useState<AgentAdapterRecord | null>(null);
   if (!agentAdapters || agentAdapters.length === 0) {
     return null;
   }
-  const requestProbe = (adapter: AgentAdapterRecord) => {
-    if (adapter.managed) {
-      setManagedProbeConfirm(adapter);
-      return;
-    }
-    onProbeAdapter(adapter.id);
-  };
-  const confirmManagedProbe = () => {
-    if (!managedProbeConfirm) return;
-    onProbeAdapter(managedProbeConfirm.id);
-    setManagedProbeConfirm(null);
-  };
   return (
     <div style={{ marginBottom: 24 }} data-testid="external-agents-adapters">
       <SectionHeader
@@ -684,40 +669,10 @@ function AdapterStatusSection({
             health={agentAdapterHealthByID.get(adapter.id) ?? null}
             loading={Boolean(agentAdapterHealthLoadingByID.get(adapter.id))}
             onCopyCommand={(command) => void copyCommand(command)}
-            onProbeAdapter={requestProbe}
+            onProbeAdapter={(item) => onProbeAdapter(item.id)}
           />
         ))}
       </div>
-      {managedProbeConfirm && (
-        <ConfirmModal
-          title="Run managed agent check?"
-          confirmLabel="Run check"
-          onClose={() => setManagedProbeConfirm(null)}
-          onConfirm={confirmManagedProbe}
-          message={
-            <div>
-              <p style={{ marginTop: 0 }}>
-                Hecate will start {managedProbeConfirm.name} to verify readiness and auth. This
-                managed agent can run its package-manager launcher
-                {managedProbeConfirm.managed_package ? (
-                  <>
-                    {" "}
-                    for{" "}
-                    <code style={{ fontFamily: "var(--font-mono)", color: "var(--t0)" }}>
-                      {managedProbeConfirm.managed_package}
-                    </code>
-                  </>
-                ) : null}
-                .
-              </p>
-              <p style={{ marginBottom: 0, color: "var(--t2)" }}>
-                Continue only if you trust this agent package. Passive startup checks never run
-                package managers.
-              </p>
-            </div>
-          }
-        />
-      )}
     </div>
   );
 }

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -472,8 +472,7 @@ describe("Connections external-agent panel", () => {
   });
 
   // External agent status panel — surfaces readiness diagnostics.
-  // Direct binaries can be checked quietly; managed package-launcher
-  // agents require an explicit confirmation before a manual check.
+  // Direct adapter binaries can be checked quietly.
   // The section is hidden when no agents are registered (no point
   // showing an empty card); otherwise each row renders inline
   // diagnostic copy when a result exists.

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -50,7 +50,6 @@ import {
   openWorkspaceTargetViaAPI,
   probeAgentAdapter,
   promoteProjectMemoryCandidate,
-  refreshAgentAdapterLauncher,
   rejectProjectMemoryCandidate,
   revertChatMessageFiles,
   revertChatWorkspaceFiles,
@@ -1402,44 +1401,6 @@ describe("api client", () => {
 
       const [url] = fetchMock.mock.lastCall ?? [];
       expect(url).toBe("/hecate/v1/agent-adapters/weird%20id/probe");
-    });
-  });
-
-  describe("refreshAgentAdapterLauncher", () => {
-    it("POSTs to the managed-launcher refresh endpoint and returns the updated adapter list", async () => {
-      fetchMock.mockResolvedValue(
-        jsonResponse({
-          object: "agent_adapters",
-          data: [
-            {
-              id: "codex",
-              name: "Codex",
-              kind: "acp",
-              command: "codex-acp-adapter",
-              managed: true,
-              available: true,
-              status: "available",
-            },
-          ],
-        }),
-      );
-
-      const result = await refreshAgentAdapterLauncher("codex");
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/hecate/v1/agent-adapters/codex/refresh-launcher",
-        expect.objectContaining({ method: "POST" }),
-      );
-      expect(result.data[0]?.id).toBe("codex");
-    });
-
-    it("URL-encodes adapter ids", async () => {
-      fetchMock.mockResolvedValue(jsonResponse({ object: "agent_adapters", data: [] }));
-
-      await refreshAgentAdapterLauncher("weird id");
-
-      const [url] = fetchMock.mock.lastCall ?? [];
-      expect(url).toBe("/hecate/v1/agent-adapters/weird%20id/refresh-launcher");
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -367,15 +367,6 @@ export async function probeAgentAdapter(adapterID: string): Promise<AgentAdapter
   );
 }
 
-export async function refreshAgentAdapterLauncher(
-  adapterID: string,
-): Promise<AgentAdapterResponse> {
-  return fetchJSON<AgentAdapterResponse>(
-    `${HECATE_API}/agent-adapters/${encodeURIComponent(adapterID)}/refresh-launcher`,
-    { method: "POST" },
-  );
-}
-
 export async function getTrace(requestID: string): Promise<TraceResponse> {
   return fetchJSON<TraceResponse>(
     `${HECATE_API}/traces?request_id=${encodeURIComponent(requestID)}`,

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -191,9 +191,6 @@ export function externalAgentSetupHint(adapter: AgentAdapterRecord): string {
   if (adapter.id === "grok_build") {
     return "Install the Grok CLI, confirm grok is on PATH, then run grok login. Grok Build also needs a model selected before send.";
   }
-  if (adapter.managed_package) {
-    return `Install Node/npm so Hecate can manage "${adapter.managed_package}", or install ${adapter.command} directly.`;
-  }
   if (adapter.docs_url) {
     return `Install ${adapter.name} and ensure ${adapter.command} is on PATH. Setup docs: ${adapter.docs_url}`;
   }

--- a/ui/src/types/agent-adapter.ts
+++ b/ui/src/types/agent-adapter.ts
@@ -6,8 +6,6 @@ export type AgentAdapterRecord = {
   kind: string;
   command: string;
   args?: string[];
-  managed?: boolean;
-  managed_package?: string;
   available: boolean;
   status: string;
   path?: string;


### PR DESCRIPTION
## Summary

- bundle released Codex/Claude ACP adapter binaries in Docker images by downloading v0.1.0-alpha.3 release archives and verifying checksums
- drop legacy managed launcher support: no npm wrapper scripts, no HECATE_AGENT_ADAPTERS_DIR, no refresh-launcher API, no managed fields in API/UI
- keep adapter discovery direct-binary only, reporting adapter_version for Go bridge binaries and agent_version for the underlying CLI
- update runtime/operator/design docs for the canonical direct ACP binary contract

## Adapter integration

Hecate now integrates Codex and Claude Code through separate binaries: codex-acp-adapter wraps the Codex CLI and claude-code-acp-adapter wraps Claude Code. Hecate discovers those adapter binaries via PATH/candidate paths, probes them with ACP initialize/new-session, and separately probes the underlying vendor CLI version. Cursor Agent and Grok Build still use ACP modes built into their vendor CLIs directly.

Separate binaries remain the default security boundary: they are independently releasable, have small provider-specific trust surfaces, and avoid running npm package managers from Hecate. The adapter repos now also expose importable Go packages for a future optional embedded mode, but this PR keeps Hecate runtime execution explicit and auditable.

## Tests

- GOCACHE="$PWD/.gocache" go test ./internal/agentadapters ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters ./internal/api
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./internal/agentadapters ./internal/api
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/app/state/rootEffects.test.tsx src/features/settings/SettingsView.test.tsx src/features/chats/ChatView.test.tsx src/lib/api.test.ts src/lib/external-agent-readiness.test.ts src/features/connections/ConnectionsPanel.test.tsx
- just docs-format-check
- just check-links
- docker build --no-cache --target adapter-downloader --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -t hecate-adapter-downloader-alpha3-test -f Dockerfile .
- docker run --rm hecate-adapter-downloader-alpha3-test /adapter-bin/codex-acp-adapter --version
- docker run --rm hecate-adapter-downloader-alpha3-test /adapter-bin/claude-code-acp-adapter --version
- ACP initialize smoke through both downloaded Docker binaries
- docker build --no-cache --target adapter-downloader --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -t hecate-release-adapter-downloader-alpha3-test -f Dockerfile.release .