### PR TITLE
Fix provider aliases and Fireworks model discovery

### DIFF
--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -142,8 +142,11 @@ normalized assistant text, model, and token usage are.
 Fireworks AI is also OpenAI Chat Completions-compatible, but its public model
 catalog is account-scoped. Hecate sends chat traffic to
 `https://api.fireworks.ai/inference/v1` and discovers the public Fireworks model
-list through `https://api.fireworks.ai/v1/accounts/fireworks/models`, which
-returns model metadata such as context length and tool support.
+list through `https://api.fireworks.ai/v1/accounts/fireworks/models` by
+default. Set the provider's **Fireworks account ID** to discover private,
+fine-tuned, or organization-scoped model catalogs instead. The chat request still
+uses the full Fireworks model ID returned by discovery, while the UI displays the
+short model name in pickers.
 
 ## Anthropic prompt caching
 
@@ -198,13 +201,13 @@ providers are unaffected.
 
 Every UI action maps to a Hecate-native settings endpoint:
 
-- `POST /hecate/v1/settings/providers` — add a provider. Body `{name, kind, protocol, base_url?, api_key?, custom_name?, preset_id?}`.
+- `POST /hecate/v1/settings/providers` — add a provider. Body `{name, kind, protocol, base_url?, api_key?, custom_name?, preset_id?, account_id?}`.
 - `GET /hecate/v1/settings/providers/local-discovery` — probe local presets
   for command presence and default endpoint availability. Used by the Add
   provider modal before a provider is created. Remote runtime mode blocks this
   endpoint and hides local presets by default.
 - `DELETE /hecate/v1/settings/providers/{id}` — remove it.
-- `PATCH /hecate/v1/settings/providers/{id}` — partial update; accepts `base_url`, `name`, and `custom_name`.
+- `PATCH /hecate/v1/settings/providers/{id}` — partial update; accepts `base_url`, `name`, `custom_name`, and provider-specific fields such as Fireworks `account_id`.
 - `PUT /hecate/v1/settings/providers/{id}/api-key` — set the API key (empty `key` clears it).
 
 The full surface lives in [`runtime-api.md`](../runtime/runtime-api.md) and is implemented in [`internal/api/handler_settings.go`](../../internal/api/handler_settings.go). Useful for terraforming a fleet of gateways from a single config source of truth.

--- a/internal/api/handler_local_provider_discovery.go
+++ b/internal/api/handler_local_provider_discovery.go
@@ -258,6 +258,14 @@ func localProviderProbeURL(provider config.BuiltInProvider) string {
 			return parsed.String()
 		}
 	}
+	if provider.ID == "lmstudio" {
+		if parsed, err := url.Parse(provider.BaseURL); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+			parsed.Path = "/api/v1/models"
+			parsed.RawQuery = ""
+			parsed.Fragment = ""
+			return parsed.String()
+		}
+	}
 
 	base := strings.TrimRight(provider.BaseURL, "/")
 	if strings.HasSuffix(base, "/models") {
@@ -313,6 +321,32 @@ func decodeLocalProviderModels(body []byte, providerID string) ([]string, error)
 		for _, model := range payload.Models {
 			if strings.TrimSpace(model.Name) != "" {
 				models = append(models, model.Name)
+			}
+		}
+		return models, nil
+	}
+	if providerID == "lmstudio" {
+		var payload struct {
+			Models []struct {
+				ID   string `json:"id"`
+				Key  string `json:"key"`
+				Type string `json:"type"`
+			} `json:"models"`
+		}
+		if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("invalid %s response: %w", providerID, err)
+		}
+		models := make([]string, 0, len(payload.Models))
+		for _, model := range payload.Models {
+			if modelType := strings.TrimSpace(model.Type); modelType != "" && !strings.EqualFold(modelType, "llm") {
+				continue
+			}
+			id := strings.TrimSpace(model.Key)
+			if id == "" {
+				id = strings.TrimSpace(model.ID)
+			}
+			if id != "" {
+				models = append(models, id)
 			}
 		}
 		return models, nil

--- a/internal/api/handler_local_provider_discovery_test.go
+++ b/internal/api/handler_local_provider_discovery_test.go
@@ -117,8 +117,8 @@ func TestDiscoverLocalProvidersRunsCommandLookupsInParallel(t *testing.T) {
 	}
 	rt := &localProviderRoundTrip{
 		body: map[string]string{
-			"http://127.0.0.1:11434/api/tags": `{"models":[]}`,
-			"http://127.0.0.1:1234/v1/models": `{"data":[]}`,
+			"http://127.0.0.1:11434/api/tags":     `{"models":[]}`,
+			"http://127.0.0.1:1234/api/v1/models": `{"models":[]}`,
 		},
 	}
 
@@ -153,8 +153,8 @@ func TestDiscoverLocalProvidersRunsHTTPProbesInParallel(t *testing.T) {
 		started: make(chan string, 2),
 		release: make(chan struct{}),
 		body: map[string]string{
-			"http://127.0.0.1:11434/api/tags": `{"models":[]}`,
-			"http://127.0.0.1:1234/v1/models": `{"data":[]}`,
+			"http://127.0.0.1:11434/api/tags":     `{"models":[]}`,
+			"http://127.0.0.1:1234/api/v1/models": `{"models":[]}`,
 		},
 	}
 	var releaseOnce sync.Once
@@ -169,8 +169,8 @@ func TestDiscoverLocalProvidersRunsHTTPProbesInParallel(t *testing.T) {
 		receiveLocalDiscoverySignal(t, rt.started),
 		receiveLocalDiscoverySignal(t, rt.started),
 	}
-	if strings.Join(urls, ",") != "http://127.0.0.1:11434/api/tags,http://127.0.0.1:1234/v1/models" &&
-		strings.Join(urls, ",") != "http://127.0.0.1:1234/v1/models,http://127.0.0.1:11434/api/tags" {
+	if strings.Join(urls, ",") != "http://127.0.0.1:11434/api/tags,http://127.0.0.1:1234/api/v1/models" &&
+		strings.Join(urls, ",") != "http://127.0.0.1:1234/api/v1/models,http://127.0.0.1:11434/api/tags" {
 		t.Fatalf("HTTP probes started = %#v, want both unique endpoints", urls)
 	}
 
@@ -223,7 +223,7 @@ func TestDiscoverLocalProvidersFindsLMStudioInNativeAppPath(t *testing.T) {
 	}
 	rt := &localProviderRoundTrip{
 		err: map[string]error{
-			"http://127.0.0.1:1234/v1/models": errors.New("connection refused"),
+			"http://127.0.0.1:1234/api/v1/models": errors.New("connection refused"),
 		},
 	}
 	lookPath := func(command string) (string, error) {
@@ -247,6 +247,38 @@ func TestDiscoverLocalProvidersFindsLMStudioInNativeAppPath(t *testing.T) {
 	}
 	if item.Status != "installed" {
 		t.Fatalf("status = %q, want installed", item.Status)
+	}
+}
+
+func TestDiscoverLocalProvidersLMStudioRunningWithNativeModels(t *testing.T) {
+	t.Parallel()
+
+	providers := []config.BuiltInProvider{
+		{ID: "lmstudio", Name: "LM Studio", Kind: "local", BaseURL: "http://127.0.0.1:1234/v1"},
+	}
+	rt := &localProviderRoundTrip{
+		body: map[string]string{
+			"http://127.0.0.1:1234/api/v1/models": `{"models":[{"key":"qwen/qwen3-4b","type":"llm"},{"key":"text-embedding-nomic","type":"embedding"}]}`,
+		},
+	}
+
+	items := discoverLocalProviders(context.Background(), providers, missingLocalCommand, rt)
+
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Status != "running" {
+		t.Fatalf("status = %q, want running", item.Status)
+	}
+	if !item.HTTPAvailable {
+		t.Fatal("HTTPAvailable = false, want true")
+	}
+	if strings.Join(item.Models, ",") != "qwen/qwen3-4b" {
+		t.Fatalf("models = %#v, want only LLM models from LM Studio native response", item.Models)
+	}
+	if item.ModelCount != 1 {
+		t.Fatalf("model count = %d, want 1", item.ModelCount)
 	}
 }
 
@@ -336,7 +368,7 @@ func TestDiscoverLocalProvidersRejectsInvalidHTTPProbeBody(t *testing.T) {
 	}
 	rt := &localProviderRoundTrip{
 		body: map[string]string{
-			"http://127.0.0.1:1234/v1/models": `not-json`,
+			"http://127.0.0.1:1234/api/v1/models": `not-json`,
 		},
 	}
 
@@ -400,6 +432,18 @@ func TestLocalProviderProbeURLUsesOllamaNativeTagsEndpoint(t *testing.T) {
 	})
 	if got != "http://127.0.0.1:11434/api/tags" {
 		t.Fatalf("probe URL = %q, want Ollama native tags endpoint", got)
+	}
+}
+
+func TestLocalProviderProbeURLUsesLMStudioNativeModelsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	got := localProviderProbeURL(config.BuiltInProvider{
+		ID:      "lmstudio",
+		BaseURL: "http://127.0.0.1:1234/v1",
+	})
+	if got != "http://127.0.0.1:1234/api/v1/models" {
+		t.Fatalf("probe URL = %q, want LM Studio native models endpoint", got)
 	}
 }
 

--- a/internal/api/handler_settings.go
+++ b/internal/api/handler_settings.go
@@ -51,13 +51,14 @@ func (h *Handler) HandleSettingsUpdateProvider(w http.ResponseWriter, r *http.Re
 		BaseURL    *string `json:"base_url,omitempty"`
 		Name       *string `json:"name,omitempty"`
 		CustomName *string `json:"custom_name,omitempty"`
+		AccountID  *string `json:"account_id,omitempty"`
 	}
 	if !decodeJSON(w, r, &req) {
 		return
 	}
 
-	if req.BaseURL == nil && req.Name == nil && req.CustomName == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "no fields to update (expected base_url, name, or custom_name)")
+	if req.BaseURL == nil && req.Name == nil && req.CustomName == nil && req.AccountID == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "no fields to update (expected base_url, name, custom_name, or account_id)")
 		return
 	}
 
@@ -66,6 +67,7 @@ func (h *Handler) HandleSettingsUpdateProvider(w http.ResponseWriter, r *http.Re
 		BaseURL:    req.BaseURL,
 		Name:       req.Name,
 		CustomName: req.CustomName,
+		AccountID:  req.AccountID,
 	})
 	if err != nil {
 		writeProviderAppError(w, err)
@@ -130,6 +132,7 @@ func (h *Handler) HandleSettingsCreateProvider(w http.ResponseWriter, r *http.Re
 		Name       string `json:"name"`
 		PresetID   string `json:"preset_id"`
 		CustomName string `json:"custom_name"`
+		AccountID  string `json:"account_id"`
 		BaseURL    string `json:"base_url"`
 		APIKey     string `json:"api_key"`
 		Kind       string `json:"kind"`
@@ -143,6 +146,7 @@ func (h *Handler) HandleSettingsCreateProvider(w http.ResponseWriter, r *http.Re
 		Name:       req.Name,
 		PresetID:   req.PresetID,
 		CustomName: req.CustomName,
+		AccountID:  req.AccountID,
 		BaseURL:    req.BaseURL,
 		APIKey:     req.APIKey,
 		Kind:       req.Kind,
@@ -261,6 +265,7 @@ func renderProviderAppRecord(record providerapp.ProviderRecord) SettingsProvider
 		Name:                 record.Name,
 		PresetID:             record.PresetID,
 		CustomName:           record.CustomName,
+		AccountID:            record.AccountID,
 		Kind:                 record.Kind,
 		Protocol:             record.Protocol,
 		BaseURL:              record.BaseURL,
@@ -280,6 +285,7 @@ func renderSettingsProvider(provider controlplane.Provider, secrets []controlpla
 		Name:            provider.Name,
 		PresetID:        provider.PresetID,
 		CustomName:      provider.CustomName,
+		AccountID:       provider.AccountID,
 		Kind:            provider.Kind,
 		Protocol:        provider.Protocol,
 		BaseURL:         provider.BaseURL,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1419,6 +1419,7 @@ type SettingsProviderRecord struct {
 	Name                 string   `json:"name"`
 	PresetID             string   `json:"preset_id,omitempty"`
 	CustomName           string   `json:"custom_name,omitempty"`
+	AccountID            string   `json:"account_id,omitempty"`
 	Kind                 string   `json:"kind"`
 	Protocol             string   `json:"protocol"`
 	BaseURL              string   `json:"base_url"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -825,6 +825,41 @@ func TestBuiltInProviderCatalogMetadata(t *testing.T) {
 	}
 }
 
+func TestFireworksModelsPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		accountID string
+		want      string
+	}{
+		{
+			name:      "default",
+			accountID: "",
+			want:      "https://api.fireworks.ai/v1/accounts/fireworks/models",
+		},
+		{
+			name:      "custom account",
+			accountID: "team-alpha",
+			want:      "https://api.fireworks.ai/v1/accounts/team-alpha/models",
+		},
+		{
+			name:      "escaped account",
+			accountID: "team alpha",
+			want:      "https://api.fireworks.ai/v1/accounts/team%20alpha/models",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FireworksModelsPath(tt.accountID); got != tt.want {
+				t.Fatalf("FireworksModelsPath(%q) = %q, want %q", tt.accountID, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadProvidersFromEnvIncludesCustomProviderFromCoreEnvKeys(t *testing.T) {
 	t.Setenv("PROVIDER_CUSTOM_PRECONFIGURED", "1")
 	t.Setenv("PROVIDER_CUSTOM_BASE_URL", "https://example.com/v1")

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -20,6 +21,16 @@ type BuiltInProvider struct {
 	DefaultModel string
 	DocsURL      string
 	Description  string
+}
+
+const FireworksDefaultAccountID = "fireworks"
+
+func FireworksModelsPath(accountID string) string {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		accountID = FireworksDefaultAccountID
+	}
+	return "https://api.fireworks.ai/v1/accounts/" + url.PathEscape(accountID) + "/models"
 }
 
 var builtInProviders = []BuiltInProvider{
@@ -91,7 +102,7 @@ var builtInProviders = []BuiltInProvider{
 		Protocol:    "openai",
 		BaseURL:     "https://api.fireworks.ai/inference/v1",
 		APIKeyEnv:   "PROVIDER_FIREWORKS_API_KEY",
-		ModelsPath:  "https://api.fireworks.ai/v1/accounts/fireworks/models",
+		ModelsPath:  FireworksModelsPath(""),
 		DocsURL:     "https://docs.fireworks.ai/getting-started/introduction",
 		Description: "Fireworks.ai serverless inference. Hosts an evolving catalog of open-weight models; model IDs are namespaced (`accounts/fireworks/models/<slug>`).",
 	},

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -19,6 +19,7 @@ type Provider struct {
 	// "Anthropic" + "Dev"). Name itself stays fixed for preset-based
 	// providers; this is the disambiguator.
 	CustomName     string    `json:"custom_name,omitempty"`
+	AccountID      string    `json:"account_id,omitempty"`
 	Kind           string    `json:"kind"`
 	Protocol       string    `json:"protocol"`
 	BaseURL        string    `json:"base_url"`
@@ -93,6 +94,7 @@ func cloneState(state State) State {
 			Name:           provider.Name,
 			PresetID:       provider.PresetID,
 			CustomName:     provider.CustomName,
+			AccountID:      provider.AccountID,
 			Kind:           provider.Kind,
 			Protocol:       provider.Protocol,
 			BaseURL:        provider.BaseURL,

--- a/internal/providerapp/application.go
+++ b/internal/providerapp/application.go
@@ -69,12 +69,14 @@ type UpdateProviderCommand struct {
 	BaseURL    *string
 	Name       *string
 	CustomName *string
+	AccountID  *string
 }
 
 type CreateProviderCommand struct {
 	Name       string
 	PresetID   string
 	CustomName string
+	AccountID  string
 	BaseURL    string
 	APIKey     string
 	Kind       string
@@ -116,6 +118,7 @@ type ProviderRecord struct {
 	Name                 string
 	PresetID             string
 	CustomName           string
+	AccountID            string
 	Kind                 string
 	Protocol             string
 	BaseURL              string
@@ -159,8 +162,8 @@ func (app *Application) UpdateProvider(ctx context.Context, cmd UpdateProviderCo
 	if app.runtime == nil {
 		return nil, ErrRuntimeNotConfigured
 	}
-	if cmd.BaseURL == nil && cmd.Name == nil && cmd.CustomName == nil {
-		return nil, Validation(errors.New("no fields to update (expected base_url, name, or custom_name)"))
+	if cmd.BaseURL == nil && cmd.Name == nil && cmd.CustomName == nil && cmd.AccountID == nil {
+		return nil, Validation(errors.New("no fields to update (expected base_url, name, custom_name, or account_id)"))
 	}
 	state, err := app.controlPlane.Snapshot(ctx)
 	if err != nil {
@@ -193,6 +196,13 @@ func (app *Application) UpdateProvider(ctx context.Context, cmd UpdateProviderCo
 	}
 	if cmd.CustomName != nil {
 		updated.CustomName = strings.TrimSpace(*cmd.CustomName)
+	}
+	if cmd.AccountID != nil {
+		accountID, err := normalizeProviderAccountID(*cmd.AccountID)
+		if err != nil {
+			return nil, Validation(err)
+		}
+		updated.AccountID = accountID
 	}
 	provider, err := app.runtime.Upsert(ctx, updated, "")
 	if err != nil {
@@ -275,11 +285,16 @@ func (app *Application) CreateProvider(ctx context.Context, cmd CreateProviderCo
 	if protocol == "" {
 		protocol = "openai"
 	}
+	accountID, err := normalizeProviderAccountID(cmd.AccountID)
+	if err != nil {
+		return nil, Validation(err)
+	}
 	provider, err := app.runtime.Upsert(ctx, controlplane.Provider{
 		ID:         id,
 		Name:       cmd.Name,
 		PresetID:   cmd.PresetID,
 		CustomName: strings.TrimSpace(cmd.CustomName),
+		AccountID:  accountID,
 		Kind:       kind,
 		Protocol:   protocol,
 		BaseURL:    cmd.BaseURL,
@@ -373,11 +388,13 @@ func buildProviderRecords(cfg config.Config, state controlplane.State) []Provide
 		if !cfg.LocalProvidersAllowed() && providerKind(cp) == "local" {
 			continue
 		}
-		preset, hasPreset := presetByID[cp.ID]
+		preset, hasPreset := builtInProviderForControlPlaneProvider(presetByID, cp)
 		record := ProviderRecord{
 			ID:             cp.ID,
 			Name:           cp.Name,
+			PresetID:       cp.PresetID,
 			CustomName:     cp.CustomName,
+			AccountID:      cp.AccountID,
 			Kind:           cp.Kind,
 			Protocol:       cp.Protocol,
 			BaseURL:        cp.BaseURL,
@@ -389,6 +406,7 @@ func buildProviderRecords(cfg config.Config, state controlplane.State) []Provide
 		}
 		if hasPreset {
 			record.PresetID = preset.ID
+			record.Name = preset.Name
 			if record.Kind == "" {
 				record.Kind = preset.Kind
 			}
@@ -422,6 +440,22 @@ func buildProviderRecords(cfg config.Config, state controlplane.State) []Provide
 	return records
 }
 
+func builtInProviderForControlPlaneProvider(
+	presetByID map[string]config.BuiltInProvider,
+	provider controlplane.Provider,
+) (config.BuiltInProvider, bool) {
+	for _, candidate := range []string{provider.PresetID, provider.Name, provider.ID} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if preset, ok := presetByID[candidate]; ok {
+			return preset, true
+		}
+	}
+	return config.BuiltInProvider{}, false
+}
+
 func createProviderKind(cmd CreateProviderCommand, id, fallback string) string {
 	if strings.TrimSpace(cmd.Kind) != "" {
 		return normalizeProviderKind(cmd.Kind)
@@ -448,6 +482,17 @@ func providerKind(provider controlplane.Provider) string {
 
 func normalizeProviderKind(kind string) string {
 	return strings.ToLower(strings.TrimSpace(kind))
+}
+
+func normalizeProviderAccountID(accountID string) (string, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return "", nil
+	}
+	if strings.ContainsAny(accountID, "/?#") {
+		return "", errors.New("account_id cannot contain /, ?, or #")
+	}
+	return accountID, nil
 }
 
 func slugify(name string) string {

--- a/internal/providerapp/application_test.go
+++ b/internal/providerapp/application_test.go
@@ -201,6 +201,51 @@ func TestApplication_StatusBuildsProviderRecordsAndPolicyRules(t *testing.T) {
 	}
 }
 
+func TestApplication_StatusCanonicalizesPresetProviderRecords(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := controlplane.NewMemoryStore()
+	if _, err := store.UpsertProvider(ctx, controlplane.Provider{
+		ID:        "fireworks-ai",
+		Name:      "fireworks",
+		AccountID: "team-alpha",
+		Kind:      "cloud",
+		Protocol:  "openai",
+		BaseURL:   "https://api.fireworks.ai/inference/v1",
+		Enabled:   true,
+	}, &controlplane.ProviderSecret{ProviderID: "fireworks-ai", APIKeyEncrypted: "cipher"}); err != nil {
+		t.Fatalf("UpsertProvider(fireworks): %v", err)
+	}
+	if _, err := store.UpsertProvider(ctx, controlplane.Provider{
+		ID:       "local-lmstudio",
+		Name:     "lmstudio",
+		Kind:     "local",
+		Protocol: "openai",
+		BaseURL:  "http://127.0.0.1:1234/v1",
+		Enabled:  true,
+	}, nil); err != nil {
+		t.Fatalf("UpsertProvider(lmstudio): %v", err)
+	}
+
+	result, err := New(Options{ControlPlane: store}).Status(ctx)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	providers := map[string]ProviderRecord{}
+	for _, provider := range result.Providers {
+		providers[provider.ID] = provider
+	}
+	fireworks := providers["fireworks-ai"]
+	if fireworks.Name != "Fireworks AI" || fireworks.PresetID != "fireworks" || fireworks.AccountID != "team-alpha" {
+		t.Fatalf("fireworks record = %+v, want canonical display metadata with account id", fireworks)
+	}
+	lmstudio := providers["local-lmstudio"]
+	if lmstudio.Name != "LM Studio" || lmstudio.PresetID != "lmstudio" {
+		t.Fatalf("lmstudio record = %+v, want canonical display metadata", lmstudio)
+	}
+}
+
 func TestApplication_StatusWithoutControlPlaneReturnsEnvDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -315,6 +360,38 @@ func TestApplication_UpdateProviderValidatesAndDispatches(t *testing.T) {
 	}
 	if _, err := app.UpdateProvider(ctx, UpdateProviderCommand{ID: "custom"}); !IsValidationError(err) {
 		t.Fatalf("UpdateProvider(no fields) error = %v, want validation", err)
+	}
+}
+
+func TestApplication_UpdateProviderAccountIDValidatesAndDispatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := controlplane.NewMemoryStore()
+	if _, err := store.UpsertProvider(ctx, controlplane.Provider{
+		ID:       "fireworks-ai",
+		Name:     "fireworks",
+		PresetID: "fireworks",
+		Kind:     "cloud",
+		Protocol: "openai",
+		BaseURL:  "https://api.fireworks.ai/inference/v1",
+		Enabled:  true,
+	}, &controlplane.ProviderSecret{ProviderID: "fireworks-ai", APIKeyEncrypted: "cipher"}); err != nil {
+		t.Fatalf("UpsertProvider: %v", err)
+	}
+	runtime := &recordingRuntime{}
+	app := New(Options{ControlPlane: store, Runtime: runtime})
+	accountID := " team-beta "
+
+	if _, err := app.UpdateProvider(ctx, UpdateProviderCommand{ID: "fireworks-ai", AccountID: &accountID}); err != nil {
+		t.Fatalf("UpdateProvider(account_id) error = %v", err)
+	}
+	if len(runtime.upsertCalls) != 1 || runtime.upsertCalls[0].provider.AccountID != "team-beta" {
+		t.Fatalf("upsert calls = %+v, want trimmed Fireworks account id", runtime.upsertCalls)
+	}
+	invalidAccountID := "team/beta"
+	if _, err := app.UpdateProvider(ctx, UpdateProviderCommand{ID: "fireworks-ai", AccountID: &invalidAccountID}); !IsValidationError(err) {
+		t.Fatalf("UpdateProvider(invalid account_id) error = %v, want validation", err)
 	}
 }
 

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,9 @@ const (
 	ollamaCapabilityDiscoveryMaxModels   = 32
 	ollamaCapabilityDiscoveryMinTimeout  = 500 * time.Millisecond
 	ollamaCapabilityDiscoveryMaxTimeout  = 3 * time.Second
+
+	fireworksModelDiscoveryPageSize = 200
+	fireworksModelDiscoveryMaxPages = 20
 )
 
 type openAIChatCompletionRequest struct {
@@ -213,8 +217,24 @@ type openAIModel struct {
 }
 
 type fireworksModelsResponse struct {
-	Models []fireworksModel `json:"models"`
-	Data   []fireworksModel `json:"data"`
+	Models           []fireworksModel `json:"models"`
+	Data             []fireworksModel `json:"data"`
+	NextPageToken    string           `json:"nextPageToken"`
+	NextPageTokenAlt string           `json:"next_page_token"`
+}
+
+func (r fireworksModelsResponse) items() []fireworksModel {
+	if len(r.Models) > 0 {
+		return r.Models
+	}
+	return r.Data
+}
+
+func (r fireworksModelsResponse) nextPageToken() string {
+	if token := strings.TrimSpace(r.NextPageToken); token != "" {
+		return token
+	}
+	return strings.TrimSpace(r.NextPageTokenAlt)
 }
 
 type fireworksModel struct {
@@ -224,6 +244,20 @@ type fireworksModel struct {
 	SupportsTools      bool   `json:"supportsTools"`
 	SupportsImageInput bool   `json:"supportsImageInput"`
 	ContextLength      int    `json:"contextLength"`
+}
+
+type lmStudioModelsResponse struct {
+	Models []lmStudioModel `json:"models"`
+}
+
+type lmStudioModel struct {
+	ID               string `json:"id"`
+	Key              string `json:"key"`
+	Type             string `json:"type"`
+	MaxContextLength int    `json:"max_context_length"`
+	Capabilities     struct {
+		TrainedForToolUse bool `json:"trained_for_tool_use"`
+	} `json:"capabilities"`
 }
 
 type ollamaShowRequest struct {
@@ -417,6 +451,12 @@ func (p *OpenAICompatibleProvider) discoverCapabilities(ctx context.Context) (Ca
 	if p.isFireworksProvider() {
 		return p.discoverFireworksCapabilities(ctx, endpoint)
 	}
+	if p.isLMStudioProvider() {
+		caps, err := p.discoverLMStudioCapabilities(ctx)
+		if err == nil && len(caps.Models) > 0 {
+			return caps, nil
+		}
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -466,10 +506,14 @@ func (p *OpenAICompatibleProvider) discoverCapabilities(ctx context.Context) (Ca
 	}, nil
 }
 
-func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Context, endpoint string) (Capabilities, error) {
+func (p *OpenAICompatibleProvider) discoverLMStudioCapabilities(ctx context.Context) (Capabilities, error) {
+	endpoint, err := lmStudioNativeModelsURL(p.config.BaseURL)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("build LM Studio models URL: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return Capabilities{}, fmt.Errorf("build Fireworks models request: %w", err)
+		return Capabilities{}, fmt.Errorf("build LM Studio models request: %w", err)
 	}
 	if p.config.APIKey != "" {
 		req.Header.Set("Authorization", "Bearer "+p.config.APIKey)
@@ -478,7 +522,7 @@ func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Con
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return Capabilities{}, fmt.Errorf("send Fireworks models request: %w", err)
+		return Capabilities{}, fmt.Errorf("send LM Studio models request: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -486,25 +530,116 @@ func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Con
 		return Capabilities{}, decodeUpstreamError(resp)
 	}
 
-	var payload fireworksModelsResponse
+	var payload lmStudioModelsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return Capabilities{}, fmt.Errorf("decode Fireworks models response: %w", err)
+		return Capabilities{}, fmt.Errorf("decode LM Studio models response: %w", err)
 	}
 
-	items := payload.Models
-	if len(items) == 0 {
-		items = payload.Data
-	}
-	models := make([]string, 0, len(items))
-	modelCapabilities := make(map[string]types.ModelCapabilities, len(items))
-	for _, item := range items {
-		id := strings.TrimSpace(item.Name)
+	models := make([]string, 0, len(payload.Models))
+	modelCapabilities := make(map[string]types.ModelCapabilities, len(payload.Models))
+	for _, item := range payload.Models {
+		if modelType := strings.TrimSpace(item.Type); modelType != "" && !strings.EqualFold(modelType, "llm") {
+			continue
+		}
+		id := strings.TrimSpace(item.Key)
 		if id == "" {
 			id = strings.TrimSpace(item.ID)
 		}
 		if id == "" || contains(models, id) {
 			continue
 		}
+		models = append(models, id)
+
+		cap := types.ModelCapabilities{
+			Streaming:      true,
+			StreamingKnown: true,
+			Source:         "provider",
+		}
+		if item.Capabilities.TrainedForToolUse {
+			cap.ToolCalling = "basic"
+		}
+		if item.MaxContextLength > 0 {
+			cap.MaxContextTokens = item.MaxContextLength
+		}
+		modelCapabilities[id] = cap
+	}
+	if len(modelCapabilities) == 0 {
+		modelCapabilities = nil
+	}
+
+	defaultModel := p.config.DefaultModel
+	if defaultModel == "" && len(models) > 0 {
+		defaultModel = models[0]
+	}
+
+	return Capabilities{
+		Name:              p.Name(),
+		Kind:              p.Kind(),
+		DefaultModel:      defaultModel,
+		Models:            models,
+		ModelCapabilities: modelCapabilities,
+		Discoverable:      true,
+		DiscoverySource:   "lmstudio_api_models",
+		RefreshedAt:       time.Now().UTC(),
+	}, nil
+}
+
+func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Context, endpoint string) (Capabilities, error) {
+	items := make([]fireworksModel, 0)
+	pageToken := ""
+	for page := 0; page < fireworksModelDiscoveryMaxPages; page++ {
+		pageEndpoint, err := fireworksModelsPageURL(endpoint, pageToken)
+		if err != nil {
+			return Capabilities{}, fmt.Errorf("build Fireworks models page URL: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageEndpoint, nil)
+		if err != nil {
+			return Capabilities{}, fmt.Errorf("build Fireworks models request: %w", err)
+		}
+		if p.config.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+p.config.APIKey)
+		}
+		injectTraceContext(req)
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return Capabilities{}, fmt.Errorf("send Fireworks models request: %w", err)
+		}
+
+		if resp.StatusCode >= http.StatusBadRequest {
+			defer resp.Body.Close()
+			return Capabilities{}, decodeUpstreamError(resp)
+		}
+
+		var payload fireworksModelsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			resp.Body.Close()
+			return Capabilities{}, fmt.Errorf("decode Fireworks models response: %w", err)
+		}
+		resp.Body.Close()
+
+		items = append(items, payload.items()...)
+		pageToken = payload.nextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+
+	models := make([]string, 0, len(items))
+	modelCapabilities := make(map[string]types.ModelCapabilities, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		id := strings.TrimSpace(item.Name)
+		if id == "" {
+			id = strings.TrimSpace(item.ID)
+		}
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
 		models = append(models, id)
 
 		cap := types.ModelCapabilities{
@@ -541,6 +676,24 @@ func (p *OpenAICompatibleProvider) discoverFireworksCapabilities(ctx context.Con
 		DiscoverySource:   "fireworks_models",
 		RefreshedAt:       time.Now().UTC(),
 	}, nil
+}
+
+func fireworksModelsPageURL(endpoint string, pageToken string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	query := u.Query()
+	if query.Get("pageSize") == "" {
+		query.Set("pageSize", strconv.Itoa(fireworksModelDiscoveryPageSize))
+	}
+	if pageToken != "" {
+		query.Set("pageToken", pageToken)
+	} else {
+		query.Del("pageToken")
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 func (p *OpenAICompatibleProvider) discoverProviderModelCapabilities(ctx context.Context, models []string) map[string]types.ModelCapabilities {
@@ -609,7 +762,40 @@ func (p *OpenAICompatibleProvider) isOllamaProvider() bool {
 }
 
 func (p *OpenAICompatibleProvider) isFireworksProvider() bool {
-	return strings.EqualFold(strings.TrimSpace(p.config.Name), "fireworks")
+	if strings.EqualFold(strings.TrimSpace(p.config.Name), "fireworks") {
+		return true
+	}
+	endpoint := buildModelsURL(p.config.BaseURL, p.config.ModelsPath)
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, "api.fireworks.ai") &&
+		strings.Contains(parsed.EscapedPath(), "/models")
+}
+
+func (p *OpenAICompatibleProvider) isLMStudioProvider() bool {
+	switch strings.ToLower(strings.TrimSpace(p.config.Name)) {
+	case "lmstudio", "lm-studio", "lm studio", "local-lmstudio":
+		return true
+	default:
+		return false
+	}
+}
+
+func lmStudioNativeModelsURL(base string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(base))
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	path := strings.TrimRight(u.Path, "/")
+	if strings.EqualFold(path, "/v1") {
+		path = ""
+	}
+	u.Path = strings.TrimRight(path, "/") + "/api/v1/models"
+	return u.String(), nil
 }
 
 func ollamaNativeBaseURL(base string) (string, error) {

--- a/internal/providers/openai_test.go
+++ b/internal/providers/openai_test.go
@@ -369,25 +369,43 @@ func TestOpenAIProviderFireworksDiscoveryUsesModelsEndpoint(t *testing.T) {
 	t.Parallel()
 
 	var calls int
+	pageTokens := make([]string, 0, 2)
 	transport := testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		calls++
 		if r.Method != http.MethodGet {
 			return nil, fmt.Errorf("method = %s, want GET", r.Method)
 		}
-		if got := r.URL.String(); got != "https://api.fireworks.ai/v1/accounts/fireworks/models" {
-			return nil, fmt.Errorf("url = %s, want Fireworks models endpoint", got)
+		if got := r.URL.Scheme + "://" + r.URL.Host + r.URL.Path; got != "https://api.fireworks.ai/v1/accounts/fireworks/models" {
+			return nil, fmt.Errorf("url path = %s, want Fireworks models endpoint", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer fireworks-key" {
 			return nil, fmt.Errorf("Authorization = %q, want Bearer fireworks-key", got)
 		}
-		return jsonHTTPResponse(fireworksModelsResponse{Models: []fireworksModel{
-			{
-				Name:          "accounts/fireworks/models/deepseek-v3p1",
-				SupportsTools: true,
-				ContextLength: 131072,
-			},
-			{ID: "accounts/fireworks/models/llama-v3p1"},
-		}})
+		query := r.URL.Query()
+		if got := query.Get("pageSize"); got != "200" {
+			return nil, fmt.Errorf("pageSize = %q, want 200", got)
+		}
+		pageToken := query.Get("pageToken")
+		pageTokens = append(pageTokens, pageToken)
+		switch pageToken {
+		case "":
+			return jsonHTTPResponse(fireworksModelsResponse{
+				Models: []fireworksModel{
+					{
+						Name:          "accounts/fireworks/models/deepseek-v3p1",
+						SupportsTools: true,
+						ContextLength: 131072,
+					},
+				},
+				NextPageToken: "next-page",
+			})
+		case "next-page":
+			return jsonHTTPResponse(fireworksModelsResponse{Models: []fireworksModel{
+				{ID: "accounts/fireworks/models/llama-v3p1"},
+			}})
+		default:
+			return nil, fmt.Errorf("unexpected pageToken = %q", pageToken)
+		}
 	})
 
 	provider := NewOpenAICompatibleProvider(config.OpenAICompatibleProviderConfig{
@@ -405,8 +423,11 @@ func TestOpenAIProviderFireworksDiscoveryUsesModelsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Capabilities() error = %v", err)
 	}
-	if calls != 1 {
-		t.Fatalf("discovery call count = %d, want 1", calls)
+	if calls != 2 {
+		t.Fatalf("discovery call count = %d, want 2", calls)
+	}
+	if len(pageTokens) != 2 || pageTokens[0] != "" || pageTokens[1] != "next-page" {
+		t.Fatalf("page tokens = %#v, want first page then next-page", pageTokens)
 	}
 	if len(caps.Models) != 2 || caps.Models[0] != "accounts/fireworks/models/deepseek-v3p1" {
 		t.Fatalf("models = %#v, want Fireworks model names", caps.Models)
@@ -417,6 +438,104 @@ func TestOpenAIProviderFireworksDiscoveryUsesModelsEndpoint(t *testing.T) {
 	capability := caps.ModelCapabilities["accounts/fireworks/models/deepseek-v3p1"]
 	if capability.ToolCalling != "basic" || capability.MaxContextTokens != 131072 {
 		t.Fatalf("model capability = %+v, want tools and context length", capability)
+	}
+}
+
+func TestOpenAIProviderLMStudioDiscoveryUsesNativeModelsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	transport := testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if r.Method != http.MethodGet {
+			return nil, fmt.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.String(); got != "http://127.0.0.1:1234/api/v1/models" {
+			return nil, fmt.Errorf("url = %s, want LM Studio native models endpoint", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"models": [
+					{
+						"key": "qwen/qwen3-4b",
+						"type": "llm",
+						"max_context_length": 32768,
+						"capabilities": {"trained_for_tool_use": true}
+					},
+					{"key": "text-embedding-nomic", "type": "embedding"}
+				]
+			}`)),
+		}, nil
+	})
+
+	provider := NewOpenAICompatibleProvider(config.OpenAICompatibleProviderConfig{
+		Name:    "lmstudio",
+		Kind:    "local",
+		BaseURL: "http://127.0.0.1:1234/v1",
+		Timeout: time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	provider.httpClient.Transport = transport
+
+	caps, err := provider.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("discovery call count = %d, want 1", calls)
+	}
+	if len(caps.Models) != 1 || caps.Models[0] != "qwen/qwen3-4b" {
+		t.Fatalf("models = %#v, want LM Studio LLM model keys", caps.Models)
+	}
+	if caps.DefaultModel != "qwen/qwen3-4b" {
+		t.Fatalf("default model = %q, want first discovered LM Studio model", caps.DefaultModel)
+	}
+	if caps.DiscoverySource != "lmstudio_api_models" {
+		t.Fatalf("discovery source = %q, want lmstudio_api_models", caps.DiscoverySource)
+	}
+	capability := caps.ModelCapabilities["qwen/qwen3-4b"]
+	if capability.ToolCalling != "basic" || capability.MaxContextTokens != 32768 || !capability.Streaming {
+		t.Fatalf("model capability = %+v, want native LM Studio tools/context/streaming", capability)
+	}
+}
+
+func TestOpenAIProviderLMStudioDiscoveryFallsBackToOpenAIModelsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	transport := testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v1/models":
+			return nil, fmt.Errorf("LM Studio native endpoint unavailable")
+		case "/v1/models":
+			return jsonHTTPResponse(openAIModelsResponse{Data: []openAIModel{{ID: "fallback-model"}}})
+		default:
+			return nil, fmt.Errorf("path = %s, want /api/v1/models or /v1/models", r.URL.Path)
+		}
+	})
+
+	provider := NewOpenAICompatibleProvider(config.OpenAICompatibleProviderConfig{
+		Name:    "LM Studio",
+		Kind:    "local",
+		BaseURL: "http://127.0.0.1:1234/v1",
+		Timeout: time.Second,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	provider.httpClient.Transport = transport
+
+	caps, err := provider.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if strings.Join(paths, ",") != "/api/v1/models,/v1/models" {
+		t.Fatalf("request paths = %#v, want native LM Studio then OpenAI fallback", paths)
+	}
+	if len(caps.Models) != 1 || caps.Models[0] != "fallback-model" {
+		t.Fatalf("models = %#v, want fallback OpenAI model list", caps.Models)
+	}
+	if caps.DiscoverySource != "upstream_v1_models" {
+		t.Fatalf("discovery source = %q, want upstream_v1_models fallback", caps.DiscoverySource)
 	}
 }
 

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -252,6 +252,9 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 		if builtIn, ok := builtInForControlPlaneProvider(item); ok {
 			cfg.ChatPath = builtIn.ChatPath
 			cfg.ModelsPath = builtIn.ModelsPath
+			if builtIn.ID == "fireworks" {
+				cfg.ModelsPath = config.FireworksModelsPath(item.AccountID)
+			}
 		}
 		if _, ok := byName[cfg.Name]; !ok {
 			order = append(order, cfg.Name)

--- a/internal/providers/runtime_manager_test.go
+++ b/internal/providers/runtime_manager_test.go
@@ -277,6 +277,42 @@ func TestControlPlaneRuntimeManagerHydratesPresetEndpointPaths(t *testing.T) {
 	}
 }
 
+func TestControlPlaneRuntimeManagerAppliesFireworksAccountID(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	store := controlplane.NewMemoryStore()
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	cipher, err := secrets.NewAESGCMCipher(key)
+	if err != nil {
+		t.Fatalf("NewAESGCMCipher() error = %v", err)
+	}
+
+	manager := NewControlPlaneRuntimeManager(logger, nil, store, cipher)
+	if _, err := manager.Upsert(context.Background(), controlplane.Provider{
+		ID:        "fireworks-ai",
+		Name:      "fireworks",
+		PresetID:  "fireworks",
+		AccountID: "team-alpha",
+		Enabled:   true,
+	}, "fw-secret"); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	registry := manager.Registry()
+	provider, ok := registry.Get("fireworks")
+	if !ok {
+		t.Fatal("expected fireworks provider in registry")
+	}
+	openaiProvider, ok := provider.(*OpenAICompatibleProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *OpenAICompatibleProvider", provider)
+	}
+	if openaiProvider.config.ModelsPath != config.FireworksModelsPath("team-alpha") {
+		t.Fatalf("models path = %q, want team account endpoint", openaiProvider.config.ModelsPath)
+	}
+}
+
 func TestControlPlaneRuntimeManagerPreservesExistingOverridesOnMinimalUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/ui/src/app/state/coordinators/providers.ts
+++ b/ui/src/app/state/coordinators/providers.ts
@@ -17,6 +17,7 @@ import { applyOverride, CoordinatorOverridesContext } from "./overrides";
 import {
   createProvider as createProviderRequest,
   deleteProvider as deleteProviderRequest,
+  setProviderAccountID as setProviderAccountIDRequest,
   setProviderAPIKey as setProviderAPIKeyRequest,
   setProviderBaseURL as setProviderBaseURLRequest,
   setProviderCustomName as setProviderCustomNameRequest,
@@ -68,6 +69,7 @@ export function useProviderActions(params: UseProviderActionsParams) {
     createParams: {
       name: string;
       preset_id?: string;
+      account_id?: string;
       custom_name?: string;
       base_url?: string;
       api_key?: string;
@@ -171,6 +173,12 @@ export function useProviderActions(params: UseProviderActionsParams) {
     await params.loadDashboard();
   }
 
+  async function setProviderAccountID(id: string, accountID: string): Promise<void> {
+    await setProviderAccountIDRequest(id, accountID);
+    await params.loadDashboard();
+    await params.refreshProviders();
+  }
+
   const overrides = useContext(CoordinatorOverridesContext);
   return applyOverride(
     {
@@ -180,6 +188,7 @@ export function useProviderActions(params: UseProviderActionsParams) {
       setProviderBaseURL,
       setProviderName,
       setProviderCustomName,
+      setProviderAccountID,
     },
     overrides?.providers,
   );

--- a/ui/src/features/providers/AddProviderModal.tsx
+++ b/ui/src/features/providers/AddProviderModal.tsx
@@ -20,6 +20,7 @@ type Props = {
 type AddFormState = {
   name: string;
   custom_name: string;
+  account_id: string;
   base_url: string;
   api_key: string;
   kind: string;
@@ -125,6 +126,7 @@ export function AddProviderModal({ open, onClose }: Props) {
         name: form.name.trim(),
         preset_id: preset?.id,
         custom_name: form.custom_name.trim() || undefined,
+        account_id: form.account_id.trim() || undefined,
         base_url: form.base_url.trim() || undefined,
         api_key: form.api_key.trim() || undefined,
         kind: form.kind,
@@ -144,6 +146,7 @@ export function AddProviderModal({ open, onClose }: Props) {
     setForm({
       name: nextPreset.name,
       custom_name: "",
+      account_id: nextPreset.id === "fireworks" ? "fireworks" : "",
       base_url: discovery?.base_url || nextPreset.base_url,
       api_key: "",
       kind: nextPreset.kind,
@@ -382,6 +385,25 @@ export function AddProviderModal({ open, onClose }: Props) {
             . Choose another provider entry or remove the existing one first.
           </div>
         )}
+        {preset?.id === "fireworks" && (
+          <div>
+            <label className="kicker-lg" style={{ display: "block", marginBottom: 6 }}>
+              Fireworks account ID
+            </label>
+            <input
+              className="input"
+              type="text"
+              value={form.account_id}
+              onChange={(e) => setForm((f) => ({ ...f, account_id: e.target.value }))}
+              placeholder="fireworks"
+              style={{ fontFamily: "var(--font-mono)" }}
+            />
+            <div style={{ marginTop: 6, fontSize: 11, color: "var(--t3)", lineHeight: 1.4 }}>
+              Keep <span style={{ fontFamily: "var(--font-mono)" }}>fireworks</span> for the public
+              catalog, or use your Fireworks account ID for private and fine-tuned models.
+            </div>
+          </div>
+        )}
         {showAPIKey && (
           <div>
             <label className="kicker-lg" style={{ display: "block", marginBottom: 6 }}>
@@ -431,7 +453,15 @@ export function AddProviderModal({ open, onClose }: Props) {
 }
 
 function emptyAddForm(kind: "cloud" | "local"): AddFormState {
-  return { name: "Custom", custom_name: "", base_url: "", api_key: "", kind, protocol: "openai" };
+  return {
+    name: "Custom",
+    custom_name: "",
+    account_id: "",
+    base_url: "",
+    api_key: "",
+    kind,
+    protocol: "openai",
+  };
 }
 
 function providerSlug(name: string): string {

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -608,6 +608,113 @@ describe("ProvidersView table renders", () => {
     expect(within(row!).getByText("1")).toBeTruthy();
   });
 
+  it("uses canonical names and runtime model counts for stored provider aliases", () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [
+          makeConfigured("fireworks-ai", {
+            name: "fireworks",
+            kind: "cloud",
+            credential_configured: true,
+            base_url: "https://api.fireworks.ai/inference/v1",
+          }),
+          makeConfigured("local-lmstudio", {
+            name: "lmstudio",
+            kind: "local",
+            base_url: "http://127.0.0.1:1234/v1",
+          }),
+        ],
+      },
+      providers: [
+        makeStatus("fireworks", {
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          credential_state: "configured",
+          models: ["accounts/fireworks/models/deepseek-v3"],
+          model_count: 50,
+        }),
+        makeStatus("lmstudio", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          credential_state: "not_required",
+          models: ["qwen2.5-coder"],
+          model_count: 1,
+        }),
+      ],
+    });
+
+    render(
+      withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    const fireworksRow = screen.getByText("Fireworks AI").closest("tr");
+    const lmStudioRow = screen.getByText("LM Studio").closest("tr");
+    expect(fireworksRow).toBeTruthy();
+    expect(lmStudioRow).toBeTruthy();
+    expect(within(fireworksRow!).queryByText("fireworks")).toBeNull();
+    expect(within(fireworksRow!).getByText("50")).toBeTruthy();
+    expect(within(lmStudioRow!).queryByText("lmstudio")).toBeNull();
+    expect(within(lmStudioRow!).getByText("1")).toBeTruthy();
+  });
+
+  it("edits Fireworks account IDs and displays short model names", async () => {
+    const setProviderAccountID = vi.fn(async () => undefined);
+    const actions = { ...createRuntimeConsoleActions(), setProviderAccountID };
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [
+          makeConfigured("fireworks-ai", {
+            name: "fireworks",
+            kind: "cloud",
+            credential_configured: true,
+            account_id: "team-alpha",
+            base_url: "",
+          }),
+        ],
+      },
+      providers: [
+        makeStatus("fireworks", {
+          kind: "cloud",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          credential_state: "configured",
+          models: ["accounts/team-alpha/models/deepseek-v3"],
+          model_count: 1,
+        }),
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
+
+    await user.click(screen.getByText("Fireworks AI"));
+
+    expect(screen.getByRole("dialog", { name: "Fireworks AI · cloud" })).toBeTruthy();
+    const accountInput = screen.getByLabelText("Fireworks account ID");
+    expect(accountInput).toHaveValue("team-alpha");
+    expect(screen.getByText("deepseek-v3")).toBeTruthy();
+    expect(screen.queryByText("accounts/team-alpha/models/deepseek-v3")).toBeNull();
+
+    await user.clear(accountInput);
+    await user.type(accountInput, "team-beta");
+    await user.click(screen.getByRole("button", { name: "Save account ID" }));
+
+    await waitFor(() => {
+      expect(setProviderAccountID).toHaveBeenCalledWith("fireworks-ai", "team-beta");
+    });
+  });
+
   it("surfaces readiness repair buttons from the summary card", async () => {
     const state = createRuntimeConsoleFixture({
       session: localSession,

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -18,7 +18,11 @@ import {
   resolvedBaseURL,
   runtimeProviderForConfigured,
 } from "../../lib/provider-utils";
-import { describeHealthErrorClass, describeRoutingBlockedReason } from "../../lib/runtime-utils";
+import {
+  describeHealthErrorClass,
+  describeRoutingBlockedReason,
+  modelDisplayName,
+} from "../../lib/runtime-utils";
 import { ProviderReadinessChecklist, ProviderReadinessSummary } from "../shared/ProviderReadiness";
 import { Badge, BrandAvatar, ConfirmModal, Icon, Icons, Modal } from "../shared/ui";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
@@ -86,6 +90,7 @@ export function ProvidersView() {
   const [pendingURL, setPendingURL] = useState("");
   const [pendingName, setPendingName] = useState("");
   const [pendingCustomName, setPendingCustomName] = useState("");
+  const [pendingAccountID, setPendingAccountID] = useState("");
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [deleteConfirmID, setDeleteConfirmID] = useState<string | null>(null);
 
@@ -119,10 +124,14 @@ export function ProvidersView() {
       setPendingURL(resolvedBaseURL(selectedID, selectedConfig ?? undefined, providerPresets));
       setPendingName(selectedConfig.name || selectedID);
       setPendingCustomName(selectedConfig.custom_name ?? "");
+      setPendingAccountID(
+        selectedConfig.account_id || (isFireworksProvider(selectedConfig) ? "fireworks" : ""),
+      );
     } else {
       setPendingURL("");
       setPendingName("");
       setPendingCustomName("");
+      setPendingAccountID("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedID]);
@@ -207,8 +216,9 @@ export function ProvidersView() {
 
   const selectedConfig = selectedID ? (configuredByID.get(selectedID) ?? null) : null;
   const selectedStatus = selectedID ? (runtimeStatusForID(selectedID) ?? null) : null;
+  const selectedRouteKey = configuredProviderRouteKey(selectedConfig) || selectedID || "";
   const selectedDisplayName = selectedID
-    ? providerDisplayName(selectedID, configuredProviders, providerPresets, providers)
+    ? providerDisplayName(selectedRouteKey, configuredProviders, providerPresets, providers)
     : "";
   const deleteConfirmName = deleteConfirmID
     ? providerDisplayName(deleteConfirmID, configuredProviders, providerPresets, providers)
@@ -603,7 +613,7 @@ export function ProvidersView() {
           <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
             {/* Header strip: brand initial + base URL */}
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-              <BrandAvatar brand={selectedID} fallback={selectedDisplayName} size={32} />
+              <BrandAvatar brand={selectedRouteKey} fallback={selectedDisplayName} size={32} />
               {selectedConfig.base_url && (
                 <span
                   style={{
@@ -746,6 +756,45 @@ export function ProvidersView() {
                 <Icon d={Icons.check} size={13} /> Save custom name
               </button>
             </div>
+
+            {isFireworksProvider(selectedConfig) && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <label className="kicker-lg">Fireworks account ID</label>
+                <input
+                  className="input"
+                  type="text"
+                  value={pendingAccountID}
+                  onChange={(e) => setPendingAccountID(e.target.value)}
+                  aria-label="Fireworks account ID"
+                  placeholder="fireworks"
+                  style={{ fontFamily: "var(--font-mono)" }}
+                />
+                <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
+                  Used for model discovery. Keep{" "}
+                  <span style={{ fontFamily: "var(--font-mono)", color: "var(--t2)" }}>
+                    fireworks
+                  </span>{" "}
+                  for the public catalog, or enter your Fireworks account ID for private and
+                  fine-tuned models.
+                </div>
+                <button
+                  className="btn btn-primary btn-sm"
+                  style={{ alignSelf: "flex-start" }}
+                  disabled={
+                    (pendingAccountID.trim() || "fireworks") ===
+                    (selectedConfig.account_id || "fireworks")
+                  }
+                  onClick={() =>
+                    void providerActions.setProviderAccountID(
+                      selectedID,
+                      pendingAccountID.trim() || "fireworks",
+                    )
+                  }
+                >
+                  <Icon d={Icons.check} size={13} /> Save account ID
+                </button>
+              </div>
+            )}
 
             {/* Editable: API key (cloud) or Endpoint URL (local) */}
             {selectedConfig.kind === "local" ? (
@@ -943,33 +992,41 @@ export function ProvidersView() {
                     padding: "0 10px",
                   }}
                 >
-                  {selectedStatus.models.map((m) => (
-                    <div
-                      key={m}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        padding: "5px 0",
-                        borderBottom: "1px solid var(--border)",
-                      }}
-                    >
-                      <span
+                  {selectedStatus.models.map((m) => {
+                    const displayModel = modelDisplayName(m);
+                    return (
+                      <div
+                        key={m}
+                        title={displayModel === m ? undefined : m}
                         style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: 12,
-                          color: "var(--t0)",
-                          flex: 1,
+                          display: "flex",
+                          alignItems: "center",
+                          padding: "5px 0",
+                          borderBottom: "1px solid var(--border)",
                         }}
                       >
-                        {m}
-                      </span>
-                      {m === selectedConfig.default_model && (
-                        <span className="badge badge-teal" style={{ fontSize: 9 }}>
-                          default
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 12,
+                            color: "var(--t0)",
+                            flex: 1,
+                            minWidth: 0,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {displayModel}
                         </span>
-                      )}
-                    </div>
-                  ))}
+                        {m === selectedConfig.default_model && (
+                          <span className="badge badge-teal" style={{ fontSize: 9 }}>
+                            default
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               </details>
             )}
@@ -1101,6 +1158,13 @@ function isProviderNeedsAttention(
   if (status?.routing_blocked_reason) return true;
   if (status?.status === "open" || status?.status === "unhealthy") return true;
   return false;
+}
+
+function isFireworksProvider(provider: ConfiguredProviderRecord | null | undefined): boolean {
+  if (!provider) return false;
+  return [provider.preset_id, provider.name, provider.id].some(
+    (value) => value?.trim().toLowerCase() === "fireworks",
+  );
 }
 
 function resolveNextReadinessStep(

--- a/ui/src/features/shared/ModelPicker.tsx
+++ b/ui/src/features/shared/ModelPicker.tsx
@@ -15,6 +15,8 @@
 import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 
+import { providerDisplayName } from "../../lib/provider-utils";
+import { modelDisplayName } from "../../lib/runtime-utils";
 import type { ModelRecord } from "../../types/model";
 import type { ProviderPresetRecord } from "../../types/provider";
 import { Icon, Icons } from "./Icons";
@@ -103,9 +105,15 @@ export function ModelPicker({
     if (open) setTimeout(() => inputRef.current?.focus(), 0);
   }, [open]);
 
-  const providerName = (id: string) => presets?.find((p) => p.id === id)?.name || id;
+  const providerName = (id: string) => providerDisplayName(id, [], presets);
   const matchedFilter = filter
-    ? models.filter((m) => m.id.toLowerCase().includes(filter.toLowerCase()))
+    ? models.filter((m) => {
+        const needle = filter.toLowerCase();
+        return (
+          m.id.toLowerCase().includes(needle) ||
+          modelDisplayName(m.id).toLowerCase().includes(needle)
+        );
+      })
     : models;
   // Sort usable models above disabled ones — within each bucket the
   // source order is preserved (provider-grouped, alphabetical-ish).
@@ -135,7 +143,9 @@ export function ModelPicker({
       ? allLabel
       : isEmpty
         ? "no models available"
-        : value || "Pick a model";
+        : value
+          ? modelDisplayName(value)
+          : "Pick a model";
   const buttonWidth = triggerWidth === undefined ? undefined : triggerWidth;
   const disabledTitle = isEmpty
     ? "No discovered models for this provider. Configure credentials or start the local runtime."
@@ -337,11 +347,13 @@ export function ModelPicker({
               const reason = provider ? disabledProviders?.get(provider) : undefined;
               const disabled = !!reason;
               const warning = !disabled ? modelWarnings?.get(m.id) : undefined;
+              const displayName = modelDisplayName(m.id);
+              const idTitle = displayName === m.id ? undefined : m.id;
               // Title combines warning (if any) with the disabled
               // reason. We skip the warning when the row is already
               // disabled — the disabled tooltip is the more
               // important signal.
-              const rowTitle = disabled ? reason : warning;
+              const rowTitle = [disabled ? reason : warning, idTitle].filter(Boolean).join("\n");
               return (
                 <button
                   key={m.id}
@@ -352,7 +364,7 @@ export function ModelPicker({
                   aria-disabled={disabled || undefined}
                   aria-selected={m.id === value}
                   role="option"
-                  title={rowTitle}
+                  title={rowTitle || undefined}
                   style={disabled ? { cursor: "not-allowed" } : undefined}
                   onClick={() => selectModel(m)}
                 >
@@ -370,7 +382,7 @@ export function ModelPicker({
                       opacity: disabled ? 0.5 : 1,
                     }}
                   >
-                    {m.id}
+                    {displayName}
                   </span>
                   {showProvider && provider && (
                     <span

--- a/ui/src/features/shared/ui.test.tsx
+++ b/ui/src/features/shared/ui.test.tsx
@@ -447,6 +447,42 @@ describe("ModelPicker", () => {
     expect(document.querySelector(".dropdown-menu")).toBeNull();
   });
 
+  it("shows account-scoped models as short names while selecting the full id", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const fireworksModels: ModelRecord[] = [
+      {
+        id: "accounts/fireworks/models/deepseek-v3p1",
+        owned_by: "fireworks",
+        metadata: { provider: "fireworks", provider_kind: "cloud", default: true },
+      },
+      {
+        id: "accounts/fireworks/models/llama-v3p1",
+        owned_by: "fireworks",
+        metadata: { provider: "fireworks", provider_kind: "cloud", default: false },
+      },
+    ];
+    render(
+      <ModelPicker
+        value="accounts/fireworks/models/deepseek-v3p1"
+        onChange={onChange}
+        models={fireworksModels}
+      />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("deepseek-v3p1");
+    await user.click(screen.getByRole("button"));
+
+    const input = screen.getByRole("textbox", { name: /filter models/i });
+    await user.type(input, "llama");
+    const menu = document.querySelector(".dropdown-menu") as HTMLElement;
+    expect(within(menu).getByText("llama-v3p1")).toBeTruthy();
+    expect(within(menu).getAllByText("Fireworks AI").length).toBeGreaterThan(0);
+
+    await user.click(within(menu).getByText("llama-v3p1"));
+    expect(onChange).toHaveBeenCalledWith("accounts/fireworks/models/llama-v3p1");
+  });
+
   it("supports filtering, arrow-key navigation, and Enter selection", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1222,7 +1222,7 @@ export async function deletePolicyRule(id: string): Promise<unknown> {
 // Credentials live behind PUT /providers/{id}/api-key, not here.
 export async function updateProvider(
   id: string,
-  patch: { base_url?: string; name?: string; custom_name?: string },
+  patch: { base_url?: string; name?: string; custom_name?: string; account_id?: string },
 ): Promise<unknown> {
   return fetchJSON(`${HECATE_API}/settings/providers/${encodeURIComponent(id)}`, {
     method: "PATCH",
@@ -1241,6 +1241,7 @@ export async function setProviderAPIKey(id: string, key: string): Promise<unknow
 export async function createProvider(params: {
   name: string;
   preset_id?: string;
+  account_id?: string;
   custom_name?: string;
   base_url?: string;
   api_key?: string;
@@ -1274,6 +1275,10 @@ export async function setProviderName(id: string, name: string): Promise<unknown
 // clears it. Allowed for any provider, including presets.
 export async function setProviderCustomName(id: string, customName: string): Promise<unknown> {
   return updateProvider(id, { custom_name: customName });
+}
+
+export async function setProviderAccountID(id: string, accountID: string): Promise<unknown> {
+  return updateProvider(id, { account_id: accountID });
 }
 
 // createProvider params include the optional custom_name disambiguator.

--- a/ui/src/lib/provider-utils.test.ts
+++ b/ui/src/lib/provider-utils.test.ts
@@ -8,7 +8,11 @@ import {
   resolvedBaseURL,
   runtimeProviderForConfigured,
 } from "./provider-utils";
-import type { ConfiguredProviderRecord, ProviderPresetRecord } from "../types/provider";
+import type {
+  ConfiguredProviderRecord,
+  ProviderPresetRecord,
+  ProviderRecord,
+} from "../types/provider";
 
 const presets: ProviderPresetRecord[] = [
   {
@@ -138,6 +142,22 @@ describe("providerDisplayName", () => {
 
     expect(providerDisplayName("fireworks-ai", configured, presets)).toBe("Fireworks AI");
     expect(providerDisplayName("fireworks", configured, presets)).toBe("Fireworks AI");
+  });
+
+  it("resolves canonical display names from stored provider names without preset ids", () => {
+    const configured = [
+      { ...makeCP("fireworks-ai"), name: "fireworks" },
+      { ...makeCP("local-lmstudio"), name: "lmstudio", kind: "local" },
+    ];
+    const runtime: ProviderRecord[] = [
+      { name: "fireworks", kind: "cloud", healthy: true, status: "healthy" },
+      { name: "lmstudio", kind: "local", healthy: true, status: "healthy" },
+    ];
+
+    expect(providerDisplayName("fireworks-ai", configured, [], runtime)).toBe("Fireworks AI");
+    expect(providerDisplayName("fireworks", configured, [], runtime)).toBe("Fireworks AI");
+    expect(providerDisplayName("local-lmstudio", configured, [], runtime)).toBe("LM Studio");
+    expect(providerDisplayName("lmstudio", configured, [], runtime)).toBe("LM Studio");
   });
 });
 

--- a/ui/src/lib/provider-utils.ts
+++ b/ui/src/lib/provider-utils.ts
@@ -84,6 +84,18 @@ export function normalizeProviderKey(value: string | null | undefined): string {
   return (value ?? "").trim().toLowerCase();
 }
 
+function canonicalProviderDisplayName(
+  key: string | null | undefined,
+  presets: ProviderPresetRecord[] = [],
+): string | undefined {
+  const normalized = normalizeProviderKey(key);
+  if (!normalized) return undefined;
+  return (
+    presets.find((preset) => normalizeProviderKey(preset.id) === normalized)?.name ||
+    PROVIDER_DISPLAY_NAMES[normalized]
+  );
+}
+
 export function configuredProviderAliases(
   provider: Pick<ConfiguredProviderRecord, "id" | "name" | "preset_id"> | null | undefined,
 ): string[] {
@@ -177,12 +189,13 @@ export function providerDisplayName(
   runtimeProviders: ProviderRecord[] = [],
 ): string {
   const configured = configuredProviderForKey(providerID, configuredProviders);
-  const presetID = configured?.preset_id || providerID;
-  const canonicalID = presetID.toLowerCase();
   const runtimeProvider = runtimeProviderForKey(providerID, runtimeProviders, configuredProviders);
   return (
-    presets.find((preset) => preset.id === presetID)?.name ||
-    PROVIDER_DISPLAY_NAMES[canonicalID] ||
+    canonicalProviderDisplayName(configured?.preset_id, presets) ||
+    canonicalProviderDisplayName(providerID, presets) ||
+    canonicalProviderDisplayName(configured?.name, presets) ||
+    canonicalProviderDisplayName(configured?.id, presets) ||
+    canonicalProviderDisplayName(runtimeProvider?.name, presets) ||
     runtimeProvider?.name ||
     configured?.name ||
     providerID

--- a/ui/src/lib/runtime-utils.test.ts
+++ b/ui/src/lib/runtime-utils.test.ts
@@ -21,6 +21,7 @@ import {
   findProvider,
   healthStatusTone,
   isRemoteRuntimeSession,
+  modelDisplayName,
   parseCSV,
   providerStatusTone,
   routeOutcomeTone,
@@ -105,6 +106,36 @@ describe("runtime-utils", () => {
     expect(filterModelsByProvider([fireworksModel], "fireworks-ai", configuredProviders)).toEqual([
       fireworksModel,
     ]);
+  });
+
+  it("filters models through stored provider names without preset ids", () => {
+    const configuredProviders: ConfiguredProviderRecord[] = [
+      {
+        id: "fireworks-ai",
+        name: "fireworks",
+        kind: "cloud",
+        protocol: "openai",
+        base_url: "https://api.fireworks.ai/inference/v1",
+        credential_configured: true,
+      },
+    ];
+    const fireworksModel: ModelRecord = {
+      id: "accounts/fireworks/models/deepseek-v3",
+      owned_by: "fireworks",
+      metadata: { provider: "fireworks", provider_kind: "cloud" },
+    };
+
+    expect(filterModelsByProvider([fireworksModel], "fireworks-ai", configuredProviders)).toEqual([
+      fireworksModel,
+    ]);
+    expect(filterModelsByProvider([fireworksModel], "fireworks", configuredProviders)).toEqual([
+      fireworksModel,
+    ]);
+  });
+
+  it("renders account-scoped model ids as short model names", () => {
+    expect(modelDisplayName("accounts/fireworks/models/deepseek-v3p1")).toBe("deepseek-v3p1");
+    expect(modelDisplayName("gpt-4o-mini")).toBe("gpt-4o-mini");
   });
 
   it("detects remote runtime sessions from cloud identity", () => {

--- a/ui/src/lib/runtime-utils.ts
+++ b/ui/src/lib/runtime-utils.ts
@@ -45,6 +45,12 @@ export function filterModelsByProvider(
   });
 }
 
+export function modelDisplayName(model: Pick<ModelRecord, "id"> | string): string {
+  const id = typeof model === "string" ? model : model.id;
+  const accountScoped = /^accounts\/[^/]+\/models\/(.+)$/.exec(id);
+  return accountScoped?.[1] || id;
+}
+
 export function isRemoteRuntimeSession(sessionInfo: SessionInfo): boolean {
   return Boolean(sessionInfo?.remote_identity);
 }

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -243,6 +243,7 @@ export type RuntimeConsoleFixtureActions = {
   setProviderBaseURL: (id: string, baseURL: string) => Promise<void>;
   setProviderName: (id: string, name: string) => Promise<void>;
   setProviderCustomName: (id: string, customName: string) => Promise<void>;
+  setProviderAccountID: (id: string, accountID: string) => Promise<void>;
   setActiveProjectID: (id: string) => void;
   loadProjects: () => Promise<void>;
   selectProject: (id: string) => Promise<void>;
@@ -319,6 +320,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setProviderBaseURL: async () => undefined,
     setProviderName: async () => undefined,
     setProviderCustomName: async () => undefined,
+    setProviderAccountID: async () => undefined,
     setActiveProjectID: () => undefined,
     loadProjects: async () => undefined,
     selectProject: async () => undefined,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -238,6 +238,7 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
       setProviderBaseURL: actions.setProviderBaseURL,
       setProviderName: actions.setProviderName,
       setProviderCustomName: actions.setProviderCustomName,
+      setProviderAccountID: actions.setProviderAccountID,
     },
     policy: {
       upsertPolicyRule: actions.upsertPolicyRule,

--- a/ui/src/test/runtime-console-test-composer.ts
+++ b/ui/src/test/runtime-console-test-composer.ts
@@ -584,6 +584,7 @@ export function useRuntimeConsole() {
       setProviderBaseURL: providerActions.setProviderBaseURL,
       setProviderName: providerActions.setProviderName,
       setProviderCustomName: providerActions.setProviderCustomName,
+      setProviderAccountID: providerActions.setProviderAccountID,
       getChatApproval: chatActions.getChatApproval,
       listChatMessageFiles: chatActions.listChatMessageFiles,
       getChatWorkspaceDiff: chatActions.getChatWorkspaceDiff,

--- a/ui/src/types/provider.ts
+++ b/ui/src/types/provider.ts
@@ -93,6 +93,7 @@ export type ConfiguredProviderRecord = {
   id: string;
   name: string;
   preset_id?: string;
+  account_id?: string;
   // custom_name is an optional operator-supplied disambiguator that
   // appears alongside name in the providers table. Used to tell two
   // instances of the same preset apart ("Anthropic" + "Prod" vs


### PR DESCRIPTION
## Summary
- show canonical provider names for configured preset aliases such as Fireworks AI and LM Studio
- add Fireworks account ID support and paginated model discovery while displaying short model names in pickers
- use LM Studio native model discovery before OpenAI-compatible fallback

## Tests
- go test ./internal/config ./internal/providerapp ./internal/providers ./internal/api
- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/providers/ProvidersView.test.tsx src/features/shared/ui.test.tsx src/lib/runtime-utils.test.ts src/lib/provider-utils.test.ts