### PR TITLE
chore(agent-adapters): bump permission-aware ACP releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.20
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,8 +24,8 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.20` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.22` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.21` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.23` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
 failure/stop-reason classification. The
@@ -60,6 +60,9 @@ a generic prompt command failure.
 Codex adapter `v0.1.0-alpha.20` propagates terminal stop reasons from the
 structured Codex stream so Hecate can show actionable stops such as token limits
 or refusals in the chat activity timeline.
+Codex adapter `v0.1.0-alpha.21` maps parsed Codex stream permission requests to
+ACP `session/request_permission`, so Hecate can record and resolve adapter tool
+approvals instead of silently auto-continuing parsed permission events.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -89,6 +92,10 @@ instead of a generic prompt command failure.
 Claude Code adapter `v0.1.0-alpha.22` propagates terminal stop reasons from the
 structured Claude result stream so Hecate can show actionable stops such as turn
 limits or refusals in the chat activity timeline.
+Claude Code adapter `v0.1.0-alpha.23` maps parsed Claude Code stream permission
+requests to ACP `session/request_permission`, so Hecate can record and resolve
+adapter tool approvals instead of silently auto-continuing parsed permission
+events.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -54,6 +54,11 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 			}
 
 			manager := NewSessionManager()
+			approvalStore := NewMemoryApprovalStore()
+			manager.SetApprovalCoordinator(NewApprovalCoordinator(CoordinatorOptions{
+				Mode:  ModeAuto,
+				Store: approvalStore,
+			}))
 			t.Cleanup(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
@@ -128,6 +133,7 @@ func TestACPAdapterReleaseBinariesSmoke(t *testing.T) {
 				t.Fatalf("Run(%s) stop reason = %q, want %q", tt.adapterID, run.StopReason, tt.wantStopReason)
 			}
 			assertReleaseToolActivities(t, tt.adapterID, activityCapture.snapshot(), tt.wantToolActivityTitle)
+			assertReleaseApprovalRecorded(t, approvalStore, "release_"+tt.adapterID, tt.adapterID, tt.wantApprovalToolName, tt.wantApprovalToolKind)
 
 			for _, commandRun := range tt.commandRuns {
 				run, err := manager.Run(context.Background(), RunRequest{
@@ -247,6 +253,8 @@ type acpReleaseSmokeTestCase struct {
 	wantReloadSameNative   bool
 	wantReloadRecovery     bool
 	wantToolActivityTitle  string
+	wantApprovalToolName   string
+	wantApprovalToolKind   string
 }
 
 type acpReleaseConfigOption struct {
@@ -302,6 +310,8 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 			wantReloadSameNative:   false,
 			wantReloadRecovery:     true,
 			wantToolActivityTitle:  "go test ./...",
+			wantApprovalToolName:   "Run tests",
+			wantApprovalToolKind:   "shell_exec",
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/review focus on tests",
@@ -344,6 +354,8 @@ func acpReleaseSmokeTestCases(t *testing.T) []acpReleaseSmokeTestCase {
 			wantReloadSameNative:   true,
 			wantReloadRecovery:     false,
 			wantToolActivityTitle:  "Bash",
+			wantApprovalToolName:   "Bash",
+			wantApprovalToolKind:   "shell_exec",
 			commandRuns: []acpReleaseCommandRun{
 				{
 					prompt:         "/verify release smoke",
@@ -391,6 +403,25 @@ func assertReleaseToolActivities(t *testing.T, adapterID string, activities []Ac
 	if !sawStart || !sawFinish {
 		t.Fatalf("Run(%s) activities = %#v, want running execute %q and completed output", adapterID, activities, wantTitle)
 	}
+}
+
+func assertReleaseApprovalRecorded(t *testing.T, store *MemoryApprovalStore, sessionID, adapterID, wantName, wantKind string) {
+	t.Helper()
+	rows, err := store.ListApprovals(context.Background(), sessionID, "")
+	if err != nil {
+		t.Fatalf("ListApprovals(%s): %v", adapterID, err)
+	}
+	for _, row := range rows {
+		if row.AdapterID == adapterID &&
+			row.ToolName == wantName &&
+			row.ToolKind == wantKind &&
+			row.Status == ApprovalStatusApproved &&
+			row.Path == PathDefaultMode &&
+			row.SelectedOption != "" {
+			return
+		}
+	}
+	t.Fatalf("approvals(%s) = %#v, want approved %s %q via default mode", adapterID, rows, wantKind, wantName)
 }
 
 func downloadACPAdapterReleaseBinary(t *testing.T, repo, binary, version, binDir string) {
@@ -532,6 +563,7 @@ case "$1" in
     printf '{"method":"item/completed","params":{"item":{"type":"agent_message","id":"msg-1","text":"%s"}}}\n' "$message"
     if [ "$message" = "go codex answer" ]; then
       finish_reason="max_tokens"
+      printf '{"method":"permission/requested","params":{"toolCall":{"toolCallId":"permission-1","title":"Run tests","kind":"execute","rawInput":{"command":"go test ./..."}},"options":[{"optionId":"allow","name":"Allow","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}\n'
     else
       finish_reason="end_turn"
     fi
@@ -592,6 +624,9 @@ case "$1" in
       *"hello claude_code"*) message="go claude answer"; stop_reason="error_max_turns";;
       *) echo "unexpected claude prompt: $*" >&2; exit 66 ;;
     esac
+    if [ "$message" = "go claude answer" ]; then
+      printf '{"type":"permission_request","toolUse":{"toolUseId":"permission-1","name":"Bash","input":{"command":"go test ./..."}},"options":[{"optionId":"allow","name":"Allow","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}\n'
+    fi
     printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Bash","input":{"command":"go test ./..."}}]}}\n'
     printf '{"type":"assistant","message":{"content":[{"type":"thinking","id":"thought-1","thinking":"checking"},{"type":"text","text":"%s"}]}}\n' "$message"
     printf '{"type":"result","subtype":"%s","usage":{"input_tokens":10,"output_tokens":5,"context_window":100}}\n' "$stop_reason"

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -271,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.20",
+			SupportedRange:       ">=0.1.0-alpha.21",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -312,7 +312,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.22",
+			SupportedRange:       ">=0.1.0-alpha.23",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.20" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.21" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.22" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.23" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump bundled Codex adapter to v0.1.0-alpha.21 and Claude Code adapter to v0.1.0-alpha.23
- raise Hecate supported ranges to those release pins
- document parsed stream permission request support
- extend release-binary smoke coverage to assert Hecate records an auto-approved adapter permission request from each released binary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -tags acp_release -run TestACPAdapterReleaseBinariesSmoke ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/api ./internal/chatapp ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go vet ./internal/agentadapters

Note: the broader API package test needed loopback access for httptest; the first sandboxed attempt failed on local bind permissions, then passed with loopback allowed.