### PR TITLE
Prefill first Projects work from setup

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -25,6 +25,8 @@ operator applies or dismisses them. Setup does not launch agents, write project
 memory automatically, install skills, or inject skill bodies into prompts.
 Use the onboarding checklist for missing settings or first-work creation; use
 the primary **Set up project** action for discovery and role/memory suggestions.
+When setup context exists and the project has no work items yet, first-work
+creation opens with a draft title, brief, and owner role for operator review.
 
 ## Work Flow
 

--- a/ui/src/features/projects/ProjectWorkItemModals.tsx
+++ b/ui/src/features/projects/ProjectWorkItemModals.tsx
@@ -19,6 +19,7 @@ import { projectWorkFieldLabelStyle, projectWorkFieldStyle } from "./projectWork
 
 type NewWorkItemModalProps = {
   error: string;
+  initialDraft?: Partial<NewWorkItemForm>;
   pending: boolean;
   project: ProjectRecord;
   roles: ProjectWorkRoleRecord[];
@@ -28,19 +29,24 @@ type NewWorkItemModalProps = {
 
 export function NewWorkItemModal({
   error,
+  initialDraft,
   pending,
   project,
   roles,
   onClose,
   onCreate,
 }: NewWorkItemModalProps) {
-  const [form, setForm] = useState<NewWorkItemForm>({
-    title: "",
-    brief: "",
-    priority: "normal",
-    ownerRoleID: roles.find((role) => role.id === "software_developer")?.id ?? roles[0]?.id ?? "",
-    rootID: "",
-  });
+  const [form, setForm] = useState<NewWorkItemForm>(() => ({
+    title: initialDraft?.title ?? "",
+    brief: initialDraft?.brief ?? "",
+    priority: initialDraft?.priority ?? "normal",
+    ownerRoleID:
+      initialDraft?.ownerRoleID ??
+      roles.find((role) => role.id === "software_developer")?.id ??
+      roles[0]?.id ??
+      "",
+    rootID: initialDraft?.rootID ?? "",
+  }));
   const valid = form.title.trim().length > 0;
   return (
     <Modal

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -74,7 +74,7 @@ import type {
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
-import { ProjectsView } from "./ProjectsView";
+import { buildFirstWorkItemDraft, ProjectsView } from "./ProjectsView";
 
 type LaunchContextContract = {
   sections: string[];
@@ -1176,6 +1176,137 @@ describe("ProjectsView index", () => {
     expect(screen.getByRole("button", { name: "Inspect context" })).toBeTruthy();
     expect(screen.queryByLabelText("Request")).toBeNull();
     expect(screen.queryByRole("button", { name: "Draft proposal" })).toBeNull();
+  });
+
+  it("prefills first work creation from setup context", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: emptyActivityData(),
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [],
+    });
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_work_roles",
+      data: [role],
+    });
+    vi.mocked(getProjectMemoryCandidates).mockResolvedValue({
+      object: "project_memory_candidates",
+      data: [memoryCandidate],
+    });
+    vi.mocked(getProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [projectSkill],
+    });
+    const bootstrappedProject: ProjectRecord = {
+      ...project,
+      description: "Make Hecate usable for supervised project work.",
+      context_sources: [
+        {
+          id: "ctx_agents",
+          kind: "workspace_instruction",
+          title: "AGENTS.md",
+          path: "AGENTS.md",
+          enabled: true,
+          source_category: "workspace_guidance",
+          trust_label: "workspace_guidance",
+          created_at: "2026-06-02T09:00:00Z",
+          updated_at: "2026-06-02T09:00:00Z",
+        },
+      ],
+    };
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", bootstrappedProject.id);
+
+    render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [bootstrappedProject] }),
+    });
+
+    const assistant = await screen.findByRole("region", { name: "Project Assistant" });
+    await within(assistant).findByText(/1 role · 1 memory candidate/);
+    await user.click(within(assistant).getByRole("button", { name: "Create first work" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "New work item" });
+    expect(within(dialog).getByLabelText("Title")).toHaveValue("Plan first work for Hecate");
+    const brief = within(dialog).getByLabelText("Brief") as HTMLTextAreaElement;
+    expect(brief.value).toContain("Purpose: Make Hecate usable for supervised project work.");
+    expect(brief.value).toContain("Guidance: AGENTS.md");
+    expect(brief.value).toContain("Relevant skills: Backend");
+    expect(brief.value).toContain(
+      "Review memory candidates before relying on them: Generated summary",
+    );
+    expect(within(dialog).getByLabelText("Owner role")).toHaveValue("software_developer");
+    expect(createProjectWorkItem).not.toHaveBeenCalled();
+  });
+
+  it("does not build a first-work draft without setup context", () => {
+    expect(
+      buildFirstWorkItemDraft({
+        memoryCandidates: [],
+        project: { ...project, description: "", context_sources: [] },
+        projectSkills: [],
+        roles: [],
+        workItems: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("opens blank work creation when project already has work items", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectActivity).mockResolvedValue({
+      object: "project_activity",
+      data: emptyActivityData(),
+    });
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [workItem],
+    });
+    vi.mocked(getProjectWorkRoles).mockResolvedValue({
+      object: "project_work_roles",
+      data: [role],
+    });
+    vi.mocked(getProjectMemoryCandidates).mockResolvedValue({
+      object: "project_memory_candidates",
+      data: [memoryCandidate],
+    });
+    vi.mocked(getProjectSkills).mockResolvedValue({
+      object: "project_skills",
+      data: [projectSkill],
+    });
+    const bootstrappedProject: ProjectRecord = {
+      ...project,
+      description: "Make Hecate usable for supervised project work.",
+      context_sources: [
+        {
+          id: "ctx_agents",
+          kind: "workspace_instruction",
+          title: "AGENTS.md",
+          path: "AGENTS.md",
+          enabled: true,
+          source_category: "workspace_guidance",
+          trust_label: "workspace_guidance",
+          created_at: "2026-06-02T09:00:00Z",
+          updated_at: "2026-06-02T09:00:00Z",
+        },
+      ],
+    };
+    const user = userEvent.setup();
+    window.localStorage.setItem("hecate.project", bootstrappedProject.id);
+
+    render(<ProjectsView />, {
+      wrapper: directWrapper({ projects: [bootstrappedProject] }),
+    });
+
+    const workPanel = await screen.findByRole("region", { name: "Work coordination" });
+    await user.click(within(workPanel).getByRole("button", { name: "Work" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "New work item" });
+    expect(within(dialog).getByLabelText("Title")).toHaveValue("");
+    expect(within(dialog).getByLabelText("Brief")).toHaveValue("");
+    expect(within(dialog).getByLabelText("Owner role")).toHaveValue("software_developer");
+    expect(createProjectWorkItem).not.toHaveBeenCalled();
   });
 
   it("keeps cockpit controls and work coordination in stable regions when work items exist", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -214,6 +214,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [rolesPending, setRolesPending] = useState(false);
   const [rolesError, setRolesError] = useState("");
   const [newWorkModalOpen, setNewWorkModalOpen] = useState(false);
+  const [newWorkDraft, setNewWorkDraft] = useState<Partial<NewWorkItemForm> | undefined>();
   const [newWorkPending, setNewWorkPending] = useState(false);
   const [newWorkError, setNewWorkError] = useState("");
   const [editingWorkItem, setEditingWorkItem] = useState<ProjectWorkItemRecord | null>(null);
@@ -1006,6 +1007,20 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     }
   }
 
+  function openNewWorkItemModal() {
+    setNewWorkError("");
+    setNewWorkDraft(
+      buildFirstWorkItemDraft({
+        memoryCandidates,
+        project: selectedProject,
+        projectSkills,
+        roles,
+        workItems,
+      }),
+    );
+    setNewWorkModalOpen(true);
+  }
+
   async function handleCreateWorkItem(form: NewWorkItemForm) {
     if (!selectedProjectID) return;
     const title = form.title.trim();
@@ -1029,6 +1044,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       }));
       setSelectedWorkItemID(payload.data.id);
       setNewWorkModalOpen(false);
+      setNewWorkDraft(undefined);
       await loadWorkItemDetail(selectedProjectID, payload.data.id);
     } catch (error) {
       setNewWorkError(errorMessage(error, "Failed to create work item."));
@@ -1613,10 +1629,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               void handleCreateAssignmentFromReviewArtifact(artifact)
             }
             onCreateAssignmentFromHandoff={handleCreateAssignmentFromHandoff}
-            onCreateWork={() => {
-              setNewWorkError("");
-              setNewWorkModalOpen(true);
-            }}
+            onCreateWork={openNewWorkItemModal}
             onCloseWorkItem={(item) => void handleCloseWorkItem(item)}
             onDeleteAssignment={setDeleteAssignment}
             onDeleteHandoff={(handoff) => void handleDeleteHandoff(handoff)}
@@ -1757,8 +1770,12 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             error={newWorkError}
             pending={newWorkPending}
             project={selectedProject}
+            initialDraft={newWorkDraft}
             roles={roles}
-            onClose={() => setNewWorkModalOpen(false)}
+            onClose={() => {
+              setNewWorkDraft(undefined);
+              setNewWorkModalOpen(false);
+            }}
             onCreate={handleCreateWorkItem}
           />
         )}
@@ -2363,6 +2380,86 @@ function upsertHandoff(items: ProjectHandoffRecord[], item: ProjectHandoffRecord
     );
     return byTime || left.id.localeCompare(right.id);
   });
+}
+
+export function buildFirstWorkItemDraft({
+  memoryCandidates,
+  project,
+  projectSkills,
+  roles,
+  workItems,
+}: {
+  memoryCandidates: ProjectMemoryCandidateRecord[];
+  project: ProjectRecord | null;
+  projectSkills: ProjectSkillRecord[];
+  roles: ProjectWorkRoleRecord[];
+  workItems: ProjectWorkItemRecord[];
+}): Partial<NewWorkItemForm> | undefined {
+  if (!project || workItems.length > 0) return undefined;
+
+  const enabledSources = (project.context_sources ?? []).filter((source) => source.enabled);
+  const availableSkills = projectSkills.filter(
+    (skill) => skill.enabled && skill.status === "available",
+  );
+  const pendingCandidates = memoryCandidates.filter((candidate) => candidate.status === "pending");
+  const hasSetupContext =
+    Boolean(project.description?.trim()) ||
+    enabledSources.length > 0 ||
+    availableSkills.length > 0 ||
+    pendingCandidates.length > 0 ||
+    roles.length > 0;
+  if (!hasSetupContext) return undefined;
+
+  const ownerRole = preferredFirstWorkRole(roles);
+  const lines = [
+    `Use the project setup context to define the first reviewable work item for ${project.name}.`,
+  ];
+  if (project.description?.trim()) lines.push(`Purpose: ${project.description.trim()}`);
+  if (enabledSources.length > 0) {
+    lines.push(`Guidance: ${enabledSources.slice(0, 3).map(contextSourceLabel).join(", ")}`);
+  }
+  if (availableSkills.length > 0) {
+    lines.push(
+      `Relevant skills: ${availableSkills
+        .slice(0, 4)
+        .map((skill) => skill.title || skill.id)
+        .join(", ")}`,
+    );
+  }
+  if (pendingCandidates.length > 0) {
+    lines.push(
+      `Review memory candidates before relying on them: ${pendingCandidates
+        .slice(0, 3)
+        .map((candidate) => candidate.title)
+        .join(", ")}`,
+    );
+  }
+  if (roles.length > 0) {
+    lines.push(
+      `Suggested owner: ${ownerRole?.name || ownerRole?.id || roles[0]?.name || roles[0]?.id}`,
+    );
+  }
+
+  return {
+    title: `Plan first work for ${project.name}`,
+    brief: lines.join("\n"),
+    ownerRoleID: ownerRole?.id ?? "",
+    priority: "normal",
+    rootID: "",
+  };
+}
+
+function preferredFirstWorkRole(roles: ProjectWorkRoleRecord[]) {
+  return (
+    roles.find((role) => /architect|planner|manager|lead/i.test(`${role.id} ${role.name}`)) ??
+    roles.find((role) => role.id === "software_developer") ??
+    roles[0] ??
+    null
+  );
+}
+
+function contextSourceLabel(source: ProjectContextSourceRecord) {
+  return source.title?.trim() || source.path || source.kind;
 }
 
 const topbarStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- prefill first work item title, brief, and owner role from project setup context
- keep first-work creation operator-reviewed; no automatic work item creation
- document the first-work draft behavior and cover it in Projects tests

## Verification
- bun run test -- src/features/projects/ProjectWorkItemModals.test.tsx src/features/projects/ProjectsView.test.tsx src/features/projects/ProjectAssistantPanel.test.tsx
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test:e2e -- e2e/projects.spec.ts
- just agent-docs-check
- git diff --check