### PR TITLE
Use readiness follow-up IDs in work detail

### DIFF
--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -562,16 +562,25 @@ describe("ProjectWorkItemDetail", () => {
 
     expect(screen.getByText("Changes requested")).toBeTruthy();
     expect(screen.getByText("risk Medium")).toBeTruthy();
-    expect(screen.getAllByText("follow-up required")).toHaveLength(2);
+    expect(screen.getAllByText("follow-up required")).toHaveLength(1);
   });
 
-  it("surfaces review follow-up as a closeout notice", async () => {
+  it("surfaces server readiness review follow-up as a closeout notice", async () => {
     const reviewArtifact = artifact({
       review_verdict: "blocked",
       review_follow_up_required: true,
     });
     const { handlers } = renderDetail({
       artifacts: [reviewArtifact],
+      closeoutReadiness: closeoutReadiness({
+        ready: false,
+        status: "blocked",
+        title: "Closeout is blocked",
+        detail: "Resolve the listed review follow-up items before marking this work done.",
+        blockers: ['Review follow-up "Architect review" is not triaged'],
+        review_follow_up_count: 1,
+        review_follow_up_artifact_ids: [reviewArtifact.id],
+      }),
     });
 
     const notice = screen.getByRole("region", { name: "Review follow-up required" });
@@ -583,7 +592,7 @@ describe("ProjectWorkItemDetail", () => {
     expect(handlers.onCreateAssignmentFromReviewArtifact).toHaveBeenCalledWith(reviewArtifact);
   });
 
-  it("does not surface review follow-up notice after a handoff is linked", () => {
+  it("does not derive review follow-up notice from client artifact fields", () => {
     renderDetail({
       artifacts: [
         artifact({
@@ -592,7 +601,10 @@ describe("ProjectWorkItemDetail", () => {
           review_follow_up_required: true,
         }),
       ],
-      handoffs: [handoff({ linked_artifact_ids: ["art_review"] })],
+      closeoutReadiness: closeoutReadiness({
+        review_follow_up_count: 0,
+        review_follow_up_artifact_ids: [],
+      }),
     });
 
     expect(screen.queryByRole("region", { name: "Review follow-up required" })).toBeNull();

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -21,7 +21,6 @@ import {
   toProjectAssignmentExecutionViewModel,
   type ProjectAssignmentEvidenceViewModel,
 } from "./projectAssignmentViewModels";
-import { reviewArtifactNeedsFollowUpPath } from "./projectInsights";
 import {
   assignmentStatusLabel,
   formatProjectRowRelativeTime,
@@ -182,8 +181,9 @@ export function ProjectWorkItemDetail({
     artifacts.length === 0 &&
     handoffs.length === 0 &&
     workItem.status !== "done";
+  const reviewFollowUpArtifactIDs = new Set(closeout.review_follow_up_artifact_ids ?? []);
   const reviewFollowUps = artifacts.filter((artifact) =>
-    reviewArtifactNeedsFollowUpPath(artifact, handoffs),
+    reviewFollowUpArtifactIDs.has(artifact.id),
   );
   const suggestedAssignmentRole = assignmentRoleForWorkItem(workItem, roleByID);
   const canAddWorkRecords = !emptyWorkItem && workItem.status !== "done";

--- a/ui/src/features/projects/projectInsights.test.ts
+++ b/ui/src/features/projects/projectInsights.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  buildProjectHealthSummary,
-  projectHealthMetrics,
-  reviewArtifactNeedsFollowUpPath,
-  reviewArtifactRequiresFollowUp,
-} from "./projectInsights";
+import { buildProjectHealthSummary, projectHealthMetrics } from "./projectInsights";
 import type { AgentProfileRecord } from "../../types/agent-profile";
 import type {
   ProjectActivityData,
@@ -252,52 +247,6 @@ describe("projectInsights", () => {
 
     expect(attention?.chatID).toBe("chat_failed");
     expect(attention?.actionLabel).toBe("View blocked");
-  });
-
-  it("shares review follow-up path detection with closeout surfaces", () => {
-    const review = reviewArtifact({
-      id: "art_review_required",
-      review_verdict: "changes_requested",
-    });
-
-    expect(reviewArtifactRequiresFollowUp(review)).toBe(true);
-    expect(reviewArtifactNeedsFollowUpPath(review, [])).toBe(true);
-    expect(
-      reviewArtifactNeedsFollowUpPath(review, [
-        {
-          ...handoff("handoff_review", "pending"),
-          linked_artifact_ids: [review.id],
-        },
-      ]),
-    ).toBe(false);
-    expect(
-      reviewArtifactNeedsFollowUpPath(review, [
-        {
-          ...handoff("handoff_review", "accepted"),
-          linked_artifact_ids: [review.id],
-        },
-      ]),
-    ).toBe(true);
-    expect(
-      reviewArtifactNeedsFollowUpPath(review, [
-        {
-          ...handoff("handoff_review", "accepted"),
-          linked_artifact_ids: [review.id],
-          target_assignment_id: "asgn_followup",
-        },
-      ]),
-    ).toBe(false);
-    expect(
-      reviewArtifactNeedsFollowUpPath(review, [
-        {
-          ...handoff("handoff_review", "dismissed"),
-          linked_artifact_ids: [review.id],
-        },
-      ]),
-    ).toBe(false);
-    expect(reviewArtifactRequiresFollowUp(reviewArtifact({ review_verdict: "approved" }))).toBe(
-      false,
-    );
   });
 });
 

--- a/ui/src/features/projects/projectInsights.ts
+++ b/ui/src/features/projects/projectInsights.ts
@@ -546,29 +546,12 @@ function reviewFollowUpAttentionItem(
   };
 }
 
-export function reviewArtifactRequiresFollowUp(
-  artifact: ProjectCollaborationArtifactRecord,
-): boolean {
+function reviewArtifactRequiresFollowUp(artifact: ProjectCollaborationArtifactRecord): boolean {
   return (
     artifact.kind === "review" &&
     (artifact.review_follow_up_required === true ||
       artifact.review_verdict === "blocked" ||
       artifact.review_verdict === "changes_requested")
-  );
-}
-
-export function reviewArtifactNeedsFollowUpPath(
-  artifact: ProjectCollaborationArtifactRecord,
-  handoffs: ProjectHandoffRecord[],
-): boolean {
-  if (!reviewArtifactRequiresFollowUp(artifact)) return false;
-  return !handoffs.some(
-    (handoff) =>
-      (handoff.linked_artifact_ids ?? []).includes(artifact.id) &&
-      (handoff.status === "pending" ||
-        handoff.status === "dismissed" ||
-        handoff.status === "superseded" ||
-        Boolean(handoff.target_assignment_id)),
   );
 }
 


### PR DESCRIPTION
## Summary
- drive the selected-work review follow-up notice from server readiness artifact IDs
- remove the exported client-side review follow-up path predicate used by that notice
- keep project health review aggregation local until there is a project-wide backend health contract

## Verification
- bun run test -- src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/projectInsights.test.ts
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test
- git diff --check
- terminology scan clean