### PR TITLE
fix(agent-adapters): restore selected ACP session config

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -229,10 +229,11 @@ through declared remote-safe env-key credential modes.
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake
 ACP peer to cover probing, auth/logout, session prepare/load, config options,
-commands, usage, and run output. Do not import standalone adapter source modules
-or `acp-adapter-kit` into Hecate just to test Codex/Claude adapter behavior;
-that parity belongs in the adapter repositories, with optional release-binary
-smokes (`just test-acp-release-smoke`) when packaging drift needs coverage.
+commands, usage, auth-required prompt errors, native session reload/recovery,
+and run output. Do not import standalone adapter source modules or
+`acp-adapter-kit` into Hecate just to test Codex/Claude adapter behavior; that
+parity belongs in the adapter repositories, with optional release-binary smokes
+(`just test-acp-release-smoke`) when packaging drift needs coverage.
 
 Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
 Session create, external-agent prepare, native session metadata persistence,

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -319,10 +319,11 @@ That opt-in smoke downloads the Codex and Claude Code adapter versions pinned in
 the Dockerfiles, verifies their release checksums, puts fake `codex` / `claude`
 CLIs on `PATH`, and runs Hecate's probe/auth/logout/session/run path against
 the real adapter binaries, including session config selector changes and
-session-level MCP propagation plus command-backed prompt execution. It
-requires network access and is intentionally not part of the normal unit-test
-ladder. The same check is available from GitHub Actions as the manual **ACP
-adapter release smoke** workflow.
+session-level MCP propagation, command-backed prompt execution, prompt
+auth-required mapping, and native session reload/recovery. It requires network
+access and is intentionally not part of the normal unit-test ladder. The same
+check is available from GitHub Actions as the manual **ACP adapter release
+smoke** workflow.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -296,8 +296,9 @@ drift needs coverage, run `just test-acp-release-smoke`; it downloads the
 Dockerfile-pinned Go adapter release binaries, verifies checksums, and smokes
 probe capability discovery, ACP authenticate/logout, session config selectors
 and selector changes, session-level MCP propagation, advertised slash commands,
-command-backed prompt execution, prompt streaming, usage mapping, and
-stop-reason mapping with fake `codex` and `claude` CLIs.
+command-backed prompt execution, prompt auth-required mapping, prompt streaming,
+usage mapping, stop-reason mapping, and native session reload/recovery with
+fake `codex` and `claude` CLIs.
 
 ## Setup checks
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -73,6 +73,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 			if prepared.DriverKind != DriverKindACP || prepared.NativeSessionID == "" || !prepared.SessionStarted {
 				t.Fatalf("PrepareSession(%s) = %#v, want started ACP session", tt.adapterID, prepared)
 			}
+			currentConfigOptions := prepared.ConfigOptions
 			for _, id := range tt.wantConfigOptionIDs {
 				if findConfigOption(prepared.ConfigOptions, id) == nil {
 					t.Fatalf("PrepareSession(%s) options = %#v, want %q", tt.adapterID, prepared.ConfigOptions, id)
@@ -96,6 +97,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 				if got == nil || got.CurrentValue != option.value {
 					t.Fatalf("SetSessionConfigOption(%s, %s) options = %#v, want current value %q", tt.adapterID, option.id, updated.ConfigOptions, option.value)
 				}
+				currentConfigOptions = updated.ConfigOptions
 			}
 
 			run, err := manager.Run(context.Background(), RunRequest{
@@ -147,6 +149,67 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 				}
 			}
 
+			if tt.authFailurePrompt != "" {
+				_, err := manager.Run(context.Background(), RunRequest{
+					SessionID:      "release_" + tt.adapterID,
+					AdapterID:      tt.adapterID,
+					Workspace:      workspace,
+					Prompt:         tt.authFailurePrompt,
+					MCPServers:     tt.mcpServers,
+					Timeout:        5 * time.Second,
+					MaxOutputBytes: 64 * 1024,
+				})
+				if err == nil {
+					t.Fatalf("Run(%s, %q) succeeded, want auth-required error", tt.adapterID, tt.authFailurePrompt)
+				}
+				normalized := NormalizeError(prepared.Adapter.Name, err)
+				for _, marker := range tt.wantAuthFailureMarkers {
+					if !strings.Contains(normalized, marker) {
+						t.Fatalf("Run(%s, %q) normalized error = %q, want marker %q", tt.adapterID, tt.authFailurePrompt, normalized, marker)
+					}
+				}
+			}
+
+			if tt.reloadPrompt != "" {
+				reloadManager := NewSessionManager()
+				t.Cleanup(func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					if err := reloadManager.Shutdown(ctx); err != nil {
+						t.Errorf("Shutdown reload manager (%s): %v", tt.adapterID, err)
+					}
+				})
+				reloaded, err := reloadManager.Run(context.Background(), RunRequest{
+					SessionID:               "release_reload_" + tt.adapterID,
+					AdapterID:               tt.adapterID,
+					Workspace:               workspace,
+					PreviousNativeSessionID: prepared.NativeSessionID,
+					Prompt:                  tt.reloadPrompt,
+					ConfigOptions:           currentConfigOptions,
+					MCPServers:              tt.mcpServers,
+					Timeout:                 5 * time.Second,
+					MaxOutputBytes:          64 * 1024,
+				})
+				if err != nil {
+					t.Fatalf("Run(%s reload): %v", tt.adapterID, err)
+				}
+				if !strings.Contains(reloaded.Output, tt.wantReloadOutput) {
+					t.Fatalf("Run(%s reload) output = %q, want %q", tt.adapterID, reloaded.Output, tt.wantReloadOutput)
+				}
+				if reloaded.SessionStarted != true || reloaded.SessionResumed != tt.wantReloadResumed {
+					t.Fatalf("Run(%s reload) session flags = started:%v resumed:%v, want started:true resumed:%v", tt.adapterID, reloaded.SessionStarted, reloaded.SessionResumed, tt.wantReloadResumed)
+				}
+				if tt.wantReloadSameNative && reloaded.NativeSessionID != prepared.NativeSessionID {
+					t.Fatalf("Run(%s reload) native session = %q, want previous %q", tt.adapterID, reloaded.NativeSessionID, prepared.NativeSessionID)
+				}
+				if tt.wantReloadRecovery && !strings.Contains(reloaded.SessionRecovery, prepared.NativeSessionID) {
+					t.Fatalf("Run(%s reload) recovery = %q, want previous native session id %q", tt.adapterID, reloaded.SessionRecovery, prepared.NativeSessionID)
+				}
+				if !tt.wantReloadRecovery && reloaded.SessionRecovery != "" {
+					t.Fatalf("Run(%s reload) recovery = %q, want empty recovery", tt.adapterID, reloaded.SessionRecovery)
+				}
+			}
+
 			logout, err := Logout(context.Background(), tt.adapterID)
 			if err != nil {
 				t.Fatalf("Logout(%s): %v", tt.adapterID, err)
@@ -159,19 +222,26 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 }
 
 type acpReleaseSmokeTestCase struct {
-	adapterID           string
-	repo                string
-	binary              string
-	version             string
-	vendorCommand       string
-	vendorScript        string
-	wantOutput          string
-	wantStopReason      string
-	wantConfigOptionIDs []string
-	setConfigOptions    []acpReleaseConfigOption
-	wantCommands        []string
-	commandRuns         []acpReleaseCommandRun
-	mcpServers          []types.MCPServerConfig
+	adapterID              string
+	repo                   string
+	binary                 string
+	version                string
+	vendorCommand          string
+	vendorScript           string
+	wantOutput             string
+	wantStopReason         string
+	wantConfigOptionIDs    []string
+	setConfigOptions       []acpReleaseConfigOption
+	wantCommands           []string
+	commandRuns            []acpReleaseCommandRun
+	mcpServers             []types.MCPServerConfig
+	authFailurePrompt      string
+	wantAuthFailureMarkers []string
+	reloadPrompt           string
+	wantReloadOutput       string
+	wantReloadResumed      bool
+	wantReloadSameNative   bool
+	wantReloadRecovery     bool
 }
 
 type acpReleaseConfigOption struct {
@@ -217,8 +287,15 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 				{id: "sandbox", value: "read-only"},
 				{id: "web_search", value: "enabled"},
 			},
-			wantCommands: []string{"review", "init"},
-			mcpServers:   mcpServers,
+			wantCommands:           []string{"review", "init"},
+			mcpServers:             mcpServers,
+			authFailurePrompt:      "/auth-fail",
+			wantAuthFailureMarkers: []string{"Codex error: Authentication required"},
+			reloadPrompt:           "reload codex",
+			wantReloadOutput:       "go codex reload",
+			wantReloadResumed:      false,
+			wantReloadSameNative:   false,
+			wantReloadRecovery:     true,
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/review focus on tests",
@@ -251,8 +328,15 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 				{id: "effort", value: "high"},
 				{id: "permission_mode", value: "plan"},
 			},
-			wantCommands: []string{"init", "review", "code-review", "security-review", "compact", "debug", "run", "verify"},
-			mcpServers:   mcpServers,
+			wantCommands:           []string{"init", "review", "code-review", "security-review", "compact", "debug", "run", "verify"},
+			mcpServers:             mcpServers,
+			authFailurePrompt:      "/auth-fail",
+			wantAuthFailureMarkers: []string{"isn't signed in", "claude_code_auth_required"},
+			reloadPrompt:           "reload claude_code",
+			wantReloadOutput:       "go claude reload",
+			wantReloadResumed:      true,
+			wantReloadSameNative:   true,
+			wantReloadRecovery:     false,
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/verify release smoke",
@@ -392,7 +476,9 @@ case "$1" in
     require_contains " --config mcp_servers.hecate_01_docs={url=\"https://docs.example.com/mcp\",http_headers={\"Authorization\"=\"Bearer token\"}} " "$@"
     require_contains " --search " "$@"
     case "$*" in
+      *"/auth-fail"*) echo "Authentication required: run codex login" >&2; exit 67;;
       *"/init focus on repo guidance"*) message="go codex init";;
+      *"reload codex"*) message="go codex reload";;
       *"hello codex"*) message="go codex answer";;
       *) echo "unexpected codex exec prompt: $*" >&2; exit 66 ;;
     esac
@@ -455,7 +541,9 @@ case "$1" in
     require_contains " --strict-mcp-config " "$@"
     require_contains " --mcp-config {\"mcpServers\":{\"docs\":{\"headers\":{\"Authorization\":\"Bearer token\"},\"type\":\"http\",\"url\":\"https://docs.example.com/mcp\"}}} " "$@"
     case "$*" in
+      *"/auth-fail"*) echo "Authentication required: run claude /login" >&2; exit 67;;
       *"/verify release smoke"*) message="go claude verify"; stop_reason="end_turn";;
+      *"reload claude_code"*) message="go claude reload"; stop_reason="end_turn";;
       *"hello claude_code"*) message="go claude answer"; stop_reason="error_max_turns";;
       *) echo "unexpected claude prompt: $*" >&2; exit 66 ;;
     esac

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -204,6 +204,20 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 				nativeID = ""
 				resumed = false
 			}
+			if nativeID != "" {
+				configOptions, loadErr = applySelectedACPConfigOptions(loadCtx, conn, nativeID, adapter, configOptions, selectedOptions)
+				if loadErr != nil {
+					recovery = fmt.Sprintf("could not restore ACP session %s: %v", previousNativeSessionID, loadErr)
+					if sessionLogger != nil {
+						sessionLogger.Warn("previous ACP session config selection failed",
+							slog.String("native_session_id", previousNativeSessionID),
+							slog.Any("error", loadErr),
+						)
+					}
+					nativeID = ""
+					resumed = false
+				}
+			}
 		}
 		cancel()
 		if loadErr == nil && nativeID != "" {
@@ -244,13 +258,22 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 		configOptions = agentcontrols.FromACPOptions(created.ConfigOptions)
 		configOptions, managedConfig = appendLaunchConfigOptions(ctx, command, adapter, configOptions, selectedOptions)
 		configOptions, err = applySelectedACPModel(newCtx, conn, nativeID, adapter, configOptions, selectedOptions)
-		cancel()
 		if err != nil {
+			cancel()
 			if sessionLogger != nil {
 				sessionLogger.Warn("ACP session model selection failed", slog.Any("error", err))
 			}
 			terminateProcess(cmd)
 			return nil, false, "", fmt.Errorf("select ACP model for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
+		}
+		configOptions, err = applySelectedACPConfigOptions(newCtx, conn, nativeID, adapter, configOptions, selectedOptions)
+		cancel()
+		if err != nil {
+			if sessionLogger != nil {
+				sessionLogger.Warn("ACP session config selection failed", slog.Any("error", err))
+			}
+			terminateProcess(cmd)
+			return nil, false, "", fmt.Errorf("select ACP config for %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 		}
 		if sessionLogger != nil {
 			sessionLogger.Info("ACP session created",
@@ -607,6 +630,10 @@ func cloneConfigOptions(options []agentcontrols.ConfigOption) []agentcontrols.Co
 	return out
 }
 
+func cloneConfigOption(option agentcontrols.ConfigOption) agentcontrols.ConfigOption {
+	return cloneConfigOptions([]agentcontrols.ConfigOption{option})[0]
+}
+
 func cloneCommands(commands []agentcontrols.Command) []agentcontrols.Command {
 	if commands == nil {
 		return nil
@@ -622,7 +649,7 @@ func preserveACPModelConfigOption(options, previous []agentcontrols.ConfigOption
 	}
 	for _, option := range previous {
 		if option.Source == agentcontrols.ConfigOptionSourceACPModel {
-			return append(options, cloneConfigOptions([]agentcontrols.ConfigOption{option})...)
+			return append(options, cloneConfigOption(option))
 		}
 	}
 	return options
@@ -644,7 +671,7 @@ func preserveManagedConfigOptions(options, previous []agentcontrols.ConfigOption
 		if _, ok := present[option.ID]; ok {
 			continue
 		}
-		out = append(out, cloneConfigOptions([]agentcontrols.ConfigOption{option})...)
+		out = append(out, cloneConfigOption(option))
 	}
 	return out
 }
@@ -685,6 +712,117 @@ func applySelectedACPModel(ctx context.Context, conn *acp.ClientSideConnection, 
 		return out, nil
 	}
 	return options, nil
+}
+
+func applySelectedACPConfigOptions(ctx context.Context, conn *acp.ClientSideConnection, nativeID string, adapter Adapter, options, selected []agentcontrols.ConfigOption) ([]agentcontrols.ConfigOption, error) {
+	if len(selected) == 0 || conn == nil || strings.TrimSpace(nativeID) == "" {
+		return options, nil
+	}
+	out := cloneConfigOptions(options)
+	for _, selectedOption := range selected {
+		index := configOptionIndex(out, selectedOption.ID)
+		if index < 0 {
+			continue
+		}
+		current := out[index]
+		if current.Source == agentcontrols.ConfigOptionSourceLaunch {
+			continue
+		}
+		if current.ID == "model" && current.Source == agentcontrols.ConfigOptionSourceACPModel {
+			continue
+		}
+		var (
+			req agentcontrols.SetConfigOptionRequest
+			ok  bool
+		)
+		switch current.Type {
+		case agentcontrols.ConfigOptionTypeSelect:
+			value := strings.TrimSpace(selectedOption.CurrentValue)
+			if value == "" || strings.HasPrefix(value, "__hecate_no_") || value == current.CurrentValue {
+				continue
+			}
+			if !configOptionAllowsValue(current, value) {
+				return nil, fmt.Errorf("value %q is not available for %s %s", value, adapter.Name, current.Name)
+			}
+			req = agentcontrols.SetConfigOptionRequest{
+				SessionID: nativeID,
+				ConfigID:  current.ID,
+				Value:     value,
+			}
+			ok = true
+		case agentcontrols.ConfigOptionTypeBoolean:
+			if selectedOption.CurrentBool == nil {
+				continue
+			}
+			if current.CurrentBool != nil && *current.CurrentBool == *selectedOption.CurrentBool {
+				continue
+			}
+			req = agentcontrols.SetConfigOptionRequest{
+				SessionID: nativeID,
+				ConfigID:  current.ID,
+				BoolValue: selectedOption.CurrentBool,
+			}
+			ok = true
+		}
+		if !ok {
+			continue
+		}
+		acpReq, err := agentcontrols.BuildACPSetRequest(req)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := conn.SetSessionConfigOption(ctx, acpReq)
+		if err != nil {
+			return nil, fmt.Errorf("select ACP config option %q for %q: %w", current.ID, adapter.ID, err)
+		}
+		out = applyACPConfigOptionSetResponse(out, resp, req)
+	}
+	return out, nil
+}
+
+func configOptionIndex(options []agentcontrols.ConfigOption, id string) int {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return -1
+	}
+	for i := range options {
+		if options[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func applyACPConfigOptionSetResponse(previous []agentcontrols.ConfigOption, resp acp.SetSessionConfigOptionResponse, req agentcontrols.SetConfigOptionRequest) []agentcontrols.ConfigOption {
+	if resp.ConfigOptions != nil {
+		updated := agentcontrols.FromACPOptions(resp.ConfigOptions)
+		if updated == nil {
+			updated = []agentcontrols.ConfigOption{}
+		}
+		return mergeConfigOptions(previous, updated)
+	}
+	out := cloneConfigOptions(previous)
+	if i := configOptionIndex(out, req.ConfigID); i >= 0 {
+		if req.BoolValue != nil {
+			value := *req.BoolValue
+			out[i].CurrentBool = &value
+		} else {
+			out[i].CurrentValue = strings.TrimSpace(req.Value)
+		}
+	}
+	return out
+}
+
+func mergeConfigOptions(previous, updated []agentcontrols.ConfigOption) []agentcontrols.ConfigOption {
+	out := cloneConfigOptions(previous)
+	for _, option := range updated {
+		if i := configOptionIndex(out, option.ID); i >= 0 {
+			out[i] = cloneConfigOption(option)
+			continue
+		}
+		out = append(out, cloneConfigOption(option))
+	}
+	return out
 }
 
 func selectedConfigOptionValue(options []agentcontrols.ConfigOption, id string) string {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -465,6 +465,59 @@ func TestSessionManagerAppliesSelectedACPModelDuringPrepare(t *testing.T) {
 	}
 }
 
+func TestSessionManagerAppliesSelectedACPConfigOptionDuringPrepare(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_CONFIG_OPTIONS", "1")
+	installFakeACPExecutable(t, "cursor-agent")
+
+	manager := NewSessionManager()
+	prepared, err := manager.PrepareSession(context.Background(), PrepareSessionRequest{
+		SessionID: "chat_cursor_preselected_mode",
+		AdapterID: "cursor_agent",
+		Workspace: t.TempDir(),
+		ConfigOptions: []agentcontrols.ConfigOption{{
+			ID:           "mode",
+			CurrentValue: "auto",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PrepareSession: %v", err)
+	}
+	mode := findConfigOption(prepared.ConfigOptions, "mode")
+	if mode == nil || mode.CurrentValue != "auto" {
+		t.Fatalf("config options = %#v, want preselected mode=auto", prepared.ConfigOptions)
+	}
+}
+
+func TestSessionManagerAppliesSelectedACPConfigOptionDuringLoad(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_CONFIG_OPTIONS", "1")
+	installFakeACPExecutable(t, "cursor-agent")
+
+	manager := NewSessionManager()
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:               "chat_cursor_load_mode",
+		AdapterID:               "cursor_agent",
+		Workspace:               t.TempDir(),
+		PreviousNativeSessionID: "fake_session_existing",
+		Prompt:                  "restored mode",
+		Timeout:                 5 * time.Second,
+		MaxOutputBytes:          64 * 1024,
+		ConfigOptions: []agentcontrols.ConfigOption{{
+			ID:           "mode",
+			CurrentValue: "auto",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !run.SessionStarted || !run.SessionResumed {
+		t.Fatalf("session flags = started:%v resumed:%v, want loaded previous session", run.SessionStarted, run.SessionResumed)
+	}
+	mode := findConfigOption(run.ConfigOptions, "mode")
+	if mode == nil || mode.CurrentValue != "auto" {
+		t.Fatalf("config options = %#v, want restored mode=auto", run.ConfigOptions)
+	}
+}
+
 func TestLogoutCallsACPLogout(t *testing.T) {
 	logoutFile := filepath.Join(t.TempDir(), "logout.called")
 	t.Setenv("HECATE_FAKE_ACP_LOGOUT_FILE", logoutFile)


### PR DESCRIPTION
## Summary
- restore selected non-model ACP session config options after ACP session/new and session/load
- extend released Codex/Claude adapter smoke coverage for auth-required prompt errors and native session reload/recovery
- document the expanded ACP release-smoke coverage

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -race -timeout 5m ./internal/agentadapters
- just test-acp-release-smoke
- just docs-format-check
- git diff --check