### PR TITLE
chore(agent-adapters): bump Go ACP adapter releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.18
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.19
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.18
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.19
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,10 +24,11 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.18` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.20` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.19` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.21` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
-external MCP handoff surface, and ACP authenticate/logout mapping. The
+external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
+failure classification. The
 `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
 usage updates, so Hecate can render External Agent activity without exposing raw
@@ -53,6 +54,9 @@ Codex adapter `v0.1.0-alpha.17` maps ACP `authenticate` to the native
 `codex login` command.
 Codex adapter `v0.1.0-alpha.18` pins the shared Go ACP adapter kit to its
 first tagged alpha release.
+Codex adapter `v0.1.0-alpha.19` classifies prompt command auth failures as ACP
+authentication-required errors so Hecate can surface the login action instead of
+a generic prompt command failure.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -76,6 +80,9 @@ Claude Code adapter `v0.1.0-alpha.19` maps ACP `authenticate` to the native
 `claude /login` command.
 Claude Code adapter `v0.1.0-alpha.20` pins the shared Go ACP adapter kit to its
 first tagged alpha release.
+Claude Code adapter `v0.1.0-alpha.21` classifies prompt command auth failures
+as ACP authentication-required errors so Hecate can surface the login action
+instead of a generic prompt command failure.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -270,7 +270,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.18",
+			SupportedRange:       ">=0.1.0-alpha.19",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -311,7 +311,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.20",
+			SupportedRange:       ">=0.1.0-alpha.21",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.18" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.19" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.20" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.21" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary

- bump bundled Codex ACP adapter to `v0.1.0-alpha.19`
- bump bundled Claude Code ACP adapter to `v0.1.0-alpha.21`
- raise Hecate supported ranges and document prompt auth-failure classification

## Verification

- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters`
- `just test-acp-release-smoke`