### PR TITLE
Add server-backed project setup readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -371,6 +371,12 @@ preflight, selected-work follow-through, or Project Assistant proposal flows.
 Review follow-up, missing completion evidence, and closeout-ready work items
 open the existing selected-work detail surface; the brief does not persist a
 plan, mark work done, or start work.
+Project setup readiness is also a server-owned projection: onboarding,
+setup-started, and first-work-ready states come from
+`GET /hecate/v1/projects/{id}/setup-readiness`, while checklist actions route
+to Project Settings, Project Assistant setup, or explicit work-item creation.
+Clients should not recreate setup readiness from local context-source, memory,
+role, or work-item heuristics.
 The selected-work detail card now reflects the same read-only backend closeout
 readiness contract as Project Operations, so Mark done is enabled from the
 server-owned assignment/evidence/handoff/review-follow-up decision rather than

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -23,8 +23,12 @@ register local skills, or launch work against files.
 Setup is reviewable. Hecate may propose roles or memory candidates, but the
 operator applies or dismisses them. Setup does not launch agents, write project
 memory automatically, install skills, or inject skill bodies into prompts.
-Use the onboarding checklist for missing settings or first-work creation; use
-the primary **Set up project** action for discovery and role/memory suggestions.
+The onboarding checklist is backed by
+`GET /hecate/v1/projects/{id}/setup-readiness`, a read-only server projection
+over project defaults, roots, context sources, memory, memory candidates,
+skills, roles, and work items. Use the checklist for missing settings or
+first-work creation; use the primary **Set up project** action for discovery
+and role/memory suggestions.
 When setup context exists and the project has no work items yet, first-work
 creation opens with a draft title, brief, and owner role for operator review.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1615,6 +1615,10 @@ written only through explicit operator API/UI actions. Enabled project memory
 entries appear as itemized chat context-packet metadata with their
 `trust_label`, but Hecate still does not perform automatic memory extraction,
 embeddings, retrieval ranking, or source-content injection.
+Project setup readiness, project health, and Project Operations are read-only
+cockpit projections over these existing records. They help the operator choose
+the next surface to open, but they do not create durable project records or
+start supervised work.
 
 ### `GET /hecate/v1/projects`
 
@@ -2467,6 +2471,73 @@ targets (`settings`, `memory`, `profiles`, `roles`, `skills`); `work_item_id`,
 to existing work, task, chat, memory-review, or activity surfaces. Clients
 should not mutate project state directly from a row; they open the referenced
 surface and use that surface's explicit typed mutation.
+
+#### `GET /hecate/v1/projects/{id}/setup-readiness`
+
+Returns a read-only Project setup readiness projection for the selected
+project. The endpoint decides whether the project should show first-run
+onboarding, whether setup has started, and whether the empty project is ready
+for first-work creation. It derives those flags from existing project roots,
+defaults, context sources, custom roles, skills metadata, project memory, memory
+candidates, and work items.
+
+The endpoint does not create tasks, runs, chats, proposals, roles, work items,
+memory entries, memory candidates, or skills. Checklist actions route the
+operator to existing typed surfaces: Project Settings, Project Assistant setup,
+or explicit work-item creation.
+
+```json
+{
+  "object": "project_setup_readiness",
+  "data": {
+    "project_id": "proj_...",
+    "generated_at": "2026-06-20T12:00:00Z",
+    "show_onboarding": true,
+    "setup_started": false,
+    "first_work_ready": false,
+    "summary": {
+      "work_item_count": 0,
+      "role_count": 0,
+      "skill_count": 0,
+      "enabled_context_source_count": 0,
+      "saved_memory_count": 0,
+      "pending_memory_candidate_count": 0,
+      "has_purpose": true,
+      "has_active_root": true,
+      "missing_defaults": false
+    },
+    "primary_action": {
+      "type": "bootstrap_project",
+      "project_id": "proj_...",
+      "label": "Set up project"
+    },
+    "checks": [
+      {
+        "id": "workspace_source",
+        "label": "Workspace source",
+        "detail": "/Users/alice/src/hecate",
+        "status": "ready"
+      },
+      {
+        "id": "first_work_item",
+        "label": "First work item",
+        "detail": "Create the first reviewable task after setup.",
+        "status": "todo",
+        "action": {
+          "type": "create_work_item",
+          "project_id": "proj_...",
+          "label": "Create work"
+        }
+      }
+    ]
+  }
+}
+```
+
+Known setup action types are `bootstrap_project`, `create_work_item`, and
+`open_project_settings`. Clients should dispatch on `action.type` and validate
+`project_id` before routing the operator. A stale or unsupported action should
+surface a refresh error rather than performing a guessed fallback.
 
 #### `GET /hecate/v1/projects/{id}/operations/brief`
 

--- a/internal/api/handler_project_setup_readiness.go
+++ b/internal/api/handler_project_setup_readiness.go
@@ -1,0 +1,305 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+const (
+	projectSetupReadinessStatusReady    = "ready"
+	projectSetupReadinessStatusTodo     = "todo"
+	projectSetupReadinessStatusOptional = "optional"
+
+	projectSetupReadinessActionBootstrap       = "bootstrap_project"
+	projectSetupReadinessActionCreateWorkItem  = "create_work_item"
+	projectSetupReadinessActionProjectSettings = "open_project_settings"
+)
+
+type ProjectSetupReadinessEnvelope struct {
+	Object string                        `json:"object"`
+	Data   ProjectSetupReadinessResponse `json:"data"`
+}
+
+type ProjectSetupReadinessResponse struct {
+	ProjectID      string                               `json:"project_id"`
+	GeneratedAt    string                               `json:"generated_at"`
+	ShowOnboarding bool                                 `json:"show_onboarding"`
+	SetupStarted   bool                                 `json:"setup_started"`
+	FirstWorkReady bool                                 `json:"first_work_ready"`
+	Summary        ProjectSetupReadinessSummaryResponse `json:"summary"`
+	PrimaryAction  ProjectSetupReadinessActionResponse  `json:"primary_action"`
+	Checks         []ProjectSetupReadinessCheckResponse `json:"checks"`
+}
+
+type ProjectSetupReadinessSummaryResponse struct {
+	WorkItemCount               int  `json:"work_item_count"`
+	RoleCount                   int  `json:"role_count"`
+	SkillCount                  int  `json:"skill_count"`
+	EnabledContextSourceCount   int  `json:"enabled_context_source_count"`
+	SavedMemoryCount            int  `json:"saved_memory_count"`
+	PendingMemoryCandidateCount int  `json:"pending_memory_candidate_count"`
+	HasPurpose                  bool `json:"has_purpose"`
+	HasActiveRoot               bool `json:"has_active_root"`
+	MissingDefaults             bool `json:"missing_defaults"`
+}
+
+type ProjectSetupReadinessCheckResponse struct {
+	ID       string                               `json:"id"`
+	Label    string                               `json:"label"`
+	Detail   string                               `json:"detail"`
+	Status   string                               `json:"status"`
+	Optional bool                                 `json:"optional,omitempty"`
+	Action   *ProjectSetupReadinessActionResponse `json:"action,omitempty"`
+}
+
+type ProjectSetupReadinessActionResponse struct {
+	Type      string `json:"type"`
+	ProjectID string `json:"project_id"`
+	Label     string `json:"label"`
+}
+
+func (h *Handler) HandleProjectSetupReadiness(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if !h.requireProject(w, r, projectID) {
+		return
+	}
+	readiness, err := h.renderProjectSetupReadiness(r.Context(), projectID)
+	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectSetupReadinessEnvelope{Object: "project_setup_readiness", Data: readiness})
+}
+
+func (h *Handler) renderProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	if !ok {
+		return ProjectSetupReadinessResponse{}, projects.ErrNotFound
+	}
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	workItems, err := h.projectWork.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	entries, err := h.projectSetupReadinessMemoryEntries(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	candidates, err := h.projectSetupReadinessMemoryCandidates(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	skills, err := h.projectSetupReadinessSkills(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+
+	summary := projectSetupReadinessSummary(project, workItems, roles, skills, entries, candidates)
+	setupStarted := summary.EnabledContextSourceCount > 0 ||
+		summary.RoleCount > 0 ||
+		summary.SkillCount > 0 ||
+		summary.SavedMemoryCount > 0 ||
+		summary.PendingMemoryCandidateCount > 0
+	firstWorkReady := summary.WorkItemCount == 0 && setupStarted
+	return ProjectSetupReadinessResponse{
+		ProjectID:      project.ID,
+		GeneratedAt:    formatOptionalTime(time.Now().UTC()),
+		ShowOnboarding: summary.WorkItemCount == 0 && !setupStarted,
+		SetupStarted:   setupStarted,
+		FirstWorkReady: firstWorkReady,
+		Summary:        summary,
+		PrimaryAction:  projectSetupReadinessAction(projectSetupReadinessActionBootstrap, project.ID, "Set up project"),
+		Checks:         projectSetupReadinessChecks(project, summary),
+	}, nil
+}
+
+func (h *Handler) projectSetupReadinessMemoryEntries(ctx context.Context, projectID string) ([]memory.Entry, error) {
+	if h.memory == nil {
+		return nil, nil
+	}
+	return h.memory.List(ctx, memory.Filter{ProjectID: strings.TrimSpace(projectID), IncludeDisabled: true})
+}
+
+func (h *Handler) projectSetupReadinessMemoryCandidates(ctx context.Context, projectID string) ([]memory.Candidate, error) {
+	if h.memoryCandidates == nil {
+		return nil, nil
+	}
+	return h.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{ProjectID: strings.TrimSpace(projectID), Status: memory.CandidateStatusPending})
+}
+
+func (h *Handler) projectSetupReadinessSkills(ctx context.Context, projectID string) ([]projectskills.Skill, error) {
+	if h.projectSkills == nil {
+		return nil, nil
+	}
+	return h.projectSkills.List(ctx, projectID)
+}
+
+func projectSetupReadinessSummary(project projects.Project, workItems []projectwork.WorkItem, roles []projectwork.AgentRoleProfile, skills []projectskills.Skill, entries []memory.Entry, candidates []memory.Candidate) ProjectSetupReadinessSummaryResponse {
+	summary := ProjectSetupReadinessSummaryResponse{
+		WorkItemCount:   len(workItems),
+		RoleCount:       len(projectSetupCustomRoles(roles)),
+		SkillCount:      len(skills),
+		HasPurpose:      strings.TrimSpace(project.Description) != "",
+		HasActiveRoot:   projectHasActiveRoot(project),
+		MissingDefaults: projectHealthMissingDefaults(project),
+	}
+	for _, source := range project.ContextSources {
+		if source.Enabled {
+			summary.EnabledContextSourceCount++
+		}
+	}
+	summary.SavedMemoryCount = len(entries)
+	summary.PendingMemoryCandidateCount = len(candidates)
+	return summary
+}
+
+func projectSetupCustomRoles(roles []projectwork.AgentRoleProfile) []projectwork.AgentRoleProfile {
+	items := make([]projectwork.AgentRoleProfile, 0, len(roles))
+	for _, role := range roles {
+		if role.BuiltIn || projectwork.IsBuiltInRoleID(role.ID) {
+			continue
+		}
+		items = append(items, role)
+	}
+	return items
+}
+
+func projectSetupReadinessChecks(project projects.Project, summary ProjectSetupReadinessSummaryResponse) []ProjectSetupReadinessCheckResponse {
+	projectID := project.ID
+	hasGuidance := summary.EnabledContextSourceCount > 0 || summary.SkillCount > 0 || summary.SavedMemoryCount > 0 || summary.PendingMemoryCandidateCount > 0
+	return []ProjectSetupReadinessCheckResponse{
+		projectSetupCheck("purpose", "Project purpose", strings.TrimSpace(project.Description), summary.HasPurpose, false, projectSetupReadinessAction(projectSetupReadinessActionProjectSettings, projectID, "Add purpose"), "Add a short purpose."),
+		projectSetupWorkspaceCheck(project),
+		projectSetupCheck("launch_defaults", "Provider and model", projectSetupDefaultsDetail(project, summary), !summary.MissingDefaults, false, projectSetupReadinessAction(projectSetupReadinessActionProjectSettings, projectID, "Set defaults"), "Not set"),
+		projectSetupCheck("sources_memory", "Sources and memory", projectSetupGuidanceDetail(summary, project), hasGuidance, false, projectSetupReadinessAction(projectSetupReadinessActionBootstrap, projectID, "Set up project"), ""),
+		projectSetupCheck("roles", "Roles", projectSetupRoleDetail(summary), summary.RoleCount > 0, false, projectSetupReadinessAction(projectSetupReadinessActionBootstrap, projectID, "Set up project"), ""),
+		projectSetupCheck("first_work_item", "First work item", projectSetupFirstWorkDetail(summary), summary.WorkItemCount > 0, false, projectSetupReadinessAction(projectSetupReadinessActionCreateWorkItem, projectID, "Create work"), ""),
+	}
+}
+
+func projectSetupCheck(id, label, detail string, done bool, optional bool, action ProjectSetupReadinessActionResponse, fallbackDetail string) ProjectSetupReadinessCheckResponse {
+	status := projectSetupReadinessStatusTodo
+	if optional {
+		status = projectSetupReadinessStatusOptional
+	} else if done {
+		status = projectSetupReadinessStatusReady
+	}
+	check := ProjectSetupReadinessCheckResponse{
+		ID:       id,
+		Label:    label,
+		Detail:   strings.TrimSpace(detail),
+		Status:   status,
+		Optional: optional,
+	}
+	if check.Detail == "" {
+		check.Detail = fallbackDetail
+	}
+	if !done && !optional {
+		check.Action = &action
+	}
+	return check
+}
+
+func projectSetupWorkspaceCheck(project projects.Project) ProjectSetupReadinessCheckResponse {
+	if root, ok := projectSetupActiveRoot(project); ok {
+		return ProjectSetupReadinessCheckResponse{
+			ID:     "workspace_source",
+			Label:  "Workspace source",
+			Detail: root.Path,
+			Status: projectSetupReadinessStatusReady,
+		}
+	}
+	return ProjectSetupReadinessCheckResponse{
+		ID:       "workspace_source",
+		Label:    "Workspace source",
+		Detail:   "Optional; attach files when this project needs them.",
+		Status:   projectSetupReadinessStatusOptional,
+		Optional: true,
+	}
+}
+
+func projectSetupActiveRoot(project projects.Project) (projects.Root, bool) {
+	for _, root := range project.Roots {
+		if root.Active && strings.TrimSpace(root.Path) != "" {
+			return root, true
+		}
+	}
+	return projects.Root{}, false
+}
+
+func projectSetupDefaultsDetail(project projects.Project, summary ProjectSetupReadinessSummaryResponse) string {
+	if summary.MissingDefaults {
+		return "Not set"
+	}
+	return strings.TrimSpace(project.DefaultProvider) + " / " + strings.TrimSpace(project.DefaultModel)
+}
+
+func projectSetupGuidanceDetail(summary ProjectSetupReadinessSummaryResponse, project projects.Project) string {
+	parts := make([]string, 0, 4)
+	if summary.EnabledContextSourceCount > 0 {
+		parts = append(parts, projectSetupCountLabel(summary.EnabledContextSourceCount, "source"))
+	}
+	if summary.SkillCount > 0 {
+		parts = append(parts, projectSetupCountLabel(summary.SkillCount, "skill"))
+	}
+	if summary.SavedMemoryCount > 0 {
+		parts = append(parts, projectSetupCountLabel(summary.SavedMemoryCount, "memory"))
+	}
+	if summary.PendingMemoryCandidateCount > 0 {
+		parts = append(parts, projectSetupCountLabel(summary.PendingMemoryCandidateCount, "candidate"))
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, " · ")
+	}
+	if projectHasActiveRoot(project) {
+		return "Set up project can discover workspace guidance and local skills."
+	}
+	return "Attach a workspace when files matter, or add sources later."
+}
+
+func projectSetupRoleDetail(summary ProjectSetupReadinessSummaryResponse) string {
+	if summary.RoleCount > 0 {
+		return projectSetupCountLabel(summary.RoleCount, "role")
+	}
+	return "Set up project can suggest roles from skills."
+}
+
+func projectSetupFirstWorkDetail(summary ProjectSetupReadinessSummaryResponse) string {
+	if summary.WorkItemCount > 0 {
+		return projectSetupCountLabel(summary.WorkItemCount, "work item")
+	}
+	return "Create the first reviewable task after setup."
+}
+
+func projectSetupCountLabel(count int, singular string) string {
+	if count == 1 {
+		return "1 " + singular
+	}
+	return intString(count) + " " + singular + "s"
+}
+
+func projectSetupReadinessAction(actionType, projectID, label string) ProjectSetupReadinessActionResponse {
+	return ProjectSetupReadinessActionResponse{
+		Type:      actionType,
+		ProjectID: projectID,
+		Label:     label,
+	}
+}

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestProjectSetupReadiness_ReadOnlyPristineProject(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_setup",
+		Name: "Setup",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	beforeWork, err := handler.projectWork.ListWorkItems(t.Context(), "proj_setup")
+	if err != nil {
+		t.Fatalf("ListWorkItems before: %v", err)
+	}
+	beforeRoles, err := handler.projectWork.ListRoles(t.Context(), "proj_setup")
+	if err != nil {
+		t.Fatalf("ListRoles before: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_setup/setup-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSetupReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode setup readiness: %v", err)
+	}
+	if response.Object != "project_setup_readiness" || response.Data.ProjectID != "proj_setup" {
+		t.Fatalf("setup readiness envelope = %+v, want project_setup_readiness for project", response)
+	}
+	if !response.Data.ShowOnboarding || response.Data.SetupStarted || response.Data.FirstWorkReady {
+		t.Fatalf("setup readiness flags = %+v, want onboarding for pristine project", response.Data)
+	}
+	if response.Data.Summary.WorkItemCount != 0 || response.Data.Summary.RoleCount != 0 || !response.Data.Summary.MissingDefaults {
+		t.Fatalf("setup readiness summary = %+v, want empty project with missing defaults", response.Data.Summary)
+	}
+	if response.Data.PrimaryAction.Type != projectSetupReadinessActionBootstrap || response.Data.PrimaryAction.Label != "Set up project" {
+		t.Fatalf("primary action = %+v, want setup action", response.Data.PrimaryAction)
+	}
+	purpose := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "purpose")
+	if purpose.Status != projectSetupReadinessStatusTodo || purpose.Action == nil || purpose.Action.Type != projectSetupReadinessActionProjectSettings {
+		t.Fatalf("purpose check = %+v, want settings todo", purpose)
+	}
+	workspace := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "workspace_source")
+	if workspace.Status != projectSetupReadinessStatusOptional || !workspace.Optional || workspace.Action != nil {
+		t.Fatalf("workspace check = %+v, want optional without action", workspace)
+	}
+	sources := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "sources_memory")
+	if sources.Status != projectSetupReadinessStatusTodo || sources.Action == nil || sources.Action.Type != projectSetupReadinessActionBootstrap {
+		t.Fatalf("sources check = %+v, want bootstrap todo", sources)
+	}
+	firstWork := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "first_work_item")
+	if firstWork.Status != projectSetupReadinessStatusTodo || firstWork.Action == nil || firstWork.Action.Type != projectSetupReadinessActionCreateWorkItem {
+		t.Fatalf("first work check = %+v, want create-work todo", firstWork)
+	}
+
+	afterWork, err := handler.projectWork.ListWorkItems(t.Context(), "proj_setup")
+	if err != nil {
+		t.Fatalf("ListWorkItems after: %v", err)
+	}
+	afterRoles, err := handler.projectWork.ListRoles(t.Context(), "proj_setup")
+	if err != nil {
+		t.Fatalf("ListRoles after: %v", err)
+	}
+	if len(beforeWork) != len(afterWork) || len(beforeRoles) != len(afterRoles) {
+		t.Fatalf("setup readiness mutated project state: work %d->%d roles %d->%d", len(beforeWork), len(afterWork), len(beforeRoles), len(afterRoles))
+	}
+}
+
+func TestProjectSetupReadiness_SetupStartedFirstWorkReady(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	root := t.TempDir()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_ready",
+		Name:            "Ready",
+		Description:     "Coordinate release work.",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+		Roots:           []projects.Root{{ID: "root_ready", Path: root, Kind: "git", Active: true}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_ready",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:        "role_ready",
+		ProjectID: "proj_ready",
+		Name:      "Owner",
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), "proj_ready", []projectskills.Skill{{
+		ID:        "skill_ready",
+		ProjectID: "proj_ready",
+		Path:      "skills/ready/SKILL.md",
+		Enabled:   true,
+		Status:    projectskills.StatusAvailable,
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:        "mem_ready",
+		ProjectID: "proj_ready",
+		Title:     "Release posture",
+		Body:      "Keep setup explicit.",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:        "memcand_ready",
+		ProjectID: "proj_ready",
+		Title:     "Candidate",
+		Body:      "Review me.",
+		Status:    memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_ready/setup-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSetupReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode setup readiness: %v", err)
+	}
+	if response.Data.ShowOnboarding || !response.Data.SetupStarted || !response.Data.FirstWorkReady {
+		t.Fatalf("setup readiness flags = %+v, want setup started and first work ready", response.Data)
+	}
+	if response.Data.Summary.EnabledContextSourceCount != 1 || response.Data.Summary.RoleCount != 1 || response.Data.Summary.SkillCount != 1 || response.Data.Summary.SavedMemoryCount != 1 || response.Data.Summary.PendingMemoryCandidateCount != 1 {
+		t.Fatalf("setup readiness summary = %+v, want setup counts", response.Data.Summary)
+	}
+	if response.Data.Summary.MissingDefaults || !response.Data.Summary.HasPurpose || !response.Data.Summary.HasActiveRoot {
+		t.Fatalf("setup readiness summary = %+v, want ready project defaults/purpose/root", response.Data.Summary)
+	}
+	for _, id := range []string{"purpose", "workspace_source", "launch_defaults", "sources_memory", "roles"} {
+		check := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, id)
+		if check.Status != projectSetupReadinessStatusReady || check.Action != nil {
+			t.Fatalf("check %s = %+v, want ready without action", id, check)
+		}
+	}
+	firstWork := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "first_work_item")
+	if firstWork.Status != projectSetupReadinessStatusTodo || firstWork.Action == nil || firstWork.Action.Type != projectSetupReadinessActionCreateWorkItem {
+		t.Fatalf("first work check = %+v, want create-work todo", firstWork)
+	}
+}
+
+func findProjectSetupReadinessCheckForTest(t *testing.T, checks []ProjectSetupReadinessCheckResponse, id string) ProjectSetupReadinessCheckResponse {
+	t.Helper()
+	for _, check := range checks {
+		if check.ID == id {
+			return check
+		}
+	}
+	t.Fatalf("missing setup readiness check %q in %+v", id, checks)
+	return ProjectSetupReadinessCheckResponse{}
+}

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -60,6 +60,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/activity"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/health"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/operations/brief"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/setup-readiness"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/roles"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/roles"},
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}/roles/{role_id}"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -97,6 +97,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/activity", handler.HandleProjectActivity)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/health", handler.HandleProjectHealth)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/operations/brief", handler.HandleProjectOperationsBrief)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/setup-readiness", handler.HandleProjectSetupReadiness)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/roles", handler.HandleProjectWorkRoles)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roles", handler.HandleCreateProjectWorkRole)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/roles/{role_id}", handler.HandleUpdateProjectWorkRole)

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -8,6 +8,7 @@ import type {
   ProjectHealth,
   ProjectMemoryCandidateRecord,
   ProjectRecord,
+  ProjectSetupReadiness,
   ProjectSkillRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
@@ -33,7 +34,11 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await page.getByRole("button", { name: "Create project" }).click();
 
   await expect(page.getByText("Set up Launch operations")).toBeVisible();
-  await page.getByRole("button", { name: "Set up project" }).click();
+  await page
+    .getByRole("region", { name: "Project onboarding" })
+    .getByRole("button", { name: "Set up project" })
+    .first()
+    .click();
   await expect(page.getByText("Bootstrap Launch operations guidance")).toBeVisible();
   await page.getByRole("button", { name: "Apply proposal" }).click();
 
@@ -337,6 +342,12 @@ async function mockProjectJourneyAPIs(page: Page) {
     }
     if (resource === "health") {
       await route.fulfill(ok({ object: "project_health", data: projectHealth(state, projectID) }));
+      return;
+    }
+    if (resource === "setup-readiness") {
+      await route.fulfill(
+        ok({ object: "project_setup_readiness", data: projectSetupReadiness(state, projectID) }),
+      );
       return;
     }
     if (resource === "operations" && parts[2] === "brief") {
@@ -804,6 +815,123 @@ function projectHealth(state: ProjectJourneyState, projectID: string): ProjectHe
       stale_or_unknown_assignment_count: 0,
     },
     attention: [],
+  };
+}
+
+function projectSetupReadiness(
+  state: ProjectJourneyState,
+  projectID: string,
+): ProjectSetupReadiness {
+  const project = state.projects.find((item) => item.id === projectID) ?? state.projects[0];
+  const enabledContextSourceCount = state.sources.filter((source) => source.enabled).length;
+  const pendingMemoryCandidateCount = state.memoryCandidates.filter(
+    (candidate) => candidate.status === "pending",
+  ).length;
+  const roleCount = state.roles.filter((role) => !role.built_in).length;
+  const skillCount = state.skills.length;
+  const workItemCount = state.workItems.filter((item) => item.project_id === projectID).length;
+  const hasActiveRoot = Boolean(project?.roots?.some((root) => root.active && root.path));
+  const missingDefaults = !(project?.default_provider && project?.default_model);
+  const setupStarted =
+    enabledContextSourceCount > 0 ||
+    roleCount > 0 ||
+    skillCount > 0 ||
+    pendingMemoryCandidateCount > 0;
+  return {
+    project_id: projectID,
+    generated_at: NOW,
+    show_onboarding: workItemCount === 0 && !setupStarted,
+    setup_started: setupStarted,
+    first_work_ready: workItemCount === 0 && setupStarted,
+    summary: {
+      work_item_count: workItemCount,
+      role_count: roleCount,
+      skill_count: skillCount,
+      enabled_context_source_count: enabledContextSourceCount,
+      saved_memory_count: 0,
+      pending_memory_candidate_count: pendingMemoryCandidateCount,
+      has_purpose: Boolean(project?.description?.trim()),
+      has_active_root: hasActiveRoot,
+      missing_defaults: missingDefaults,
+    },
+    primary_action: {
+      type: "bootstrap_project",
+      project_id: projectID,
+      label: "Set up project",
+    },
+    checks: [
+      {
+        id: "purpose",
+        label: "Project purpose",
+        detail: project?.description || "Add a short purpose.",
+        status: project?.description?.trim() ? "ready" : "todo",
+        action: project?.description?.trim()
+          ? undefined
+          : { type: "open_project_settings", project_id: projectID, label: "Add purpose" },
+      },
+      {
+        id: "workspace_source",
+        label: "Workspace source",
+        detail:
+          project?.roots?.find((root) => root.active && root.path)?.path ||
+          "Optional; attach files when this project needs them.",
+        status: hasActiveRoot ? "ready" : "optional",
+        optional: !hasActiveRoot,
+      },
+      {
+        id: "launch_defaults",
+        label: "Provider and model",
+        detail: missingDefaults
+          ? "Not set"
+          : `${project?.default_provider} / ${project?.default_model}`,
+        status: missingDefaults ? "todo" : "ready",
+        action: missingDefaults
+          ? { type: "open_project_settings", project_id: projectID, label: "Set defaults" }
+          : undefined,
+      },
+      {
+        id: "sources_memory",
+        label: "Sources and memory",
+        detail:
+          enabledContextSourceCount > 0 || pendingMemoryCandidateCount > 0 || skillCount > 0
+            ? `${enabledContextSourceCount} source(s), ${pendingMemoryCandidateCount} memory candidate(s), ${skillCount} skill(s)`
+            : "Attach a workspace when files matter, or add sources later.",
+        status:
+          enabledContextSourceCount > 0 || pendingMemoryCandidateCount > 0 || skillCount > 0
+            ? "ready"
+            : "todo",
+        action:
+          enabledContextSourceCount > 0 || pendingMemoryCandidateCount > 0 || skillCount > 0
+            ? undefined
+            : { type: "bootstrap_project", project_id: projectID, label: "Set up project" },
+      },
+      {
+        id: "roles",
+        label: "Roles",
+        detail:
+          roleCount > 0
+            ? `${roleCount} role(s) configured.`
+            : "Set up project can suggest roles from skills.",
+        status: roleCount > 0 ? "ready" : "todo",
+        action:
+          roleCount > 0
+            ? undefined
+            : { type: "bootstrap_project", project_id: projectID, label: "Set up project" },
+      },
+      {
+        id: "first_work_item",
+        label: "First work item",
+        detail:
+          workItemCount > 0
+            ? `${workItemCount} work item(s) created.`
+            : "Create the first reviewable task after setup.",
+        status: workItemCount > 0 ? "ready" : "todo",
+        action:
+          workItemCount > 0
+            ? undefined
+            : { type: "create_work_item", project_id: projectID, label: "Create work" },
+      },
+    ],
   };
 }
 

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -15,6 +15,7 @@ import {
   getProjectHandoffs,
   getProjectHealth,
   getProjectOperationsBrief,
+  getProjectSetupReadiness,
   getProjectWorkItem,
   getProjectWorkItemReadiness,
   getProjectWorkItems,
@@ -23,6 +24,7 @@ import {
 import type {
   ProjectAssignmentRecord,
   ProjectHealth,
+  ProjectSetupReadiness,
   ProjectWorkItemRecord,
 } from "../types/project";
 
@@ -50,6 +52,10 @@ vi.mock("../lib/api", async (importOriginal) => {
     getProjectHealth: vi.fn(async () => ({
       object: "project_health",
       data: emptyProjectHealthData(),
+    })),
+    getProjectSetupReadiness: vi.fn(async () => ({
+      object: "project_setup_readiness",
+      data: emptyProjectSetupReadinessData(),
     })),
     getProjectWorkRoles: vi.fn(async () => ({ object: "project_roles", data: [] })),
     getProjectWorkItems: vi.fn(async () => ({ object: "project_work_items", data: [] })),
@@ -146,6 +152,33 @@ function emptyProjectHealthData(): ProjectHealth {
   };
 }
 
+function emptyProjectSetupReadinessData(): ProjectSetupReadiness {
+  return {
+    project_id: "",
+    generated_at: "",
+    show_onboarding: false,
+    setup_started: true,
+    first_work_ready: false,
+    summary: {
+      work_item_count: 0,
+      role_count: 0,
+      skill_count: 0,
+      enabled_context_source_count: 0,
+      saved_memory_count: 0,
+      pending_memory_candidate_count: 0,
+      has_purpose: false,
+      has_active_root: false,
+      missing_defaults: false,
+    },
+    primary_action: {
+      type: "bootstrap_project",
+      project_id: "",
+      label: "Set up project",
+    },
+    checks: [],
+  };
+}
+
 function resetProjectWorkMocks() {
   const emptyWorkItem: ProjectWorkItemRecord = {
     id: "",
@@ -167,6 +200,10 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectHealth).mockResolvedValue({
     object: "project_health",
     data: emptyProjectHealthData(),
+  });
+  vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+    object: "project_setup_readiness",
+    data: emptyProjectSetupReadinessData(),
   });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({ object: "project_work_items", data: [] });

--- a/ui/src/features/projects/ProjectHealthPanel.test.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.test.tsx
@@ -96,6 +96,7 @@ function renderPanel(overrides: Partial<Parameters<typeof ProjectHealthPanel>[0]
   const handlers = {
     onAttentionBucket: vi.fn(),
     onAttentionDefaults: vi.fn(),
+    onAttentionError: vi.fn(),
     onAttentionMemory: vi.fn(),
     onAttentionProfiles: vi.fn(),
     onAttentionReviewCandidate: vi.fn(),
@@ -163,6 +164,32 @@ describe("ProjectHealthPanel", () => {
     );
 
     expect(handlers.onAttentionMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports stale project attention targets without navigating", async () => {
+    const { handlers } = renderPanel({
+      attentionItems: [
+        {
+          id: "proj_other:defaults",
+          project_id: "proj_other",
+          title: "Provider/model defaults missing",
+          detail: "Set defaults before starting assignments.",
+          status: "awaiting_approval",
+          action: "settings",
+        },
+      ],
+      selectedProjectID: "proj_1",
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Project attention: 1" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Open attention item Provider/model defaults missing" }),
+    );
+
+    expect(handlers.onAttentionError).toHaveBeenCalledWith(
+      "Project attention target changed. Refresh project work and try again.",
+    );
+    expect(handlers.onAttentionDefaults).not.toHaveBeenCalled();
   });
 
   it("shows when lower-priority attention items are hidden", async () => {

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../../types/project";
 import { Badge, Icon, Icons } from "../shared/ui";
 import { useFloatingMenu } from "../shared/useFloatingMenu";
+import { routeProjectHealthAttention, type ProjectActionRoute } from "./projectActionRouting";
 import { activitySignalLabel } from "./projectInsights";
 
 export type ProjectHealthPanelProps = {
@@ -15,9 +16,11 @@ export type ProjectHealthPanelProps = {
   disabled?: boolean;
   memoryCandidates: ProjectMemoryCandidateRecord[];
   omittedAttentionCount?: number;
+  selectedProjectID?: string;
   summary?: ProjectHealthSummary;
   onAttentionBucket: (bucket: ProjectActivityBucketKey) => void;
   onAttentionDefaults: () => void;
+  onAttentionError?: (message: string) => void;
   onAttentionMemory: () => void;
   onAttentionProfiles: () => void;
   onAttentionReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
@@ -33,9 +36,11 @@ export function ProjectHealthPanel({
   disabled = false,
   memoryCandidates,
   omittedAttentionCount = 0,
+  selectedProjectID,
   summary,
   onAttentionBucket,
   onAttentionDefaults,
+  onAttentionError,
   onAttentionMemory,
   onAttentionProfiles,
   onAttentionReviewCandidate,
@@ -60,28 +65,56 @@ export function ProjectHealthPanel({
   const postureRows = projectHealthPostureRows(summary);
   const closeMenu = () => attentionMenu.close();
   const handleAttentionAction = (item: ProjectHealthAttention) => {
-    if (item.action === "settings" || item.id.endsWith(":defaults")) {
-      onAttentionDefaults();
-    } else if (item.action === "skills") {
-      onAttentionSkills();
-    } else if (item.action === "profiles") {
-      onAttentionProfiles();
-    } else if (item.action === "roles") {
-      onAttentionRoles();
-    } else if (item.candidate_id) {
-      const candidate = memoryCandidates.find((candidate) => candidate.id === item.candidate_id);
-      if (candidate) onAttentionReviewCandidate(candidate);
-      else onAttentionMemory();
-    } else if (item.work_item_id) {
-      onAttentionWorkItem(item.work_item_id);
-    } else if (item.task_id) {
-      onAttentionTask?.(item.task_id, item.run_id);
-    } else if (item.bucket) {
-      onAttentionBucket(item.bucket);
-    } else if (item.action === "memory" || item.id.endsWith(":context")) {
-      onAttentionMemory();
-    }
+    const candidate = memoryCandidates.find((candidate) => candidate.id === item.candidate_id);
+    handleAttentionRoute(
+      routeProjectHealthAttention(item, {
+        hasMemoryCandidate: Boolean(candidate),
+        selectedProjectID,
+      }),
+      candidate,
+    );
     closeMenu();
+  };
+  const handleAttentionRoute = (
+    route: ProjectActionRoute,
+    candidate?: ProjectMemoryCandidateRecord,
+  ) => {
+    switch (route.kind) {
+      case "error":
+        onAttentionError?.(route.message);
+        return;
+      case "open_project_settings":
+        onAttentionDefaults();
+        return;
+      case "open_skills":
+        onAttentionSkills();
+        return;
+      case "open_profiles":
+        onAttentionProfiles();
+        return;
+      case "open_roles":
+        onAttentionRoles();
+        return;
+      case "review_memory_candidate":
+        if (candidate) onAttentionReviewCandidate(candidate);
+        else onAttentionMemory();
+        return;
+      case "open_work_item":
+        if (route.bucket) onAttentionBucket(route.bucket);
+        onAttentionWorkItem(route.workItemID);
+        return;
+      case "open_task":
+        onAttentionTask?.(route.taskID, route.runID);
+        return;
+      case "open_activity_bucket":
+        onAttentionBucket(route.bucket);
+        return;
+      case "open_memory_review":
+        onAttentionMemory();
+        return;
+      default:
+        return;
+    }
   };
   return (
     <div ref={attentionMenu.wrapRef} style={projectAttentionMenuStyle}>

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -8,6 +8,7 @@ import type {
   ProjectAssignmentRecord,
   ProjectMemoryCandidateRecord,
   ProjectRecord,
+  ProjectSetupReadiness,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
 } from "../../types/project";
@@ -183,6 +184,77 @@ function assistant() {
   } as unknown as ProjectWorkspaceViewProps["assistant"];
 }
 
+function setupReadiness(overrides: Partial<ProjectSetupReadiness> = {}): ProjectSetupReadiness {
+  return {
+    project_id: "proj_1",
+    generated_at: "2026-06-20T00:00:00Z",
+    show_onboarding: true,
+    setup_started: false,
+    first_work_ready: false,
+    summary: {
+      work_item_count: 0,
+      role_count: 0,
+      skill_count: 0,
+      enabled_context_source_count: 0,
+      saved_memory_count: 0,
+      pending_memory_candidate_count: 0,
+      has_purpose: false,
+      has_active_root: false,
+      missing_defaults: true,
+    },
+    primary_action: {
+      type: "bootstrap_project",
+      project_id: "proj_1",
+      label: "Set up project",
+    },
+    checks: [
+      {
+        id: "purpose",
+        label: "Project purpose",
+        detail: "Add a short purpose.",
+        status: "todo",
+        action: { type: "open_project_settings", project_id: "proj_1", label: "Add purpose" },
+      },
+      {
+        id: "workspace_source",
+        label: "Workspace source",
+        detail: "Optional; attach files when this project needs them.",
+        status: "optional",
+        optional: true,
+      },
+      {
+        id: "launch_defaults",
+        label: "Provider and model",
+        detail: "Not set",
+        status: "todo",
+        action: { type: "open_project_settings", project_id: "proj_1", label: "Set defaults" },
+      },
+      {
+        id: "sources_memory",
+        label: "Sources and memory",
+        detail: "Attach a workspace when files matter, or add sources later.",
+        status: "todo",
+        action: { type: "bootstrap_project", project_id: "proj_1", label: "Set up project" },
+      },
+      {
+        id: "roles",
+        label: "Roles",
+        detail: "Set up project can suggest roles from skills.",
+        status: "todo",
+        action: { type: "bootstrap_project", project_id: "proj_1", label: "Set up project" },
+      },
+      {
+        id: "first_work_item",
+        label: "First work item",
+        detail: "Create the first reviewable task after setup.",
+        status: "todo",
+        action: { type: "create_work_item", project_id: "proj_1", label: "Create work" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
 function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
   const handlers = {
     onActivityBucketChange: vi.fn(),
@@ -229,6 +301,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     onSetHandoffStatus: vi.fn(),
     onStartAssignment: vi.fn(),
     onStartHandoff: vi.fn(),
+    onSetupReadinessAction: vi.fn(),
     onUpdateProjectSkill: vi.fn(),
     onWorkspaceTabChange: vi.fn(),
   };
@@ -258,6 +331,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     projectEmptyDetail: "Choose a project.",
     projectEmptyTitle: "No project selected",
     projectNeedsOnboarding: false,
+    projectSetupReadiness: null,
     operationsBrief: null,
     operationsBriefError: "",
     operationsBriefLoadState: "idle",
@@ -289,11 +363,10 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
 
 describe("ProjectWorkspaceView", () => {
   it("renders onboarding and delegates setup actions", async () => {
-    const assistantState = assistant();
     const { handlers } = renderWorkspace({
-      assistant: assistantState,
       project: project({ name: "Console" }),
       projectNeedsOnboarding: true,
+      projectSetupReadiness: setupReadiness(),
     });
 
     expect(screen.getByText("Set up Console")).toBeTruthy();
@@ -307,12 +380,31 @@ describe("ProjectWorkspaceView", () => {
     expect(screen.queryByRole("button", { name: "Set up" })).toBeNull();
     const firstWorkCheck = screen.getByRole("group", { name: "First work item" });
     await userEvent.click(within(firstWorkCheck).getByRole("button", { name: "Create work" }));
-    await userEvent.click(screen.getByRole("button", { name: "Set up project" }));
+    await userEvent.click(screen.getAllByRole("button", { name: "Set up project" })[0]);
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 
-    expect(assistantState.bootstrap).toHaveBeenCalledTimes(1);
-    expect(handlers.onCreateWork).toHaveBeenCalledTimes(1);
-    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(3);
+    expect(handlers.onSetupReadinessAction).toHaveBeenCalledTimes(4);
+    expect(handlers.onSetupReadinessAction).toHaveBeenNthCalledWith(1, {
+      type: "open_project_settings",
+      project_id: "proj_1",
+      label: "Add purpose",
+    });
+    expect(handlers.onSetupReadinessAction).toHaveBeenNthCalledWith(2, {
+      type: "open_project_settings",
+      project_id: "proj_1",
+      label: "Set defaults",
+    });
+    expect(handlers.onSetupReadinessAction).toHaveBeenNthCalledWith(3, {
+      type: "create_work_item",
+      project_id: "proj_1",
+      label: "Create work",
+    });
+    expect(handlers.onSetupReadinessAction).toHaveBeenNthCalledWith(4, {
+      type: "bootstrap_project",
+      project_id: "proj_1",
+      label: "Set up project",
+    });
+    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(1);
   });
 
   it("renders workspace tabs and delegates tab changes", async () => {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -13,13 +13,15 @@ import type {
   ProjectOperationsBrief,
   ProjectOperationsBriefItem,
   ProjectRecord,
+  ProjectSetupReadiness,
+  ProjectSetupReadinessAction,
+  ProjectSetupReadinessCheck,
   ProjectSkillRecord,
   ProjectWorkItemReadinessRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
   UpdateProjectSkillPayload,
 } from "../../types/project";
-import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
 import { ProjectMemoryPanel } from "./ProjectMemoryPanel";
@@ -118,12 +120,14 @@ export type ProjectWorkspaceViewProps = {
   onSetHandoffStatus: (handoff: ProjectHandoffRecord, status: string) => void;
   onStartAssignment: (assignment: ProjectAssignmentRecord) => void;
   onStartHandoff: (handoff: ProjectHandoffRecord) => void;
+  onSetupReadinessAction: (action: ProjectSetupReadinessAction) => void;
   onUpdateProjectSkill: (skill: ProjectSkillRecord, patch: UpdateProjectSkillPayload) => void;
   onWorkspaceTabChange: (tab: ProjectWorkspaceTab) => void;
   project: ProjectRecord | null;
   projectEmptyDetail: string;
   projectEmptyTitle: string;
   projectNeedsOnboarding: boolean;
+  projectSetupReadiness: ProjectSetupReadiness | null;
   operationsBrief: ProjectOperationsBrief | null;
   operationsBriefError: string;
   operationsBriefLoadState: LoadState;
@@ -213,12 +217,14 @@ export function ProjectWorkspaceView({
   onSetHandoffStatus,
   onStartAssignment,
   onStartHandoff,
+  onSetupReadinessAction,
   onUpdateProjectSkill,
   onWorkspaceTabChange,
   project,
   projectEmptyDetail,
   projectEmptyTitle,
   projectNeedsOnboarding,
+  projectSetupReadiness,
   operationsBrief,
   operationsBriefError,
   operationsBriefLoadState,
@@ -241,15 +247,13 @@ export function ProjectWorkspaceView({
   workLoadState,
   workspaceTab,
 }: ProjectWorkspaceViewProps) {
-  const enabledContextSourceCount =
-    project?.context_sources?.filter((source) => source.enabled).length ?? 0;
-  const projectSetupStarted =
-    enabledContextSourceCount > 0 ||
-    roles.length > 0 ||
-    projectSkills.length > 0 ||
-    memoryEntries.length > 0 ||
-    memoryCandidates.length > 0;
-  const projectSetupFirst = workItems.length === 0 && !selectedWorkItem;
+  const projectSetupStarted = projectSetupReadiness?.setup_started ?? false;
+  const projectSetupFirst = projectSetupReadiness?.first_work_ready ?? false;
+  const projectSetupAssistantMode =
+    projectSetupFirst ||
+    (workItems.length === 0 &&
+      !selectedWorkItem &&
+      (Boolean(assistant.proposal) || Boolean(assistant.applyResult)));
 
   return (
     <section style={detailStyle} aria-label="Selected work item">
@@ -257,16 +261,15 @@ export function ProjectWorkspaceView({
         {project ? (
           <section style={domainSectionStyle} aria-label="Project workspace">
             {projectNeedsOnboarding ? (
-              <ProjectOnboardingPanel
-                bootstrapPending={assistant.bootstrapPending}
-                contextSourceCount={enabledContextSourceCount}
-                onBootstrap={() => void assistant.bootstrap()}
-                onCreateWork={onCreateWork}
-                onOpenSettings={onOpenSettings}
-                project={project}
-                roleCount={roles.length}
-                skillCount={projectSkills.length}
-              />
+              projectSetupReadiness && (
+                <ProjectOnboardingPanel
+                  bootstrapPending={assistant.bootstrapPending}
+                  onAction={onSetupReadinessAction}
+                  onOpenSettings={onOpenSettings}
+                  project={project}
+                  readiness={projectSetupReadiness}
+                />
+              )
             ) : (
               <>
                 <ProjectAssistantPanel
@@ -300,7 +303,7 @@ export function ProjectWorkspaceView({
                   roles={roles}
                   memoryCandidateCount={memoryCandidates.length}
                   roleCount={roles.length}
-                  setupFirst={projectSetupFirst}
+                  setupFirst={projectSetupAssistantMode}
                   setupStarted={projectSetupStarted}
                   status={assistant.status}
                   workItem={selectedWorkItem}
@@ -567,86 +570,20 @@ function SectionHeader({
   );
 }
 
-type ProjectOnboardingCheck = {
-  action?: () => void;
-  actionDisabled?: boolean;
-  actionLabel?: string;
-  detail: string;
-  done: boolean;
-  label: string;
-  optional?: boolean;
-};
-
 function ProjectOnboardingPanel({
   bootstrapPending,
-  contextSourceCount,
-  onBootstrap,
-  onCreateWork,
+  onAction,
   onOpenSettings,
   project,
-  roleCount,
-  skillCount,
+  readiness,
 }: {
   bootstrapPending: boolean;
-  contextSourceCount: number;
-  onBootstrap: () => void;
-  onCreateWork: () => void;
+  onAction: (action: ProjectSetupReadinessAction) => void;
   onOpenSettings: () => void;
   project: ProjectRecord;
-  roleCount: number;
-  skillCount: number;
+  readiness: ProjectSetupReadiness;
 }) {
-  const hasRoot = project.roots.some((root) => root.active !== false && root.path);
-  const workspace = projectDefaultWorkspace(project);
-  const hasPurpose = Boolean(project.description?.trim());
-  const hasDefaults = Boolean(project.default_provider && project.default_model);
-  const hasGuidance = contextSourceCount > 0 || skillCount > 0;
-  const checks: ProjectOnboardingCheck[] = [
-    {
-      label: "Project purpose",
-      detail: hasPurpose ? project.description?.trim() || "Ready" : "Add a short purpose.",
-      done: hasPurpose,
-      actionLabel: "Add purpose",
-      action: onOpenSettings,
-    },
-    {
-      label: "Workspace source",
-      detail: hasRoot
-        ? workspace || "Ready"
-        : "Optional; attach files when this project needs them.",
-      done: true,
-      optional: !hasRoot,
-    },
-    {
-      label: "Provider and model",
-      detail: hasDefaults ? `${project.default_provider} / ${project.default_model}` : "Not set",
-      done: hasDefaults,
-      actionLabel: "Set defaults",
-      action: onOpenSettings,
-    },
-    {
-      label: "Sources and memory",
-      detail: hasGuidance
-        ? `${contextSourceCount} sources · ${skillCount} skills`
-        : hasRoot
-          ? "Set up project can discover workspace guidance and local skills."
-          : "Attach a workspace when files matter, or add sources later.",
-      done: hasGuidance,
-    },
-    {
-      label: "Roles",
-      detail:
-        roleCount > 0 ? `${roleCount} roles` : "Set up project can suggest roles from skills.",
-      done: roleCount > 0,
-    },
-    {
-      label: "First work item",
-      detail: "Create the first reviewable task after setup.",
-      done: false,
-      actionLabel: "Create work",
-      action: onCreateWork,
-    },
-  ];
+  const primaryAction = readiness.primary_action;
   return (
     <section aria-label="Project onboarding" style={projectOnboardingStyle}>
       <div style={projectOnboardingCopyStyle}>
@@ -662,11 +599,13 @@ function ProjectOnboardingPanel({
           <button
             className="btn btn-primary btn-sm"
             type="button"
-            disabled={bootstrapPending}
-            onClick={onBootstrap}
+            disabled={bootstrapPending && primaryAction.type === "bootstrap_project"}
+            onClick={() => onAction(primaryAction)}
           >
             <Icon d={Icons.refresh} size={13} />
-            {bootstrapPending ? "Setting up..." : "Set up project"}
+            {bootstrapPending && primaryAction.type === "bootstrap_project"
+              ? "Setting up..."
+              : primaryAction.label}
           </button>
           <button className="btn btn-ghost btn-sm" type="button" onClick={onOpenSettings}>
             <Icon d={Icons.settings} size={13} />
@@ -675,32 +614,32 @@ function ProjectOnboardingPanel({
         </div>
       </div>
       <div style={projectOnboardingChecklistStyle}>
-        {checks.map((check) => (
+        {readiness.checks.map((check) => (
           <div
             aria-label={check.label}
-            key={check.label}
+            key={check.id}
             role="group"
             style={projectOnboardingCheckStyle}
           >
             <span
-              className={check.done ? "badge badge-green" : "badge badge-muted"}
+              className={projectOnboardingCheckBadgeClass(check)}
               style={projectOnboardingCheckBadgeStyle}
             >
-              {check.optional ? "optional" : check.done ? "ready" : "todo"}
+              {projectOnboardingCheckBadgeLabel(check)}
             </span>
             <div style={{ minWidth: 0 }}>
               <div style={titleStyle}>{check.label}</div>
               <div style={subtleTextStyle}>{check.detail}</div>
             </div>
-            {!check.done && check.action && (
+            {check.status !== "ready" && !check.optional && check.action && (
               <button
                 className="btn btn-ghost btn-sm"
-                disabled={check.actionDisabled}
-                onClick={check.action}
+                disabled={bootstrapPending && check.action.type === "bootstrap_project"}
+                onClick={() => onAction(check.action!)}
                 style={projectOnboardingCheckActionStyle}
                 type="button"
               >
-                {check.actionLabel}
+                {check.action.label}
               </button>
             )}
           </div>
@@ -708,6 +647,16 @@ function ProjectOnboardingPanel({
       </div>
     </section>
   );
+}
+
+function projectOnboardingCheckBadgeClass(check: ProjectSetupReadinessCheck): string {
+  return check.status === "ready" ? "badge badge-green" : "badge badge-muted";
+}
+
+function projectOnboardingCheckBadgeLabel(check: ProjectSetupReadinessCheck): string {
+  if (check.optional || check.status === "optional") return "optional";
+  if (check.status === "ready") return "ready";
+  return "todo";
 }
 
 function ProjectOperationsBriefPanel({

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -39,6 +39,7 @@ import {
   getProjectMemory,
   getProjectMemoryCandidates,
   getProjectSkills,
+  getProjectSetupReadiness,
   getProjectWorkItem,
   getProjectWorkItemReadiness,
   getProjectWorkItems,
@@ -74,6 +75,7 @@ import type {
   ProjectMemoryCandidateRecord,
   ProjectMemoryRecord,
   ProjectRecord,
+  ProjectSetupReadiness,
   ProjectSkillRecord,
   ProjectWorkItemRecord,
   ProjectWorkRoleRecord,
@@ -173,6 +175,37 @@ function projectHealthData(
   };
 }
 
+function projectSetupReadinessData(
+  projectID: string,
+  overrides: Partial<ProjectSetupReadiness> = {},
+): ProjectSetupReadiness {
+  return {
+    project_id: projectID,
+    generated_at: "2026-06-20T00:00:00Z",
+    show_onboarding: false,
+    setup_started: true,
+    first_work_ready: false,
+    summary: {
+      work_item_count: 1,
+      role_count: 1,
+      skill_count: 0,
+      enabled_context_source_count: 0,
+      saved_memory_count: 0,
+      pending_memory_candidate_count: 0,
+      has_purpose: true,
+      has_active_root: true,
+      missing_defaults: false,
+    },
+    primary_action: {
+      type: "bootstrap_project",
+      project_id: projectID,
+      label: "Set up project",
+    },
+    checks: [],
+    ...overrides,
+  };
+}
+
 async function openProjectWorkspaceTab(name: RegExp | string) {
   await userEvent.click(await screen.findByRole("tab", { name }));
 }
@@ -193,6 +226,10 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getProjectHealth: vi.fn(async () => ({
       object: "project_health",
       data: emptyProjectHealthData(),
+    })),
+    getProjectSetupReadiness: vi.fn(async () => ({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(""),
     })),
     getProjectOperationsBrief: vi.fn(async () => ({
       object: "project_operations_brief",
@@ -582,6 +619,10 @@ function resetProjectWorkMocks() {
   vi.mocked(getProjectHealth).mockResolvedValue({
     object: "project_health",
     data: { ...emptyProjectHealthData(), project_id: project.id },
+  });
+  vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+    object: "project_setup_readiness",
+    data: projectSetupReadinessData(project.id),
   });
   vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_roles", data: [role] });
   vi.mocked(getProjectWorkItems).mockResolvedValue({
@@ -1132,6 +1173,7 @@ afterEach(() => {
   vi.mocked(getProjectActivity).mockReset();
   vi.mocked(getProjectHealth).mockReset();
   vi.mocked(getProjectOperationsBrief).mockReset();
+  vi.mocked(getProjectSetupReadiness).mockReset();
   vi.mocked(getProjectWorkRoles).mockReset();
   vi.mocked(getProjectWorkItems).mockReset();
   vi.mocked(getProjectWorkItem).mockReset();
@@ -1213,6 +1255,33 @@ describe("ProjectsView index", () => {
       object: "project_work_items",
       data: [],
     });
+    vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(project.id, {
+        show_onboarding: true,
+        setup_started: false,
+        first_work_ready: false,
+        summary: {
+          work_item_count: 0,
+          role_count: 0,
+          skill_count: 0,
+          enabled_context_source_count: 0,
+          saved_memory_count: 0,
+          pending_memory_candidate_count: 0,
+          has_purpose: true,
+          has_active_root: true,
+          missing_defaults: false,
+        },
+        checks: [
+          {
+            id: "workspace_source",
+            label: "Workspace source",
+            detail: "/Users/alice/dev/hecate",
+            status: "ready",
+          },
+        ],
+      }),
+    });
     window.localStorage.setItem("hecate.project", project.id);
     window.localStorage.setItem("hecate.projects.panel_collapsed", "1");
 
@@ -1259,6 +1328,25 @@ describe("ProjectsView index", () => {
       data: [],
     });
     vi.mocked(getProjectWorkRoles).mockResolvedValue({ object: "project_work_roles", data: [] });
+    vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(project.id, {
+        show_onboarding: false,
+        setup_started: true,
+        first_work_ready: true,
+        summary: {
+          work_item_count: 0,
+          role_count: 0,
+          skill_count: 0,
+          enabled_context_source_count: 1,
+          saved_memory_count: 0,
+          pending_memory_candidate_count: 0,
+          has_purpose: true,
+          has_active_root: true,
+          missing_defaults: false,
+        },
+      }),
+    });
     const bootstrappedProject: ProjectRecord = {
       ...project,
       context_sources: [
@@ -1331,6 +1419,25 @@ describe("ProjectsView index", () => {
         },
       ],
     };
+    vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(bootstrappedProject.id, {
+        show_onboarding: false,
+        setup_started: true,
+        first_work_ready: true,
+        summary: {
+          work_item_count: 0,
+          role_count: 1,
+          skill_count: 1,
+          enabled_context_source_count: 1,
+          saved_memory_count: 0,
+          pending_memory_candidate_count: 1,
+          has_purpose: true,
+          has_active_root: true,
+          missing_defaults: false,
+        },
+      }),
+    });
     const user = userEvent.setup();
     window.localStorage.setItem("hecate.project", bootstrappedProject.id);
 
@@ -1893,6 +2000,25 @@ describe("ProjectsView cockpit", () => {
       object: "project_work_items",
       data: [],
     });
+    vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(project.id, {
+        show_onboarding: true,
+        setup_started: false,
+        first_work_ready: false,
+        summary: {
+          work_item_count: 0,
+          role_count: 0,
+          skill_count: 0,
+          enabled_context_source_count: 0,
+          saved_memory_count: 0,
+          pending_memory_candidate_count: 0,
+          has_purpose: true,
+          has_active_root: true,
+          missing_defaults: false,
+        },
+      }),
+    });
     const discoveredProject: ProjectRecord = {
       ...project,
       context_sources: [
@@ -2082,6 +2208,25 @@ describe("ProjectsView cockpit", () => {
     vi.mocked(getProjectActivity).mockResolvedValue({
       object: "project_activity",
       data: emptyActivityData(),
+    });
+    vi.mocked(getProjectSetupReadiness).mockResolvedValue({
+      object: "project_setup_readiness",
+      data: projectSetupReadinessData(project.id, {
+        show_onboarding: true,
+        setup_started: false,
+        first_work_ready: false,
+        summary: {
+          work_item_count: 0,
+          role_count: 0,
+          skill_count: 0,
+          enabled_context_source_count: 0,
+          saved_memory_count: 0,
+          pending_memory_candidate_count: 0,
+          has_purpose: true,
+          has_active_root: true,
+          missing_defaults: false,
+        },
+      }),
     });
     const user = userEvent.setup();
     window.localStorage.setItem("hecate.project", project.id);

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -31,6 +31,7 @@ import {
   getProjectMemory,
   getProjectMemoryCandidates,
   getProjectOperationsBrief,
+  getProjectSetupReadiness,
   getProjectSkills,
   getProjectWorkItem,
   getProjectWorkItemReadiness,
@@ -62,6 +63,11 @@ import { CreateProjectModal } from "./CreateProjectModal";
 import { CreateProjectWorktreeModal } from "./CreateProjectWorktreeModal";
 import { ProjectHandoffModal } from "./ProjectHandoffModal";
 import { ProjectHealthPanel } from "./ProjectHealthPanel";
+import {
+  routeProjectOperationAction,
+  routeProjectSetupAction,
+  type ProjectActionRoute,
+} from "./projectActionRouting";
 import { ProjectMemoryModal, ProjectSourceModal, type MemoryForm } from "./ProjectMemoryPanel";
 import { ProjectReviewArtifactModal } from "./ProjectReviewArtifactModal";
 import { type ProjectAssignmentChatLaunchRequest } from "./ProjectWorkItemDetail";
@@ -89,8 +95,8 @@ import type {
   ProjectHealthAttention,
   ProjectMemoryRecord,
   ProjectOperationsBrief,
-  ProjectOperationsBriefAction,
   ProjectOperationsBriefItem,
+  ProjectSetupReadiness,
   ProjectContextSourceRecord,
   ProjectSkillRecord,
   ProjectRecord,
@@ -240,6 +246,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [workItemSummaries, setWorkItemSummaries] = useState<Record<string, WorkItemSummary>>({});
   const [activity, setActivity] = useState<ProjectActivityData | null>(null);
   const [projectHealth, setProjectHealth] = useState<ProjectHealth | null>(null);
+  const [projectSetupReadiness, setProjectSetupReadiness] = useState<ProjectSetupReadiness | null>(
+    null,
+  );
   const [operationsBrief, setOperationsBrief] = useState<ProjectOperationsBrief | null>(null);
   const [operationsBriefError, setOperationsBriefError] = useState("");
   const [operationsBriefLoadState, setOperationsBriefLoadState] = useState<LoadState>("idle");
@@ -320,17 +329,30 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     setProjectHealth(payload.data ?? null);
   }, []);
 
+  const loadProjectSetupReadiness = useCallback(async (projectID: string) => {
+    if (!projectID) {
+      setProjectSetupReadiness(null);
+      return;
+    }
+    const payload = await getProjectSetupReadiness(projectID);
+    setProjectSetupReadiness(payload.data ?? null);
+  }, []);
+
   const refreshProjectHealth = useCallback(
     (projectID: string) => {
       if (!projectID) {
         setProjectHealth(null);
+        setProjectSetupReadiness(null);
         return;
       }
       void loadProjectHealth(projectID).catch(() => {
         setProjectHealth(null);
       });
+      void loadProjectSetupReadiness(projectID).catch(() => {
+        setProjectSetupReadiness(null);
+      });
     },
-    [loadProjectHealth],
+    [loadProjectHealth, loadProjectSetupReadiness],
   );
 
   const loadAgentProfiles = useCallback(async (cancelled?: () => boolean) => {
@@ -417,6 +439,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     setWorkItemSummaries({});
     setActivity(null);
     setProjectHealth(null);
+    setProjectSetupReadiness(null);
     setOperationsBrief(null);
     setOperationsBriefError("");
     if (!preferredWorkItemID) {
@@ -430,6 +453,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     if (!projectID) {
       setWorkLoadState("idle");
       setOperationsBriefLoadState("idle");
+      setProjectSetupReadiness(null);
       return "";
     }
     setWorkLoadState("loading");
@@ -441,19 +465,23 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
         return null;
       });
       const healthLoad = getProjectHealth(projectID).catch(() => null);
-      const [rolesRes, workRes, activityRes, healthRes, operationsBriefRes] = await Promise.all([
-        getProjectWorkRoles(projectID),
-        getProjectWorkItems(projectID),
-        activityLoad,
-        healthLoad,
-        operationsBriefLoad,
-      ]);
+      const setupReadinessLoad = getProjectSetupReadiness(projectID).catch(() => null);
+      const [rolesRes, workRes, activityRes, healthRes, operationsBriefRes, setupReadinessRes] =
+        await Promise.all([
+          getProjectWorkRoles(projectID),
+          getProjectWorkItems(projectID),
+          activityLoad,
+          healthLoad,
+          operationsBriefLoad,
+          setupReadinessLoad,
+        ]);
       const nextRoles = rolesRes.data ?? [];
       const nextItems = workRes.data ?? [];
       setRoles(nextRoles);
       setWorkItems(nextItems);
       setActivity(activityRes?.data ?? null);
       setProjectHealth(healthRes?.data ?? null);
+      setProjectSetupReadiness(setupReadinessRes?.data ?? null);
       setOperationsBrief(operationsBriefRes?.data ?? null);
       setOperationsBriefLoadState(operationsBriefRes ? "loaded" : "error");
       setWorkItemSummaries(
@@ -471,6 +499,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       setWorkLoadState("error");
       setOperationsBriefLoadState("error");
       setProjectHealth(null);
+      setProjectSetupReadiness(null);
       setWorkError(errorMessage(error, "Failed to load project work."));
       return "";
     }
@@ -1099,6 +1128,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       setSelectedWorkItemID(payload.data.id);
       setNewWorkModalOpen(false);
       setNewWorkDraft(undefined);
+      await loadProjectSetupReadiness(selectedProjectID);
       await loadWorkItemDetail(selectedProjectID, payload.data.id);
     } catch (error) {
       setNewWorkError(errorMessage(error, "Failed to create work item."));
@@ -1197,38 +1227,33 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   }
 
   function handleOperationsBriefAction(item: ProjectOperationsBriefItem) {
-    const action = item.action;
-    if (!action?.type) {
-      setWorkError("Project operation is missing an action. Refresh project work and try again.");
-      return;
-    }
-    if (action.project_id && selectedProjectID && action.project_id !== selectedProjectID) {
-      setWorkError("Project operation target changed. Refresh project work and try again.");
-      return;
-    }
-    if (action.type === "draft_project_proposal") {
-      const request = action.request?.trim();
-      if (!request) {
-        setWorkError("Project operation is missing a Project Assistant draft request.");
-        return;
-      }
-      setWorkspaceTab("work");
-      if (action.work_item_id) {
-        setSelectedWorkItemID(action.work_item_id);
-      }
-      void assistant.propose(
-        {
-          request,
-          roleID: PROJECT_ASSISTANT_AUTO,
-          driverKind: PROJECT_ASSISTANT_AUTO,
-          draftMode: "deterministic",
-        },
-        action.work_item_id,
-      );
-      return;
-    }
+    handleProjectActionRoute(routeProjectOperationAction(item, selectedProjectID));
+  }
 
-    switch (action.type) {
+  function handleSetupReadinessAction(action: ProjectSetupReadiness["primary_action"]) {
+    handleProjectActionRoute(routeProjectSetupAction(action, selectedProjectID));
+  }
+
+  function handleProjectActionRoute(route: ProjectActionRoute) {
+    switch (route.kind) {
+      case "error":
+        setWorkError(route.message);
+        return;
+      case "draft_project_proposal":
+        setWorkspaceTab("work");
+        if (route.workItemID) {
+          setSelectedWorkItemID(route.workItemID);
+        }
+        void assistant.propose(
+          {
+            request: route.request,
+            roleID: PROJECT_ASSISTANT_AUTO,
+            driverKind: PROJECT_ASSISTANT_AUTO,
+            draftMode: "deterministic",
+          },
+          route.workItemID,
+        );
+        return;
       case "open_project_settings":
         setDefaultsError("");
         setSettingsPanelOpen(true);
@@ -1237,31 +1262,32 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
         setWorkspaceTab("memory");
         return;
       case "open_assignment_preflight":
-        selectOperationWorkTarget(action);
-        if (action.assignment_id) {
-          setPreparingAssignmentID(action.assignment_id);
-        } else {
-          setWorkError("Project operation is missing an assignment preflight target.");
-        }
+        selectProjectWorkRoute(route);
+        setPreparingAssignmentID(route.assignmentID);
         return;
       case "open_work_item":
-        selectOperationWorkTarget(action);
+        selectProjectWorkRoute(route);
+        return;
+      case "bootstrap_project":
+        void assistant.bootstrap();
+        return;
+      case "create_work_item":
+        openNewWorkItemModal();
         return;
       default:
-        setWorkError(
-          "Project operation action is not supported. Refresh project work and try again.",
-        );
+        return;
     }
   }
 
-  function selectOperationWorkTarget(action: ProjectOperationsBriefAction) {
+  function selectProjectWorkRoute(
+    route: Extract<ProjectActionRoute, { kind: "open_assignment_preflight" | "open_work_item" }>,
+  ) {
     setWorkspaceTab("work");
-    const bucket = projectOperationsActivityBucket(action.activity_bucket);
-    if (bucket) {
-      setActivityBucket(bucket);
+    if (route.bucket) {
+      setActivityBucket(route.bucket);
     }
-    if (action.work_item_id) {
-      setSelectedWorkItemID(action.work_item_id);
+    if (route.workItemID) {
+      setSelectedWorkItemID(route.workItemID);
     }
   }
 
@@ -1535,19 +1561,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
 
   const hasWorkItemDetail =
     Boolean(selectedWorkItemID) || detailLoadState === "loading" || Boolean(detailError);
-  const selectedProjectEnabledSourceCount =
-    selectedProject?.context_sources?.filter((source) => source.enabled).length ?? 0;
-  const projectHasSetupState =
-    selectedProjectEnabledSourceCount > 0 ||
-    roles.length > 0 ||
-    projectSkills.length > 0 ||
-    memoryEntries.length > 0 ||
-    memoryCandidates.length > 0;
   const projectNeedsOnboarding =
-    Boolean(selectedProject) &&
+    Boolean(selectedProject && projectSetupReadiness?.show_onboarding) &&
     workLoadState === "loaded" &&
-    workItems.length === 0 &&
-    !projectHasSetupState &&
     !assistant.proposal &&
     !assistant.applyResult;
   const projectEmptyTitle =
@@ -1634,6 +1650,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             setDefaultsError("");
             setSettingsPanelOpen(true);
           }}
+          onAttentionError={setWorkError}
           onAttentionMemory={() => setWorkspaceTab("memory")}
           onAttentionProfiles={() => {
             setProfilesError("");
@@ -1811,12 +1828,14 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             onSetHandoffStatus={(handoff, status) => void handleSetHandoffStatus(handoff, status)}
             onStartAssignment={handleStartAssignment}
             onStartHandoff={(handoff) => void handleStartHandoff(handoff)}
+            onSetupReadinessAction={handleSetupReadinessAction}
             onUpdateProjectSkill={(skill, patch) => void handleUpdateProjectSkill(skill, patch)}
             onWorkspaceTabChange={setWorkspaceTab}
             project={selectedProject}
             projectEmptyDetail={projectEmptyDetail}
             projectEmptyTitle={projectEmptyTitle}
             projectNeedsOnboarding={projectNeedsOnboarding}
+            projectSetupReadiness={projectSetupReadiness}
             operationsBrief={operationsBrief}
             operationsBriefError={operationsBriefError}
             operationsBriefLoadState={operationsBriefLoadState}
@@ -2289,6 +2308,7 @@ function ProjectHeader({
   settingsOpen,
   onAttentionBucket,
   onAttentionDefaults,
+  onAttentionError,
   onAttentionMemory,
   onAttentionProfiles,
   onAttentionReviewCandidate,
@@ -2309,6 +2329,7 @@ function ProjectHeader({
   settingsOpen: boolean;
   onAttentionBucket: (bucket: ProjectActivityBucketKey) => void;
   onAttentionDefaults: () => void;
+  onAttentionError?: (message: string) => void;
   onAttentionMemory: () => void;
   onAttentionProfiles: () => void;
   onAttentionReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
@@ -2345,9 +2366,11 @@ function ProjectHeader({
             disabled={!project}
             memoryCandidates={memoryCandidates}
             omittedAttentionCount={omittedAttentionCount}
+            selectedProjectID={project.id}
             summary={healthSummary}
             onAttentionBucket={onAttentionBucket}
             onAttentionDefaults={onAttentionDefaults}
+            onAttentionError={onAttentionError}
             onAttentionMemory={onAttentionMemory}
             onAttentionProfiles={onAttentionProfiles}
             onAttentionReviewCandidate={onAttentionReviewCandidate}
@@ -2596,19 +2619,6 @@ function preferredFirstWorkRole(roles: ProjectWorkRoleRecord[]) {
 
 function contextSourceLabel(source: ProjectContextSourceRecord) {
   return source.title?.trim() || source.path || source.kind;
-}
-
-function projectOperationsActivityBucket(value?: string): ProjectActivityBucketKey | null {
-  switch (value) {
-    case "all":
-    case "active":
-    case "blocked":
-    case "completed":
-    case "recent":
-      return value;
-    default:
-      return null;
-  }
 }
 
 const topbarStyle: CSSProperties = {

--- a/ui/src/features/projects/projectActionRouting.test.ts
+++ b/ui/src/features/projects/projectActionRouting.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ProjectHealthAttention,
+  ProjectOperationsBriefItem,
+  ProjectSetupReadinessAction,
+} from "../../types/project";
+import {
+  projectActivityBucket,
+  routeProjectHealthAttention,
+  routeProjectOperationAction,
+  routeProjectSetupAction,
+} from "./projectActionRouting";
+
+function operationItem(overrides: Partial<ProjectOperationsBriefItem> = {}) {
+  return {
+    id: "op_1",
+    kind: "assignment_preflight",
+    priority: "high",
+    title: "Prepare next step",
+    detail: "Assignment is ready to launch.",
+    action_label: "Prepare",
+    target: {
+      surface: "work",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      assignment_id: "assign_1",
+    },
+    action: {
+      type: "open_assignment_preflight",
+      project_id: "proj_1",
+      work_item_id: "work_1",
+      assignment_id: "assign_1",
+      activity_bucket: "active",
+    },
+    ...overrides,
+  } satisfies ProjectOperationsBriefItem;
+}
+
+describe("projectActionRouting", () => {
+  it("routes server operations without client-side derivation", () => {
+    expect(routeProjectOperationAction(operationItem(), "proj_1")).toEqual({
+      kind: "open_assignment_preflight",
+      assignmentID: "assign_1",
+      bucket: "active",
+      workItemID: "work_1",
+    });
+
+    expect(
+      routeProjectOperationAction(
+        operationItem({
+          action: {
+            type: "draft_project_proposal",
+            project_id: "proj_1",
+            work_item_id: "work_2",
+            request: "  Queue reviewer  ",
+          },
+        }),
+        "proj_1",
+      ),
+    ).toEqual({
+      kind: "draft_project_proposal",
+      request: "Queue reviewer",
+      workItemID: "work_2",
+    });
+
+    expect(
+      routeProjectOperationAction(
+        operationItem({ action: { type: "open_memory_review", project_id: "proj_1" } }),
+        "proj_1",
+      ),
+    ).toEqual({ kind: "open_memory_review" });
+  });
+
+  it("rejects stale or incomplete server operations", () => {
+    expect(
+      routeProjectOperationAction(
+        operationItem({ action: { type: "open_project_settings", project_id: "other" } }),
+        "proj_1",
+      ),
+    ).toEqual({
+      kind: "error",
+      message: "Project operation target changed. Refresh project work and try again.",
+    });
+
+    expect(
+      routeProjectOperationAction(
+        operationItem({
+          action: { type: "draft_project_proposal", project_id: "proj_1", request: " " },
+        }),
+        "proj_1",
+      ),
+    ).toEqual({
+      kind: "error",
+      message: "Project operation is missing a Project Assistant draft request.",
+    });
+
+    expect(
+      routeProjectOperationAction(
+        operationItem({
+          action: { type: "open_assignment_preflight", project_id: "proj_1" },
+        }),
+        "proj_1",
+      ),
+    ).toEqual({
+      kind: "error",
+      message: "Project operation is missing an assignment preflight target.",
+    });
+  });
+
+  it("routes setup-readiness actions from the server contract", () => {
+    const bootstrap: ProjectSetupReadinessAction = {
+      type: "bootstrap_project",
+      project_id: "proj_1",
+      label: "Set up project",
+    };
+    expect(routeProjectSetupAction(bootstrap, "proj_1")).toEqual({ kind: "bootstrap_project" });
+    expect(
+      routeProjectSetupAction(
+        { type: "create_work_item", project_id: "proj_1", label: "Create work" },
+        "proj_1",
+      ),
+    ).toEqual({ kind: "create_work_item" });
+    expect(
+      routeProjectSetupAction(
+        { type: "open_project_settings", project_id: "proj_1", label: "Set defaults" },
+        "proj_1",
+      ),
+    ).toEqual({ kind: "open_project_settings" });
+    expect(routeProjectSetupAction({ ...bootstrap, project_id: "other" }, "proj_1")).toEqual({
+      kind: "error",
+      message: "Project setup target changed. Refresh the project.",
+    });
+  });
+
+  it("routes project health attention items to existing cockpit surfaces", () => {
+    const attention = (overrides: Partial<ProjectHealthAttention>): ProjectHealthAttention => ({
+      id: "attn_1",
+      title: "Needs attention",
+      detail: "Open the right surface.",
+      status: "blocked",
+      ...overrides,
+    });
+
+    expect(routeProjectHealthAttention(attention({ action: "settings" }))).toEqual({
+      kind: "open_project_settings",
+    });
+    expect(
+      routeProjectHealthAttention(attention({ action: "settings", project_id: "other" }), {
+        selectedProjectID: "proj_1",
+      }),
+    ).toEqual({
+      kind: "error",
+      message: "Project attention target changed. Refresh project work and try again.",
+    });
+    expect(routeProjectHealthAttention(attention({ action: "skills" }))).toEqual({
+      kind: "open_skills",
+    });
+    expect(routeProjectHealthAttention(attention({ candidate_id: "cand_1" }))).toEqual({
+      kind: "open_memory_review",
+    });
+    expect(
+      routeProjectHealthAttention(attention({ candidate_id: "cand_1" }), {
+        hasMemoryCandidate: true,
+      }),
+    ).toEqual({ kind: "review_memory_candidate", candidateID: "cand_1" });
+    expect(
+      routeProjectHealthAttention(attention({ work_item_id: "work_1", bucket: "blocked" })),
+    ).toEqual({
+      kind: "open_work_item",
+      workItemID: "work_1",
+      bucket: "blocked",
+    });
+    expect(routeProjectHealthAttention(attention({ task_id: "task_1", run_id: "run_1" }))).toEqual({
+      kind: "open_task",
+      taskID: "task_1",
+      runID: "run_1",
+    });
+  });
+
+  it("accepts only known activity buckets", () => {
+    expect(projectActivityBucket("recent")).toBe("recent");
+    expect(projectActivityBucket("unexpected")).toBeUndefined();
+  });
+});

--- a/ui/src/features/projects/projectActionRouting.ts
+++ b/ui/src/features/projects/projectActionRouting.ts
@@ -1,0 +1,183 @@
+import type {
+  ProjectActivityBucketKey,
+  ProjectHealthAttention,
+  ProjectOperationsBriefAction,
+  ProjectOperationsBriefItem,
+  ProjectSetupReadinessAction,
+} from "../../types/project";
+
+export type ProjectActionRoute =
+  | { kind: "bootstrap_project" }
+  | { kind: "create_work_item" }
+  | { kind: "draft_project_proposal"; request: string; workItemID?: string }
+  | { kind: "error"; message: string }
+  | { kind: "none" }
+  | { kind: "open_activity_bucket"; bucket: ProjectActivityBucketKey }
+  | {
+      kind: "open_assignment_preflight";
+      assignmentID: string;
+      bucket?: ProjectActivityBucketKey;
+      workItemID?: string;
+    }
+  | { kind: "open_memory_review" }
+  | { kind: "open_profiles" }
+  | { kind: "open_project_settings" }
+  | { kind: "open_roles" }
+  | { kind: "open_skills" }
+  | { kind: "open_task"; taskID: string; runID?: string }
+  | { kind: "open_work_item"; bucket?: ProjectActivityBucketKey; workItemID: string }
+  | { kind: "review_memory_candidate"; candidateID: string };
+
+export function routeProjectOperationAction(
+  item: ProjectOperationsBriefItem,
+  selectedProjectID: string,
+): ProjectActionRoute {
+  const action = item.action;
+  if (!action?.type) {
+    return {
+      kind: "error",
+      message: "Project operation is missing an action. Refresh project work and try again.",
+    };
+  }
+  if (action.project_id && selectedProjectID && action.project_id !== selectedProjectID) {
+    return {
+      kind: "error",
+      message: "Project operation target changed. Refresh project work and try again.",
+    };
+  }
+  if (action.type === "draft_project_proposal") {
+    const request = action.request?.trim();
+    if (!request) {
+      return {
+        kind: "error",
+        message: "Project operation is missing a Project Assistant draft request.",
+      };
+    }
+    return { kind: "draft_project_proposal", request, workItemID: action.work_item_id };
+  }
+  switch (action.type) {
+    case "open_project_settings":
+      return { kind: "open_project_settings" };
+    case "open_memory_review":
+      return { kind: "open_memory_review" };
+    case "open_assignment_preflight":
+      return routeProjectAssignmentPreflight(action);
+    case "open_work_item":
+      return routeProjectWorkTarget(action);
+    default:
+      return {
+        kind: "error",
+        message: "Project operation action is not supported. Refresh project work and try again.",
+      };
+  }
+}
+
+export function routeProjectSetupAction(
+  action: ProjectSetupReadinessAction | undefined,
+  selectedProjectID: string,
+): ProjectActionRoute {
+  if (!action?.type) {
+    return { kind: "error", message: "Project setup action is missing. Refresh the project." };
+  }
+  if (action.project_id && selectedProjectID && action.project_id !== selectedProjectID) {
+    return { kind: "error", message: "Project setup target changed. Refresh the project." };
+  }
+  switch (action.type) {
+    case "bootstrap_project":
+      return { kind: "bootstrap_project" };
+    case "create_work_item":
+      return { kind: "create_work_item" };
+    case "open_project_settings":
+      return { kind: "open_project_settings" };
+    default:
+      return {
+        kind: "error",
+        message: "Project setup action is not supported. Refresh the project.",
+      };
+  }
+}
+
+export function routeProjectHealthAttention(
+  item: ProjectHealthAttention,
+  options: { hasMemoryCandidate?: boolean; selectedProjectID?: string } = {},
+): ProjectActionRoute {
+  if (
+    item.project_id &&
+    options.selectedProjectID &&
+    item.project_id !== options.selectedProjectID
+  ) {
+    return {
+      kind: "error",
+      message: "Project attention target changed. Refresh project work and try again.",
+    };
+  }
+  if (item.action === "settings" || item.id.endsWith(":defaults")) {
+    return { kind: "open_project_settings" };
+  }
+  if (item.action === "skills") return { kind: "open_skills" };
+  if (item.action === "profiles") return { kind: "open_profiles" };
+  if (item.action === "roles") return { kind: "open_roles" };
+  if (item.candidate_id) {
+    return options.hasMemoryCandidate
+      ? { kind: "review_memory_candidate", candidateID: item.candidate_id }
+      : { kind: "open_memory_review" };
+  }
+  if (item.work_item_id) {
+    return {
+      kind: "open_work_item",
+      workItemID: item.work_item_id,
+      bucket: projectActivityBucket(item.bucket),
+    };
+  }
+  if (item.task_id) {
+    return { kind: "open_task", taskID: item.task_id, runID: item.run_id };
+  }
+  const bucket = projectActivityBucket(item.bucket);
+  if (bucket) return { kind: "open_activity_bucket", bucket };
+  if (item.action === "memory" || item.id.endsWith(":context")) {
+    return { kind: "open_memory_review" };
+  }
+  return { kind: "none" };
+}
+
+function routeProjectAssignmentPreflight(action: ProjectOperationsBriefAction): ProjectActionRoute {
+  if (!action.assignment_id) {
+    return {
+      kind: "error",
+      message: "Project operation is missing an assignment preflight target.",
+    };
+  }
+  return {
+    kind: "open_assignment_preflight",
+    assignmentID: action.assignment_id,
+    bucket: projectActivityBucket(action.activity_bucket),
+    workItemID: action.work_item_id,
+  };
+}
+
+function routeProjectWorkTarget(action: ProjectOperationsBriefAction): ProjectActionRoute {
+  if (!action.work_item_id) {
+    return {
+      kind: "error",
+      message: "Project operation is missing a work item target.",
+    };
+  }
+  return {
+    kind: "open_work_item",
+    bucket: projectActivityBucket(action.activity_bucket),
+    workItemID: action.work_item_id,
+  };
+}
+
+export function projectActivityBucket(value?: string): ProjectActivityBucketKey | undefined {
+  switch (value) {
+    case "all":
+    case "active":
+    case "blocked":
+    case "completed":
+    case "recent":
+      return value;
+    default:
+      return undefined;
+  }
+}

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -39,6 +39,7 @@ import {
   getProjectMemory,
   getProjectMemoryCandidates,
   getProjectOperationsBrief,
+  getProjectSetupReadiness,
   getProjectWorkItem,
   getProjectWorkItemReadiness,
   getProjectWorkItems,
@@ -287,13 +288,14 @@ describe("api client", () => {
 
   it("builds project work coordination requests", async () => {
     fetchMock.mockClear();
-    for (let i = 0; i < 10; i += 1) {
+    for (let i = 0; i < 11; i += 1) {
       fetchMock.mockResolvedValueOnce(jsonResponse({ object: "ok", data: [] }));
     }
 
     await getProjectActivity("proj/1");
     await getProjectHealth("proj/1");
     await getProjectOperationsBrief("proj/1");
+    await getProjectSetupReadiness("proj/1");
     await getProjectWorkRoles("proj/1");
     await getProjectWorkItems("proj/1");
     await getProjectWorkItem("proj/1", "work/1");
@@ -319,36 +321,41 @@ describe("api client", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       4,
-      "/hecate/v1/projects/proj%2F1/roles",
+      "/hecate/v1/projects/proj%2F1/setup-readiness",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       5,
-      "/hecate/v1/projects/proj%2F1/work-items",
+      "/hecate/v1/projects/proj%2F1/roles",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       6,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
+      "/hecate/v1/projects/proj%2F1/work-items",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       7,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/readiness",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       8,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/readiness",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       9,
-      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       10,
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/artifacts",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      11,
       "/hecate/v1/projects/proj%2F1/work-items/work%2F1/handoffs",
       expect.objectContaining({ method: "GET" }),
     );

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -99,6 +99,7 @@ import type {
   ProjectMemoryResponse,
   ProjectOperationsBriefResponse,
   ProjectResponse,
+  ProjectSetupReadinessResponse,
   ProjectSkillResponse,
   ProjectSkillsResponse,
   ProjectWorkItemsResponse,
@@ -604,6 +605,14 @@ export async function getProjectOperationsBrief(
 ): Promise<ProjectOperationsBriefResponse> {
   return fetchJSON<ProjectOperationsBriefResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/operations/brief`,
+  );
+}
+
+export async function getProjectSetupReadiness(
+  projectID: string,
+): Promise<ProjectSetupReadinessResponse> {
+  return fetchJSON<ProjectSetupReadinessResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/setup-readiness`,
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -826,6 +826,7 @@ export type ProjectHealthAttentionAction =
 
 export type ProjectHealthAttention = {
   id: string;
+  project_id?: string;
   title: string;
   detail: string;
   status: string;
@@ -872,6 +873,57 @@ export type ProjectHealth = {
 export type ProjectHealthResponse = {
   object: string;
   data: ProjectHealth;
+};
+
+export type ProjectSetupReadinessActionType =
+  | "bootstrap_project"
+  | "create_work_item"
+  | "open_project_settings"
+  | (string & {});
+
+export type ProjectSetupReadinessAction = {
+  type: ProjectSetupReadinessActionType;
+  project_id: string;
+  label: string;
+};
+
+export type ProjectSetupReadinessCheckStatus = "ready" | "todo" | "optional" | (string & {});
+
+export type ProjectSetupReadinessCheck = {
+  id: string;
+  label: string;
+  detail: string;
+  status: ProjectSetupReadinessCheckStatus;
+  optional?: boolean;
+  action?: ProjectSetupReadinessAction;
+};
+
+export type ProjectSetupReadinessSummary = {
+  work_item_count: number;
+  role_count: number;
+  skill_count: number;
+  enabled_context_source_count: number;
+  saved_memory_count: number;
+  pending_memory_candidate_count: number;
+  has_purpose: boolean;
+  has_active_root: boolean;
+  missing_defaults: boolean;
+};
+
+export type ProjectSetupReadiness = {
+  project_id: string;
+  generated_at: string;
+  show_onboarding: boolean;
+  setup_started: boolean;
+  first_work_ready: boolean;
+  summary: ProjectSetupReadinessSummary;
+  primary_action: ProjectSetupReadinessAction;
+  checks: ProjectSetupReadinessCheck[];
+};
+
+export type ProjectSetupReadinessResponse = {
+  object: string;
+  data: ProjectSetupReadiness;
 };
 
 export type ProjectOperationsBriefPriority = "high" | "medium" | "low" | (string & {});


### PR DESCRIPTION
## Summary

- add read-only project setup readiness API for onboarding, setup-started, first-work-ready, checklist, and typed setup actions
- consume setup readiness in the Projects cockpit and route setup, operations, and health actions through a shared project action routing helper
- refresh setup readiness after first work creation, update project journey fixtures, and document the server-owned setup contract

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api ./internal/projectwork ./internal/projectworkapp ./internal/projectassistant ./internal/memory`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test src/features/projects/projectActionRouting.test.ts src/features/projects/ProjectWorkspaceView.test.tsx src/features/projects/ProjectsView.test.tsx src/features/projects/ProjectHealthPanel.test.tsx src/lib/api.test.ts src/app/AppShell.test.tsx`
- `cd ui && bun run test`
- `cd ui && bun run test:e2e projects.spec.ts`
- reserved-name scan: no matches
