### PR TITLE
feat(chats): clarify agent approval decisions

### DIFF
--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -144,6 +144,16 @@ Acceptance:
 - **`ui/dist/.gitkeep` must be tracked.** The `//go:embed all:ui/dist` directive in `embed.go` fails at compile time if `ui/dist` is completely absent from the tree. `.gitignore` keeps `ui/dist/*` but un-ignores `.gitkeep` via negation — the negation only works if `/dist/` (not `dist/`) is the rule anchoring the goreleaser output directory. If `go build` fails with `pattern all:ui/dist: no matching files found`, check that `ui/dist/.gitkeep` is tracked (`git ls-files ui/dist/`) and that `.gitignore` anchors the root dist rule with a leading `/`.
 - **`Dockerfile.release` is what goreleaser uses, not `Dockerfile`.** `Dockerfile` is the source-build image used by `docker compose up --build`; `Dockerfile.release` copies the prebuilt binary into the published GHCR image. They are two build paths for the same runtime shape, so any runtime package, bundled External Agent CLI/adapter, `ENV` var, volume, or default must land in both.
 - **Bundled External Agent versions are deliberate.** The Dockerfiles pin the top-level npm package versions for the upstream Codex CLI, Claude Code CLI, and Grok Build CLI. The Codex and Claude Code ACP adapters are bundled as checksum-verified GitHub release binaries, not npm packages. Cursor Agent comes from Cursor's official installer; because that script has no version flag, the Dockerfiles pin the installer SHA-256 and fail the build when Cursor rotates it. Review the new script, confirm the hardcoded Cursor package it installs, then update both Dockerfiles together.
+- **ACP adapter bumps are a three-file contract.** When cutting a new
+  `codex-acp-adapter` or `claude-code-acp-adapter` release for Hecate, update
+  both `Dockerfile` and `Dockerfile.release`, then update the matching
+  `SupportedRange` in `internal/agentadapters/registry.go`. The
+  `internal/agentadapters/dockerfile_test.go` guard fails if those three drift.
+  After the bump, run `just test-acp-release-smoke` locally when network access
+  is available, or dispatch the manual **ACP adapter release smoke** workflow;
+  that check downloads the pinned release binaries and exercises probe, auth,
+  config selectors, MCP propagation, prompt execution, stream activity,
+  permission approvals, and grant reuse through Hecate.
 - **CI's `e2e-ollama` job runs under `-tags 'e2e ollama'`** — `just verify` only covers `-tags 'e2e docker'` locally, so an ollama-only regression sails through the local gate. The `v0.1.0-alpha.7` cut hit this with the env-PRECONFIGURED gate: `gateway_test.go` was patched but `ollama_test.go` was missed. Before tagging, also run `OLLAMA_BASE_URL=http://127.0.0.1:11434 OLLAMA_MODEL=smollm2:135m go test -tags 'e2e ollama' -count=1 ./e2e/...` if any e2e helper has changed.
 - **Lychee link-check runs only on master pushes**, not on tag pushes — a broken markdown link in `AGENTS.md` / `docs-ai/**` won't block a release, but it'll blink red on the next master push. Run `just check-links` (or grep for the suspected dangling target) before tagging when the change set is doc-heavy.
 

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -320,10 +320,11 @@ the Dockerfiles, verifies their release checksums, puts fake `codex` / `claude`
 CLIs on `PATH`, and runs Hecate's probe/auth/logout/session/run path against
 the real adapter binaries, including session config selector changes and
 session-level MCP propagation, command-backed prompt execution, prompt
-auth-required mapping, structured activity mapping, and native session
-reload/recovery. It requires network access and is intentionally not part of the
-normal unit-test ladder. The same check is available from GitHub Actions as the
-manual **ACP adapter release smoke** workflow.
+auth-required mapping, structured activity mapping, prompt-mode permission
+approval, session-scoped grant reuse, and native session reload/recovery. It
+requires network access and is intentionally not part of the normal unit-test
+ladder. The same check is available from GitHub Actions as the manual **ACP
+adapter release smoke** workflow.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/ui/src/features/chats/AgentApprovalModal.test.tsx
+++ b/ui/src/features/chats/AgentApprovalModal.test.tsx
@@ -88,6 +88,33 @@ describe("AgentApprovalModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("explains deny/cancel semantics and selected grant scope", async () => {
+    const { fetchApproval, onResolve, onCancel, onClose } = setup();
+    render(
+      <AgentApprovalModal
+        sessionID="s"
+        approvalID="ap-1"
+        onClose={onClose}
+        fetchApproval={fetchApproval}
+        onResolve={onResolve}
+        onCancel={onCancel}
+      />,
+    );
+    await waitFor(() => expect(fetchApproval).toHaveBeenCalled());
+
+    expect(await screen.findByText(/Deny sends the selected reject option/)).toBeTruthy();
+    expect(screen.getByText("allow always")).toBeTruthy();
+    expect(screen.getByTestId("agent-approval-modal-scope-description").textContent).toContain(
+      "Only this pending request",
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("agent-approval-modal-scope-session"));
+    expect(screen.getByTestId("agent-approval-modal-scope-description").textContent).toContain(
+      "external-agent chat session",
+    );
+  });
+
   it("requires a confirm step when the broad agent-tool scope is picked", async () => {
     const { fetchApproval, onResolve, onCancel, onClose } = setup();
     render(
@@ -107,6 +134,9 @@ describe("AgentApprovalModal", () => {
     await user.click(await screen.findByTestId("agent-approval-modal-scope-adapter_tool"));
     expect(screen.getByTestId("agent-approval-modal-broad-warning")).toBeTruthy();
     expect(screen.getByText("agent tool")).toBeTruthy();
+    expect(screen.getByTestId("agent-approval-modal-scope-description").textContent).toContain(
+      "Every future call",
+    );
     expect(screen.queryByText("adapter_tool")).toBeNull();
 
     // First submit click only arms — must not have called onResolve yet.

--- a/ui/src/features/chats/AgentApprovalModal.tsx
+++ b/ui/src/features/chats/AgentApprovalModal.tsx
@@ -77,6 +77,7 @@ export function AgentApprovalModal({
   const buttonLabel = decision === "allow" ? "Allow" : "Deny";
   const submitLabel =
     isBroadScope && !confirmingBroadScope ? `${buttonLabel} (broad scope)` : buttonLabel;
+  const scopeDescription = approvalScopeDescription(scope);
 
   async function handleSubmit() {
     if (!row || busy) return;
@@ -209,6 +210,17 @@ export function AgentApprovalModal({
             >
               Decision
             </label>
+            <p
+              style={{
+                margin: "0 0 6px",
+                color: "var(--t3)",
+                fontSize: 11,
+                lineHeight: 1.4,
+              }}
+            >
+              Deny sends the selected reject option to the agent. Cancel returns ACP Cancelled
+              without selecting an agent option.
+            </p>
             <div
               style={{
                 display: "flex",
@@ -307,7 +319,7 @@ export function AgentApprovalModal({
                       <span
                         style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--t3)" }}
                       >
-                        {opt.kind}
+                        {approvalOptionKindLabel(opt.kind)}
                       </span>
                     </label>
                   );
@@ -339,6 +351,7 @@ export function AgentApprovalModal({
                     key={s}
                     type="button"
                     onClick={() => setScope(s)}
+                    title={approvalScopeDescription(s)}
                     data-testid={`agent-approval-modal-scope-${s}`}
                     style={{
                       padding: "4px 10px",
@@ -355,6 +368,19 @@ export function AgentApprovalModal({
                   </button>
                 ))}
               </div>
+              {scopeDescription && (
+                <div
+                  data-testid="agent-approval-modal-scope-description"
+                  style={{
+                    marginTop: 8,
+                    color: "var(--t3)",
+                    fontSize: 11,
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {scopeDescription}
+                </div>
+              )}
               {isBroadScope && (
                 <div
                   data-testid="agent-approval-modal-broad-warning"
@@ -368,9 +394,9 @@ export function AgentApprovalModal({
                     fontSize: 11,
                   }}
                 >
-                  <Icon d={Icons.warning} size={12} /> <strong>Broad scope:</strong> the agent-tool
-                  scope grants this decision to every future call to this tool from this agent.
-                  Click {buttonLabel} once to arm, then again to confirm.
+                  <Icon d={Icons.warning} size={12} /> <strong>Broad scope:</strong> this creates a
+                  durable grant for every future call to this tool from this agent. Click{" "}
+                  {buttonLabel} once to arm, then again to confirm.
                 </div>
               )}
             </div>
@@ -425,6 +451,36 @@ function approvalScopeLabel(scope: string): string {
       return "agent tool";
     default:
       return scope.replaceAll("_", " ");
+  }
+}
+
+function approvalScopeDescription(scope: string): string {
+  switch (scope) {
+    case "once":
+      return "Only this pending request will use the selected ACP option.";
+    case "session":
+      return "Matching requests in this external-agent chat session can reuse this decision.";
+    case "workspace_tool":
+      return "Matching calls to this tool in this workspace can reuse this decision.";
+    case "adapter_tool":
+      return "Every future call to this tool from this agent can reuse this decision.";
+    default:
+      return "";
+  }
+}
+
+function approvalOptionKindLabel(kind: string): string {
+  switch (kind) {
+    case "allow_once":
+      return "allow once";
+    case "allow_always":
+      return "allow always";
+    case "reject_once":
+      return "reject once";
+    case "reject_always":
+      return "reject always";
+    default:
+      return kind.replaceAll("_", " ");
   }
 }
 


### PR DESCRIPTION
## Summary
- make agent approval options and grant scopes easier to understand in the modal
- clarify deny vs cancel semantics for ACP permission requests
- document the adapter release-bump contract and release-smoke coverage

## Tests
- `cd ui && bun run test -- AgentApprovalModal`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters -run 'TestDockerfilesPinSameGoACPAdapterVersions|TestDockerfilesInstallGoACPAdapterReleaseBinaries'`
- `just docs-format-check`