### PR TITLE
Expose Project Operations cap summary

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -60,6 +60,10 @@ project records.
 When there is no server-backed operation to show, the tab keeps only the
 compact resume summary; clients should not derive a second actionable
 next-action cascade from project state.
+The operations brief is intentionally compact. The server sorts operations by
+operator urgency before applying its item cap, and the response summary reports
+how many operations were available, returned, and omitted so the UI can show
+when lower-priority work is hidden by the cap.
 
 Use the top Project Operations action for the single most useful operator step,
 then jump to

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2413,7 +2413,9 @@ proposals, memory entries, or memory candidates, and it never starts queued
 work.
 The eight-item cap is applied after sorting by priority, explicit operation
 kind urgency, recency, and stable ID, so truncation is part of the operator
-priority policy.
+priority policy. The summary reports the returned item count, available item
+count before the cap, omitted item count, and current item limit so clients can
+show when lower-priority operations are hidden.
 
 Each item has a `kind` that explains why it appears and an `action` that is the
 typed client routing contract. Clients should dispatch on `action.type`, not on
@@ -2442,6 +2444,9 @@ where the operator reviews the typed proposal before any durable mutation.
     "generated_at": "2026-06-20T12:00:00Z",
     "summary": {
       "item_count": 2,
+      "available_item_count": 2,
+      "omitted_item_count": 0,
+      "item_limit": 8,
       "high_count": 1,
       "medium_count": 1,
       "low_count": 0,

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -41,6 +41,9 @@ type ProjectOperationsBriefResponse struct {
 
 type ProjectOperationsBriefSummaryResponse struct {
 	ItemCount                   int `json:"item_count"`
+	AvailableItemCount          int `json:"available_item_count"`
+	OmittedItemCount            int `json:"omitted_item_count"`
+	ItemLimit                   int `json:"item_limit"`
 	HighCount                   int `json:"high_count"`
 	MediumCount                 int `json:"medium_count"`
 	LowCount                    int `json:"low_count"`
@@ -146,6 +149,7 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 	}
 
 	sortProjectOperationsItems(items)
+	availableItemCount := len(items)
 	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
 	response := ProjectOperationsBriefResponse{
 		ProjectID:   projectID,
@@ -153,6 +157,9 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 		Items:       items,
 	}
 	response.Summary.ItemCount = len(items)
+	response.Summary.AvailableItemCount = availableItemCount
+	response.Summary.OmittedItemCount = availableItemCount - len(items)
+	response.Summary.ItemLimit = projectOperationsBriefItemLimit
 	response.Summary.PendingMemoryCandidateCount = pendingMemoryCandidates
 	for _, handoff := range handoffs {
 		if handoff.Status == projectwork.HandoffStatusPending {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -104,6 +104,9 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	if response.Data.Summary.PendingMemoryCandidateCount != 1 || response.Data.Summary.PendingHandoffCount != 1 {
 		t.Fatalf("operations summary = %+v, want memory candidate and handoff counts", response.Data.Summary)
 	}
+	if response.Data.Summary.ItemLimit != projectOperationsBriefItemLimit || response.Data.Summary.AvailableItemCount != response.Data.Summary.ItemCount || response.Data.Summary.OmittedItemCount != 0 {
+		t.Fatalf("operations summary = %+v, want untruncated item counts", response.Data.Summary)
+	}
 	assertProjectOperationsItemsHaveActions(t, response.Data.Items)
 
 	defaults := findProjectOperationsItemForTest(t, response.Data.Items, "configure_project_defaults")
@@ -137,6 +140,49 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	}
 	if len(afterAssignments) != len(beforeAssignments) || len(afterCandidates) != len(beforeCandidates) {
 		t.Fatalf("operations brief mutated project state: assignments %d->%d candidates %d->%d", len(beforeAssignments), len(afterAssignments), len(beforeCandidates), len(afterCandidates))
+	}
+}
+
+func TestProjectOperationsBrief_SummaryReportsBoundedItems(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_cap",
+		Name:            "Cap",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	for idx := 0; idx < projectOperationsBriefItemLimit+3; idx++ {
+		if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+			ID:        "work_cap_" + intString(idx),
+			ProjectID: "proj_cap",
+			Title:     "Prepare work " + intString(idx),
+			Status:    projectwork.WorkItemStatusReady,
+			UpdatedAt: time.Date(2026, 6, 20, 12, idx, 0, 0, time.UTC),
+		}); err != nil {
+			t.Fatalf("CreateWorkItem(%d): %v", idx, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_cap/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if response.Data.Summary.ItemLimit != projectOperationsBriefItemLimit {
+		t.Fatalf("summary item_limit = %d, want %d", response.Data.Summary.ItemLimit, projectOperationsBriefItemLimit)
+	}
+	if response.Data.Summary.AvailableItemCount != projectOperationsBriefItemLimit+3 || response.Data.Summary.ItemCount != projectOperationsBriefItemLimit || response.Data.Summary.OmittedItemCount != 3 {
+		t.Fatalf("summary = %+v, want available %d visible %d omitted 3", response.Data.Summary, projectOperationsBriefItemLimit+3, projectOperationsBriefItemLimit)
+	}
+	if len(response.Data.Items) != projectOperationsBriefItemLimit {
+		t.Fatalf("items len = %d, want %d", len(response.Data.Items), projectOperationsBriefItemLimit)
 	}
 }
 

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -381,6 +381,53 @@ describe("ProjectWorkspaceView", () => {
     expect(handlers.onOperationAction).toHaveBeenCalledWith(operationItem);
   });
 
+  it("explains compact project operations limits", () => {
+    const operationItems = Array.from({ length: 5 }, (_, index) => ({
+      id: `prepare_first_assignment:proj_1:work_${index}`,
+      kind: "prepare_first_assignment",
+      priority: "medium",
+      title: `Prepare first assignment: Work ${index}`,
+      detail: "This work item has no queued or running assignments yet.",
+      action_label: "Draft assignment",
+      target: {
+        surface: "work",
+        project_id: "proj_1",
+        work_item_id: `work_${index}`,
+      },
+      action: {
+        type: "draft_project_proposal",
+        project_id: "proj_1",
+        work_item_id: `work_${index}`,
+        request: `Queue an assignment for Work ${index}`,
+      },
+    }));
+    renderWorkspace({
+      operationsBrief: {
+        project_id: "proj_1",
+        generated_at: "2026-06-13T00:00:00Z",
+        summary: {
+          item_count: 5,
+          available_item_count: 9,
+          omitted_item_count: 4,
+          item_limit: 8,
+          high_count: 0,
+          medium_count: 5,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: operationItems,
+      },
+    });
+
+    const operations = screen.getByRole("region", { name: "Project operations" });
+    expect(
+      within(operations).getByText(
+        "Showing top 4 of 9 operations; 4 lower-priority operations were omitted by the server cap.",
+      ),
+    ).toBeTruthy();
+  });
+
   it("renders a resume summary and delegates resume actions", async () => {
     const item = workItem({ id: "work_blocked", title: "Fix blocked launch" });
     const { handlers } = renderWorkspace({

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -730,6 +730,8 @@ function ProjectOperationsBriefPanel({
   const items = brief?.items ?? [];
   const primary = items[0] ?? null;
   const secondary = items.slice(1, 4);
+  const shownItemCount = (primary ? 1 : 0) + secondary.length;
+  const limitDetail = projectOperationsLimitDetail(brief, shownItemCount);
   const title = loading && !brief ? "Loading operations..." : primary?.title || "Operations clear";
   const detail =
     loading && !brief
@@ -781,9 +783,26 @@ function ProjectOperationsBriefPanel({
           ))}
         </div>
       )}
+      {limitDetail && <div style={subtleTextStyle}>{limitDetail}</div>}
       {error && <InlineError message={error} />}
     </section>
   );
+}
+
+function projectOperationsLimitDetail(
+  brief: ProjectOperationsBrief | null,
+  shownItemCount: number,
+) {
+  if (!brief || shownItemCount === 0) return "";
+  const availableItemCount = brief.summary.available_item_count ?? brief.items.length;
+  const omittedItemCount = brief.summary.omitted_item_count ?? 0;
+  if (omittedItemCount > 0) {
+    return `Showing top ${shownItemCount} of ${availableItemCount} operations; ${omittedItemCount} lower-priority ${omittedItemCount === 1 ? "operation was" : "operations were"} omitted by the server cap.`;
+  }
+  if (brief.items.length > shownItemCount) {
+    return `Showing top ${shownItemCount} of ${brief.items.length} operations.`;
+  }
+  return "";
 }
 
 function projectOperationBadge(item: ProjectOperationsBriefItem): string {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -862,6 +862,9 @@ export type ProjectOperationsBriefItem = {
 
 export type ProjectOperationsBriefSummary = {
   item_count: number;
+  available_item_count?: number;
+  omitted_item_count?: number;
+  item_limit?: number;
   high_count: number;
   medium_count: number;
   low_count: number;


### PR DESCRIPTION
## Summary
- add Project Operations summary fields for available, omitted, and capped item counts
- show compact-panel/cap detail in the Project Operations panel when operations are hidden
- document the cap metadata in operator and runtime API docs

## Verification
- go test ./internal/api -run 'TestProjectOperationsBrief|TestSortProjectOperationsItems'
- go test ./internal/api (rerun outside sandbox after httptest bind was blocked)
- go vet ./internal/api
- bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test
- git diff --check
- terminology scan clean