### PR TITLE
Improve Projects work item actions

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -50,6 +50,9 @@ with a guided prepare action. Hecate can draft the first assignment from the
 work item role and context, but the operator still reviews and applies the
 proposal before execution records are created.
 
+After a work item has activity, use its Add strip to attach more assignments,
+evidence, or handoffs without scanning each section header for separate actions.
+
 ## Roots And Worktrees
 
 Project roots are concrete workspace paths, not project identity. A single

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -61,7 +61,7 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await page.getByRole("button", { name: "Start assignment" }).click();
 
   await expect(page.getByText("completed", { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Evidence" }).click();
+  await page.getByRole("button", { name: "Add evidence" }).click();
   await page
     .getByRole("dialog", { name: "Record evidence" })
     .getByLabel("Title")

--- a/ui/src/features/projects/ProjectAssignmentModals.test.tsx
+++ b/ui/src/features/projects/ProjectAssignmentModals.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -98,15 +98,40 @@ describe("ProjectAssignmentModals", () => {
       />,
     );
 
+    const plan = screen.getByRole("region", { name: "Queued assignment plan" });
+    expect(within(plan).getByText("Review before start")).toBeTruthy();
+    expect(within(plan).getByText("Software developer")).toBeTruthy();
+    expect(within(plan).getByText("Uses the work item root")).toBeTruthy();
     fireEvent.change(screen.getByLabelText("Role"), { target: { value: "researcher" } });
     expect(screen.getByLabelText("Driver")).toHaveValue("external_agent");
-    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+    expect(within(plan).getByText("Researcher")).toBeTruthy();
+    expect(within(plan).getByText("external_agent")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Create queued assignment" }));
 
     expect(onCreate).toHaveBeenCalledWith({
       roleID: "researcher",
       driverKind: "external_agent",
       rootID: "",
     });
+  });
+
+  it("keeps assignment plan fields unresolved until a role is available", () => {
+    render(
+      <NewAssignmentModal
+        error=""
+        pending={false}
+        project={project()}
+        workItem={workItem()}
+        roles={[]}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    const plan = screen.getByRole("region", { name: "Queued assignment plan" });
+    expect(screen.getByRole("dialog", { name: "Create queued assignment" })).toBeTruthy();
+    expect(within(plan).getAllByText("Select a role")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Create queued assignment" })).toBeDisabled();
   });
 
   it("edits canonical assignment execution reference fields", async () => {

--- a/ui/src/features/projects/ProjectAssignmentModals.tsx
+++ b/ui/src/features/projects/ProjectAssignmentModals.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 
 import type {
   ProjectAssignmentRecord,
@@ -8,6 +8,7 @@ import type {
 } from "../../types/project";
 import { InlineError, Modal } from "../shared/ui";
 import { ProjectRootSelect } from "./ProjectRootSelect";
+import { projectRootOptionLabel } from "./projectSettings";
 import {
   ASSIGNMENT_STATUSES,
   assignmentStatusFromValue,
@@ -47,9 +48,20 @@ export function NewAssignmentModal({
     rootID: "",
   });
   const valid = form.roleID.trim().length > 0;
+  const selectedRole = roles.find((role) => role.id === form.roleID) ?? null;
+  const selectedRoot = project.roots.find((root) => root.id === form.rootID) ?? null;
+  const inheritedRootLabel = workItem?.root_id
+    ? "Uses the work item root"
+    : project.default_root_id
+      ? "Uses the project default root"
+      : "Uses the first active project root";
+  const rootSummary = selectedRoot ? projectRootOptionLabel(selectedRoot) : inheritedRootLabel;
+  const driverSummary = selectedRole
+    ? form.driverKind || defaultDriverForRole(selectedRole)
+    : "Select a role";
   return (
     <Modal
-      title="Add assignment"
+      title="Create queued assignment"
       onClose={onClose}
       width={520}
       footer={
@@ -60,7 +72,7 @@ export function NewAssignmentModal({
           onClick={() => void onCreate(form)}
           style={{ width: "100%", justifyContent: "center" }}
         >
-          {pending ? "Adding…" : "Add assignment"}
+          {pending ? "Creating..." : "Create queued assignment"}
         </button>
       }
     >
@@ -72,6 +84,26 @@ export function NewAssignmentModal({
         style={{ display: "grid", gap: 12 }}
       >
         {error && <InlineError message={error} />}
+        <section style={assignmentPlanStyle} aria-label="Queued assignment plan">
+          <div style={assignmentPlanHeaderStyle}>
+            <div style={assignmentPlanTitleStyle}>Queued assignment</div>
+            <span className="badge badge-muted">Review before start</span>
+          </div>
+          <div style={assignmentPlanGridStyle}>
+            <div>
+              <div style={assignmentPlanLabelStyle}>Role</div>
+              <div style={assignmentPlanValueStyle}>{selectedRole?.name || "Select a role"}</div>
+            </div>
+            <div>
+              <div style={assignmentPlanLabelStyle}>Driver</div>
+              <div style={assignmentPlanValueStyle}>{driverSummary}</div>
+            </div>
+            <div>
+              <div style={assignmentPlanLabelStyle}>Root</div>
+              <div style={assignmentPlanValueStyle}>{rootSummary}</div>
+            </div>
+          </div>
+        </section>
         <label style={projectWorkFieldStyle}>
           <span style={projectWorkFieldLabelStyle}>Role</span>
           <select
@@ -123,6 +155,53 @@ export function NewAssignmentModal({
     </Modal>
   );
 }
+
+const assignmentPlanStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  display: "grid",
+  gap: 10,
+  minWidth: 0,
+  padding: "10px 11px",
+};
+
+const assignmentPlanHeaderStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  gap: 8,
+  justifyContent: "space-between",
+  minWidth: 0,
+};
+
+const assignmentPlanTitleStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: 13,
+  fontWeight: 700,
+};
+
+const assignmentPlanGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  minWidth: 0,
+};
+
+const assignmentPlanLabelStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  textTransform: "uppercase",
+};
+
+const assignmentPlanValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  lineHeight: 1.35,
+  marginTop: 3,
+  minWidth: 0,
+  overflowWrap: "anywhere",
+};
 
 type EditAssignmentModalProps = {
   assignment: ProjectAssignmentRecord;

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -349,8 +349,8 @@ describe("ProjectWorkItemDetail", () => {
     expect(screen.queryByText("No assignments recorded yet.")).toBeNull();
 
     await userEvent.click(screen.getByRole("button", { name: "Prepare next step" }));
+    await userEvent.click(screen.getByText("Add manually"));
     const manualActions = screen.getByRole("group", { name: "Manual work item actions" });
-    expect(within(manualActions).getByText("Other ways to add context")).toBeTruthy();
     await userEvent.click(within(manualActions).getByRole("button", { name: "Assignment" }));
     await userEvent.click(within(manualActions).getByRole("button", { name: "Evidence" }));
     await userEvent.click(within(manualActions).getByRole("button", { name: "Handoff" }));
@@ -409,6 +409,24 @@ describe("ProjectWorkItemDetail", () => {
     expect(handlers.onCloseWorkItem).toHaveBeenCalledWith(item);
   });
 
+  it("groups manual record creation for active work items", async () => {
+    const { handlers } = renderDetail({
+      assignments: [assignment({ status: "completed", execution_ref: { kind: "none" } })],
+    });
+
+    const addActions = screen.getByRole("region", { name: "Add to work item" });
+    expect(within(addActions).getByText("Add")).toBeTruthy();
+    expect(within(addActions).getByText(/Add an assignment, source evidence/)).toBeTruthy();
+
+    await userEvent.click(within(addActions).getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(addActions).getByRole("button", { name: "Add evidence" }));
+    await userEvent.click(within(addActions).getByRole("button", { name: "Add handoff" }));
+
+    expect(handlers.onAddAssignment).toHaveBeenCalledTimes(1);
+    expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
+    expect(handlers.onAddHandoff).toHaveBeenCalledTimes(1);
+  });
+
   it("shows already-done closeout state without a mark-done action", () => {
     renderDetail({
       assignments: [assignment({ status: "failed", execution_ref: { kind: "none" } })],
@@ -417,6 +435,7 @@ describe("ProjectWorkItemDetail", () => {
 
     expect(screen.getByText("Work item is done")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Mark done" })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Add to work item" })).toBeNull();
   });
 
   it("loads launch preflight before starting an assignment", async () => {
@@ -563,7 +582,7 @@ describe("ProjectWorkItemDetail", () => {
     expect(screen.getByRole("link", { name: "https://example.invalid/source" })).toBeTruthy();
     expect(screen.getByText("provider docs · external DOC-42")).toBeTruthy();
 
-    await userEvent.click(screen.getByRole("button", { name: "Evidence" }));
+    await userEvent.click(screen.getByRole("button", { name: "Add evidence" }));
 
     expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -192,6 +192,7 @@ export function ProjectWorkItemDetail({
     reviewArtifactNeedsFollowUpPath(artifact, handoffs),
   );
   const suggestedAssignmentRole = assignmentRoleForWorkItem(workItem, roleByID);
+  const canAddWorkRecords = !emptyWorkItem && workItem.status !== "done";
   return (
     <div style={workItemDetailStyle}>
       <article style={workItemCardStyle} aria-label={`${workItem.title} work item`}>
@@ -279,6 +280,13 @@ export function ProjectWorkItemDetail({
             onClose={() => onCloseWorkItem(workItem)}
           />
         )}
+        {canAddWorkRecords && (
+          <WorkItemAddActions
+            onAddAssignment={onAddAssignment}
+            onAddEvidenceLink={onAddEvidenceLink}
+            onAddHandoff={onAddHandoff}
+          />
+        )}
         {reviewFollowUps.length > 0 && (
           <ReviewFollowUpNotice
             artifact={reviewFollowUps[0]}
@@ -292,15 +300,6 @@ export function ProjectWorkItemDetail({
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Assignments</div>
               <span className="badge badge-muted">{assignments.length}</span>
-              <button
-                className="btn btn-primary btn-sm"
-                type="button"
-                onClick={onAddAssignment}
-                style={{ marginLeft: "auto" }}
-              >
-                <Icon d={Icons.plus} size={12} />
-                Assignment
-              </button>
             </div>
             {assignments.length === 0 ? (
               <div style={subtleTextStyle}>No assignments recorded yet.</div>
@@ -410,15 +409,6 @@ export function ProjectWorkItemDetail({
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Collaboration Artifacts</div>
               <span className="badge badge-muted">{artifacts.length}</span>
-              <button
-                className="btn btn-primary btn-sm"
-                type="button"
-                onClick={onAddEvidenceLink}
-                style={{ marginLeft: "auto" }}
-              >
-                <Icon d={Icons.plus} size={12} />
-                Evidence
-              </button>
             </div>
             {artifacts.length === 0 ? (
               <div style={subtleTextStyle}>No collaboration artifacts recorded yet.</div>
@@ -498,15 +488,6 @@ export function ProjectWorkItemDetail({
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Handoffs</div>
               <span className="badge badge-muted">{handoffs.length}</span>
-              <button
-                className="btn btn-primary btn-sm"
-                type="button"
-                onClick={onAddHandoff}
-                style={{ marginLeft: "auto" }}
-              >
-                <Icon d={Icons.plus} size={12} />
-                Handoff
-              </button>
             </div>
             {handoffError && <InlineError message={handoffError} />}
             {handoffs.length === 0 ? (
@@ -588,7 +569,7 @@ function WorkItemStartPanel({
         </div>
         <div style={{ ...subtleTextStyle, marginTop: 5 }}>
           {role
-            ? `Hecate will choose the ${role.name || role.id} role, reuse this work item context, and draft a reviewable assignment proposal. You still review and apply it before anything is created.`
+            ? `Hecate will use the ${role.name || role.id} role and this work item context to draft a reviewable assignment proposal. You still approve it before anything is created.`
             : "Create or select a project role so Hecate can prepare this work from defaults."}
         </div>
       </div>
@@ -609,21 +590,73 @@ function WorkItemStartPanel({
             Manage roles
           </button>
         )}
-        <div aria-label="Manual work item actions" role="group" style={startPanelSecondaryStyle}>
-          <span style={startPanelSecondaryLabelStyle}>Other ways to add context</span>
-          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddAssignment}>
-            <Icon d={Icons.plus} size={12} />
-            Assignment
-          </button>
-          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddEvidenceLink}>
-            <Icon d={Icons.plus} size={12} />
-            Evidence
-          </button>
-          <button className="btn btn-ghost btn-sm" type="button" onClick={onAddHandoff}>
-            <Icon d={Icons.plus} size={12} />
-            Handoff
-          </button>
+        <details style={manualAddDetailsStyle}>
+          <summary style={manualAddSummaryStyle}>Add manually</summary>
+          <div aria-label="Manual work item actions" role="group" style={startPanelSecondaryStyle}>
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onAddAssignment}>
+              <Icon d={Icons.plus} size={12} />
+              Assignment
+            </button>
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onAddEvidenceLink}>
+              <Icon d={Icons.plus} size={12} />
+              Evidence
+            </button>
+            <button className="btn btn-ghost btn-sm" type="button" onClick={onAddHandoff}>
+              <Icon d={Icons.plus} size={12} />
+              Handoff
+            </button>
+          </div>
+        </details>
+      </div>
+    </section>
+  );
+}
+
+function WorkItemAddActions({
+  onAddAssignment,
+  onAddEvidenceLink,
+  onAddHandoff,
+}: {
+  onAddAssignment: () => void;
+  onAddEvidenceLink: () => void;
+  onAddHandoff: () => void;
+}) {
+  return (
+    <section style={addActionsPanelStyle} aria-label="Add to work item">
+      <div style={addActionsCopyStyle}>
+        <div style={sectionLabelStyle}>Add</div>
+        <div style={subtleTextStyle}>
+          Add an assignment, source evidence, or a structured handoff to this work item.
         </div>
+      </div>
+      <div aria-label="Add work item records" role="group" style={addActionsButtonsStyle}>
+        <button
+          aria-label="Add assignment"
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onAddAssignment}
+        >
+          <Icon d={Icons.plus} size={12} />
+          Assignment
+        </button>
+        <button
+          aria-label="Add evidence"
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onAddEvidenceLink}
+        >
+          <Icon d={Icons.plus} size={12} />
+          Evidence
+        </button>
+        <button
+          aria-label="Add handoff"
+          className="btn btn-ghost btn-sm"
+          type="button"
+          onClick={onAddHandoff}
+        >
+          <Icon d={Icons.plus} size={12} />
+          Handoff
+        </button>
       </div>
     </section>
   );
@@ -1880,11 +1913,44 @@ const startPanelSecondaryStyle: CSSProperties = {
   minWidth: 0,
 };
 
-const startPanelSecondaryLabelStyle: CSSProperties = {
+const manualAddDetailsStyle: CSSProperties = {
+  color: "var(--t2)",
+  justifySelf: "end",
+  minWidth: 0,
+};
+
+const manualAddSummaryStyle: CSSProperties = {
   color: "var(--t3)",
+  cursor: "pointer",
   fontFamily: "var(--font-mono)",
   fontSize: 10,
   textTransform: "uppercase",
+};
+
+const addActionsPanelStyle: CSSProperties = {
+  alignItems: "center",
+  borderTop: "1px solid var(--border)",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 10,
+  justifyContent: "space-between",
+  marginTop: 12,
+  minWidth: 0,
+  paddingTop: 12,
+};
+
+const addActionsCopyStyle: CSSProperties = {
+  flex: "1 1 260px",
+  minWidth: 0,
+};
+
+const addActionsButtonsStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  justifyContent: "flex-end",
+  minWidth: 0,
 };
 
 const closeoutListStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4693,11 +4693,11 @@ describe("ProjectsView cockpit", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
     await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
-    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
+    const dialog = await screen.findByRole("dialog", { name: "Create queued assignment" });
     fireEvent.change(screen.getByLabelText("Driver"), {
       target: { value: "external_agent" },
     });
-    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create queued assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
       role_id: "software_developer",
@@ -4770,11 +4770,11 @@ describe("ProjectsView cockpit", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
     await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
-    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
+    const dialog = await screen.findByRole("dialog", { name: "Create queued assignment" });
     fireEvent.change(screen.getByLabelText("Root"), {
       target: { value: "root_feature" },
     });
-    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create queued assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(rootedProject.id, workItem.id, {
       role_id: "software_developer",
@@ -5075,11 +5075,11 @@ describe("ProjectsView cockpit", () => {
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
     await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
-    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
+    const dialog = await screen.findByRole("dialog", { name: "Create queued assignment" });
     fireEvent.change(screen.getByLabelText("Role"), {
       target: { value: "role_external" },
     });
-    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create queued assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
       role_id: "role_external",

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -3052,7 +3052,7 @@ describe("ProjectsView cockpit", () => {
 
     expect(await screen.findByText("Expose project work and native starts.")).toBeTruthy();
     const detail = await screen.findByRole("region", { name: "Selected work item" });
-    await userEvent.click(within(detail).getByRole("button", { name: "Evidence" }));
+    await userEvent.click(within(detail).getByRole("button", { name: "Add evidence" }));
 
     const dialog = await screen.findByRole("dialog", { name: "Record evidence" });
     fireEvent.change(within(dialog).getByLabelText("Title"), {
@@ -4692,11 +4692,12 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
+    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
     fireEvent.change(screen.getByLabelText("Driver"), {
       target: { value: "external_agent" },
     });
-    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
       role_id: "software_developer",
@@ -4768,11 +4769,12 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
+    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
     fireEvent.change(screen.getByLabelText("Root"), {
       target: { value: "root_feature" },
     });
-    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(rootedProject.id, workItem.id, {
       role_id: "software_developer",
@@ -5072,11 +5074,12 @@ describe("ProjectsView cockpit", () => {
     });
     render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
 
-    await userEvent.click(await screen.findByRole("button", { name: "Assignment" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Add assignment" }));
+    const dialog = await screen.findByRole("dialog", { name: "Add assignment" });
     fireEvent.change(screen.getByLabelText("Role"), {
       target: { value: "role_external" },
     });
-    await userEvent.click(screen.getByRole("button", { name: "Add assignment" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Add assignment" }));
 
     expect(createProjectAssignment).toHaveBeenCalledWith(project.id, workItem.id, {
       role_id: "role_external",


### PR DESCRIPTION
## Summary
- consolidate selected work item assignment/evidence/handoff creation into one Add strip
- make the pristine work-item path prioritize Prepare next step and tuck manual actions behind Add manually
- clarify assignment creation with a queued-assignment plan summary and Create queued assignment submit action
- update operator docs and Projects unit/e2e coverage

## Verification
- bun run test
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test:e2e -- e2e/projects.spec.ts
- just agent-docs-check
- git diff --check