### PR TITLE
test(agent-adapters): smoke release activity mapping

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -229,8 +229,9 @@ through declared remote-safe env-key credential modes.
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake
 ACP peer to cover probing, auth/logout, session prepare/load, config options,
-commands, usage, auth-required prompt errors, native session reload/recovery,
-and run output. Do not import standalone adapter source modules or
+commands, usage, structured activity mapping, auth-required prompt errors,
+native session reload/recovery, and run output. Do not import standalone adapter
+source modules or
 `acp-adapter-kit` into Hecate just to test Codex/Claude adapter behavior; that
 parity belongs in the adapter repositories, with optional release-binary smokes
 (`just test-acp-release-smoke`) when packaging drift needs coverage.

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -320,10 +320,10 @@ the Dockerfiles, verifies their release checksums, puts fake `codex` / `claude`
 CLIs on `PATH`, and runs Hecate's probe/auth/logout/session/run path against
 the real adapter binaries, including session config selector changes and
 session-level MCP propagation, command-backed prompt execution, prompt
-auth-required mapping, and native session reload/recovery. It requires network
-access and is intentionally not part of the normal unit-test ladder. The same
-check is available from GitHub Actions as the manual **ACP adapter release
-smoke** workflow.
+auth-required mapping, structured activity mapping, and native session
+reload/recovery. It requires network access and is intentionally not part of the
+normal unit-test ladder. The same check is available from GitHub Actions as the
+manual **ACP adapter release smoke** workflow.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -297,8 +297,8 @@ Dockerfile-pinned Go adapter release binaries, verifies checksums, and smokes
 probe capability discovery, ACP authenticate/logout, session config selectors
 and selector changes, session-level MCP propagation, advertised slash commands,
 command-backed prompt execution, prompt auth-required mapping, prompt streaming,
-usage mapping, stop-reason mapping, and native session reload/recovery with
-fake `codex` and `claude` CLIs.
+usage mapping, structured activity mapping, stop-reason mapping, and native
+session reload/recovery with fake `codex` and `claude` CLIs.
 
 ## Setup checks
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,6 +101,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 				currentConfigOptions = updated.ConfigOptions
 			}
 
+			var activityCapture acpReleaseActivityCapture
 			run, err := manager.Run(context.Background(), RunRequest{
 				SessionID:      "release_" + tt.adapterID,
 				AdapterID:      tt.adapterID,
@@ -108,6 +110,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 				MCPServers:     tt.mcpServers,
 				Timeout:        5 * time.Second,
 				MaxOutputBytes: 64 * 1024,
+				OnActivity:     activityCapture.record,
 			})
 			if err != nil {
 				t.Fatalf("Run(%s): %v", tt.adapterID, err)
@@ -124,6 +127,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 			if run.StopReason != tt.wantStopReason {
 				t.Fatalf("Run(%s) stop reason = %q, want %q", tt.adapterID, run.StopReason, tt.wantStopReason)
 			}
+			assertReleaseToolActivities(t, tt.adapterID, activityCapture.snapshot(), tt.wantToolActivityTitle)
 
 			for _, commandRun := range tt.commandRuns {
 				run, err := manager.Run(context.Background(), RunRequest{
@@ -242,6 +246,7 @@ type acpReleaseSmokeTestCase struct {
 	wantReloadResumed      bool
 	wantReloadSameNative   bool
 	wantReloadRecovery     bool
+	wantToolActivityTitle  string
 }
 
 type acpReleaseConfigOption struct {
@@ -296,6 +301,7 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 			wantReloadResumed:      false,
 			wantReloadSameNative:   false,
 			wantReloadRecovery:     true,
+			wantToolActivityTitle:  "go test ./...",
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/review focus on tests",
@@ -337,6 +343,7 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 			wantReloadResumed:      true,
 			wantReloadSameNative:   true,
 			wantReloadRecovery:     false,
+			wantToolActivityTitle:  "Bash",
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/verify release smoke",
@@ -345,6 +352,44 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 				},
 			},
 		},
+	}
+}
+
+type acpReleaseActivityCapture struct {
+	mu         sync.Mutex
+	activities []Activity
+}
+
+func (c *acpReleaseActivityCapture) record(activity Activity) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.activities = append(c.activities, activity)
+}
+
+func (c *acpReleaseActivityCapture) snapshot() []Activity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Activity, len(c.activities))
+	copy(out, c.activities)
+	return out
+}
+
+func assertReleaseToolActivities(t *testing.T, adapterID string, activities []Activity, wantTitle string) {
+	t.Helper()
+	var sawStart, sawFinish bool
+	for _, activity := range activities {
+		if activity.Type != "tool_call" || activity.Kind != "execute" {
+			continue
+		}
+		if activity.Status == "running" && strings.Contains(activity.Title, wantTitle) {
+			sawStart = true
+		}
+		if activity.Status == "completed" && (strings.Contains(activity.ArtifactPreview, "ok") || strings.Contains(activity.Detail, "ok")) {
+			sawFinish = true
+		}
+	}
+	if !sawStart || !sawFinish {
+		t.Fatalf("Run(%s) activities = %#v, want running execute %q and completed output", adapterID, activities, wantTitle)
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture Hecate activity events during the released ACP adapter smoke prompt
- assert Codex and Claude Code released binaries map vendor shell/tool events into running and completed Hecate execute activities
- document structured activity mapping as part of the release-smoke coverage

## Verification
- just test-acp-release-smoke
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -race -timeout 5m ./internal/agentadapters
- just docs-format-check
- git diff --check