### PR TITLE
feat(agent-adapters): surface terminal stop reasons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.19
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.19
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,11 +24,11 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.19` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.21` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.20` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.22` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
-failure classification. The
+failure/stop-reason classification. The
 `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
 usage updates, so Hecate can render External Agent activity without exposing raw
@@ -57,6 +57,9 @@ first tagged alpha release.
 Codex adapter `v0.1.0-alpha.19` classifies prompt command auth failures as ACP
 authentication-required errors so Hecate can surface the login action instead of
 a generic prompt command failure.
+Codex adapter `v0.1.0-alpha.20` propagates terminal stop reasons from the
+structured Codex stream so Hecate can show actionable stops such as token limits
+or refusals in the chat activity timeline.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -83,6 +86,9 @@ first tagged alpha release.
 Claude Code adapter `v0.1.0-alpha.21` classifies prompt command auth failures
 as ACP authentication-required errors so Hecate can surface the login action
 instead of a generic prompt command failure.
+Claude Code adapter `v0.1.0-alpha.22` propagates terminal stop reasons from the
+structured Claude result stream so Hecate can show actionable stops such as turn
+limits or refusals in the chat activity timeline.
 
 ## Supported External Agents
 
@@ -289,8 +295,8 @@ adapter parity lives in the standalone adapter repositories. When packaging
 drift needs coverage, run `just test-acp-release-smoke`; it downloads the
 Dockerfile-pinned Go adapter release binaries, verifies checksums, and smokes
 probe capability discovery, ACP authenticate/logout, session config selectors,
-advertised slash commands, prompt streaming, and usage mapping with fake
-`codex` and `claude` CLIs.
+advertised slash commands, prompt streaming, usage mapping, and stop-reason
+mapping with fake `codex` and `claude` CLIs.
 
 ## Setup checks
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -101,6 +101,9 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 			if run.Usage.ContextSize == 0 || run.Usage.ContextUsed == 0 {
 				t.Fatalf("Run(%s) usage = %#v, want adapter-reported usage", tt.adapterID, run.Usage)
 			}
+			if run.StopReason != tt.wantStopReason {
+				t.Fatalf("Run(%s) stop reason = %q, want %q", tt.adapterID, run.StopReason, tt.wantStopReason)
+			}
 
 			logout, err := Logout(context.Background(), tt.adapterID)
 			if err != nil {
@@ -121,6 +124,7 @@ type acpReleaseSmokeTestCase struct {
 	vendorCommand       string
 	vendorScript        string
 	wantOutput          string
+	wantStopReason      string
 	wantConfigOptionIDs []string
 	wantCommands        []string
 }
@@ -130,13 +134,14 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 	dev := readDockerfile(t, "Dockerfile")
 	return []acpReleaseSmokeTestCase{
 		{
-			adapterID:     "codex",
-			repo:          "codex-acp-adapter",
-			binary:        "codex-acp-adapter",
-			version:       dockerfileArgValue(dev, "CODEX_ACP_ADAPTER_VERSION"),
-			vendorCommand: "codex",
-			vendorScript:  fakeCodexCLIScript,
-			wantOutput:    "go codex answer",
+			adapterID:      "codex",
+			repo:           "codex-acp-adapter",
+			binary:         "codex-acp-adapter",
+			version:        dockerfileArgValue(dev, "CODEX_ACP_ADAPTER_VERSION"),
+			vendorCommand:  "codex",
+			vendorScript:   fakeCodexCLIScript,
+			wantOutput:     "go codex answer",
+			wantStopReason: "max_tokens",
 			wantConfigOptionIDs: []string{
 				"model",
 				"reasoning_effort",
@@ -146,13 +151,14 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 			wantCommands: []string{"review", "init"},
 		},
 		{
-			adapterID:     "claude_code",
-			repo:          "claude-code-acp-adapter",
-			binary:        "claude-code-acp-adapter",
-			version:       dockerfileArgValue(dev, "CLAUDE_CODE_ACP_ADAPTER_VERSION"),
-			vendorCommand: "claude",
-			vendorScript:  fakeClaudeCodeCLIScript,
-			wantOutput:    "go claude answer",
+			adapterID:      "claude_code",
+			repo:           "claude-code-acp-adapter",
+			binary:         "claude-code-acp-adapter",
+			version:        dockerfileArgValue(dev, "CLAUDE_CODE_ACP_ADAPTER_VERSION"),
+			vendorCommand:  "claude",
+			vendorScript:   fakeClaudeCodeCLIScript,
+			wantOutput:     "go claude answer",
+			wantStopReason: "max_turn_requests",
 			wantConfigOptionIDs: []string{
 				"model",
 				"effort",
@@ -279,7 +285,7 @@ case "$1" in
     printf '{"method":"item/started","params":{"item":{"type":"local_shell_call","id":"tool-1","command":"go test ./..."}}}\n'
     printf '{"method":"item/reasoning/textDelta","params":{"item_id":"thought-1","delta":"checking"}}\n'
     printf '{"method":"item/completed","params":{"item":{"type":"agent_message","id":"msg-1","text":"go codex answer"}}}\n'
-    printf '{"method":"turn/completed","params":{"usage":{"input_tokens":10,"output_tokens":5,"context_window":100}}}\n'
+    printf '{"method":"turn/completed","params":{"finish_reason":"max_tokens","usage":{"input_tokens":10,"output_tokens":5,"context_window":100}}}\n'
     printf '{"method":"item/completed","params":{"item":{"type":"local_shell_call","id":"tool-1","status":"completed","stdout":"ok"}}}\n'
     exit 0
     ;;
@@ -307,7 +313,7 @@ case "$1" in
   --print)
     printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Bash","input":{"command":"go test ./..."}}]}}\n'
     printf '{"type":"assistant","message":{"content":[{"type":"thinking","id":"thought-1","thinking":"checking"},{"type":"text","text":"go claude answer"}]}}\n'
-    printf '{"type":"result","usage":{"input_tokens":10,"output_tokens":5,"context_window":100}}\n'
+    printf '{"type":"result","subtype":"error_max_turns","usage":{"input_tokens":10,"output_tokens":5,"context_window":100}}\n'
     printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]}}\n'
     exit 0
     ;;

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -293,6 +293,7 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 		SessionId: acp.SessionId(s.nativeID),
 		Prompt:    []acp.ContentBlock{acp.TextBlock(req.Prompt)},
 	})
+	stopReason := string(resp.StopReason)
 	if runErr == nil && resp.StopReason == acp.StopReasonCancelled {
 		runErr = context.Canceled
 	}
@@ -314,7 +315,7 @@ func (s *acpSession) RunTurn(ctx context.Context, req RunRequest) (RunResult, er
 		}
 	}
 	output, raw, usage := turn.snapshot()
-	result, err := captureACPTurnResult(ctx, s.adapter, req, s.nativeID, output, raw, usage, exitCode, started, completed, initialDiffStat, initialDiff, runErr)
+	result, err := captureACPTurnResult(ctx, s.adapter, req, s.nativeID, stopReason, output, raw, usage, exitCode, started, completed, initialDiffStat, initialDiff, runErr)
 	result.ConfigOptions = s.configOptionsSnapshot()
 	result.AvailableCommands, result.AvailableCommandsKnown = s.availableCommandsSnapshot()
 	return result, err
@@ -774,7 +775,7 @@ func (s *acpSession) cancelActiveTurn(ctx context.Context) error {
 	}
 }
 
-func captureACPTurnResult(ctx context.Context, adapter Adapter, req RunRequest, nativeSessionID, output, rawOutput string, usage Usage, exitCode int, started, completed time.Time, initialDiffStat, initialDiff string, runErr error) (RunResult, error) {
+func captureACPTurnResult(ctx context.Context, adapter Adapter, req RunRequest, nativeSessionID, stopReason, output, rawOutput string, usage Usage, exitCode int, started, completed time.Time, initialDiffStat, initialDiff string, runErr error) (RunResult, error) {
 	maxOutput := maxTurnOutputBytes(req)
 	diffStat, diff := captureGitDiff(ctx, req.Workspace, maxOutput)
 	if sameCapturedDiff(initialDiffStat, initialDiff, diffStat, diff) {
@@ -785,6 +786,7 @@ func captureACPTurnResult(ctx context.Context, adapter Adapter, req RunRequest, 
 		Adapter:         adapter,
 		DriverKind:      DriverKindACP,
 		NativeSessionID: nativeSessionID,
+		StopReason:      strings.TrimSpace(stopReason),
 		Output:          normalizeOutput(adapter.ID, output),
 		RawOutput:       rawOutput,
 		ExitCode:        exitCode,

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -76,8 +76,35 @@ func TestSessionManagerRunsTurnsThroughACP(t *testing.T) {
 	if !strings.Contains(second.Output, "turn 2: second turn") {
 		t.Fatalf("second output = %q", second.Output)
 	}
+	if first.StopReason != string(acp.StopReasonEndTurn) || second.StopReason != string(acp.StopReasonEndTurn) {
+		t.Fatalf("stop reasons = %q / %q, want end_turn", first.StopReason, second.StopReason)
+	}
 	if second.Usage.ContextSize != 200_000 || second.Usage.ContextUsed != 20_000 {
 		t.Fatalf("second usage = %+v, want turn 2 context usage", second.Usage)
+	}
+}
+
+func TestSessionManagerPreservesACPStopReason(t *testing.T) {
+	installFakeACPExecutable(t, "codex-acp-adapter")
+	workspace := t.TempDir()
+
+	manager := NewSessionManager()
+	result, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      "chat_stop_reason",
+		AdapterID:      "codex",
+		Workspace:      workspace,
+		Prompt:         "max_tokens",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.StopReason != string(acp.StopReasonMaxTokens) {
+		t.Fatalf("StopReason = %q, want max_tokens", result.StopReason)
+	}
+	if !strings.Contains(result.Output, "partial due to token limit") {
+		t.Fatalf("output = %q, want partial token-limit output", result.Output)
 	}
 }
 
@@ -2261,6 +2288,15 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 			return acp.PromptResponse{}, err
 		}
 		select {}
+	}
+	if prompt == "max_tokens" {
+		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update:    acp.UpdateAgentMessageText("partial due to token limit"),
+		}); err != nil {
+			return acp.PromptResponse{}, err
+		}
+		return acp.PromptResponse{StopReason: acp.StopReasonMaxTokens}, nil
 	}
 
 	if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -208,6 +208,7 @@ type RunResult struct {
 	Adapter                Adapter
 	DriverKind             string
 	NativeSessionID        string
+	StopReason             string
 	SessionStarted         bool
 	SessionResumed         bool
 	SessionRecovery        string
@@ -270,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.19",
+			SupportedRange:       ">=0.1.0-alpha.20",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -311,7 +312,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.21",
+			SupportedRange:       ">=0.1.0-alpha.22",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.19" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.20" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.21" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.22" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {
@@ -689,6 +689,7 @@ func TestCaptureACPTurnResultOmitsUnchangedPreexistingDiff(t *testing.T) {
 		Adapter{ID: "grok_build"},
 		RunRequest{Workspace: root, MaxOutputBytes: 64 * 1024},
 		"native_1",
+		"",
 		"done",
 		"done",
 		Usage{},
@@ -725,6 +726,7 @@ func TestCaptureACPTurnResultIncludesDiffChangedDuringTurn(t *testing.T) {
 		Adapter{ID: "grok_build"},
 		RunRequest{Workspace: root, MaxOutputBytes: 64 * 1024},
 		"native_1",
+		"",
 		"done",
 		"done",
 		Usage{},

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -815,6 +815,9 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		telemetry.AttrHecateAgentNativeSessionID: result.NativeSessionID,
 		"process.exit.code":                      result.ExitCode,
 	})
+	if strings.TrimSpace(result.StopReason) != "" {
+		terminalAttrs["hecate.agent.stop_reason"] = result.StopReason
+	}
 	if runErr != nil {
 		terminalAttrs[telemetry.AttrHecateResult] = telemetry.ResultError
 		terminalAttrs[telemetry.AttrHecateErrorKind] = telemetry.ErrorKindOther
@@ -878,6 +881,9 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 		}
 		if result.DiffStat != "" {
 			message.Activities = append(message.Activities, newChatActivity("files_changed", "completed", "Files changed", result.DiffStat))
+		}
+		if activity, ok := externalAgentStopReasonActivity(result.StopReason); ok {
+			message.Activities = append(message.Activities, activity)
 		}
 		message.Context = chatcontext.Normalize(message.Context, chatcontext.MergeRefs(
 			chatcontext.ChatMessageRefs(session.ID, assistantID, session.ProjectID),

--- a/internal/api/handler_chat_activities.go
+++ b/internal/api/handler_chat_activities.go
@@ -65,6 +65,22 @@ func newChatActivity(kind, status, title, detail string) chat.Activity {
 	}
 }
 
+func externalAgentStopReasonActivity(reason string) (chat.Activity, bool) {
+	reason = strings.TrimSpace(reason)
+	switch reason {
+	case "", "end_turn", "cancelled":
+		return chat.Activity{}, false
+	case "max_tokens":
+		return newChatActivity("stop_reason", "completed", "Agent stop reason", "The external agent stopped because it reached its token limit."), true
+	case "max_turn_requests":
+		return newChatActivity("stop_reason", "completed", "Agent stop reason", "The external agent stopped because it reached its turn limit."), true
+	case "refusal":
+		return newChatActivity("stop_reason", "completed", "Agent stop reason", "The external agent refused to continue this turn."), true
+	default:
+		return newChatActivity("stop_reason", "completed", "Agent stop reason", "ACP stop reason: "+reason), true
+	}
+}
+
 func agentChatActivityFromAdapter(activity agentadapters.Activity) chat.Activity {
 	return chat.Activity{
 		ID:              strings.TrimSpace(activity.ID),

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1358,6 +1358,38 @@ func TestAgentChatRunsExternalAdapter(t *testing.T) {
 	}
 }
 
+func TestAgentChatSurfacesExternalAgentStopReason(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	apiHandler.SetAgentChatRunner(&fakeAgentChatRunner{
+		output:     "partial answer\n",
+		stopReason: "max_tokens",
+	})
+	handler := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, handler)
+
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"codex","workspace":%q}`, dir))
+	updated := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/messages", `{"content":"answer until the context limit"}`)
+	if len(updated.Data.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(updated.Data.Messages))
+	}
+	assistant := updated.Data.Messages[1]
+	var found *ChatActivityItem
+	for i := range assistant.Activities {
+		if assistant.Activities[i].Type == "stop_reason" {
+			found = &assistant.Activities[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("activities = %#v, want stop_reason activity", assistant.Activities)
+	}
+	if found.Status != "completed" || found.Title != "Agent stop reason" || !strings.Contains(found.Detail, "token limit") {
+		t.Fatalf("stop reason activity = %#v, want completed token-limit detail", *found)
+	}
+}
+
 func TestUpdateChatSessionRenamesSession(t *testing.T) {
 	t.Parallel()
 
@@ -2754,6 +2786,7 @@ type fakeAgentChatRunner struct {
 	sessionStarted         bool
 	sessionResumed         bool
 	sessionRecovery        string
+	stopReason             string
 	seenPreviousID         string
 	usage                  agentadapters.Usage
 	diffStat               string
@@ -2866,6 +2899,7 @@ func (r *fakeAgentChatRunner) result(req agentadapters.RunRequest, output string
 		Adapter:                adapter,
 		DriverKind:             agentadapters.DriverKindACP,
 		NativeSessionID:        nativeSessionID,
+		StopReason:             r.stopReason,
 		SessionStarted:         r.sessionStarted,
 		SessionResumed:         r.sessionResumed,
 		SessionRecovery:        r.sessionRecovery,


### PR DESCRIPTION
## Summary
- bump Dockerfile-pinned Go ACP adapters to codex v0.1.0-alpha.20 and Claude Code v0.1.0-alpha.22
- preserve ACP prompt stop reasons in external-agent run results
- show non-normal external-agent stop reasons as chat activity timeline entries
- extend ACP release smoke coverage to assert stop-reason mapping from the released binaries
- update external-agent runtime docs and supported adapter ranges

## Adapter releases
- acp-adapter-kit v0.1.0-alpha.3
- codex-acp-adapter v0.1.0-alpha.20
- claude-code-acp-adapter v0.1.0-alpha.22

## Tests
- go test ./commandbridge (kit)
- go test ./... (kit)
- go vet ./... (kit)
- go test ./codexadapter
- go test ./... (codex adapter)
- go vet ./... (codex adapter)
- go test ./claudecodeadapter
- go test ./... (Claude adapter)
- go vet ./... (Claude adapter)
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/api -run 'TestAgentChatSurfacesExternalAgentStopReason|TestAgentChatRunsExternalAdapter'
- GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache go test ./internal/api
- just test-acp-release-smoke
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -race -timeout 10m ./...
- just docs-format-check