### PR TITLE
ci(agent-adapters): add manual release smoke

### DIFF
--- a/.github/workflows/acp-release-smoke.yml
+++ b/.github/workflows/acp-release-smoke.yml
@@ -1,0 +1,35 @@
+name: ACP adapter release smoke
+
+# Manual packaging check for the standalone Go ACP adapters. Normal PR CI keeps
+# using the repo-local fake ACP peer; this workflow downloads released adapter
+# binaries and proves the Dockerfile-pinned artifacts still satisfy Hecate's ACP
+# boundary.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Release binary smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up just
+        uses: extractions/setup-just@v4
+
+      - name: Run ACP adapter release smoke
+        run: just test-acp-release-smoke

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -319,7 +319,8 @@ That opt-in smoke downloads the Codex and Claude Code adapter versions pinned in
 the Dockerfiles, verifies their release checksums, puts fake `codex` / `claude`
 CLIs on `PATH`, and runs Hecate's probe/auth/logout/session/run path against
 the real adapter binaries. It requires network access and is intentionally not
-part of the normal unit-test ladder.
+part of the normal unit-test ladder. The same check is available from GitHub
+Actions as the manual **ACP adapter release smoke** workflow.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -283,8 +283,7 @@ drift needs coverage, run `just test-acp-release-smoke`; it downloads the
 Dockerfile-pinned Go adapter release binaries, verifies checksums, and smokes
 probe capability discovery, ACP authenticate/logout, session config selectors,
 advertised slash commands, prompt streaming, and usage mapping with fake
-`codex` and `claude` CLIs. npm adapter wrappers are not part of the supported
-test path.
+`codex` and `claude` CLIs.
 
 ## Setup checks
 

--- a/internal/agentadapters/dockerfile_test.go
+++ b/internal/agentadapters/dockerfile_test.go
@@ -39,7 +39,7 @@ func TestDockerfilesInstallGoACPAdapterReleaseBinaries(t *testing.T) {
 				"@agentclientprotocol/claude-agent-acp",
 			} {
 				if strings.Contains(text, forbidden) {
-					t.Fatalf("%s contains legacy npm ACP adapter package %q", name, forbidden)
+					t.Fatalf("%s contains unsupported ACP adapter package %q", name, forbidden)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow for `just test-acp-release-smoke`
- document that the packaged adapter smoke is available from Actions
- keep External Agent docs focused on the supported Go ACP adapter binary path

## Verification
- `just docs-format-check`
- YAML parse: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/acp-release-smoke.yml")'`
- `git diff --check`
- `just test-acp-release-smoke`