### PR TITLE
feat(projects): add work readiness contract

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -370,9 +370,10 @@ preflight, selected-work follow-through, or Project Assistant proposal flows.
 Review follow-up, missing completion evidence, and closeout-ready work items
 open the existing selected-work detail surface; the brief does not persist a
 plan, mark work done, or start work.
-The selected-work detail card still computes its closeout gate locally for V1;
-the next convergence step is a read-only backend closeout readiness contract
-that both Project Operations and the detail card reflect.
+The selected-work detail card now reflects the same read-only backend closeout
+readiness contract as Project Operations, so Mark done is enabled from the
+server-owned assignment/evidence/handoff/review-follow-up decision rather than
+a separate client cascade.
 Assignment rows now render compact execution evidence from canonical
 assignment/activity refs, while the Context Inspector renders the full persisted
 launch packet with Profile, Instructions, Skills, Memory, Project sources, Work

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -47,23 +47,27 @@ actionable project state: missing launch defaults, pending approvals, blocked
 or stale assignments, queued assignments that need preflight, pending handoffs,
 memory candidates awaiting review, review artifacts that need follow-up,
 missing completion evidence, work items ready for closeout, or work items that
-need their first assignment. Each operation routes to an existing surface such
-as Project Settings, Work Coordination, Memory/Context, or assignment preflight.
+need their first assignment. When no actionable work remains, the server can
+offer a low-priority latest-work operation so the operator can reopen the most
+recently updated work item without the client inventing a separate fallback
+order. Each operation routes to an existing surface such as Project Settings,
+Work Coordination, Memory/Context, or assignment preflight.
 Clients route these items through the server-provided `action.type`; `kind`
 explains why the item appears, while `action` is the follow-through contract.
 Draftable operations seed the normal Project Assistant proposal rail; the
 operator still reviews and applies typed changes before Hecate creates durable
 project records.
-When there is no server-backed operation to show, the tab keeps only the compact
-resume summary; clients should not derive a second actionable next-action
-cascade from project state.
+When there is no server-backed operation to show, the tab keeps only the
+compact resume summary; clients should not derive a second actionable
+next-action cascade from project state.
 
 Use the top Project Operations action for the single most useful operator step,
 then jump to
 blocked, active, recent, or memory-review work from the resume summary before
 drilling into the full work queue. Review follow-up and closeout operations
-open selected-work detail; the operator still creates follow-up paths or marks
-work done explicitly from that surface.
+open selected-work detail. Closeout readiness is the server contract shared by
+Project Operations and selected-work detail; the operator still creates
+follow-up paths or marks work done explicitly from that surface.
 
 For a new work item with no assignments or artifacts yet, the detail view starts
 with a guided prepare action. Hecate can draft the first assignment from the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2203,13 +2203,17 @@ non-cancelled assignment, makes it `blocked`. Otherwise the stored work-item
 status is returned.
 
 The Projects UI also exposes an operator closeout action for selected work
-items. That action uses the normal work-item `PATCH` path with `status="done"`
-after showing readiness derived from assignments, handoffs, and review
-artifacts. Readiness is advisory UI state: Hecate does not auto-mutate the
-stored work-item status from review verdicts, handoffs, or assignment rollups
-without an explicit operator update. The guided closeout action is disabled
-while blockers remain; operators can still make an intentional manual override
-through the normal work-item edit flow.
+items. The read-only
+`GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness` contract is
+the shared closeout authority for Project Operations and selected-work detail:
+it derives blockers from assignments, completion evidence, handoffs, and review
+follow-up without mutating project state. The guided action still uses the
+normal work-item `PATCH` path with `status="done"` only after the operator
+clicks Mark done. Hecate does not auto-mutate stored work-item status from
+review verdicts, handoffs, or assignment rollups without an explicit operator
+update. The guided closeout action is disabled while blockers remain; operators
+can still make an intentional manual override through the normal work-item edit
+flow.
 
 #### `GET /hecate/v1/projects/{id}/activity`
 
@@ -2400,10 +2404,13 @@ Returns a read-only Project Operations brief for the selected project. The
 brief is an operator-facing triage layer over existing project state: launch
 defaults, the project activity buckets, work items without assignments, pending
 handoffs, pending memory candidates, review artifacts that need follow-up,
-missing completion evidence, and work items ready for closeout. It is bounded
-and deterministic; it does not create tasks, runs, chats, assignments,
-handoffs, proposals, memory entries, or memory candidates, and it never starts
-queued work.
+missing completion evidence, and work items ready for closeout. When none of
+those operations exists, the server may return a low-priority `open_latest_work`
+orientation item so the operator can reopen the most recently updated work item
+without clients deriving their own fallback cascade. It is bounded and
+deterministic; it does not create tasks, runs, chats, assignments, handoffs,
+proposals, memory entries, or memory candidates, and it never starts queued
+work.
 The eight-item cap is applied after sorting by priority, explicit operation
 kind urgency, recency, and stable ID, so truncation is part of the operator
 priority policy.
@@ -2691,6 +2698,37 @@ Returns:
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}`
 
 Returns one work item or `404 not_found`.
+
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness`
+
+Returns the read-only closeout readiness contract for one work item. This is
+the same server-side decision path used by Project Operations when it surfaces
+review follow-up, missing completion evidence, or closeout-ready items.
+
+The response does not create, update, or delete project records. `ready=true`
+means the selected-work detail may enable the guided Mark done action; the
+operator still applies the durable `status="done"` mutation through
+`PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}`.
+
+```json
+{
+  "object": "project_work_item_readiness",
+  "data": {
+    "project_id": "proj_...",
+    "work_item_id": "work_...",
+    "ready": false,
+    "status": "blocked",
+    "title": "Closeout is blocked",
+    "detail": "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done.",
+    "blockers": ["1 completed assignment is missing evidence"],
+    "warnings": [],
+    "assignment_count": 1,
+    "completed_assignments": 1,
+    "review_follow_up_count": 0,
+    "missing_evidence_assignment_ids": ["asgn_..."]
+  }
+}
+```
 
 #### `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}`
 

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -139,6 +139,11 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 		items = append(items, memoryCandidateOperationItem(projectID, pendingMemoryCandidates))
 	}
 	items = append(items, assignmentGapOperationItems(projectID, workItems, assignments)...)
+	if len(items) == 0 {
+		if item := latestWorkOperationItem(projectID, workItems); item != nil {
+			items = append(items, *item)
+		}
+	}
 
 	sortProjectOperationsItems(items)
 	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
@@ -299,8 +304,7 @@ func handoffOperationItems(projectID string, handoffs []projectwork.Handoff) []P
 
 func selectedWorkFollowThroughOperationItems(projectID string, workItems []projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) []ProjectOperationsBriefItemResponse {
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
-	assignmentsByID := projectOperationsAssignmentsByID(assignments)
-	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
+	assignmentsByID := projectWorkReadinessAssignmentsByID(assignments)
 	allArtifactsByWorkItem := projectOperationsArtifactsByWorkItem(artifacts)
 	handoffsByWorkItem := projectOperationsHandoffsByWorkItem(handoffs)
 	items := make([]ProjectOperationsBriefItemResponse, 0, len(workItems))
@@ -308,20 +312,22 @@ func selectedWorkFollowThroughOperationItems(projectID string, workItems []proje
 		if projectWorkItemClosed(workItem.Status) {
 			continue
 		}
-		if review := projectOperationsReviewFollowUpArtifact(allArtifactsByWorkItem[workItem.ID], handoffs); review != nil {
+		workItemAssignments := assignmentsByWorkItem[workItem.ID]
+		workItemArtifacts := allArtifactsByWorkItem[workItem.ID]
+		workItemHandoffs := handoffsByWorkItem[workItem.ID]
+		readiness := renderProjectWorkItemReadiness(workItem, workItemAssignments, workItemArtifacts, workItemHandoffs)
+		if review := projectWorkReadinessReviewFollowUpArtifact(workItemArtifacts, workItemHandoffs); review != nil {
 			items = append(items, reviewFollowUpOperationItem(projectID, workItem, *review))
 		}
-		for _, assignment := range assignmentsByWorkItem[workItem.ID] {
-			if projectOperationsAssignmentStatus(assignment) != projectwork.AssignmentStatusCompleted {
-				continue
-			}
-			if projectOperationsAssignmentHasEvidence(assignment, artifactsByAssignment, artifactsByWorkItem) {
+		for _, assignmentID := range readiness.MissingEvidenceAssignmentIDs {
+			assignment, ok := assignmentsByID[assignmentID]
+			if !ok {
 				continue
 			}
 			items = append(items, completionEvidenceOperationItem(projectID, workItem, assignment))
 		}
-		if projectOperationsWorkItemReadyToClose(workItem, assignmentsByWorkItem[workItem.ID], artifactsByAssignment, artifactsByWorkItem, handoffsByWorkItem[workItem.ID], assignmentsByID) {
-			items = append(items, closeWorkItemOperationItem(projectID, workItem, assignmentsByWorkItem[workItem.ID]))
+		if readiness.Ready && len(workItemAssignments) > 0 {
+			items = append(items, closeWorkItemOperationItem(projectID, workItem, workItemAssignments))
 		}
 	}
 	return items
@@ -476,6 +482,40 @@ func assignmentGapOperationItems(projectID string, workItems []projectwork.WorkI
 	return items
 }
 
+func latestWorkOperationItem(projectID string, workItems []projectwork.WorkItem) *ProjectOperationsBriefItemResponse {
+	if len(workItems) == 0 {
+		return nil
+	}
+	items := append([]projectwork.WorkItem(nil), workItems...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := projectworkTime(items[i].UpdatedAt, items[i].CreatedAt), projectworkTime(items[j].UpdatedAt, items[j].CreatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+	workItem := items[0]
+	rendered := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:    "work",
+		ProjectID:  projectID,
+		WorkItemID: workItem.ID,
+	}
+	return &ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("open_latest_work", projectID, workItem.ID),
+		Kind:        "open_latest_work",
+		Priority:    projectOperationsPriorityLow,
+		Title:       "Open latest work: " + firstNonEmpty(workItem.Title, workItem.ID),
+		Detail:      "Review the most recently updated work item.",
+		ActionLabel: "Open work",
+		Status:      firstNonEmpty(workItem.Status, projectwork.WorkItemStatusReady),
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, "", "", ""),
+		WorkItem:    &rendered,
+		UpdatedAt:   formatOptionalTime(projectworkTime(workItem.UpdatedAt, workItem.CreatedAt)),
+	}
+}
+
 func sortProjectOperationsItems(items []ProjectOperationsBriefItemResponse) {
 	sort.SliceStable(items, func(i, j int) bool {
 		leftRank, rightRank := projectOperationsPriorityRank(items[i].Priority), projectOperationsPriorityRank(items[j].Priority)
@@ -539,6 +579,8 @@ func projectOperationsKindRank(kind string) int {
 		return 110
 	case "close_work_item":
 		return 120
+	case "open_latest_work":
+		return 130
 	default:
 		return 1000
 	}
@@ -628,153 +670,6 @@ func projectWorkItemClosed(status string) bool {
 	}
 }
 
-func projectOperationsReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
-	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
-	sort.SliceStable(items, func(i, j int) bool {
-		left, right := projectworkTime(items[i].UpdatedAt, items[i].CreatedAt), projectworkTime(items[j].UpdatedAt, items[j].CreatedAt)
-		if !left.Equal(right) {
-			return left.After(right)
-		}
-		return items[i].ID < items[j].ID
-	})
-	for i := range items {
-		if !projectOperationsReviewArtifactRequiresFollowUp(items[i]) {
-			continue
-		}
-		if projectOperationsArtifactHasLinkedFollowUpPath(items[i].ID, handoffs) {
-			continue
-		}
-		return &items[i]
-	}
-	return nil
-}
-
-func projectOperationsReviewArtifactRequiresFollowUp(artifact projectwork.CollaborationArtifact) bool {
-	if artifact.Kind != projectwork.ArtifactKindReview {
-		return false
-	}
-	return artifact.ReviewFollowUpRequired || artifact.ReviewVerdict == projectwork.ReviewVerdictBlocked || artifact.ReviewVerdict == projectwork.ReviewVerdictChangesRequested
-}
-
-func projectOperationsArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwork.Handoff) bool {
-	artifactID = strings.TrimSpace(artifactID)
-	if artifactID == "" {
-		return false
-	}
-	for _, handoff := range handoffs {
-		for _, linkedID := range handoff.LinkedArtifactIDs {
-			if strings.TrimSpace(linkedID) != artifactID {
-				continue
-			}
-			if handoff.Status == projectwork.HandoffStatusPending ||
-				handoff.Status == projectwork.HandoffStatusDismissed ||
-				handoff.Status == projectwork.HandoffStatusSuperseded ||
-				strings.TrimSpace(handoff.TargetAssignmentID) != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func projectOperationsWorkItemReadyToClose(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifactsByAssignment, artifactsByWorkItem map[string][]projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) bool {
-	if projectWorkItemClosed(workItem.Status) || len(assignments) == 0 {
-		return false
-	}
-	for _, assignment := range assignments {
-		if projectOperationsAssignmentStatus(assignment) != projectwork.AssignmentStatusCompleted {
-			return false
-		}
-		if !projectOperationsAssignmentHasEvidence(assignment, artifactsByAssignment, artifactsByWorkItem) {
-			return false
-		}
-	}
-	for _, handoff := range handoffs {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			return false
-		}
-	}
-	for _, artifact := range artifactsByWorkItem[workItem.ID] {
-		if projectOperationsReviewFollowUpBlocker(artifact, handoffs, assignmentsByID) {
-			return false
-		}
-	}
-	for _, assignment := range assignments {
-		for _, artifact := range artifactsByAssignment[assignment.ID] {
-			if projectOperationsReviewFollowUpBlocker(artifact, handoffs, assignmentsByID) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func projectOperationsAssignmentStatus(assignment projectwork.Assignment) string {
-	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
-}
-
-func projectOperationsAssignmentHasEvidence(assignment projectwork.Assignment, artifactsByAssignment, artifactsByWorkItem map[string][]projectwork.CollaborationArtifact) bool {
-	if projectOperationsArtifactsIncludeEvidence(artifactsByAssignment[assignment.ID]) {
-		return true
-	}
-	return projectOperationsArtifactsIncludeEvidence(artifactsByWorkItem[assignment.WorkItemID])
-}
-
-func projectOperationsArtifactsIncludeEvidence(artifacts []projectwork.CollaborationArtifact) bool {
-	for _, artifact := range artifacts {
-		if artifact.Kind == projectwork.ArtifactKindEvidenceLink {
-			return true
-		}
-	}
-	return false
-}
-
-func projectOperationsReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) bool {
-	if !projectOperationsReviewArtifactRequiresFollowUp(artifact) {
-		return false
-	}
-	linked := make([]projectwork.Handoff, 0)
-	for _, handoff := range handoffs {
-		for _, artifactID := range handoff.LinkedArtifactIDs {
-			if strings.TrimSpace(artifactID) == artifact.ID {
-				linked = append(linked, handoff)
-				break
-			}
-		}
-	}
-	if len(linked) == 0 {
-		return true
-	}
-	hasTargetAssignment := false
-	hasCompletedTarget := false
-	hasDismissedOrSuperseded := false
-	for _, handoff := range linked {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			return true
-		}
-		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
-			hasDismissedOrSuperseded = true
-		}
-		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
-			continue
-		}
-		hasTargetAssignment = true
-		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
-			hasCompletedTarget = hasCompletedTarget || projectOperationsAssignmentStatus(assignment) == projectwork.AssignmentStatusCompleted
-		}
-	}
-	if hasCompletedTarget {
-		return false
-	}
-	if hasTargetAssignment {
-		return true
-	}
-	if hasDismissedOrSuperseded {
-		return false
-	}
-	return true
-}
-
 func projectOperationsArtifactsByWorkItem(artifacts []projectwork.CollaborationArtifact) map[string][]projectwork.CollaborationArtifact {
 	byWorkItem := make(map[string][]projectwork.CollaborationArtifact)
 	for _, artifact := range artifacts {
@@ -795,14 +690,6 @@ func projectOperationsHandoffsByWorkItem(handoffs []projectwork.Handoff) map[str
 		byWorkItem[handoff.WorkItemID] = append(byWorkItem[handoff.WorkItemID], handoff)
 	}
 	return byWorkItem
-}
-
-func projectOperationsAssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
-	byID := make(map[string]projectwork.Assignment, len(assignments))
-	for _, assignment := range assignments {
-		byID[assignment.ID] = assignment
-	}
-	return byID
 }
 
 func projectOperationsLatestAssignmentTime(assignments []projectwork.Assignment, fallback time.Time) time.Time {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -245,6 +246,137 @@ func TestProjectOperationsBrief_SelectedWorkFollowThrough(t *testing.T) {
 	requireProjectOperationsItemAbsentForTest(t, response.Data.Items, "prepare_first_assignment")
 }
 
+func TestProjectWorkItemReadiness_ReadOnlyCloseoutContract(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_readiness",
+		Name: "Readiness",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_readiness",
+		ProjectID: "proj_readiness",
+		Title:     "Verify closeout",
+		Status:    projectwork.WorkItemStatusReview,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_complete",
+		ProjectID:  "proj_readiness",
+		WorkItemID: "work_readiness",
+		RoleID:     "developer",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+
+	beforeAssignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_readiness", WorkItemID: "work_readiness"})
+	if err != nil {
+		t.Fatalf("ListAssignments before: %v", err)
+	}
+	beforeArtifacts, err := handler.projectWork.ListArtifacts(t.Context(), projectwork.ArtifactFilter{ProjectID: "proj_readiness", WorkItemID: "work_readiness"})
+	if err != nil {
+		t.Fatalf("ListArtifacts before: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_readiness/work-items/work_readiness/readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode readiness: %v", err)
+	}
+	if response.Object != "project_work_item_readiness" || response.Data.ProjectID != "proj_readiness" || response.Data.WorkItemID != "work_readiness" {
+		t.Fatalf("readiness envelope = %+v, want work item readiness", response)
+	}
+	if response.Data.Ready || response.Data.Status != "blocked" || len(response.Data.MissingEvidenceAssignmentIDs) != 1 || response.Data.MissingEvidenceAssignmentIDs[0] != "asgn_complete" {
+		t.Fatalf("readiness = %+v, want missing evidence blocker", response.Data)
+	}
+
+	afterAssignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: "proj_readiness", WorkItemID: "work_readiness"})
+	if err != nil {
+		t.Fatalf("ListAssignments after: %v", err)
+	}
+	afterArtifacts, err := handler.projectWork.ListArtifacts(t.Context(), projectwork.ArtifactFilter{ProjectID: "proj_readiness", WorkItemID: "work_readiness"})
+	if err != nil {
+		t.Fatalf("ListArtifacts after: %v", err)
+	}
+	if len(afterAssignments) != len(beforeAssignments) || len(afterArtifacts) != len(beforeArtifacts) {
+		t.Fatalf("readiness mutated project state: assignments %d->%d artifacts %d->%d", len(beforeAssignments), len(afterAssignments), len(beforeArtifacts), len(afterArtifacts))
+	}
+
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                 "artifact_evidence",
+		ProjectID:          "proj_readiness",
+		WorkItemID:         "work_readiness",
+		AssignmentID:       "asgn_complete",
+		Kind:               projectwork.ArtifactKindEvidenceLink,
+		Title:              "Evidence",
+		Body:               "Evidence recorded.",
+		EvidenceURL:        "https://example.com/evidence",
+		EvidenceTrustLabel: "operator_reviewed",
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence): %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_readiness/work-items/work_readiness/readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readiness with evidence status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode readiness with evidence: %v", err)
+	}
+	if !response.Data.Ready || response.Data.Status != "ready" || response.Data.CompletedAssignments != 1 || response.Data.AssignmentCount != 1 {
+		t.Fatalf("readiness with evidence = %+v, want ready closeout", response.Data)
+	}
+}
+
+func TestProjectOperationsBrief_OpenLatestWorkWhenNoOperations(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_latest",
+		Name:            "Latest Work",
+		DefaultProvider: "ollama",
+		DefaultModel:    "qwen2.5-coder",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	older := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 20, 11, 0, 0, 0, time.UTC)
+	for _, item := range []projectwork.WorkItem{
+		{ID: "work_older", ProjectID: "proj_latest", Title: "Older work", Status: projectwork.WorkItemStatusDone, CreatedAt: older, UpdatedAt: older},
+		{ID: "work_newer", ProjectID: "proj_latest", Title: "Newer work", Status: projectwork.WorkItemStatusDone, CreatedAt: newer, UpdatedAt: newer},
+	} {
+		if _, err := handler.projectWork.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatalf("CreateWorkItem(%s): %v", item.ID, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_latest/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if len(response.Data.Items) != 1 {
+		t.Fatalf("operations items = %+v, want only latest work fallback", response.Data.Items)
+	}
+	item := response.Data.Items[0]
+	if item.Kind != "open_latest_work" || item.Target.WorkItemID != "work_newer" || item.Action.Type != projectOperationsActionOpenWorkItem {
+		t.Fatalf("latest work item = %+v, want newest work target", item)
+	}
+}
+
 func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 	t.Parallel()
 	artifact := projectwork.CollaborationArtifact{
@@ -259,10 +391,10 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusAccepted,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, acceptedWithoutTarget) {
+	if projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, acceptedWithoutTarget) {
 		t.Fatal("accepted handoff without target assignment should not hide review follow-up operation")
 	}
-	if !projectOperationsReviewFollowUpBlocker(artifact, acceptedWithoutTarget, nil) {
+	if projectWorkReadinessReviewFollowUpBlocker(artifact, acceptedWithoutTarget, nil) == "" {
 		t.Fatal("accepted handoff without target assignment should still block closeout")
 	}
 
@@ -271,7 +403,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusPending,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, pending) || !projectOperationsReviewFollowUpBlocker(artifact, pending, nil) {
+	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, pending) || projectWorkReadinessReviewFollowUpBlocker(artifact, pending, nil) == "" {
 		t.Fatal("pending handoff should route through handoff review and block closeout")
 	}
 
@@ -280,7 +412,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusDismissed,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, dismissed) || projectOperationsReviewFollowUpBlocker(artifact, dismissed, nil) {
+	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, dismissed) || projectWorkReadinessReviewFollowUpBlocker(artifact, dismissed, nil) != "" {
 		t.Fatal("dismissed handoff should clear review follow-up without blocking closeout")
 	}
 
@@ -293,7 +425,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 	assignmentsByID := map[string]projectwork.Assignment{
 		"asgn_followup": {ID: "asgn_followup", Status: projectwork.AssignmentStatusCompleted},
 	}
-	if !projectOperationsArtifactHasLinkedFollowUpPath(artifact.ID, completedTarget) || projectOperationsReviewFollowUpBlocker(artifact, completedTarget, assignmentsByID) {
+	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, completedTarget) || projectWorkReadinessReviewFollowUpBlocker(artifact, completedTarget, assignmentsByID) != "" {
 		t.Fatal("completed target assignment should clear review follow-up closeout blocker")
 	}
 }

--- a/internal/api/handler_project_work_readiness.go
+++ b/internal/api/handler_project_work_readiness.go
@@ -1,0 +1,334 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type ProjectWorkItemReadinessEnvelope struct {
+	Object string                           `json:"object"`
+	Data   ProjectWorkItemReadinessResponse `json:"data"`
+}
+
+type ProjectWorkItemReadinessResponse struct {
+	ProjectID                    string   `json:"project_id"`
+	WorkItemID                   string   `json:"work_item_id"`
+	Ready                        bool     `json:"ready"`
+	Status                       string   `json:"status"`
+	Title                        string   `json:"title"`
+	Detail                       string   `json:"detail"`
+	Blockers                     []string `json:"blockers"`
+	Warnings                     []string `json:"warnings"`
+	AssignmentCount              int      `json:"assignment_count"`
+	CompletedAssignments         int      `json:"completed_assignments"`
+	ReviewFollowUpCount          int      `json:"review_follow_up_count"`
+	ReviewFollowUpArtifactIDs    []string `json:"review_follow_up_artifact_ids,omitempty"`
+	MissingEvidenceAssignmentIDs []string `json:"missing_evidence_assignment_ids,omitempty"`
+}
+
+func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	readiness, err := h.renderProjectWorkItemReadiness(r.Context(), projectID, r.PathValue("work_item_id"))
+	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkItemReadinessEnvelope{Object: "project_work_item_readiness", Data: readiness})
+}
+
+func (h *Handler) renderProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	if _, ok, err := h.projects.Get(ctx, projectID); err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	} else if !ok {
+		return ProjectWorkItemReadinessResponse{}, projects.ErrNotFound
+	}
+	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	if !ok {
+		return ProjectWorkItemReadinessResponse{}, projects.ErrNotFound
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	artifacts, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	return renderProjectWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
+}
+
+func renderProjectWorkItemReadiness(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) ProjectWorkItemReadinessResponse {
+	statuses := make([]string, 0, len(assignments))
+	assignmentsByID := projectWorkReadinessAssignmentsByID(assignments)
+	closed := projectWorkItemClosed(workItem.Status)
+	readiness := ProjectWorkItemReadinessResponse{
+		ProjectID:            workItem.ProjectID,
+		WorkItemID:           workItem.ID,
+		Status:               "ready",
+		Title:                "Ready to mark done",
+		Detail:               "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
+		AssignmentCount:      len(assignments),
+		CompletedAssignments: 0,
+	}
+
+	for _, assignment := range assignments {
+		status := projectWorkReadinessAssignmentStatus(assignment)
+		statuses = append(statuses, status)
+		if status != projectwork.AssignmentStatusCompleted {
+			continue
+		}
+		readiness.CompletedAssignments++
+		if !closed && !projectWorkReadinessAssignmentHasEvidence(assignment, artifacts) {
+			readiness.MissingEvidenceAssignmentIDs = append(readiness.MissingEvidenceAssignmentIDs, assignment.ID)
+		}
+	}
+	if closed {
+		readiness.Status = "done"
+		readiness.Title = "Work item is done"
+		readiness.Detail = "This work item has already been marked done by the operator."
+		return readiness
+	}
+
+	activeAssignments := projectWorkReadinessStatusCount(statuses, projectWorkReadinessActiveAssignmentStatus)
+	failedAssignments := projectWorkReadinessStatusCount(statuses, func(status string) bool {
+		return status == projectwork.AssignmentStatusFailed
+	})
+	cancelledAssignments := projectWorkReadinessStatusCount(statuses, func(status string) bool {
+		return status == projectwork.AssignmentStatusCancelled
+	})
+	unresolvedAssignments := projectWorkReadinessStatusCount(statuses, projectWorkReadinessUnresolvedAssignmentStatus)
+	pendingHandoffs := 0
+	for _, handoff := range handoffs {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			pendingHandoffs++
+		}
+	}
+	if activeAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(activeAssignments, "assignment is still active", "assignments are still active"))
+	}
+	if failedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(failedAssignments, "assignment failed", "assignments failed"))
+	}
+	if cancelledAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"))
+	}
+	if unresolvedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(unresolvedAssignments, "assignment is not complete", "assignments are not complete"))
+	}
+	if pendingHandoffs > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(pendingHandoffs, "handoff is pending", "handoffs are pending"))
+	}
+	if len(readiness.MissingEvidenceAssignmentIDs) > 0 {
+		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(len(readiness.MissingEvidenceAssignmentIDs), "completed assignment is missing evidence", "completed assignments are missing evidence"))
+	}
+	if len(assignments) == 0 {
+		readiness.Warnings = append(readiness.Warnings, "No assignments are linked to this work item; closeout is manual.")
+	}
+	for _, artifact := range artifacts {
+		if projectWorkReadinessReviewArtifactNeedsPath(artifact, handoffs) {
+			readiness.ReviewFollowUpArtifactIDs = append(readiness.ReviewFollowUpArtifactIDs, artifact.ID)
+		}
+		if blocker := projectWorkReadinessReviewFollowUpBlocker(artifact, handoffs, assignmentsByID); blocker != "" {
+			readiness.Blockers = append(readiness.Blockers, blocker)
+		}
+	}
+	readiness.ReviewFollowUpCount = len(readiness.ReviewFollowUpArtifactIDs)
+	readiness.Blockers = projectWorkReadinessUniqueStrings(readiness.Blockers)
+	readiness.Warnings = projectWorkReadinessUniqueStrings(readiness.Warnings)
+	if len(readiness.Blockers) > 0 {
+		readiness.Status = "blocked"
+		readiness.Title = "Closeout is blocked"
+		readiness.Detail = "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done."
+	}
+	readiness.Ready = readiness.Status == "ready"
+	return readiness
+}
+
+func projectWorkReadinessReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
+	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := projectworkTime(items[i].UpdatedAt, items[i].CreatedAt), projectworkTime(items[j].UpdatedAt, items[j].CreatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+	for i := range items {
+		if projectWorkReadinessReviewArtifactNeedsPath(items[i], handoffs) {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+func projectWorkReadinessReviewArtifactNeedsPath(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) bool {
+	if !projectWorkReadinessReviewArtifactRequiresFollowUp(artifact) {
+		return false
+	}
+	return !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, handoffs)
+}
+
+func projectWorkReadinessReviewArtifactRequiresFollowUp(artifact projectwork.CollaborationArtifact) bool {
+	if artifact.Kind != projectwork.ArtifactKindReview {
+		return false
+	}
+	return artifact.ReviewFollowUpRequired || artifact.ReviewVerdict == projectwork.ReviewVerdictBlocked || artifact.ReviewVerdict == projectwork.ReviewVerdictChangesRequested
+}
+
+func projectWorkReadinessArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwork.Handoff) bool {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return false
+	}
+	for _, handoff := range handoffs {
+		for _, linkedID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(linkedID) != artifactID {
+				continue
+			}
+			if handoff.Status == projectwork.HandoffStatusPending ||
+				handoff.Status == projectwork.HandoffStatusDismissed ||
+				handoff.Status == projectwork.HandoffStatusSuperseded ||
+				strings.TrimSpace(handoff.TargetAssignmentID) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func projectWorkReadinessReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) string {
+	if !projectWorkReadinessReviewArtifactRequiresFollowUp(artifact) {
+		return ""
+	}
+	title := firstNonEmpty(artifact.Title, artifact.ID)
+	linked := make([]projectwork.Handoff, 0)
+	for _, handoff := range handoffs {
+		for _, artifactID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(artifactID) == artifact.ID {
+				linked = append(linked, handoff)
+				break
+			}
+		}
+	}
+	if len(linked) == 0 {
+		return fmt.Sprintf("Review follow-up %q is not triaged", title)
+	}
+	hasTargetAssignment := false
+	hasCompletedTarget := false
+	hasDismissedOrSuperseded := false
+	for _, handoff := range linked {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			return fmt.Sprintf("Review follow-up %q has a pending handoff", title)
+		}
+		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
+			hasDismissedOrSuperseded = true
+		}
+		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
+			continue
+		}
+		hasTargetAssignment = true
+		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
+			hasCompletedTarget = hasCompletedTarget || projectWorkReadinessAssignmentStatus(assignment) == projectwork.AssignmentStatusCompleted
+		}
+	}
+	if hasCompletedTarget {
+		return ""
+	}
+	if hasTargetAssignment {
+		return fmt.Sprintf("Review follow-up %q assignment is not completed", title)
+	}
+	if hasDismissedOrSuperseded {
+		return ""
+	}
+	return fmt.Sprintf("Review follow-up %q is not triaged", title)
+}
+
+func projectWorkReadinessAssignmentStatus(assignment projectwork.Assignment) string {
+	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
+}
+
+func projectWorkReadinessActiveAssignmentStatus(status string) bool {
+	return status == projectwork.AssignmentStatusQueued || status == projectwork.AssignmentStatusRunning || status == projectwork.AssignmentStatusAwaitingApproval
+}
+
+func projectWorkReadinessUnresolvedAssignmentStatus(status string) bool {
+	return status != projectwork.AssignmentStatusCompleted &&
+		status != projectwork.AssignmentStatusFailed &&
+		status != projectwork.AssignmentStatusCancelled &&
+		!projectWorkReadinessActiveAssignmentStatus(status)
+}
+
+func projectWorkReadinessAssignmentHasEvidence(assignment projectwork.Assignment, artifacts []projectwork.CollaborationArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Kind != projectwork.ArtifactKindEvidenceLink {
+			continue
+		}
+		if artifact.AssignmentID == "" || artifact.AssignmentID == assignment.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func projectWorkReadinessStatusCount(statuses []string, predicate func(string) bool) int {
+	count := 0
+	for _, status := range statuses {
+		if predicate(status) {
+			count++
+		}
+	}
+	return count
+}
+
+func projectWorkReadinessAssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
+	byID := make(map[string]projectwork.Assignment, len(assignments))
+	for _, assignment := range assignments {
+		byID[assignment.ID] = assignment
+	}
+	return byID
+}
+
+func projectWorkReadinessPlural(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
+}
+
+func projectWorkReadinessUniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -66,6 +66,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/work-items"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/readiness"},
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}"},
 	{method: http.MethodDelete, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -103,6 +103,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items", handler.HandleProjectWorkItems)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items", handler.HandleCreateProjectWorkItem)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleProjectWorkItem)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness", handler.HandleProjectWorkItemReadiness)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleUpdateProjectWorkItem)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}", handler.HandleDeleteProjectWorkItem)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleProjectWorkAssignments)

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -411,6 +411,16 @@ async function handleWorkItemRoute(
     }
   }
 
+  if (subresource === "readiness" && method === "GET") {
+    await route.fulfill(
+      ok({
+        object: "project_work_item_readiness",
+        data: projectWorkItemReadiness(state, item),
+      }),
+    );
+    return;
+  }
+
   if (subresource === "assignments") {
     const assignmentID = parts[4] || "";
     if (!assignmentID) {
@@ -625,6 +635,80 @@ function assignmentPreflight(projectID: string, workItemID: string, assignmentID
         included: true,
       },
     ],
+  };
+}
+
+function projectWorkItemReadiness(state: ProjectJourneyState, workItem: ProjectWorkItemRecord) {
+  const assignments = state.assignments.filter(
+    (assignment) => assignment.work_item_id === workItem.id,
+  );
+  const artifacts = state.artifacts.filter((artifact) => artifact.work_item_id === workItem.id);
+  const completedAssignments = assignments.filter(
+    (assignment) => (assignment.execution_ref?.status || assignment.status) === "completed",
+  );
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  if (workItem.status === "done") {
+    return {
+      project_id: workItem.project_id,
+      work_item_id: workItem.id,
+      ready: false,
+      status: "done",
+      title: "Work item is done",
+      detail: "This work item has already been marked done by the operator.",
+      blockers,
+      warnings,
+      assignment_count: assignments.length,
+      completed_assignments: completedAssignments.length,
+      review_follow_up_count: 0,
+    };
+  }
+
+  const activeAssignments = assignments.filter((assignment) =>
+    ["queued", "running", "awaiting_approval"].includes(
+      assignment.execution_ref?.status || assignment.status,
+    ),
+  ).length;
+  const missingEvidenceAssignments = completedAssignments.filter(
+    (assignment) =>
+      !artifacts.some(
+        (artifact) =>
+          artifact.kind === "evidence_link" &&
+          (!artifact.assignment_id || artifact.assignment_id === assignment.id),
+      ),
+  );
+  if (activeAssignments > 0) {
+    blockers.push(
+      `${activeAssignments} assignment${activeAssignments === 1 ? " is" : "s are"} still active`,
+    );
+  }
+  if (missingEvidenceAssignments.length > 0) {
+    blockers.push(
+      `${missingEvidenceAssignments.length} completed assignment${
+        missingEvidenceAssignments.length === 1 ? " is" : "s are"
+      } missing evidence`,
+    );
+  }
+  if (assignments.length === 0) {
+    warnings.push("No assignments are linked to this work item; closeout is manual.");
+  }
+
+  const ready = blockers.length === 0;
+  return {
+    project_id: workItem.project_id,
+    work_item_id: workItem.id,
+    ready,
+    status: ready ? "ready" : "blocked",
+    title: ready ? "Ready to mark done" : "Closeout is blocked",
+    detail: ready
+      ? "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done."
+      : "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done.",
+    blockers,
+    warnings,
+    assignment_count: assignments.length,
+    completed_assignments: completedAssignments.length,
+    review_follow_up_count: 0,
+    missing_evidence_assignment_ids: missingEvidenceAssignments.map((assignment) => assignment.id),
   };
 }
 

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -15,6 +15,7 @@ import {
   getProjectHandoffs,
   getProjectOperationsBrief,
   getProjectWorkItem,
+  getProjectWorkItemReadiness,
   getProjectWorkItems,
   getProjectWorkRoles,
 } from "../lib/api";
@@ -44,6 +45,22 @@ vi.mock("../lib/api", async (importOriginal) => {
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: emptyWorkItem })),
+    getProjectWorkItemReadiness: vi.fn(async () => ({
+      object: "project_work_item_readiness",
+      data: {
+        project_id: "",
+        work_item_id: "",
+        ready: false,
+        status: "blocked",
+        title: "Closeout readiness unavailable",
+        detail: "Refresh work item detail before marking done.",
+        blockers: ["Closeout readiness is unavailable."],
+        warnings: [],
+        assignment_count: 0,
+        completed_assignments: 0,
+        review_follow_up_count: 0,
+      },
+    })),
     getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
     getProjectCollaborationArtifacts: vi.fn(async () => ({
       object: "project_collaboration_artifacts",
@@ -113,6 +130,22 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectWorkItem).mockResolvedValue({
     object: "project_work_item",
     data: emptyWorkItem,
+  });
+  vi.mocked(getProjectWorkItemReadiness).mockResolvedValue({
+    object: "project_work_item_readiness",
+    data: {
+      project_id: "",
+      work_item_id: "",
+      ready: false,
+      status: "blocked",
+      title: "Closeout readiness unavailable",
+      detail: "Refresh work item detail before marking done.",
+      blockers: ["Closeout readiness is unavailable."],
+      warnings: [],
+      assignment_count: 0,
+      completed_assignments: 0,
+      review_follow_up_count: 0,
+    },
   });
   vi.mocked(getProjectAssignments).mockResolvedValue({ object: "project_assignments", data: [] });
   vi.mocked(getProjectCollaborationArtifacts).mockResolvedValue({

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -8,6 +8,7 @@ import type {
   ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
   ProjectRecord,
+  ProjectWorkItemReadinessRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
@@ -79,6 +80,26 @@ function workItem(overrides: Partial<ProjectWorkItemRecord> = {}): ProjectWorkIt
     reviewer_role_ids: ["architect"],
     created_at: "2026-06-12T00:00:00Z",
     updated_at: "2026-06-13T09:00:00Z",
+    ...overrides,
+  };
+}
+
+function closeoutReadiness(
+  overrides: Partial<ProjectWorkItemReadinessRecord> = {},
+): ProjectWorkItemReadinessRecord {
+  return {
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    ready: true,
+    status: "ready",
+    title: "Ready to mark done",
+    detail:
+      "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
+    blockers: [],
+    warnings: [],
+    assignment_count: 1,
+    completed_assignments: 1,
+    review_follow_up_count: 0,
     ...overrides,
   };
 }
@@ -220,6 +241,7 @@ function renderDetail(overrides: Partial<ProjectWorkItemDetailProps> = {}) {
     project: record,
     roleByID,
     closingWorkItemID: "",
+    closeoutReadiness: closeoutReadiness(),
     startingAssignmentID: "",
     workItem: workItem(),
     ...handlers,
@@ -389,6 +411,15 @@ describe("ProjectWorkItemDetail", () => {
   it("shows closeout blockers while assignments are active", () => {
     renderDetail({
       assignments: [assignment({ status: "running", execution_ref: { kind: "none" } })],
+      closeoutReadiness: closeoutReadiness({
+        ready: false,
+        status: "blocked",
+        title: "Closeout is blocked",
+        detail:
+          "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done.",
+        blockers: ["1 assignment is still active"],
+        completed_assignments: 0,
+      }),
     });
 
     expect(screen.getByText("Closeout is blocked")).toBeTruthy();
@@ -430,6 +461,14 @@ describe("ProjectWorkItemDetail", () => {
   it("shows already-done closeout state without a mark-done action", () => {
     renderDetail({
       assignments: [assignment({ status: "failed", execution_ref: { kind: "none" } })],
+      closeoutReadiness: closeoutReadiness({
+        ready: false,
+        status: "done",
+        title: "Work item is done",
+        detail: "This work item has already been marked done by the operator.",
+        blockers: [],
+        completed_assignments: 0,
+      }),
       workItem: workItem({ status: "done" }),
     });
 

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -9,6 +9,7 @@ import type {
   ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
   ProjectRecord,
+  ProjectWorkItemReadinessRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
@@ -20,11 +21,7 @@ import {
   toProjectAssignmentExecutionViewModel,
   type ProjectAssignmentEvidenceViewModel,
 } from "./projectAssignmentViewModels";
-import {
-  buildProjectWorkCloseoutReadiness,
-  reviewArtifactNeedsFollowUpPath,
-  type ProjectWorkCloseoutReadiness,
-} from "./projectInsights";
+import { reviewArtifactNeedsFollowUpPath } from "./projectInsights";
 import {
   assignmentStatusLabel,
   formatProjectRowRelativeTime,
@@ -118,6 +115,7 @@ export type ProjectWorkItemDetailProps = {
   project: ProjectRecord | null;
   roleByID: Map<string, ProjectWorkRoleRecord>;
   closingWorkItemID: string;
+  closeoutReadiness: ProjectWorkItemReadinessRecord | null;
   startingAssignmentID: string;
   workItem: ProjectWorkItemRecord | null;
 };
@@ -166,6 +164,7 @@ export function ProjectWorkItemDetail({
   project,
   roleByID,
   closingWorkItemID,
+  closeoutReadiness,
   startingAssignmentID,
   workItem,
 }: ProjectWorkItemDetailProps) {
@@ -177,12 +176,7 @@ export function ProjectWorkItemDetail({
       />
     );
   }
-  const closeout = buildProjectWorkCloseoutReadiness({
-    assignments,
-    artifacts,
-    handoffs,
-    workItem,
-  });
+  const closeout = closeoutReadiness ?? unavailableCloseoutReadiness(workItem, loading);
   const emptyWorkItem =
     assignments.length === 0 &&
     artifacts.length === 0 &&
@@ -693,12 +687,33 @@ function EvidenceArtifactMetadata({ artifact }: { artifact: ProjectCollaboration
   );
 }
 
+function unavailableCloseoutReadiness(
+  workItem: ProjectWorkItemRecord,
+  loading: boolean,
+): ProjectWorkItemReadinessRecord {
+  return {
+    project_id: workItem.project_id,
+    work_item_id: workItem.id,
+    ready: false,
+    status: "blocked",
+    title: loading ? "Checking closeout readiness" : "Closeout readiness unavailable",
+    detail: loading
+      ? "Loading closeout readiness from the project operations contract."
+      : "Refresh work item detail before marking done.",
+    blockers: [loading ? "Closeout readiness is loading." : "Closeout readiness is unavailable."],
+    warnings: [],
+    assignment_count: 0,
+    completed_assignments: 0,
+    review_follow_up_count: 0,
+  };
+}
+
 function WorkItemCloseoutPanel({
   closeout,
   onClose,
   pending,
 }: {
-  closeout: ProjectWorkCloseoutReadiness;
+  closeout: ProjectWorkItemReadinessRecord;
   onClose: () => void;
   pending: boolean;
 }) {
@@ -710,7 +725,7 @@ function WorkItemCloseoutPanel({
         <div style={sectionLabelStyle}>Closeout</div>
         <Badge status={status} label={closeout.status === "done" ? "done" : closeout.status} />
         <span className="badge badge-muted">
-          {closeout.completedAssignments}/{closeout.assignmentCount} assignments complete
+          {closeout.completed_assignments}/{closeout.assignment_count} assignments complete
         </span>
         {closeout.status !== "done" && (
           <button

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -267,6 +267,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     roleByID: new Map(),
     roles: [],
     selectedWorkItem: null,
+    selectedWorkItemReadiness: null,
     selectedWorkItemID: "",
     closingWorkItemID: "",
     skillsError: "",

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -13,6 +13,7 @@ import type {
   ProjectOperationsBriefItem,
   ProjectRecord,
   ProjectSkillRecord,
+  ProjectWorkItemReadinessRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectSkillPayload,
@@ -134,6 +135,7 @@ export type ProjectWorkspaceViewProps = {
   roleByID: Map<string, ProjectWorkRoleRecord>;
   roles: ProjectWorkRoleRecord[];
   selectedWorkItem: ProjectWorkItemRecord | null;
+  selectedWorkItemReadiness: ProjectWorkItemReadinessRecord | null;
   selectedWorkItemID: string;
   closingWorkItemID: string;
   skillsError: string;
@@ -228,6 +230,7 @@ export function ProjectWorkspaceView({
   roleByID,
   roles,
   selectedWorkItem,
+  selectedWorkItemReadiness,
   selectedWorkItemID,
   closingWorkItemID,
   skillsError,
@@ -406,6 +409,7 @@ export function ProjectWorkspaceView({
                         project={project}
                         roleByID={roleByID}
                         closingWorkItemID={closingWorkItemID}
+                        closeoutReadiness={selectedWorkItemReadiness}
                         startingAssignmentID={startingAssignmentID}
                         workItem={selectedWorkItem}
                         onAddAssignment={onAddAssignment}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -39,6 +39,7 @@ import {
   getProjectMemoryCandidates,
   getProjectSkills,
   getProjectWorkItem,
+  getProjectWorkItemReadiness,
   getProjectWorkItems,
   getProjectWorkRoles,
   draftProjectAssistant,
@@ -145,6 +146,10 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
     getProjectWorkItem: vi.fn(async () => ({ object: "project_work_item", data: null })),
+    getProjectWorkItemReadiness: vi.fn(async () => ({
+      object: "project_work_item_readiness",
+      data: workItemReadiness(),
+    })),
     getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
     getProjectAssignmentContext: vi.fn(async () => ({ object: "context_packet", data: null })),
     getProjectAssignmentPreflight: vi.fn(async () => ({
@@ -363,6 +368,24 @@ const workItem: ProjectWorkItemRecord = {
   updated_at: "2026-06-02T11:00:00Z",
 };
 
+function workItemReadiness(overrides = {}) {
+  return {
+    project_id: project.id,
+    work_item_id: workItem.id,
+    ready: false,
+    status: "blocked",
+    title: "Closeout is blocked",
+    detail:
+      "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done.",
+    blockers: ["1 assignment is still active"],
+    warnings: [],
+    assignment_count: 1,
+    completed_assignments: 0,
+    review_follow_up_count: 0,
+    ...overrides,
+  };
+}
+
 const hecateAssignment: ProjectAssignmentRecord = {
   id: "asgn_1",
   project_id: "proj_1",
@@ -509,6 +532,10 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectWorkItem).mockResolvedValue({
     object: "project_work_item",
     data: workItem,
+  });
+  vi.mocked(getProjectWorkItemReadiness).mockResolvedValue({
+    object: "project_work_item_readiness",
+    data: workItemReadiness(),
   });
   vi.mocked(getProjectAssignments).mockResolvedValue({
     object: "project_assignments",
@@ -1048,6 +1075,7 @@ afterEach(() => {
   vi.mocked(getProjectWorkRoles).mockReset();
   vi.mocked(getProjectWorkItems).mockReset();
   vi.mocked(getProjectWorkItem).mockReset();
+  vi.mocked(getProjectWorkItemReadiness).mockReset();
   vi.mocked(getProjectAssignments).mockReset();
   vi.mocked(getProjectAssignmentContext).mockReset();
   vi.mocked(getProjectAssignmentPreflight).mockReset();
@@ -4819,6 +4847,19 @@ describe("ProjectsView cockpit", () => {
     vi.mocked(getProjectAssignments).mockResolvedValue({
       object: "project_assignments",
       data: [completedAssignment],
+    });
+    vi.mocked(getProjectWorkItemReadiness).mockResolvedValue({
+      object: "project_work_item_readiness",
+      data: workItemReadiness({
+        ready: true,
+        status: "ready",
+        title: "Ready to mark done",
+        detail:
+          "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
+        blockers: [],
+        assignment_count: 1,
+        completed_assignments: 1,
+      }),
     });
     vi.mocked(updateProjectWorkItem).mockResolvedValue({
       object: "project_work_item",

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -32,6 +32,7 @@ import {
   getProjectOperationsBrief,
   getProjectSkills,
   getProjectWorkItem,
+  getProjectWorkItemReadiness,
   getProjectWorkItems,
   getProjectWorkRoles,
   startProjectAssignment,
@@ -94,6 +95,7 @@ import type {
   ProjectContextSourceRecord,
   ProjectSkillRecord,
   ProjectRecord,
+  ProjectWorkItemReadinessRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectPayload,
@@ -246,6 +248,8 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [roles, setRoles] = useState<ProjectWorkRoleRecord[]>([]);
   const [selectedWorkItemID, setSelectedWorkItemID] = useState("");
   const [selectedWorkItem, setSelectedWorkItem] = useState<ProjectWorkItemRecord | null>(null);
+  const [selectedWorkItemReadiness, setSelectedWorkItemReadiness] =
+    useState<ProjectWorkItemReadinessRecord | null>(null);
   const [assignments, setAssignments] = useState<ProjectAssignmentRecord[]>([]);
   const [artifacts, setArtifacts] = useState<ProjectCollaborationArtifactRecord[]>([]);
   const [handoffs, setHandoffs] = useState<ProjectHandoffRecord[]>([]);
@@ -422,6 +426,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     if (!preferredWorkItemID) {
       setSelectedWorkItemID("");
       setSelectedWorkItem(null);
+      setSelectedWorkItemReadiness(null);
       setAssignments([]);
       setArtifacts([]);
       setHandoffs([]);
@@ -527,21 +532,25 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     setAssignmentErrors({});
     if (!projectID || !workItemID) {
       setSelectedWorkItem(null);
+      setSelectedWorkItemReadiness(null);
       setAssignments([]);
       setArtifacts([]);
       setHandoffs([]);
       setDetailLoadState("idle");
       return;
     }
+    setSelectedWorkItemReadiness(null);
     setDetailLoadState("loading");
     try {
-      const [itemRes, assignmentRes, artifactRes, handoffRes] = await Promise.all([
+      const [itemRes, assignmentRes, artifactRes, handoffRes, readinessRes] = await Promise.all([
         getProjectWorkItem(projectID, workItemID),
         getProjectAssignments(projectID, workItemID),
         getProjectCollaborationArtifacts(projectID, workItemID),
         getProjectHandoffs(projectID, workItemID),
+        getProjectWorkItemReadiness(projectID, workItemID),
       ]);
       setSelectedWorkItem(itemRes.data);
+      setSelectedWorkItemReadiness(readinessRes.data);
       setAssignments(assignmentRes.data ?? []);
       setArtifacts(artifactRes.data ?? []);
       setHandoffs(handoffRes.data ?? []);
@@ -552,6 +561,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       }));
       setDetailLoadState("loaded");
     } catch (error) {
+      setSelectedWorkItemReadiness(null);
       setDetailLoadState("error");
       setDetailError(errorMessage(error, "Failed to load work item detail."));
     }
@@ -1789,6 +1799,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             roleByID={roleByID}
             roles={roles}
             selectedWorkItem={selectedWorkItem}
+            selectedWorkItemReadiness={selectedWorkItemReadiness}
             selectedWorkItemID={selectedWorkItemID}
             skillsError={skillsError}
             skillsLoadState={skillsLoadState}

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildProjectHealthSummary,
-  buildProjectWorkCloseoutReadiness,
   projectHealthMetrics,
   reviewArtifactNeedsFollowUpPath,
   reviewArtifactRequiresFollowUp,
@@ -11,12 +10,10 @@ import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
   ProjectActivityData,
   ProjectActivityItemRecord,
-  ProjectAssignmentRecord,
   ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
   ProjectRecord,
   ProjectSkillRecord,
-  ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
 
@@ -257,114 +254,6 @@ describe("projectInsights", () => {
     expect(attention?.actionLabel).toBe("View blocked");
   });
 
-  it("marks work closeout ready when assignments and follow-up are complete", () => {
-    const readiness = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [assignmentRecord({ status: "completed" })],
-      artifacts: [],
-      handoffs: [],
-    });
-
-    expect(readiness).toMatchObject({
-      ready: true,
-      status: "ready",
-      completedAssignments: 1,
-      assignmentCount: 1,
-      blockers: [],
-    });
-  });
-
-  it("blocks work closeout on active assignments and pending handoffs", () => {
-    const readiness = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [assignmentRecord({ status: "running" })],
-      artifacts: [],
-      handoffs: [handoff("handoff_pending", "pending")],
-    });
-
-    expect(readiness.ready).toBe(false);
-    expect(readiness.blockers).toEqual(["1 assignment is still active", "1 handoff is pending"]);
-  });
-
-  it("blocks work closeout on unknown assignment states", () => {
-    const readiness = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [assignmentRecord({ status: "stale_unknown" })],
-      artifacts: [],
-      handoffs: [],
-    });
-
-    expect(readiness.ready).toBe(false);
-    expect(readiness.blockers).toEqual(["1 assignment is not complete"]);
-  });
-
-  it("blocks guided work closeout on failed and cancelled assignments", () => {
-    const readiness = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [
-        assignmentRecord({ id: "asgn_failed", status: "failed" }),
-        assignmentRecord({ id: "asgn_cancelled", status: "cancelled" }),
-      ],
-      artifacts: [],
-      handoffs: [],
-    });
-
-    expect(readiness.ready).toBe(false);
-    expect(readiness.blockers).toEqual(["1 assignment failed", "1 assignment was cancelled"]);
-  });
-
-  it("shows already-done work as closed without requiring readiness", () => {
-    const readiness = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord({ status: "done" }),
-      assignments: [assignmentRecord({ status: "failed" })],
-      artifacts: [],
-      handoffs: [],
-    });
-
-    expect(readiness).toMatchObject({
-      ready: false,
-      status: "done",
-      title: "Work item is done",
-      blockers: [],
-    });
-  });
-
-  it("blocks review follow-up until a linked follow-up assignment is complete", () => {
-    const review = reviewArtifact({
-      id: "art_review_required",
-      review_verdict: "changes_requested",
-      review_follow_up_required: true,
-    });
-    const blocked = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [assignmentRecord({ id: "asgn_impl", status: "completed" })],
-      artifacts: [review],
-      handoffs: [],
-    });
-
-    expect(blocked.ready).toBe(false);
-    expect(blocked.blockers).toContain('Review follow-up "Review" is not triaged');
-
-    const ready = buildProjectWorkCloseoutReadiness({
-      workItem: workItemRecord(),
-      assignments: [
-        assignmentRecord({ id: "asgn_impl", status: "completed" }),
-        assignmentRecord({ id: "asgn_followup", status: "completed" }),
-      ],
-      artifacts: [review],
-      handoffs: [
-        {
-          ...handoff("handoff_review", "accepted"),
-          linked_artifact_ids: [review.id],
-          target_assignment_id: "asgn_followup",
-        },
-      ],
-    });
-
-    expect(ready.ready).toBe(true);
-    expect(ready.blockers).toEqual([]);
-  });
-
   it("shares review follow-up path detection with closeout surfaces", () => {
     const review = reviewArtifact({
       id: "art_review_required",
@@ -489,33 +378,6 @@ function reviewArtifact(
     title: "Review",
     body: "Verdict: Changes requested",
     author_role_id: "reviewer_qa",
-    created_at: "2026-06-04T10:00:00Z",
-    updated_at: "2026-06-04T10:00:00Z",
-    ...patch,
-  };
-}
-
-function workItemRecord(patch: Partial<ProjectWorkItemRecord> = {}): ProjectWorkItemRecord {
-  return {
-    id: "work_1",
-    project_id: "proj_ready",
-    title: "Coordinate release",
-    status: "review",
-    priority: "normal",
-    created_at: "2026-06-04T10:00:00Z",
-    updated_at: "2026-06-04T10:00:00Z",
-    ...patch,
-  };
-}
-
-function assignmentRecord(patch: Partial<ProjectAssignmentRecord> = {}): ProjectAssignmentRecord {
-  return {
-    id: "asgn_1",
-    project_id: "proj_ready",
-    work_item_id: "work_1",
-    role_id: "role_1",
-    status: "queued",
-    driver_kind: "hecate_task",
     created_at: "2026-06-04T10:00:00Z",
     updated_at: "2026-06-04T10:00:00Z",
     ...patch,

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -107,17 +107,6 @@ export type ProjectHealthSummary = {
   attention: ProjectHealthAttention[];
 };
 
-export type ProjectWorkCloseoutReadiness = {
-  ready: boolean;
-  status: "blocked" | "done" | "ready";
-  title: string;
-  detail: string;
-  blockers: string[];
-  warnings: string[];
-  completedAssignments: number;
-  assignmentCount: number;
-};
-
 export type ProjectHealthSummaryOptions = {
   agentProfiles?: AgentProfileRecord[];
   artifacts?: ProjectCollaborationArtifactRecord[];
@@ -420,102 +409,6 @@ export function projectHealthMetrics(health: ProjectHealthSummary): ProjectHealt
   ];
 }
 
-export function buildProjectWorkCloseoutReadiness({
-  assignments,
-  artifacts,
-  handoffs,
-  workItem,
-}: {
-  assignments: ProjectAssignmentRecord[];
-  artifacts: ProjectCollaborationArtifactRecord[];
-  handoffs: ProjectHandoffRecord[];
-  workItem: ProjectWorkItemRecord | null;
-}): ProjectWorkCloseoutReadiness {
-  if (!workItem) {
-    return closeoutReadiness({
-      status: "blocked",
-      title: "No work item selected",
-      detail: "Select a work item before reviewing closeout readiness.",
-    });
-  }
-  const assignmentStatuses = assignments.map(assignmentCloseoutStatus);
-  const completedAssignments = assignmentStatuses.filter((status) => status === "completed").length;
-  if (workItem.status === "done") {
-    return closeoutReadiness({
-      status: "done",
-      title: "Work item is done",
-      detail: "This work item has already been marked done by the operator.",
-      assignmentCount: assignments.length,
-      completedAssignments,
-    });
-  }
-
-  const blockers: string[] = [];
-  const warnings: string[] = [];
-  const activeAssignments = assignmentStatuses.filter(isActiveCloseoutAssignmentStatus).length;
-  const failedAssignments = assignmentStatuses.filter((status) => status === "failed").length;
-  const cancelledAssignments = assignmentStatuses.filter((status) => status === "cancelled").length;
-  const unresolvedAssignments = assignmentStatuses.filter(
-    isUnresolvedCloseoutAssignmentStatus,
-  ).length;
-  const pendingHandoffs = handoffs.filter((handoff) => handoff.status === "pending").length;
-  if (activeAssignments > 0) {
-    blockers.push(
-      pluralize(activeAssignments, "assignment is still active", "assignments are still active"),
-    );
-  }
-  if (failedAssignments > 0) {
-    blockers.push(pluralize(failedAssignments, "assignment failed", "assignments failed"));
-  }
-  if (cancelledAssignments > 0) {
-    blockers.push(
-      pluralize(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"),
-    );
-  }
-  if (unresolvedAssignments > 0) {
-    blockers.push(
-      pluralize(
-        unresolvedAssignments,
-        "assignment is not complete",
-        "assignments are not complete",
-      ),
-    );
-  }
-  if (pendingHandoffs > 0) {
-    blockers.push(pluralize(pendingHandoffs, "handoff is pending", "handoffs are pending"));
-  }
-  if (assignments.length === 0) {
-    warnings.push("No assignments are linked to this work item; closeout is manual.");
-  }
-
-  for (const artifact of artifacts.filter(reviewArtifactRequiresFollowUp)) {
-    const blocker = closeoutReviewFollowUpBlocker(artifact, handoffs, assignments);
-    if (blocker) blockers.push(blocker);
-  }
-
-  if (blockers.length > 0) {
-    return closeoutReadiness({
-      status: "blocked",
-      title: "Closeout is blocked",
-      detail:
-        "Resolve the listed assignment, handoff, or review follow-up items before marking this work done.",
-      blockers: uniqueStrings(blockers),
-      warnings,
-      assignmentCount: assignments.length,
-      completedAssignments,
-    });
-  }
-  return closeoutReadiness({
-    status: "ready",
-    title: "Ready to mark done",
-    detail:
-      "Assignments and review follow-up are clear. The operator can mark this work item done.",
-    warnings,
-    assignmentCount: assignments.length,
-    completedAssignments,
-  });
-}
-
 export function projectActivityWorkItemToWorkItem(
   projectID: string,
   item: ProjectActivityItemRecord["work_item"],
@@ -677,81 +570,6 @@ export function reviewArtifactNeedsFollowUpPath(
         handoff.status === "superseded" ||
         Boolean(handoff.target_assignment_id)),
   );
-}
-
-function closeoutReviewFollowUpBlocker(
-  artifact: ProjectCollaborationArtifactRecord,
-  handoffs: ProjectHandoffRecord[],
-  assignments: ProjectAssignmentRecord[],
-): string {
-  const linkedHandoffs = handoffs.filter((handoff) =>
-    (handoff.linked_artifact_ids ?? []).includes(artifact.id),
-  );
-  const pending = linkedHandoffs.filter((handoff) => handoff.status === "pending").length;
-  if (pending > 0) {
-    return `Review follow-up "${artifact.title || artifact.id}" has a pending handoff`;
-  }
-  const targetAssignmentIDs = linkedHandoffs
-    .map((handoff) => handoff.target_assignment_id ?? "")
-    .filter(Boolean);
-  const targetAssignments = targetAssignmentIDs
-    .map((assignmentID) => assignments.find((assignment) => assignment.id === assignmentID))
-    .filter(Boolean) as ProjectAssignmentRecord[];
-  if (
-    targetAssignments.some((assignment) => assignmentCloseoutStatus(assignment) === "completed")
-  ) {
-    return "";
-  }
-  if (targetAssignmentIDs.length > 0) {
-    return `Review follow-up "${artifact.title || artifact.id}" assignment is not completed`;
-  }
-  if (
-    linkedHandoffs.some(
-      (handoff) => handoff.status === "dismissed" || handoff.status === "superseded",
-    )
-  ) {
-    return "";
-  }
-  return `Review follow-up "${artifact.title || artifact.id}" is not triaged`;
-}
-
-function closeoutReadiness(
-  patch: Partial<ProjectWorkCloseoutReadiness> &
-    Pick<ProjectWorkCloseoutReadiness, "detail" | "status" | "title">,
-): ProjectWorkCloseoutReadiness {
-  return {
-    ready: patch.status === "ready",
-    blockers: [],
-    warnings: [],
-    assignmentCount: 0,
-    completedAssignments: 0,
-    ...patch,
-  };
-}
-
-function assignmentCloseoutStatus(assignment: ProjectAssignmentRecord): string {
-  return toProjectAssignmentExecutionViewModel(assignment).status || assignment.status;
-}
-
-function isActiveCloseoutAssignmentStatus(status: string): boolean {
-  return status === "queued" || status === "running" || status === "awaiting_approval";
-}
-
-function isUnresolvedCloseoutAssignmentStatus(status: string): boolean {
-  return (
-    status !== "completed" &&
-    status !== "failed" &&
-    status !== "cancelled" &&
-    !isActiveCloseoutAssignmentStatus(status)
-  );
-}
-
-function pluralize(count: number, singular: string, plural: string): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return Array.from(new Set(values.filter(Boolean)));
 }
 
 function addHandoffStatus(summary: ProjectHealthSummary["handoffs"], status: string) {

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -39,6 +39,7 @@ import {
   getProjectMemoryCandidates,
   getProjectOperationsBrief,
   getProjectWorkItem,
+  getProjectWorkItemReadiness,
   getProjectWorkItems,
   getProjectWorkRoles,
   getUsageEvents,
@@ -285,7 +286,7 @@ describe("api client", () => {
 
   it("builds project work coordination requests", async () => {
     fetchMock.mockClear();
-    for (let i = 0; i < 8; i += 1) {
+    for (let i = 0; i < 9; i += 1) {
       fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
     }
 
@@ -294,6 +295,7 @@ describe("api client", () => {
     await getProjectWorkRoles("proj/1");
     await getProjectWorkItems("proj/1");
     await getProjectWorkItem("proj/1", "work/1");
+    await getProjectWorkItemReadiness("proj/1", "work/1");
     await getProjectAssignments("proj/1", "work/1");
     await getProjectCollaborationArtifacts("proj/1", "work/1");
     await getProjectHandoffs("proj/1", "work/1");
@@ -325,16 +327,21 @@ describe("api client", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       6,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/readiness",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       7,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       8,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      9,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs",
       expect.objectContaining({ method: "GET" }),
     );

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -102,6 +102,7 @@ import type {
   ProjectSkillsResponse,
   ProjectWorkItemsResponse,
   ProjectWorkItemResponse,
+  ProjectWorkItemReadinessResponse,
   ProjectWorkRoleResponse,
   ProjectWorkRolesResponse,
   ProjectsResponse,
@@ -679,6 +680,15 @@ export async function getProjectWorkItem(
 ): Promise<ProjectWorkItemResponse> {
   return fetchJSON<ProjectWorkItemResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}`,
+  );
+}
+
+export async function getProjectWorkItemReadiness(
+  projectID: string,
+  workItemID: string,
+): Promise<ProjectWorkItemReadinessResponse> {
+  return fetchJSON<ProjectWorkItemReadinessResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/readiness`,
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -526,6 +526,22 @@ export type CreateProjectWorkItemPayload = {
 
 export type UpdateProjectWorkItemPayload = Partial<CreateProjectWorkItemPayload>;
 
+export type ProjectWorkItemReadinessRecord = {
+  project_id: string;
+  work_item_id: string;
+  ready: boolean;
+  status: "blocked" | "done" | "ready" | (string & {});
+  title: string;
+  detail: string;
+  blockers: string[];
+  warnings: string[];
+  assignment_count: number;
+  completed_assignments: number;
+  review_follow_up_count: number;
+  review_follow_up_artifact_ids?: string[];
+  missing_evidence_assignment_ids?: string[];
+};
+
 export type ProjectAssignmentStatus =
   | "queued"
   | "running"
@@ -893,6 +909,11 @@ export type ProjectWorkItemsResponse = {
 export type ProjectWorkItemResponse = {
   object: string;
   data: ProjectWorkItemRecord;
+};
+
+export type ProjectWorkItemReadinessResponse = {
+  object: string;
+  data: ProjectWorkItemReadinessRecord;
 };
 
 export type ProjectAssignmentsResponse = {


### PR DESCRIPTION
## Summary
- add a read-only project work item readiness endpoint shared by Project Operations and selected-work detail
- refactor Project Operations follow-through to reuse backend readiness and add a low-priority latest-work orientation item
- wire the UI to render backend readiness instead of deriving closeout locally, with docs and tests updated

## Verification
- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestProjectWorkItemReadiness|TestProjectOperationsBrief|TestProjectOperationItemFromActivity|TestProjectOperationsReviewFollowUpPathAndBlockerSemantics|TestSortProjectOperationsItems|TestRemoteRuntimeRoutePolicy'\n- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./...\n- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./internal/api\n- GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go vet ./...\n- cd ui && bun run typecheck\n- cd ui && bun run lint\n- cd ui && bun run format:check\n- cd ui && bun run test\n- git diff --check\n- rg -n -i "omnigent" . (no matches)