### PR TITLE
Guide Projects Review Follow-Up Closeout

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -41,7 +41,14 @@ Tasks, Chats, and External Agents remain the execution surfaces.
 The Work Coordination tab starts with a deterministic next action and compact
 resume summary. Use the next action for the single most useful operator step,
 then jump to blocked, active, recent, or memory-review work from the resume
-summary before drilling into the full work queue.
+summary before drilling into the full work queue. Review artifacts that require
+follow-up are surfaced as closeout blockers with direct follow-up creation
+actions.
+
+For a new work item with no assignments or artifacts yet, the detail view starts
+with a guided prepare action. Hecate can draft the first assignment from the
+work item role and context, but the operator still reviews and applies the
+proposal before execution records are created.
 
 ## Roots And Worktrees
 

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -48,7 +48,7 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await page.getByRole("button", { name: "Create work item" }).click();
 
   await expect(page.getByRole("heading", { name: "Verify launch checklist" })).toBeVisible();
-  await page.getByRole("button", { name: "Draft first assignment" }).click();
+  await page.getByRole("button", { name: "Prepare next step" }).click();
   await expect(
     page.getByText("Queue the implementation role for the selected work item."),
   ).toBeVisible();

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -343,14 +343,14 @@ describe("ProjectWorkItemDetail", () => {
     });
 
     expect(screen.getByRole("region", { name: "Start work" })).toBeTruthy();
-    expect(screen.getByText("Ready to queue the first assignment")).toBeTruthy();
+    expect(screen.getByText("Let Hecate prepare the first step")).toBeTruthy();
     expect(screen.queryByText("No reviewer roles configured")).toBeNull();
     expect(screen.queryByRole("button", { name: "Mark done" })).toBeNull();
     expect(screen.queryByText("No assignments recorded yet.")).toBeNull();
 
-    await userEvent.click(screen.getByRole("button", { name: "Draft first assignment" }));
+    await userEvent.click(screen.getByRole("button", { name: "Prepare next step" }));
     const manualActions = screen.getByRole("group", { name: "Manual work item actions" });
-    expect(within(manualActions).getByText("Manual options")).toBeTruthy();
+    expect(within(manualActions).getByText("Other ways to add context")).toBeTruthy();
     await userEvent.click(within(manualActions).getByRole("button", { name: "Assignment" }));
     await userEvent.click(within(manualActions).getByRole("button", { name: "Evidence" }));
     await userEvent.click(within(manualActions).getByRole("button", { name: "Handoff" }));
@@ -504,7 +504,40 @@ describe("ProjectWorkItemDetail", () => {
 
     expect(screen.getByText("Changes requested")).toBeTruthy();
     expect(screen.getByText("risk Medium")).toBeTruthy();
-    expect(screen.getByText("follow-up required")).toBeTruthy();
+    expect(screen.getAllByText("follow-up required")).toHaveLength(2);
+  });
+
+  it("surfaces review follow-up as a closeout notice", async () => {
+    const reviewArtifact = artifact({
+      review_verdict: "blocked",
+      review_follow_up_required: true,
+    });
+    const { handlers } = renderDetail({
+      artifacts: [reviewArtifact],
+    });
+
+    const notice = screen.getByRole("region", { name: "Review follow-up required" });
+    expect(within(notice).getByText("Architect review")).toBeTruthy();
+    expect(within(notice).getByText("follow-up required")).toBeTruthy();
+
+    await userEvent.click(within(notice).getByRole("button", { name: "Create follow-up" }));
+
+    expect(handlers.onCreateAssignmentFromReviewArtifact).toHaveBeenCalledWith(reviewArtifact);
+  });
+
+  it("does not surface review follow-up notice after a handoff is linked", () => {
+    renderDetail({
+      artifacts: [
+        artifact({
+          id: "art_review",
+          review_verdict: "blocked",
+          review_follow_up_required: true,
+        }),
+      ],
+      handoffs: [handoff({ linked_artifact_ids: ["art_review"] })],
+    });
+
+    expect(screen.queryByRole("region", { name: "Review follow-up required" })).toBeNull();
   });
 
   it("renders evidence link metadata and delegates evidence creation", async () => {

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -187,6 +187,9 @@ export function ProjectWorkItemDetail({
     artifacts.length === 0 &&
     handoffs.length === 0 &&
     workItem.status !== "done";
+  const reviewFollowUps = artifacts.filter((artifact) =>
+    reviewArtifactNeedsFollowUpPath(artifact, handoffs),
+  );
   const suggestedAssignmentRole = assignmentRoleForWorkItem(workItem, roleByID);
   return (
     <div style={workItemDetailStyle}>
@@ -273,6 +276,14 @@ export function ProjectWorkItemDetail({
             closeout={closeout}
             pending={closingWorkItemID === workItem.id}
             onClose={() => onCloseWorkItem(workItem)}
+          />
+        )}
+        {reviewFollowUps.length > 0 && (
+          <ReviewFollowUpNotice
+            artifact={reviewFollowUps[0]}
+            count={reviewFollowUps.length}
+            pending={artifactActionID === reviewFollowUps[0].id}
+            onCreateAssignment={() => onCreateAssignmentFromReviewArtifact(reviewFollowUps[0])}
           />
         )}
         {(!emptyWorkItem || assignments.length > 0) && (
@@ -572,11 +583,11 @@ function WorkItemStartPanel({
       <div style={startPanelCopyStyle}>
         <div style={sectionLabelStyle}>Next step</div>
         <div style={titleStyle}>
-          {role ? "Ready to queue the first assignment" : "Add a role before assigning work"}
+          {role ? "Let Hecate prepare the first step" : "Add a role before assigning work"}
         </div>
         <div style={{ ...subtleTextStyle, marginTop: 5 }}>
           {role
-            ? `Hecate can draft a reviewable ${role.name || role.id} assignment proposal from this work item. You will review and apply it before anything is created.`
+            ? `Hecate will choose the ${role.name || role.id} role, reuse this work item context, and draft a reviewable assignment proposal. You still review and apply it before anything is created.`
             : "Create or select a project role so Hecate can prepare this work from defaults."}
         </div>
       </div>
@@ -589,7 +600,7 @@ function WorkItemStartPanel({
             disabled={drafting}
           >
             <Icon d={Icons.tasks} size={13} />
-            {drafting ? "Drafting..." : "Draft first assignment"}
+            {drafting ? "Preparing..." : "Prepare next step"}
           </button>
         ) : (
           <button className="btn btn-primary btn-sm" type="button" onClick={onManageRoles}>
@@ -598,7 +609,7 @@ function WorkItemStartPanel({
           </button>
         )}
         <div aria-label="Manual work item actions" role="group" style={startPanelSecondaryStyle}>
-          <span style={startPanelSecondaryLabelStyle}>Manual options</span>
+          <span style={startPanelSecondaryLabelStyle}>Other ways to add context</span>
           <button className="btn btn-ghost btn-sm" type="button" onClick={onAddAssignment}>
             <Icon d={Icons.plus} size={12} />
             Assignment
@@ -698,6 +709,58 @@ function WorkItemCloseoutPanel({
       )}
     </section>
   );
+}
+
+function ReviewFollowUpNotice({
+  artifact,
+  count,
+  onCreateAssignment,
+  pending,
+}: {
+  artifact: ProjectCollaborationArtifactRecord;
+  count: number;
+  onCreateAssignment: () => void;
+  pending: boolean;
+}) {
+  return (
+    <section style={reviewFollowUpNoticeStyle} aria-label="Review follow-up required">
+      <div style={workItemSectionHeaderStyle}>
+        <span className="badge badge-amber">follow-up required</span>
+        {count > 1 && <span className="badge badge-muted">{count} reviews</span>}
+        <button
+          className="btn btn-primary btn-sm"
+          type="button"
+          onClick={onCreateAssignment}
+          disabled={pending}
+          style={{ marginLeft: "auto" }}
+        >
+          <Icon d={Icons.tasks} size={12} />
+          {pending ? "Creating..." : "Create follow-up"}
+        </button>
+      </div>
+      <div style={{ ...titleStyle, marginTop: 8 }}>{artifact.title || "Review follow-up"}</div>
+      <div style={{ ...subtleTextStyle, marginTop: 4 }}>
+        Review outcome blocks closeout until the operator creates and completes a follow-up path.
+      </div>
+    </section>
+  );
+}
+
+function reviewArtifactRequiresFollowUp(artifact: ProjectCollaborationArtifactRecord): boolean {
+  return (
+    artifact.kind === "review" &&
+    (artifact.review_follow_up_required === true ||
+      artifact.review_verdict === "blocked" ||
+      artifact.review_verdict === "changes_requested")
+  );
+}
+
+function reviewArtifactNeedsFollowUpPath(
+  artifact: ProjectCollaborationArtifactRecord,
+  handoffs: ProjectHandoffRecord[],
+): boolean {
+  if (!reviewArtifactRequiresFollowUp(artifact)) return false;
+  return !handoffs.some((handoff) => (handoff.linked_artifact_ids ?? []).includes(artifact.id));
 }
 
 function ReviewerSetupNotice({
@@ -1846,6 +1909,15 @@ const closeoutListStyle: CSSProperties = {
   lineHeight: 1.45,
   margin: "8px 0 0",
   paddingLeft: 18,
+};
+
+const reviewFollowUpNoticeStyle: CSSProperties = {
+  background: "rgba(245, 158, 11, 0.08)",
+  border: "1px solid rgba(245, 158, 11, 0.35)",
+  borderRadius: "var(--radius-sm)",
+  marginTop: 12,
+  minWidth: 0,
+  padding: 12,
 };
 
 const evidenceArtifactMetadataStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -22,6 +22,7 @@ import {
 } from "./projectAssignmentViewModels";
 import {
   buildProjectWorkCloseoutReadiness,
+  reviewArtifactNeedsFollowUpPath,
   type ProjectWorkCloseoutReadiness,
 } from "./projectInsights";
 import {
@@ -744,23 +745,6 @@ function ReviewFollowUpNotice({
       </div>
     </section>
   );
-}
-
-function reviewArtifactRequiresFollowUp(artifact: ProjectCollaborationArtifactRecord): boolean {
-  return (
-    artifact.kind === "review" &&
-    (artifact.review_follow_up_required === true ||
-      artifact.review_verdict === "blocked" ||
-      artifact.review_verdict === "changes_requested")
-  );
-}
-
-function reviewArtifactNeedsFollowUpPath(
-  artifact: ProjectCollaborationArtifactRecord,
-  handoffs: ProjectHandoffRecord[],
-): boolean {
-  if (!reviewArtifactRequiresFollowUp(artifact)) return false;
-  return !handoffs.some((handoff) => (handoff.linked_artifact_ids ?? []).includes(artifact.id));
 }
 
 function ReviewerSetupNotice({

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -635,6 +635,32 @@ describe("ProjectWorkspaceView", () => {
       <ProjectWorkspaceView
         {...props}
         {...handlers}
+        artifacts={[
+          artifact({
+            id: "art_review",
+            kind: "review",
+            title: "Architect review",
+            review_follow_up_required: true,
+            review_verdict: "changes_requested",
+          }),
+        ]}
+        assignments={[completed]}
+        handoffs={[]}
+        selectedWorkItem={item}
+        workItems={[item]}
+      />,
+    );
+    nextAction = screen.getByRole("region", { name: "Project next action" });
+    expect(within(nextAction).getByText("Create review follow-up")).toBeTruthy();
+    await userEvent.click(within(nextAction).getByRole("button", { name: "Create follow-up" }));
+    expect(handlers.onCreateAssignmentFromReviewArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "art_review" }),
+    );
+
+    rerender(
+      <ProjectWorkspaceView
+        {...props}
+        {...handlers}
         assignments={[completed]}
         handoffs={[]}
         selectedWorkItem={item}

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -319,6 +319,7 @@ export function ProjectWorkspaceView({
                   onBucketChange={onActivityBucketChange}
                   onCloseWorkItem={onCloseWorkItem}
                   onCreateAssignmentFromHandoff={onCreateAssignmentFromHandoff}
+                  onCreateAssignmentFromReviewArtifact={onCreateAssignmentFromReviewArtifact}
                   onCreateWork={onCreateWork}
                   onDraftDefaultAssignment={onDraftDefaultAssignment}
                   onReviewMemory={() => onWorkspaceTabChange("memory")}
@@ -743,6 +744,7 @@ function ProjectNextAction({
   onBucketChange,
   onCloseWorkItem,
   onCreateAssignmentFromHandoff,
+  onCreateAssignmentFromReviewArtifact,
   onCreateWork,
   onDraftDefaultAssignment,
   onReviewMemory,
@@ -762,6 +764,7 @@ function ProjectNextAction({
   onBucketChange: (bucket: ProjectActivityBucketKey) => void;
   onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
+  onCreateAssignmentFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
   onCreateWork: () => void;
   onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
   onReviewMemory: () => void;
@@ -782,6 +785,7 @@ function ProjectNextAction({
     onBucketChange,
     onCloseWorkItem,
     onCreateAssignmentFromHandoff,
+    onCreateAssignmentFromReviewArtifact,
     onCreateWork,
     onDraftDefaultAssignment,
     onReviewMemory,
@@ -825,6 +829,7 @@ function buildProjectNextAction({
   onBucketChange,
   onCloseWorkItem,
   onCreateAssignmentFromHandoff,
+  onCreateAssignmentFromReviewArtifact,
   onCreateWork,
   onDraftDefaultAssignment,
   onReviewMemory,
@@ -844,6 +849,7 @@ function buildProjectNextAction({
   onBucketChange: (bucket: ProjectActivityBucketKey) => void;
   onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
   onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
+  onCreateAssignmentFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
   onCreateWork: () => void;
   onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
   onReviewMemory: () => void;
@@ -893,17 +899,16 @@ function buildProjectNextAction({
     };
   }
 
-  if (memoryCandidateCount > 0) {
+  const reviewFollowUp = artifacts.find((artifact) =>
+    reviewArtifactNeedsFollowUpAction(artifact, handoffs),
+  );
+  if (selectedWorkItem && reviewFollowUp && selectedWorkItem.status !== "done") {
     return {
-      actionLabel: "Review memory",
-      detail:
-        "Pending memory candidates should be accepted, edited, or rejected before more context accumulates.",
-      onAction: onReviewMemory,
-      status: "awaiting_approval",
-      title:
-        memoryCandidateCount === 1
-          ? "Review 1 memory candidate"
-          : `Review ${memoryCandidateCount} memory candidates`,
+      actionLabel: "Create follow-up",
+      detail: `${reviewFollowUp.title || "Review"} needs follow-up before this work can close.`,
+      onAction: () => onCreateAssignmentFromReviewArtifact(reviewFollowUp),
+      status: reviewFollowUp.review_verdict === "blocked" ? "blocked" : "awaiting_approval",
+      title: "Create review follow-up",
     };
   }
 
@@ -918,6 +923,20 @@ function buildProjectNextAction({
           : onCreateAssignmentFromHandoff(pendingHandoff),
       status: "awaiting_approval",
       title: `Continue handoff: ${pendingHandoff.title}`,
+    };
+  }
+
+  if (memoryCandidateCount > 0) {
+    return {
+      actionLabel: "Review memory",
+      detail:
+        "Pending memory candidates should be accepted, edited, or rejected before more context accumulates.",
+      onAction: onReviewMemory,
+      status: "awaiting_approval",
+      title:
+        memoryCandidateCount === 1
+          ? "Review 1 memory candidate"
+          : `Review ${memoryCandidateCount} memory candidates`,
     };
   }
 
@@ -1275,6 +1294,24 @@ function latestProjectWorkItem(items: ProjectWorkItemRecord[]): ProjectWorkItemR
       (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
     );
   })[0];
+}
+
+function reviewArtifactNeedsFollowUpAction(
+  artifact: ProjectCollaborationArtifactRecord,
+  handoffs: ProjectHandoffRecord[],
+): boolean {
+  if (
+    artifact.kind !== "review" ||
+    (artifact.review_follow_up_required !== true &&
+      artifact.review_verdict !== "blocked" &&
+      artifact.review_verdict !== "changes_requested")
+  ) {
+    return false;
+  }
+  const linkedHandoffs = handoffs.filter((handoff) =>
+    (handoff.linked_artifact_ids ?? []).includes(artifact.id),
+  );
+  return linkedHandoffs.length === 0;
 }
 
 export function ProjectEmptyBlock({ title, detail }: { title: string; detail: string }) {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -31,6 +31,7 @@ import {
   activitySignalLabel,
   buildProjectWorkCloseoutReadiness,
   projectActivityWorkItemToWorkItem,
+  reviewArtifactNeedsFollowUpPath,
   type ProjectActivityBucketKey,
 } from "./projectInsights";
 import { useProjectAssistantController } from "./useProjectAssistantController";
@@ -900,7 +901,7 @@ function buildProjectNextAction({
   }
 
   const reviewFollowUp = artifacts.find((artifact) =>
-    reviewArtifactNeedsFollowUpAction(artifact, handoffs),
+    reviewArtifactNeedsFollowUpPath(artifact, handoffs),
   );
   if (selectedWorkItem && reviewFollowUp && selectedWorkItem.status !== "done") {
     return {
@@ -1294,24 +1295,6 @@ function latestProjectWorkItem(items: ProjectWorkItemRecord[]): ProjectWorkItemR
       (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
     );
   })[0];
-}
-
-function reviewArtifactNeedsFollowUpAction(
-  artifact: ProjectCollaborationArtifactRecord,
-  handoffs: ProjectHandoffRecord[],
-): boolean {
-  if (
-    artifact.kind !== "review" ||
-    (artifact.review_follow_up_required !== true &&
-      artifact.review_verdict !== "blocked" &&
-      artifact.review_verdict !== "changes_requested")
-  ) {
-    return false;
-  }
-  const linkedHandoffs = handoffs.filter((handoff) =>
-    (handoff.linked_artifact_ids ?? []).includes(artifact.id),
-  );
-  return linkedHandoffs.length === 0;
 }
 
 export function ProjectEmptyBlock({ title, detail }: { title: string; detail: string }) {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4727,8 +4727,8 @@ describe("ProjectsView cockpit", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
     const detail = await screen.findByRole("region", { name: "Selected work item" });
-    await within(detail).findByText("Ready to queue the first assignment");
-    await userEvent.click(within(detail).getByRole("button", { name: "Draft first assignment" }));
+    await within(detail).findByText("Let Hecate prepare the first step");
+    await userEvent.click(within(detail).getByRole("button", { name: "Prepare next step" }));
 
     await waitFor(() =>
       expect(draftProjectAssistant).toHaveBeenCalledWith({

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -4,6 +4,8 @@ import {
   buildProjectHealthSummary,
   buildProjectWorkCloseoutReadiness,
   projectHealthMetrics,
+  reviewArtifactNeedsFollowUpPath,
+  reviewArtifactRequiresFollowUp,
 } from "./projectInsights";
 import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
@@ -361,6 +363,27 @@ describe("projectInsights", () => {
 
     expect(ready.ready).toBe(true);
     expect(ready.blockers).toEqual([]);
+  });
+
+  it("shares review follow-up path detection with closeout surfaces", () => {
+    const review = reviewArtifact({
+      id: "art_review_required",
+      review_verdict: "changes_requested",
+    });
+
+    expect(reviewArtifactRequiresFollowUp(review)).toBe(true);
+    expect(reviewArtifactNeedsFollowUpPath(review, [])).toBe(true);
+    expect(
+      reviewArtifactNeedsFollowUpPath(review, [
+        {
+          ...handoff("handoff_review", "pending"),
+          linked_artifact_ids: [review.id],
+        },
+      ]),
+    ).toBe(false);
+    expect(reviewArtifactRequiresFollowUp(reviewArtifact({ review_verdict: "approved" }))).toBe(
+      false,
+    );
   });
 });
 

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -653,13 +653,23 @@ function reviewFollowUpAttentionItem(
   };
 }
 
-function reviewArtifactRequiresFollowUp(artifact: ProjectCollaborationArtifactRecord): boolean {
+export function reviewArtifactRequiresFollowUp(
+  artifact: ProjectCollaborationArtifactRecord,
+): boolean {
   return (
     artifact.kind === "review" &&
     (artifact.review_follow_up_required === true ||
       artifact.review_verdict === "blocked" ||
       artifact.review_verdict === "changes_requested")
   );
+}
+
+export function reviewArtifactNeedsFollowUpPath(
+  artifact: ProjectCollaborationArtifactRecord,
+  handoffs: ProjectHandoffRecord[],
+): boolean {
+  if (!reviewArtifactRequiresFollowUp(artifact)) return false;
+  return !handoffs.some((handoff) => (handoff.linked_artifact_ids ?? []).includes(artifact.id));
 }
 
 function closeoutReviewFollowUpBlocker(


### PR DESCRIPTION
## Summary
- surface review artifacts that require follow-up as closeout blockers with direct follow-up creation
- make the Projects next action prioritize untriaged review follow-up before memory review
- reframe pristine work items around a guided prepare-next-step action with manual context options secondary
- update operator docs for review follow-up and guided first-assignment preparation

## Tests
- bun run test -- src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectWorkspaceView.test.tsx
- bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run test
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test:e2e -- e2e/projects.spec.ts
- just docs-format-check
- just agent-docs-check
- git diff --check