### PR TITLE
Show Project health summary in Needs Attention

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -46,8 +46,11 @@ The project header's **Needs Attention** menu is server-derived from
 `GET /hecate/v1/projects/{id}/health`. It surfaces compact setup and operations
 signals such as missing defaults, missing roots, profile or skill reference
 issues, pending handoffs, review follow-up, stale assignment links, empty
-memory/context posture, and pending memory candidates. The menu opens existing
-surfaces only; it does not create records, launch agents, or write memory.
+memory/context posture, and pending memory candidates. The menu also shows the
+server summary counts for setup, memory, context, and work follow-up so the
+operator can see why the project needs attention before opening a specific
+item. The menu opens existing surfaces only; it does not create records, launch
+agents, or write memory.
 
 The Work Coordination tab starts with Project Operations when the server finds
 actionable project state: missing launch defaults, pending approvals, blocked

--- a/ui/src/features/projects/ProjectHealthPanel.test.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.test.tsx
@@ -2,7 +2,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import type { ProjectHealthAttention, ProjectMemoryCandidateRecord } from "../../types/project";
+import type {
+  ProjectHealthAttention,
+  ProjectHealthSummary,
+  ProjectMemoryCandidateRecord,
+} from "../../types/project";
 import { ProjectHealthPanel } from "./ProjectHealthPanel";
 
 function memoryCandidate(overrides: Partial<ProjectMemoryCandidateRecord> = {}) {
@@ -18,6 +22,32 @@ function memoryCandidate(overrides: Partial<ProjectMemoryCandidateRecord> = {}) 
     updated_at: "2026-06-12T00:00:00Z",
     ...overrides,
   } satisfies ProjectMemoryCandidateRecord;
+}
+
+function healthSummary(overrides: Partial<ProjectHealthSummary> = {}) {
+  return {
+    attention_count: 5,
+    available_attention_count: 5,
+    omitted_attention_count: 0,
+    attention_limit: 5,
+    missing_defaults: false,
+    missing_project_root: false,
+    enabled_memory_count: 0,
+    saved_memory_count: 0,
+    enabled_context_source_count: 0,
+    pending_memory_candidate_count: 0,
+    promoted_memory_candidate_count: 0,
+    rejected_memory_candidate_count: 0,
+    pending_handoff_count: 0,
+    accepted_handoff_count: 0,
+    superseded_handoff_count: 0,
+    dismissed_handoff_count: 0,
+    review_follow_up_count: 0,
+    blocked_review_count: 0,
+    changes_requested_review_count: 0,
+    stale_or_unknown_assignment_count: 0,
+    ...overrides,
+  } satisfies ProjectHealthSummary;
 }
 
 function renderPanel(overrides: Partial<Parameters<typeof ProjectHealthPanel>[0]> = {}) {
@@ -141,7 +171,47 @@ describe("ProjectHealthPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "Project attention: 5, 2 hidden" }));
 
     expect(screen.getAllByText("5+").length).toBeGreaterThan(0);
-    expect(screen.getByText("2 lower-priority items are hidden by the server cap.")).toBeTruthy();
+    expect(
+      screen.getByText("Showing 5 of 7 attention items; 2 lower-priority items are hidden."),
+    ).toBeTruthy();
+  });
+
+  it("shows the server project health summary without deriving attention", async () => {
+    renderPanel({
+      summary: healthSummary({
+        available_attention_count: 8,
+        omitted_attention_count: 3,
+        missing_defaults: true,
+        missing_project_root: true,
+        enabled_memory_count: 2,
+        saved_memory_count: 3,
+        enabled_context_source_count: 4,
+        pending_memory_candidate_count: 1,
+        pending_handoff_count: 1,
+        review_follow_up_count: 2,
+        stale_or_unknown_assignment_count: 1,
+      }),
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Project attention: 5, 3 hidden" }));
+
+    expect(screen.getByLabelText("Project health summary")).toBeTruthy();
+    expect(screen.getByText("2 gaps")).toBeTruthy();
+    expect(screen.getByText("defaults, root")).toBeTruthy();
+    expect(screen.getByText("2/3 enabled")).toBeTruthy();
+    expect(screen.getByText("1 candidate pending")).toBeTruthy();
+    expect(screen.getByText("4 sources")).toBeTruthy();
+    expect(screen.getByText("4 follow-ups")).toBeTruthy();
+    expect(screen.getByText("1 handoff, 2 reviews, 1 assignment link")).toBeTruthy();
+  });
+
+  it("uses cleaner summary copy when the project has no saved memory", async () => {
+    renderPanel({ summary: healthSummary() });
+
+    await openMenu();
+
+    expect(screen.getByText("No memory yet")).toBeTruthy();
+    expect(screen.queryByText("0/0 enabled")).toBeNull();
   });
 
   it("shows empty guidance when there are no attention items", async () => {

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import type {
   ProjectActivityBucketKey,
   ProjectHealthAttention,
+  ProjectHealthSummary,
   ProjectMemoryCandidateRecord,
 } from "../../types/project";
 import { Badge, Icon, Icons } from "../shared/ui";
@@ -14,6 +15,7 @@ export type ProjectHealthPanelProps = {
   disabled?: boolean;
   memoryCandidates: ProjectMemoryCandidateRecord[];
   omittedAttentionCount?: number;
+  summary?: ProjectHealthSummary;
   onAttentionBucket: (bucket: ProjectActivityBucketKey) => void;
   onAttentionDefaults: () => void;
   onAttentionMemory: () => void;
@@ -31,6 +33,7 @@ export function ProjectHealthPanel({
   disabled = false,
   memoryCandidates,
   omittedAttentionCount = 0,
+  summary,
   onAttentionBucket,
   onAttentionDefaults,
   onAttentionMemory,
@@ -46,12 +49,15 @@ export function ProjectHealthPanel({
     portalSelector: null,
   });
   const attentionCount = attentionItems.length;
-  const totalAttentionCount = attentionCount + omittedAttentionCount;
+  const totalAttentionCount =
+    summary?.available_attention_count ?? attentionCount + omittedAttentionCount;
+  const hiddenAttentionCount = Math.max(0, totalAttentionCount - attentionCount);
   const attentionLabel =
     totalAttentionCount > 0
-      ? `Project attention: ${attentionCount}${omittedAttentionCount > 0 ? `, ${omittedAttentionCount} hidden` : ""}`
+      ? `Project attention: ${attentionCount}${hiddenAttentionCount > 0 ? `, ${hiddenAttentionCount} hidden` : ""}`
       : "Project attention";
-  const attentionBadge = omittedAttentionCount > 0 ? `${attentionCount}+` : `${attentionCount}`;
+  const attentionBadge = hiddenAttentionCount > 0 ? `${attentionCount}+` : `${attentionCount}`;
+  const postureRows = projectHealthPostureRows(summary);
   const closeMenu = () => attentionMenu.close();
   const handleAttentionAction = (item: ProjectHealthAttention) => {
     if (item.action === "settings" || item.id.endsWith(":defaults")) {
@@ -107,10 +113,22 @@ export function ProjectHealthPanel({
             <div style={sectionLabelStyle}>Needs Attention</div>
             <span className="badge badge-muted">{attentionBadge}</span>
           </div>
-          {omittedAttentionCount > 0 && (
+          {postureRows.length > 0 && (
+            <div style={projectPostureGridStyle} aria-label="Project health summary">
+              {postureRows.map((row) => (
+                <div key={row.id} style={projectPostureRowStyle}>
+                  <div style={projectPostureTitleStyle}>{row.title}</div>
+                  <div style={projectPostureValueStyle}>{row.value}</div>
+                  {row.detail && <div style={subtleTextStyle}>{row.detail}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+          {hiddenAttentionCount > 0 && (
             <div style={subtleTextStyle}>
-              {omittedAttentionCount} lower-priority{" "}
-              {omittedAttentionCount === 1 ? "item is" : "items are"} hidden by the server cap.
+              Showing {attentionCount} of {totalAttentionCount} attention{" "}
+              {totalAttentionCount === 1 ? "item" : "items"}; {hiddenAttentionCount} lower-priority{" "}
+              {hiddenAttentionCount === 1 ? "item is" : "items are"} hidden.
             </div>
           )}
           {attentionItems.length === 0 ? (
@@ -251,6 +269,77 @@ function ProjectHealthAttentionRow({
   );
 }
 
+type ProjectHealthPostureRow = {
+  id: string;
+  title: string;
+  value: string;
+  detail?: string;
+};
+
+function projectHealthPostureRows(summary?: ProjectHealthSummary): ProjectHealthPostureRow[] {
+  if (!summary) return [];
+  const setupGaps = [
+    summary.missing_defaults ? "defaults" : "",
+    summary.missing_project_root ? "root" : "",
+  ].filter(Boolean);
+  const pendingMemory = summary.pending_memory_candidate_count;
+  const workFollowUp =
+    summary.pending_handoff_count +
+    summary.review_follow_up_count +
+    summary.stale_or_unknown_assignment_count;
+  return [
+    {
+      id: "setup",
+      title: "Setup",
+      value: setupGaps.length > 0 ? `${setupGaps.length} gap${plural(setupGaps.length)}` : "Ready",
+      detail: setupGaps.length > 0 ? setupGaps.join(", ") : undefined,
+    },
+    {
+      id: "memory",
+      title: "Memory",
+      value:
+        summary.saved_memory_count === 0
+          ? "No memory yet"
+          : `${summary.enabled_memory_count}/${summary.saved_memory_count} enabled`,
+      detail:
+        pendingMemory > 0
+          ? `${pendingMemory} candidate${plural(pendingMemory)} pending`
+          : undefined,
+    },
+    {
+      id: "context",
+      title: "Context",
+      value: `${summary.enabled_context_source_count} source${plural(
+        summary.enabled_context_source_count,
+      )}`,
+    },
+    {
+      id: "work",
+      title: "Work",
+      value: workFollowUp > 0 ? `${workFollowUp} follow-up${plural(workFollowUp)}` : "Clear",
+      detail: projectHealthWorkDetail(summary),
+    },
+  ];
+}
+
+function projectHealthWorkDetail(summary: ProjectHealthSummary): string | undefined {
+  const parts = [
+    countLabel(summary.pending_handoff_count, "handoff"),
+    countLabel(summary.review_follow_up_count, "review"),
+    countLabel(summary.stale_or_unknown_assignment_count, "assignment link"),
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+function countLabel(count: number, label: string): string {
+  if (count <= 0) return "";
+  return `${count} ${label}${plural(count)}`;
+}
+
+function plural(count: number): string {
+  return count === 1 ? "" : "s";
+}
+
 const projectAttentionMenuStyle: CSSProperties = {
   position: "relative",
 };
@@ -297,6 +386,38 @@ const projectAttentionPopoverHeaderStyle: CSSProperties = {
   gap: 8,
   justifyContent: "space-between",
   minWidth: 0,
+};
+
+const projectPostureGridStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 0,
+  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+  overflow: "hidden",
+};
+
+const projectPostureRowStyle: CSSProperties = {
+  borderBottom: "1px solid var(--border)",
+  borderRight: "1px solid var(--border)",
+  display: "grid",
+  gap: 3,
+  minWidth: 0,
+  padding: "8px 9px",
+};
+
+const projectPostureTitleStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 11,
+};
+
+const projectPostureValueStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: 12,
+  fontWeight: 700,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
 };
 
 const sectionLabelStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -423,7 +423,7 @@ describe("ProjectWorkspaceView", () => {
     const operations = screen.getByRole("region", { name: "Project operations" });
     expect(
       within(operations).getByText(
-        "Showing top 4 of 8 returned operations (9 available; 1 lower-priority operation was capped by the server).",
+        "Showing 4 of 9 operations; 5 lower-priority operations are hidden (1 capped by the server).",
       ),
     ).toBeTruthy();
   });

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -801,18 +801,12 @@ function projectOperationsLimitDetail(
     brief.summary.omitted_item_count ?? availableItemCount - returnedItemCount,
     0,
   );
-  const returnedLabel = `${returnedItemCount} returned ${returnedItemCount === 1 ? "operation" : "operations"}`;
-  const shownLabel =
-    shownItemCount >= returnedItemCount
-      ? `Showing all ${returnedLabel}`
-      : `Showing top ${shownItemCount} of ${returnedLabel}`;
-  if (omittedItemCount > 0) {
-    return `${shownLabel} (${availableItemCount} available; ${omittedItemCount} lower-priority ${omittedItemCount === 1 ? "operation was" : "operations were"} capped by the server).`;
-  }
-  if (returnedItemCount > shownItemCount) {
-    return `${shownLabel}.`;
-  }
-  return "";
+  const hiddenItemCount = Math.max(availableItemCount - shownItemCount, 0);
+  if (hiddenItemCount === 0) return "";
+  const operationLabel = availableItemCount === 1 ? "operation" : "operations";
+  const hiddenLabel = hiddenItemCount === 1 ? "operation is" : "operations are";
+  const capDetail = omittedItemCount > 0 ? ` (${omittedItemCount} capped by the server)` : "";
+  return `Showing ${shownItemCount} of ${availableItemCount} ${operationLabel}; ${hiddenItemCount} lower-priority ${hiddenLabel} hidden${capDetail}.`;
 }
 
 function projectOperationBadge(item: ProjectOperationsBriefItem): string {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4246,6 +4246,10 @@ describe("ProjectsView cockpit", () => {
 
     await screen.findByText("Work Queue");
     const health = await openProjectAttentionMenu();
+    expect(within(health).getByLabelText("Project health summary")).toBeTruthy();
+    expect(within(health).getByText("1 candidate pending")).toBeTruthy();
+    expect(within(health).getByText("1 follow-up")).toBeTruthy();
+    expect(within(health).getByText("1 handoff")).toBeTruthy();
     expect(within(health).getByText(/Pending handoff: Build cockpit UI/i)).toBeTruthy();
     expect(within(health).getByText(/QA handoff/i)).toBeTruthy();
     expect(within(health).getByText("Memory candidate pending review")).toBeTruthy();

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1624,6 +1624,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
         <ProjectHeader
           attentionItems={projectHealth?.attention ?? []}
           omittedAttentionCount={projectHealth?.summary?.omitted_attention_count ?? 0}
+          healthSummary={projectHealth?.summary}
           memoryCandidates={memoryCandidates}
           project={selectedProject}
           onAttentionBucket={(bucket) => {
@@ -2281,6 +2282,7 @@ function ProjectIndexRow({
 
 function ProjectHeader({
   attentionItems,
+  healthSummary,
   omittedAttentionCount,
   memoryCandidates,
   project,
@@ -2300,6 +2302,7 @@ function ProjectHeader({
   onRefresh,
 }: {
   attentionItems: ProjectHealthAttention[];
+  healthSummary?: ProjectHealth["summary"];
   omittedAttentionCount: number;
   memoryCandidates: ProjectMemoryCandidateRecord[];
   project: ProjectRecord | null;
@@ -2342,6 +2345,7 @@ function ProjectHeader({
             disabled={!project}
             memoryCandidates={memoryCandidates}
             omittedAttentionCount={omittedAttentionCount}
+            summary={healthSummary}
             onAttentionBucket={onAttentionBucket}
             onAttentionDefaults={onAttentionDefaults}
             onAttentionMemory={onAttentionMemory}


### PR DESCRIPTION
## Summary
- Render the server Project health summary inside the Needs Attention menu for setup, memory, context, and work follow-up posture.
- Reconcile hidden attention copy against the server available-attention count while retaining the old omitted-count fallback for compatibility.
- Document that the header menu now shows server summary counts without adding mutations or agent launches.

## Validation
- bun run test src/features/projects/ProjectHealthPanel.test.tsx src/features/projects/ProjectsView.test.tsx
- bun run typecheck
- bun run format:check
- bun run lint
- bun run test
- git diff --check
- reserved-name scan: no matches