### PR TITLE
Add Project Operations brief

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -363,12 +363,16 @@ defaults, handoff summaries, memory candidates, and memory/context metadata so
 operators can separate live assignment buckets from actionable setup gaps,
 waiting approvals, blocked or stale assignments, pending handoffs, memory review
 work, missing provider/model defaults, and context readiness without adding a
-separate persisted health model. Assignment rows now render compact execution
-evidence from canonical assignment/activity refs, while the Context Inspector
-renders the full persisted launch packet with Profile, Instructions, Skills,
-Memory, Project sources, Work context, and Runtime evidence groups. Task and run
-records now carry direct project/work/assignment linkage when created from
-project-scoped surfaces; profiles and presets are not linked to `project_id` yet.
+separate persisted health model. The Project Operations brief now exposes the
+top bounded operator actions from those same records and routes them back into
+existing Project Settings, Work Coordination, Memory/Context, preflight, or
+Project Assistant proposal flows; it does not persist a plan or start work.
+Assignment rows now render compact execution evidence from canonical
+assignment/activity refs, while the Context Inspector renders the full persisted
+launch packet with Profile, Instructions, Skills, Memory, Project sources, Work
+context, and Runtime evidence groups. Task and run records now carry direct
+project/work/assignment linkage when created from project-scoped surfaces;
+profiles and presets are not linked to `project_id` yet.
 
 Persist `project_id` on:
 

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -42,12 +42,21 @@ For each work item:
 Assignments keep their own execution records. Projects coordinate the work, but
 Tasks, Chats, and External Agents remain the execution surfaces.
 
-The Work Coordination tab starts with a deterministic next action and compact
-resume summary. Use the next action for the single most useful operator step,
-then jump to blocked, active, recent, or memory-review work from the resume
-summary before drilling into the full work queue. Review artifacts that require
-follow-up are surfaced as closeout blockers with direct follow-up creation
-actions.
+The Work Coordination tab starts with Project Operations when the server finds
+actionable project state: missing launch defaults, pending approvals, blocked
+or stale assignments, queued assignments that need preflight, pending handoffs,
+memory candidates awaiting review, or work items that need their first
+assignment. Each operation routes to an existing surface such as Project
+Settings, Work Coordination, Memory/Context, or assignment preflight. Draftable
+operations seed the normal Project Assistant proposal rail; the operator still
+reviews and applies typed changes before Hecate creates durable project records.
+When there is no server-backed operation to show, the tab falls back to the
+deterministic next action and compact resume summary.
+
+Use the top action for the single most useful operator step, then jump to
+blocked, active, recent, or memory-review work from the resume summary before
+drilling into the full work queue. Review artifacts that require follow-up are
+surfaced as closeout blockers with direct follow-up creation actions.
 
 For a new work item with no assignments or artifacts yet, the detail view starts
 with a guided prepare action. Hecate can draft the first assignment from the

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -52,6 +52,9 @@ operations seed the normal Project Assistant proposal rail; the operator still
 reviews and applies typed changes before Hecate creates durable project records.
 When there is no server-backed operation to show, the tab falls back to the
 deterministic next action and compact resume summary.
+That fallback is transitional: new project-operations prioritization should
+land in the server brief first so clients do not maintain competing next-action
+cascades.
 
 Use the top action for the single most useful operator step, then jump to
 blocked, active, recent, or memory-review work from the resume summary before

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -39,6 +39,12 @@ selected work item, the draft creates a new project work item. In both cases
 `Draft proposal` creates reviewable data only; it does not create a chat, task,
 run, assignment, or agent session.
 
+Project Operations brief items may seed this same draft flow with a
+`draft_request` and an optional work-item target. The brief is read-only routing
+state; it can open Project Settings, Work Coordination, Memory/Context, or an
+assignment preflight, and draftable items still become ordinary Project
+Assistant proposals that must be reviewed and explicitly applied.
+
 Project-linked Hecate Chat has a compact `Draft proposal` composer action for
 turning the current draft message into the same Project Assistant proposal
 shape. The same deterministic handoff is available as `/proposal <request>` in

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2467,6 +2467,10 @@ The response is a convenience contract for operator workspaces, not a new
 durable planner. Project Activity remains the source for live assignment
 buckets, Project Assistant remains the proposal author, and assignment start
 still goes through preflight and explicit operator confirmation.
+Items are capped after sorting by priority, then an explicit operation-kind
+urgency rank, then recency, then id. This keeps blocked or waiting work ahead of
+setup gaps, handoffs ahead of memory triage, and active/completion hygiene below
+operator-gated work when the brief has more candidates than it can show.
 
 #### `GET /hecate/v1/projects/{id}/skills`
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2394,6 +2394,80 @@ the same source or target assignment. Handoffs that are not assignment-linked
 are still available from the handoff list/detail endpoints; V1 does not create
 standalone activity rows for them.
 
+#### `GET /hecate/v1/projects/{id}/operations/brief`
+
+Returns a read-only Project Operations brief for the selected project. The
+brief is an operator-facing triage layer over existing project state: launch
+defaults, the project activity buckets, work items without assignments, pending
+handoffs, and pending memory candidates. It is bounded and deterministic; it
+does not create tasks, runs, chats, assignments, handoffs, proposals, memory
+entries, or memory candidates, and it never starts queued work.
+
+Each item points at an existing Hecate surface with `target.surface`:
+`project_settings`, `work`, `memory`, or `skills`. Items may include
+`work_item`, `assignment`, or `handoff` summaries copied from the existing
+project APIs so clients can route without reinterpreting raw ids. Items that can
+seed Project Assistant carry a plain `draft_request`; clients must still call
+the normal Project Assistant draft/propose/apply flow, where the operator
+reviews the typed proposal before any durable mutation.
+
+```json
+{
+  "object": "project_operations_brief",
+  "data": {
+    "project_id": "proj_...",
+    "generated_at": "2026-06-20T12:00:00Z",
+    "summary": {
+      "item_count": 2,
+      "high_count": 1,
+      "medium_count": 1,
+      "low_count": 0,
+      "pending_memory_candidate_count": 3,
+      "pending_handoff_count": 1
+    },
+    "items": [
+      {
+        "id": "approve_assignment:proj_...:asgn_...",
+        "kind": "approve_assignment",
+        "priority": "high",
+        "title": "Review pending approval: Backend substrate",
+        "detail": "1 approval pending",
+        "action_label": "Open approval",
+        "status": "awaiting_approval",
+        "target": {
+          "surface": "work",
+          "project_id": "proj_...",
+          "work_item_id": "work_...",
+          "assignment_id": "asgn_...",
+          "activity_bucket": "blocked"
+        }
+      },
+      {
+        "id": "review_memory_candidates:proj_...",
+        "kind": "review_memory_candidates",
+        "priority": "medium",
+        "title": "Review memory candidates",
+        "detail": "Promote, edit, or reject pending memory candidates before they become stale.",
+        "action_label": "Review memory",
+        "status": "pending",
+        "target": {
+          "surface": "memory",
+          "project_id": "proj_..."
+        },
+        "metadata": {
+          "candidate_count": "3"
+        }
+      }
+    ]
+  }
+}
+```
+
+The response is a convenience contract for operator workspaces, not a new
+durable planner. Project Activity remains the source for live assignment
+buckets, Project Assistant remains the proposal author, and assignment start
+still goes through preflight and explicit operator confirmation.
+
 #### `GET /hecate/v1/projects/{id}/skills`
 
 Lists persisted project skills. These are project metadata records, not loaded

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -1,0 +1,420 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+const (
+	projectOperationsPriorityHigh   = "high"
+	projectOperationsPriorityMedium = "medium"
+	projectOperationsPriorityLow    = "low"
+)
+
+type ProjectOperationsBriefEnvelope struct {
+	Object string                         `json:"object"`
+	Data   ProjectOperationsBriefResponse `json:"data"`
+}
+
+type ProjectOperationsBriefResponse struct {
+	ProjectID   string                                `json:"project_id"`
+	GeneratedAt string                                `json:"generated_at"`
+	Summary     ProjectOperationsBriefSummaryResponse `json:"summary"`
+	Items       []ProjectOperationsBriefItemResponse  `json:"items"`
+}
+
+type ProjectOperationsBriefSummaryResponse struct {
+	ItemCount                   int `json:"item_count"`
+	HighCount                   int `json:"high_count"`
+	MediumCount                 int `json:"medium_count"`
+	LowCount                    int `json:"low_count"`
+	PendingMemoryCandidateCount int `json:"pending_memory_candidate_count"`
+	PendingHandoffCount         int `json:"pending_handoff_count"`
+}
+
+type ProjectOperationsBriefItemResponse struct {
+	ID           string                               `json:"id"`
+	Kind         string                               `json:"kind"`
+	Priority     string                               `json:"priority"`
+	Title        string                               `json:"title"`
+	Detail       string                               `json:"detail"`
+	ActionLabel  string                               `json:"action_label"`
+	Status       string                               `json:"status,omitempty"`
+	Target       ProjectOperationsBriefTargetResponse `json:"target"`
+	DraftRequest string                               `json:"draft_request,omitempty"`
+	WorkItem     *ProjectActivityWorkItemResponse     `json:"work_item,omitempty"`
+	Assignment   *ProjectWorkAssignmentResponse       `json:"assignment,omitempty"`
+	Handoff      *ProjectHandoffResponse              `json:"handoff,omitempty"`
+	UpdatedAt    string                               `json:"updated_at,omitempty"`
+	Metadata     map[string]string                    `json:"metadata,omitempty"`
+}
+
+type ProjectOperationsBriefTargetResponse struct {
+	Surface        string `json:"surface"`
+	ProjectID      string `json:"project_id"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	HandoffID      string `json:"handoff_id,omitempty"`
+	ActivityBucket string `json:"activity_bucket,omitempty"`
+}
+
+func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	brief, err := h.renderProjectOperationsBrief(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectOperationsBriefEnvelope{Object: "project_operations_brief", Data: brief})
+}
+
+func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	if !ok {
+		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
+	}
+	activity, err := h.renderProjectActivity(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	workItems, err := h.projectWork.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	pendingMemoryCandidates, err := h.pendingProjectMemoryCandidateCount(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+
+	items := make([]ProjectOperationsBriefItemResponse, 0, 8)
+	items = append(items, projectDefaultOperationItems(project)...)
+	items = append(items, assignmentOperationItems(activity)...)
+	items = append(items, handoffOperationItems(projectID, handoffs)...)
+	if pendingMemoryCandidates > 0 {
+		items = append(items, memoryCandidateOperationItem(projectID, pendingMemoryCandidates))
+	}
+	items = append(items, assignmentGapOperationItems(projectID, workItems, assignments)...)
+
+	sortProjectOperationsItems(items)
+	items = boundedProjectOperationsItems(items, 8)
+	response := ProjectOperationsBriefResponse{
+		ProjectID:   projectID,
+		GeneratedAt: formatOptionalTime(time.Now().UTC()),
+		Items:       items,
+	}
+	response.Summary.ItemCount = len(items)
+	response.Summary.PendingMemoryCandidateCount = pendingMemoryCandidates
+	for _, handoff := range handoffs {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			response.Summary.PendingHandoffCount++
+		}
+	}
+	for _, item := range items {
+		switch item.Priority {
+		case projectOperationsPriorityHigh:
+			response.Summary.HighCount++
+		case projectOperationsPriorityMedium:
+			response.Summary.MediumCount++
+		case projectOperationsPriorityLow:
+			response.Summary.LowCount++
+		}
+	}
+	return response, nil
+}
+
+func (h *Handler) pendingProjectMemoryCandidateCount(ctx context.Context, projectID string) (int, error) {
+	if h.memoryCandidates == nil {
+		return 0, nil
+	}
+	items, err := h.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+		ProjectID: strings.TrimSpace(projectID),
+		Status:    memory.CandidateStatusPending,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return len(items), nil
+}
+
+func projectDefaultOperationItems(project projects.Project) []ProjectOperationsBriefItemResponse {
+	missing := make([]string, 0, 3)
+	if strings.TrimSpace(project.DefaultProvider) == "" {
+		missing = append(missing, "provider")
+	}
+	if strings.TrimSpace(project.DefaultModel) == "" {
+		missing = append(missing, "model")
+	}
+	if projectHasActiveRoot(project) && strings.TrimSpace(project.DefaultRootID) == "" {
+		missing = append(missing, "default root")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return []ProjectOperationsBriefItemResponse{{
+		ID:          projectOperationsItemID("configure_project_defaults", project.ID),
+		Kind:        "configure_project_defaults",
+		Priority:    projectOperationsPriorityHigh,
+		Title:       "Set project launch defaults",
+		Detail:      "Missing " + strings.Join(missing, ", ") + ". Assignments can override defaults, but project launches need a clear baseline.",
+		ActionLabel: "Project settings",
+		Target: ProjectOperationsBriefTargetResponse{
+			Surface:   "project_settings",
+			ProjectID: project.ID,
+		},
+		UpdatedAt: formatOptionalTime(project.UpdatedAt),
+		Metadata: map[string]string{
+			"missing": strings.Join(missing, ","),
+		},
+	}}
+}
+
+func assignmentOperationItems(activity ProjectActivityDataResponse) []ProjectOperationsBriefItemResponse {
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(activity.Buckets.Blocked)+len(activity.Buckets.Active))
+	for _, item := range activity.Buckets.Blocked {
+		switch item.BlockingSignal {
+		case "awaiting_approval":
+			items = append(items, projectOperationItemFromActivity(item, "approve_assignment", projectOperationsPriorityHigh, "Review pending approval", item.StatusSummary, "Open approval"))
+		case "failed":
+			items = append(items, projectOperationItemFromActivity(item, "review_failed_assignment", projectOperationsPriorityHigh, "Review failed assignment", item.StatusSummary, "Open work"))
+		case "cancelled":
+			items = append(items, projectOperationItemFromActivity(item, "review_cancelled_assignment", projectOperationsPriorityMedium, "Review cancelled assignment", item.StatusSummary, "Open work"))
+		case "stale_unknown":
+			items = append(items, projectOperationItemFromActivity(item, "inspect_stale_assignment", projectOperationsPriorityHigh, "Inspect stale assignment link", item.StatusSummary, "Open work"))
+		case "not_started":
+			items = append(items, projectOperationItemFromActivity(item, "start_queued_assignment", projectOperationsPriorityHigh, "Review queued assignment", "Open launch preflight before starting this assignment.", "Review start"))
+		}
+	}
+	for _, item := range activity.Buckets.Active {
+		items = append(items, projectOperationItemFromActivity(item, "inspect_active_assignment", projectOperationsPriorityLow, "Inspect active assignment", item.StatusSummary, "Inspect work"))
+	}
+	for _, item := range activity.Buckets.Completed {
+		if item.ArtifactSummary.Count > 0 {
+			continue
+		}
+		items = append(items, projectOperationItemFromActivity(item, "record_completion_evidence", projectOperationsPriorityLow, "Record completion evidence", "Completed assignments should leave reviewable evidence before work is closed.", "Open work"))
+	}
+	return items
+}
+
+func projectOperationItemFromActivity(activity ProjectActivityItemResponse, kind, priority, title, detail, actionLabel string) ProjectOperationsBriefItemResponse {
+	workItem := activity.WorkItem
+	assignment := activity.Assignment
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID(kind, activity.ProjectID, activity.Assignment.ID),
+		Kind:        kind,
+		Priority:    priority,
+		Title:       title + ": " + firstNonEmpty(activity.WorkItem.Title, activity.Assignment.ID),
+		Detail:      firstNonEmpty(detail, activity.StatusSummary),
+		ActionLabel: actionLabel,
+		Status:      activity.BlockingSignal,
+		Target: ProjectOperationsBriefTargetResponse{
+			Surface:        "work",
+			ProjectID:      activity.ProjectID,
+			WorkItemID:     activity.WorkItem.ID,
+			AssignmentID:   activity.Assignment.ID,
+			ActivityBucket: projectActivityBucket(activity),
+		},
+		WorkItem:   &workItem,
+		Assignment: &assignment,
+		UpdatedAt:  activity.UpdatedAt,
+	}
+}
+
+func handoffOperationItems(projectID string, handoffs []projectwork.Handoff) []ProjectOperationsBriefItemResponse {
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(handoffs))
+	for _, handoff := range handoffs {
+		if handoff.Status != projectwork.HandoffStatusPending {
+			continue
+		}
+		rendered := renderProjectHandoff(handoff)
+		items = append(items, ProjectOperationsBriefItemResponse{
+			ID:          projectOperationsItemID("review_pending_handoff", projectID, handoff.ID),
+			Kind:        "review_pending_handoff",
+			Priority:    projectOperationsPriorityMedium,
+			Title:       "Review pending handoff: " + firstNonEmpty(handoff.Title, handoff.ID),
+			Detail:      firstNonEmpty(handoff.RecommendedNextAction, handoff.Summary, "Review the handoff and decide the next assignment."),
+			ActionLabel: "Open handoff",
+			Status:      handoff.Status,
+			Target: ProjectOperationsBriefTargetResponse{
+				Surface:      "work",
+				ProjectID:    projectID,
+				WorkItemID:   handoff.WorkItemID,
+				HandoffID:    handoff.ID,
+				AssignmentID: firstNonEmpty(handoff.TargetAssignmentID, handoff.SourceAssignmentID),
+			},
+			Handoff:   &rendered,
+			UpdatedAt: formatOptionalTime(projectworkTime(handoff.UpdatedAt, handoff.CreatedAt)),
+		})
+	}
+	return items
+}
+
+func memoryCandidateOperationItem(projectID string, count int) ProjectOperationsBriefItemResponse {
+	title := "Review memory candidates"
+	if count == 1 {
+		title = "Review 1 memory candidate"
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("review_memory_candidates", projectID),
+		Kind:        "review_memory_candidates",
+		Priority:    projectOperationsPriorityMedium,
+		Title:       title,
+		Detail:      "Promote, edit, or reject pending memory candidates before they become stale.",
+		ActionLabel: "Review memory",
+		Status:      "pending",
+		Target: ProjectOperationsBriefTargetResponse{
+			Surface:   "memory",
+			ProjectID: projectID,
+		},
+		Metadata: map[string]string{
+			"candidate_count": intString(count),
+		},
+	}
+}
+
+func assignmentGapOperationItems(projectID string, workItems []projectwork.WorkItem, assignments []projectwork.Assignment) []ProjectOperationsBriefItemResponse {
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(workItems)+1)
+	if len(workItems) == 0 {
+		items = append(items, ProjectOperationsBriefItemResponse{
+			ID:           projectOperationsItemID("create_first_work_item", projectID),
+			Kind:         "create_first_work_item",
+			Priority:     projectOperationsPriorityMedium,
+			Title:        "Create the first work item",
+			Detail:       "Start with one reviewable project work item before queueing assignments.",
+			ActionLabel:  "Draft work",
+			DraftRequest: "Create the first project work item",
+			Target: ProjectOperationsBriefTargetResponse{
+				Surface:   "work",
+				ProjectID: projectID,
+			},
+		})
+		return items
+	}
+	for _, workItem := range workItems {
+		if projectWorkItemClosed(workItem.Status) || len(assignmentsByWorkItem[workItem.ID]) > 0 {
+			continue
+		}
+		rendered := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+		items = append(items, ProjectOperationsBriefItemResponse{
+			ID:           projectOperationsItemID("prepare_first_assignment", projectID, workItem.ID),
+			Kind:         "prepare_first_assignment",
+			Priority:     projectOperationsPriorityMedium,
+			Title:        "Prepare first assignment: " + firstNonEmpty(workItem.Title, workItem.ID),
+			Detail:       "This work item has no queued or running assignments yet.",
+			ActionLabel:  "Draft assignment",
+			DraftRequest: "Queue an assignment for " + firstNonEmpty(workItem.Title, workItem.ID),
+			Status:       firstNonEmpty(workItem.Status, projectwork.WorkItemStatusReady),
+			Target: ProjectOperationsBriefTargetResponse{
+				Surface:    "work",
+				ProjectID:  projectID,
+				WorkItemID: workItem.ID,
+			},
+			WorkItem:  &rendered,
+			UpdatedAt: formatOptionalTime(projectworkTime(workItem.UpdatedAt, workItem.CreatedAt)),
+		})
+	}
+	return items
+}
+
+func sortProjectOperationsItems(items []ProjectOperationsBriefItemResponse) {
+	sort.SliceStable(items, func(i, j int) bool {
+		leftRank, rightRank := projectOperationsPriorityRank(items[i].Priority), projectOperationsPriorityRank(items[j].Priority)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftTime, rightTime := parseProjectActivityTime(items[i].UpdatedAt), parseProjectActivityTime(items[j].UpdatedAt)
+		if !leftTime.Equal(rightTime) {
+			return leftTime.After(rightTime)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func projectOperationsPriorityRank(priority string) int {
+	switch strings.TrimSpace(priority) {
+	case projectOperationsPriorityHigh:
+		return 0
+	case projectOperationsPriorityMedium:
+		return 1
+	case projectOperationsPriorityLow:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func boundedProjectOperationsItems(items []ProjectOperationsBriefItemResponse, limit int) []ProjectOperationsBriefItemResponse {
+	if len(items) == 0 {
+		return []ProjectOperationsBriefItemResponse{}
+	}
+	if limit > 0 && len(items) > limit {
+		return append([]ProjectOperationsBriefItemResponse(nil), items[:limit]...)
+	}
+	return append([]ProjectOperationsBriefItemResponse(nil), items...)
+}
+
+func projectOperationsItemID(kind string, parts ...string) string {
+	values := make([]string, 0, len(parts)+1)
+	values = append(values, strings.TrimSpace(kind))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			values = append(values, part)
+		}
+	}
+	return strings.Join(values, ":")
+}
+
+func projectHasActiveRoot(project projects.Project) bool {
+	for _, root := range project.Roots {
+		if root.Active && strings.TrimSpace(root.Path) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func projectWorkItemClosed(status string) bool {
+	switch strings.TrimSpace(status) {
+	case projectwork.WorkItemStatusDone, projectwork.WorkItemStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectworkTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func intString(value int) string {
+	return strconv.Itoa(value)
+}

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -345,6 +345,10 @@ func sortProjectOperationsItems(items []ProjectOperationsBriefItemResponse) {
 		if leftRank != rightRank {
 			return leftRank < rightRank
 		}
+		leftKindRank, rightKindRank := projectOperationsKindRank(items[i].Kind), projectOperationsKindRank(items[j].Kind)
+		if leftKindRank != rightKindRank {
+			return leftKindRank < rightKindRank
+		}
 		leftTime, rightTime := parseProjectActivityTime(items[i].UpdatedAt), parseProjectActivityTime(items[j].UpdatedAt)
 		if !leftTime.Equal(rightTime) {
 			return leftTime.After(rightTime)
@@ -363,6 +367,37 @@ func projectOperationsPriorityRank(priority string) int {
 		return 2
 	default:
 		return 3
+	}
+}
+
+func projectOperationsKindRank(kind string) int {
+	switch strings.TrimSpace(kind) {
+	case "approve_assignment":
+		return 0
+	case "review_failed_assignment":
+		return 10
+	case "inspect_stale_assignment":
+		return 20
+	case "start_queued_assignment":
+		return 30
+	case "configure_project_defaults":
+		return 40
+	case "review_cancelled_assignment":
+		return 50
+	case "review_pending_handoff":
+		return 60
+	case "prepare_first_assignment":
+		return 70
+	case "create_first_work_item":
+		return 80
+	case "review_memory_candidates":
+		return 90
+	case "inspect_active_assignment":
+		return 100
+	case "record_completion_evidence":
+		return 110
+	default:
+		return 1000
 	}
 }
 

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -138,6 +138,57 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	}
 }
 
+func TestSortProjectOperationsItems_UsesExplicitUrgencyBeforeRecency(t *testing.T) {
+	t.Parallel()
+	items := []ProjectOperationsBriefItemResponse{
+		{
+			ID:        "memory",
+			Kind:      "review_memory_candidates",
+			Priority:  projectOperationsPriorityMedium,
+			UpdatedAt: "2026-06-20T12:04:00Z",
+		},
+		{
+			ID:        "defaults",
+			Kind:      "configure_project_defaults",
+			Priority:  projectOperationsPriorityHigh,
+			UpdatedAt: "2026-06-20T12:05:00Z",
+		},
+		{
+			ID:        "handoff",
+			Kind:      "review_pending_handoff",
+			Priority:  projectOperationsPriorityMedium,
+			UpdatedAt: "2026-06-20T12:00:00Z",
+		},
+		{
+			ID:        "active",
+			Kind:      "inspect_active_assignment",
+			Priority:  projectOperationsPriorityLow,
+			UpdatedAt: "2026-06-20T12:06:00Z",
+		},
+		{
+			ID:        "approval",
+			Kind:      "approve_assignment",
+			Priority:  projectOperationsPriorityHigh,
+			UpdatedAt: "2026-06-20T12:01:00Z",
+		},
+	}
+
+	sortProjectOperationsItems(items)
+	got := make([]string, 0, len(items))
+	for _, item := range boundedProjectOperationsItems(items, 3) {
+		got = append(got, item.Kind)
+	}
+	want := []string{"approve_assignment", "configure_project_defaults", "review_pending_handoff"}
+	if len(got) != len(want) {
+		t.Fatalf("bounded sorted operations = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("bounded sorted operations = %v, want %v", got, want)
+		}
+	}
+}
+
 func findProjectOperationsItemForTest(t *testing.T, items []ProjectOperationsBriefItemResponse, kind string) ProjectOperationsBriefItemResponse {
 	t.Helper()
 	for _, item := range items {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:    "proj_ops",
+		Name:  "Operations",
+		Roots: []projects.Root{{ID: "root_ops", Path: t.TempDir(), Kind: "git", Active: true}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_review",
+		ProjectID: "proj_ops",
+		Title:     "Review backend",
+		Status:    projectwork.WorkItemStatusRunning,
+		Priority:  "high",
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_review): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_approval",
+		ProjectID:  "proj_ops",
+		WorkItemID: "work_review",
+		RoleID:     "software_developer",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusAwaitingApproval,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:                 projectwork.AssignmentExecutionKindTaskRun,
+			TaskID:               "task_approval",
+			RunID:                "run_approval",
+			Status:               projectwork.AssignmentStatusAwaitingApproval,
+			PendingApprovalCount: 1,
+		},
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_approval): %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_empty",
+		ProjectID: "proj_ops",
+		Title:     "Build operator brief",
+		Status:    projectwork.WorkItemStatusReady,
+		Priority:  "normal",
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_empty): %v", err)
+	}
+	if _, err := handler.projectWork.CreateHandoff(t.Context(), projectwork.Handoff{
+		ID:                    "handoff_review",
+		ProjectID:             "proj_ops",
+		WorkItemID:            "work_review",
+		SourceAssignmentID:    "asgn_approval",
+		TargetRoleID:          "reviewer_qa",
+		Title:                 "Review follow-up",
+		Summary:               "Review the pending backend handoff.",
+		RecommendedNextAction: "Create a review assignment.",
+		Status:                projectwork.HandoffStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateHandoff: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:        "memcand_ops",
+		ProjectID: "proj_ops",
+		Title:     "Remember review boundary",
+		Body:      "Review work should stay explicit.",
+		Status:    memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+
+	beforeAssignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_ops"})
+	if err != nil {
+		t.Fatalf("ListAssignments before: %v", err)
+	}
+	beforeCandidates, err := handler.memoryCandidates.ListCandidates(t.Context(), memory.CandidateFilter{ProjectID: "proj_ops"})
+	if err != nil {
+		t.Fatalf("ListCandidates before: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_ops/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if response.Object != "project_operations_brief" || response.Data.ProjectID != "proj_ops" {
+		t.Fatalf("operations envelope = %+v, want project_operations_brief for project", response)
+	}
+	if response.Data.Summary.PendingMemoryCandidateCount != 1 || response.Data.Summary.PendingHandoffCount != 1 {
+		t.Fatalf("operations summary = %+v, want memory candidate and handoff counts", response.Data.Summary)
+	}
+
+	defaults := findProjectOperationsItemForTest(t, response.Data.Items, "configure_project_defaults")
+	if defaults.Target.Surface != "project_settings" || defaults.ActionLabel != "Project settings" {
+		t.Fatalf("defaults item = %+v, want project settings target", defaults)
+	}
+	approval := findProjectOperationsItemForTest(t, response.Data.Items, "approve_assignment")
+	if approval.Target.WorkItemID != "work_review" || approval.Target.AssignmentID != "asgn_approval" || approval.Target.ActivityBucket != "blocked" {
+		t.Fatalf("approval item = %+v, want blocked assignment target", approval)
+	}
+	handoff := findProjectOperationsItemForTest(t, response.Data.Items, "review_pending_handoff")
+	if handoff.Handoff == nil || handoff.Handoff.ID != "handoff_review" || handoff.Target.HandoffID != "handoff_review" {
+		t.Fatalf("handoff item = %+v, want rendered handoff target", handoff)
+	}
+	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
+	if memoryItem.Target.Surface != "memory" {
+		t.Fatalf("memory item = %+v, want memory target", memoryItem)
+	}
+	assignmentGap := findProjectOperationsItemForTest(t, response.Data.Items, "prepare_first_assignment")
+	if assignmentGap.Target.WorkItemID != "work_empty" || assignmentGap.DraftRequest == "" {
+		t.Fatalf("assignment gap item = %+v, want draft request for empty work item", assignmentGap)
+	}
+
+	afterAssignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_ops"})
+	if err != nil {
+		t.Fatalf("ListAssignments after: %v", err)
+	}
+	afterCandidates, err := handler.memoryCandidates.ListCandidates(t.Context(), memory.CandidateFilter{ProjectID: "proj_ops"})
+	if err != nil {
+		t.Fatalf("ListCandidates after: %v", err)
+	}
+	if len(afterAssignments) != len(beforeAssignments) || len(afterCandidates) != len(beforeCandidates) {
+		t.Fatalf("operations brief mutated project state: assignments %d->%d candidates %d->%d", len(beforeAssignments), len(afterAssignments), len(beforeCandidates), len(afterCandidates))
+	}
+}
+
+func findProjectOperationsItemForTest(t *testing.T, items []ProjectOperationsBriefItemResponse, kind string) ProjectOperationsBriefItemResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.Kind == kind {
+			return item
+		}
+	}
+	t.Fatalf("operations item kind %q missing from %+v", kind, items)
+	return ProjectOperationsBriefItemResponse{}
+}

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -58,6 +58,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}/memory/{memory_id}"},
 	{method: http.MethodDelete, path: "/hecate/v1/projects/{id}/memory/{memory_id}"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/activity"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/operations/brief"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/roles"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/roles"},
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}/roles/{role_id}"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -95,6 +95,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/memory/{memory_id}", handler.HandleUpdateProjectMemoryEntry)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/memory/{memory_id}", handler.HandleDeleteProjectMemoryEntry)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/activity", handler.HandleProjectActivity)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/operations/brief", handler.HandleProjectOperationsBrief)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/roles", handler.HandleProjectWorkRoles)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roles", handler.HandleCreateProjectWorkRole)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/roles/{role_id}", handler.HandleUpdateProjectWorkRole)

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -279,6 +279,12 @@ async function mockProjectJourneyAPIs(page: Page) {
       await route.fulfill(ok({ object: "project_activity", data: projectActivity(state) }));
       return;
     }
+    if (resource === "operations" && parts[2] === "brief") {
+      await route.fulfill(
+        ok({ object: "project_operations_brief", data: projectOperationsBrief(projectID) }),
+      );
+      return;
+    }
     if (resource === "work-items") {
       await handleWorkItemRoute(route, state, parts, method, projectID, ok);
       return;
@@ -620,5 +626,21 @@ function projectActivity(state: ProjectJourneyState): ProjectActivityData {
       recent: item,
     },
     recent: item,
+  };
+}
+
+function projectOperationsBrief(projectID: string) {
+  return {
+    project_id: projectID,
+    generated_at: NOW,
+    summary: {
+      item_count: 0,
+      high_count: 0,
+      medium_count: 0,
+      low_count: 0,
+      pending_memory_candidate_count: 0,
+      pending_handoff_count: 0,
+    },
+    items: [],
   };
 }

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -13,6 +13,7 @@ import {
   getProjectActivity,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
+  getProjectOperationsBrief,
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
@@ -35,6 +36,10 @@ vi.mock("../lib/api", async (importOriginal) => {
     getProjectActivity: vi.fn(async () => ({
       object: "project_activity",
       data: emptyActivityData(),
+    })),
+    getProjectOperationsBrief: vi.fn(async () => ({
+      object: "project_operations_brief",
+      data: emptyOperationsBriefData(),
     })),
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
@@ -69,6 +74,22 @@ function emptyActivityData() {
   };
 }
 
+function emptyOperationsBriefData() {
+  return {
+    project_id: "",
+    generated_at: "",
+    summary: {
+      item_count: 0,
+      high_count: 0,
+      medium_count: 0,
+      low_count: 0,
+      pending_memory_candidate_count: 0,
+      pending_handoff_count: 0,
+    },
+    items: [],
+  };
+}
+
 function resetProjectWorkMocks() {
   const emptyWorkItem: ProjectWorkItemRecord = {
     id: "",
@@ -82,6 +103,10 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectActivity).mockResolvedValue({
     object: "project_activity",
     data: emptyActivityData(),
+  });
+  vi.mocked(getProjectOperationsBrief).mockResolvedValue({
+    object: "project_operations_brief",
+    data: emptyOperationsBriefData(),
   });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -254,6 +254,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     onOpenChat: vi.fn(),
     onOpenConnections: vi.fn(),
     onOpenSettings: vi.fn(),
+    onOperationAction: vi.fn(),
     onOpenTask: vi.fn(),
     onPromoteCandidate: vi.fn(),
     onRefreshMemory: vi.fn(),
@@ -293,6 +294,9 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     projectEmptyDetail: "Choose a project.",
     projectEmptyTitle: "No project selected",
     projectNeedsOnboarding: false,
+    operationsBrief: null,
+    operationsBriefError: "",
+    operationsBriefLoadState: "idle",
     projectSkills: [],
     preparingAssignmentID: "",
     rejectingCandidateID: "",
@@ -363,6 +367,46 @@ describe("ProjectWorkspaceView", () => {
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(1, "timeline");
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(2, "memory");
     expect(handlers.onWorkspaceTabChange).toHaveBeenNthCalledWith(3, "skills");
+  });
+
+  it("renders project operations brief items", async () => {
+    const operationItem = {
+      id: "start_queued_assignment:proj_1:asgn_1",
+      kind: "start_queued_assignment",
+      priority: "high",
+      title: "Review queued assignment: Build cockpit UI",
+      detail: "Open launch preflight before starting this assignment.",
+      action_label: "Review start",
+      status: "not_started",
+      target: {
+        surface: "work",
+        project_id: "proj_1",
+        work_item_id: "work_1",
+        assignment_id: "asgn_1",
+        activity_bucket: "blocked",
+      },
+      updated_at: "2026-06-13T00:00:00Z",
+    } as const;
+    const { handlers } = renderWorkspace({
+      operationsBrief: {
+        project_id: "proj_1",
+        generated_at: "2026-06-13T00:00:00Z",
+        summary: {
+          item_count: 1,
+          high_count: 1,
+          medium_count: 0,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: [operationItem],
+      },
+    });
+
+    const operations = screen.getByRole("region", { name: "Project operations" });
+    expect(within(operations).getByText("Review queued assignment: Build cockpit UI")).toBeTruthy();
+    await userEvent.click(within(operations).getByRole("button", { name: /Review start/ }));
+    expect(handlers.onOperationAction).toHaveBeenCalledWith(operationItem);
   });
 
   it("renders a resume summary and delegates resume actions", async () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -9,6 +9,8 @@ import type {
   ProjectHandoffRecord,
   ProjectMemoryCandidateRecord,
   ProjectMemoryRecord,
+  ProjectOperationsBrief,
+  ProjectOperationsBriefItem,
   ProjectRecord,
   ProjectSkillRecord,
   ProjectWorkItemRecord,
@@ -109,6 +111,7 @@ export type ProjectWorkspaceViewProps = {
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
   onOpenConnections?: () => void;
   onOpenSettings: () => void;
+  onOperationAction: (item: ProjectOperationsBriefItem) => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onPromoteCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
   onRefreshMemory: () => void;
@@ -125,6 +128,9 @@ export type ProjectWorkspaceViewProps = {
   projectEmptyDetail: string;
   projectEmptyTitle: string;
   projectNeedsOnboarding: boolean;
+  operationsBrief: ProjectOperationsBrief | null;
+  operationsBriefError: string;
+  operationsBriefLoadState: LoadState;
   projectSkills: ProjectSkillRecord[];
   preparingAssignmentID: string;
   rejectingCandidateID: string;
@@ -199,6 +205,7 @@ export function ProjectWorkspaceView({
   onOpenChat,
   onOpenConnections,
   onOpenSettings,
+  onOperationAction,
   onOpenTask,
   onPromoteCandidate,
   onRefreshMemory,
@@ -215,6 +222,9 @@ export function ProjectWorkspaceView({
   projectEmptyDetail,
   projectEmptyTitle,
   projectNeedsOnboarding,
+  operationsBrief,
+  operationsBriefError,
+  operationsBriefLoadState,
   projectSkills,
   preparingAssignmentID,
   rejectingCandidateID,
@@ -310,26 +320,34 @@ export function ProjectWorkspaceView({
             )}
             {!projectNeedsOnboarding && workspaceTab === "work" && (
               <section style={projectTabPanelStyle} aria-label="Work coordination">
-                <ProjectNextAction
-                  activity={activity}
-                  assignments={assignments}
-                  artifacts={artifacts}
-                  handoffs={handoffs}
-                  memoryCandidateCount={memoryCandidates.length}
-                  onAddEvidenceLink={onAddEvidenceLink}
-                  onBucketChange={onActivityBucketChange}
-                  onCloseWorkItem={onCloseWorkItem}
-                  onCreateAssignmentFromHandoff={onCreateAssignmentFromHandoff}
-                  onCreateAssignmentFromReviewArtifact={onCreateAssignmentFromReviewArtifact}
-                  onCreateWork={onCreateWork}
-                  onDraftDefaultAssignment={onDraftDefaultAssignment}
-                  onReviewMemory={() => onWorkspaceTabChange("memory")}
-                  onSelectWorkItem={onSelectWorkItem}
-                  onStartAssignment={onStartAssignment}
-                  onStartHandoff={onStartHandoff}
-                  selectedWorkItem={selectedWorkItem}
-                  startingAssignmentID={startingAssignmentID}
-                  workItems={workItems}
+                <ProjectOperationsBriefPanel
+                  brief={operationsBrief}
+                  error={operationsBriefError}
+                  loading={operationsBriefLoadState === "loading"}
+                  onAction={onOperationAction}
+                  fallback={
+                    <ProjectNextAction
+                      activity={activity}
+                      assignments={assignments}
+                      artifacts={artifacts}
+                      handoffs={handoffs}
+                      memoryCandidateCount={memoryCandidates.length}
+                      onAddEvidenceLink={onAddEvidenceLink}
+                      onBucketChange={onActivityBucketChange}
+                      onCloseWorkItem={onCloseWorkItem}
+                      onCreateAssignmentFromHandoff={onCreateAssignmentFromHandoff}
+                      onCreateAssignmentFromReviewArtifact={onCreateAssignmentFromReviewArtifact}
+                      onCreateWork={onCreateWork}
+                      onDraftDefaultAssignment={onDraftDefaultAssignment}
+                      onReviewMemory={() => onWorkspaceTabChange("memory")}
+                      onSelectWorkItem={onSelectWorkItem}
+                      onStartAssignment={onStartAssignment}
+                      onStartHandoff={onStartHandoff}
+                      selectedWorkItem={selectedWorkItem}
+                      startingAssignmentID={startingAssignmentID}
+                      workItems={workItems}
+                    />
+                  }
                 />
                 <ProjectResumeSummary
                   activity={activity}
@@ -724,6 +742,94 @@ type ProjectNextActionState = {
   status: string;
   title: string;
 };
+
+function ProjectOperationsBriefPanel({
+  brief,
+  error,
+  fallback,
+  loading,
+  onAction,
+}: {
+  brief: ProjectOperationsBrief | null;
+  error: string;
+  fallback: ReactNode;
+  loading: boolean;
+  onAction: (item: ProjectOperationsBriefItem) => void;
+}) {
+  if ((!brief || brief.items.length === 0) && !loading) {
+    return (
+      <>
+        {fallback}
+        {error && <InlineError message={error} />}
+      </>
+    );
+  }
+
+  const items = brief?.items ?? [];
+  const primary = items[0] ?? null;
+  const secondary = items.slice(1, 4);
+  const title = loading && !brief ? "Loading operations..." : primary?.title || "Operations clear";
+  const detail =
+    loading && !brief
+      ? "Checking project work, memory candidates, handoffs, and launch defaults."
+      : primary?.detail || "No queued, blocked, handoff, or memory-review items need attention.";
+
+  return (
+    <section aria-label="Project operations" style={projectOperationsBriefStyle}>
+      <div style={projectOperationsBriefMainStyle}>
+        <div style={sectionLabelStyle}>Project Operations</div>
+        <div style={titleStyle}>{title}</div>
+        <div style={subtleTextStyle}>{detail}</div>
+      </div>
+      <div style={projectOperationsBriefControlsStyle}>
+        {primary ? (
+          <>
+            <Badge
+              status={primary.status || primary.priority}
+              label={projectOperationBadge(primary)}
+            />
+            <button
+              aria-label={`${primary.action_label}: ${primary.title}`}
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => onAction(primary)}
+            >
+              {primary.action_label}
+            </button>
+          </>
+        ) : (
+          <span className="badge badge-green">clear</span>
+        )}
+      </div>
+      {secondary.length > 0 && (
+        <div style={projectOperationsListStyle}>
+          {secondary.map((item) => (
+            <button
+              aria-label={`${item.action_label}: ${item.title}`}
+              className="btn btn-ghost btn-sm"
+              key={item.id}
+              onClick={() => onAction(item)}
+              style={projectOperationsItemButtonStyle}
+              type="button"
+            >
+              <span className="badge badge-muted">{projectOperationBadge(item)}</span>
+              <span style={projectOperationsItemTitleStyle}>{item.title}</span>
+              <span style={projectOperationsItemActionStyle}>{item.action_label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <InlineError message={error} />}
+    </section>
+  );
+}
+
+function projectOperationBadge(item: ProjectOperationsBriefItem): string {
+  if (item.priority === "high") return "attention";
+  if (item.priority === "medium") return "review";
+  if (item.priority === "low") return "watch";
+  return item.priority || item.status || "operation";
+}
 
 function ProjectNextAction({
   activity,
@@ -1513,6 +1619,58 @@ const projectNextActionStyle: CSSProperties = {
   display: "grid",
   gap: 12,
   gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const projectOperationsBriefStyle: CSSProperties = {
+  ...panelStyle,
+  alignItems: "center",
+  display: "grid",
+  gap: 12,
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const projectOperationsBriefMainStyle: CSSProperties = {
+  display: "grid",
+  gap: 5,
+  minWidth: 0,
+};
+
+const projectOperationsBriefControlsStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  justifyContent: "flex-end",
+  minWidth: 0,
+};
+
+const projectOperationsListStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  display: "grid",
+  gap: 4,
+  gridColumn: "1 / -1",
+  paddingTop: 8,
+};
+
+const projectOperationsItemButtonStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  gridTemplateColumns: "auto minmax(0, 1fr) auto",
+  justifyContent: "stretch",
+  minHeight: 32,
+  textAlign: "left",
+};
+
+const projectOperationsItemTitleStyle: CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const projectOperationsItemActionStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 11,
+  whiteSpace: "nowrap",
 };
 
 const projectNextActionControlsStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -325,6 +325,8 @@ export function ProjectWorkspaceView({
                   error={operationsBriefError}
                   loading={operationsBriefLoadState === "loading"}
                   onAction={onOperationAction}
+                  // Transitional fallback: keep Project Operations as the server-backed source of truth
+                  // for new next-action derivation once the brief has proven out.
                   fallback={
                     <ProjectNextAction
                       activity={activity}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -27,6 +27,7 @@ import {
   discoverProjectRoots,
   discoverProjectSkills,
   getProjectActivity,
+  getProjectOperationsBrief,
   getAgentProfiles,
   getProjectAssignmentContext,
   getProjectAssignmentPreflight,
@@ -104,6 +105,22 @@ function emptyActivityData() {
   };
 }
 
+function emptyOperationsBriefData() {
+  return {
+    project_id: "",
+    generated_at: "",
+    summary: {
+      item_count: 0,
+      high_count: 0,
+      medium_count: 0,
+      low_count: 0,
+      pending_memory_candidate_count: 0,
+      pending_handoff_count: 0,
+    },
+    items: [],
+  };
+}
+
 async function openProjectWorkspaceTab(name: RegExp | string) {
   await userEvent.click(await screen.findByRole("tab", { name }));
 }
@@ -120,6 +137,10 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getProjectActivity: vi.fn(async () => ({
       object: "project_activity",
       data: emptyActivityData(),
+    })),
+    getProjectOperationsBrief: vi.fn(async () => ({
+      object: "project_operations_brief",
+      data: emptyOperationsBriefData(),
     })),
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
@@ -475,6 +496,10 @@ function resetProjectWorkMocks() {
       },
       recent: [],
     },
+  });
+  vi.mocked(getProjectOperationsBrief).mockResolvedValue({
+    object: "project_operations_brief",
+    data: emptyOperationsBriefData(),
   });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [role] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({
@@ -1019,6 +1044,7 @@ afterEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
   vi.mocked(getProjectActivity).mockReset();
+  vi.mocked(getProjectOperationsBrief).mockReset();
   vi.mocked(getProjectWorkRoles).mockReset();
   vi.mocked(getProjectWorkItems).mockReset();
   vi.mocked(getProjectWorkItem).mockReset();
@@ -4873,6 +4899,74 @@ describe("ProjectsView cockpit", () => {
     expect(await within(assistant).findByText("Create assignment")).toBeTruthy();
     expect(createProjectAssignment).not.toHaveBeenCalled();
     expect(getProjectAssignmentPreflight).not.toHaveBeenCalled();
+    expect(startProjectAssignment).not.toHaveBeenCalled();
+  });
+
+  it("drafts a Project Assistant proposal from an operations brief item", async () => {
+    resetProjectWorkMocks();
+    const emptyWorkItem = { ...workItem, reviewer_role_ids: [], assignments: [] };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [emptyWorkItem],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: emptyWorkItem,
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [],
+    });
+    vi.mocked(getProjectOperationsBrief).mockResolvedValue({
+      object: "project_operations_brief",
+      data: {
+        project_id: project.id,
+        generated_at: "2026-06-14T00:00:00Z",
+        summary: {
+          item_count: 1,
+          high_count: 0,
+          medium_count: 1,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: [
+          {
+            id: "prepare_first_assignment:proj_1:work_1",
+            kind: "prepare_first_assignment",
+            priority: "medium",
+            title: "Prepare first assignment: Build cockpit UI",
+            detail: "This work item has no queued or running assignments yet.",
+            action_label: "Draft assignment",
+            draft_request: "Queue an assignment for Build cockpit UI",
+            target: {
+              surface: "work",
+              project_id: project.id,
+              work_item_id: workItem.id,
+            },
+            updated_at: "2026-06-14T00:00:00Z",
+          },
+        ],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const operations = await screen.findByRole("region", { name: "Project operations" });
+    await userEvent.click(within(operations).getByRole("button", { name: /Draft assignment/ }));
+
+    await waitFor(() =>
+      expect(draftProjectAssistant).toHaveBeenCalledWith({
+        project_id: project.id,
+        work_item_id: workItem.id,
+        request: "Queue an assignment for Build cockpit UI",
+      }),
+    );
+    expect(createProjectAssignment).not.toHaveBeenCalled();
     expect(startProjectAssignment).not.toHaveBeenCalled();
   });
 

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -29,6 +29,7 @@ import {
   getProjectHandoffs,
   getProjectMemory,
   getProjectMemoryCandidates,
+  getProjectOperationsBrief,
   getProjectSkills,
   getProjectWorkItem,
   getProjectWorkItems,
@@ -87,6 +88,8 @@ import type {
   CreateProjectWorktreeRootPayload,
   ProjectHandoffRecord,
   ProjectMemoryRecord,
+  ProjectOperationsBrief,
+  ProjectOperationsBriefItem,
   ProjectContextSourceRecord,
   ProjectSkillRecord,
   ProjectRecord,
@@ -234,6 +237,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [workItems, setWorkItems] = useState<ProjectWorkItemRecord[]>([]);
   const [workItemSummaries, setWorkItemSummaries] = useState<Record<string, WorkItemSummary>>({});
   const [activity, setActivity] = useState<ProjectActivityData | null>(null);
+  const [operationsBrief, setOperationsBrief] = useState<ProjectOperationsBrief | null>(null);
+  const [operationsBriefError, setOperationsBriefError] = useState("");
+  const [operationsBriefLoadState, setOperationsBriefLoadState] = useState<LoadState>("idle");
   const [activityBucket, setActivityBucket] = useState<ProjectActivityBucketKey>("all");
   const [workspaceTab, setWorkspaceTab] = useState<ProjectWorkspaceTab>("work");
   const [roles, setRoles] = useState<ProjectWorkRoleRecord[]>([]);
@@ -410,6 +416,8 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     setWorkItems([]);
     setWorkItemSummaries({});
     setActivity(null);
+    setOperationsBrief(null);
+    setOperationsBriefError("");
     if (!preferredWorkItemID) {
       setSelectedWorkItemID("");
       setSelectedWorkItem(null);
@@ -419,21 +427,30 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     }
     if (!projectID) {
       setWorkLoadState("idle");
+      setOperationsBriefLoadState("idle");
       return "";
     }
     setWorkLoadState("loading");
+    setOperationsBriefLoadState("loading");
     try {
       const activityLoad = getProjectActivity(projectID).catch(() => null);
-      const [rolesRes, workRes, activityRes] = await Promise.all([
+      const operationsBriefLoad = getProjectOperationsBrief(projectID).catch((error) => {
+        setOperationsBriefError(errorMessage(error, "Failed to load project operations."));
+        return null;
+      });
+      const [rolesRes, workRes, activityRes, operationsBriefRes] = await Promise.all([
         getProjectWorkRoles(projectID),
         getProjectWorkItems(projectID),
         activityLoad,
+        operationsBriefLoad,
       ]);
       const nextRoles = rolesRes.data ?? [];
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
       setActivity(activityRes?.data ?? null);
+      setOperationsBrief(operationsBriefRes?.data ?? null);
+      setOperationsBriefLoadState(operationsBriefRes ? "loaded" : "error");
       setWorkItemSummaries(
         Object.fromEntries(
           nextItems.map((item) => [item.id, summarizeAssignments(item.assignments ?? [])] as const),
@@ -447,6 +464,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       return nextSelectedID;
     } catch (error) {
       setWorkLoadState("error");
+      setOperationsBriefLoadState("error");
       setWorkError(errorMessage(error, "Failed to load project work."));
       return "";
     }
@@ -1142,6 +1160,51 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     });
   }
 
+  function handleOperationsBriefAction(item: ProjectOperationsBriefItem) {
+    const target = item.target;
+    if (item.draft_request) {
+      setWorkspaceTab("work");
+      if (target.work_item_id) {
+        setSelectedWorkItemID(target.work_item_id);
+      }
+      void assistant.propose(
+        {
+          request: item.draft_request,
+          roleID: PROJECT_ASSISTANT_AUTO,
+          driverKind: PROJECT_ASSISTANT_AUTO,
+          draftMode: "deterministic",
+        },
+        target.work_item_id,
+      );
+      return;
+    }
+    if (target.surface === "project_settings") {
+      setDefaultsError("");
+      setSettingsPanelOpen(true);
+      return;
+    }
+    if (target.surface === "memory") {
+      setWorkspaceTab("memory");
+      return;
+    }
+    if (target.surface === "skills") {
+      setWorkspaceTab("skills");
+      return;
+    }
+    setWorkspaceTab("work");
+    const bucket = projectOperationsActivityBucket(target.activity_bucket);
+    if (bucket) {
+      setActivityBucket(bucket);
+    }
+    if (target.work_item_id) {
+      setSelectedWorkItemID(target.work_item_id);
+    }
+    const assignmentID = target.assignment_id;
+    if (item.kind === "start_queued_assignment" && assignmentID) {
+      setPreparingAssignmentID(assignmentID);
+    }
+  }
+
   async function handleUpdateAssignment(form: EditAssignmentForm) {
     if (!selectedProjectID || !selectedWorkItemID) return;
     const roleID = form.roleID.trim();
@@ -1675,6 +1738,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               setDefaultsError("");
               setSettingsPanelOpen(true);
             }}
+            onOperationAction={handleOperationsBriefAction}
             onOpenTask={onOpenTask}
             onPromoteCandidate={setPromotingCandidate}
             onRefreshMemory={() => void loadProjectMemory(selectedProjectID)}
@@ -1691,6 +1755,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             projectEmptyDetail={projectEmptyDetail}
             projectEmptyTitle={projectEmptyTitle}
             projectNeedsOnboarding={projectNeedsOnboarding}
+            operationsBrief={operationsBrief}
+            operationsBriefError={operationsBriefError}
+            operationsBriefLoadState={operationsBriefLoadState}
             projectSkills={projectSkills}
             preparingAssignmentID={preparingAssignmentID}
             rejectingCandidateID={rejectingCandidateID}
@@ -2460,6 +2527,19 @@ function preferredFirstWorkRole(roles: ProjectWorkRoleRecord[]) {
 
 function contextSourceLabel(source: ProjectContextSourceRecord) {
   return source.title?.trim() || source.path || source.kind;
+}
+
+function projectOperationsActivityBucket(value?: string): ProjectActivityBucketKey | null {
+  switch (value) {
+    case "all":
+    case "active":
+    case "blocked":
+    case "completed":
+    case "recent":
+      return value;
+    default:
+      return null;
+  }
 }
 
 const topbarStyle: CSSProperties = {

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -59,14 +59,18 @@ export function useProjectAssistantController(options: Options) {
   const [bootstrapPending, setBootstrapPending] = useState(false);
 
   const propose = useCallback(
-    async (form: ProjectAssistantDraftForm) => {
+    async (form: ProjectAssistantDraftForm, workItemID?: string) => {
       if (!options.project) return;
       setStatus("proposing");
       setError("");
       setApplyResult(null);
       try {
         const payload = await draftProjectAssistant(
-          projectAssistantDraftPayload(form, options.project.id, options.selectedWorkItem?.id),
+          projectAssistantDraftPayload(
+            form,
+            options.project.id,
+            workItemID ?? options.selectedWorkItem?.id,
+          ),
         );
         setProposal(payload.data);
         setChatDraftSource(null);

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -37,6 +37,7 @@ import {
   getProjectHandoffs,
   getProjectMemory,
   getProjectMemoryCandidates,
+  getProjectOperationsBrief,
   getProjectWorkItem,
   getProjectWorkItems,
   getProjectWorkRoles,
@@ -284,11 +285,12 @@ describe("api client", () => {
 
   it("builds project work coordination requests", async () => {
     fetchMock.mockClear();
-    for (let i = 0; i < 7; i += 1) {
+    for (let i = 0; i < 8; i += 1) {
       fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
     }
 
     await getProjectActivity("proj/1");
+    await getProjectOperationsBrief("proj/1");
     await getProjectWorkRoles("proj/1");
     await getProjectWorkItems("proj/1");
     await getProjectWorkItem("proj/1", "work/1");
@@ -303,31 +305,36 @@ describe("api client", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/hecate/v1/projects/proj%2F1/roles",
+      "/hecate/v1/projects/proj%2F1/operations/brief",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
-      "/hecate/v1/projects/proj%2F1/work-items",
+      "/hecate/v1/projects/proj%2F1/roles",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       4,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      "/hecate/v1/projects/proj%2F1/work-items",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       5,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       6,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       7,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      8,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs",
       expect.objectContaining({ method: "GET" }),
     );

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -96,6 +96,7 @@ import type {
   ProjectMemoryCandidateResponse,
   ProjectMemoryListResponse,
   ProjectMemoryResponse,
+  ProjectOperationsBriefResponse,
   ProjectResponse,
   ProjectSkillResponse,
   ProjectSkillsResponse,
@@ -587,6 +588,14 @@ export async function rejectProjectMemoryCandidate(
 export async function getProjectActivity(projectID: string): Promise<ProjectActivityResponse> {
   return fetchJSON<ProjectActivityResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/activity`,
+  );
+}
+
+export async function getProjectOperationsBrief(
+  projectID: string,
+): Promise<ProjectOperationsBriefResponse> {
+  return fetchJSON<ProjectOperationsBriefResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/operations/brief`,
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -798,6 +798,55 @@ export type ProjectActivityResponse = {
   data: ProjectActivityData;
 };
 
+export type ProjectOperationsBriefPriority = "high" | "medium" | "low" | (string & {});
+
+export type ProjectOperationsBriefTarget = {
+  surface: "project_settings" | "work" | "memory" | "skills" | string;
+  project_id: string;
+  work_item_id?: string;
+  assignment_id?: string;
+  handoff_id?: string;
+  activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
+};
+
+export type ProjectOperationsBriefItem = {
+  id: string;
+  kind: string;
+  priority: ProjectOperationsBriefPriority;
+  title: string;
+  detail: string;
+  action_label: string;
+  status?: string;
+  target: ProjectOperationsBriefTarget;
+  draft_request?: string;
+  work_item?: ProjectActivityWorkItemRecord;
+  assignment?: ProjectAssignmentRecord;
+  handoff?: ProjectHandoffRecord;
+  updated_at?: string;
+  metadata?: Record<string, string>;
+};
+
+export type ProjectOperationsBriefSummary = {
+  item_count: number;
+  high_count: number;
+  medium_count: number;
+  low_count: number;
+  pending_memory_candidate_count: number;
+  pending_handoff_count: number;
+};
+
+export type ProjectOperationsBrief = {
+  project_id: string;
+  generated_at: string;
+  summary: ProjectOperationsBriefSummary;
+  items: ProjectOperationsBriefItem[];
+};
+
+export type ProjectOperationsBriefResponse = {
+  object: string;
+  data: ProjectOperationsBrief;
+};
+
 export type ProjectWorkRolesResponse = {
   object: string;
   data: ProjectWorkRoleRecord[];


### PR DESCRIPTION
## Summary

Adds a read-only Project Operations brief for Projects Work Coordination. The
new endpoint derives bounded operator actions from existing project state:
launch defaults, activity buckets, pending handoffs, pending memory candidates,
and work items that need assignments.

The Projects UI renders those server-backed operation items above the work
queue and routes them through existing safe surfaces: Project Settings, Work
Coordination, Memory/Context, assignment preflight, or the normal Project
Assistant proposal rail. Draftable operation items seed Project Assistant with
a request, but durable changes still require typed proposal review/apply.

Docs now describe the runtime API contract, operator behavior, and Project
Assistant boundary.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api`
- `cd ui && bun run format:check`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx src/app/AppShell.test.tsx src/lib/api.test.ts`
- `git diff --check`
- `rg -n -i 'omnigent' .` returned no matches
