### PR TITLE
chore(agent): bump Go ACP adapter releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.21
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,11 +24,12 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.21` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.23` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.22` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.24` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
-failure/stop-reason classification. The
+failure/stop-reason classification, or the local-login environment contract that
+is exercised by the real CLI smoke suite. The
 `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
 usage updates, so Hecate can render External Agent activity without exposing raw
@@ -63,6 +64,9 @@ or refusals in the chat activity timeline.
 Codex adapter `v0.1.0-alpha.21` maps parsed Codex stream permission requests to
 ACP `session/request_permission`, so Hecate can record and resolve adapter tool
 approvals instead of silently auto-continuing parsed permission events.
+Codex adapter `v0.1.0-alpha.22` keeps first-party CLI local-login detection
+visible to the spawned Codex process while retaining the sanitized adapter
+environment, and the release is covered by the opt-in real CLI smoke suite.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -96,6 +100,10 @@ Claude Code adapter `v0.1.0-alpha.23` maps parsed Claude Code stream permission
 requests to ACP `session/request_permission`, so Hecate can record and resolve
 adapter tool approvals instead of silently auto-continuing parsed permission
 events.
+Claude Code adapter `v0.1.0-alpha.24` keeps first-party CLI local-login
+detection visible to the spawned Claude process while retaining the sanitized
+adapter environment, and the release is covered by the opt-in real CLI smoke
+suite.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -644,6 +644,21 @@ require_contains() {
   esac
 }
 
+original_args="$*"
+while true; do
+  case "$1" in
+    --ask-for-approval)
+      shift 2
+      ;;
+    --search)
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 case "$1" in
   --version)
     printf 'codex 9.8.7\n'
@@ -658,11 +673,12 @@ case "$1" in
     exit 0
     ;;
   exec)
+    require_contains " --ask-for-approval never " "$original_args"
+    require_contains " --search " "$original_args"
     require_contains " --sandbox read-only " "$@"
     require_contains " --model gpt-5-codex " "$@"
     require_contains " --config model_reasoning_effort=\"high\" " "$@"
     require_contains " --config mcp_servers.hecate_01_docs={url=\"https://docs.example.com/mcp\",http_headers={\"Authorization\"=\"Bearer token\"}} " "$@"
-    require_contains " --search " "$@"
     case "$*" in
       *"/auth-fail"*) echo "Authentication required: run codex login" >&2; exit 67;;
       *"/init focus on repo guidance"*) message="go codex init";;

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -271,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.21",
+			SupportedRange:       ">=0.1.0-alpha.22",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -312,7 +312,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.23",
+			SupportedRange:       ">=0.1.0-alpha.24",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.21" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.22" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.23" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.24" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump bundled Codex ACP adapter to v0.1.0-alpha.22
- bump bundled Claude Code ACP adapter to v0.1.0-alpha.24
- align built-in supported ranges and external-agent docs with the new release floors
- update the ACP release-smoke fake Codex CLI to assert the corrected global-flag-before-exec invocation

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -tags acp_release -count=1 -run 'TestACPAdapterReleaseBinaries' -timeout 5m ./internal/agentadapters
- just docs-format-check
- just check-links