### PR TITLE
feat(projects): route project operations follow-through

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -364,9 +364,15 @@ operators can separate live assignment buckets from actionable setup gaps,
 waiting approvals, blocked or stale assignments, pending handoffs, memory review
 work, missing provider/model defaults, and context readiness without adding a
 separate persisted health model. The Project Operations brief now exposes the
-top bounded operator actions from those same records and routes them back into
-existing Project Settings, Work Coordination, Memory/Context, preflight, or
-Project Assistant proposal flows; it does not persist a plan or start work.
+top bounded operator actions from those same records with typed `action`
+routing back into existing Project Settings, Work Coordination, Memory/Context,
+preflight, selected-work follow-through, or Project Assistant proposal flows.
+Review follow-up, missing completion evidence, and closeout-ready work items
+open the existing selected-work detail surface; the brief does not persist a
+plan, mark work done, or start work.
+The selected-work detail card still computes its closeout gate locally for V1;
+the next convergence step is a read-only backend closeout readiness contract
+that both Project Operations and the detail card reflect.
 Assignment rows now render compact execution evidence from canonical
 assignment/activity refs, while the Context Inspector renders the full persisted
 launch packet with Profile, Instructions, Skills, Memory, Project sources, Work

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -45,21 +45,25 @@ Tasks, Chats, and External Agents remain the execution surfaces.
 The Work Coordination tab starts with Project Operations when the server finds
 actionable project state: missing launch defaults, pending approvals, blocked
 or stale assignments, queued assignments that need preflight, pending handoffs,
-memory candidates awaiting review, or work items that need their first
-assignment. Each operation routes to an existing surface such as Project
-Settings, Work Coordination, Memory/Context, or assignment preflight. Draftable
-operations seed the normal Project Assistant proposal rail; the operator still
-reviews and applies typed changes before Hecate creates durable project records.
-When there is no server-backed operation to show, the tab falls back to the
-deterministic next action and compact resume summary.
-That fallback is transitional: new project-operations prioritization should
-land in the server brief first so clients do not maintain competing next-action
-cascades.
+memory candidates awaiting review, review artifacts that need follow-up,
+missing completion evidence, work items ready for closeout, or work items that
+need their first assignment. Each operation routes to an existing surface such
+as Project Settings, Work Coordination, Memory/Context, or assignment preflight.
+Clients route these items through the server-provided `action.type`; `kind`
+explains why the item appears, while `action` is the follow-through contract.
+Draftable operations seed the normal Project Assistant proposal rail; the
+operator still reviews and applies typed changes before Hecate creates durable
+project records.
+When there is no server-backed operation to show, the tab keeps only the compact
+resume summary; clients should not derive a second actionable next-action
+cascade from project state.
 
-Use the top action for the single most useful operator step, then jump to
+Use the top Project Operations action for the single most useful operator step,
+then jump to
 blocked, active, recent, or memory-review work from the resume summary before
-drilling into the full work queue. Review artifacts that require follow-up are
-surfaced as closeout blockers with direct follow-up creation actions.
+drilling into the full work queue. Review follow-up and closeout operations
+open selected-work detail; the operator still creates follow-up paths or marks
+work done explicitly from that surface.
 
 For a new work item with no assignments or artifacts yet, the detail view starts
 with a guided prepare action. Hecate can draft the first assignment from the

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -39,11 +39,12 @@ selected work item, the draft creates a new project work item. In both cases
 `Draft proposal` creates reviewable data only; it does not create a chat, task,
 run, assignment, or agent session.
 
-Project Operations brief items may seed this same draft flow with a
-`draft_request` and an optional work-item target. The brief is read-only routing
-state; it can open Project Settings, Work Coordination, Memory/Context, or an
-assignment preflight, and draftable items still become ordinary Project
-Assistant proposals that must be reviewed and explicitly applied.
+Project Operations brief items may seed this same draft flow with a typed
+`draft_project_proposal` action, `action.request`, and an optional work-item
+target. The brief is read-only routing state; it can open Project Settings,
+Work Coordination, Memory/Context, or an assignment preflight, and
+draftable items still become ordinary Project Assistant proposals that must be
+reviewed and explicitly applied.
 
 Project-linked Hecate Chat has a compact `Draft proposal` composer action for
 turning the current draft message into the same Project Assistant proposal

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2399,17 +2399,33 @@ standalone activity rows for them.
 Returns a read-only Project Operations brief for the selected project. The
 brief is an operator-facing triage layer over existing project state: launch
 defaults, the project activity buckets, work items without assignments, pending
-handoffs, and pending memory candidates. It is bounded and deterministic; it
-does not create tasks, runs, chats, assignments, handoffs, proposals, memory
-entries, or memory candidates, and it never starts queued work.
+handoffs, pending memory candidates, review artifacts that need follow-up,
+missing completion evidence, and work items ready for closeout. It is bounded
+and deterministic; it does not create tasks, runs, chats, assignments,
+handoffs, proposals, memory entries, or memory candidates, and it never starts
+queued work.
+The eight-item cap is applied after sorting by priority, explicit operation
+kind urgency, recency, and stable ID, so truncation is part of the operator
+priority policy.
 
-Each item points at an existing Hecate surface with `target.surface`:
-`project_settings`, `work`, `memory`, or `skills`. Items may include
-`work_item`, `assignment`, or `handoff` summaries copied from the existing
-project APIs so clients can route without reinterpreting raw ids. Items that can
-seed Project Assistant carry a plain `draft_request`; clients must still call
-the normal Project Assistant draft/propose/apply flow, where the operator
-reviews the typed proposal before any durable mutation.
+Each item has a `kind` that explains why it appears and an `action` that is the
+typed client routing contract. Clients should dispatch on `action.type`, not on
+`kind` or `target.surface`. `target` remains descriptive context for existing
+Hecate surfaces (`project_settings`, `work`, or `memory`) and for summaries
+copied from the existing project APIs.
+
+Known action types are:
+
+- `open_project_settings`
+- `open_work_item`
+- `open_assignment_preflight`
+- `open_memory_review`
+- `draft_project_proposal`
+
+Actions do not directly mutate project state. `open_assignment_preflight` opens
+the existing assignment launch preflight before any start. `draft_project_proposal`
+uses `action.request` and the normal Project Assistant draft/propose/apply flow,
+where the operator reviews the typed proposal before any durable mutation.
 
 ```json
 {
@@ -2440,6 +2456,13 @@ reviews the typed proposal before any durable mutation.
           "work_item_id": "work_...",
           "assignment_id": "asgn_...",
           "activity_bucket": "blocked"
+        },
+        "action": {
+          "type": "open_work_item",
+          "project_id": "proj_...",
+          "work_item_id": "work_...",
+          "assignment_id": "asgn_...",
+          "activity_bucket": "blocked"
         }
       },
       {
@@ -2452,6 +2475,10 @@ reviews the typed proposal before any durable mutation.
         "status": "pending",
         "target": {
           "surface": "memory",
+          "project_id": "proj_..."
+        },
+        "action": {
+          "type": "open_memory_review",
           "project_id": "proj_..."
         },
         "metadata": {

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -17,6 +17,14 @@ const (
 	projectOperationsPriorityHigh   = "high"
 	projectOperationsPriorityMedium = "medium"
 	projectOperationsPriorityLow    = "low"
+
+	projectOperationsBriefItemLimit = 8
+
+	projectOperationsActionDraftProjectProposal    = "draft_project_proposal"
+	projectOperationsActionOpenAssignmentPreflight = "open_assignment_preflight"
+	projectOperationsActionOpenMemoryReview        = "open_memory_review"
+	projectOperationsActionOpenProjectSettings     = "open_project_settings"
+	projectOperationsActionOpenWorkItem            = "open_work_item"
 )
 
 type ProjectOperationsBriefEnvelope struct {
@@ -41,20 +49,20 @@ type ProjectOperationsBriefSummaryResponse struct {
 }
 
 type ProjectOperationsBriefItemResponse struct {
-	ID           string                               `json:"id"`
-	Kind         string                               `json:"kind"`
-	Priority     string                               `json:"priority"`
-	Title        string                               `json:"title"`
-	Detail       string                               `json:"detail"`
-	ActionLabel  string                               `json:"action_label"`
-	Status       string                               `json:"status,omitempty"`
-	Target       ProjectOperationsBriefTargetResponse `json:"target"`
-	DraftRequest string                               `json:"draft_request,omitempty"`
-	WorkItem     *ProjectActivityWorkItemResponse     `json:"work_item,omitempty"`
-	Assignment   *ProjectWorkAssignmentResponse       `json:"assignment,omitempty"`
-	Handoff      *ProjectHandoffResponse              `json:"handoff,omitempty"`
-	UpdatedAt    string                               `json:"updated_at,omitempty"`
-	Metadata     map[string]string                    `json:"metadata,omitempty"`
+	ID          string                               `json:"id"`
+	Kind        string                               `json:"kind"`
+	Priority    string                               `json:"priority"`
+	Title       string                               `json:"title"`
+	Detail      string                               `json:"detail"`
+	ActionLabel string                               `json:"action_label"`
+	Status      string                               `json:"status,omitempty"`
+	Target      ProjectOperationsBriefTargetResponse `json:"target"`
+	Action      ProjectOperationsBriefActionResponse `json:"action"`
+	WorkItem    *ProjectActivityWorkItemResponse     `json:"work_item,omitempty"`
+	Assignment  *ProjectWorkAssignmentResponse       `json:"assignment,omitempty"`
+	Handoff     *ProjectHandoffResponse              `json:"handoff,omitempty"`
+	UpdatedAt   string                               `json:"updated_at,omitempty"`
+	Metadata    map[string]string                    `json:"metadata,omitempty"`
 }
 
 type ProjectOperationsBriefTargetResponse struct {
@@ -64,6 +72,16 @@ type ProjectOperationsBriefTargetResponse struct {
 	AssignmentID   string `json:"assignment_id,omitempty"`
 	HandoffID      string `json:"handoff_id,omitempty"`
 	ActivityBucket string `json:"activity_bucket,omitempty"`
+}
+
+type ProjectOperationsBriefActionResponse struct {
+	Type           string `json:"type"`
+	ProjectID      string `json:"project_id"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	HandoffID      string `json:"handoff_id,omitempty"`
+	ActivityBucket string `json:"activity_bucket,omitempty"`
+	Request        string `json:"request,omitempty"`
 }
 
 func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Request) {
@@ -103,22 +121,27 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}
+	artifacts, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
 	pendingMemoryCandidates, err := h.pendingProjectMemoryCandidateCount(ctx, projectID)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}
 
-	items := make([]ProjectOperationsBriefItemResponse, 0, 8)
+	items := make([]ProjectOperationsBriefItemResponse, 0, projectOperationsBriefItemLimit)
 	items = append(items, projectDefaultOperationItems(project)...)
 	items = append(items, assignmentOperationItems(activity)...)
 	items = append(items, handoffOperationItems(projectID, handoffs)...)
+	items = append(items, selectedWorkFollowThroughOperationItems(projectID, workItems, assignments, artifacts, handoffs)...)
 	if pendingMemoryCandidates > 0 {
 		items = append(items, memoryCandidateOperationItem(projectID, pendingMemoryCandidates))
 	}
 	items = append(items, assignmentGapOperationItems(projectID, workItems, assignments)...)
 
 	sortProjectOperationsItems(items)
-	items = boundedProjectOperationsItems(items, 8)
+	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
 	response := ProjectOperationsBriefResponse{
 		ProjectID:   projectID,
 		GeneratedAt: formatOptionalTime(time.Now().UTC()),
@@ -183,6 +206,7 @@ func projectDefaultOperationItems(project projects.Project) []ProjectOperationsB
 			Surface:   "project_settings",
 			ProjectID: project.ID,
 		},
+		Action:    projectOperationsOpenProjectSettingsAction(project.ID),
 		UpdatedAt: formatOptionalTime(project.UpdatedAt),
 		Metadata: map[string]string{
 			"missing": strings.Join(missing, ","),
@@ -209,18 +233,23 @@ func assignmentOperationItems(activity ProjectActivityDataResponse) []ProjectOpe
 	for _, item := range activity.Buckets.Active {
 		items = append(items, projectOperationItemFromActivity(item, "inspect_active_assignment", projectOperationsPriorityLow, "Inspect active assignment", item.StatusSummary, "Inspect work"))
 	}
-	for _, item := range activity.Buckets.Completed {
-		if item.ArtifactSummary.Count > 0 {
-			continue
-		}
-		items = append(items, projectOperationItemFromActivity(item, "record_completion_evidence", projectOperationsPriorityLow, "Record completion evidence", "Completed assignments should leave reviewable evidence before work is closed.", "Open work"))
-	}
 	return items
 }
 
 func projectOperationItemFromActivity(activity ProjectActivityItemResponse, kind, priority, title, detail, actionLabel string) ProjectOperationsBriefItemResponse {
 	workItem := activity.WorkItem
 	assignment := activity.Assignment
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:        "work",
+		ProjectID:      activity.ProjectID,
+		WorkItemID:     activity.WorkItem.ID,
+		AssignmentID:   activity.Assignment.ID,
+		ActivityBucket: projectActivityBucket(activity),
+	}
+	action := projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, "", target.ActivityBucket)
+	if kind == "start_queued_assignment" {
+		action = projectOperationsOpenAssignmentPreflightAction(target.ProjectID, target.WorkItemID, target.AssignmentID, target.ActivityBucket)
+	}
 	return ProjectOperationsBriefItemResponse{
 		ID:          projectOperationsItemID(kind, activity.ProjectID, activity.Assignment.ID),
 		Kind:        kind,
@@ -229,16 +258,11 @@ func projectOperationItemFromActivity(activity ProjectActivityItemResponse, kind
 		Detail:      firstNonEmpty(detail, activity.StatusSummary),
 		ActionLabel: actionLabel,
 		Status:      activity.BlockingSignal,
-		Target: ProjectOperationsBriefTargetResponse{
-			Surface:        "work",
-			ProjectID:      activity.ProjectID,
-			WorkItemID:     activity.WorkItem.ID,
-			AssignmentID:   activity.Assignment.ID,
-			ActivityBucket: projectActivityBucket(activity),
-		},
-		WorkItem:   &workItem,
-		Assignment: &assignment,
-		UpdatedAt:  activity.UpdatedAt,
+		Target:      target,
+		Action:      action,
+		WorkItem:    &workItem,
+		Assignment:  &assignment,
+		UpdatedAt:   activity.UpdatedAt,
 	}
 }
 
@@ -249,6 +273,13 @@ func handoffOperationItems(projectID string, handoffs []projectwork.Handoff) []P
 			continue
 		}
 		rendered := renderProjectHandoff(handoff)
+		target := ProjectOperationsBriefTargetResponse{
+			Surface:      "work",
+			ProjectID:    projectID,
+			WorkItemID:   handoff.WorkItemID,
+			HandoffID:    handoff.ID,
+			AssignmentID: firstNonEmpty(handoff.TargetAssignmentID, handoff.SourceAssignmentID),
+		}
 		items = append(items, ProjectOperationsBriefItemResponse{
 			ID:          projectOperationsItemID("review_pending_handoff", projectID, handoff.ID),
 			Kind:        "review_pending_handoff",
@@ -257,18 +288,123 @@ func handoffOperationItems(projectID string, handoffs []projectwork.Handoff) []P
 			Detail:      firstNonEmpty(handoff.RecommendedNextAction, handoff.Summary, "Review the handoff and decide the next assignment."),
 			ActionLabel: "Open handoff",
 			Status:      handoff.Status,
-			Target: ProjectOperationsBriefTargetResponse{
-				Surface:      "work",
-				ProjectID:    projectID,
-				WorkItemID:   handoff.WorkItemID,
-				HandoffID:    handoff.ID,
-				AssignmentID: firstNonEmpty(handoff.TargetAssignmentID, handoff.SourceAssignmentID),
-			},
-			Handoff:   &rendered,
-			UpdatedAt: formatOptionalTime(projectworkTime(handoff.UpdatedAt, handoff.CreatedAt)),
+			Target:      target,
+			Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, target.HandoffID, ""),
+			Handoff:     &rendered,
+			UpdatedAt:   formatOptionalTime(projectworkTime(handoff.UpdatedAt, handoff.CreatedAt)),
 		})
 	}
 	return items
+}
+
+func selectedWorkFollowThroughOperationItems(projectID string, workItems []projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) []ProjectOperationsBriefItemResponse {
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	assignmentsByID := projectOperationsAssignmentsByID(assignments)
+	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
+	allArtifactsByWorkItem := projectOperationsArtifactsByWorkItem(artifacts)
+	handoffsByWorkItem := projectOperationsHandoffsByWorkItem(handoffs)
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(workItems))
+	for _, workItem := range workItems {
+		if projectWorkItemClosed(workItem.Status) {
+			continue
+		}
+		if review := projectOperationsReviewFollowUpArtifact(allArtifactsByWorkItem[workItem.ID], handoffs); review != nil {
+			items = append(items, reviewFollowUpOperationItem(projectID, workItem, *review))
+		}
+		for _, assignment := range assignmentsByWorkItem[workItem.ID] {
+			if projectOperationsAssignmentStatus(assignment) != projectwork.AssignmentStatusCompleted {
+				continue
+			}
+			if projectOperationsAssignmentHasEvidence(assignment, artifactsByAssignment, artifactsByWorkItem) {
+				continue
+			}
+			items = append(items, completionEvidenceOperationItem(projectID, workItem, assignment))
+		}
+		if projectOperationsWorkItemReadyToClose(workItem, assignmentsByWorkItem[workItem.ID], artifactsByAssignment, artifactsByWorkItem, handoffsByWorkItem[workItem.ID], assignmentsByID) {
+			items = append(items, closeWorkItemOperationItem(projectID, workItem, assignmentsByWorkItem[workItem.ID]))
+		}
+	}
+	return items
+}
+
+func reviewFollowUpOperationItem(projectID string, workItem projectwork.WorkItem, artifact projectwork.CollaborationArtifact) ProjectOperationsBriefItemResponse {
+	renderedWorkItem := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+	status := "awaiting_approval"
+	if artifact.ReviewVerdict == projectwork.ReviewVerdictBlocked {
+		status = "blocked"
+	}
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:    "work",
+		ProjectID:  projectID,
+		WorkItemID: workItem.ID,
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("review_follow_up", projectID, artifact.ID),
+		Kind:        "review_follow_up",
+		Priority:    projectOperationsPriorityMedium,
+		Title:       "Review follow-up: " + firstNonEmpty(workItem.Title, artifact.Title, artifact.ID),
+		Detail:      "Review artifact " + firstNonEmpty(artifact.Title, artifact.ID) + " needs a follow-up path before closeout.",
+		ActionLabel: "Open review",
+		Status:      status,
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, "", "", ""),
+		WorkItem:    &renderedWorkItem,
+		UpdatedAt:   formatOptionalTime(projectworkTime(artifact.UpdatedAt, artifact.CreatedAt, workItem.UpdatedAt, workItem.CreatedAt)),
+		Metadata: map[string]string{
+			"artifact_id":    artifact.ID,
+			"review_verdict": artifact.ReviewVerdict,
+		},
+	}
+}
+
+func completionEvidenceOperationItem(projectID string, workItem projectwork.WorkItem, assignment projectwork.Assignment) ProjectOperationsBriefItemResponse {
+	renderedWorkItem := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+	renderedAssignment := renderProjectWorkAssignment(assignment)
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:      "work",
+		ProjectID:    projectID,
+		WorkItemID:   workItem.ID,
+		AssignmentID: assignment.ID,
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("record_completion_evidence", projectID, assignment.ID),
+		Kind:        "record_completion_evidence",
+		Priority:    projectOperationsPriorityLow,
+		Title:       "Record completion evidence: " + firstNonEmpty(workItem.Title, assignment.ID),
+		Detail:      "Completed assignments should leave reviewable evidence before work is closed.",
+		ActionLabel: "Open work",
+		Status:      projectwork.AssignmentStatusCompleted,
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, "", "completed"),
+		WorkItem:    &renderedWorkItem,
+		Assignment:  &renderedAssignment,
+		UpdatedAt:   formatOptionalTime(projectworkTime(assignment.CompletedAt, assignment.UpdatedAt, assignment.CreatedAt, workItem.UpdatedAt, workItem.CreatedAt)),
+	}
+}
+
+func closeWorkItemOperationItem(projectID string, workItem projectwork.WorkItem, assignments []projectwork.Assignment) ProjectOperationsBriefItemResponse {
+	renderedWorkItem := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:    "work",
+		ProjectID:  projectID,
+		WorkItemID: workItem.ID,
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("close_work_item", projectID, workItem.ID),
+		Kind:        "close_work_item",
+		Priority:    projectOperationsPriorityLow,
+		Title:       "Close out work item: " + firstNonEmpty(workItem.Title, workItem.ID),
+		Detail:      "Assignments, evidence, handoffs, and review follow-up are clear. Mark done from selected-work detail.",
+		ActionLabel: "Open closeout",
+		Status:      "ready",
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, "", "", ""),
+		WorkItem:    &renderedWorkItem,
+		UpdatedAt:   formatOptionalTime(projectOperationsLatestAssignmentTime(assignments, projectworkTime(workItem.UpdatedAt, workItem.CreatedAt))),
+		Metadata: map[string]string{
+			"assignment_count": intString(len(assignments)),
+		},
+	}
 }
 
 func memoryCandidateOperationItem(projectID string, count int) ProjectOperationsBriefItemResponse {
@@ -288,6 +424,7 @@ func memoryCandidateOperationItem(projectID string, count int) ProjectOperations
 			Surface:   "memory",
 			ProjectID: projectID,
 		},
+		Action: projectOperationsOpenMemoryReviewAction(projectID),
 		Metadata: map[string]string{
 			"candidate_count": intString(count),
 		},
@@ -299,17 +436,17 @@ func assignmentGapOperationItems(projectID string, workItems []projectwork.WorkI
 	items := make([]ProjectOperationsBriefItemResponse, 0, len(workItems)+1)
 	if len(workItems) == 0 {
 		items = append(items, ProjectOperationsBriefItemResponse{
-			ID:           projectOperationsItemID("create_first_work_item", projectID),
-			Kind:         "create_first_work_item",
-			Priority:     projectOperationsPriorityMedium,
-			Title:        "Create the first work item",
-			Detail:       "Start with one reviewable project work item before queueing assignments.",
-			ActionLabel:  "Draft work",
-			DraftRequest: "Create the first project work item",
+			ID:          projectOperationsItemID("create_first_work_item", projectID),
+			Kind:        "create_first_work_item",
+			Priority:    projectOperationsPriorityMedium,
+			Title:       "Create the first work item",
+			Detail:      "Start with one reviewable project work item before queueing assignments.",
+			ActionLabel: "Draft work",
 			Target: ProjectOperationsBriefTargetResponse{
 				Surface:   "work",
 				ProjectID: projectID,
 			},
+			Action: projectOperationsDraftProjectProposalAction(projectID, "", "Create the first project work item"),
 		})
 		return items
 	}
@@ -319,19 +456,19 @@ func assignmentGapOperationItems(projectID string, workItems []projectwork.WorkI
 		}
 		rendered := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
 		items = append(items, ProjectOperationsBriefItemResponse{
-			ID:           projectOperationsItemID("prepare_first_assignment", projectID, workItem.ID),
-			Kind:         "prepare_first_assignment",
-			Priority:     projectOperationsPriorityMedium,
-			Title:        "Prepare first assignment: " + firstNonEmpty(workItem.Title, workItem.ID),
-			Detail:       "This work item has no queued or running assignments yet.",
-			ActionLabel:  "Draft assignment",
-			DraftRequest: "Queue an assignment for " + firstNonEmpty(workItem.Title, workItem.ID),
-			Status:       firstNonEmpty(workItem.Status, projectwork.WorkItemStatusReady),
+			ID:          projectOperationsItemID("prepare_first_assignment", projectID, workItem.ID),
+			Kind:        "prepare_first_assignment",
+			Priority:    projectOperationsPriorityMedium,
+			Title:       "Prepare first assignment: " + firstNonEmpty(workItem.Title, workItem.ID),
+			Detail:      "This work item has no queued or running assignments yet.",
+			ActionLabel: "Draft assignment",
+			Status:      firstNonEmpty(workItem.Status, projectwork.WorkItemStatusReady),
 			Target: ProjectOperationsBriefTargetResponse{
 				Surface:    "work",
 				ProjectID:  projectID,
 				WorkItemID: workItem.ID,
 			},
+			Action:    projectOperationsDraftProjectProposalAction(projectID, workItem.ID, "Queue an assignment for "+firstNonEmpty(workItem.Title, workItem.ID)),
 			WorkItem:  &rendered,
 			UpdatedAt: formatOptionalTime(projectworkTime(workItem.UpdatedAt, workItem.CreatedAt)),
 		})
@@ -371,6 +508,8 @@ func projectOperationsPriorityRank(priority string) int {
 }
 
 func projectOperationsKindRank(kind string) int {
+	// Kind rank is operator urgency within each priority tier because the brief cap
+	// keeps only the first sorted items.
 	switch strings.TrimSpace(kind) {
 	case "approve_assignment":
 		return 0
@@ -386,6 +525,8 @@ func projectOperationsKindRank(kind string) int {
 		return 50
 	case "review_pending_handoff":
 		return 60
+	case "review_follow_up":
+		return 65
 	case "prepare_first_assignment":
 		return 70
 	case "create_first_work_item":
@@ -396,6 +537,8 @@ func projectOperationsKindRank(kind string) int {
 		return 100
 	case "record_completion_evidence":
 		return 110
+	case "close_work_item":
+		return 120
 	default:
 		return 1000
 	}
@@ -409,6 +552,50 @@ func boundedProjectOperationsItems(items []ProjectOperationsBriefItemResponse, l
 		return append([]ProjectOperationsBriefItemResponse(nil), items[:limit]...)
 	}
 	return append([]ProjectOperationsBriefItemResponse(nil), items...)
+}
+
+func projectOperationsDraftProjectProposalAction(projectID, workItemID, request string) ProjectOperationsBriefActionResponse {
+	return ProjectOperationsBriefActionResponse{
+		Type:       projectOperationsActionDraftProjectProposal,
+		ProjectID:  projectID,
+		WorkItemID: strings.TrimSpace(workItemID),
+		Request:    strings.TrimSpace(request),
+	}
+}
+
+func projectOperationsOpenAssignmentPreflightAction(projectID, workItemID, assignmentID, bucket string) ProjectOperationsBriefActionResponse {
+	return ProjectOperationsBriefActionResponse{
+		Type:           projectOperationsActionOpenAssignmentPreflight,
+		ProjectID:      projectID,
+		WorkItemID:     workItemID,
+		AssignmentID:   assignmentID,
+		ActivityBucket: bucket,
+	}
+}
+
+func projectOperationsOpenMemoryReviewAction(projectID string) ProjectOperationsBriefActionResponse {
+	return ProjectOperationsBriefActionResponse{
+		Type:      projectOperationsActionOpenMemoryReview,
+		ProjectID: projectID,
+	}
+}
+
+func projectOperationsOpenProjectSettingsAction(projectID string) ProjectOperationsBriefActionResponse {
+	return ProjectOperationsBriefActionResponse{
+		Type:      projectOperationsActionOpenProjectSettings,
+		ProjectID: projectID,
+	}
+}
+
+func projectOperationsOpenWorkItemAction(projectID, workItemID, assignmentID, handoffID, bucket string) ProjectOperationsBriefActionResponse {
+	return ProjectOperationsBriefActionResponse{
+		Type:           projectOperationsActionOpenWorkItem,
+		ProjectID:      projectID,
+		WorkItemID:     workItemID,
+		AssignmentID:   assignmentID,
+		HandoffID:      handoffID,
+		ActivityBucket: bucket,
+	}
 }
 
 func projectOperationsItemID(kind string, parts ...string) string {
@@ -439,6 +626,195 @@ func projectWorkItemClosed(status string) bool {
 	default:
 		return false
 	}
+}
+
+func projectOperationsReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
+	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := projectworkTime(items[i].UpdatedAt, items[i].CreatedAt), projectworkTime(items[j].UpdatedAt, items[j].CreatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+	for i := range items {
+		if !projectOperationsReviewArtifactRequiresFollowUp(items[i]) {
+			continue
+		}
+		if projectOperationsArtifactHasLinkedFollowUpPath(items[i].ID, handoffs) {
+			continue
+		}
+		return &items[i]
+	}
+	return nil
+}
+
+func projectOperationsReviewArtifactRequiresFollowUp(artifact projectwork.CollaborationArtifact) bool {
+	if artifact.Kind != projectwork.ArtifactKindReview {
+		return false
+	}
+	return artifact.ReviewFollowUpRequired || artifact.ReviewVerdict == projectwork.ReviewVerdictBlocked || artifact.ReviewVerdict == projectwork.ReviewVerdictChangesRequested
+}
+
+func projectOperationsArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwork.Handoff) bool {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return false
+	}
+	for _, handoff := range handoffs {
+		for _, linkedID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(linkedID) != artifactID {
+				continue
+			}
+			if handoff.Status == projectwork.HandoffStatusPending ||
+				handoff.Status == projectwork.HandoffStatusDismissed ||
+				handoff.Status == projectwork.HandoffStatusSuperseded ||
+				strings.TrimSpace(handoff.TargetAssignmentID) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func projectOperationsWorkItemReadyToClose(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifactsByAssignment, artifactsByWorkItem map[string][]projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) bool {
+	if projectWorkItemClosed(workItem.Status) || len(assignments) == 0 {
+		return false
+	}
+	for _, assignment := range assignments {
+		if projectOperationsAssignmentStatus(assignment) != projectwork.AssignmentStatusCompleted {
+			return false
+		}
+		if !projectOperationsAssignmentHasEvidence(assignment, artifactsByAssignment, artifactsByWorkItem) {
+			return false
+		}
+	}
+	for _, handoff := range handoffs {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			return false
+		}
+	}
+	for _, artifact := range artifactsByWorkItem[workItem.ID] {
+		if projectOperationsReviewFollowUpBlocker(artifact, handoffs, assignmentsByID) {
+			return false
+		}
+	}
+	for _, assignment := range assignments {
+		for _, artifact := range artifactsByAssignment[assignment.ID] {
+			if projectOperationsReviewFollowUpBlocker(artifact, handoffs, assignmentsByID) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func projectOperationsAssignmentStatus(assignment projectwork.Assignment) string {
+	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
+}
+
+func projectOperationsAssignmentHasEvidence(assignment projectwork.Assignment, artifactsByAssignment, artifactsByWorkItem map[string][]projectwork.CollaborationArtifact) bool {
+	if projectOperationsArtifactsIncludeEvidence(artifactsByAssignment[assignment.ID]) {
+		return true
+	}
+	return projectOperationsArtifactsIncludeEvidence(artifactsByWorkItem[assignment.WorkItemID])
+}
+
+func projectOperationsArtifactsIncludeEvidence(artifacts []projectwork.CollaborationArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Kind == projectwork.ArtifactKindEvidenceLink {
+			return true
+		}
+	}
+	return false
+}
+
+func projectOperationsReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) bool {
+	if !projectOperationsReviewArtifactRequiresFollowUp(artifact) {
+		return false
+	}
+	linked := make([]projectwork.Handoff, 0)
+	for _, handoff := range handoffs {
+		for _, artifactID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(artifactID) == artifact.ID {
+				linked = append(linked, handoff)
+				break
+			}
+		}
+	}
+	if len(linked) == 0 {
+		return true
+	}
+	hasTargetAssignment := false
+	hasCompletedTarget := false
+	hasDismissedOrSuperseded := false
+	for _, handoff := range linked {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			return true
+		}
+		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
+			hasDismissedOrSuperseded = true
+		}
+		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
+			continue
+		}
+		hasTargetAssignment = true
+		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
+			hasCompletedTarget = hasCompletedTarget || projectOperationsAssignmentStatus(assignment) == projectwork.AssignmentStatusCompleted
+		}
+	}
+	if hasCompletedTarget {
+		return false
+	}
+	if hasTargetAssignment {
+		return true
+	}
+	if hasDismissedOrSuperseded {
+		return false
+	}
+	return true
+}
+
+func projectOperationsArtifactsByWorkItem(artifacts []projectwork.CollaborationArtifact) map[string][]projectwork.CollaborationArtifact {
+	byWorkItem := make(map[string][]projectwork.CollaborationArtifact)
+	for _, artifact := range artifacts {
+		if artifact.WorkItemID == "" {
+			continue
+		}
+		byWorkItem[artifact.WorkItemID] = append(byWorkItem[artifact.WorkItemID], artifact)
+	}
+	return byWorkItem
+}
+
+func projectOperationsHandoffsByWorkItem(handoffs []projectwork.Handoff) map[string][]projectwork.Handoff {
+	byWorkItem := make(map[string][]projectwork.Handoff)
+	for _, handoff := range handoffs {
+		if handoff.WorkItemID == "" {
+			continue
+		}
+		byWorkItem[handoff.WorkItemID] = append(byWorkItem[handoff.WorkItemID], handoff)
+	}
+	return byWorkItem
+}
+
+func projectOperationsAssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
+	byID := make(map[string]projectwork.Assignment, len(assignments))
+	for _, assignment := range assignments {
+		byID[assignment.ID] = assignment
+	}
+	return byID
+}
+
+func projectOperationsLatestAssignmentTime(assignments []projectwork.Assignment, fallback time.Time) time.Time {
+	latest := fallback
+	for _, assignment := range assignments {
+		for _, value := range []time.Time{assignment.CompletedAt, assignment.StartedAt, assignment.UpdatedAt, assignment.CreatedAt} {
+			if value.After(latest) {
+				latest = value
+			}
+		}
+	}
+	return latest
 }
 
 func projectworkTime(values ...time.Time) time.Time {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -103,26 +103,27 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	if response.Data.Summary.PendingMemoryCandidateCount != 1 || response.Data.Summary.PendingHandoffCount != 1 {
 		t.Fatalf("operations summary = %+v, want memory candidate and handoff counts", response.Data.Summary)
 	}
+	assertProjectOperationsItemsHaveActions(t, response.Data.Items)
 
 	defaults := findProjectOperationsItemForTest(t, response.Data.Items, "configure_project_defaults")
-	if defaults.Target.Surface != "project_settings" || defaults.ActionLabel != "Project settings" {
+	if defaults.Target.Surface != "project_settings" || defaults.Action.Type != projectOperationsActionOpenProjectSettings || defaults.ActionLabel != "Project settings" {
 		t.Fatalf("defaults item = %+v, want project settings target", defaults)
 	}
 	approval := findProjectOperationsItemForTest(t, response.Data.Items, "approve_assignment")
-	if approval.Target.WorkItemID != "work_review" || approval.Target.AssignmentID != "asgn_approval" || approval.Target.ActivityBucket != "blocked" {
+	if approval.Target.WorkItemID != "work_review" || approval.Target.AssignmentID != "asgn_approval" || approval.Target.ActivityBucket != "blocked" || approval.Action.Type != projectOperationsActionOpenWorkItem {
 		t.Fatalf("approval item = %+v, want blocked assignment target", approval)
 	}
 	handoff := findProjectOperationsItemForTest(t, response.Data.Items, "review_pending_handoff")
-	if handoff.Handoff == nil || handoff.Handoff.ID != "handoff_review" || handoff.Target.HandoffID != "handoff_review" {
+	if handoff.Handoff == nil || handoff.Handoff.ID != "handoff_review" || handoff.Target.HandoffID != "handoff_review" || handoff.Action.Type != projectOperationsActionOpenWorkItem {
 		t.Fatalf("handoff item = %+v, want rendered handoff target", handoff)
 	}
 	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
-	if memoryItem.Target.Surface != "memory" {
+	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
 		t.Fatalf("memory item = %+v, want memory target", memoryItem)
 	}
 	assignmentGap := findProjectOperationsItemForTest(t, response.Data.Items, "prepare_first_assignment")
-	if assignmentGap.Target.WorkItemID != "work_empty" || assignmentGap.DraftRequest == "" {
-		t.Fatalf("assignment gap item = %+v, want draft request for empty work item", assignmentGap)
+	if assignmentGap.Target.WorkItemID != "work_empty" || assignmentGap.Action.Type != projectOperationsActionDraftProjectProposal || assignmentGap.Action.Request == "" {
+		t.Fatalf("assignment gap item = %+v, want draft action for empty work item", assignmentGap)
 	}
 
 	afterAssignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_ops"})
@@ -135,6 +136,165 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	}
 	if len(afterAssignments) != len(beforeAssignments) || len(afterCandidates) != len(beforeCandidates) {
 		t.Fatalf("operations brief mutated project state: assignments %d->%d candidates %d->%d", len(beforeAssignments), len(afterAssignments), len(beforeCandidates), len(afterCandidates))
+	}
+}
+
+func TestProjectOperationItemFromActivity_StartQueuedUsesPreflightAction(t *testing.T) {
+	t.Parallel()
+	item := projectOperationItemFromActivity(ProjectActivityItemResponse{
+		ProjectID:       "proj_ops",
+		BlockingSignal:  "not_started",
+		StatusSummary:   "queued",
+		UpdatedAt:       "2026-06-20T12:00:00Z",
+		WorkItem:        ProjectActivityWorkItemResponse{ID: "work_ops", Title: "Prepare release"},
+		Assignment:      ProjectWorkAssignmentResponse{ID: "asgn_ops", ProjectID: "proj_ops", WorkItemID: "work_ops"},
+		ArtifactSummary: ProjectActivityArtifactSummaryResponse{},
+	}, "start_queued_assignment", projectOperationsPriorityHigh, "Review queued assignment", "Open launch preflight before starting this assignment.", "Review start")
+
+	if item.Action.Type != projectOperationsActionOpenAssignmentPreflight {
+		t.Fatalf("operation action = %+v, want assignment preflight action", item.Action)
+	}
+	if item.Action.ProjectID != "proj_ops" || item.Action.WorkItemID != "work_ops" || item.Action.AssignmentID != "asgn_ops" || item.Action.ActivityBucket != "blocked" {
+		t.Fatalf("operation action = %+v, want project/work/assignment/bucket refs", item.Action)
+	}
+}
+
+func TestProjectOperationsBrief_SelectedWorkFollowThrough(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_follow",
+		Name:            "Follow Through",
+		DefaultProvider: "ollama",
+		DefaultModel:    "qwen2.5-coder",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	for _, item := range []projectwork.WorkItem{
+		{ID: "work_review_followup", ProjectID: "proj_follow", Title: "Review requested changes", Status: projectwork.WorkItemStatusReview},
+		{ID: "work_missing_evidence", ProjectID: "proj_follow", Title: "Record release evidence", Status: projectwork.WorkItemStatusReview},
+		{ID: "work_close", ProjectID: "proj_follow", Title: "Ship operator brief", Status: projectwork.WorkItemStatusReview},
+	} {
+		if _, err := handler.projectWork.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatalf("CreateWorkItem(%s): %v", item.ID, err)
+		}
+	}
+	for _, assignment := range []projectwork.Assignment{
+		{ID: "asgn_review_followup", ProjectID: "proj_follow", WorkItemID: "work_review_followup", RoleID: "reviewer", Status: projectwork.AssignmentStatusCompleted},
+		{ID: "asgn_missing_evidence", ProjectID: "proj_follow", WorkItemID: "work_missing_evidence", RoleID: "developer", Status: projectwork.AssignmentStatusCompleted},
+		{ID: "asgn_close", ProjectID: "proj_follow", WorkItemID: "work_close", RoleID: "developer", Status: projectwork.AssignmentStatusCompleted},
+	} {
+		if _, err := handler.projectWork.CreateAssignment(t.Context(), assignment); err != nil {
+			t.Fatalf("CreateAssignment(%s): %v", assignment.ID, err)
+		}
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                     "artifact_review_followup",
+		ProjectID:              "proj_follow",
+		WorkItemID:             "work_review_followup",
+		AssignmentID:           "asgn_review_followup",
+		Kind:                   "review",
+		Title:                  "Architecture review",
+		Body:                   "Needs a follow-up assignment.",
+		ReviewVerdict:          "changes_requested",
+		ReviewFollowUpRequired: true,
+	}); err != nil {
+		t.Fatalf("CreateArtifact(review): %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                 "artifact_close_evidence",
+		ProjectID:          "proj_follow",
+		WorkItemID:         "work_close",
+		AssignmentID:       "asgn_close",
+		Kind:               "evidence_link",
+		Title:              "Release evidence",
+		Body:               "Evidence recorded.",
+		EvidenceURL:        "https://example.com/evidence",
+		EvidenceTrustLabel: "operator_reviewed",
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence): %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_follow/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	assertProjectOperationsItemsHaveActions(t, response.Data.Items)
+
+	review := findProjectOperationsItemForTest(t, response.Data.Items, "review_follow_up")
+	if review.Target.WorkItemID != "work_review_followup" || review.Action.Type != projectOperationsActionOpenWorkItem || review.Metadata["artifact_id"] != "artifact_review_followup" {
+		t.Fatalf("review follow-up item = %+v, want review follow-up work target", review)
+	}
+	reviewEvidence := findProjectOperationsItemForWorkItemForTest(t, response.Data.Items, "record_completion_evidence", "work_review_followup")
+	if reviewEvidence.Target.AssignmentID != "asgn_review_followup" || reviewEvidence.Action.Type != projectOperationsActionOpenWorkItem {
+		t.Fatalf("review evidence item = %+v, want review artifact not to satisfy evidence", reviewEvidence)
+	}
+	evidence := findProjectOperationsItemForWorkItemForTest(t, response.Data.Items, "record_completion_evidence", "work_missing_evidence")
+	if evidence.Target.WorkItemID != "work_missing_evidence" || evidence.Target.AssignmentID != "asgn_missing_evidence" || evidence.Action.Type != projectOperationsActionOpenWorkItem {
+		t.Fatalf("evidence item = %+v, want missing-evidence work target", evidence)
+	}
+	closeout := findProjectOperationsItemForTest(t, response.Data.Items, "close_work_item")
+	if closeout.Target.WorkItemID != "work_close" || closeout.Status != "ready" || closeout.Action.Type != projectOperationsActionOpenWorkItem || closeout.Metadata["assignment_count"] != "1" {
+		t.Fatalf("closeout item = %+v, want ready closeout work target", closeout)
+	}
+	requireProjectOperationsItemAbsentForTest(t, response.Data.Items, "prepare_first_assignment")
+}
+
+func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
+	t.Parallel()
+	artifact := projectwork.CollaborationArtifact{
+		ID:                     "artifact_review",
+		Kind:                   projectwork.ArtifactKindReview,
+		ReviewVerdict:          projectwork.ReviewVerdictChangesRequested,
+		ReviewFollowUpRequired: true,
+	}
+
+	acceptedWithoutTarget := []projectwork.Handoff{{
+		ID:                "handoff_accepted",
+		Status:            projectwork.HandoffStatusAccepted,
+		LinkedArtifactIDs: []string{artifact.ID},
+	}}
+	if projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, acceptedWithoutTarget) {
+		t.Fatal("accepted handoff without target assignment should not hide review follow-up operation")
+	}
+	if !projectOperationsReviewFollowUpBlocker(artifact, acceptedWithoutTarget, nil) {
+		t.Fatal("accepted handoff without target assignment should still block closeout")
+	}
+
+	pending := []projectwork.Handoff{{
+		ID:                "handoff_pending",
+		Status:            projectwork.HandoffStatusPending,
+		LinkedArtifactIDs: []string{artifact.ID},
+	}}
+	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, pending) || !projectOperationsReviewFollowUpBlocker(artifact, pending, nil) {
+		t.Fatal("pending handoff should route through handoff review and block closeout")
+	}
+
+	dismissed := []projectwork.Handoff{{
+		ID:                "handoff_dismissed",
+		Status:            projectwork.HandoffStatusDismissed,
+		LinkedArtifactIDs: []string{artifact.ID},
+	}}
+	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, dismissed) || projectOperationsReviewFollowUpBlocker(artifact, dismissed, nil) {
+		t.Fatal("dismissed handoff should clear review follow-up without blocking closeout")
+	}
+
+	completedTarget := []projectwork.Handoff{{
+		ID:                 "handoff_completed",
+		Status:             projectwork.HandoffStatusAccepted,
+		TargetAssignmentID: "asgn_followup",
+		LinkedArtifactIDs:  []string{artifact.ID},
+	}}
+	assignmentsByID := map[string]projectwork.Assignment{
+		"asgn_followup": {ID: "asgn_followup", Status: projectwork.AssignmentStatusCompleted},
+	}
+	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, completedTarget) || projectOperationsReviewFollowUpBlocker(artifact, completedTarget, assignmentsByID) {
+		t.Fatal("completed target assignment should clear review follow-up closeout blocker")
 	}
 }
 
@@ -189,6 +349,21 @@ func TestSortProjectOperationsItems_UsesExplicitUrgencyBeforeRecency(t *testing.
 	}
 }
 
+func assertProjectOperationsItemsHaveActions(t *testing.T, items []ProjectOperationsBriefItemResponse) {
+	t.Helper()
+	if len(items) == 0 {
+		t.Fatal("expected operation items")
+	}
+	for _, item := range items {
+		if item.Action.Type == "" || item.Action.ProjectID == "" {
+			t.Fatalf("operation item %q has incomplete action: %+v", item.Kind, item.Action)
+		}
+		if item.Action.Type == projectOperationsActionDraftProjectProposal && item.Action.Request == "" {
+			t.Fatalf("draft operation item %q has empty action request: %+v", item.Kind, item.Action)
+		}
+	}
+}
+
 func findProjectOperationsItemForTest(t *testing.T, items []ProjectOperationsBriefItemResponse, kind string) ProjectOperationsBriefItemResponse {
 	t.Helper()
 	for _, item := range items {
@@ -198,4 +373,24 @@ func findProjectOperationsItemForTest(t *testing.T, items []ProjectOperationsBri
 	}
 	t.Fatalf("operations item kind %q missing from %+v", kind, items)
 	return ProjectOperationsBriefItemResponse{}
+}
+
+func findProjectOperationsItemForWorkItemForTest(t *testing.T, items []ProjectOperationsBriefItemResponse, kind, workItemID string) ProjectOperationsBriefItemResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.Kind == kind && item.Target.WorkItemID == workItemID {
+			return item
+		}
+	}
+	t.Fatalf("operations item kind %q for work item %q missing from %+v", kind, workItemID, items)
+	return ProjectOperationsBriefItemResponse{}
+}
+
+func requireProjectOperationsItemAbsentForTest(t *testing.T, items []ProjectOperationsBriefItemResponse, kind string) {
+	t.Helper()
+	for _, item := range items {
+		if item.Kind == kind {
+			t.Fatalf("operations item kind %q unexpectedly present in %+v", kind, items)
+		}
+	}
 }

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -6,8 +6,6 @@ import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
   ProjectAssignmentRecord,
-  ProjectCollaborationArtifactRecord,
-  ProjectHandoffRecord,
   ProjectMemoryCandidateRecord,
   ProjectRecord,
   ProjectWorkItemRecord,
@@ -161,40 +159,6 @@ function memoryCandidate(
     suggested_kind: "note",
     suggested_trust_label: "operator_review",
     suggested_source_kind: "dogfood",
-    created_at: "2026-06-13T00:00:00Z",
-    updated_at: "2026-06-13T00:00:00Z",
-    ...overrides,
-  };
-}
-
-function handoff(overrides: Partial<ProjectHandoffRecord> = {}): ProjectHandoffRecord {
-  return {
-    id: "handoff_1",
-    project_id: "proj_1",
-    work_item_id: "work_1",
-    title: "Implementation handoff",
-    summary: "Follow up on the implementation.",
-    recommended_next_action: "Create the follow-up assignment.",
-    status: "pending",
-    provenance_kind: "operator",
-    trust_label: "operator_review",
-    created_at: "2026-06-13T00:00:00Z",
-    updated_at: "2026-06-13T00:00:00Z",
-    status_changed_at: "2026-06-13T00:00:00Z",
-    ...overrides,
-  };
-}
-
-function artifact(
-  overrides: Partial<ProjectCollaborationArtifactRecord> = {},
-): ProjectCollaborationArtifactRecord {
-  return {
-    id: "artifact_1",
-    project_id: "proj_1",
-    work_item_id: "work_1",
-    kind: "evidence_link",
-    title: "Launch checklist",
-    body: "Evidence recorded.",
     created_at: "2026-06-13T00:00:00Z",
     updated_at: "2026-06-13T00:00:00Z",
     ...overrides,
@@ -385,6 +349,13 @@ describe("ProjectWorkspaceView", () => {
         assignment_id: "asgn_1",
         activity_bucket: "blocked",
       },
+      action: {
+        type: "open_assignment_preflight",
+        project_id: "proj_1",
+        work_item_id: "work_1",
+        assignment_id: "asgn_1",
+        activity_bucket: "blocked",
+      },
       updated_at: "2026-06-13T00:00:00Z",
     } as const;
     const { handlers } = renderWorkspace({
@@ -528,230 +499,35 @@ describe("ProjectWorkspaceView", () => {
     ).toBeTruthy();
   });
 
-  it("renders next action for queued, blocked, active, and memory states", async () => {
-    const queuedActivity = activity();
-    const blockedItem = activityItem({
-      blocking_signal: "failed",
-      id: "assign_failed",
-      status: "failed",
-      status_summary: "failed",
-      work_item: {
-        id: "work_failed",
-        title: "Repair failed launch",
-        status: "ready",
-        priority: "normal",
-      },
-    });
-    const activeItem = activityItem({
-      assignment: assignment({
-        id: "assign_active",
-        work_item_id: "work_active",
-        status: "running",
-      }),
-      blocking_signal: "running",
-      id: "assign_active",
-      status: "running",
-      work_item: {
-        id: "work_active",
-        title: "Continue execution",
-        status: "ready",
-        priority: "normal",
-      },
-    });
-    const { handlers, props, rerender } = renderWorkspace({
-      activity: queuedActivity,
-      memoryCandidates: [memoryCandidate()],
-    });
-
-    let nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Start queued assignment")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Start assignment" }));
-    expect(handlers.onStartAssignment).toHaveBeenCalledWith(
-      queuedActivity.buckets.blocked[0].assignment,
-    );
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        activity={activity({
-          summary: {
-            work_item_count: 1,
-            assignment_count: 1,
-            active_count: 0,
-            blocked_count: 1,
-            completed_count: 0,
-            recent_count: 1,
-          },
-          buckets: {
-            active: [],
-            blocked: [blockedItem],
-            completed: [],
-            recent: [blockedItem],
-          },
-          recent: [blockedItem],
-        })}
-        memoryCandidates={[]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Resolve blocked assignment")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Open blocked work" }));
-    expect(handlers.onActivityBucketChange).toHaveBeenCalledWith("blocked");
-    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_failed");
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        activity={activity({
-          summary: {
-            work_item_count: 1,
-            assignment_count: 1,
-            active_count: 1,
-            blocked_count: 0,
-            completed_count: 0,
-            recent_count: 1,
-          },
-          buckets: {
-            active: [activeItem],
-            blocked: [],
-            completed: [],
-            recent: [activeItem],
-          },
-          recent: [activeItem],
-        })}
-        memoryCandidates={[]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Inspect active assignment")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Inspect work" }));
-    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_active");
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        activity={null}
-        memoryCandidates={[memoryCandidate()]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Review 1 memory candidate")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Review memory" }));
-    expect(handlers.onWorkspaceTabChange).toHaveBeenCalledWith("memory");
-  });
-
-  it("renders next action for selected-work follow through", async () => {
-    const item = workItem();
-    const completed = assignment({
-      execution_ref: { kind: "task_run", status: "completed" },
-      status: "completed",
-    });
-    const pendingHandoff = handoff();
-    const { handlers, props, rerender } = renderWorkspace({
-      selectedWorkItem: item,
-      workItems: [item],
-      handoffs: [pendingHandoff],
-    });
-
-    let nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Continue handoff: Implementation handoff")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Create assignment" }));
-    expect(handlers.onCreateAssignmentFromHandoff).toHaveBeenCalledWith(pendingHandoff);
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        handoffs={[]}
-        selectedWorkItem={item}
-        workItems={[item]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Create the first assignment")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Draft assignment" }));
-    expect(handlers.onDraftDefaultAssignment).toHaveBeenCalledWith(item);
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        artifacts={[
-          artifact({
-            id: "art_review",
-            kind: "review",
-            title: "Architect review",
-            review_follow_up_required: true,
-            review_verdict: "changes_requested",
-          }),
-        ]}
-        assignments={[completed]}
-        handoffs={[]}
-        selectedWorkItem={item}
-        workItems={[item]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Create review follow-up")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Create follow-up" }));
-    expect(handlers.onCreateAssignmentFromReviewArtifact).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "art_review" }),
-    );
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        assignments={[completed]}
-        handoffs={[]}
-        selectedWorkItem={item}
-        workItems={[item]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Record completion evidence")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Add evidence" }));
-    expect(handlers.onAddEvidenceLink).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <ProjectWorkspaceView
-        {...props}
-        {...handlers}
-        artifacts={[artifact()]}
-        assignments={[completed]}
-        handoffs={[]}
-        selectedWorkItem={item}
-        workItems={[item]}
-      />,
-    );
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Close out selected work")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Mark done" }));
-    expect(handlers.onCloseWorkItem).toHaveBeenCalledWith(item);
-  });
-
-  it("renders next action for empty and latest-work fallbacks", async () => {
+  it("does not derive local next actions when operations brief has no items", () => {
     const latest = workItem({
       id: "work_latest",
       title: "Polish project onboarding",
       created_at: "2026-06-12T00:00:00Z",
       updated_at: "2026-06-14T00:00:00Z",
     });
-    const { handlers, props, rerender } = renderWorkspace();
+    renderWorkspace({
+      activity: activity(),
+      memoryCandidates: [memoryCandidate()],
+      operationsBrief: {
+        project_id: "proj_1",
+        generated_at: "2026-06-13T00:00:00Z",
+        summary: {
+          item_count: 0,
+          high_count: 0,
+          medium_count: 0,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: [],
+      },
+      workItems: [latest],
+    });
 
-    let nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Create the first work item")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Create work" }));
-    expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
-
-    rerender(<ProjectWorkspaceView {...props} {...handlers} workItems={[latest]} />);
-    nextAction = screen.getByRole("region", { name: "Project next action" });
-    expect(within(nextAction).getByText("Continue existing work")).toBeTruthy();
-    await userEvent.click(within(nextAction).getByRole("button", { name: "Continue work" }));
-    expect(handlers.onSelectWorkItem).toHaveBeenCalledWith("work_latest");
+    expect(screen.queryByRole("region", { name: "Project next action" })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Project operations" })).toBeNull();
+    expect(screen.getByRole("region", { name: "Project resume" })).toBeTruthy();
   });
 
   it("renders project empty state when nothing is selected", () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -30,10 +30,7 @@ import {
 import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
 import { formatProjectRowRelativeTime, workStatusLabel } from "./projectDisplay";
 import {
-  activitySignalLabel,
-  buildProjectWorkCloseoutReadiness,
   projectActivityWorkItemToWorkItem,
-  reviewArtifactNeedsFollowUpPath,
   type ProjectActivityBucketKey,
 } from "./projectInsights";
 import { useProjectAssistantController } from "./useProjectAssistantController";
@@ -325,31 +322,6 @@ export function ProjectWorkspaceView({
                   error={operationsBriefError}
                   loading={operationsBriefLoadState === "loading"}
                   onAction={onOperationAction}
-                  // Transitional fallback: keep Project Operations as the server-backed source of truth
-                  // for new next-action derivation once the brief has proven out.
-                  fallback={
-                    <ProjectNextAction
-                      activity={activity}
-                      assignments={assignments}
-                      artifacts={artifacts}
-                      handoffs={handoffs}
-                      memoryCandidateCount={memoryCandidates.length}
-                      onAddEvidenceLink={onAddEvidenceLink}
-                      onBucketChange={onActivityBucketChange}
-                      onCloseWorkItem={onCloseWorkItem}
-                      onCreateAssignmentFromHandoff={onCreateAssignmentFromHandoff}
-                      onCreateAssignmentFromReviewArtifact={onCreateAssignmentFromReviewArtifact}
-                      onCreateWork={onCreateWork}
-                      onDraftDefaultAssignment={onDraftDefaultAssignment}
-                      onReviewMemory={() => onWorkspaceTabChange("memory")}
-                      onSelectWorkItem={onSelectWorkItem}
-                      onStartAssignment={onStartAssignment}
-                      onStartHandoff={onStartHandoff}
-                      selectedWorkItem={selectedWorkItem}
-                      startingAssignmentID={startingAssignmentID}
-                      workItems={workItems}
-                    />
-                  }
                 />
                 <ProjectResumeSummary
                   activity={activity}
@@ -736,35 +708,19 @@ function ProjectOnboardingPanel({
   );
 }
 
-type ProjectNextActionState = {
-  actionLabel: string;
-  detail: string;
-  disabled?: boolean;
-  onAction: () => void;
-  status: string;
-  title: string;
-};
-
 function ProjectOperationsBriefPanel({
   brief,
   error,
-  fallback,
   loading,
   onAction,
 }: {
   brief: ProjectOperationsBrief | null;
   error: string;
-  fallback: ReactNode;
   loading: boolean;
   onAction: (item: ProjectOperationsBriefItem) => void;
 }) {
   if ((!brief || brief.items.length === 0) && !loading) {
-    return (
-      <>
-        {fallback}
-        {error && <InlineError message={error} />}
-      </>
-    );
+    return error ? <InlineError message={error} /> : null;
   }
 
   const items = brief?.items ?? [];
@@ -833,278 +789,6 @@ function projectOperationBadge(item: ProjectOperationsBriefItem): string {
   return item.priority || item.status || "operation";
 }
 
-function ProjectNextAction({
-  activity,
-  assignments,
-  artifacts,
-  handoffs,
-  memoryCandidateCount,
-  onAddEvidenceLink,
-  onBucketChange,
-  onCloseWorkItem,
-  onCreateAssignmentFromHandoff,
-  onCreateAssignmentFromReviewArtifact,
-  onCreateWork,
-  onDraftDefaultAssignment,
-  onReviewMemory,
-  onSelectWorkItem,
-  onStartAssignment,
-  onStartHandoff,
-  selectedWorkItem,
-  startingAssignmentID,
-  workItems,
-}: {
-  activity: ProjectActivityData | null;
-  assignments: ProjectAssignmentRecord[];
-  artifacts: ProjectCollaborationArtifactRecord[];
-  handoffs: ProjectHandoffRecord[];
-  memoryCandidateCount: number;
-  onAddEvidenceLink: () => void;
-  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
-  onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
-  onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
-  onCreateAssignmentFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
-  onCreateWork: () => void;
-  onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
-  onReviewMemory: () => void;
-  onSelectWorkItem: (workItemID: string) => void;
-  onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
-  onStartHandoff: (handoff: ProjectHandoffRecord) => void;
-  selectedWorkItem: ProjectWorkItemRecord | null;
-  startingAssignmentID: string;
-  workItems: ProjectWorkItemRecord[];
-}) {
-  const nextAction = buildProjectNextAction({
-    activity,
-    assignments,
-    artifacts,
-    handoffs,
-    memoryCandidateCount,
-    onAddEvidenceLink,
-    onBucketChange,
-    onCloseWorkItem,
-    onCreateAssignmentFromHandoff,
-    onCreateAssignmentFromReviewArtifact,
-    onCreateWork,
-    onDraftDefaultAssignment,
-    onReviewMemory,
-    onSelectWorkItem,
-    onStartAssignment,
-    onStartHandoff,
-    selectedWorkItem,
-    startingAssignmentID,
-    workItems,
-  });
-
-  return (
-    <section aria-label="Project next action" style={projectNextActionStyle}>
-      <div style={projectResumeCopyStyle}>
-        <div style={sectionLabelStyle}>Next action</div>
-        <div style={titleStyle}>{nextAction.title}</div>
-        <div style={subtleTextStyle}>{nextAction.detail}</div>
-      </div>
-      <div style={projectNextActionControlsStyle}>
-        <Badge status={nextAction.status} label={activitySignalLabel(nextAction.status)} />
-        <button
-          className="btn btn-primary btn-sm"
-          type="button"
-          onClick={nextAction.onAction}
-          disabled={nextAction.disabled}
-        >
-          {nextAction.actionLabel}
-        </button>
-      </div>
-    </section>
-  );
-}
-
-function buildProjectNextAction({
-  activity,
-  assignments,
-  artifacts,
-  handoffs,
-  memoryCandidateCount,
-  onAddEvidenceLink,
-  onBucketChange,
-  onCloseWorkItem,
-  onCreateAssignmentFromHandoff,
-  onCreateAssignmentFromReviewArtifact,
-  onCreateWork,
-  onDraftDefaultAssignment,
-  onReviewMemory,
-  onSelectWorkItem,
-  onStartAssignment,
-  onStartHandoff,
-  selectedWorkItem,
-  startingAssignmentID,
-  workItems,
-}: {
-  activity: ProjectActivityData | null;
-  assignments: ProjectAssignmentRecord[];
-  artifacts: ProjectCollaborationArtifactRecord[];
-  handoffs: ProjectHandoffRecord[];
-  memoryCandidateCount: number;
-  onAddEvidenceLink: () => void;
-  onBucketChange: (bucket: ProjectActivityBucketKey) => void;
-  onCloseWorkItem: (item: ProjectWorkItemRecord) => void;
-  onCreateAssignmentFromHandoff: (handoff: ProjectHandoffRecord) => void;
-  onCreateAssignmentFromReviewArtifact: (artifact: ProjectCollaborationArtifactRecord) => void;
-  onCreateWork: () => void;
-  onDraftDefaultAssignment: (item: ProjectWorkItemRecord) => void;
-  onReviewMemory: () => void;
-  onSelectWorkItem: (workItemID: string) => void;
-  onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
-  onStartHandoff: (handoff: ProjectHandoffRecord) => void;
-  selectedWorkItem: ProjectWorkItemRecord | null;
-  startingAssignmentID: string;
-  workItems: ProjectWorkItemRecord[];
-}): ProjectNextActionState {
-  const blockedItems = activity?.buckets.blocked ?? [];
-  const queuedItem = blockedItems.find((item) => item.blocking_signal === "not_started");
-  if (queuedItem) {
-    return {
-      actionLabel:
-        startingAssignmentID === queuedItem.assignment.id ? "Starting..." : "Start assignment",
-      detail: `${queuedItem.work_item.title} is queued and ready for operator dispatch.`,
-      disabled: startingAssignmentID === queuedItem.assignment.id,
-      onAction: () => onStartAssignment(queuedItem.assignment),
-      status: "awaiting_approval",
-      title: "Start queued assignment",
-    };
-  }
-
-  const blockedItem = blockedItems[0] ?? null;
-  if (blockedItem) {
-    return {
-      actionLabel: "Open blocked work",
-      detail: `${blockedItem.work_item.title} needs operator attention: ${blockedItem.status_summary}.`,
-      onAction: () => {
-        onBucketChange("blocked");
-        onSelectWorkItem(blockedItem.work_item.id);
-      },
-      status: blockedItem.blocking_signal,
-      title: "Resolve blocked assignment",
-    };
-  }
-
-  const activeItem = activity?.buckets.active[0] ?? null;
-  if (activeItem) {
-    return {
-      actionLabel: "Inspect work",
-      detail: `${activeItem.work_item.title} has an assignment in progress.`,
-      onAction: () => onSelectWorkItem(activeItem.work_item.id),
-      status: activeItem.blocking_signal,
-      title: "Inspect active assignment",
-    };
-  }
-
-  const reviewFollowUp = artifacts.find((artifact) =>
-    reviewArtifactNeedsFollowUpPath(artifact, handoffs),
-  );
-  if (selectedWorkItem && reviewFollowUp && selectedWorkItem.status !== "done") {
-    return {
-      actionLabel: "Create follow-up",
-      detail: `${reviewFollowUp.title || "Review"} needs follow-up before this work can close.`,
-      onAction: () => onCreateAssignmentFromReviewArtifact(reviewFollowUp),
-      status: reviewFollowUp.review_verdict === "blocked" ? "blocked" : "awaiting_approval",
-      title: "Create review follow-up",
-    };
-  }
-
-  const pendingHandoff = handoffs.find((handoff) => handoff.status === "pending");
-  if (pendingHandoff) {
-    return {
-      actionLabel: pendingHandoff.target_assignment_id ? "Start handoff" : "Create assignment",
-      detail: pendingHandoff.recommended_next_action || pendingHandoff.summary,
-      onAction: () =>
-        pendingHandoff.target_assignment_id
-          ? onStartHandoff(pendingHandoff)
-          : onCreateAssignmentFromHandoff(pendingHandoff),
-      status: "awaiting_approval",
-      title: `Continue handoff: ${pendingHandoff.title}`,
-    };
-  }
-
-  if (memoryCandidateCount > 0) {
-    return {
-      actionLabel: "Review memory",
-      detail:
-        "Pending memory candidates should be accepted, edited, or rejected before more context accumulates.",
-      onAction: onReviewMemory,
-      status: "awaiting_approval",
-      title:
-        memoryCandidateCount === 1
-          ? "Review 1 memory candidate"
-          : `Review ${memoryCandidateCount} memory candidates`,
-    };
-  }
-
-  if (selectedWorkItem && assignments.length === 0 && selectedWorkItem.status !== "done") {
-    return {
-      actionLabel: "Draft assignment",
-      detail:
-        "This work item has no assignments yet. Let the Project Assistant draft the first one.",
-      onAction: () => onDraftDefaultAssignment(selectedWorkItem),
-      status: "not_started",
-      title: "Create the first assignment",
-    };
-  }
-
-  const hasCompletedAssignment = assignments.some(
-    (assignment) => assignment.status === "completed",
-  );
-  const hasEvidence = artifacts.some((artifact) => artifact.kind === "evidence_link");
-  if (
-    selectedWorkItem &&
-    hasCompletedAssignment &&
-    !hasEvidence &&
-    selectedWorkItem.status !== "done"
-  ) {
-    return {
-      actionLabel: "Add evidence",
-      detail: "A completed assignment should leave reviewable evidence before this work is closed.",
-      onAction: onAddEvidenceLink,
-      status: "completed",
-      title: "Record completion evidence",
-    };
-  }
-
-  const closeout = buildProjectWorkCloseoutReadiness({
-    assignments,
-    artifacts,
-    handoffs,
-    workItem: selectedWorkItem,
-  });
-  if (selectedWorkItem && closeout.ready && closeout.status === "ready") {
-    return {
-      actionLabel: "Mark done",
-      detail: closeout.detail,
-      onAction: () => onCloseWorkItem(selectedWorkItem),
-      status: "completed",
-      title: "Close out selected work",
-    };
-  }
-
-  const latestWorkItem = latestProjectWorkItem(workItems);
-  if (latestWorkItem) {
-    return {
-      actionLabel: "Continue work",
-      detail: `Pick up ${latestWorkItem.title}, last updated ${formatProjectRowRelativeTime(latestWorkItem.updated_at)}.`,
-      onAction: () => onSelectWorkItem(latestWorkItem.id),
-      status: latestWorkItem.status,
-      title: "Continue existing work",
-    };
-  }
-
-  return {
-    actionLabel: "Create work",
-    detail: "Start with one reviewable work item that Hecate can coordinate.",
-    onAction: onCreateWork,
-    status: "not_started",
-    title: "Create the first work item",
-  };
-}
-
 function ProjectResumeSummary({
   activity,
   memoryCandidateCount,
@@ -1133,7 +817,7 @@ function ProjectResumeSummary({
     attentionItem?.blocking_signal === "not_started"
       ? "Queued assignment is ready to start."
       : blocked > 0
-        ? "Open the blocked assignment and resolve the next action."
+        ? "Open the blocked assignment and resolve the blocker."
         : active > 0
           ? "An assignment is in progress; inspect or continue it."
           : "";
@@ -1615,14 +1299,6 @@ const workActivityPanelStyle: CSSProperties = {
   gap: 10,
 };
 
-const projectNextActionStyle: CSSProperties = {
-  ...panelStyle,
-  alignItems: "center",
-  display: "grid",
-  gap: 12,
-  gridTemplateColumns: "minmax(0, 1fr) auto",
-};
-
 const projectOperationsBriefStyle: CSSProperties = {
   ...panelStyle,
   alignItems: "center",
@@ -1673,15 +1349,6 @@ const projectOperationsItemActionStyle: CSSProperties = {
   color: "var(--t3)",
   fontSize: 11,
   whiteSpace: "nowrap",
-};
-
-const projectNextActionControlsStyle: CSSProperties = {
-  alignItems: "center",
-  display: "flex",
-  flexWrap: "wrap",
-  gap: 8,
-  justifyContent: "flex-end",
-  minWidth: 0,
 };
 
 const projectResumeSummaryStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4938,11 +4938,16 @@ describe("ProjectsView cockpit", () => {
             title: "Prepare first assignment: Build cockpit UI",
             detail: "This work item has no queued or running assignments yet.",
             action_label: "Draft assignment",
-            draft_request: "Queue an assignment for Build cockpit UI",
             target: {
               surface: "work",
               project_id: project.id,
               work_item_id: workItem.id,
+            },
+            action: {
+              type: "draft_project_proposal",
+              project_id: project.id,
+              work_item_id: workItem.id,
+              request: "Queue an assignment for Build cockpit UI",
             },
             updated_at: "2026-06-14T00:00:00Z",
           },
@@ -4966,6 +4971,183 @@ describe("ProjectsView cockpit", () => {
         request: "Queue an assignment for Build cockpit UI",
       }),
     );
+    expect(createProjectAssignment).not.toHaveBeenCalled();
+    expect(startProjectAssignment).not.toHaveBeenCalled();
+  });
+
+  it("opens assignment preflight from an operations brief item without starting it", async () => {
+    resetProjectWorkMocks();
+    const queuedAssignment: ProjectAssignmentRecord = {
+      ...hecateAssignment,
+      status: "queued",
+      execution: undefined,
+      execution_ref: undefined,
+      started_at: undefined,
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [{ ...workItem, assignments: [queuedAssignment] }],
+    });
+    vi.mocked(getProjectWorkItem).mockResolvedValue({
+      object: "project_work_item",
+      data: { ...workItem, assignments: [queuedAssignment] },
+    });
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [queuedAssignment],
+    });
+    vi.mocked(getProjectOperationsBrief).mockResolvedValue({
+      object: "project_operations_brief",
+      data: {
+        project_id: project.id,
+        generated_at: "2026-06-14T00:00:00Z",
+        summary: {
+          item_count: 1,
+          high_count: 1,
+          medium_count: 0,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: [
+          {
+            id: "start_queued_assignment:proj_1:asgn_1",
+            kind: "start_queued_assignment",
+            priority: "high",
+            title: "Review queued assignment: Build cockpit UI",
+            detail: "Open launch preflight before starting this assignment.",
+            action_label: "Review start",
+            status: "not_started",
+            target: {
+              surface: "work",
+              project_id: project.id,
+              work_item_id: workItem.id,
+              assignment_id: queuedAssignment.id,
+              activity_bucket: "blocked",
+            },
+            action: {
+              type: "open_assignment_preflight",
+              project_id: project.id,
+              work_item_id: workItem.id,
+              assignment_id: queuedAssignment.id,
+              activity_bucket: "blocked",
+            },
+            updated_at: "2026-06-14T00:00:00Z",
+          },
+        ],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const operations = await screen.findByRole("region", { name: "Project operations" });
+    await userEvent.click(within(operations).getByRole("button", { name: /Review start/ }));
+
+    expect(getProjectAssignmentPreflight).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      queuedAssignment.id,
+    );
+    const preflight = await screen.findByRole("dialog", {
+      name: "Assignment asgn_1 launch preflight",
+    });
+    expect(within(preflight).getByText("Launch preflight")).toBeTruthy();
+    expect(startProjectAssignment).not.toHaveBeenCalled();
+    await userEvent.click(within(preflight).getByRole("button", { name: "Start assignment" }));
+
+    expect(startProjectAssignment).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      queuedAssignment.id,
+      "hecate_task",
+    );
+  });
+
+  it("opens selected work follow-through from an operations brief item without mutating work", async () => {
+    resetProjectWorkMocks();
+    const reviewWorkItem: ProjectWorkItemRecord = {
+      ...workItem,
+      id: "work_review_followup",
+      title: "Review requested changes",
+      brief: "Follow up on review findings.",
+      status: "review",
+      assignments: [],
+    };
+    vi.mocked(getProjectWorkItems).mockResolvedValue({
+      object: "project_work_items",
+      data: [workItem, reviewWorkItem],
+    });
+    vi.mocked(getProjectWorkItem).mockImplementation(async (_projectID, workItemID) => ({
+      object: "project_work_item",
+      data: workItemID === reviewWorkItem.id ? reviewWorkItem : workItem,
+    }));
+    vi.mocked(getProjectAssignments).mockResolvedValue({
+      object: "project_assignments",
+      data: [],
+    });
+    vi.mocked(getProjectOperationsBrief).mockResolvedValue({
+      object: "project_operations_brief",
+      data: {
+        project_id: project.id,
+        generated_at: "2026-06-14T00:00:00Z",
+        summary: {
+          item_count: 1,
+          high_count: 0,
+          medium_count: 1,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: [
+          {
+            id: "review_follow_up:proj_1:artifact_review",
+            kind: "review_follow_up",
+            priority: "medium",
+            title: "Review follow-up: Review requested changes",
+            detail: "Review artifact Architecture review needs a follow-up path before closeout.",
+            action_label: "Open review",
+            status: "awaiting_approval",
+            target: {
+              surface: "work",
+              project_id: project.id,
+              work_item_id: reviewWorkItem.id,
+            },
+            action: {
+              type: "open_work_item",
+              project_id: project.id,
+              work_item_id: reviewWorkItem.id,
+            },
+            metadata: {
+              artifact_id: "artifact_review",
+              review_verdict: "changes_requested",
+            },
+            updated_at: "2026-06-14T00:00:00Z",
+          },
+        ],
+      },
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    const operations = await screen.findByRole("region", { name: "Project operations" });
+    await userEvent.click(within(operations).getByRole("button", { name: /Open review/ }));
+
+    await waitFor(() =>
+      expect(getProjectWorkItem).toHaveBeenCalledWith(project.id, reviewWorkItem.id),
+    );
+    expect(
+      await screen.findByRole("article", { name: "Review requested changes work item" }),
+    ).toBeTruthy();
+    expect(draftProjectAssistant).not.toHaveBeenCalled();
+    expect(createProjectHandoff).not.toHaveBeenCalled();
     expect(createProjectAssignment).not.toHaveBeenCalled();
     expect(startProjectAssignment).not.toHaveBeenCalled();
   });

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -89,6 +89,7 @@ import type {
   ProjectHandoffRecord,
   ProjectMemoryRecord,
   ProjectOperationsBrief,
+  ProjectOperationsBriefAction,
   ProjectOperationsBriefItem,
   ProjectContextSourceRecord,
   ProjectSkillRecord,
@@ -1161,47 +1162,71 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   }
 
   function handleOperationsBriefAction(item: ProjectOperationsBriefItem) {
-    const target = item.target;
-    if (item.draft_request) {
+    const action = item.action;
+    if (!action?.type) {
+      setWorkError("Project operation is missing an action. Refresh project work and try again.");
+      return;
+    }
+    if (action.project_id && selectedProjectID && action.project_id !== selectedProjectID) {
+      setWorkError("Project operation target changed. Refresh project work and try again.");
+      return;
+    }
+    if (action.type === "draft_project_proposal") {
+      const request = action.request?.trim();
+      if (!request) {
+        setWorkError("Project operation is missing a Project Assistant draft request.");
+        return;
+      }
       setWorkspaceTab("work");
-      if (target.work_item_id) {
-        setSelectedWorkItemID(target.work_item_id);
+      if (action.work_item_id) {
+        setSelectedWorkItemID(action.work_item_id);
       }
       void assistant.propose(
         {
-          request: item.draft_request,
+          request,
           roleID: PROJECT_ASSISTANT_AUTO,
           driverKind: PROJECT_ASSISTANT_AUTO,
           draftMode: "deterministic",
         },
-        target.work_item_id,
+        action.work_item_id,
       );
       return;
     }
-    if (target.surface === "project_settings") {
-      setDefaultsError("");
-      setSettingsPanelOpen(true);
-      return;
+
+    switch (action.type) {
+      case "open_project_settings":
+        setDefaultsError("");
+        setSettingsPanelOpen(true);
+        return;
+      case "open_memory_review":
+        setWorkspaceTab("memory");
+        return;
+      case "open_assignment_preflight":
+        selectOperationWorkTarget(action);
+        if (action.assignment_id) {
+          setPreparingAssignmentID(action.assignment_id);
+        } else {
+          setWorkError("Project operation is missing an assignment preflight target.");
+        }
+        return;
+      case "open_work_item":
+        selectOperationWorkTarget(action);
+        return;
+      default:
+        setWorkError(
+          "Project operation action is not supported. Refresh project work and try again.",
+        );
     }
-    if (target.surface === "memory") {
-      setWorkspaceTab("memory");
-      return;
-    }
-    if (target.surface === "skills") {
-      setWorkspaceTab("skills");
-      return;
-    }
+  }
+
+  function selectOperationWorkTarget(action: ProjectOperationsBriefAction) {
     setWorkspaceTab("work");
-    const bucket = projectOperationsActivityBucket(target.activity_bucket);
+    const bucket = projectOperationsActivityBucket(action.activity_bucket);
     if (bucket) {
       setActivityBucket(bucket);
     }
-    if (target.work_item_id) {
-      setSelectedWorkItemID(target.work_item_id);
-    }
-    const assignmentID = target.assignment_id;
-    if (item.kind === "start_queued_assignment" && assignmentID) {
-      setPreparingAssignmentID(assignmentID);
+    if (action.work_item_id) {
+      setSelectedWorkItemID(action.work_item_id);
     }
   }
 

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -381,6 +381,31 @@ describe("projectInsights", () => {
         },
       ]),
     ).toBe(false);
+    expect(
+      reviewArtifactNeedsFollowUpPath(review, [
+        {
+          ...handoff("handoff_review", "accepted"),
+          linked_artifact_ids: [review.id],
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      reviewArtifactNeedsFollowUpPath(review, [
+        {
+          ...handoff("handoff_review", "accepted"),
+          linked_artifact_ids: [review.id],
+          target_assignment_id: "asgn_followup",
+        },
+      ]),
+    ).toBe(false);
+    expect(
+      reviewArtifactNeedsFollowUpPath(review, [
+        {
+          ...handoff("handoff_review", "dismissed"),
+          linked_artifact_ids: [review.id],
+        },
+      ]),
+    ).toBe(false);
     expect(reviewArtifactRequiresFollowUp(reviewArtifact({ review_verdict: "approved" }))).toBe(
       false,
     );

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -669,7 +669,14 @@ export function reviewArtifactNeedsFollowUpPath(
   handoffs: ProjectHandoffRecord[],
 ): boolean {
   if (!reviewArtifactRequiresFollowUp(artifact)) return false;
-  return !handoffs.some((handoff) => (handoff.linked_artifact_ids ?? []).includes(artifact.id));
+  return !handoffs.some(
+    (handoff) =>
+      (handoff.linked_artifact_ids ?? []).includes(artifact.id) &&
+      (handoff.status === "pending" ||
+        handoff.status === "dismissed" ||
+        handoff.status === "superseded" ||
+        Boolean(handoff.target_assignment_id)),
+  );
 }
 
 function closeoutReviewFollowUpBlocker(

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -800,13 +800,31 @@ export type ProjectActivityResponse = {
 
 export type ProjectOperationsBriefPriority = "high" | "medium" | "low" | (string & {});
 
+export type ProjectOperationsBriefActionType =
+  | "draft_project_proposal"
+  | "open_assignment_preflight"
+  | "open_memory_review"
+  | "open_project_settings"
+  | "open_work_item"
+  | (string & {});
+
 export type ProjectOperationsBriefTarget = {
-  surface: "project_settings" | "work" | "memory" | "skills" | string;
+  surface: "project_settings" | "work" | "memory" | string;
   project_id: string;
   work_item_id?: string;
   assignment_id?: string;
   handoff_id?: string;
   activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
+};
+
+export type ProjectOperationsBriefAction = {
+  type: ProjectOperationsBriefActionType;
+  project_id: string;
+  work_item_id?: string;
+  assignment_id?: string;
+  handoff_id?: string;
+  activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
+  request?: string;
 };
 
 export type ProjectOperationsBriefItem = {
@@ -818,7 +836,7 @@ export type ProjectOperationsBriefItem = {
   action_label: string;
   status?: string;
   target: ProjectOperationsBriefTarget;
-  draft_request?: string;
+  action: ProjectOperationsBriefAction;
   work_item?: ProjectActivityWorkItemRecord;
   assignment?: ProjectAssignmentRecord;
   handoff?: ProjectHandoffRecord;


### PR DESCRIPTION
## Summary

- Adds a typed Project Operations `action` contract and removes the client-side next-action fallback cascade.
- Routes queued starts through assignment preflight, draftable operations through Project Assistant proposals, and read-only follow-through through selected-work detail.
- Adds server-backed selected-work operations for review follow-up, missing completion evidence, and closeout-ready work items without starting work or mutating project records directly.
- Documents the Project Operations routing boundary and updates API/operator docs.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./...`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestProjectOperationsBrief|TestProjectOperationItemFromActivity|TestProjectOperationsReviewFollowUpPathAndBlockerSemantics|TestSortProjectOperationsItems'`
- `cd ui && bun run typecheck`
- `cd ui && bun run test -- src/features/projects/projectInsights.test.ts src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `git diff --check`
- terminology scan clean
