### PR TITLE
Streamline Projects onboarding setup

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -23,6 +23,8 @@ register local skills, or launch work against files.
 Setup is reviewable. Hecate may propose roles or memory candidates, but the
 operator applies or dismisses them. Setup does not launch agents, write project
 memory automatically, install skills, or inject skill bodies into prompts.
+Use the onboarding checklist for missing settings or first-work creation; use
+the primary **Set up project** action for discovery and role/memory suggestions.
 
 ## Work Flow
 

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -102,15 +102,21 @@ describe("ProjectAssistantPanel", () => {
       name: "Project Assistant apply result",
     });
     expect(within(result).getByText("Applied 2 actions")).toBeTruthy();
+    expect(within(result).getByText("Next up")).toBeTruthy();
+    expect(
+      within(result).getByText("review memory, review roles, then create first work"),
+    ).toBeTruthy();
     expect(within(assistant).queryByRole("button", { name: "Set up project" })).toBeNull();
 
     await user.click(within(result).getByRole("button", { name: "Review memory" }));
     await user.click(within(result).getByRole("button", { name: "Review roles" }));
     await user.click(within(result).getByRole("button", { name: "Create first work" }));
+    await user.click(within(result).getByRole("button", { name: "Continue setup" }));
 
     expect(handlers.onReviewMemory).toHaveBeenCalledTimes(1);
     expect(handlers.onManageRoles).toHaveBeenCalledTimes(1);
     expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
+    expect(handlers.onOpenWork).toHaveBeenCalledTimes(1);
   });
 
   it("routes applied work proposals back to the work queue", async () => {
@@ -127,6 +133,8 @@ describe("ProjectAssistantPanel", () => {
 
     const result = screen.getByRole("status", { name: "Project Assistant apply result" });
     expect(within(result).queryByRole("button", { name: "Create first work" })).toBeNull();
+    expect(within(result).getByText("Next up")).toBeTruthy();
+    expect(within(result).getAllByText("Open work queue")).toHaveLength(2);
 
     await user.click(within(result).getByRole("button", { name: "Open work queue" }));
 

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -408,6 +408,7 @@ export function ProjectAssistantPanel({
           onOpenWork={onOpenWork}
           onReviewMemory={onReviewMemory}
           roleCount={roleCount}
+          setupFirst={setupFirst}
           workItemCount={workItemCount}
         />
       )}
@@ -423,6 +424,7 @@ function ProjectAssistantApplyResultPanel({
   onReviewMemory,
   result,
   roleCount,
+  setupFirst,
   workItemCount,
 }: {
   memoryCandidateCount: number;
@@ -432,6 +434,7 @@ function ProjectAssistantApplyResultPanel({
   onReviewMemory?: () => void;
   result: ProjectAssistantApplyResult;
   roleCount: number;
+  setupFirst: boolean;
   workItemCount: number;
 }) {
   const resultActions = projectAssistantFollowUpActions({
@@ -442,8 +445,10 @@ function ProjectAssistantApplyResultPanel({
     onReviewMemory,
     result,
     roleCount,
+    setupFirst,
     workItemCount,
   });
+  const resultSummaryActions = resultActions.filter((action) => action.includeInSummary !== false);
 
   return (
     <div style={assistantResultStyle} role="status" aria-label="Project Assistant apply result">
@@ -457,18 +462,28 @@ function ProjectAssistantApplyResultPanel({
         </div>
       </div>
       {resultActions.length > 0 && (
-        <div style={assistantResultActionsStyle} aria-label="Project Assistant next steps">
-          {resultActions.map((action) => (
-            <button
-              key={action.key}
-              className={`btn ${action.primary ? "btn-primary" : "btn-ghost"} btn-sm`}
-              type="button"
-              onClick={action.onClick}
-            >
-              <Icon d={action.icon} size={13} />
-              {action.label}
-            </button>
-          ))}
+        <div style={assistantResultNextStyle} aria-label="Project Assistant next steps">
+          <div style={assistantResultNextCopyStyle}>
+            <div style={sectionLabelStyle}>Next up</div>
+            <div style={subtleTextStyle}>
+              {resultSummaryActions.length > 0
+                ? projectAssistantNextUpSummary(resultSummaryActions)
+                : "Continue setup"}
+            </div>
+          </div>
+          <div style={assistantResultActionsStyle}>
+            {resultActions.map((action) => (
+              <button
+                key={action.key}
+                className={`btn ${action.primary ? "btn-primary" : "btn-ghost"} btn-sm`}
+                type="button"
+                onClick={action.onClick}
+              >
+                <Icon d={action.icon} size={13} />
+                {action.label}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>
@@ -720,6 +735,7 @@ function projectAssistantFollowUpActions({
   onReviewMemory,
   result,
   roleCount,
+  setupFirst,
   workItemCount,
 }: {
   memoryCandidateCount: number;
@@ -729,9 +745,11 @@ function projectAssistantFollowUpActions({
   onReviewMemory?: () => void;
   result: ProjectAssistantApplyResult;
   roleCount: number;
+  setupFirst: boolean;
   workItemCount: number;
 }): Array<{
   icon: string | string[];
+  includeInSummary?: boolean;
   key: string;
   label: string;
   onClick: () => void;
@@ -740,6 +758,7 @@ function projectAssistantFollowUpActions({
   const appliedKinds = new Set(result.actions.map((action) => action.kind));
   const actions: Array<{
     icon: string | string[];
+    includeInSummary?: boolean;
     key: string;
     label: string;
     onClick: () => void;
@@ -779,8 +798,24 @@ function projectAssistantFollowUpActions({
       primary: actions.length === 0,
     });
   }
+  if (setupFirst && onOpenWork) {
+    actions.push({
+      icon: Icons.tasks,
+      includeInSummary: false,
+      key: "continue-setup",
+      label: "Continue setup",
+      onClick: onOpenWork,
+    });
+  }
 
   return actions;
+}
+
+function projectAssistantNextUpSummary(actions: Array<{ label: string }>) {
+  if (actions.length === 1) return actions[0].label;
+  const labels = actions.map((action) => action.label.toLowerCase());
+  const last = labels.pop();
+  return `${labels.join(", ")}, then ${last}`;
 }
 
 function projectAssistantSetupSummary({
@@ -1153,6 +1188,19 @@ const assistantResultActionsStyle: CSSProperties = {
   gap: 8,
   justifyContent: "flex-start",
   minWidth: 0,
+};
+
+const assistantResultNextStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  display: "grid",
+  gap: 8,
+  marginTop: 10,
+  paddingTop: 10,
+};
+
+const assistantResultNextCopyStyle: CSSProperties = {
+  display: "grid",
+  gap: 3,
 };
 
 const domainHeaderStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -334,16 +334,16 @@ describe("ProjectWorkspaceView", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Add purpose" }));
     await userEvent.click(screen.getByRole("button", { name: "Set defaults" }));
-    await userEvent.click(screen.getByRole("button", { name: "Review setup" }));
-    await userEvent.click(screen.getByRole("button", { name: "Set up" }));
+    expect(screen.queryByRole("button", { name: "Review setup" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Set up" })).toBeNull();
     const firstWorkCheck = screen.getByRole("group", { name: "First work item" });
     await userEvent.click(within(firstWorkCheck).getByRole("button", { name: "Create work" }));
     await userEvent.click(screen.getByRole("button", { name: "Set up project" }));
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 
-    expect(assistantState.bootstrap).toHaveBeenCalledTimes(2);
+    expect(assistantState.bootstrap).toHaveBeenCalledTimes(1);
     expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
-    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(4);
+    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(3);
   });
 
   it("renders workspace tabs and delegates tab changes", async () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -607,7 +607,6 @@ function ProjectOnboardingPanel({
   const hasPurpose = Boolean(project.description?.trim());
   const hasDefaults = Boolean(project.default_provider && project.default_model);
   const hasGuidance = contextSourceCount > 0 || skillCount > 0;
-  const bootstrapActionLabel = bootstrapPending ? "Setting up..." : "Set up";
   const checks: ProjectOnboardingCheck[] = [
     {
       label: "Project purpose",
@@ -636,20 +635,15 @@ function ProjectOnboardingPanel({
       detail: hasGuidance
         ? `${contextSourceCount} sources · ${skillCount} skills`
         : hasRoot
-          ? "Setup can discover workspace guidance and local skills."
-          : "Add sources manually, or attach a workspace when files matter.",
+          ? "Set up project can discover workspace guidance and local skills."
+          : "Attach a workspace when files matter, or add sources later.",
       done: hasGuidance,
-      actionLabel: hasRoot ? "Discover" : "Review setup",
-      action: hasRoot ? onBootstrap : onOpenSettings,
-      actionDisabled: bootstrapPending,
     },
     {
       label: "Roles",
-      detail: roleCount > 0 ? `${roleCount} roles` : "Setup can suggest roles from skills.",
+      detail:
+        roleCount > 0 ? `${roleCount} roles` : "Set up project can suggest roles from skills.",
       done: roleCount > 0,
-      actionLabel: bootstrapActionLabel,
-      action: onBootstrap,
-      actionDisabled: bootstrapPending,
     },
     {
       label: "First work item",
@@ -679,10 +673,6 @@ function ProjectOnboardingPanel({
           >
             <Icon d={Icons.refresh} size={13} />
             {bootstrapPending ? "Setting up..." : "Set up project"}
-          </button>
-          <button className="btn btn-ghost btn-sm" type="button" onClick={onCreateWork}>
-            <Icon d={Icons.plus} size={13} />
-            Create work
           </button>
           <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenSettings}>
             <Icon d={Icons.settings} size={13} />


### PR DESCRIPTION
## Summary
- make Project onboarding use one primary Set up project automation path
- keep checklist row actions focused on concrete fixes and first-work creation
- add a Next up section after Project Assistant apply results so setup follow-through is explicit
- update operator docs and Projects tests

## Verification
- bun run test -- src/features/projects/ProjectAssistantPanel.test.tsx src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test:e2e -- e2e/projects.spec.ts
- just agent-docs-check
- git diff --check