### PR TITLE
Cover Projects V1 exit journeys

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -57,6 +57,20 @@ proposal before execution records are created.
 After a work item has activity, use its Add strip to attach more assignments,
 evidence, or handoffs without scanning each section header for separate actions.
 
+## V1 Stop Line
+
+Projects V1 is good enough for Hecate dogfooding when an operator can:
+
+- create a rootless planning/research/design project and manage manual work
+  without attaching a workspace;
+- create a workspace-backed code project, run setup, review proposed memory and
+  roles, then create the first work item;
+- inspect assignment context, start supervised work, record evidence or review
+  artifacts, create handoffs, and close work only after blockers are clear.
+
+Prefer dogfooding and small friction fixes over adding new Projects concepts
+until those journeys break down in real Hecate development work.
+
 ## Roots And Worktrees
 
 Project roots are concrete workspace paths, not project identity. A single

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -83,6 +83,61 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   expect(state.artifacts).toHaveLength(1);
 });
 
+test("Projects rootless journey: plan work without setup or workspace", async ({ page }) => {
+  const state = await mockProjectJourneyAPIs(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.workspace", "projects");
+  });
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByLabel("Name").fill("Research notes");
+  await page.getByLabel("Purpose").fill("Coordinate interview synthesis and writing tasks.");
+  await expect(page.getByLabel("Folder path")).toHaveCount(0);
+  await page.getByRole("button", { name: "Create project" }).click();
+
+  await expect(page.getByText("Set up Research notes")).toBeVisible();
+  await expect(
+    page.getByText("Optional; attach files when this project needs them."),
+  ).toBeVisible();
+  const onboarding = page.getByRole("region", { name: "Project onboarding" });
+  await onboarding.getByRole("button", { name: "Create work" }).click();
+
+  await page.getByLabel("Title").fill("Summarize interview themes");
+  await page
+    .getByLabel("Brief")
+    .fill("Turn interview notes into a reviewable theme summary for the next planning pass.");
+  await expect(page.getByLabel("Owner role")).toHaveValue("");
+  await page.getByRole("button", { name: "Create work item" }).click();
+
+  await expect(page.getByRole("heading", { name: "Summarize interview themes" })).toBeVisible();
+  await expect(page.getByText("Add a role before assigning work")).toBeVisible();
+  await page.getByText("Add manually").click();
+  const manualActions = page.getByRole("group", { name: "Manual work item actions" });
+  await manualActions.getByRole("button", { name: "Evidence" }).click();
+  await page
+    .getByRole("dialog", { name: "Record evidence" })
+    .getByLabel("Title")
+    .fill("Interview source notes");
+  await page.getByLabel("URL").fill("https://example.test/interviews");
+  await page.getByLabel("Summary").fill("Source notes reviewed for the theme summary.");
+  await page.getByRole("button", { name: "Record evidence" }).click();
+
+  await expect(page.getByText("Interview source notes", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Mark done" }).click();
+  await expect(page.getByRole("article", { name: /Summarize interview themes/ })).toContainText(
+    "done",
+  );
+
+  expect(state.projects[0]?.roots).toHaveLength(0);
+  expect(state.roles).toHaveLength(0);
+  expect(state.workItems[0]?.owner_role_id).toBe("");
+  expect(state.workItems[0]?.status).toBe("done");
+  expect(state.artifacts).toHaveLength(1);
+});
+
 async function mockProjectJourneyAPIs(page: Page) {
   const state = {
     projects: [] as ProjectRecord[],


### PR DESCRIPTION
## Summary
- add a browser-level rootless Projects journey covering non-code planning work without setup or workspace attachment
- keep the existing workspace-backed setup/assignment/evidence/closeout journey as the companion acceptance path
- document the Projects V1 stop line so future work favors dogfooding and small friction fixes over new concepts

## Verification
- bun run test:e2e -- e2e/projects.spec.ts
- bun run typecheck
- bun run lint
- bun run format:check
- just agent-docs-check
- git diff --check