### PR TITLE
Add project next action guidance

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -38,9 +38,10 @@ For each work item:
 Assignments keep their own execution records. Projects coordinate the work, but
 Tasks, Chats, and External Agents remain the execution surfaces.
 
-The Work Coordination tab starts with a compact resume summary. Use it to jump
-back to blocked, active, recent, or memory-review work before drilling into the
-full work queue.
+The Work Coordination tab starts with a deterministic next action and compact
+resume summary. Use the next action for the single most useful operator step,
+then jump to blocked, active, recent, or memory-review work from the resume
+summary before drilling into the full work queue.
 
 ## Roots And Worktrees
 

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -6,6 +6,9 @@ import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
   ProjectAssignmentRecord,
+  ProjectCollaborationArtifactRecord,
+  ProjectHandoffRecord,
+  ProjectMemoryCandidateRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
@@ -141,6 +144,58 @@ function activityItem(
     blocking_signal: "not_started",
     status_summary: "not started",
     artifact_summary: { count: 0 },
+    updated_at: "2026-06-13T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function memoryCandidate(
+  overrides: Partial<ProjectMemoryCandidateRecord> = {},
+): ProjectMemoryCandidateRecord {
+  return {
+    id: "memcand_1",
+    project_id: "proj_1",
+    title: "Project lesson",
+    body: "Remember the launch flow.",
+    status: "pending",
+    suggested_kind: "note",
+    suggested_trust_label: "operator_review",
+    suggested_source_kind: "dogfood",
+    created_at: "2026-06-13T00:00:00Z",
+    updated_at: "2026-06-13T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function handoff(overrides: Partial<ProjectHandoffRecord> = {}): ProjectHandoffRecord {
+  return {
+    id: "handoff_1",
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    title: "Implementation handoff",
+    summary: "Follow up on the implementation.",
+    recommended_next_action: "Create the follow-up assignment.",
+    status: "pending",
+    provenance_kind: "operator",
+    trust_label: "operator_review",
+    created_at: "2026-06-13T00:00:00Z",
+    updated_at: "2026-06-13T00:00:00Z",
+    status_changed_at: "2026-06-13T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function artifact(
+  overrides: Partial<ProjectCollaborationArtifactRecord> = {},
+): ProjectCollaborationArtifactRecord {
+  return {
+    id: "artifact_1",
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    kind: "evidence_link",
+    title: "Launch checklist",
+    body: "Evidence recorded.",
+    created_at: "2026-06-13T00:00:00Z",
     updated_at: "2026-06-13T00:00:00Z",
     ...overrides,
   };
@@ -314,20 +369,7 @@ describe("ProjectWorkspaceView", () => {
     const item = workItem({ id: "work_blocked", title: "Fix blocked launch" });
     const { handlers } = renderWorkspace({
       activity: activity(),
-      memoryCandidates: [
-        {
-          id: "memcand_1",
-          project_id: "proj_1",
-          title: "Project lesson",
-          body: "Remember the launch flow.",
-          status: "pending",
-          suggested_kind: "note",
-          suggested_trust_label: "operator_review",
-          suggested_source_kind: "dogfood",
-          created_at: "2026-06-13T00:00:00Z",
-          updated_at: "2026-06-13T00:00:00Z",
-        },
-      ],
+      memoryCandidates: [memoryCandidate()],
       workItems: [item],
     });
 
@@ -363,18 +405,7 @@ describe("ProjectWorkspaceView", () => {
         priority: "normal",
       },
     });
-    const memoryCandidate: ProjectWorkspaceViewProps["memoryCandidates"][number] = {
-      id: "memcand_1",
-      project_id: "proj_1",
-      title: "Project lesson",
-      body: "Remember the launch flow.",
-      status: "pending",
-      suggested_kind: "note",
-      suggested_trust_label: "operator_review",
-      suggested_source_kind: "dogfood",
-      created_at: "2026-06-13T00:00:00Z",
-      updated_at: "2026-06-13T00:00:00Z",
-    };
+    const candidate = memoryCandidate();
     const latest = workItem({
       id: "work_latest",
       title: "Polish project onboarding",
@@ -416,7 +447,7 @@ describe("ProjectWorkspaceView", () => {
         {...props}
         {...handlers}
         activity={null}
-        memoryCandidates={[memoryCandidate]}
+        memoryCandidates={[candidate]}
         workItems={[]}
       />,
     );
@@ -451,6 +482,206 @@ describe("ProjectWorkspaceView", () => {
     expect(
       within(resume).getByText("Create a work item when there is something to coordinate."),
     ).toBeTruthy();
+  });
+
+  it("renders next action for queued, blocked, active, and memory states", async () => {
+    const queuedActivity = activity();
+    const blockedItem = activityItem({
+      blocking_signal: "failed",
+      id: "assign_failed",
+      status: "failed",
+      status_summary: "failed",
+      work_item: {
+        id: "work_failed",
+        title: "Repair failed launch",
+        status: "ready",
+        priority: "normal",
+      },
+    });
+    const activeItem = activityItem({
+      assignment: assignment({
+        id: "assign_active",
+        work_item_id: "work_active",
+        status: "running",
+      }),
+      blocking_signal: "running",
+      id: "assign_active",
+      status: "running",
+      work_item: {
+        id: "work_active",
+        title: "Continue execution",
+        status: "ready",
+        priority: "normal",
+      },
+    });
+    const { handlers, props, rerender } = renderWorkspace({
+      activity: queuedActivity,
+      memoryCandidates: [memoryCandidate()],
+    });
+
+    let nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Start queued assignment")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Start assignment" }));
+    expect(handlers.onStartAssignment).toHaveBeenCalledWith(
+      queuedActivity.buckets.blocked[0].assignment,
+    );
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={activity({
+          summary: {
+            work_item_count: 1,
+            assignment_count: 1,
+            active_count: 0,
+            blocked_count: 1,
+            completed_count: 0,
+            recent_count: 1,
+          },
+          buckets: {
+            active: [],
+            blocked: [blockedItem],
+            completed: [],
+            recent: [blockedItem],
+          },
+          recent: [blockedItem],
+        })}
+        memoryCandidates={[]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Resolve blocked assignment")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Open blocked work" }));
+    expect(handlers.onActivityBucketChange).toHaveBeenCalledWith("blocked");
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_failed");
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={activity({
+          summary: {
+            work_item_count: 1,
+            assignment_count: 1,
+            active_count: 1,
+            blocked_count: 0,
+            completed_count: 0,
+            recent_count: 1,
+          },
+          buckets: {
+            active: [activeItem],
+            blocked: [],
+            completed: [],
+            recent: [activeItem],
+          },
+          recent: [activeItem],
+        })}
+        memoryCandidates={[]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Inspect active assignment")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Inspect work" }));
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_active");
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        activity={null}
+        memoryCandidates={[memoryCandidate()]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Review 1 memory candidate")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Review memory" }));
+    expect(handlers.onWorkspaceTabChange).toHaveBeenCalledWith("memory");
+  });
+
+  it("renders next action for selected-work follow through", async () => {
+    const item = workItem();
+    const completed = assignment({
+      execution_ref: { kind: "task_run", status: "completed" },
+      status: "completed",
+    });
+    const pendingHandoff = handoff();
+    const { handlers, props, rerender } = renderWorkspace({
+      selectedWorkItem: item,
+      workItems: [item],
+      handoffs: [pendingHandoff],
+    });
+
+    let nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Continue handoff: Implementation handoff")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Create assignment" }));
+    expect(handlers.onCreateAssignmentFromHandoff).toHaveBeenCalledWith(pendingHandoff);
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        handoffs={[]}
+        selectedWorkItem={item}
+        workItems={[item]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Create the first assignment")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Draft assignment" }));
+    expect(handlers.onDraftDefaultAssignment).toHaveBeenCalledWith(item);
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        assignments={[completed]}
+        handoffs={[]}
+        selectedWorkItem={item}
+        workItems={[item]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Record completion evidence")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Add evidence" }));
+    expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
+        artifacts={[artifact()]}
+        assignments={[completed]}
+        handoffs={[]}
+        selectedWorkItem={item}
+        workItems={[item]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Close out selected work")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Mark done" }));
+    expect(handlers.onCloseWorkItem).toHaveBeenCalledWith(item);
+  });
+
+  it("renders next action for empty and latest-work fallbacks", async () => {
+    const latest = workItem({
+      id: "work_latest",
+      title: "Polish project onboarding",
+      created_at: "2026-06-12T00:00:00Z",
+      updated_at: "2026-06-14T00:00:00Z",
+    });
+    const { handlers, props, rerender } = renderWorkspace();
+
+    let nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Create the first work item")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Create work" }));
+    expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
+
+    rerender(<ProjectWorkspaceView {...props} {...handlers} workItems={[latest]} />);
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Continue existing work")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Continue work" }));
+    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_latest");
   });
 
   it("renders project empty state when nothing is selected", () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -28,6 +28,8 @@ import {
 import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
 import { formatProjectRowRelativeTime, workStatusLabel } from "./projectDisplay";
 import {
+  activitySignalLabel,
+  buildProjectWorkCloseoutReadiness,
   projectActivityWorkItemToWorkItem,
   type ProjectActivityBucketKey,
 } from "./projectInsights";
@@ -307,6 +309,26 @@ export function ProjectWorkspaceView({
             )}
             {!projectNeedsOnboarding && workspaceTab === "work" && (
               <section style={projectTabPanelStyle} aria-label="Work coordination">
+                <ProjectNextAction
+                  activity={activity}
+                  assignments={assignments}
+                  artifacts={artifacts}
+                  handoffs={handoffs}
+                  memoryCandidateCount={memoryCandidates.length}
+                  onAddEvidenceLink={onAddEvidenceLink}
+                  onBucketChange={onActivityBucketChange}
+                  onCloseWorkItem={onCloseWorkItem}
+                  onCreateAssignmentFromHandoff={onCreateAssignmentFromHandoff}
+                  onCreateWork={onCreateWork}
+                  onDraftDefaultAssignment={onDraftDefaultAssignment}
+                  onReviewMemory={() => onWorkspaceTabChange("memory")}
+                  onSelectWorkItem={onSelectWorkItem}
+                  onStartAssignment={onStartAssignment}
+                  onStartHandoff={onStartHandoff}
+                  selectedWorkItem={selectedWorkItem}
+                  startingAssignmentID={startingAssignmentID}
+                  workItems={workItems}
+                />
                 <ProjectResumeSummary
                   activity={activity}
                   memoryCandidateCount={memoryCandidates.length}
@@ -700,6 +722,269 @@ function ProjectOnboardingPanel({
       </div>
     </section>
   );
+}
+
+type ProjectNextActionState = {
+  actionLabel: string;
+  detail: string;
+  disabled?: boolean;
+  onAction: () => void;
+  status: string;
+  title: string;
+};
+
+function ProjectNextAction({
+  activity,
+  assignments,
+  artifacts,
+  handoffs,
+  memoryCandidateCount,
+  onAddEvidenceLink,
+  onBucketChange,
+  onCloseWorkItem,
+  onCreateAssignmentFromHandoff,
+  onCreateWork,
+  onDraftDefaultAssignment,
+  onReviewMemory,
+  onSelectWorkItem,
+  onStartAssignment,
+  onStartHandoff,
+  selectedWorkItem,
+  startingAssignmentID,
+  workItems,
+}: {
+  activity: ProjectActivityData | null;
+  assignments: ProjectAssignmentRecord[];
+  artifacts: ProjectCollaborationArtifactRecord[];
+  handoffs: ProjectHandoffRecord[];
+  memoryCandidateCount: number;
+  onAddEvidenceLink: () => void;
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
+  onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
+  onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
+  onCreateWork: () => void;
+  onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
+  onReviewMemory: () => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onStartHandoff: (handoff: ProjectHandoffRecord) => void;
+  selectedWorkItem: ProjectWorkItemRecord | null;
+  startingAssignmentID: string;
+  workItems: ProjectWorkItemRecord[];
+}) {
+  const nextAction = buildProjectNextAction({
+    activity,
+    assignments,
+    artifacts,
+    handoffs,
+    memoryCandidateCount,
+    onAddEvidenceLink,
+    onBucketChange,
+    onCloseWorkItem,
+    onCreateAssignmentFromHandoff,
+    onCreateWork,
+    onDraftDefaultAssignment,
+    onReviewMemory,
+    onSelectWorkItem,
+    onStartAssignment,
+    onStartHandoff,
+    selectedWorkItem,
+    startingAssignmentID,
+    workItems,
+  });
+
+  return (
+    <section aria-label="Project next action" style={projectNextActionStyle}>
+      <div style={projectResumeCopyStyle}>
+        <div style={sectionLabelStyle}>Next action</div>
+        <div style={titleStyle}>{nextAction.title}</div>
+        <div style={subtleTextStyle}>{nextAction.detail}</div>
+      </div>
+      <div style={projectNextActionControlsStyle}>
+        <Badge status={nextAction.status} label={activitySignalLabel(nextAction.status)} />
+        <button
+          className="btn btn-primary btn-sm"
+          type="button"
+          onClick={nextAction.onAction}
+          disabled={nextAction.disabled}
+        >
+          {nextAction.actionLabel}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function buildProjectNextAction({
+  activity,
+  assignments,
+  artifacts,
+  handoffs,
+  memoryCandidateCount,
+  onAddEvidenceLink,
+  onBucketChange,
+  onCloseWorkItem,
+  onCreateAssignmentFromHandoff,
+  onCreateWork,
+  onDraftDefaultAssignment,
+  onReviewMemory,
+  onSelectWorkItem,
+  onStartAssignment,
+  onStartHandoff,
+  selectedWorkItem,
+  startingAssignmentID,
+  workItems,
+}: {
+  activity: ProjectActivityData | null;
+  assignments: ProjectAssignmentRecord[];
+  artifacts: ProjectCollaborationArtifactRecord[];
+  handoffs: ProjectHandoffRecord[];
+  memoryCandidateCount: number;
+  onAddEvidenceLink: () => void;
+  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
+  onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
+  onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
+  onCreateWork: () => void;
+  onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
+  onReviewMemory: () => void;
+  onSelectWorkItem: (workItemID: string) => void;
+  onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
+  onStartHandoff: (handoff: ProjectHandoffRecord) => void;
+  selectedWorkItem: ProjectWorkItemRecord | null;
+  startingAssignmentID: string;
+  workItems: ProjectWorkItemRecord[];
+}): ProjectNextActionState {
+  const blockedItems = activity?.buckets.blocked ?? [];
+  const queuedItem = blockedItems.find((item) => item.blocking_signal === "not_started");
+  if (queuedItem) {
+    return {
+      actionLabel:
+        startingAssignmentID === queuedItem.assignment.id ? "Starting..." : "Start assignment",
+      detail: `${queuedItem.work_item.title} is queued and ready for operator dispatch.`,
+      disabled: startingAssignmentID === queuedItem.assignment.id,
+      onAction: () => onStartAssignment(queuedItem.assignment),
+      status: "awaiting_approval",
+      title: "Start queued assignment",
+    };
+  }
+
+  const blockedItem = blockedItems[0] ?? null;
+  if (blockedItem) {
+    return {
+      actionLabel: "Open blocked work",
+      detail: `${blockedItem.work_item.title} needs operator attention: ${blockedItem.status_summary}.`,
+      onAction: () => {
+        onBucketChange("blocked");
+        onSelectWorkItem(blockedItem.work_item.id);
+      },
+      status: blockedItem.blocking_signal,
+      title: "Resolve blocked assignment",
+    };
+  }
+
+  const activeItem = activity?.buckets.active[0] ?? null;
+  if (activeItem) {
+    return {
+      actionLabel: "Inspect work",
+      detail: `${activeItem.work_item.title} has an assignment in progress.`,
+      onAction: () => onSelectWorkItem(activeItem.work_item.id),
+      status: activeItem.blocking_signal,
+      title: "Inspect active assignment",
+    };
+  }
+
+  if (memoryCandidateCount > 0) {
+    return {
+      actionLabel: "Review memory",
+      detail:
+        "Pending memory candidates should be accepted, edited, or rejected before more context accumulates.",
+      onAction: onReviewMemory,
+      status: "awaiting_approval",
+      title:
+        memoryCandidateCount === 1
+          ? "Review 1 memory candidate"
+          : `Review ${memoryCandidateCount} memory candidates`,
+    };
+  }
+
+  const pendingHandoff = handoffs.find((handoff) => handoff.status === "pending");
+  if (pendingHandoff) {
+    return {
+      actionLabel: pendingHandoff.target_assignment_id ? "Start handoff" : "Create assignment",
+      detail: pendingHandoff.recommended_next_action || pendingHandoff.summary,
+      onAction: () =>
+        pendingHandoff.target_assignment_id
+          ? onStartHandoff(pendingHandoff)
+          : onCreateAssignmentFromHandoff(pendingHandoff),
+      status: "awaiting_approval",
+      title: `Continue handoff: ${pendingHandoff.title}`,
+    };
+  }
+
+  if (selectedWorkItem && assignments.length === 0 && selectedWorkItem.status !== "done") {
+    return {
+      actionLabel: "Draft assignment",
+      detail:
+        "This work item has no assignments yet. Let the Project Assistant draft the first one.",
+      onAction: () => onDraftDefaultAssignment(selectedWorkItem),
+      status: "not_started",
+      title: "Create the first assignment",
+    };
+  }
+
+  const hasCompletedAssignment = assignments.some(
+    (assignment) => assignment.status === "completed",
+  );
+  const hasEvidence = artifacts.some((artifact) => artifact.kind === "evidence_link");
+  if (
+    selectedWorkItem &&
+    hasCompletedAssignment &&
+    !hasEvidence &&
+    selectedWorkItem.status !== "done"
+  ) {
+    return {
+      actionLabel: "Add evidence",
+      detail: "A completed assignment should leave reviewable evidence before this work is closed.",
+      onAction: onAddEvidenceLink,
+      status: "completed",
+      title: "Record completion evidence",
+    };
+  }
+
+  const closeout = buildProjectWorkCloseoutReadiness({
+    assignments,
+    artifacts,
+    handoffs,
+    workItem: selectedWorkItem,
+  });
+  if (selectedWorkItem && closeout.ready && closeout.status === "ready") {
+    return {
+      actionLabel: "Mark done",
+      detail: closeout.detail,
+      onAction: () => onCloseWorkItem(selectedWorkItem),
+      status: "completed",
+      title: "Close out selected work",
+    };
+  }
+
+  const latestWorkItem = latestProjectWorkItem(workItems);
+  if (latestWorkItem) {
+    return {
+      actionLabel: "Continue work",
+      detail: `Pick up ${latestWorkItem.title}, last updated ${formatProjectRowRelativeTime(latestWorkItem.updated_at)}.`,
+      onAction: () => onSelectWorkItem(latestWorkItem.id),
+      status: latestWorkItem.status,
+      title: "Continue existing work",
+    };
+  }
+
+  return {
+    actionLabel: "Create work",
+    detail: "Start with one reviewable work item that Hecate can coordinate.",
+    onAction: onCreateWork,
+    status: "not_started",
+    title: "Create the first work item",
+  };
 }
 
 function ProjectResumeSummary({
@@ -1210,6 +1495,23 @@ const workActivityPanelStyle: CSSProperties = {
   ...panelStyle,
   display: "grid",
   gap: 10,
+};
+
+const projectNextActionStyle: CSSProperties = {
+  ...panelStyle,
+  alignItems: "center",
+  display: "grid",
+  gap: 12,
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const projectNextActionControlsStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "flex-end",
+  minWidth: 0,
 };
 
 const projectResumeSummaryStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- add a deterministic next-action strip above the Projects work resume
- route the primary action to memory review, assignment start/inspection, handoff follow-up, first assignment drafting, evidence capture, closeout, existing work, or first work creation
- update operator docs for the next-action and resume workflow

## Tests
- bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run test
- bun run test:e2e -- e2e/projects.spec.ts
- bun run typecheck
- bun run lint
- bun run format:check
- just docs-format-check
- just agent-docs-check
- git diff --check